### PR TITLE
feat(ui): unify SMD logo lockup across marketing, admin, and portal

### DIFF
--- a/.design/NAVIGATION.md
+++ b/.design/NAVIGATION.md
@@ -1010,29 +1010,28 @@ Base URL: `portal.smd.services`. Authenticated client.
 
 ## C.1 Chrome allowed
 
-### Header (three-icon contact control)
+### Header (SmdLogo + client name + three-icon contact control)
+
+**Revised 2026-05-25 (Captain decision):** Single SMD lockup across all surfaces beats client-first signaling for brand consistency. Marketing, admin, and portal now share `src/components/SmdLogo.astro`; the portal post-auth header carries the lockup on the left and demotes the client name to a smaller secondary label.
 
 ```html
-<header role="banner" class="sticky top-0 z-50 bg-white border-b border-[#e2e8f0] h-14 md:h-16">
-  <div class="max-w-5xl mx-auto h-full flex items-center justify-between gap-4 px-4 md:px-6">
-    <p class="text-[13px] leading-[18px] font-medium tracking-[0.01em] text-[#475569] truncate"><client name></p>
+<header role="banner" class="sticky top-0 z-50 h-14 md:h-16 w-full bg-[color:var(--ss-color-background)] border-b-[3px] border-[color:var(--ss-color-text-primary)]">
+  <div class="max-w-5xl mx-auto h-full px-4 md:px-6 flex items-center justify-between gap-stack">
+    <div class="flex items-baseline gap-3 md:gap-4 min-w-0">
+      <SmdLogo href="/portal" />
+      <p class="hidden sm:block font-['Archivo_Narrow'] text-xs font-semibold uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)] truncate">
+        <client name>
+      </p>
+    </div>
     <div class="flex items-center gap-1">
-      <a href="mailto:<email>" aria-label="Email Scott" class="inline-flex items-center justify-center w-11 h-11 rounded-lg text-[#475569] hover:text-[#1e40af] active:text-[#1e40af] focus-visible:ring-2 focus-visible:ring-[#3b82f6] focus-visible:ring-offset-2">
-        <span class="material-symbols-outlined" aria-hidden="true">mail</span>
-      </a>
-      <a href="sms:<phone>" aria-label="Text Scott" class="inline-flex items-center justify-center w-11 h-11 rounded-lg text-[#475569] hover:text-[#1e40af] active:text-[#1e40af] focus-visible:ring-2 focus-visible:ring-[#3b82f6] focus-visible:ring-offset-2">
-        <span class="material-symbols-outlined" aria-hidden="true">sms</span>
-      </a>
-      <a href="tel:<phone>" aria-label="Call Scott" class="inline-flex items-center justify-center w-11 h-11 rounded-lg text-[#475569] hover:text-[#1e40af] active:text-[#1e40af] focus-visible:ring-2 focus-visible:ring-[#3b82f6] focus-visible:ring-offset-2">
-        <span class="material-symbols-outlined" aria-hidden="true">call</span>
-      </a>
+      <!-- email / sms / tel icons unchanged -->
       <slot /> <!-- host page may pass Sign out form -->
     </div>
   </div>
 </header>
 ```
 
-Shipped component: `src/components/portal/PortalHeader.astro`.
+Shipped component: `src/components/portal/PortalHeader.astro`. Logo primitive: `src/components/SmdLogo.astro`.
 
 ### Back affordance (detail archetypes)
 
@@ -1068,9 +1067,8 @@ Universal anti-patterns. Additionally:
 
 - Breadcrumbs — never
 - Sticky-bottom action bar — primary action in ActionCard above the fold
-- Logo in header — client name identifies context
 
-(Note: v2 forbade "Global nav tabs" on portal. v3 rescinds this: persistent tabs are the pattern on portal per §4.4. Nav tabs remain forbidden on `token-auth` and `public` surfaces.)
+(Note: v2 forbade "Global nav tabs" on portal. v3 rescinds this: persistent tabs are the pattern on portal per §4.4. Nav tabs remain forbidden on `token-auth` and `public` surfaces. The v2 "Logo in header — never" rule was reversed 2026-05-25 per §C.1.)
 
 ## C.3 Archetype-specific notes
 

