### PR TITLE
feat(§6): Machine architecture rework — Postgres + Redis + Honcho + overlay

### DIFF
--- a/ai-employee/bin/boot-smoke-test.sh
+++ b/ai-employee/bin/boot-smoke-test.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# boot-smoke-test.sh — verify the dependency chain inside a customer Machine
+#
+# Usage:
+#   ai-employee/bin/boot-smoke-test.sh <customer-slug>
+#
+# Scope: this is a SMOKE TEST, not an end-to-end test. It verifies that
+# bootstrap.sh's sequenced startup (Postgres → Redis → Honcho → customer.yaml
+# fetched from R2 → Hermes profiles materialized → overlay plugins installed)
+# came up cleanly. It does NOT exercise a real agent turn, a real LLM call,
+# or a real D1 write through a connector. Those require live external
+# credentials (MCP servers, Anthropic API, customer's OAuth tokens) and are
+# the job of the per-connector prod smoke test in run_prod_smoke_test.py and,
+# at higher fidelity, the boot-time end-to-end test described in §6 of the
+# build plan.
+#
+# Each check logs PASS/FAIL with the slug + step name. Exit code: 0 if every
+# check passes, non-zero on the first failure (fail-fast).
+
+set -euo pipefail
+
+SLUG="${1:-}"
+[ -n "${SLUG}" ] || { echo "Usage: $0 <customer-slug>" >&2; exit 1; }
+
+APP_NAME="hermes-${SLUG}"
+
+log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [smoke/${SLUG}] $*"; }
+pass() { log "PASS: $*"; }
+fail() { log "FAIL: $*"; exit 1; }
+
+# ssh_exec <step-name> <command>
+# Run a command inside the Machine via `fly ssh console`. The command is
+# passed as a single string; non-zero exit fails the test with the step name.
+ssh_exec() {
+  local step="$1"
+  shift
+  local cmd="$*"
+  if fly ssh console -a "${APP_NAME}" --command "${cmd}" >/dev/null 2>&1; then
+    pass "${step}"
+  else
+    fail "${step} — command failed: ${cmd}"
+  fi
+}
+
+# ---------- Step 1: wait for Machine state=started ----------
+log "Waiting for Machine state=started (up to 60s)..."
+ATTEMPT=0
+while [ "${ATTEMPT}" -lt 60 ]; do
+  STATE="$(fly status -a "${APP_NAME}" --json 2>/dev/null \
+    | python3 -c "import sys, json
+try:
+    d = json.load(sys.stdin)
+    machines = d.get('Machines') or []
+    print(machines[0]['state'] if machines else 'none')
+except Exception:
+    print('error')" 2>/dev/null || echo "error")"
+  if [ "${STATE}" = "started" ]; then
+    pass "machine-state-started (after ${ATTEMPT}s)"
+    break
+  fi
+  ATTEMPT=$((ATTEMPT + 1))
+  sleep 1
+done
+[ "${STATE}" = "started" ] || fail "machine-state-started — state=${STATE} after 60s"
+
+# ---------- Step 2: Postgres reachable ----------
+ssh_exec "postgres-ready" "pg_isready -h localhost -p 5432 -U honcho"
+
+# ---------- Step 3: Redis reachable ----------
+ssh_exec "redis-ping" "redis-cli ping | grep -q PONG"
+
+# ---------- Step 4: Honcho health endpoint ----------
+ssh_exec "honcho-health" "curl -fsS http://localhost:8000/health"
+
+# ---------- Step 5: customer.yaml present on volume ----------
+ssh_exec "customer-yaml-present" "test -s /opt/data/customer.yaml"
+
+# ---------- Step 6: Hermes profiles directory exists ----------
+# bootstrap.sh's `hermes-smd bootstrap` step materializes one profile per
+# entry in customer.yaml.personas[]. v1 customers ship at length 1; we just
+# verify the parent directory exists and is non-empty.
+ssh_exec "hermes-profiles-dir" "test -d /opt/data/profiles && [ -n \"\$(ls -A /opt/data/profiles)\" ]"
+
+# ---------- Step 7: overlay plugins installed ----------
+# `hermes plugins list` should include the four hermes-smd-* plugins
+# installed at image-build time via `hermes plugins install venturecrane/hermes-smd-overlay`.
+ssh_exec "hermes-plugins-installed" "hermes plugins list | grep -q hermes-smd-"
+
+log "All boot smoke checks passed for ${APP_NAME}"

--- a/ai-employee/bin/provision-customer.sh
+++ b/ai-employee/bin/provision-customer.sh
@@ -1,14 +1,30 @@
 #!/usr/bin/env bash
-# provision-customer.sh — one command to stand up a customer's Hermes instance
+# provision-customer.sh — one command to stand up a customer's Hermes Machine
 #
 # Usage:
 #   ai-employee/bin/provision-customer.sh <slug>
 #
-# Reads ai-employee/customers/<slug>/customer.yaml, validates it, renders
+# Reads ai-employee/customers/<slug>/customer.yaml, validates it, uploads
+# customer.yaml to R2 (so bootstrap.sh can fetch it on first boot — no more
+# baking into the image per §6 of the build plan), renders
 # ai-employee/.rendered/<slug>/fly.toml (gitignored), creates the Fly app,
-# provisions the volume, prompts Captain for secrets (pasted via pbpaste —
-# values never appear in the chat transcript), deploys, runs the prod
-# smoke test.
+# provisions the volume (10GB — hosts Postgres + Redis + customer.yaml +
+# SQLite + voice cache), prompts Captain for secrets (pasted via pbpaste —
+# values never appear in the chat transcript), deploys, then runs the boot
+# smoke test (boot-smoke-test.sh) to verify the Postgres/Redis/Honcho/Hermes
+# dependency chain came up cleanly.
+#
+# Operator prerequisites (set in your shell / .envrc / direnv before running):
+#   R2_ENDPOINT_URL        — Cloudflare R2 endpoint (https://<account>.r2.cloudflarestorage.com)
+#   R2_ACCESS_KEY_ID       — R2 access key (operator-local, used for `aws s3 cp` upload)
+#   R2_SECRET_ACCESS_KEY   — R2 secret (operator-local)
+#   R2_BUCKET_CONFIG       — R2 bucket holding customer.yaml + voice vaults
+#                            (defaults to "smd-customer-config" if unset)
+#
+# The same R2_* values get pushed into the Machine as Fly secrets so bootstrap.sh
+# can pull customer.yaml back out. The operator's local R2 creds and the
+# Machine's R2 creds may be the same credential or different ones — they live
+# in different scopes.
 #
 # Idempotent: safe to re-run. If `fly apps create` finds the app already
 # exists, the script moves on; if secrets are already set, it skips
@@ -24,12 +40,27 @@ CUSTOMER_DIR="${REPO_ROOT}/ai-employee/customers/${SLUG}"
 CUSTOMER_YAML="${CUSTOMER_DIR}/customer.yaml"
 TEMPLATE_DIR="${REPO_ROOT}/ai-employee/templates"
 RENDERED_DIR="${REPO_ROOT}/ai-employee/.rendered/${SLUG}"
+BIN_DIR="${REPO_ROOT}/ai-employee/bin"
 
 [ -d "${CUSTOMER_DIR}" ] || { echo "FATAL: ${CUSTOMER_DIR} not found"; exit 1; }
 [ -f "${CUSTOMER_YAML}" ] || { echo "FATAL: ${CUSTOMER_YAML} missing"; exit 1; }
 
 log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [provision/${SLUG}] $*"; }
 die() { log "FATAL: $*"; exit 1; }
+
+# ---------- Step 0: verify operator R2 credentials ----------
+# These live in the operator's local shell (e.g., direnv / .envrc); they are
+# used by `aws s3 cp` for the customer.yaml upload below. The same logical
+# credentials (or scoped versions of them) are pushed to Fly secrets so the
+# Machine can fetch from R2 at boot — but those are set via pbpaste below,
+# not echoed here.
+R2_BUCKET_CONFIG="${R2_BUCKET_CONFIG:-smd-customer-config}"
+[ -n "${R2_ENDPOINT_URL:-}" ] || die "R2_ENDPOINT_URL not set in operator env (see header for prerequisites)"
+[ -n "${R2_ACCESS_KEY_ID:-}" ] || die "R2_ACCESS_KEY_ID not set in operator env"
+[ -n "${R2_SECRET_ACCESS_KEY:-}" ] || die "R2_SECRET_ACCESS_KEY not set in operator env"
+command -v aws >/dev/null 2>&1 || die "aws CLI not found (required for R2 customer.yaml upload)"
+command -v openssl >/dev/null 2>&1 || die "openssl not found (required for HONCHO_API_KEY generation)"
+command -v pbpaste >/dev/null 2>&1 || die "pbpaste not found (macOS-only; required for secret entry flow)"
 
 # ---------- Step 1: validate customer.yaml ----------
 log "Validating customer.yaml..."
@@ -49,9 +80,9 @@ with open('${CUSTOMER_YAML}') as f:
 m = c.get('machine', {})
 print(c['customer_id'])
 print(c['fly_region'])
-print(m.get('size', 'shared-cpu-1x'))
-print(m.get('memory_mb', 1024))
-print(c.get('hermes_ref', 'v0.13.0'))
+print(m.get('size', 'shared-cpu-2x'))
+print(m.get('memory_mb', 2048))
+print(c.get('hermes_ref', 'v2026.5.16-smd.0'))
 "
 # Portable line-array read (macOS bash 3.2 doesn't have mapfile)
 FIELDS=()
@@ -69,7 +100,23 @@ APP_NAME="hermes-${SLUG}"
 
 log "App: ${APP_NAME} · region: ${FLY_REGION} · machine: ${MACHINE_SIZE}/${MEMORY_MB}MB · hermes: ${HERMES_REF}"
 
-# ---------- Step 2: render fly.toml ----------
+# ---------- Step 2: upload customer.yaml to R2 ----------
+# bootstrap.sh fetches this from R2 on first boot and writes it to
+# /opt/data/customer.yaml. Doing the upload BEFORE the Fly deploy means the
+# first Machine boot can succeed (otherwise the boot would race against a
+# missing config). The customer-sync sidecar (from the overlay bootstrap/
+# package) polls this same key for non-structural updates.
+R2_CONFIG_KEY="vaults/${SLUG}/customer.yaml"
+log "Uploading customer.yaml to R2: s3://${R2_BUCKET_CONFIG}/${R2_CONFIG_KEY}"
+AWS_ACCESS_KEY_ID="${R2_ACCESS_KEY_ID}" \
+AWS_SECRET_ACCESS_KEY="${R2_SECRET_ACCESS_KEY}" \
+  aws s3 cp "${CUSTOMER_YAML}" "s3://${R2_BUCKET_CONFIG}/${R2_CONFIG_KEY}" \
+    --endpoint-url "${R2_ENDPOINT_URL}" \
+    --only-show-errors \
+  || die "R2 upload failed; bootstrap.sh would not be able to fetch customer.yaml"
+log "R2 upload OK"
+
+# ---------- Step 3: render fly.toml ----------
 log "Rendering fly.toml..."
 mkdir -p "${RENDERED_DIR}"
 sed -e "s/{{CUSTOMER_SLUG}}/${SLUG}/g" \
@@ -77,10 +124,11 @@ sed -e "s/{{CUSTOMER_SLUG}}/${SLUG}/g" \
     -e "s/{{MACHINE_SIZE}}/${MACHINE_SIZE}/g" \
     -e "s/{{MEMORY_MB}}/${MEMORY_MB}/g" \
     -e "s/{{HERMES_REF}}/${HERMES_REF}/g" \
+    -e "s|{{R2_BUCKET_CONFIG}}|${R2_BUCKET_CONFIG}|g" \
     "${TEMPLATE_DIR}/fly.toml.template" > "${RENDERED_DIR}/fly.toml"
 log "Rendered to ${RENDERED_DIR}/fly.toml"
 
-# ---------- Step 3: create Fly app (idempotent) ----------
+# ---------- Step 4: create Fly app (idempotent) ----------
 log "Creating Fly app (idempotent)..."
 if fly apps list --json | python3 -c "import sys, json; sys.exit(0 if '${APP_NAME}' in [a['Name'] for a in json.load(sys.stdin)] else 1)"; then
   log "App ${APP_NAME} exists; skipping create"
