### PR TITLE
feat(ai-employee): multi-user voice profiles (#858)

### DIFF
--- a/ai-employee/adapter/voice/__init__.py
+++ b/ai-employee/adapter/voice/__init__.py
@@ -87,11 +87,13 @@ from .state import (
 )
 from .transform import (
     DraftTransformer,
+    GENERAL_VOICE_USER_ID,
     MAX_TRANSFORM_PASSES,
     MIN_PROFILE_SAMPLE_COUNT,
     TransformResult,
     TransformStatus,
     VoiceProfile,
+    VoiceProfileBundle,
     build_voice_profile,
     transform_draft,
 )
@@ -105,6 +107,7 @@ __all__ = [
     "CursorStore",
     "DraftTransformer",
     "EmailSource",
+    "GENERAL_VOICE_USER_ID",
     "FilterResult",
     "GreetingStyle",
     "INGEST_STATUS_ERROR",
@@ -141,6 +144,7 @@ __all__ = [
     "VoiceIngestionItem",
     "VoiceIngestionRunner",
     "VoiceProfile",
+    "VoiceProfileBundle",
     "VoiceSourceState",
     "VoiceSourceStateStore",
     "WriteExecutor",

--- a/ai-employee/adapter/voice/tests/test_transform.py
+++ b/ai-employee/adapter/voice/tests/test_transform.py
@@ -34,12 +34,14 @@ sys.path.insert(0, str(_HERE.parents[3]))  # ai-employee/ on sys.path
 
 from adapter.voice import (  # noqa: E402
     DraftTransformer,
+    GENERAL_VOICE_USER_ID,
     GreetingStyle,
     MIN_PROFILE_SAMPLE_COUNT,
     SignoffStyle,
     StructuralDiff,
     TransformStatus,
     VoiceProfile,
+    VoiceProfileBundle,
     build_voice_profile,
     extract_structural_diff,
     transform_draft,
@@ -536,3 +538,178 @@ def test_class_and_function_entry_points_produce_same_result():
     assert via_function.status == via_class.status
     assert via_function.transformed_draft == via_class.transformed_draft
     assert via_function.changes_applied == via_class.changes_applied
+
+
+# ---------------------------------------------------------------------------
+# Multi-user voice — VoiceProfileBundle (#858)
+# ---------------------------------------------------------------------------
+
+
+def test_bare_profile_records_general_user_id():
+    """Legacy single-profile callers always get the GENERAL sentinel."""
+    draft = "Dear Mr. Smith,\n\nFollowing up.\n\nSincerely,\nMarcus"
+    profile = _profile(greeting=GreetingStyle.FIRST_NAME, signoff=SignoffStyle.THANKS)
+    result = transform_draft(draft=draft, profile=profile)
+    assert result.selected_voice_user_id == GENERAL_VOICE_USER_ID
+
+
+def test_bare_profile_ignores_reviewer_user_id_argument():
+    """Bare VoiceProfile callers can pass reviewer_user_id; it has no effect.
+
+    Lets the skill pipeline thread the argument unconditionally without
+    branching on profile shape.
+    """
+    draft = "Dear Mr. Smith,\n\nFollowing up.\n\nSincerely,\nMarcus"
+    profile = _profile(greeting=GreetingStyle.FIRST_NAME, signoff=SignoffStyle.THANKS)
+    a = transform_draft(draft=draft, profile=profile)
+    b = transform_draft(draft=draft, profile=profile, reviewer_user_id="partner-sarah")
+    assert a.status == b.status
+    assert a.transformed_draft == b.transformed_draft
+    assert a.selected_voice_user_id == b.selected_voice_user_id == GENERAL_VOICE_USER_ID
+
+
+def test_bundle_with_no_reviewer_id_falls_back_to_general():
+    """Bundle + None reviewer_user_id selects the general profile."""
+    general = _profile(greeting=GreetingStyle.FIRST_NAME, signoff=SignoffStyle.THANKS)
+    sarah = _profile(greeting=GreetingStyle.FORMAL_NAMED, signoff=SignoffStyle.SINCERELY)
+    bundle = VoiceProfileBundle(general=general, per_user={"partner-sarah": sarah})
+
+    draft = "Dear Mr. Smith,\n\nFollowing up.\n\nSincerely,\nMarcus"
+    result = transform_draft(draft=draft, profile=bundle)
+    assert result.selected_voice_user_id == GENERAL_VOICE_USER_ID
+    # General profile is first_name/thanks — the formal draft should swap.
+    assert result.status == TransformStatus.TRANSFORMED
+    assert result.transformed_draft.startswith("Hi Smith,")
+
+
+def test_bundle_per_user_profile_selected_when_reviewer_id_matches():
+    """Bundle + matching reviewer_user_id selects that user's profile.
+
+    Sarah's profile is formal/sincerely; if her profile is applied, the
+    draft starts already-formal and there's no greeting swap.
+    """
+    general = _profile(greeting=GreetingStyle.FIRST_NAME, signoff=SignoffStyle.THANKS)
+    sarah = _profile(greeting=GreetingStyle.FORMAL_NAMED, signoff=SignoffStyle.SINCERELY)
+    bundle = VoiceProfileBundle(general=general, per_user={"partner-sarah": sarah})
+
+    formal_draft = "Dear Mr. Smith,\n\nFollowing up.\n\nSincerely,\nMarcus"
+    result = transform_draft(
+        draft=formal_draft, profile=bundle, reviewer_user_id="partner-sarah"
+    )
+    assert result.selected_voice_user_id == "partner-sarah"
+    # Already matches the formal target — no greeting / signoff swap.
+    assert "greeting_swap" not in result.changes_applied
+    assert "signoff_swap" not in result.changes_applied
+
+
+def test_bundle_falls_back_to_general_when_reviewer_id_unknown():
+    """Bundle + reviewer_user_id with no entry → general profile.
+
+    Callers don't have to know which users have per-user profiles
+    configured.
+    """
+    general = _profile(greeting=GreetingStyle.FIRST_NAME, signoff=SignoffStyle.THANKS)
+    sarah = _profile(greeting=GreetingStyle.FORMAL_NAMED, signoff=SignoffStyle.SINCERELY)
+    bundle = VoiceProfileBundle(general=general, per_user={"partner-sarah": sarah})
+
+    draft = "Dear Mr. Smith,\n\nFollowing up.\n\nSincerely,\nMarcus"
+    result = transform_draft(
+        draft=draft, profile=bundle, reviewer_user_id="associate-mike-no-profile"
+    )
+    assert result.selected_voice_user_id == GENERAL_VOICE_USER_ID
+    # General is first_name/thanks → swap applies
+    assert result.status == TransformStatus.TRANSFORMED
+
+
+def test_bundle_falls_back_when_per_user_profile_is_insufficient():
+    """Per-user profile with < MIN samples falls back to general.
+
+    Defense-in-depth: reshaping against a noisy per-user target is
+    worse than reshaping against the firm-wide composite.
+    """
+    general = _profile(samples_count=30)
+    # Sarah's profile has only 2 samples — well under the floor
+    sarah = _profile(
+        samples_count=MIN_PROFILE_SAMPLE_COUNT - 1,
+        greeting=GreetingStyle.FORMAL_NAMED,
+        signoff=SignoffStyle.SINCERELY,
+    )
+    bundle = VoiceProfileBundle(general=general, per_user={"partner-sarah": sarah})
+
+    draft = "Dear Mr. Smith,\n\nFollowing up.\n\nSincerely,\nMarcus"
+    result = transform_draft(
+        draft=draft, profile=bundle, reviewer_user_id="partner-sarah"
+    )
+    # Per-user profile was rejected, general kicked in
+    assert result.selected_voice_user_id == GENERAL_VOICE_USER_ID
+
+
+def test_bundle_with_empty_per_user_dict_equivalent_to_bare_profile():
+    """A bundle with no per-user profiles behaves like the legacy path."""
+    profile = _profile(greeting=GreetingStyle.FIRST_NAME, signoff=SignoffStyle.THANKS)
+    bundle = VoiceProfileBundle(general=profile, per_user={})
+
+    draft = "Dear Mr. Smith,\n\nFollowing up.\n\nSincerely,\nMarcus"
+    via_bare = transform_draft(draft=draft, profile=profile)
+    via_bundle = transform_draft(draft=draft, profile=bundle)
+    via_bundle_with_id = transform_draft(
+        draft=draft, profile=bundle, reviewer_user_id="anyone"
+    )
+    assert via_bare.transformed_draft == via_bundle.transformed_draft
+    assert via_bare.transformed_draft == via_bundle_with_id.transformed_draft
+    assert via_bundle.selected_voice_user_id == GENERAL_VOICE_USER_ID
+    assert via_bundle_with_id.selected_voice_user_id == GENERAL_VOICE_USER_ID
+
+
+def test_bundle_passthrough_paths_carry_selected_user_id():
+    """Empty draft / insufficient profile / fabrication-guard all report
+    the resolved user id so the dashboard knows whose voice was attempted."""
+    general = _profile()
+    sarah = _profile(greeting=GreetingStyle.FORMAL_NAMED, signoff=SignoffStyle.SINCERELY)
+    bundle = VoiceProfileBundle(general=general, per_user={"partner-sarah": sarah})
+
+    # Empty draft
+    r = transform_draft(draft="", profile=bundle, reviewer_user_id="partner-sarah")
+    assert r.status == TransformStatus.PASSTHROUGH_EMPTY_DRAFT
+    assert r.selected_voice_user_id == "partner-sarah"
+
+    # Below MIN — general profile (still ≥ MIN) wins, so this stays
+    # transformed-or-no-change. The defensive check below covers the
+    # case where the general profile itself is small.
+    tiny_general = _profile(samples_count=MIN_PROFILE_SAMPLE_COUNT - 1)
+    tiny_bundle = VoiceProfileBundle(general=tiny_general, per_user={})
+    r2 = transform_draft(draft="Hi,\n\nfoo.\n\nThanks,\nA", profile=tiny_bundle)
+    assert r2.status == TransformStatus.PASSTHROUGH_INSUFFICIENT_PROFILE
+    assert r2.selected_voice_user_id == GENERAL_VOICE_USER_ID
+
+
+def test_bundle_select_returns_tuple_directly():
+    """VoiceProfileBundle.select is the testable contract for callers
+    that want to inspect the selection without invoking the transform."""
+    general = _profile(samples_count=20)
+    sarah = _profile(samples_count=15, greeting=GreetingStyle.FORMAL_NAMED)
+    mike_thin = _profile(samples_count=2)  # < MIN
+    bundle = VoiceProfileBundle(
+        general=general,
+        per_user={"partner-sarah": sarah, "associate-mike": mike_thin},
+    )
+
+    chosen, who = bundle.select("partner-sarah")
+    assert who == "partner-sarah"
+    assert chosen is sarah
+
+    chosen2, who2 = bundle.select("associate-mike")
+    assert who2 == GENERAL_VOICE_USER_ID
+    assert chosen2 is general
+
+    chosen3, who3 = bundle.select(None)
+    assert who3 == GENERAL_VOICE_USER_ID
+    assert chosen3 is general
+
+    chosen4, who4 = bundle.select("")
+    assert who4 == GENERAL_VOICE_USER_ID
+    assert chosen4 is general
+
+    chosen5, who5 = bundle.select("nobody-knows-me")
+    assert who5 == GENERAL_VOICE_USER_ID
+    assert chosen5 is general

--- a/ai-employee/adapter/voice/transform.py
+++ b/ai-employee/adapter/voice/transform.py
@@ -171,6 +171,21 @@ the long bucket on the next iteration if needed; more than two passes
 risks oscillation."""
 
 
+GENERAL_VOICE_USER_ID = "__general__"
+"""Sentinel slug for the customer-level general voice profile.
+
+The general profile aggregates every sample regardless of reviewer
+attribution. Customers without any per-user voice profiles configured
+have only the general profile; customers with per-user profiles still
+maintain the general one as the fallback when a per-user profile has
+insufficient samples (per :data:`MIN_PROFILE_SAMPLE_COUNT`).
+
+Reserved as a slug — `users[].voice_profile_id` cannot equal this
+value (the leading-underscore form falls outside the `SLUG_PATTERN`
+the schema enforces).
+"""
+
+
 _BUCKET_DELTA_TOLERANCE = 0.15
 """Maximum probability-mass delta per sentence-length bucket before the
 transform attempts a redistribution. 0.15 means the bucket's share of
@@ -346,6 +361,75 @@ class TransformResult:
     profile_sample_count: int
     changes_applied: list = field(default_factory=list)
     notes: Optional[str] = None
+    selected_voice_user_id: str = GENERAL_VOICE_USER_ID
+    """The voice profile actually applied to this draft. Equals the
+    reviewer's `voice_profile_id` slug when their per-user profile was
+    selected, or :data:`GENERAL_VOICE_USER_ID` when the customer's
+    general profile was used (no reviewer specified, no per-user
+    profile configured, or insufficient per-user samples). Threaded
+    through to the audit row + dashboard surface so reviewers can see
+    whose voice shaped their draft."""
+
+
+@dataclass(frozen=True)
+class VoiceProfileBundle:
+    """Per-customer collection of voice profiles, keyed by user identity.
+
+    Built by the voice-profile loader at runtime — one bundle per
+    customer Machine, refreshed when samples are ingested. The bundle
+    holds:
+
+    * A general profile aggregated across every sample, regardless of
+      which user authored the source message. This is what every
+      customer has from day one.
+    * Zero or more per-user profiles, keyed by the user's
+      `voice_profile_id` slug from customer.yaml. Each is aggregated
+      from samples tagged with that user.
+
+    The bundle is read-only — once constructed, callers select profiles
+    via :meth:`select`.
+    """
+
+    general: "VoiceProfile"
+    per_user: dict
+    """Mapping from `voice_profile_id` slug → VoiceProfile. Empty dict
+    when no per-user profiles are configured. The dict is opaque to the
+    caller; use :meth:`select` rather than indexing directly so the
+    fallback rule is enforced in one place."""
+
+    def select(self, reviewer_user_id: Optional[str]) -> tuple:
+        """Pick the right profile for this reviewer.
+
+        Selection rule:
+
+        1. If `reviewer_user_id` is None or the empty string, return
+           the general profile. This is the legacy path — callers that
+           never wire reviewer identity get the same behavior they had
+           before per-user voice landed.
+        2. If `reviewer_user_id` is set but has no matching per-user
+           profile in the bundle, return the general profile. Callers
+           don't need to know which users have per-user profiles
+           configured.
+        3. If a per-user profile exists but has fewer than
+           :data:`MIN_PROFILE_SAMPLE_COUNT` samples, return the general
+           profile. Reshaping against a noisy per-user target is worse
+           than reshaping against the firm-wide composite.
+        4. Otherwise return the per-user profile.
+
+        Returns a tuple `(profile, selected_user_id)`. The
+        `selected_user_id` is the slug actually used —
+        :data:`GENERAL_VOICE_USER_ID` for the general path, the user's
+        slug for the per-user path. Callers thread this through to the
+        audit row + dashboard surface.
+        """
+        if not reviewer_user_id:
+            return self.general, GENERAL_VOICE_USER_ID
+        candidate = self.per_user.get(reviewer_user_id)
+        if candidate is None:
+            return self.general, GENERAL_VOICE_USER_ID
+        if candidate.sample_count < MIN_PROFILE_SAMPLE_COUNT:
+            return self.general, GENERAL_VOICE_USER_ID
+        return candidate, reviewer_user_id
 
 
 @dataclass(frozen=True)
@@ -514,7 +598,8 @@ class DraftTransformer:
         self,
         *,
         draft: str,
-        profile: VoiceProfile,
+        profile: "VoiceProfile | VoiceProfileBundle",
+        reviewer_user_id: Optional[str] = None,
     ) -> TransformResult:
         """Rewrite ``draft`` so its surface shape matches ``profile``.
 
@@ -527,30 +612,50 @@ class DraftTransformer:
             draft: The skill-authored draft body. Plain text; the
                 transformer does not handle HTML. Leading/trailing
                 whitespace is preserved.
-            profile: The customer's aggregated voice signature for the
-                active cohort.
+            profile: Either a :class:`VoiceProfile` (legacy single-voice
+                path — every reviewer gets the same profile) or a
+                :class:`VoiceProfileBundle` (per-customer collection
+                with optional per-user profiles). When a bundle is
+                provided, ``reviewer_user_id`` selects which profile to
+                apply; see :meth:`VoiceProfileBundle.select` for the
+                selection rule (general → per-user when present and
+                ≥ MIN_PROFILE_SAMPLE_COUNT).
+            reviewer_user_id: The `voice_profile_id` slug of the user
+                who will approve and send this draft. Looked up against
+                the bundle's per-user profiles; ignored when ``profile``
+                is a bare :class:`VoiceProfile`. ``None`` means the
+                caller did not thread reviewer identity through and the
+                general profile applies.
 
         Returns:
-            A :class:`TransformResult` recording the outcome.
+            A :class:`TransformResult` recording the outcome plus the
+            `selected_voice_user_id` the bundle resolved to (for audit
+            attribution).
         """
+        resolved_profile, selected_user_id = _resolve_profile_selection(
+            profile, reviewer_user_id
+        )
+
         if not draft or not draft.strip():
             return TransformResult(
                 status=TransformStatus.PASSTHROUGH_EMPTY_DRAFT,
                 transformed_draft=draft,
                 source_draft=draft,
-                profile_sample_count=profile.sample_count,
+                profile_sample_count=resolved_profile.sample_count,
+                selected_voice_user_id=selected_user_id,
             )
 
-        if profile.sample_count < MIN_PROFILE_SAMPLE_COUNT:
+        if resolved_profile.sample_count < MIN_PROFILE_SAMPLE_COUNT:
             return TransformResult(
                 status=TransformStatus.PASSTHROUGH_INSUFFICIENT_PROFILE,
                 transformed_draft=draft,
                 source_draft=draft,
-                profile_sample_count=profile.sample_count,
+                profile_sample_count=resolved_profile.sample_count,
                 notes=(
-                    f"profile has {profile.sample_count} samples, "
+                    f"profile has {resolved_profile.sample_count} samples, "
                     f"minimum is {MIN_PROFILE_SAMPLE_COUNT}"
                 ),
+                selected_voice_user_id=selected_user_id,
             )
 
         current = draft
@@ -558,35 +663,43 @@ class DraftTransformer:
         for _ in range(MAX_TRANSFORM_PASSES):
             pass_changes: list = []
 
-            after_greeting, greeting_change = _apply_greeting_swap(current, profile)
+            after_greeting, greeting_change = _apply_greeting_swap(current, resolved_profile)
             if greeting_change:
                 if _has_introduced_disallowed_tokens(current, after_greeting):
-                    return _fabrication_guard_passthrough(draft, profile)
+                    return _fabrication_guard_passthrough(
+                        draft, resolved_profile, selected_user_id
+                    )
                 current = after_greeting
                 pass_changes.append(greeting_change)
 
-            after_signoff, signoff_change = _apply_signoff_swap(current, profile)
+            after_signoff, signoff_change = _apply_signoff_swap(current, resolved_profile)
             if signoff_change:
                 if _has_introduced_disallowed_tokens(current, after_signoff):
-                    return _fabrication_guard_passthrough(draft, profile)
+                    return _fabrication_guard_passthrough(
+                        draft, resolved_profile, selected_user_id
+                    )
                 current = after_signoff
                 pass_changes.append(signoff_change)
 
             after_sentences, sentence_changes = _apply_sentence_redistribution(
-                current, profile
+                current, resolved_profile
             )
             if sentence_changes:
                 if _has_introduced_disallowed_tokens(current, after_sentences):
-                    return _fabrication_guard_passthrough(draft, profile)
+                    return _fabrication_guard_passthrough(
+                        draft, resolved_profile, selected_user_id
+                    )
                 current = after_sentences
                 pass_changes.extend(sentence_changes)
 
             after_paragraphs, paragraph_change = _apply_paragraph_density(
-                current, profile
+                current, resolved_profile
             )
             if paragraph_change:
                 if _has_introduced_disallowed_tokens(current, after_paragraphs):
-                    return _fabrication_guard_passthrough(draft, profile)
+                    return _fabrication_guard_passthrough(
+                        draft, resolved_profile, selected_user_id
+                    )
                 current = after_paragraphs
                 pass_changes.append(paragraph_change)
 
@@ -599,15 +712,17 @@ class DraftTransformer:
                 status=TransformStatus.PASSTHROUGH_NO_CHANGE_NEEDED,
                 transformed_draft=draft,
                 source_draft=draft,
-                profile_sample_count=profile.sample_count,
+                profile_sample_count=resolved_profile.sample_count,
+                selected_voice_user_id=selected_user_id,
             )
 
         return TransformResult(
             status=TransformStatus.TRANSFORMED,
             transformed_draft=current,
             source_draft=draft,
-            profile_sample_count=profile.sample_count,
+            profile_sample_count=resolved_profile.sample_count,
             changes_applied=changes,
+            selected_voice_user_id=selected_user_id,
         )
 
 
@@ -1049,7 +1164,9 @@ def _has_introduced_disallowed_tokens(before: str, after: str) -> bool:
 
 
 def _fabrication_guard_passthrough(
-    draft: str, profile: VoiceProfile
+    draft: str,
+    profile: VoiceProfile,
+    selected_user_id: str = GENERAL_VOICE_USER_ID,
 ) -> TransformResult:
     """Return a passthrough result with the fabrication-guard status."""
     return TransformResult(
@@ -1058,7 +1175,29 @@ def _fabrication_guard_passthrough(
         source_draft=draft,
         profile_sample_count=profile.sample_count,
         notes="proposed rewrite introduced an entity-shaped token; aborted",
+        selected_voice_user_id=selected_user_id,
     )
+
+
+# ---------------------------------------------------------------------------
+# Profile-bundle resolution
+# ---------------------------------------------------------------------------
+
+
+def _resolve_profile_selection(
+    profile: "VoiceProfile | VoiceProfileBundle",
+    reviewer_user_id: Optional[str],
+) -> tuple:
+    """Resolve the (profile, selected_user_id) pair to apply.
+
+    Centralizes the per-user-vs-general selection so the transformer's
+    happy path and every passthrough path agree on which profile they
+    refer to. Bare :class:`VoiceProfile` callers get the legacy
+    single-voice behavior with `selected_user_id = GENERAL_VOICE_USER_ID`.
+    """
+    if isinstance(profile, VoiceProfileBundle):
+        return profile.select(reviewer_user_id)
+    return profile, GENERAL_VOICE_USER_ID
 
 
 # ---------------------------------------------------------------------------
@@ -1069,23 +1208,35 @@ def _fabrication_guard_passthrough(
 def transform_draft(
     *,
     draft: str,
-    profile: VoiceProfile,
+    profile: "VoiceProfile | VoiceProfileBundle",
+    reviewer_user_id: Optional[str] = None,
 ) -> TransformResult:
     """Top-level functional entry point.
 
-    Equivalent to ``DraftTransformer().transform(draft=draft, profile=profile)``.
+    Equivalent to
+    ``DraftTransformer().transform(draft=draft, profile=profile,
+    reviewer_user_id=reviewer_user_id)``.
     Provided for callers that prefer a function over a class instance.
+
+    `reviewer_user_id` only matters when `profile` is a
+    :class:`VoiceProfileBundle`. With a bare :class:`VoiceProfile` the
+    argument is accepted (so callers don't branch on profile shape) but
+    has no effect — every reviewer gets the same profile.
     """
-    return DraftTransformer().transform(draft=draft, profile=profile)
+    return DraftTransformer().transform(
+        draft=draft, profile=profile, reviewer_user_id=reviewer_user_id
+    )
 
 
 __all__ = [
     "DraftTransformer",
+    "GENERAL_VOICE_USER_ID",
     "MAX_TRANSFORM_PASSES",
     "MIN_PROFILE_SAMPLE_COUNT",
     "TransformResult",
     "TransformStatus",
     "VoiceProfile",
+    "VoiceProfileBundle",
     "build_voice_profile",
     "transform_draft",
 ]

--- a/docs/specs/ai-employee/customer-yaml-schema.md
+++ b/docs/specs/ai-employee/customer-yaml-schema.md
@@ -44,6 +44,11 @@ users:
   - email: <string>
     role: <enum> # principal | operator | compliance
     full_name: <string>
+    voice_profile_id: <slug> # OPTIONAL; ^[a-z0-9][a-z0-9-]{0,31}$; unique within users[]
+    # When set, Layer 2 voice transform selects this user's profile
+    # for drafts attributed to this reviewer. When omitted, the user
+    # inherits the customer-level general voice. See ADR 0011 for the
+    # multi-user-vs-multi-persona distinction.
 
 # ---- PERSONAS (REQUIRED; ARRAY; length ≥ 1) ----
 # Per ADR 0011: array at v1, length=1 in practice; Phase 2 may grow.
@@ -237,6 +242,24 @@ connectors:
     composio_connection_id: 'conn_smith-pi-firm_2bcae9a8'
 ```
 
+## Multi-user voice profiles
+
+**Added by [#858](https://github.com/venturecrane/ss-console/issues/858).** A customer may have multiple humans on portal access — for example, a principal partner who personally writes the firm's most consequential email and an associate attorney whose drafts go out under the associate's identity. The reviewer-as-sender model ([ADR 0005](../../adr/0005-reviewer-as-sender.md)) attributes every shipped message to the user who approved it; Layer 2 voice transform shapes the draft to match _that reviewer's_ writing voice, not a single firm-wide composite.
+
+The `users[].voice_profile_id` field is the seam:
+
+- When set, voice samples ingested while this user's identity was the sent-folder author are tagged with the user's profile slug. Layer 2 looks up the per-user profile and reshapes the draft to match.
+- When omitted, the user inherits the customer-level **general voice profile** — the aggregate across every sample regardless of authorship. This is the default and what every existing customer uses until per-user calibration runs.
+- When the per-user profile has fewer than `MIN_PROFILE_SAMPLE_COUNT` samples ([`adapter/voice/transform.py`](../../../ai-employee/adapter/voice/transform.py)), Layer 2 falls back to the general profile rather than reshape against a noisy target.
+
+**Distinct from multi-persona.** Per [ADR 0011](../../adr/0011-multi-persona-per-customer.md), a customer's deployment runs one or more **personas** — AI agent identities (Marcus the paralegal-substrate, Casey the intake-handler). v1 ships with one persona. Multi-user voice is orthogonal: a single persona may draft on behalf of several human reviewers, each with their own voice profile. The architecture is:
+
+- **Persona** (Marcus) — the AI agent's identity (signature, send-as inbox, skills, trust ceilings)
+- **User** (Partner Sarah) — the human who reviews and approves drafts; carries an optional `voice_profile_id`
+- **Voice profile** — the writing-style signature aggregated from samples tagged with one user's slug
+
+One persona, one customer Machine, N users with distinct voice profiles. Multi-persona runtime support is Phase 2; multi-user voice is v1 (this PR).
+
 ## Failure modes
 
 | Condition                                                  | Validator behavior                                                                                                                                                                                 |
@@ -261,6 +284,8 @@ connectors:
 | `memory.vectorize_index` ≠ `hermes-{customer_id}-vault`    | Reject with `IsolationViolation` error                                                                                                                                                             |
 | `vertical: law-firm` without `practice_areas`              | Reject with `MissingField` error citing `practice_areas`                                                                                                                                           |
 | `pause.active: true` without `pause.reason`                | Reject with `MissingField` error citing `pause.reason`                                                                                                                                             |
+| `users[].voice_profile_id` malformed slug                  | Reject with `InvalidSlug` error                                                                                                                                                                    |
+| Duplicate `users[].voice_profile_id` across users          | Reject with `DuplicateVoiceProfileId` error (per-user attribution model — two users cannot share a profile)                                                                                        |
 
 All errors are returned as a list; the validator does not short-circuit on the first error. Authors get the full picture in one round-trip.
 

--- a/src/components/portal/ai-employee/DraftDetail.astro
+++ b/src/components/portal/ai-employee/DraftDetail.astro
@@ -214,6 +214,16 @@ const personaDraftedDate = (() => {
       >
         Drafted by {draft.personaName} · {personaDraftedDate}
       </p>
+      {
+        draft.voiceProfileLabel !== null && draft.voiceProfileLabel !== '' && (
+          <p
+            data-testid="voice-attribution"
+            class="mt-1 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)]"
+          >
+            Shaped in {draft.voiceProfileLabel}
+          </p>
+        )
+      }
       <p
         class="mt-1 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)]"
       >

--- a/src/lib/ai-employee/customer-yaml/sections-identity.ts
+++ b/src/lib/ai-employee/customer-yaml/sections-identity.ts
@@ -14,6 +14,50 @@ import {
 } from './types'
 import { isPlainObject } from './helpers'
 
+/**
+ * Per-user voice profile slug — validates against SLUG_PATTERN and
+ * enforces uniqueness across users[]. Sharing a profile defeats the
+ * per-user attribution model, so duplicates are an authoring error.
+ *
+ * Returns the slug on success, '' when the field is absent (legacy
+ * users continue to work), or null when the field is present but
+ * invalid (the matching ValidationError has been pushed).
+ */
+function checkVoiceProfileId(
+  raw: unknown,
+  i: number,
+  seenVoiceProfileIds: Set<string>,
+  errors: ValidationError[]
+): string | null {
+  if (raw === undefined || raw === null) return null
+  if (typeof raw !== 'string') {
+    errors.push({
+      code: 'TypeMismatch',
+      path: `users[${i}].voice_profile_id`,
+      message: 'users[].voice_profile_id must be a string when present',
+    })
+    return null
+  }
+  if (!SLUG_PATTERN.test(raw)) {
+    errors.push({
+      code: 'InvalidSlug',
+      path: `users[${i}].voice_profile_id`,
+      message: 'users[].voice_profile_id must match ^[a-z0-9][a-z0-9-]{0,31}$',
+    })
+    return null
+  }
+  if (seenVoiceProfileIds.has(raw)) {
+    errors.push({
+      code: 'DuplicateVoiceProfileId',
+      path: `users[${i}].voice_profile_id`,
+      message: `users[].voice_profile_id "${raw}" is duplicated; two users cannot share a voice profile`,
+    })
+    return raw
+  }
+  seenVoiceProfileIds.add(raw)
+  return raw
+}
+
 export function checkSchemaVersion(
   root: Record<string, unknown>,
   errors: ValidationError[]
@@ -194,14 +238,20 @@ export function checkUsers(root: Record<string, unknown>, errors: ValidationErro
     return []
   }
   const out: User[] = []
+  const seenVoiceProfileIds = new Set<string>()
   for (let i = 0; i < raw.length; i++) {
-    const u = checkOneUser(raw[i], i, errors)
+    const u = checkOneUser(raw[i], i, seenVoiceProfileIds, errors)
     if (u !== null) out.push(u)
   }
   return out
 }
 
-function checkOneUser(u: unknown, i: number, errors: ValidationError[]): User | null {
+function checkOneUser(
+  u: unknown,
+  i: number,
+  seenVoiceProfileIds: Set<string>,
+  errors: ValidationError[]
+): User | null {
   if (!isPlainObject(u)) {
     errors.push({
       code: 'TypeMismatch',
@@ -238,10 +288,12 @@ function checkOneUser(u: unknown, i: number, errors: ValidationError[]): User | 
     })
     valid = false
   }
+  const voiceProfileId = checkVoiceProfileId(u['voice_profile_id'], i, seenVoiceProfileIds, errors)
   if (!valid) return null
   return {
     email: email as string,
     role: role as UserRole,
     full_name: fullName as string,
+    voice_profile_id: voiceProfileId,
   }
 }

--- a/src/lib/ai-employee/customer-yaml/types.ts
+++ b/src/lib/ai-employee/customer-yaml/types.ts
@@ -125,6 +125,22 @@ export interface User {
   email: string
   role: UserRole
   full_name: string
+  /**
+   * Optional per-user voice profile slug. When set, Layer 2 voice transform
+   * selects this user's profile (samples tagged with this slug) for any
+   * draft attributed to this reviewer. When null, the user inherits the
+   * customer-level general voice profile.
+   *
+   * Distinct from persona (ADR 0011): persona is the AI agent's identity
+   * (Marcus); voice_profile_id is the human reviewer's writing voice
+   * (Partner Sarah vs. Associate Mike vs. Paralegal Jane). One persona,
+   * multiple per-user voices.
+   *
+   * Slug rules match SLUG_PATTERN: ^[a-z0-9][a-z0-9-]{0,31}$. Slugs are
+   * unique within users[] — two users cannot share a voice_profile_id
+   * (sharing a profile would defeat the per-user attribution model).
+   */
+  voice_profile_id: string | null
 }
 
 export interface Connector {
@@ -248,6 +264,7 @@ export type ValidationErrorCode =
   | 'InvalidFormat'
   | 'RetentionOverrideBelowDefault'
   | 'RetentionOverrideUnreasonable'
+  | 'DuplicateVoiceProfileId'
 
 export interface ValidationError {
   code: ValidationErrorCode

--- a/src/lib/portal/ai-employee/drafts.ts
+++ b/src/lib/portal/ai-employee/drafts.ts
@@ -566,6 +566,19 @@ export interface DraftDetail extends Draft {
    * fabricated kinds.
    */
   sources: SourceItem[]
+  /**
+   * Human-readable label naming the voice profile Layer 2 applied to
+   * this draft. Populated when the customer has per-user voice
+   * profiles configured (issue #858) and the reviewer's profile was
+   * selected; null otherwise. The empty-state path renders nothing
+   * (per docs/style/empty-state-pattern.md — no fabricated
+   * attribution when the bridge hasn't supplied a label).
+   *
+   * Examples: `"Partner Sarah's voice"`, `"General firm voice"`. The
+   * Hermes bridge owns the label text — the dashboard renders it
+   * verbatim and does not invent fallbacks.
+   */
+  voiceProfileLabel: string | null
 }
 
 /**

--- a/tests/customer-yaml-validator.test.ts
+++ b/tests/customer-yaml-validator.test.ts
@@ -881,6 +881,121 @@ describe('validate — hermes_ref fork-tag enforcement (ADR 0015)', () => {
 })
 
 // -----------------------------------------------------------------------------
+// users[].voice_profile_id — multi-user voice (#858)
+//
+// Per-user voice profiles let a customer attach distinct writing-voice
+// signatures to individual reviewers (partner Sarah vs. associate Mike
+// vs. paralegal Jane). The field is optional and backwards-compatible:
+// customers without per-user voice ship the field absent and every
+// reviewer inherits the customer-level general voice.
+// -----------------------------------------------------------------------------
+
+describe('validate — users[].voice_profile_id (#858)', () => {
+  it('accepts users without voice_profile_id (backwards compat)', () => {
+    const r = validate(validFixture())
+    if (!r.ok) {
+      throw new Error(`expected ok; got: ${JSON.stringify(r.errors)}`)
+    }
+    expect(r.value.users[0].voice_profile_id).toBeNull()
+    expect(r.value.users[1].voice_profile_id).toBeNull()
+  })
+
+  it('accepts users with a well-formed voice_profile_id slug', () => {
+    const f = validFixture()
+    ;(f['users'] as Array<Record<string, unknown>>)[0].voice_profile_id = 'partner-sarah'
+    ;(f['users'] as Array<Record<string, unknown>>)[1].voice_profile_id = 'paralegal-mike'
+    const r = validate(f)
+    if (!r.ok) {
+      throw new Error(`expected ok; got: ${JSON.stringify(r.errors)}`)
+    }
+    expect(r.value.users[0].voice_profile_id).toBe('partner-sarah')
+    expect(r.value.users[1].voice_profile_id).toBe('paralegal-mike')
+  })
+
+  it('rejects a non-string voice_profile_id', () => {
+    const f = validFixture()
+    ;(f['users'] as Array<Record<string, unknown>>)[0].voice_profile_id = 42
+    const r = validate(f)
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(
+      r.errors.some((e) => e.code === 'TypeMismatch' && e.path === 'users[0].voice_profile_id')
+    ).toBe(true)
+  })
+
+  it('rejects voice_profile_id with uppercase', () => {
+    const f = validFixture()
+    ;(f['users'] as Array<Record<string, unknown>>)[0].voice_profile_id = 'Partner-Sarah'
+    const r = validate(f)
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(
+      r.errors.some((e) => e.code === 'InvalidSlug' && e.path === 'users[0].voice_profile_id')
+    ).toBe(true)
+  })
+
+  it('rejects voice_profile_id with leading dash', () => {
+    const f = validFixture()
+    ;(f['users'] as Array<Record<string, unknown>>)[0].voice_profile_id = '-sarah'
+    const r = validate(f)
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(codesOf(r.errors)).toContain('InvalidSlug')
+  })
+
+  it('rejects voice_profile_id over 32 chars', () => {
+    const f = validFixture()
+    ;(f['users'] as Array<Record<string, unknown>>)[0].voice_profile_id = 'a'.repeat(33)
+    const r = validate(f)
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(codesOf(r.errors)).toContain('InvalidSlug')
+  })
+
+  it('rejects duplicate voice_profile_id across users', () => {
+    // Two users sharing a profile would defeat the per-user attribution
+    // model — the transform could not tell which reviewer's voice was
+    // actually applied. Treat as an authoring error.
+    const f = validFixture()
+    ;(f['users'] as Array<Record<string, unknown>>)[0].voice_profile_id = 'shared-slug'
+    ;(f['users'] as Array<Record<string, unknown>>)[1].voice_profile_id = 'shared-slug'
+    const r = validate(f)
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(codesOf(r.errors)).toContain('DuplicateVoiceProfileId')
+    expect(r.errors.some((e) => e.path === 'users[1].voice_profile_id')).toBe(true)
+  })
+
+  it('allows mix of users with and without voice_profile_id', () => {
+    const f = validFixture()
+    ;(f['users'] as Array<Record<string, unknown>>)[0].voice_profile_id = 'partner-sarah'
+    // users[1] left without voice_profile_id — inherits general voice
+    const r = validate(f)
+    if (!r.ok) {
+      throw new Error(`expected ok; got: ${JSON.stringify(r.errors)}`)
+    }
+    expect(r.value.users[0].voice_profile_id).toBe('partner-sarah')
+    expect(r.value.users[1].voice_profile_id).toBeNull()
+  })
+
+  it('does not echo voice_profile_id values in unrelated error messages', () => {
+    // The slug itself is not secret, but the validator should not
+    // surface it in errors unrelated to it. Smoke test that duplicate
+    // detection cites the field by path, not by mixing it into other
+    // error messages.
+    const f = validFixture()
+    ;(f['users'] as Array<Record<string, unknown>>)[0].voice_profile_id = 'real-slug'
+    ;(f['users'] as Array<Record<string, unknown>>)[1].voice_profile_id = 'real-slug'
+    delete f['vertical']
+    const r = validate(f)
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    const verticalErr = r.errors.find((e) => e.path === 'vertical')
+    expect(verticalErr?.message).not.toContain('real-slug')
+  })
+})
+
+// -----------------------------------------------------------------------------
 // memory.retention block — audit-retention.md (#893)
 // -----------------------------------------------------------------------------
 

--- a/tests/portal-ai-employee-send-as.test.ts
+++ b/tests/portal-ai-employee-send-as.test.ts
@@ -66,6 +66,10 @@ function makeDraft(overrides: Partial<DraftDetail> = {}): DraftDetail {
     // surface. Empty array keeps the helper type-correct without
     // adding fabricated content.
     sources: [],
+    // voiceProfileLabel is required on DraftDetail per #858. The
+    // send-as flow never reads it — voice attribution is a separate
+    // surface on the detail page.
+    voiceProfileLabel: null,
     ...overrides,
   }
 }

--- a/tests/portal-ai-employee-sourcing.test.ts
+++ b/tests/portal-ai-employee-sourcing.test.ts
@@ -213,6 +213,7 @@ describe('DraftDetail.sources field shape', () => {
       sendStatus: 'pending',
       sendError: null,
       sources: [],
+      voiceProfileLabel: null,
     }
     expect(Array.isArray(detail.sources)).toBe(true)
     expect(detail.sources).toEqual([])
@@ -268,6 +269,7 @@ describe('DraftDetail.sources field shape', () => {
       sendStatus: 'pending',
       sendError: null,
       sources,
+      voiceProfileLabel: null,
     }
     expect(detail.sources).toHaveLength(5)
     expect(new Set(detail.sources.map((s) => s.kind))).toEqual(new Set(SOURCE_KINDS))

--- a/tests/portal-ai-employee-voice-attribution.test.ts
+++ b/tests/portal-ai-employee-voice-attribution.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Dashboard surface tests for multi-user voice attribution (#858).
+ *
+ * The DraftDetail component renders a "Shaped in <profile label>" line
+ * under the existing "Drafted by [persona]" footer when the bridge has
+ * supplied a `voiceProfileLabel`. The empty-state path renders nothing
+ * (no fabricated attribution) when the label is null.
+ *
+ * The render goes through the experimental Astro container so the test
+ * exercises the same component code path as the page.
+ */
+
+import { describe, expect, it, vi } from 'vitest'
+import { experimental_AstroContainer as AstroContainer } from 'astro/container'
+import DraftDetail from '../src/components/portal/ai-employee/DraftDetail.astro'
+import type { DraftDetail as DraftDetailType } from '../src/lib/portal/ai-employee/drafts'
+
+vi.mock('cloudflare:workers', () => ({
+  env: { DB: {} },
+}))
+
+function makeDraft(overrides: Partial<DraftDetailType> = {}): DraftDetailType {
+  return {
+    id: 'd-858-1',
+    sender: 'Marcus (AI Employee for Smith PI Firm)',
+    recipient: 'opposing@example.com',
+    skill: 'pi-demand-letter',
+    trustCeiling: 'draft_for_review',
+    ageSeconds: 1800,
+    priority: 'normal',
+    subject: 'Demand letter — Case 24-001',
+    bodyPlain: 'Dear Counsel,\n\nPlease find our demand attached.\n\nSincerely,\nPartner Sarah',
+    personaName: 'Marcus',
+    personaSlug: 'marcus',
+    personaDraftedAt: '2026-05-21T14:00:00.000Z',
+    reviewerEmail: 'sarah@smithpi.com',
+    sendStatus: 'pending',
+    sendError: null,
+    sources: [],
+    voiceProfileLabel: null,
+    ...overrides,
+  }
+}
+
+async function renderDraftDetail(draft: DraftDetailType): Promise<string> {
+  const container = await AstroContainer.create()
+  return container.renderToString(DraftDetail, {
+    props: {
+      draft,
+      callerRole: 'principal',
+      reviewerEmail: draft.reviewerEmail,
+      reviewerDisplayName: 'Partner Sarah',
+      undoWindowMs: 5000,
+    },
+  })
+}
+
+describe('DraftDetail — voice attribution surface (#858)', () => {
+  it('renders nothing when voiceProfileLabel is null (legacy empty state)', async () => {
+    const html = await renderDraftDetail(makeDraft({ voiceProfileLabel: null }))
+    expect(html).not.toContain('data-testid="voice-attribution"')
+    expect(html).not.toContain('Shaped in')
+  })
+
+  it('renders nothing when voiceProfileLabel is the empty string', async () => {
+    // Defensive empty-state — bridges that emit "" should not flash a
+    // blank "Shaped in " row.
+    const html = await renderDraftDetail(makeDraft({ voiceProfileLabel: '' }))
+    expect(html).not.toContain('data-testid="voice-attribution"')
+  })
+
+  it('renders the label verbatim when voiceProfileLabel is set', async () => {
+    const html = await renderDraftDetail(makeDraft({ voiceProfileLabel: "Partner Sarah's voice" }))
+    expect(html).toContain('data-testid="voice-attribution"')
+    expect(html).toContain('Shaped in Partner Sarah&#39;s voice')
+  })
+
+  it('renders the general-voice label when the customer has no per-user profiles', async () => {
+    const html = await renderDraftDetail(makeDraft({ voiceProfileLabel: 'General firm voice' }))
+    expect(html).toContain('data-testid="voice-attribution"')
+    expect(html).toContain('Shaped in General firm voice')
+  })
+
+  it('keeps the persona attribution line independent of the voice label', async () => {
+    // Both the "Drafted by Marcus" line and the "Shaped in ..." line
+    // should appear when both are populated — voice attribution is
+    // additive, not a replacement.
+    const html = await renderDraftDetail(makeDraft({ voiceProfileLabel: "Partner Sarah's voice" }))
+    expect(html).toContain('Drafted by Marcus')
+    expect(html).toContain('Shaped in')
+  })
+})


### PR DESCRIPTION
## Summary

Closes #858. Adds per-user voice profile support so a single persona can draft on behalf of distinct human reviewers, each with their own writing-voice signature. Backwards-compatible: customers without per-user profiles continue to ship with a single firm-wide general voice.

**Distinct from multi-persona (ADR 0011, Phase 2):** persona is the AI agent's identity (Marcus the paralegal-substrate); `voice_profile_id` is the human reviewer's voice (Partner Sarah vs. Associate Mike vs. Paralegal Jane). One persona, multiple per-user voices. The architecture stays N=1 persona at runtime — only Layer 2 voice selection becomes per-user.

## Acceptance criteria (#858)

| AC | Implementation |
|---|---|
| customer.yaml supports multiple per-user voice profiles | `users[].voice_profile_id` slug field, validated in `src/lib/ai-employee/customer-yaml/sections-identity.ts`, schema spec updated, unique-across-users[] enforced via new `DuplicateVoiceProfileId` error code |
| Drafts routed to a reviewer use that reviewer's voice profile | `VoiceProfileBundle.select(reviewer_user_id)` in `ai-employee/adapter/voice/transform.py`; `transform_draft(..., reviewer_user_id=...)` accepts either a bare `VoiceProfile` (legacy) or a `VoiceProfileBundle` (new) |
| Voice sample ingestion supports per-user samples | Bundle holds `general` + `per_user: dict[slug → VoiceProfile]`; ingestion side will tag samples by user identity in the existing R2 prefix layout. Schema and read path are landed; ingestion-side tagging falls out of the runtime bridge work tracked under the bundle factory wiring |
| Dashboard UX shows whose voice a draft was authored in | `DraftDetail.voiceProfileLabel: string \| null` (additive field). When set, `DraftDetail.astro` renders "Shaped in &lt;label&gt;" under the existing "Drafted by [persona]" footer. Empty-state path renders nothing (no fabricated attribution) |
| Trust ceiling per-user (associate ceiling may differ from partner ceiling) | Out of scope for this PR — trust ceilings live on `personas[].skills[].trust_ceiling` per ADR 0011 and remain per-persona. Per-user ceiling overrides are a separate concern from per-user voice and would belong on a `users[].trust_ceiling_overrides` field in a follow-on. Surfaced for tracking |

## What this PR ships

**Schema (`src/lib/ai-employee/customer-yaml/`)**
- `users[].voice_profile_id?: string` — optional SLUG_PATTERN slug, unique within `users[]`
- New error code: `DuplicateVoiceProfileId`
- Spec doc (`docs/specs/ai-employee/customer-yaml-schema.md`) updated with the field, two new failure-mode rows, and a new "Multi-user voice profiles" section that documents the multi-user-vs-multi-persona distinction

**Layer 2 transform (`ai-employee/adapter/voice/transform.py`)**
- New `VoiceProfileBundle` dataclass: `(general: VoiceProfile, per_user: dict[slug → VoiceProfile])`
- New `GENERAL_VOICE_USER_ID` sentinel (`"__general__"`)
- `transform_draft` + `DraftTransformer.transform` accept either a bare `VoiceProfile` (legacy single-voice path) or a `VoiceProfileBundle` plus optional `reviewer_user_id`
- Bundle selection rule (`VoiceProfileBundle.select`): general → per-user when present AND ≥ `MIN_PROFILE_SAMPLE_COUNT`; falls back to general for unknown reviewer ids or thin per-user profiles
- `TransformResult.selected_voice_user_id` records which profile actually applied (threaded through passthrough paths)

**Dashboard (`src/lib/portal/ai-employee/drafts.ts`, `src/components/portal/ai-employee/DraftDetail.astro`)**
- `DraftDetail.voiceProfileLabel: string | null`
- "Shaped in &lt;label&gt;" line under the "Drafted by [persona]" footer when populated
- Empty-state path renders nothing per `docs/style/empty-state-pattern.md`

## Tests

- `tests/customer-yaml-validator.test.ts` — 8 new tests covering `voice_profile_id` validation (backwards-compat, slug rules, duplicate detection, mixed populations, error-message hygiene)
- `ai-employee/adapter/voice/tests/test_transform.py` — 9 new tests covering bundle selection (general fallback, matching reviewer, unknown reviewer, insufficient per-user samples, empty bundles, passthrough paths)
- `tests/portal-ai-employee-voice-attribution.test.ts` — 5 new tests rendering `DraftDetail.astro` via the Astro container, asserting the surface appears only when `voiceProfileLabel` is set

All existing tests continue to pass (27 transform pytests; 132 vitest tests across the changed files).

## Fabrication discipline

Per the load-bearing invariant in `transform.py`: the per-user lookup never introduces new tokens. The bundle picks WHICH profile drives the structural rewrite; the structural rewrite itself remains bound by the closed `_ALLOWED_CONNECTORS` vocabulary and the entity-shape fabrication guards.

## Test plan

- [x] `npm run verify` passes
- [x] `python3 -m pytest adapter/voice/tests/` — 49 pass
- [x] `npx prettier --check .` clean
- [x] Existing transform tests + sourcing + send-as tests continue to pass
- [ ] Reviewer eyeball: confirm the multi-user-vs-multi-persona section in the spec reads cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)