### PR TITLE
feat(§5): tighten hermes_ref fork-tag regex per rewritten ADR 0015

### DIFF
--- a/src/lib/ai-employee/customer-yaml/helpers.ts
+++ b/src/lib/ai-employee/customer-yaml/helpers.ts
@@ -31,18 +31,21 @@ export function checkRequiredString(
   }
 }
 
-// Fork-tag pattern per ADR 0015 (docs/adr/0015-hermes-fork-vs-upstream.md).
-// hermes_ref MUST pin a fork tag of the form v{semver}-smd.{n}:
-//   - {semver} is a SemVer-2.0 core version (X.Y.Z, with optional pre-release
-//     and build metadata). The fork's tag scheme uses date-based upstream
-//     references (e.g. v2026.5.7); SemVer accommodates that since each
-//     dot-separated identifier is numeric.
+// Fork-tag pattern per ADR 0015 (docs/adr/0015-hermes-fork-vs-upstream.md, rewritten).
+// hermes_ref MUST pin a fork tag of the form v{YYYY}.{M}.{D}-smd.{n} or
+// v{YYYY}.{M}.{D}-smd.security.{n}:
+//   - {YYYY}.{M}.{D} is Hermes' date-based upstream version (e.g. v2026.5.16).
+//     Legacy SemVer upstream tags (v0.14.0) are no longer accepted; Hermes
+//     switched to date-based tagging in 2026.
 //   - {n} is a non-negative integer SMD revision counter (0 for "fork exists,
-//     no SMD code yet"; increments per SMD-side change).
+//     zero patches"; increments per SMD-side change).
+//   - The optional `security.` segment marks an emergency CVE patch (see
+//     venturecrane/hermes-agent SMD_FORK_POLICY.md "Security-patch escape
+//     valve"). Emergency patches must be upstream-merged or retired within
+//     30 days per the policy.
 // Bare upstream tags (no -smd.N suffix) are rejected: per ADR 0015 §Decision,
 // customer.yaml pins the fork ref, not the upstream ref.
-const FORK_TAG_PATTERN =
-  /^v(?:0|[1-9]\d*)(?:\.(?:0|[1-9]\d*))+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?-smd\.(?:0|[1-9]\d*)$/
+const FORK_TAG_PATTERN = /^v\d{4}\.\d{1,2}\.\d{1,2}-smd\.(security\.)?\d+$/
 
 export function checkHermesRef(root: Record<string, unknown>, errors: ValidationError[]): void {
   const v = root['hermes_ref']
@@ -54,9 +57,10 @@ export function checkHermesRef(root: Record<string, unknown>, errors: Validation
       code: 'InvalidFormat',
       path: 'hermes_ref',
       message:
-        'hermes_ref must pin a fork tag of the form v{upstream}-smd.{n} ' +
-        '(e.g. v2026.5.7-smd.0); bare upstream tags are not accepted. ' +
-        'See ADR 0015 and venturecrane/hermes-agent releases.',
+        'hermes_ref must pin a fork tag of the form v{YYYY}.{M}.{D}-smd.{n} ' +
+        'or v{YYYY}.{M}.{D}-smd.security.{n} (e.g. v2026.5.16-smd.0); ' +
+        'bare upstream tags and legacy SemVer-style tags are not accepted. ' +
+        'See ADR 0015 and venturecrane/hermes-agent SMD_FORK_POLICY.md.',
     })
   }
 }

--- a/tests/customer-yaml-validator.test.ts
+++ b/tests/customer-yaml-validator.test.ts
@@ -790,16 +790,34 @@ describe('validate — hermes_ref fork-tag enforcement (ADR 0015)', () => {
     expect(validate(f).ok).toBe(true)
   })
 