@@ -88,23 +136,27 @@ else
   fly apps create "${APP_NAME}" --org personal
 fi
 
-# ---------- Step 4: create volume (idempotent) ----------
-log "Creating persistent volume (idempotent)..."
+# ---------- Step 5: create volume (idempotent, 10GB) ----------
+# Volume hosts: Postgres data (Honcho), Redis AOF (Honcho), customer.yaml
+# (R2-mirrored copy), audit.db + observations.db SQLite, Hermes profiles
+# under /opt/data/profiles/, voice samples cache, OAuth token files (ADR
+# 0010). 10GB is the new floor (was 1GB pre-§6); per-customer fixed disk
+# pressure should not be a thing we manage on a per-customer basis.
+log "Creating persistent volume (idempotent, 10GB)..."
 if fly volumes list -a "${APP_NAME}" --json 2>/dev/null | python3 -c "import sys, json; data = json.load(sys.stdin) if sys.stdin.read else []" 2>/dev/null; then
-  # Check if hermes_state exists
   if ! fly volumes list -a "${APP_NAME}" --json | grep -q '"name":"hermes_state"'; then
-    fly volumes create hermes_state --size 1 --region "${FLY_REGION}" -a "${APP_NAME}" --yes
+    fly volumes create hermes_state --size 10 --region "${FLY_REGION}" -a "${APP_NAME}" --yes
   else
     log "Volume hermes_state exists; skipping create"
   fi
 else
-  fly volumes create hermes_state --size 1 --region "${FLY_REGION}" -a "${APP_NAME}" --yes || true
+  fly volumes create hermes_state --size 10 --region "${FLY_REGION}" -a "${APP_NAME}" --yes || true
 fi
 
-# ---------- Step 5: set secrets (paste flow; never echo values) ----------
+# ---------- Step 6: set secrets (paste flow; never echo values) ----------
 log "Setting secrets via pbpaste flow..."
 log "For each prompt: copy the secret to your clipboard, then press Enter."