--- a/src/components/AuthHeader.astro
+++ b/src/components/AuthHeader.astro
@@ -2,12 +2,14 @@
 /**
  * Brand header for unauthenticated routes (sign-in / sign-up / verify).
  *
- * Same monogram and chrome as Nav.astro (the marketing site header) so
- * the auth surfaces feel like part of the same site. No nav links and
- * no CTA — those would distract from the sign-in flow. Optional
- * cross-link (Sign in ↔ Create account) renders on the right when a
+ * Uses the shared SmdLogo component — same lockup as marketing Nav,
+ * admin chrome, and portal post-auth header. No nav links and no CTA;
+ * those would distract from the sign-in flow. Optional cross-link
+ * (Sign in ↔ Create account) renders on the right when a
  * crossLinkHref/Label pair is provided.
  */
+
+import SmdLogo from './SmdLogo.astro'
 
 interface Props {
   crossLinkHref?: string
@@ -24,20 +26,7 @@ const { crossLinkHref, crossLinkLabel } = Astro.props
   <div
     class="mx-auto flex h-14 md:h-16 w-full max-w-5xl items-center justify-between gap-3 px-4 md:px-6"
   >
-    <a
-      href="/"
-      aria-label="SMD Services"
-      class="inline-flex items-baseline gap-2 text-base md:text-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2"
-    >
-      <span
-        class="inline-block bg-[color:var(--ss-color-primary)] px-1.5 py-0.5 font-['Archivo'] font-black uppercase leading-none tracking-tight text-white"
-        >SMD</span
-      >
-      <span
-        class="font-['Archivo_Narrow'] font-semibold uppercase tracking-[0.08em] leading-none text-[color:var(--ss-color-text-primary)]"
-        >Services</span
-      >
-    </a>
+    <SmdLogo />
 
     {
       crossLinkHref && crossLinkLabel && (

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -1,4 +1,6 @@
 ---
+import SmdLogo from './SmdLogo.astro'
+
 const navLinks = [
   { href: '/ai-employee', label: 'AI Employee' },
   { href: '/contact', label: 'Contact' },
@@ -12,20 +14,7 @@ const navLinks = [
   <div
     class="mx-auto flex h-14 md:h-16 w-full max-w-5xl items-center justify-between gap-3 px-4 md:px-6"
   >
-    <a
-      href="/"
-      aria-label="SMD Services"
-      class="inline-flex items-baseline gap-2 text-base md:text-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2"
-    >
-      <span
-        class="inline-block bg-[color:var(--ss-color-primary)] px-1.5 py-0.5 font-['Archivo'] font-black uppercase leading-none tracking-tight text-white"
-        >SMD</span
-      >
-      <span
-        class="font-['Archivo_Narrow'] font-semibold uppercase tracking-[0.08em] leading-none text-[color:var(--ss-color-text-primary)]"
-        >Services</span
-      >
-    </a>
+    <SmdLogo />
 
     <div class="flex items-center gap-3 md:gap-6">
       {
@@ -71,21 +60,7 @@ const navLinks = [
     <!-- Overlay header: mirrors the bar structure so there is no visual jump.
          Brand on the left, Close on the right. -->
     <div class="flex h-14 flex-none items-center justify-between px-4 border-b-[3px] border-white">
-      <a
-        href="/"
-        aria-label="SMD Services"
-        class="inline-flex items-baseline gap-2 text-base focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--ss-color-surface-inverse)]"
-        data-nav-link
-      >
-        <span
-          class="inline-block bg-[color:var(--ss-color-primary)] px-1.5 py-0.5 font-['Archivo'] font-black uppercase leading-none tracking-tight text-white"
-          >SMD</span
-        >
-        <span
-          class="font-['Archivo_Narrow'] font-semibold uppercase tracking-[0.08em] leading-none text-white"
-          >Services</span
-        >
-      </a>
+      <SmdLogo inverse data-nav-link />
       <button
         type="button"
         aria-label="Close menu"

--- a/src/components/SmdLogo.astro
+++ b/src/components/SmdLogo.astro
@@ -1,0 +1,65 @@
+---
+/**
+ * Shared SMD brand lockup: orange "SMD" block + "Services" wordmark.
+ *
+ * Single source of truth for the SMD identity across marketing, admin,
+ * and portal surfaces. The marketing site (Nav.astro) is the canonical
+ * model — admin and portal align to it.
+ *
+ * Variants:
+ *   - <SmdLogo />                       canonical (sticky header, auth chrome)
+ *   - <SmdLogo inverse />               white wordmark for ink overlays (mobile dialog)
+ *   - <SmdLogo badge="Admin" href="/admin" />  admin top bar
+ *   - <SmdLogo href="/portal" />        portal chrome
+ */
+
+interface Props {
+  href?: string
+  inverse?: boolean
+  badge?: string
+  [key: `data-${string}`]: string | boolean | undefined
+}
+
+const { href = '/', inverse = false, badge, ...rest } = Astro.props
+
+const wordmarkColor = inverse ? 'text-white' : 'text-[color:var(--ss-color-text-primary)]'
+const badgeColor = inverse ? 'text-white' : 'text-[color:var(--ss-color-text-primary)]'
+const badgeBorder = inverse ? 'border-white' : 'border-[color:var(--ss-color-text-primary)]'
+const focusRingOffset = inverse
+  ? 'focus-visible:ring-offset-[color:var(--ss-color-surface-inverse)]'
+  : ''
+---
+
+<a
+  href={href}
+  aria-label={badge ? `SMD Services ${badge}` : 'SMD Services'}
+  class:list={[
+    'inline-flex items-baseline gap-2 text-base md:text-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2',
+    focusRingOffset,
+  ]}
+  {...rest}
+>
+  <span
+    class="inline-block bg-[color:var(--ss-color-primary)] px-1.5 py-0.5 font-['Archivo'] font-black uppercase leading-none tracking-tight text-white"
+    >SMD</span
+  >
+  <span
+    class:list={[
+      "font-['Archivo_Narrow'] font-semibold uppercase tracking-[0.08em] leading-none",
+      wordmarkColor,
+    ]}>Services</span
+  >
+  {
+    badge && (
+      <span
+        class:list={[
+          "font-['Archivo_Narrow'] text-[11px] font-bold uppercase tracking-[0.14em] border px-2 py-0.5 leading-none",
+          badgeColor,
+          badgeBorder,
+        ]}
+      >
+        {badge}
+      </span>
+    )
+  }
+</a>

--- a/src/components/portal/PortalHeader.astro
+++ b/src/components/portal/PortalHeader.astro
@@ -1,9 +1,10 @@
 ---
 /**
- * Minimal portal top band. Per .design/NAVIGATION.md §C.1:
+ * Portal top band. Per .design/NAVIGATION.md §C.1 (revised 2026-05-25):
  *
  * - sticky top-0, h-14 md:h-16 on <header> (not the inner div)
- * - Client name on the left, stands alone (no logo, no decoration)
+ * - Shared SmdLogo on the left (brand consistency across marketing / admin /
+ *   portal); client name as a smaller secondary label after the logo.
  * - Three-icon contact control on the right: email / SMS / phone. Each
  *   channel only renders when we have data for it. Clients pick the channel
  *   that works for them — spec decision: "clients know what they want."
@@ -12,6 +13,8 @@
  * The full team member block (avatar + role + next-touchpoint) lives in
  * ConsultantBlock.astro.
  */
+
+import SmdLogo from '../SmdLogo.astro'
 
 interface Props {
   clientName: string
@@ -45,11 +48,14 @@ const iconClasses =
   class="sticky top-0 z-50 h-14 md:h-16 w-full bg-[color:var(--ss-color-background)] border-b-[3px] border-[color:var(--ss-color-text-primary)]"
 >
   <div class="max-w-5xl mx-auto h-full px-4 md:px-6 flex items-center justify-between gap-stack">
-    <p
-      class="font-['Archivo_Narrow'] text-sm font-bold uppercase tracking-[0.18em] text-[color:var(--ss-color-text-primary)] truncate"
-    >
-      {clientName}
-    </p>
+    <div class="flex items-baseline gap-3 md:gap-4 min-w-0">
+      <SmdLogo href="/portal" />
+      <p
+        class="hidden sm:block font-['Archivo_Narrow'] text-xs font-semibold uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)] truncate"
+      >
+        {clientName}
+      </p>
+    </div>
     <div class="flex items-center gap-1">
       {
         mailtoHref && (

--- a/src/layouts/AdminLayout.astro
+++ b/src/layouts/AdminLayout.astro
@@ -1,6 +1,7 @@
 ---
 import '../styles/global.css'
 import SkipToMain from '../components/SkipToMain.astro'
+import SmdLogo from '../components/SmdLogo.astro'
 
 interface BreadcrumbItem {
   label: string
@@ -69,17 +70,7 @@ const navItems = [
       class="sticky top-0 z-50 h-14 md:h-16 bg-[color:var(--ss-color-background)] border-b-[3px] border-[color:var(--ss-color-text-primary)]"
     >
       <div class={`${maxWidth} mx-auto h-full px-4 md:px-6 flex items-center justify-between`}>
-        <div class="flex items-center gap-3">
-          <a
-            href="/admin"
-            class="font-['Archivo'] text-lg font-black uppercase tracking-[-0.01em] text-[color:var(--ss-color-text-primary)] hover:text-[color:var(--ss-color-primary)] active:text-[color:var(--ss-color-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2 transition-colors"
-            >SMD Services</a
-          >
-          <span
-            class="font-['Archivo_Narrow'] text-[11px] font-bold uppercase tracking-[0.14em] border border-[color:var(--ss-color-text-primary)] px-2 py-0.5 text-[color:var(--ss-color-text-primary)]"
-            >Admin</span
-          >
-        </div>
+        <SmdLogo href="/admin" badge="Admin" />
 
         <!-- Desktop: inline nav tabs + email + sign out -->
         <div class="hidden md:flex items-center gap-4">


### PR DESCRIPTION
## Summary

- Extract the marketing logo lockup (orange SMD block + \"Services\" wordmark) into `src/components/SmdLogo.astro`; reuse on every surface.
- Admin top bar now shows the same lockup plus a small `[ADMIN]` pill (via `badge` prop).
- Portal post-auth header shows the lockup on the left with the client name demoted to a secondary `Archivo_Narrow` label.
- Auth pages (sign-in/sign-up) already used `AuthHeader.astro`, which now delegates to `SmdLogo`.

Captain caught three different logos across the three subdomains. Marketing was the model. This is PR 1 of 3 in the style+auth unification plan; PR 2 collapses admin PBKDF2 auth into Clerk, PR 3 decommissions legacy login files.

## Files changed

**Created**
- `src/components/SmdLogo.astro` — shared brand lockup with `href`, `inverse`, `badge`, and rest-attr passthrough props.

**Modified**
- `src/components/Nav.astro` — sticky header + mobile dialog use `SmdLogo`.
- `src/components/AuthHeader.astro` — drops duplicated markup, uses `SmdLogo`.
- `src/layouts/AdminLayout.astro` — uses `<SmdLogo href=\"/admin\" badge=\"Admin\" />` in place of the wordmark + bordered pill.
- `src/components/portal/PortalHeader.astro` — adds `SmdLogo` on the left of the client name.
- `.design/NAVIGATION.md` — updates §C.1 with the new \"SmdLogo + client name\" pattern; reverses the prior \"Logo in header — never\" rule (rationale recorded with the Captain 2026-05-25 decision).

## Test plan

- [x] `npm run lint` — 0 errors (pre-existing Clerk-type warnings only).
- [x] `npm run typecheck` — 0 errors, 0 warnings.
- [x] `npm run test` — 2741 pass.
- [x] `npm run format:check` — clean after Prettier.
- [x] `npm run build` — succeeds.
- [x] `npm run verify` — exit 0.
- [x] Visual verification of marketing home (`http://localhost:4321/`) matches Captain's reference Image 3.
- [ ] Visual verification of admin and portal in a deployed environment after merge (local `astro dev` hits a pre-existing Vite/Clerk dep optimizer error on Clerk-mounted routes — unrelated to this PR, prod build succeeds).
- [ ] Lightweight admin button audit — no `CtaButton` matches the admin form/dialog scales verbatim; admin buttons stay as-is. Documented in the implementation thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)