-  it('accepts a fork tag built on a SemVer upstream', () => {
+  it('accepts a security-patch fork tag (escape-valve shape)', () => {
     const f = validFixture()
-    f['hermes_ref'] = 'v0.14.0-smd.0'
+    f['hermes_ref'] = 'v2026.5.16-smd.security.0'
     expect(validate(f).ok).toBe(true)
   })
 
-  it('accepts a fork tag with SemVer pre-release identifiers', () => {
+  it('accepts a security-patch tag at higher iteration', () => {
+    const f = validFixture()
+    f['hermes_ref'] = 'v2026.5.16-smd.security.7'
+    expect(validate(f).ok).toBe(true)
+  })
+
+  it('rejects legacy SemVer-style upstream tags (Hermes moved to date-based tags in 2026)', () => {
+    const f = validFixture()
+    f['hermes_ref'] = 'v0.14.0-smd.0'
+    const r = validate(f)
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(codesOf(r.errors)).toContain('InvalidFormat')
+  })
+
+  it('rejects SemVer pre-release identifiers', () => {
     const f = validFixture()
     f['hermes_ref'] = 'v0.14.0-rc.1-smd.0'
-    expect(validate(f).ok).toBe(true)
+    const r = validate(f)
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(codesOf(r.errors)).toContain('InvalidFormat')
   })
 
   it('rejects a bare upstream tag (no -smd.N suffix)', () => {
@@ -838,13 +856,16 @@ describe('validate — hermes_ref fork-tag enforcement (ADR 0015)', () => {
     expect(codesOf(r.errors)).toContain('InvalidFormat')
   })
 
-  it('rejects an -smd.N counter with leading zeros', () => {
+  // The rewritten ADR 0015 regex (^v\d{4}\.\d{1,2}\.\d{1,2}-smd\.(security\.)?\d+$)
+  // intentionally allows any decimal counter shape, including leading zeros.
+  // The original regex's leading-zero rejection was a defensive invariant
+  // that the rewritten ADR did not carry forward; operationally, fork-tag
+  // counters are author-controlled and the linter on the fork repo catches
+  // shape violations before any customer.yaml sees the value.
+  it('accepts an -smd.N counter with leading zeros (per rewritten ADR 0015)', () => {
     const f = validFixture()
     f['hermes_ref'] = 'v2026.5.7-smd.01'
-    const r = validate(f)
-    expect(r.ok).toBe(false)
-    if (r.ok) return
-    expect(codesOf(r.errors)).toContain('InvalidFormat')
+    expect(validate(f).ok).toBe(true)
   })
 
   it('rejects an arbitrary content-hash SHA', () => {


### PR DESCRIPTION
## Summary

Implements the ss-console-side of §5 of the locked-plan Hermes alignment work — tightens \`customer.yaml.hermes_ref\` validator regex to the date-based shape Hermes uses today + a security-patch escape-valve variant.

**Companion artifacts (already shipped):**
- \`venturecrane/hermes-agent\` tag \`v2026.5.16-smd.0\` pushed (points at upstream commit \`a91a57fa5a\`, zero patches)
- \`venturecrane/hermes-agent\` PR [#7](https://github.com/venturecrane/hermes-agent/pull/7) — adds \`SMD_FORK_POLICY.md\` + \`SMD_CHANGELOG.md\`

## Regex change

**OLD** (permissive SemVer-compatible shape):
\`\`\`
^v(?:0|[1-9]\\d*)(?:\\.(?:0|[1-9]\\d*))+(?:-[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?(?:\\+[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?-smd\\.(?:0|[1-9]\\d*)$
\`\`\`

**NEW** (date-based + security-patch variant per rewritten ADR 0015):
\`\`\`
^v\\d{4}\\.\\d{1,2}\\.\\d{1,2}-smd\\.(security\\.)?\\d+$
\`\`\`

| Tag | Old regex | New regex |
|---|---|---|
| \`v2026.5.16-smd.0\` | accept | accept (initial pin) |
| \`v2026.5.16-smd.7\` | accept | accept (later SMD revision) |
| \`v2026.5.16-smd.security.0\` | reject | **accept** (NEW: CVE escape-valve) |
| \`v2026.5.16-smd.security.7\` | reject | **accept** |
| \`v2026.5.16-smd.01\` | reject | accept (rewritten ADR loosens leading-zero rule) |
| \`v0.14.0-smd.0\` | accept | **reject** (legacy SemVer upstream; Hermes moved to date-based tags in 2026) |
| \`v0.14.0-rc.1-smd.0\` | accept | **reject** (SemVer pre-release) |
| \`v2026.5.16\` | reject | reject (bare upstream) |
| \`v2026.5.16-smd\` | reject | reject (no counter) |
| \`v2026.5.16-smd.beta\` | reject | reject (non-integer) |
| \`2026.5.16-smd.0\` | reject | reject (missing v-prefix) |
| SHA hash | reject | reject |

## Tests

- ✅ Added: acceptance of \`v2026.5.16-smd.security.{0,7}\`
- ✅ Converted: \`v0.14.0-smd.0\` and \`v0.14.0-rc.1-smd.0\` from acceptance to rejection
- ✅ Converted: \`v2026.5.7-smd.01\` (leading zeros) from rejection to acceptance with documenting comment
- ✅ All other existing tests (bare upstream, missing v-prefix, non-integer counter, missing counter, SHA) continue to pass against the new regex

## ADR alignment

Per rewritten ADR 0015 (PR #1034): "The validator enforces the \`vYYYY.M.D-smd.N\` shape (regex \`^v\\d{4}\\.\\d{1,2}\\.\\d{1,2}-smd\\.(security\\.)?\\d+$\`)." This PR implements that regex.

## What's NOT in this PR

- **Dockerfile clone-source change** (\`NousResearch/hermes-agent\` → \`venturecrane/hermes-agent\` at the SMD-tagged ref). That belongs in PR #1035 (§6 Machine architecture) or a separate follow-on after #1035 merges.
- **CI assertion** that the installed Hermes commit SHA matches upstream at the tagged ref. Same follow-on scope.
- **Cleanup of fork \`main\` branch** back to upstream (currently carries legacy \`smd/hooks/*\` commits from fork PRs #4/#5/#6). Requires Captain-authorized force-push; deferred until Captain explicitly directs.

## Test plan

- [ ] CI: TypeScript compiles
- [ ] CI: vitest passes (\`tests/customer-yaml-validator.test.ts\`)
- [ ] CI: pre-existing tests still pass (no behavior change on accepted shapes)
- [ ] Captain: review the regex against the rewritten ADR 0015 spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)