### PR TITLE
fix(db): break entities ↔ entities-extra import cycle

### DIFF
--- a/src/lib/db/entities.ts
+++ b/src/lib/db/entities.ts
@@ -656,5 +656,7 @@ export async function transitionStage(
  */
 // Re-export slug utility for convenience
 export { computeSlug } from '../entities/slug.js'
-// Re-export extended entity queries (extracted to stay within file-line ceiling)
-export { getLatestLostReasonsByEntity, mergeEntities } from './entities-extra.js'
+// Extended entity queries live in entities-extra.ts (extracted to stay within
+// file-line ceiling). Import them directly from there — re-exporting through
+// this module creates an entities ↔ entities-extra cycle that Vite warns
+// about during chunked production builds (see PR #1039).

--- a/src/pages/admin/entities/index.astro
+++ b/src/pages/admin/entities/index.astro
@@ -7,11 +7,11 @@ import { buildEntityRowView } from '../../../lib/admin/entity-row-view'
 import {
   listEntities,
   countEntitiesPerStage,
-  getLatestLostReasonsByEntity,
   getSignalMetadataForEntities,
   ENTITY_STAGES,
 } from '../../../lib/db/entities'
 import type { Entity, EntityStage, EntitySignalMetadata } from '../../../lib/db/entities'
+import { getLatestLostReasonsByEntity } from '../../../lib/db/entities-extra'
 import { getActiveQuotesForEntities, getQuotesForEntities } from '../../../lib/db/quotes'
 import type { Quote } from '../../../lib/db/quotes'
 import { getMeetingsForEntities } from '../../../lib/db/meetings'

--- a/src/pages/api/admin/entities/[id]/merge.ts
+++ b/src/pages/api/admin/entities/[id]/merge.ts
@@ -1,5 +1,5 @@
 import type { APIRoute } from 'astro'
-import { mergeEntities } from '../../../../../lib/db/entities'
+import { mergeEntities } from '../../../../../lib/db/entities-extra'
 import { env } from 'cloudflare:workers'
 
 /**

--- a/tests/lost-reason.test.ts
+++ b/tests/lost-reason.test.ts
@@ -22,12 +22,8 @@ import {
 import { resolve } from 'path'
 import type { D1Database } from '@cloudflare/workers-types'
 
-import {
-  createEntity,
-  transitionStage,
-  getLatestLostReasonsByEntity,
-  type EntityStage,
-} from '../src/lib/db/entities'
+import { createEntity, transitionStage, type EntityStage } from '../src/lib/db/entities'
+import { getLatestLostReasonsByEntity } from '../src/lib/db/entities-extra'
 import { LOST_REASONS, isLostReasonCode } from '../src/lib/db/lost-reasons'
 
 const migrationsDir = resolve(process.cwd(), 'migrations')


### PR DESCRIPTION
## Summary

Vite warned during chunked production builds that \`src/lib/db/entities.ts\` and \`src/lib/db/entities-extra.ts\` form a module-level cycle: \`entities-extra\` imports \`getEntity\` + \`Entity\` from \`entities\`, and \`entities\` re-exports \`getLatestLostReasonsByEntity\` + \`mergeEntities\` back through itself. In chunked production builds the two files land in different chunks and module init order isn't guaranteed.

Pre-existing since PR #722 (2026-05-06); cleanup pulled out of the Hermes-alignment build verification.

## Changes

| File | Change |
|---|---|
| \`src/lib/db/entities.ts:660\` | Drop the re-export; leave a comment pointing future callers at \`entities-extra\` directly |
| \`src/pages/admin/entities/index.astro\` | Import \`getLatestLostReasonsByEntity\` from \`entities-extra\` |
| \`src/pages/api/admin/entities/[id]/merge.ts\` | Import \`mergeEntities\` from \`entities-extra\` |
| \`tests/lost-reason.test.ts\` | Import \`getLatestLostReasonsByEntity\` from \`entities-extra\` (caught by failing test on first iteration) |

## Verification

- \`npm test\` → 2742 passed / 2 skipped / 0 failed
- \`npm run build\` → \`astro build\` clean, no circular-dependency warnings

## Test plan

- [ ] CI: typecheck, lint, format, test all pass
- [ ] CI: no Vite circular-dep warnings in the build log
- [ ] Spot-check the entities admin list page renders Lost reasons correctly
- [ ] Spot-check the entity merge API still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)