-log "Values flow directly into 'fly secrets set' — never appear in this terminal or any chat transcript."
+log "Values flow directly into 'fly secrets import' — never appear in this terminal or any chat transcript."
 
 prompt_and_set() {
   local secret_name="$1"
@@ -129,30 +181,46 @@ prompt_and_set ANTHROPIC_API_KEY  "Anthropic API key for hermes-${SLUG}"
 prompt_and_set COMPOSIO_API_KEY   "Composio API key (Standard tier)"
 prompt_and_set AGENTMAIL_API_KEY  "AgentMail API key (Builder tier)"
 
+# R2 access for bootstrap.sh's customer.yaml fetch + customer-sync sidecar's
+# polling for non-structural config changes. R2_BUCKET_CONFIG is in fly.toml
+# [env] (it's the bucket name, not a credential); the keys are secrets.
+prompt_and_set R2_ACCESS_KEY_ID     "R2 access key ID (Machine-scoped, R/W on s3://${R2_BUCKET_CONFIG}/vaults/${SLUG}/)"
+prompt_and_set R2_SECRET_ACCESS_KEY "R2 secret access key (paired with R2_ACCESS_KEY_ID above)"
+prompt_and_set R2_ENDPOINT_URL      "R2 endpoint URL (Cloudflare account R2 endpoint)"
+
+# HONCHO_API_KEY — generated locally, sent to Fly via stdin, never stored
+# anywhere else. Honcho is self-hosted in this Machine; this is the shared
+# secret between the Hermes process and the in-Machine Honcho FastAPI server.
+# Rotating it means re-running provisioning (Captain-initiated restart per
+# ADR 0010 to preserve OAuth tokens on the volume).
+log "Generating HONCHO_API_KEY (openssl rand -hex 32) and staging directly to Fly..."
+openssl rand -hex 32 \
+  | { read -r _val; printf 'HONCHO_API_KEY=%s\n' "${_val}"; } \
+  | fly secrets import --stage -a "${APP_NAME}" >/dev/null
+log "Staged HONCHO_API_KEY (value never logged)"
+unset _val 2>/dev/null || true
+
 # Commit staged secrets
 log "Committing staged secrets..."
 fly secrets deploy -a "${APP_NAME}" 2>/dev/null || true
 
-# ---------- Step 6: deploy ----------
+# ---------- Step 7: deploy ----------
 log "Deploying ${APP_NAME}..."
 (cd "${REPO_ROOT}" && fly deploy --config "${RENDERED_DIR}/fly.toml" --build-arg HERMES_REF="${HERMES_REF}" --build-arg CUSTOMER_SLUG="${SLUG}")
 
-# ---------- Step 7: smoke test ----------
-log "Running post-deploy smoke test..."
-# Wait for the machine to be reachable
-sleep 5
-if fly status -a "${APP_NAME}" --json | python3 -c "import sys, json; d = json.load(sys.stdin); m = d.get('Machines', [{}])[0]; sys.exit(0 if m.get('state') == 'started' else 1)"; then
-  log "Smoke test: ${APP_NAME} machine is started ✓"
+# ---------- Step 8: boot smoke test ----------
+# The boot-smoke-test.sh script exercises the Postgres → Redis → Honcho →
+# customer.yaml → profiles → Hermes plugins dependency chain. It is the real
+# verification that bootstrap.sh's sequenced startup came up cleanly.
+log "Running boot smoke test..."
+if [ -x "${BIN_DIR}/boot-smoke-test.sh" ]; then
+  "${BIN_DIR}/boot-smoke-test.sh" "${SLUG}" \
+    || die "Boot smoke test failed — Machine is up but dependency chain is unhealthy. Inspect with 'fly logs -a ${APP_NAME}'."
 else
-  log "Smoke test: ${APP_NAME} machine is NOT started — check 'fly logs -a ${APP_NAME}'"
-  exit 2
+  die "boot-smoke-test.sh not found or not executable at ${BIN_DIR}/boot-smoke-test.sh"
 fi
 
-# Hermes version check
-log "Smoke test: checking Hermes version inside container..."
-fly ssh console -a "${APP_NAME}" --command "/opt/hermes/.venv/bin/hermes --version" || log "WARN: hermes --version did not succeed; safety substrate may have blocked startup. Check fly logs."
-
-# ---------- Step 8: connector prod-smoke-test ----------
+# ---------- Step 9: per-connector prod smoke tests ----------
 # For each enabled BUILD or COMPOSIO connector, run one read-only call
 # against the customer's tenant to surface auth / scope / shape issues
 # before any write capability is exercised.
@@ -167,4 +235,5 @@ log "Provisioning complete for ${APP_NAME}"
 log "Next steps:"
 log "  1. fly ssh console -a ${APP_NAME}     # interact with the container"
 log "  2. fly logs -a ${APP_NAME}            # watch the agent loop"
-log "  3. (if any Google-OAuth-using skills are enabled) run google-workspace setup inside the container"
+log "  3. (if any OAuth-using connectors are enabled) run the relevant OAuth setup inside the container"
+log "  4. customer.yaml live at s3://${R2_BUCKET_CONFIG}/${R2_CONFIG_KEY} (non-structural edits picked up by sidecar)"

--- a/ai-employee/bin/provision-customer.sh
+++ b/ai-employee/bin/provision-customer.sh
@@ -100,6 +100,21 @@ APP_NAME="hermes-${SLUG}"
 
 log "App: ${APP_NAME} · region: ${FLY_REGION} · machine: ${MACHINE_SIZE}/${MEMORY_MB}MB · hermes: ${HERMES_REF}"
 
+# ---------- Step 1b: resolve Hermes upstream SHA for no-patches assertion ----------
+# Strip the -smd.N (or -smd.security.N) suffix from the fork tag to get the
+# equivalent upstream tag. Look up its SHA via git ls-remote against
+# NousResearch/hermes-agent. The Dockerfile asserts the fork tag's HEAD
+# matches this SHA; any divergence fails the build (ADR 0015 no-patches
+# discipline, load-bearing for AGPL §13 unmodified-deployment safe harbor).
+UPSTREAM_REF="${HERMES_REF%-smd.*}"
+[ "${UPSTREAM_REF}" != "${HERMES_REF}" ] || die "hermes_ref ${HERMES_REF} does not match the vYYYY.M.D-smd.N fork-tag pattern (PR #1037 validator)"
+
+log "Resolving upstream SHA for ${UPSTREAM_REF} (stripped from ${HERMES_REF})..."
+HERMES_UPSTREAM_SHA=$(git ls-remote --tags https://github.com/NousResearch/hermes-agent.git "refs/tags/${UPSTREAM_REF}" | awk '{print $1}' | head -1)
+[ -n "${HERMES_UPSTREAM_SHA}" ] || die "Could not resolve upstream SHA for ${UPSTREAM_REF}; check the tag exists at NousResearch/hermes-agent"
+[ "${#HERMES_UPSTREAM_SHA}" -eq 40 ] || die "Resolved upstream SHA has unexpected length (got ${#HERMES_UPSTREAM_SHA}, expected 40): ${HERMES_UPSTREAM_SHA}"
+log "Upstream SHA: ${HERMES_UPSTREAM_SHA}"
+
 # ---------- Step 2: upload customer.yaml to R2 ----------
 # bootstrap.sh fetches this from R2 on first boot and writes it to
 # /opt/data/customer.yaml. Doing the upload BEFORE the Fly deploy means the
@@ -124,6 +139,7 @@ sed -e "s/{{CUSTOMER_SLUG}}/${SLUG}/g" \
     -e "s/{{MACHINE_SIZE}}/${MACHINE_SIZE}/g" \
     -e "s/{{MEMORY_MB}}/${MEMORY_MB}/g" \
     -e "s/{{HERMES_REF}}/${HERMES_REF}/g" \
+    -e "s/{{HERMES_UPSTREAM_SHA}}/${HERMES_UPSTREAM_SHA}/g" \
     -e "s|{{R2_BUCKET_CONFIG}}|${R2_BUCKET_CONFIG}|g" \
     "${TEMPLATE_DIR}/fly.toml.template" > "${RENDERED_DIR}/fly.toml"
 log "Rendered to ${RENDERED_DIR}/fly.toml"
@@ -206,7 +222,10 @@ fly secrets deploy -a "${APP_NAME}" 2>/dev/null || true
 
 # ---------- Step 7: deploy ----------
 log "Deploying ${APP_NAME}..."
-(cd "${REPO_ROOT}" && fly deploy --config "${RENDERED_DIR}/fly.toml" --build-arg HERMES_REF="${HERMES_REF}" --build-arg CUSTOMER_SLUG="${SLUG}")
+(cd "${REPO_ROOT}" && fly deploy --config "${RENDERED_DIR}/fly.toml" \
+  --build-arg HERMES_REF="${HERMES_REF}" \
+  --build-arg HERMES_UPSTREAM_SHA="${HERMES_UPSTREAM_SHA}" \
+  --build-arg CUSTOMER_SLUG="${SLUG}")
 
 # ---------- Step 8: boot smoke test ----------
 # The boot-smoke-test.sh script exercises the Postgres → Redis → Honcho →

--- a/ai-employee/templates/Dockerfile
+++ b/ai-employee/templates/Dockerfile
@@ -45,10 +45,10 @@ ARG HERMES_UPSTREAM_SHA=a91a57fa5a13d516c38b07a141a9ce8a3daabeb0
 ARG HONCHO_PIP_SPEC="honcho-ai==1.0.0"
 
 # hermes-smd overlay (venturecrane/hermes-smd-overlay): plugin pack + CLI
-# (`hermes-smd bootstrap`, `hermes-smd customer-sync`). TODO(pin): replace
-# the branch ref with a tagged release once §7 lands.
+# (`hermes-smd bootstrap`, `hermes-smd customer-sync`). Pinned to a tagged
+# release; bump in lockstep with overlay-side feature work.
 ARG OVERLAY_REPO="https://github.com/venturecrane/hermes-smd-overlay.git"
-ARG OVERLAY_REF="feat/section-7-adapter-port"
+ARG OVERLAY_REF="v0.1.0"
 
 ARG CUSTOMER_SLUG=customer-zero
 

--- a/ai-employee/templates/Dockerfile
+++ b/ai-employee/templates/Dockerfile
@@ -21,9 +21,22 @@
 #   - ai-employee/templates/bootstrap.sh
 
 # ---------- Build args ----------
-# Hermes uses date-based tags (v2026.MM.DD). Pinned to v2026.5.16 per §6.
-# Move to a SHA pin once the upstream tag-vs-SHA workflow stabilizes.
-ARG HERMES_REF=v2026.5.16
+# customer.yaml.hermes_ref pins a fork tag of the form vYYYY.M.D-smd.N per
+# ADR 0015 (rewritten) and SMD_FORK_POLICY.md on venturecrane/hermes-agent.
+# The customer.yaml validator (src/lib/ai-employee/customer-yaml/helpers.ts,
+# PR #1037) enforces that shape. We clone from the venturecrane fork because
+# only the fork carries those tags; for the no-patches discipline, the
+# post-clone assertion below verifies the tag points at the matching upstream
+# commit SHA — any divergence fails the build (load-bearing for AGPL §13
+# unmodified-deployment safe harbor).
+ARG HERMES_REF=v2026.5.16-smd.0
+
+# Upstream commit SHA at the equivalent NousResearch/hermes-agent tag. The
+# build orchestrator pins this alongside HERMES_REF. If the fork tag points
+# anywhere else, the fork is carrying patches and the build fails. The default
+# below is the SHA for upstream tag v2026.5.16, documented in
+# SMD_FORK_POLICY.md (venturecrane/hermes-agent) and SMD_CHANGELOG.md.
+ARG HERMES_UPSTREAM_SHA=a91a57fa5a13d516c38b07a141a9ce8a3daabeb0
 
 # Honcho upstream is plastic-labs/honcho (AGPL-3.0). Pinned via the pip
 # package version below. TODO(ci): add a CI assertion that the installed
@@ -42,10 +55,19 @@ ARG CUSTOMER_SLUG=customer-zero
 # ---------- Stage 1: clone Hermes at pinned ref ----------
 FROM alpine/git:2.45.2 AS hermes_source
 ARG HERMES_REF
+ARG HERMES_UPSTREAM_SHA
 WORKDIR /src
 RUN git clone --depth 1 --branch ${HERMES_REF} \
-    https://github.com/NousResearch/hermes-agent.git . \
- && git rev-parse HEAD > /src/HERMES_SHA
+    https://github.com/venturecrane/hermes-agent.git . \
+ && git rev-parse HEAD > /src/HERMES_SHA \
+ && INSTALLED_SHA="$(cat /src/HERMES_SHA)" \
+ && if [ "${INSTALLED_SHA}" != "${HERMES_UPSTREAM_SHA}" ]; then \
+      echo "FATAL: Hermes fork tag ${HERMES_REF} points at ${INSTALLED_SHA}" >&2 ; \
+      echo "       Expected upstream SHA ${HERMES_UPSTREAM_SHA}." >&2 ; \
+      echo "       The fork carries patches; AGPL §13 safe-harbor invalid." >&2 ; \
+      echo "       See ADR 0015 and SMD_FORK_POLICY.md on venturecrane/hermes-agent." >&2 ; \
+      exit 1 ; \
+    fi
 
 # ---------- Stage 2: runtime image ----------
 FROM ghcr.io/astral-sh/uv:0.11.6-python3.13-trixie AS uv_source

--- a/ai-employee/templates/Dockerfile
+++ b/ai-employee/templates/Dockerfile
@@ -1,23 +1,42 @@
 # SMD AI Employee — customer-shape Hermes container
 #
-# Builds Hermes from upstream at a pinned ref, layers in our AIEmployee
-# adapter + customer config + skill library, and starts the agent loop
-# under tini for proper signal/zombie handling.
+# Builds Hermes from upstream at a pinned ref, installs the hermes-smd
+# overlay plugins + companion CLI, layers in our AIEmployee adapter / skill
+# library / connectors / safety-substrate tests, and bundles Postgres + Redis
+# + Honcho (Plastic Labs, AGPL-3.0) as in-container memory infrastructure.
+#
+# The container runs a multi-process startup under tini (PID 1, zombie
+# reaper). bootstrap.sh launches Postgres, Redis, Honcho, the customer-sync
+# sidecar, and finally execs Hermes. See bootstrap.sh for the full sequence.
+#
+# Per §6 of the locked build plan and ADR 0019: customer.yaml is NOT baked
+# into the image. Provisioning writes it to R2 at vaults/<slug>/customer.yaml;
+# bootstrap.sh fetches it to /opt/data/customer.yaml on first boot.
 #
 # Per-customer build context expects:
-#   - ai-employee/adapter/        (AIEmployee adapter — Python)
-#   - ai-employee/skills/         (canonical skill library — markdown)
-#   - ai-employee/connectors/     (Tier-1 custom MCP wrappers)
-#   - ai-employee/customers/<slug>/customer.yaml (rendered into /app/customer.yaml)
-#
-# The bootstrap.sh entrypoint reads /app/customer.yaml, resolves skill
-# version pins, runs the safety-substrate invariant checks, and starts
-# Hermes only after substrate passes.
+#   - ai-employee/adapter/         (AIEmployee adapter — Python)
+#   - ai-employee/skills/          (canonical skill library — markdown)
+#   - ai-employee/connectors/      (Tier-1 custom MCP wrappers)
+#   - ai-employee/safety-substrate/ (Phase A.5 invariant fixtures + runner)
+#   - ai-employee/templates/bootstrap.sh
 
-# ---------- Build args (set by provision-customer.sh per customer) ----------
-# Hermes uses date-based tags (v2026.MM.DD). Latest at time of writing: v2026.5.7.
-# Move to a SHA pin in Phase A.5 for stronger reproducibility.
-ARG HERMES_REF=v2026.5.7
+# ---------- Build args ----------
+# Hermes uses date-based tags (v2026.MM.DD). Pinned to v2026.5.16 per §6.
+# Move to a SHA pin once the upstream tag-vs-SHA workflow stabilizes.
+ARG HERMES_REF=v2026.5.16
+
+# Honcho upstream is plastic-labs/honcho (AGPL-3.0). Pinned via the pip
+# package version below. TODO(ci): add a CI assertion that the installed
+# Honcho commit hash matches upstream — mirroring the HERMES_SHA check
+# pattern so a transparent version drift is caught at build time.
+ARG HONCHO_PIP_SPEC="honcho-ai==1.0.0"
+
+# hermes-smd overlay (venturecrane/hermes-smd-overlay): plugin pack + CLI
+# (`hermes-smd bootstrap`, `hermes-smd customer-sync`). TODO(pin): replace
+# the branch ref with a tagged release once §7 lands.
+ARG OVERLAY_REPO="https://github.com/venturecrane/hermes-smd-overlay.git"
+ARG OVERLAY_REF="feat/section-7-adapter-port"
+
 ARG CUSTOMER_SLUG=customer-zero
 
 # ---------- Stage 1: clone Hermes at pinned ref ----------
@@ -28,33 +47,41 @@ RUN git clone --depth 1 --branch ${HERMES_REF} \
     https://github.com/NousResearch/hermes-agent.git . \
  && git rev-parse HEAD > /src/HERMES_SHA
 
-# ---------- Stage 2: build base from upstream Hermes Dockerfile pattern ----------
+# ---------- Stage 2: runtime image ----------
 FROM ghcr.io/astral-sh/uv:0.11.6-python3.13-trixie AS uv_source
 FROM debian:13.4
 
 ARG CUSTOMER_SLUG
-ENV CUSTOMER_SLUG=${CUSTOMER_SLUG}
+ARG HONCHO_PIP_SPEC
+ARG OVERLAY_REPO
+ARG OVERLAY_REF
 
+ENV CUSTOMER_SLUG=${CUSTOMER_SLUG}
 ENV PYTHONUNBUFFERED=1
 ENV PLAYWRIGHT_BROWSERS_PATH=/opt/hermes/.playwright
 ENV HERMES_HOME=/opt/data
-ENV PATH="/opt/data/.local/bin:${PATH}"
+ENV PATH="/opt/data/.local/bin:/usr/lib/postgresql/16/bin:${PATH}"
 
-# tini reaps orphaned zombie processes (MCP stdio subprocesses, etc.) that
-# would otherwise accumulate when hermes runs as PID 1.
+# ---------- System packages ----------
+# tini: PID 1 zombie reaper (signals + orphaned MCP stdio subprocesses).
+# postgresql-16 + redis: in-container Honcho data plane (Debian 13 defaults).
+# awscli: needed by bootstrap.sh to fetch customer.yaml from R2 (S3-compat).
+# curl + ca-certificates: health checks against the Honcho FastAPI server.
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
-      build-essential curl nodejs npm python3 ripgrep ffmpeg gcc \
-      python3-dev libffi-dev procps git openssh-client docker-cli tini \
-      ca-certificates \
+      build-essential curl nodejs npm python3 python3-pip python3-venv \
+      ripgrep ffmpeg gcc python3-dev libffi-dev procps git openssh-client \
+      docker-cli tini ca-certificates \
+      postgresql-16 postgresql-client-16 redis-server awscli \
  && rm -rf /var/lib/apt/lists/*
 
+# ---------- hermes user ----------
 RUN useradd -u 10000 -m -d /opt/data hermes
 COPY --chmod=0755 --from=uv_source /usr/local/bin/uv /usr/local/bin/uvx /usr/local/bin/
 
 WORKDIR /opt/hermes
 
-# Pull Hermes source from stage 1
+# ---------- Pull Hermes source from stage 1 ----------
 COPY --from=hermes_source /src/ /opt/hermes/
 COPY --from=hermes_source /src/HERMES_SHA /opt/hermes/HERMES_SHA
 
@@ -70,6 +97,26 @@ RUN uv sync --frozen --no-install-project --extra all
 RUN cd web && npm run build && cd ../ui-tui && npm run build
 RUN uv pip install --no-cache-dir --no-deps -e "."
 
+# ---------- Honcho (memory service) ----------
+# Installed into Hermes' venv so the migration runner + FastAPI server share
+# the same Python. Upstream: github.com/plastic-labs/honcho (AGPL-3.0).
+# Postgres + Redis are managed by bootstrap.sh; Honcho talks to 127.0.0.1.
+RUN /opt/hermes/.venv/bin/pip install --no-cache-dir "${HONCHO_PIP_SPEC}"
+
+# ---------- hermes-smd overlay (plugins + CLI) ----------
+# Pip-install the overlay (provides `hermes-smd` console script for the
+# bootstrap translator and customer-sync sidecar) and then register the
+# plugin pack with Hermes. Plugins land under ~/.hermes/plugins/ where the
+# Hermes plugin loader discovers them at runtime.
+RUN /opt/hermes/.venv/bin/pip install --no-cache-dir \
+      "git+${OVERLAY_REPO}@${OVERLAY_REF}"
+
+# Plugin install runs as root against /opt/data (the hermes home dir);
+# we chown below so the hermes user owns the result.
+RUN /opt/hermes/.venv/bin/hermes plugins install \
+      venturecrane/hermes-smd-overlay --enable \
+ || echo "WARN: hermes plugins install failed; continuing (TODO: harden once overlay registry exists)"
+
 # ---------- Layer in SMD's AI Employee bits ----------
 WORKDIR /app
 
@@ -82,31 +129,50 @@ COPY ai-employee/skills/ /app/skills/
 # Tier-1 custom MCP wrappers (one subdir per connector)
 COPY ai-employee/connectors/ /app/connectors/
 
-# Per-customer config — provision-customer.sh renders the right customer.yaml
-# into this exact path before building.
-COPY ai-employee/customers/${CUSTOMER_SLUG}/customer.yaml /app/customer.yaml
-
-# Safety-substrate tests — Phase A.5 runs these on container start
+# Safety-substrate tests — bootstrap.sh runs these on container start
 COPY ai-employee/safety-substrate/ /app/safety-substrate/
 
 # Bootstrap entrypoint
 COPY ai-employee/templates/bootstrap.sh /app/bootstrap.sh
 RUN chmod +x /app/bootstrap.sh
 
+# NOTE: customer.yaml is NOT copied into the image. It lives on the Fly
+# volume at /opt/data/customer.yaml; bootstrap.sh fetches it from R2 on
+# first boot if the volume copy is absent. See §6 of the build plan and
+# the customer.yaml -> per-profile config translation ADR.
+
+# ---------- Volume data dirs for Postgres + Redis ----------
+# The volume mounts at /opt/data, but initdb (run on first boot in
+# bootstrap.sh) needs the parent dir to exist with hermes ownership. We
+# create them here so the directory tree is right before the volume mounts;
+# the volume mount will shadow them on first boot, then bootstrap.sh's
+# mkdir + initdb populate the mounted directories.
+RUN mkdir -p /opt/data/honcho/pg /opt/data/honcho/redis /opt/data/.local/bin
+
 # ---------- Permissions ----------
+# Everything Hermes / Honcho / bootstrap writes to must be owned by hermes
+# (uid 10000). The plugin install above ran as root and dropped files into
+# /opt/data/.hermes — chown sweeps them to the right owner.
 RUN chmod -R a+rX /opt/hermes /app \
- && chown -R hermes:hermes /opt/hermes/.venv /opt/hermes/ui-tui /opt/hermes/node_modules /app /opt/data
+ && chown -R hermes:hermes \
+      /opt/hermes/.venv \
+      /opt/hermes/ui-tui \
+      /opt/hermes/node_modules \
+      /app \
+      /opt/data
 
 ENV HERMES_WEB_DIST=/opt/hermes/hermes_cli/web_dist
 
 VOLUME [ "/opt/data" ]
 
 # Drop to non-root for runtime. bootstrap.sh does no root-requiring work:
-# env validation, customer.yaml read, safety-substrate python run, and
-# symlink creation in hermes-owned /opt/data all work as the hermes user.
+# env validation, R2 fetch, Postgres/Redis startup (data dirs pre-owned by
+# hermes), Honcho migrations + serve, safety-substrate python run, and
+# hermes-smd bootstrap all run as the hermes user.
 # Closes semgrep dockerfile.security.last-user-is-root.
 USER hermes
 
-# tini for signal handling + zombie reaping; bootstrap.sh runs safety
-# substrate then starts Hermes.
+# tini as PID 1: reaps zombies, forwards signals to the foreground child
+# (Hermes via `exec` in bootstrap.sh) and to the supervised background
+# children (Postgres, Redis, Honcho, customer-sync sidecar).
 ENTRYPOINT [ "/usr/bin/tini", "-g", "--", "/app/bootstrap.sh" ]

--- a/ai-employee/templates/README.md
+++ b/ai-employee/templates/README.md
@@ -35,11 +35,11 @@ The flow runs as `ai-employee/bin/provision-customer.sh <slug>` from the repo ro
 
 Set these in your local shell (e.g., via `.envrc` + `direnv`) before running provisioning. The R2 credentials below are used by `aws s3 cp` for the customer.yaml upload step; the Machine gets its own R2 credentials staged via the `pbpaste` flow.
 
-| Env var                | Purpose                                                                                      |
-| ---------------------- | -------------------------------------------------------------------------------------------- |
-| `R2_ENDPOINT_URL`      | Cloudflare R2 endpoint (e.g., `https://<account-id>.r2.cloudflarestorage.com`)               |
-| `R2_ACCESS_KEY_ID`     | R2 access key with R/W on the config bucket                                                  |
-| `R2_SECRET_ACCESS_KEY` | R2 secret paired with the access key                                                         |
+| Env var                | Purpose                                                                                       |
+| ---------------------- | --------------------------------------------------------------------------------------------- |
+| `R2_ENDPOINT_URL`      | Cloudflare R2 endpoint (e.g., `https://<account-id>.r2.cloudflarestorage.com`)                |
+| `R2_ACCESS_KEY_ID`     | R2 access key with R/W on the config bucket                                                   |
+| `R2_SECRET_ACCESS_KEY` | R2 secret paired with the access key                                                          |
 | `R2_BUCKET_CONFIG`     | R2 bucket holding `customer.yaml` + voice vaults (defaults to `smd-customer-config` if unset) |
 
 Tools required on the operator machine: `fly`, `aws` (any version with S3-compatible `--endpoint-url`), `openssl`, `pbpaste` (macOS), `python3`, `uv`.
@@ -79,16 +79,16 @@ These are set as `[env]` entries in `fly.toml.template` (rendered per-customer):
 
 The 10GB Fly volume mounts at `/opt/data` and hosts everything stateful. `customer.yaml` is volume-write at provisioning and R2-mirrored for non-structural updates (ADR 0019).
 
-| Path                         | Contents                                                                         |
-| ---------------------------- | -------------------------------------------------------------------------------- |
+| Path                         | Contents                                                                          |
+| ---------------------------- | --------------------------------------------------------------------------------- |
 | `/opt/data/customer.yaml`    | Live customer config. Fetched from R2 at first boot; refreshed by sidecar.        |
 | `/opt/data/honcho/pg/`       | Postgres data dir (Honcho's primary store).                                       |
 | `/opt/data/honcho/redis/`    | Redis AOF (Honcho's cache).                                                       |
 | `/opt/data/audit.db`         | Per-customer audit log SQLite (`hermes-smd-audit` writes).                        |
 | `/opt/data/observations.db`  | Honcho-mirror SQLite (`hermes-smd-memory-mirror` writes). ADR 0016.               |
 | `/opt/data/profiles/<slug>/` | Hermes per-persona profiles (one per `customer.yaml.personas[]`). ADR 0011, 0019. |
-| `/opt/data/oauth/`           | Per-provider OAuth token files. ADR 0010.                                          |
-| `/opt/data/voice/`           | Voice samples warm cache (R2-backed).                                              |
+| `/opt/data/oauth/`           | Per-provider OAuth token files. ADR 0010.                                         |
+| `/opt/data/voice/`           | Voice samples warm cache (R2-backed).                                             |
 
 ## Boot sequence (summary)
 
@@ -130,10 +130,10 @@ We do not fail-closed because a memory-system bug should not brick the customer'
 
 The change rule (ADR 0019):
 
-| Change kind        | Examples                                                       | What happens                                                                                                                                |
-| ------------------ | -------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Non-structural** | Escalation contacts, voice samples, rule edits, scope tweaks   | Sidecar diffs R2, rewrites the volume copy, signals each profile to reload its config. No Machine restart.                                  |
-| **Structural**    | Persona add/remove, adapter swap, new connector binding         | Sidecar logs a warning, posts to the admin portal that a Captain re-provision is required. No automatic restart (preserves OAuth tokens). |
+| Change kind        | Examples                                                     | What happens                                                                                                                              |
+| ------------------ | ------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| **Non-structural** | Escalation contacts, voice samples, rule edits, scope tweaks | Sidecar diffs R2, rewrites the volume copy, signals each profile to reload its config. No Machine restart.                                |
+| **Structural**     | Persona add/remove, adapter swap, new connector binding      | Sidecar logs a warning, posts to the admin portal that a Captain re-provision is required. No automatic restart (preserves OAuth tokens). |
 
 Captain-initiated re-provision is the only path for structural changes; the OAuth tokens on the volume are deliberately scoped to the Machine lifetime per ADR 0010.
 
@@ -152,16 +152,16 @@ The most common state at the target-buyer profile is no working PM system at all
 
 ## Operating runbook
 
-| Task                            | Command                                                                                          |
-| ------------------------------- | ------------------------------------------------------------------------------------------------ |
-| Pause a Machine                 | `fly machine stop -a hermes-<slug> <machine-id>`                                                 |
-| Decommission a customer         | `fly apps destroy hermes-<slug>` (irreversible; volume contents are lost)                        |
-| Run the boot smoke test         | `ai-employee/bin/boot-smoke-test.sh <slug>` (Postgres → Redis → Honcho → customer.yaml → profiles → plugins) |
-| Run connector prod smoke tests  | `uv run python3 ai-employee/adapter/run_prod_smoke_test.py --customer <slug> --app hermes-<slug> --customer-yaml ai-employee/customers/<slug>/customer.yaml` |
-| Inspect logs                    | `fly logs -a hermes-<slug>`                                                                      |
-| Interactive shell               | `fly ssh console -a hermes-<slug>`                                                               |
-| Generate evidence packet        | `fly ssh console -a hermes-<slug> --command "tar czf - /opt/data/audit.db /opt/data/observations.db" > evidence-<slug>-$(date +%Y%m%d).tar.gz` |
-| Force customer.yaml resync      | `fly ssh console -a hermes-<slug> --command "kill -HUP \$(pgrep -f customer-sync)"`              |
+| Task                           | Command                                                                                                                                                      |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Pause a Machine                | `fly machine stop -a hermes-<slug> <machine-id>`                                                                                                             |
+| Decommission a customer        | `fly apps destroy hermes-<slug>` (irreversible; volume contents are lost)                                                                                    |
+| Run the boot smoke test        | `ai-employee/bin/boot-smoke-test.sh <slug>` (Postgres → Redis → Honcho → customer.yaml → profiles → plugins)                                                 |
+| Run connector prod smoke tests | `uv run python3 ai-employee/adapter/run_prod_smoke_test.py --customer <slug> --app hermes-<slug> --customer-yaml ai-employee/customers/<slug>/customer.yaml` |
+| Inspect logs                   | `fly logs -a hermes-<slug>`                                                                                                                                  |
+| Interactive shell              | `fly ssh console -a hermes-<slug>`                                                                                                                           |
+| Generate evidence packet       | `fly ssh console -a hermes-<slug> --command "tar czf - /opt/data/audit.db /opt/data/observations.db" > evidence-<slug>-$(date +%Y%m%d).tar.gz`               |
+| Force customer.yaml resync     | `fly ssh console -a hermes-<slug> --command "kill -HUP \$(pgrep -f customer-sync)"`                                                                          |
 
 ### Boot smoke test scope
 
@@ -169,10 +169,10 @@ The most common state at the target-buyer profile is no working PM system at all
 
 ## ADR references
 
-| ADR                                                                          | Topic                                                                                                |
-| ---------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
-| [0007](../../docs/adr/0007-per-customer-machine-isolation.md)                | Per-customer Machine isolation (one Fly app, one Machine, per customer).                              |
-| [0010](../../docs/adr/0010-oauth-token-storage.md)                           | Per-customer OAuth token storage on the Fly volume.                                                   |
-| [0016](../../docs/adr/0016-honcho-disposition.md)                            | Honcho disposition — mirror, don't gate; tuned config; TTL archival.                                  |
-| 0019                                                                         | `customer.yaml` → per-profile config translation. Structural vs. non-structural change rule.          |
-| 0020                                                                         | Connector strategy — `mcp:` / `build:` / `composio:` / `synthetic:` backend prefixes.                 |
+| ADR                                                           | Topic                                                                                        |
+| ------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| [0007](../../docs/adr/0007-per-customer-machine-isolation.md) | Per-customer Machine isolation (one Fly app, one Machine, per customer).                     |
+| [0010](../../docs/adr/0010-oauth-token-storage.md)            | Per-customer OAuth token storage on the Fly volume.                                          |
+| [0016](../../docs/adr/0016-honcho-disposition.md)             | Honcho disposition — mirror, don't gate; tuned config; TTL archival.                         |
+| 0019                                                          | `customer.yaml` → per-profile config translation. Structural vs. non-structural change rule. |
+| 0020                                                          | Connector strategy — `mcp:` / `build:` / `composio:` / `synthetic:` backend prefixes.        |

--- a/ai-employee/templates/README.md
+++ b/ai-employee/templates/README.md
@@ -6,7 +6,7 @@ Templates an operator copies during provisioning. Each file is read once at prov
 
 A customer Machine is a single Fly.io Machine running one container that supervises multiple processes under `tini`. Inside that container:
 
-- **Hermes Agent** (`NousResearch/hermes-agent`, pinned via `customer.yaml.hermes_ref`) — the substrate. Skills, profiles, the tool registry, the plugin hook surface, and MCP integration are all Hermes-native. We do not modify core files (ADR 0015).
+- **Hermes Agent** — the substrate. Skills, profiles, the tool registry, the plugin hook surface, and MCP integration are all Hermes-native. We do not modify core files (ADR 0015). Pinned via `customer.yaml.hermes_ref` to a fork tag (`vYYYY.M.D-smd.N`) on `venturecrane/hermes-agent`. The Dockerfile's stage-1 clone runs against the fork and asserts the cloned commit SHA matches the equivalent upstream tag's SHA from `NousResearch/hermes-agent` — divergence means the fork is patched and the build fails. This is the load-bearing enforcement of the no-patches discipline (ADR 0015 + AGPL §13 safe harbor).
 - **Honcho** — self-hosted from the upstream image, stock binary, configuration-only customization. Honcho's data store is the in-container Postgres; Redis is its cache.
 - **Postgres** — local data store for Honcho.
 - **Redis** — local cache for Honcho (AOF-persisted on the volume).

--- a/ai-employee/templates/README.md
+++ b/ai-employee/templates/README.md
@@ -1,6 +1,23 @@
 # ai-employee/templates
 
-Templates an operator copies during provisioning. Each file is read once at provision time and never imported by runtime code -- runtime configuration lives under `ai-employee/customers/{firm-slug}/`.
+Templates an operator copies during provisioning. Each file is read once at provision time and never imported by runtime code — runtime configuration lives under `ai-employee/customers/{customer-slug}/` and the per-Machine R2 vault at `s3://${R2_BUCKET_CONFIG}/vaults/<slug>/`.
+
+## Overview
+
+A customer Machine is a single Fly.io Machine running one container that supervises multiple processes under `tini`. Inside that container:
+
+- **Hermes Agent** (`NousResearch/hermes-agent`, pinned via `customer.yaml.hermes_ref`) — the substrate. Skills, profiles, the tool registry, the plugin hook surface, and MCP integration are all Hermes-native. We do not modify core files (ADR 0015).
+- **Honcho** — self-hosted from the upstream image, stock binary, configuration-only customization. Honcho's data store is the in-container Postgres; Redis is its cache.
+- **Postgres** — local data store for Honcho.
+- **Redis** — local cache for Honcho (AOF-persisted on the volume).
+- **hermes-smd-overlay plugins** — four narrow plugins installed at image-build time from `venturecrane/hermes-smd-overlay`:
+  - `hermes-smd-audit` — per-tool / per-LLM audit emission to per-customer SQLite.
+  - `hermes-smd-trust` — trust-ceiling enforcement + Composio per-connection guard.
+  - `hermes-smd-voice` — sample-driven voice transformation.
+  - `hermes-smd-memory-mirror` — mirrors Honcho conclusions to per-customer SQLite with provenance.
+- **customer-sync sidecar** (from the overlay's `bootstrap/` package) — polls R2 for non-structural `customer.yaml` changes at a 5-minute cadence.
+
+No public HTTP. Honcho's FastAPI binds localhost only. All inbound traffic is SSH via `fly ssh console -a hermes-<slug>`.
 
 ## Runtime templates
 
@@ -10,17 +27,152 @@ Templates an operator copies during provisioning. Each file is read once at prov
 | `fly.toml.template` | `bin/provision-customer.sh`   | Fly app config; placeholders resolved per-customer at provision time |
 | `bootstrap.sh`      | Per-customer Fly Machine boot | First-run substrate setup inside the Machine                         |
 
-## Customer.yaml templates
+## Provisioning a new customer
 
-Two starter templates for the most common buyer states. Each is copied into `ai-employee/customers/{firm-slug}/customer.yaml`, then the bracketed values are filled in. The reserved `_template` directory is never a real customer slug.
+The flow runs as `ai-employee/bin/provision-customer.sh <slug>` from the repo root.
+
+### Operator prerequisites
+
+Set these in your local shell (e.g., via `.envrc` + `direnv`) before running provisioning. The R2 credentials below are used by `aws s3 cp` for the customer.yaml upload step; the Machine gets its own R2 credentials staged via the `pbpaste` flow.
+
+| Env var                | Purpose                                                                                      |
+| ---------------------- | -------------------------------------------------------------------------------------------- |
+| `R2_ENDPOINT_URL`      | Cloudflare R2 endpoint (e.g., `https://<account-id>.r2.cloudflarestorage.com`)               |
+| `R2_ACCESS_KEY_ID`     | R2 access key with R/W on the config bucket                                                  |
+| `R2_SECRET_ACCESS_KEY` | R2 secret paired with the access key                                                         |
+| `R2_BUCKET_CONFIG`     | R2 bucket holding `customer.yaml` + voice vaults (defaults to `smd-customer-config` if unset) |
+
+Tools required on the operator machine: `fly`, `aws` (any version with S3-compatible `--endpoint-url`), `openssl`, `pbpaste` (macOS), `python3`, `uv`.
+
+### Provisioning steps
+
+`provision-customer.sh` executes the following sequence. Every step is idempotent — re-running the script after a partial failure picks up where it left off.
+
+1. **Validate `customer.yaml`** via `ai-employee/adapter/validate_customer_yaml.py` against the skill catalog, connector adapters, and fixtures. Fail-fast on schema or reference errors.
+2. **Upload `customer.yaml` to R2** at `s3://${R2_BUCKET_CONFIG}/vaults/<slug>/customer.yaml`. This happens BEFORE the Fly deploy so the first Machine boot can fetch it. The customer-sync sidecar polls this same key for non-structural updates.
+3. **Render `fly.toml`** from `fly.toml.template` to `ai-employee/.rendered/<slug>/fly.toml` (gitignored).
+4. **Create the Fly app** `hermes-<slug>` (skipped if it exists).
+5. **Create the 10GB volume** `hermes_state` in the customer's region (skipped if it exists). 10GB hosts Postgres + Redis + customer.yaml + audit/observations SQLite + voice cache + OAuth tokens with headroom.
+6. **Stage secrets via the pbpaste flow.** For each secret, the operator copies the value to clipboard and presses Enter; the value flows from `pbpaste` directly into `fly secrets import --stage` over stdin. Values never appear on the command line, in the terminal, or in any chat transcript. The set of staged secrets:
+   - `ANTHROPIC_API_KEY` — model access for Hermes.
+   - `COMPOSIO_API_KEY` — long-tail connector access.
+   - `AGENTMAIL_API_KEY` — agent-side mailbox.
+   - `R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` / `R2_ENDPOINT_URL` — Machine-scoped R2 credentials used by `bootstrap.sh` and the customer-sync sidecar.
+   - `HONCHO_API_KEY` — generated locally via `openssl rand -hex 32`, piped straight to `fly secrets import --stage` over stdin. Never logged, never stored elsewhere. Rotating it requires a Captain-initiated re-provision.
+7. **Deploy** with `fly deploy` against the rendered `fly.toml`.
+8. **Boot smoke test** (`bin/boot-smoke-test.sh <slug>`) — see the section below.
+9. **Per-connector prod smoke tests** (`run_prod_smoke_test.py`) — one read-only call per enabled BUILD or COMPOSIO connector against the customer's tenant. Surfaces auth / scope / shape issues before any write capability is exercised.
+
+### Non-secret config in fly.toml
+
+These are set as `[env]` entries in `fly.toml.template` (rendered per-customer):
+
+- `R2_BUCKET_CONFIG` — the bucket name (NOT a credential).
+- `SMD_D1_AUDIT_BINDING` — defaults to `/opt/data/audit.db`.
+- `SMD_D1_OBSERVATIONS_BINDING` — defaults to `/opt/data/observations.db`.
+- `HONCHO_BASE_URL` — `http://localhost:8000` (Honcho FastAPI binds localhost only).
+- `HONCHO_DATABASE_URL` — `postgresql://honcho@localhost:5432/honcho` (in-container Postgres).
+- `HERMES_HOME` — `/opt/data`.
+- `CUSTOMER_SLUG` — the slug, propagated for log filtering and skill resolution.
+
+## Storage layout on `/opt/data`
+
+The 10GB Fly volume mounts at `/opt/data` and hosts everything stateful. `customer.yaml` is volume-write at provisioning and R2-mirrored for non-structural updates (ADR 0019).
+
+| Path                         | Contents                                                                         |
+| ---------------------------- | -------------------------------------------------------------------------------- |
+| `/opt/data/customer.yaml`    | Live customer config. Fetched from R2 at first boot; refreshed by sidecar.        |
+| `/opt/data/honcho/pg/`       | Postgres data dir (Honcho's primary store).                                       |
+| `/opt/data/honcho/redis/`    | Redis AOF (Honcho's cache).                                                       |
+| `/opt/data/audit.db`         | Per-customer audit log SQLite (`hermes-smd-audit` writes).                        |
+| `/opt/data/observations.db`  | Honcho-mirror SQLite (`hermes-smd-memory-mirror` writes). ADR 0016.               |
+| `/opt/data/profiles/<slug>/` | Hermes per-persona profiles (one per `customer.yaml.personas[]`). ADR 0011, 0019. |
+| `/opt/data/oauth/`           | Per-provider OAuth token files. ADR 0010.                                          |
+| `/opt/data/voice/`           | Voice samples warm cache (R2-backed).                                              |
+
+## Boot sequence (summary)
+
+`bootstrap.sh` runs as the container entrypoint under `tini`. Eleven sequenced steps; each waits on the previous and fail-fasts on timeout:
+
+1. Validate required env vars.
+2. Fetch `customer.yaml` from R2 if `/opt/data/customer.yaml` is missing; otherwise use the volume copy.
+3. Start Postgres (mounted on `/opt/data/honcho/pg/`); wait on `pg_isready`.
+4. Start Redis (mounted on `/opt/data/honcho/redis/`); wait on `redis-cli ping`.
+5. Run Honcho schema migrations (idempotent).
+6. Start Honcho FastAPI; wait on `curl -fsS http://localhost:8000/health`.
+7. Run `hermes-smd bootstrap` from the overlay repo — translates `customer.yaml.personas[]` into N profile directories under `/opt/data/profiles/`, writes each profile's `config.yaml` and `SOUL.md`.
+8. Run the safety-substrate invariant checks (`/app/safety-substrate/run_invariants.py`).
+9. Pause-guard check.
+10. Start the `hermes-smd customer-sync` sidecar in the background (R2 polling).
+11. Launch Hermes with the four overlay plugins discovered from `~/.hermes/plugins/`.
+
+The full step list and the exact failure-handling lives in `bootstrap.sh` itself; this section is a summary.
+
+## Honcho failure semantics
+
+If Honcho's FastAPI server becomes unresponsive mid-session (process crash, OOM, Postgres connection failure), Hermes degrades gracefully:
+
+- The agent continues to function without Honcho writes for that turn.
+- `hermes-smd-audit` emits a `MEMORY_PROVIDER_DEGRADED` audit row with the timestamp and last-known Honcho status.
+- The admin portal surfaces this as a yellow-state Machine.
+- `tini` reaps the dead Honcho process and the bootstrap sequencer restarts it.
+- On reconnect, `hermes-smd-audit` emits a `MEMORY_PROVIDER_RECOVERED` audit row.
+
+We do not fail-closed because a memory-system bug should not brick the customer's AI Employee. The per-draft reviewer-as-sender pattern catches any single bad draft regardless of memory state. ADR 0016 governs the mirror, the dismissal flow, and TTL archival.
+
+## Updating customer.yaml
+
+`customer.yaml` lives in three places:
+
+- Git: `ai-employee/customers/<slug>/customer.yaml` (source of truth, ADR 0012).
+- R2: `s3://${R2_BUCKET_CONFIG}/vaults/<slug>/customer.yaml` (uploaded by provisioning, polled by sidecar).
+- Volume: `/opt/data/customer.yaml` (mirror, refreshed by sidecar on R2 change).
+
+The change rule (ADR 0019):
+
+| Change kind        | Examples                                                       | What happens                                                                                                                                |
+| ------------------ | -------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Non-structural** | Escalation contacts, voice samples, rule edits, scope tweaks   | Sidecar diffs R2, rewrites the volume copy, signals each profile to reload its config. No Machine restart.                                  |
+| **Structural**    | Persona add/remove, adapter swap, new connector binding         | Sidecar logs a warning, posts to the admin portal that a Captain re-provision is required. No automatic restart (preserves OAuth tokens). |
+
+Captain-initiated re-provision is the only path for structural changes; the OAuth tokens on the volume are deliberately scoped to the Machine lifetime per ADR 0010.
+
+## Customer.yaml starter templates
 
 | File                                                                           | When to use                                                                                                                                                                                                                  |
 | ------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [`../customers/_template/customer.yaml`](../customers/_template/customer.yaml) | The fully bracketed default. Use when the customer's capability bindings are not yet known -- the assessment call fills them in.                                                                                             |
+| [`../customers/_template/customer.yaml`](../customers/_template/customer.yaml) | The fully bracketed default. Use when the customer's capability bindings are not yet known — the assessment call fills them in.                                                                                              |
 | [`customer-no-pm-system.yaml`](customer-no-pm-system.yaml)                     | The customer has no working practice-management system (paper + Outlook + OneDrive + QuickBooks for billing). Ships with `no_pm` PracticeManagement + Microsoft Graph + DocuSign + QuickBooks + OneDrive bindings pre-wired. |
 
 Both pass through the same validator (`src/lib/ai-employee/customer-yaml/validator.ts`); the bracketed-field shape rejects an unedited template at validation time, forcing the operator to substitute real values before provisioning.
 
 ### no-PM-system mode
 
-The most common state at the target-buyer profile is no working PM system at all. The `customer-no-pm-system.yaml` template is the matching capability binding set -- see the spec at [`docs/specs/ai-employee/no-pm-system-mode.md`](../../docs/specs/ai-employee/no-pm-system-mode.md) for the scene-by-scene demo flow and the `no_pm` adapter README at [`../connectors/no_pm/README.md`](../connectors/no_pm/README.md) for the synthetic matter store. Issue [#853](https://github.com/venturecrane/ss-console/issues/853).
+The most common state at the target-buyer profile is no working PM system at all. The `customer-no-pm-system.yaml` template is the matching capability binding set — see the spec at [`docs/specs/ai-employee/no-pm-system-mode.md`](../../docs/specs/ai-employee/no-pm-system-mode.md) for the scene-by-scene demo flow and the `no_pm` adapter README at [`../connectors/no_pm/README.md`](../connectors/no_pm/README.md) for the synthetic matter store. Issue [#853](https://github.com/venturecrane/ss-console/issues/853).
+
+## Operating runbook
+
+| Task                            | Command                                                                                          |
+| ------------------------------- | ------------------------------------------------------------------------------------------------ |
+| Pause a Machine                 | `fly machine stop -a hermes-<slug> <machine-id>`                                                 |
+| Decommission a customer         | `fly apps destroy hermes-<slug>` (irreversible; volume contents are lost)                        |
+| Run the boot smoke test         | `ai-employee/bin/boot-smoke-test.sh <slug>` (Postgres → Redis → Honcho → customer.yaml → profiles → plugins) |
+| Run connector prod smoke tests  | `uv run python3 ai-employee/adapter/run_prod_smoke_test.py --customer <slug> --app hermes-<slug> --customer-yaml ai-employee/customers/<slug>/customer.yaml` |
+| Inspect logs                    | `fly logs -a hermes-<slug>`                                                                      |
+| Interactive shell               | `fly ssh console -a hermes-<slug>`                                                               |
+| Generate evidence packet        | `fly ssh console -a hermes-<slug> --command "tar czf - /opt/data/audit.db /opt/data/observations.db" > evidence-<slug>-$(date +%Y%m%d).tar.gz` |
+| Force customer.yaml resync      | `fly ssh console -a hermes-<slug> --command "kill -HUP \$(pgrep -f customer-sync)"`              |
+
+### Boot smoke test scope
+
+`boot-smoke-test.sh` exercises the dependency chain only: Machine state, Postgres readiness, Redis readiness, Honcho health, `customer.yaml` presence, profiles directory presence, and overlay plugins installation. It does **not** run a real agent turn or exercise live MCP / Anthropic credentials. Those are the job of `run_prod_smoke_test.py` (per-connector) and the end-to-end test described in §6 of the build plan.
+
+## ADR references
+
+| ADR                                                                          | Topic                                                                                                |
+| ---------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| [0007](../../docs/adr/0007-per-customer-machine-isolation.md)                | Per-customer Machine isolation (one Fly app, one Machine, per customer).                              |
+| [0010](../../docs/adr/0010-oauth-token-storage.md)                           | Per-customer OAuth token storage on the Fly volume.                                                   |
+| [0016](../../docs/adr/0016-honcho-disposition.md)                            | Honcho disposition — mirror, don't gate; tuned config; TTL archival.                                  |
+| 0019                                                                         | `customer.yaml` → per-profile config translation. Structural vs. non-structural change rule.          |
+| 0020                                                                         | Connector strategy — `mcp:` / `build:` / `composio:` / `synthetic:` backend prefixes.                 |

--- a/ai-employee/templates/bootstrap.sh
+++ b/ai-employee/templates/bootstrap.sh
@@ -1,17 +1,42 @@
 #!/usr/bin/env bash
-# bootstrap.sh — container entrypoint for the AI Employee customer instance
+# bootstrap.sh — container entrypoint for the AI Employee customer Machine
 #
-# Runs at container start. Validates env, resolves skill version pins from
-# /app/customer.yaml, runs the safety-substrate invariant checks, then
-# starts the Hermes agent loop under the AIEmployee adapter.
+# Per §6 of the locked build plan and ADRs 0007/0010/0016/0019, this script
+# runs an 11-step sequenced startup under tini (PID 1, zombie reaper):
+#
+#   1.  Validate required env vars.
+#   2.  Verify (or fetch from R2) /opt/data/customer.yaml.
+#   3.  Start Postgres (Honcho's data store) as a supervised child.
+#   4.  Start Redis (Honcho's queue/cache) as a supervised child.
+#   5.  Run Honcho schema migrations (idempotent).
+#   6.  Start Honcho FastAPI server as a supervised child.
+#   7.  Run `hermes-smd bootstrap` (customer.yaml -> per-profile config + SOUL.md).
+#   8.  Run the safety-substrate invariant checks (Phase A.5 gate).
+#   9.  Pause guard.
+#   10. Start `hermes-smd customer-sync` sidecar (R2 poller).
+#   11. exec Hermes (becomes the foreground child of tini).
+#
+# Storage model:
+#   - customer.yaml is volume-mounted, NOT baked into the image.
+#   - Provisioning writes it to R2 at vaults/<slug>/customer.yaml.
+#   - First boot: fetch from R2 -> /opt/data/customer.yaml.
+#   - Subsequent boots: use the volume copy.
+#
+# Process supervision:
+#   - tini (PID 1) reaps zombies and forwards signals.
+#   - Postgres, Redis, Honcho, and the customer-sync sidecar are launched
+#     under restart wrappers so a crashed dependency self-heals.
+#   - The memory-mirror plugin handles graceful degradation when Honcho is
+#     unhealthy mid-session; this script does not health-monitor Honcho at
+#     runtime (only at startup).
 #
 # Fails fast on any of:
-#   - missing required env vars (secrets not set as Fly secrets)
-#   - customer.yaml malformed or skill versions un-resolvable
+#   - missing required env vars
+#   - customer.yaml missing AND not fetchable from R2
+#   - Postgres/Redis/Honcho not healthy within bounded retries
+#   - Honcho schema migration error
+#   - `hermes-smd bootstrap` error (bad customer.yaml structure)
 #   - safety-substrate invariant test failures
-#
-# The substrate gate is non-negotiable: if any of the five invariants fail
-# their fixtures, the agent does not start. This is the OpenClaw mitigation.
 
 set -euo pipefail
 
@@ -24,22 +49,70 @@ die() {
   exit 1
 }
 
+# Bounded retry helper: wait_for <description> <max_attempts> <sleep_seconds> <check_command...>
+wait_for() {
+  local desc="$1"
+  local max="$2"
+  local delay="$3"
+  shift 3
+  local attempt=1
+  while (( attempt <= max )); do
+    if "$@" >/dev/null 2>&1; then
+      log "${desc} ready (attempt ${attempt}/${max})"
+      return 0
+    fi
+    log "${desc} not ready, retry ${attempt}/${max} in ${delay}s..."
+    sleep "${delay}"
+    attempt=$(( attempt + 1 ))
+  done
+  return 1
+}
+
+# Restart-on-crash wrapper for foundational child processes. Logs a
+# fatal-style line on each crash so the audit plugin / operator sees the
+# transition; tini still reaps the dying child.
+supervise() {
+  local name="$1"
+  shift
+  (
+    while true; do
+      log "supervisor: starting ${name}"
+      if "$@"; then
+        log "supervisor: ${name} exited 0; restarting in 5s"
+      else
+        local rc=$?
+        log "supervisor: ${name} exited ${rc}; restarting in 5s"
+      fi
+      sleep 5
+    done
+  ) &
+  log "supervisor: ${name} pid=$!"
+}
+
 CUSTOMER_SLUG="${CUSTOMER_SLUG:-}"
 [ -n "${CUSTOMER_SLUG}" ] || die "CUSTOMER_SLUG env var is unset"
-
-CUSTOMER_YAML="/app/customer.yaml"
-[ -f "${CUSTOMER_YAML}" ] || die "customer.yaml missing at ${CUSTOMER_YAML}"
 
 log "Starting bootstrap for customer: ${CUSTOMER_SLUG}"
 log "Hermes SHA: $(cat /opt/hermes/HERMES_SHA 2>/dev/null || echo unknown)"
 
-# ---------- Step 1: validate required env vars ----------
-# Secrets are set via `fly secrets set` from provision-customer.sh.
-# Never echo values; only check presence.
+# ============================================================================
+# Step 1: validate required env vars
+# ============================================================================
+# Secrets are set via `fly secrets set` from provision-customer.sh. Never echo
+# values; only check presence.
 REQUIRED_ENV=(
   ANTHROPIC_API_KEY
   COMPOSIO_API_KEY
   AGENTMAIL_API_KEY
+  # R2 access for customer.yaml fetch (vaults/<slug>/customer.yaml).
+  R2_BUCKET_CONFIG
+  R2_ACCESS_KEY_ID
+  R2_SECRET_ACCESS_KEY
+  # D1 bindings for the audit + observations mirror tables (ADR 0016/0017).
+  SMD_D1_AUDIT_BINDING
+  SMD_D1_OBSERVATIONS_BINDING
+  # Honcho FastAPI access token, generated per-Machine at provisioning.
+  HONCHO_API_KEY
 )
 
 for var in "${REQUIRED_ENV[@]}"; do
@@ -54,30 +127,166 @@ done
 OPTIONAL_ENV=(
   GOOGLE_TOKEN_JSON
   GOOGLE_CLIENT_SECRET_JSON
+  # R2 endpoint URL override (defaults to the Cloudflare R2 S3 endpoint).
+  R2_ENDPOINT_URL
 )
 
 for var in "${OPTIONAL_ENV[@]}"; do
   if [ -n "${!var:-}" ]; then
     log "env check OK: ${var} present (optional)"
   else
-    log "env check: ${var} not set (skill that needs Google OAuth will refuse)"
+    log "env check: ${var} not set (default will apply)"
   fi
 done
 
-# ---------- Step 2: resolve skill version pins ----------
-# customer.yaml's skills[] entries pin to a content-hash. We verify each
-# pinned skill exists in /app/skills/ and matches the pinned hash. A pin
-# mismatch is a deploy error — the customer is on a skill version we don't
-# have in the image. Rollback or deploy a fresh image with the right SHAs.
-log "Resolving skill version pins from customer.yaml..."
-/opt/hermes/.venv/bin/python3 /app/adapter/resolve_skill_pins.py "${CUSTOMER_YAML}" /app/skills \
-  || die "Skill pin resolution failed; check customer.yaml versions vs /app/skills/ content"
-log "Skill pins resolved OK"
+# ============================================================================
+# Step 2: verify (or fetch) customer.yaml on the volume
+# ============================================================================
+# Storage model change (§6): customer.yaml lives on the volume, not baked
+# into the image. R2 at vaults/<slug>/customer.yaml is the source of truth;
+# provisioning writes it there. Bootstrap fetches to /opt/data on first boot
+# and uses the volume copy on subsequent boots.
+CUSTOMER_YAML="/opt/data/customer.yaml"
+R2_ENDPOINT_URL="${R2_ENDPOINT_URL:-https://${R2_ACCOUNT_ID:-}.r2.cloudflarestorage.com}"
+R2_CUSTOMER_YAML_URI="s3://${R2_BUCKET_CONFIG}/vaults/${CUSTOMER_SLUG}/customer.yaml"
 
-# ---------- Step 3: run safety substrate invariant checks ----------
-# Phase A.5 gate. The five invariants must hold across compaction, restart,
-# tool failure, prompt injection, ceiling-escalation attempts. Re-runs on
-# every container start so a Hermes SHA bump can't regress the floor.
+if [ -f "${CUSTOMER_YAML}" ]; then
+  log "customer.yaml present on volume: ${CUSTOMER_YAML}"
+else
+  log "customer.yaml missing on volume; fetching from R2: ${R2_CUSTOMER_YAML_URI}"
+  # awscli is installed in the Dockerfile. R2 speaks S3 with a custom endpoint.
+  AWS_ACCESS_KEY_ID="${R2_ACCESS_KEY_ID}" \
+  AWS_SECRET_ACCESS_KEY="${R2_SECRET_ACCESS_KEY}" \
+    aws s3 cp \
+      --endpoint-url "${R2_ENDPOINT_URL}" \
+      "${R2_CUSTOMER_YAML_URI}" \
+      "${CUSTOMER_YAML}" \
+    || die "Failed to fetch customer.yaml from R2 (${R2_CUSTOMER_YAML_URI})"
+  log "customer.yaml fetched from R2 -> ${CUSTOMER_YAML}"
+fi
+
+# ============================================================================
+# Step 3: start Postgres (Honcho data store)
+# ============================================================================
+# Honcho stores conclusions/observations in Postgres. Data dir lives on the
+# volume so it survives Machine restarts. Initialize on first boot; subsequent
+# boots reuse the cluster. Postgres runs as the hermes user (uid 10000) — the
+# image creates the data dir with hermes ownership.
+PGDATA="/opt/data/honcho/pg"
+PG_BIN="/usr/lib/postgresql/16/bin"
+export PGDATA
+
+if [ ! -s "${PGDATA}/PG_VERSION" ]; then
+  log "Postgres data dir empty; running initdb (first boot)"
+  mkdir -p "${PGDATA}"
+  "${PG_BIN}/initdb" \
+    --pgdata "${PGDATA}" \
+    --username "honcho" \
+    --auth-local "trust" \
+    --auth-host "trust" \
+    --encoding "UTF8" \
+    --locale "C" \
+    || die "Postgres initdb failed"
+  # Listen on localhost only; no external exposure.
+  cat >> "${PGDATA}/postgresql.conf" <<EOF
+listen_addresses = '127.0.0.1'
+port = 5432
+unix_socket_directories = '/tmp'
+EOF
+  log "Postgres cluster initialized"
+fi
+
+# Supervised start. pg_ctl backgrounds itself; we use postgres directly so
+# tini sees the process. The supervise() wrapper keeps it alive.
+supervise "postgres" "${PG_BIN}/postgres" -D "${PGDATA}"
+
+# Health-wait. 30 attempts × 1s = 30s ceiling.
+if ! wait_for "Postgres" 30 1 "${PG_BIN}/pg_isready" -h 127.0.0.1 -p 5432 -U honcho; then
+  die "Postgres did not become ready within 30s"
+fi
+
+# Ensure the honcho database exists (createdb is idempotent via DO block).
+"${PG_BIN}/psql" -h 127.0.0.1 -U honcho -d postgres -tAc \
+  "SELECT 1 FROM pg_database WHERE datname='honcho'" | grep -q 1 \
+  || "${PG_BIN}/createdb" -h 127.0.0.1 -U honcho honcho \
+  || die "Failed to create honcho database"
+log "Postgres ready (database=honcho)"
+
+# ============================================================================
+# Step 4: start Redis (Honcho cache/queue)
+# ============================================================================
+# AOF persistence keeps Honcho's queue durable across restarts. Data dir lives
+# on the volume.
+REDIS_DIR="/opt/data/honcho/redis"
+mkdir -p "${REDIS_DIR}"
+
+supervise "redis" redis-server \
+  --bind 127.0.0.1 \
+  --port 6379 \
+  --appendonly yes \
+  --dir "${REDIS_DIR}" \
+  --protected-mode no \
+  --save ""
+
+if ! wait_for "Redis" 30 1 redis-cli -h 127.0.0.1 -p 6379 ping; then
+  die "Redis did not become ready within 30s"
+fi
+log "Redis ready"
+
+# ============================================================================
+# Step 5: Honcho schema migrations
+# ============================================================================
+# Idempotent — Honcho's migration runner is safe to re-run on every boot.
+# Tuned config knobs from ADR 0016 are applied via env vars consumed by the
+# Honcho process itself (set in step 6) and via the hermes-smd bootstrap
+# translator in step 7 (writes them into each profile's memory-provider
+# config). We export DB/Redis URLs here so the migration runner can find them.
+export HONCHO_DB_URL="postgresql://honcho@127.0.0.1:5432/honcho"
+export HONCHO_REDIS_URL="redis://127.0.0.1:6379/0"
+
+log "Running Honcho schema migrations..."
+python3 -m honcho.migrations \
+  || die "Honcho schema migration failed"
+log "Honcho migrations applied"
+
+# ============================================================================
+# Step 6: start Honcho FastAPI server
+# ============================================================================
+# Local-only on port 8000; the memory-mirror plugin in Hermes talks to it via
+# 127.0.0.1.
+supervise "honcho" python3 -m honcho.server \
+  --host 127.0.0.1 \
+  --port 8000
+
+if ! wait_for "Honcho FastAPI" 60 1 curl -fsS http://127.0.0.1:8000/health; then
+  die "Honcho FastAPI did not become healthy within 60s"
+fi
+log "Honcho FastAPI ready"
+
+# ============================================================================
+# Step 7: hermes-smd bootstrap (customer.yaml -> per-profile config)
+# ============================================================================
+# Installed at image build time via `pip install hermes-smd-overlay`. Reads
+# /opt/data/customer.yaml, writes N profile directories under
+# $HERMES_HOME/profiles/<slug>/ with config.yaml and SOUL.md. Each profile's
+# memory-provider block is configured to talk to the local Honcho FastAPI
+# with the ADR 0016 tuned knobs.
+log "Running hermes-smd bootstrap (customer.yaml -> profiles)..."
+hermes-smd bootstrap \
+  --customer-yaml "${CUSTOMER_YAML}" \
+  --hermes-home "${HERMES_HOME}" \
+  --honcho-url "http://127.0.0.1:8000" \
+  --honcho-api-key "${HONCHO_API_KEY}" \
+  || die "hermes-smd bootstrap failed; check customer.yaml structure"
+log "Profile config(s) generated under ${HERMES_HOME}/profiles/"
+
+# ============================================================================
+# Step 8: safety substrate invariant checks (Phase A.5 gate)
+# ============================================================================
+# PRESERVED VERBATIM from the prior bootstrap.sh. The five invariants must
+# hold across compaction, restart, tool failure, prompt injection, and
+# ceiling-escalation attempts. Re-runs on every container start so a Hermes
+# SHA bump can't regress the floor. This is the OpenClaw mitigation.
 log "Running safety substrate invariant checks (Phase A.5 gate)..."
 if ! /opt/hermes/.venv/bin/python3 /app/safety-substrate/run_invariants.py \
        --customer "${CUSTOMER_SLUG}" \
@@ -88,10 +297,12 @@ Inspect /app/safety-substrate/logs/$(date -u +%Y%m%d).log for which invariant fa
 fi
 log "Safety substrate invariants PASSED"
 
-# ---------- Step 4: pause guard ----------
-# pause-customer.sh writes a sentinel at /opt/data/.paused. If present, we
-# log and exit cleanly — keeps the machine running but agent loop dormant
-# until the operator unpauses.
+# ============================================================================
+# Step 9: pause guard
+# ============================================================================
+# PRESERVED VERBATIM from the prior bootstrap.sh. pause-customer.sh writes a
+# sentinel at /opt/data/.paused; if present, we log and park on tail so
+# `fly ssh console` still works but the agent loop stays dormant.
 if [ -f /opt/data/.paused ]; then
   log "PAUSE sentinel present at /opt/data/.paused — agent will not start"
   log "Reason: $(cat /opt/data/.paused)"
@@ -99,37 +310,37 @@ if [ -f /opt/data/.paused ]; then
   exec tail -f /dev/null
 fi
 
-# ---------- Step 5: register AIEmployee adapter with Hermes ----------
-# The adapter wraps Hermes' tool dispatch with the trust-ceiling enforcement
-# layer. Skills declare their ceiling in SKILL.md frontmatter; the adapter
-# enforces it on every tool call regardless of what the model prompt says.
-log "Registering AIEmployee adapter..."
+# ============================================================================
+# Step 10: customer-sync sidecar (R2 poller)
+# ============================================================================
+# Polls R2 at vaults/<slug>/customer.yaml every 5 minutes. On non-structural
+# change: rewrites /opt/data/customer.yaml and signals Hermes (SIGHUP) to
+# reload profile config. On structural change: logs warning + posts to admin
+# portal, but does NOT restart (preserves OAuth tokens per ADR 0010).
+log "Starting customer-sync sidecar (R2 polling every 300s)..."
+AWS_ACCESS_KEY_ID="${R2_ACCESS_KEY_ID}" \
+AWS_SECRET_ACCESS_KEY="${R2_SECRET_ACCESS_KEY}" \
+  hermes-smd customer-sync \
+    --customer-yaml "${CUSTOMER_YAML}" \
+    --r2-bucket "${R2_BUCKET_CONFIG}" \
+    --r2-endpoint "${R2_ENDPOINT_URL}" \
+    --interval 300 \
+    &
+SIDECAR_PID=$!
+log "customer-sync sidecar pid=${SIDECAR_PID}"
+
+# ============================================================================
+# Step 11: launch Hermes (foreground under tini)
+# ============================================================================
+# Overlay plugins were installed at image build time and live under
+# ~/.hermes/plugins/. The first profile in personas[] (the only one in v1 per
+# the §7 validator) becomes the active session. `exec` so Hermes inherits
+# PID-1-ish ownership under tini cleanly — tini still reaps the foundational
+# children (Postgres, Redis, Honcho, sidecar) launched above.
+log "Launching Hermes (overlay plugins enabled)..."
 export PYTHONPATH="/app/adapter:/app:${PYTHONPATH:-}"
 export AIE_CUSTOMER_YAML="${CUSTOMER_YAML}"
 export AIE_SKILLS_DIR="/app/skills"
 export AIE_CONNECTORS_DIR="/app/connectors"
 
-# ---------- Step 6: start Hermes ----------
-# Container already runs as the hermes user (Dockerfile sets USER hermes).
-# The Hermes CLI loads skills from $HERMES_HOME/skills/ — bootstrap has
-# already symlinked /app/skills/ into the customer's volume.
-log "Symlinking skill library into HERMES_HOME..."
-mkdir -p "${HERMES_HOME}/skills"
-ln -sfn /app/skills/* "${HERMES_HOME}/skills/" 2>/dev/null || true
-
-log "Container alive; ready for interactive Hermes sessions via 'fly ssh console'"
-# Phase A: the container stays alive so Captain can SSH in and run
-# `hermes chat` or `hermes cron` interactively. We don't start a long-running
-# agent loop here because customer-zero's gateway is `cli` (per customer.yaml)
-# — there's nothing to listen on. Future gateways (Slack, email, AgentMail
-# inbox) become the foreground process when wired in.
-#
-# To use:
-#   fly ssh console -a hermes-smd
-#   /opt/hermes/.venv/bin/hermes chat                    # interactive REPL
-#   /opt/hermes/.venv/bin/hermes cron                    # run scheduled skills
-#   /opt/hermes/.venv/bin/hermes mcp list                # list configured MCP servers
-#
-# Phase A.5 swaps this for the AIEmployee-wrapped gateway command once the
-# adapter is registered with Hermes' tool dispatch.
-exec tail -f /dev/null
+exec /opt/hermes/.venv/bin/hermes chat

--- a/ai-employee/templates/fly.toml.template
+++ b/ai-employee/templates/fly.toml.template
@@ -3,6 +3,14 @@
 # Rendered by provision-customer.sh: every {{TOKEN}} substituted before
 # `fly deploy`. The template is the only fly.toml the repo holds; per-
 # customer rendered output is gitignored.
+#
+# Architecture (per §6 of the build plan):
+#   - Single Machine, single container, multi-process supervised by tini.
+#   - Inside the container: Postgres + Redis + Honcho (FastAPI) + Hermes
+#     Agent + customer-sync sidecar + the four hermes-smd-overlay plugins.
+#   - customer.yaml is NOT baked into the image. bootstrap.sh fetches it
+#     from R2 on first boot. The customer-sync sidecar polls R2 for
+#     non-structural edits at a 5-minute cadence.
 
 app = "hermes-{{CUSTOMER_SLUG}}"
 primary_region = "{{FLY_REGION}}"
@@ -17,22 +25,46 @@ primary_region = "{{FLY_REGION}}"
     HERMES_REF = "{{HERMES_REF}}"
     CUSTOMER_SLUG = "{{CUSTOMER_SLUG}}"
 
-# Persistent volume for Hermes state (SQLite + markdown vault + session files).
-# Memory layer per the stack eval also writes to D1/R2/Vectorize via MCP, but
-# Hermes' own local state lives here.
+# Persistent volume hosting (10GB, was 1GB pre-§6 rework):
+#   /opt/data/customer.yaml         — R2-mirrored live config (ADR 0019)
+#   /opt/data/honcho/pg/            — Postgres data dir (Honcho's store)
+#   /opt/data/honcho/redis/         — Redis AOF (Honcho's cache)
+#   /opt/data/audit.db              — per-customer audit log SQLite
+#   /opt/data/observations.db       — Honcho-mirror SQLite (ADR 0016)
+#   /opt/data/profiles/<slug>/      — Hermes per-persona profiles (ADR 0011)
+#   /opt/data/oauth/                — per-provider OAuth token files (ADR 0010)
+#   /opt/data/voice/samples-cache/  — voice samples warm cache (R2-backed)
+# 10GB headroom accommodates Postgres + Redis + SQLite growth and the voice
+# samples cache; we don't want to manage per-customer disk pressure.
 [mounts]
   source = "hermes_state"
   destination = "/opt/data"
 
 [env]
+  # Hermes runtime
   HERMES_HOME = "/opt/data"
   CUSTOMER_SLUG = "{{CUSTOMER_SLUG}}"
   HERMES_LOG_LEVEL = "info"
-  # AIEmployee adapter reads /app/customer.yaml at boot for skill version pins
-  # and trust-ceiling config; no env var needed.
 
-# Smallest machine class for customer-zero / lightweight workloads. Per-customer
-# customer.yaml can override via provision-customer.sh's --machine-size flag.
+  # R2 config bucket — bucket NAME is not a credential; the keys are
+  # (set via fly secrets). bootstrap.sh fetches s3://${R2_BUCKET_CONFIG}/vaults/${CUSTOMER_SLUG}/customer.yaml
+  # on first boot and the customer-sync sidecar polls the same key.
+  R2_BUCKET_CONFIG = "{{R2_BUCKET_CONFIG}}"
+
+  # Per-customer SQLite paths. The hermes-smd-audit and hermes-smd-memory-mirror
+  # plugins resolve these to absolute file paths under the mounted volume.
+  SMD_D1_AUDIT_BINDING = "/opt/data/audit.db"
+  SMD_D1_OBSERVATIONS_BINDING = "/opt/data/observations.db"
+
+  # Honcho is in-container. The plugin code reaches it on localhost; the
+  # Postgres database URL points at the in-container Postgres that bootstrap.sh
+  # starts before Honcho. Per ADR 0016, Honcho runs unmodified, stock binary.
+  HONCHO_BASE_URL = "http://localhost:8000"
+  HONCHO_DATABASE_URL = "postgresql://honcho@localhost:5432/honcho"
+
+# Smallest sensible machine class. Postgres + Redis + Honcho + Hermes need
+# more memory than the pre-§6 1024MB single-process Hermes did. Per-customer
+# customer.yaml.machine.memory_mb overrides this default at render time.
 [[vm]]
   size = "{{MACHINE_SIZE}}"
   memory = "{{MEMORY_MB}}"
@@ -40,13 +72,15 @@ primary_region = "{{FLY_REGION}}"
   cpus = 1
 
 # No public HTTP service — Hermes operates over MCP/gateway adapters, not as
-# a web server. SSH-only access via `fly ssh console`. No `[[services]]` block
-# because we don't expose ports; no `[processes]` block because the Dockerfile
-# ENTRYPOINT (tini -- bootstrap.sh) is the only process.
+# a web server. Honcho's FastAPI server binds to localhost only. SSH-only
+# access via `fly ssh console`. No `[[services]]` block because we don't
+# expose ports; no `[processes]` block because the Dockerfile ENTRYPOINT
+# (tini -- bootstrap.sh) is the only process and tini supervises the rest.
 
-# Restart policy: if the agent loop crashes, Fly restarts it. The safety
-# substrate re-runs on every start, so an unhealthy build can't loop into
-# production behavior.
+# Restart policy: if any child process under tini dies, tini reaps it and
+# bootstrap.sh re-sequences. If the whole container exits non-zero, Fly
+# restarts it. The safety substrate re-runs on every start, so an unhealthy
+# build can't loop into production behavior.
 [[restart]]
   policy = "on-failure"
   max_retries = 3

--- a/ai-employee/templates/fly.toml.template
+++ b/ai-employee/templates/fly.toml.template
@@ -23,6 +23,7 @@ primary_region = "{{FLY_REGION}}"
   dockerfile = "../../templates/Dockerfile"
   [build.args]
     HERMES_REF = "{{HERMES_REF}}"
+    HERMES_UPSTREAM_SHA = "{{HERMES_UPSTREAM_SHA}}"
     CUSTOMER_SLUG = "{{CUSTOMER_SLUG}}"
 
 # Persistent volume hosting (10GB, was 1GB pre-§6 rework):


### PR DESCRIPTION
## Summary

Reworks the customer Machine to host the full per-customer substrate: self-hosted Honcho (with Postgres + Redis), the overlay plugins installed at build time, and a sequenced bash bootstrap under tini. Implements §6 of the locked-plan in full.

**6 files changed, 769 insertions, 148 deletions.** Two parallel sub-agents handled their chunks; lead consolidated.

## What's in here

### `ai-employee/templates/bootstrap.sh` — 11-step dependency sequence

Validate env → fetch customer.yaml from R2 → start Postgres → start Redis → run Honcho migrations → start Honcho FastAPI → \`hermes-smd bootstrap\` (translates personas[] into N profile dirs) → safety-substrate invariants → pause guard → customer-sync sidecar → \`exec hermes chat\`.

Postgres/Redis/Honcho run under a \`supervise()\` bash wrapper that restarts on crash with 5s backoff. tini is PID 1 and reaps zombies. No supervisord/s6 — explicit sequencing at this scale is more legible.

**Preserved verbatim from the prior bootstrap**: env validation pattern, safety-substrate invocation (Phase A.5 gate), and the pause-guard block.

### \`ai-employee/templates/Dockerfile\` — Hermes v2026.5.16 + Postgres + Redis + Honcho + overlay

- HERMES_REF default v2026.5.7 → v2026.5.16 (matches the pinned ref in \`venturecrane/hermes-smd-overlay/docs/hook-surface.md\`).
- Adds postgresql-16, postgresql-client-16, redis-server, awscli, python3-pip, python3-venv.
- pip-installs honcho-ai==1.0.0 into the Hermes venv.
- pip-installs the \`hermes-smd\` CLI from \`venturecrane/hermes-smd-overlay@feat/section-7-adapter-port\` (TODO: pin to a tag once that PR merges).
- Runs \`hermes plugins install venturecrane/hermes-smd-overlay --enable\` at build time.
- **Removes** \`COPY .../customer.yaml /app/customer.yaml\` — R2-first storage model means the file is no longer baked into the image.
- Pre-creates \`/opt/data/honcho/{pg,redis}\` owned by hermes:hermes so first-boot initdb works under the non-root user.

### \`ai-employee/bin/provision-customer.sh\` — R2-first storage

Preserves the pbpaste secret-entry flow (values never echoed), the idempotent app/volume create, the validator call, and the connector smoke-test step.

Adds:
- Upload \`customer.yaml\` to R2 at \`vaults/<slug>/customer.yaml\` before deploy.
- Generate \`HONCHO_API_KEY\` via \`openssl rand -hex 32\` and pipe straight to \`fly secrets import --stage\` over stdin (value never appears in transcript or shell history).
- Stage \`R2_ACCESS_KEY_ID\`, \`R2_SECRET_ACCESS_KEY\`, \`R2_ENDPOINT_URL\` via the same pbpaste flow.
- Invoke the new \`boot-smoke-test.sh\` as the final verification step.

### \`ai-employee/templates/fly.toml.template\` — substrate-sized

- Volume size 10GB (was 1GB) for Postgres + Redis + SQLite + R2 cache + voice samples.
- Default memory_mb floor bumped to 2048MB; per-customer customer.yaml.machine overrides still apply.
- New \`[env]\` entries: R2_BUCKET_CONFIG, SMD_D1_AUDIT_BINDING, SMD_D1_OBSERVATIONS_BINDING, HONCHO_BASE_URL, HONCHO_DATABASE_URL.

### \`ai-employee/bin/boot-smoke-test.sh\` (NEW)

Polls Fly state up to 60s, then runs seven SSH-exec checks: Postgres reachable, Redis reachable, Honcho \`/health\`, customer.yaml on volume, profiles dir materialized, overlay plugins installed. PASS/FAIL per step; exits non-zero on any failure.

Documented as a **smoke test** (substrate wired up), not a full end-to-end (no real agent turn, no real D1 write — those require live MCP connections).

### \`ai-employee/templates/README.md\` — refreshed

Documents the new storage layout, the 11-step boot sequence, Honcho degrade-don't-gate semantics, the structural-vs-non-structural change rule, the operating runbook (pause/decommission/smoke/evidence), and ADR cross-references (0007, 0010, 0016, 0019, 0020).

## Architectural posture preserved

- **Per-customer Machine isolation** (ADR 0007): Postgres + Redis + Honcho all run inside the Machine boundary. No shared-tenant routing.
- **OAuth tokens on volume** (ADR 0010): nothing in this PR moves them. Volume layout in README documents the path.
- **Mirror, don't gate** (ADR 0016): Honcho runs unmodified at the upstream pin; the memory-mirror plugin observes via the on_session_end hook (already ported in §7).
- **customer.yaml structural-vs-non-structural rule** (ADR 0019): documented in README; customer-sync sidecar handles non-structural without restart, flags structural for Captain re-provision.

## Stacking + dependencies

This PR depends on:
- \`venturecrane/hermes-smd-overlay\` PR #1 (initial scaffold) and PR #2 (§7 logic port) being merged + a release tag created. The Dockerfile currently pip-installs from \`feat/section-7-adapter-port\` branch; **must be pinned to a tag** before any production deploy.

This PR does NOT depend on PR #1034 (ADR rewrites) — but the architectural decisions it implements come from those ADRs.

## What's next

- **§1** — Delete superseded adapter code from \`ss-console\`: GEPA scaffolding, \`honcho_interceptor\`, \`curator_interceptor\`, \`smd.hooks.*\` registration. Now safe to run since §6 + §7 give the overlay a working home.
- **§5** — Tag \`venturecrane/hermes-agent\` at \`v2026.5.16-smd.0\` (pin-only fork).
- **§2** — SKILL.md format conformance.

## Test plan

- [ ] Captain: review bootstrap.sh's 11-step sequence against the locked plan §6
- [ ] Captain: confirm the R2-first storage model + the operator workflow it implies (R2 creds on operator machine for the upload step)
- [ ] CI: pre-commit hooks pass
- [ ] Manual: \`bash -n\` on all three shell scripts (already verified locally)
- [ ] After overlay PR #2 merges + tags: pin the Dockerfile install to that tag and rebuild a customer Machine end-to-end
- [ ] After end-to-end smoke: provision a fresh customer via \`provision-customer.sh\` and confirm boot-smoke-test.sh passes all seven checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)