### PR TITLE
feat(ai-employee): ar-chaser uses execute_code for per-invoice fetch loop

### DIFF
--- a/ai-employee/skills/ar-chaser/SKILL.md
+++ b/ai-employee/skills/ar-chaser/SKILL.md
@@ -51,16 +51,97 @@ hermes run ar-chaser --client "Acme Co"
 
 ## Procedure
 
-1. **Pull AR aging.** QBO Aging Detail report for the agency. Filter invoices past 7+ days.
-2. **For each overdue invoice, decide the cadence step.**
-   - 7-13 days overdue: gentle reminder, blame-the-postal-system tone
-   - 14-29 days: firmer; ask if they need anything to process
-   - 30-44 days: direct; reference payment terms; offer to call
-   - 45+ days: ESCALATE to owner in Slack; do not draft another email (owner needs to call or pause services)
-3. **Draft per the cadence.** Pull the client's prior threads from Gmail to match voice and reference any prior conversation. Use templates in `references/output-format.md` as starting structure, but voice-match per-client.
-4. **Check for context.** If the client recently sent any email mentioning payment ("payment is in process," "we'll get to it next week"), the agent's draft acknowledges that and offers to follow up at the date they named — does not just repeat the same dunning sequence.
-5. **Surface unusual patterns.** If a normally-prompt client is suddenly 30 days late, flag it as a relationship-health signal in the Slack thread. If multiple clients of the same vendor stack are late, that's a market signal to surface.
-6. **Write to drafts.** `customer_notes/drafts/ar/{client}-{invoice-id}-{stage}.md`. Slack post in `ar-drafts` channel summarizing the day's drafts + escalations.
+The skill runs in two phases. The mechanical per-invoice fetch loop runs inside a single `execute_code` block — intermediate per-invoice QBO + Gmail tool results never enter the conversation context (ADR 0021 Stream A). Cadence decisions, voice matching, draft prose, and relationship-health surfacing stay in the agent's reasoning loop where they belong.
+
+### Phase 1 — Fetch (single `execute_code` block)
+
+Invoke `execute_code` with a Python script that does the mechanical work. The script reads the QBO Aging Detail, then for each overdue invoice cross-checks payment status (defending against drafting a chase on an already-paid invoice — the #1 pitfall in `## Pitfalls` below) and pulls prior Gmail thread context for voice matching:
+
+```python
+import json
+import shlex
+
+DAYS_OVERDUE_FLOOR = 7   # ignore anything under floor
+DAYS_OVERDUE_CEILING = 90  # nothing useful past 90; flag separately
+
+def run(cmd: str) -> str:
+    """Call into the Hermes-exposed terminal tool. Strips trailing whitespace."""
+    return terminal(cmd).strip()
+
+def safe_json(raw: str, fallback_id: str) -> dict:
+    """Parse a connector response; on failure, record + continue rather than abort."""
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return {"error": "parse_failed", "fallback_id": fallback_id, "raw_excerpt": raw[:200]}
+
+# 1. Pull QBO Aging Detail, filter by overdue range.
+aging_raw = run(
+    f'qbo_connector.py aging --min-days {DAYS_OVERDUE_FLOOR} --max-days {DAYS_OVERDUE_CEILING} --format json'
+)
+aging = safe_json(aging_raw, fallback_id="aging")
+invoices = aging.get("invoices", []) if isinstance(aging, dict) else []
+
+# 2. For each overdue invoice, cross-check payment status + pull prior thread context.
+invoice_payloads = []
+for inv in invoices:
+    invoice_id = inv.get("invoice_id")
+    client_slug = inv.get("client_slug")
+
+    # Payment status cross-check — defend against chasing an already-paid invoice.
+    payment_raw = run(
+        f'qbo_connector.py invoice payment-status {shlex.quote(str(invoice_id))} --format json'
+    )
+    payment = safe_json(payment_raw, fallback_id=f"payment.{invoice_id}")
+
+    # Skip if QBO confirms paid since the aging snapshot.
+    if isinstance(payment, dict) and payment.get("status") == "paid":
+        invoice_payloads.append({
+            "invoice_id": invoice_id,
+            "client_slug": client_slug,
+            "skipped_reason": "paid_since_snapshot",
+            "payment_status": payment,
+        })
+        continue
+
+    # Prior Gmail thread context — for voice match + payment-promise detection.
+    thread_raw = run(
+        f'gmail_connector.py threads --client {shlex.quote(str(client_slug))} --limit 5 --format json'
+    )
+    prior_threads = safe_json(thread_raw, fallback_id=f"thread.{client_slug}")
+
+    invoice_payloads.append({
+        "invoice_id": invoice_id,
+        "client_slug": client_slug,
+        "invoice": inv,
+        "payment_status": payment,
+        "prior_threads": prior_threads,
+    })
+
+# 3. Emit ONE JSON document. This is the only thing that enters context.
+print(json.dumps({
+    "as_of": aging.get("as_of") if isinstance(aging, dict) else None,
+    "overdue_count": len(invoice_payloads),
+    "invoices": invoice_payloads,
+}, ensure_ascii=False))
+```
+
+Only the final `print()` output enters the conversation context — typically ~30-50k tokens for ~5-15 overdue invoices, instead of one tool-call result block per QBO and Gmail call. The per-invoice payment cross-check happens in the child process; invoices that came back paid since the aging snapshot are marked `skipped_reason: paid_since_snapshot` and the agent does NOT draft for them. A single connector failure becomes a `parse_failed` row inside the payload — the batch does not abort.
+
+### Phase 2 — Reason (agent, in-context)
+
+The agent reads the JSON returned by `execute_code` and, per the rules in `references/algorithm.md`, processes each overdue invoice:
+
+1. **Skip paid-since-snapshot invoices.** Any payload entry with `skipped_reason: paid_since_snapshot` is omitted from the day's drafts. These appear in the Slack summary as "skipped (paid since snapshot)" so the owner can see the cross-check fired.
+2. **Pick the cadence stage** by days-overdue: 7-13 (gentle reminder), 14-29 (firmer; ask if they need anything), 30-44 (direct; reference payment terms; offer call), 45+ (ESCALATE — no email; Slack-only).
+3. **Detect payment-promise context** in `prior_threads`. If the client recently said "payment is in process" or "we'll get to it next week," the draft acknowledges that and offers to follow up at the date they named — it does NOT repeat the dunning sequence.
+4. **Voice-match** against the client's prior thread tone (formality, paragraph density, salutation). The AR draft matches the relationship's existing tonality.
+5. **Draft per cadence** for invoices in the 7-44 day band. Templates per stage live in `references/output-format.md`; the agent fills them with invoice number, amount, due date, days overdue, and prior-thread acknowledgments where present.
+6. **Escalate at 45+ days** via Slack `@<owner>` mention in `ar-drafts`. No email draft is written for 45+ — the owner needs to call or pause services, not send another templated nudge.
+7. **Surface relationship-health signals.** A normally-prompt client suddenly 30 days late is flagged in the Slack summary; multiple clients of the same vendor stack going late at once is a market-signal flag. These are anomaly notes, not blockers to drafting.
+8. **Write per-invoice drafts** to `customer_notes/drafts/ar/{client_slug}-{invoice_id}-{stage}.md`. Post ONE summary thread to `ar-drafts` listing all drafts written, all escalations, and all anomaly flags.
+
+Detailed cadence-stage thresholds, payment-promise detection rules, voice-matching logic, and anomaly heuristics live in `references/algorithm.md`. The reference is the source of truth for what "good AR chasing" looks like; this procedure is the dispatch shape.
 
 ### Trust Ceiling
 
@@ -103,6 +184,7 @@ Common failures: drafting on an already-paid invoice (always cross-check QBO pay
 
 ## References
 
+- `references/algorithm.md` — detailed cadence-stage rules, payment-promise detection, voice-matching, paid-invoice cross-check, anomaly heuristics (preserved for graders post-`execute_code` rewrite)
 - `references/voice.md` — AR voice (firm + warm; no apology, no threat)
 - `references/output-format.md` — template per cadence stage; Slack-post structure
 - `references/categorization-rubric.md` — cadence stage thresholds; relationship-health signals
@@ -110,9 +192,18 @@ Common failures: drafting on an already-paid invoice (always cross-check QBO pay
 
 ## Cost estimate (filled by grading)
 
-- Typical tokens-in per overdue invoice: ~6K (invoice details + prior thread context)
-- Typical tokens-out per draft: ~500
-- Tool calls per run: ~10 (QBO aging + per-invoice + Gmail thread reads + Slack post)
-- Typical cadence: daily; ~5 drafts/day at a 20-client agency
+Post-`execute_code` rewrite (ADR 0021 Stream A). Per-invoice QBO and Gmail
+intermediate results no longer enter the conversation context; only the
+single Phase-1 JSON payload does.
 
-Monthly per customer at typical volume: <$3 in tokens, <$1 in tool calls.
+- Typical tokens-in per run (5-15 overdue invoices): ~30-50K — one JSON document covering every overdue invoice with its payment-status cross-check and prior-thread context.
+- Typical tokens-out per draft: ~500 (one per 7-44-day invoice; 45+ get a Slack escalation instead of an email draft).
+- Hermes tool calls per run: 2 (one `execute_code` + one file-write / Slack-post batch). The per-invoice QBO and Gmail calls happen inside `execute_code` and don't count toward conversation context.
+- Typical cadence: daily; ~5 drafts/day at a 20-client agency.
+
+Pre-rewrite the parent agent saw ~10-25 separate tool-call result blocks per
+run (one `execute_code` block replaces those, and adds the per-invoice
+payment-status cross-check at zero conversation-context cost). Token
+reduction expected ≥ 50% vs. baseline; grading harness confirms.
+
+Monthly per customer at typical volume: <$2 in tokens, <$0.50 in tool calls.

--- a/ai-employee/skills/ar-chaser/references/algorithm.md
+++ b/ai-employee/skills/ar-chaser/references/algorithm.md
@@ -1,0 +1,242 @@
+# AR Chaser — Per-Invoice Algorithm
+
+Detailed prose procedure preserved for graders. The SKILL.md's `## Procedure`
+section delegates the per-invoice fetch loop to `execute_code` (ADR 0021
+Stream A) and references this file for the cadence decisions, voice
+matching, payment-promise detection, and relationship-health surfacing
+that constitute the actual judgment work. This file is the source of truth
+for what "good AR chasing" looks like.
+
+## Inputs the agent receives from Phase 1
+
+`execute_code` emits one JSON document with shape:
+
+```
+{
+  "as_of": "<aging snapshot timestamp>",
+  "overdue_count": <N>,
+  "invoices": [
+    {
+      "invoice_id": "<qbo invoice id>",
+      "client_slug": "<slug>",
+      "invoice": { ...full QBO invoice row... },
+      "payment_status": { ...QBO payment-status detail... },
+      "prior_threads": [ ...last 5 Gmail threads with this client... ]
+    },
+    // OR — skipped because payment cleared between snapshot and run:
+    {
+      "invoice_id": "<id>",
+      "client_slug": "<slug>",
+      "skipped_reason": "paid_since_snapshot",
+      "payment_status": { ...QBO confirming paid... }
+    },
+    ...
+  ]
+}
+```
+
+Any connector that returns invalid JSON appears in the payload as
+`{"error": "parse_failed", "fallback_id": "...", "raw_excerpt": "..."}`
+rather than aborting the batch. The agent treats `parse_failed` for QBO
+payment-status as a HARD STOP for that invoice — it does NOT draft when
+it cannot confirm the invoice is still unpaid. The flagged invoice
+surfaces in the Slack summary as "could not verify payment status; owner
+to check QBO manually."
+
+## Pre-draft filters
+
+Before scoring cadence, the agent applies two filters:
+
+1. **Paid-since-snapshot skip.** Any payload entry with `skipped_reason:
+   paid_since_snapshot` is omitted from the day's drafts. These appear in
+   the Slack summary as `"{client} — INV-{id}: skipped (paid since snapshot)"`
+   so the owner can see the cross-check fired and saved them from sending
+   a chase on a paid invoice.
+2. **Payment-promise detection.** Scan `prior_threads` for recent (within
+   the last 14 days) outbound mentions of payment from the client matching
+   patterns like:
+   - "payment is in process"
+   - "we'll get to it next week"
+   - "approved internally, going through AP"
+   - "[specific date or week] for payment"
+
+   If such a mention exists and the named date has not yet passed, the
+   draft shape changes from "dunning sequence step" to "acknowledgment
+   of the promise + offer to follow up after the named date." The agent
+   does NOT just repeat the next cadence step over a fresh payment promise.
+
+## Cadence stages
+
+A days-overdue value drives the cadence stage. The thresholds are:
+
+### 7-13 days overdue — gentle reminder
+
+- Tone: gentle, blame-the-postal-system; assume good faith and process slowness.
+- Draft includes: invoice number, amount, due date, days overdue, a polite "any chance you can take a look" ask, and an offer to resend the invoice if it never arrived.
+- Voice: matches the client's existing thread tone (formal / business-casual / casual per their prior messages).
+- DO NOT reference late fees, terms violation, or service implications at this stage. Doing so reads as escalation on a postal-delay-equivalent timeline.
+
+### 14-29 days overdue — firmer; ask if they need anything
+
+- Tone: firmer; assume there's friction on the AP side.
+- Draft includes: invoice details, an explicit "is there anything you need from us to process this" offer (new format, fresh copy, different payee details, a call to clarify), and a soft mention of the original payment terms.
+- Voice: still matches the client's tone — firmer doesn't mean adversarial.
+- DO NOT mention legal action, collections, or service pause at this stage.
+
+### 30-44 days overdue — direct; reference payment terms; offer call
+
+- Tone: direct without being adversarial. The client is clearly past the negotiated terms.
+- Draft includes: invoice details, explicit reference to the SOW's payment terms, an offer to schedule a call to discuss any issues blocking payment, and a clear statement that the agency would like to resolve before this affects services.
+- Voice: matches client tone; "professional and clear" overrides "casual" if their prior tone was very casual.
+- This is the LAST stage where the agent drafts an email autonomously. The 45+ stage is Slack-only.
+
+### 45+ days overdue — ESCALATE; no draft
+
+- The agent does NOT draft an email at this stage. The escalation needs human judgment.
+- Slack `@<owner>` mention in `ar-drafts` with:
+  - Client name + invoice ID + amount + days overdue
+  - Cadence history (what drafts were sent at 7/14/30 days)
+  - Prior-thread summary (any payment promises, any disputes, any silence)
+  - Recommendation: "call the client" / "pause services per SOW" / "escalate to accounts team"
+- Owner decides the next action; the agent does not pre-draft another templated message.
+
+## Voice-matching
+
+To match the client's existing tone, the agent reads `prior_threads` and
+calibrates:
+
+1. **Salutation.** Match the client's last outbound greeting style (first
+   name / formal / none).
+2. **Formality level.** Mirror sentence length and word choice from the
+   most recent shipped agency message to this client.
+3. **Sign-off.** Use the agency's standard AR sign-off unless `customer.yaml:
+   clients.{slug}.report_voice.signoff` overrides.
+4. **Reference framing.** If prior threads use ticket / project / matter
+   numbers, the draft references them. If prior threads use service names
+   ("the Q3 campaign"), use those.
+
+A draft that violates the voice rules (`references/voice.md`) is
+downgraded — the agent surfaces it as `LOW` confidence in the Slack
+summary and writes a one-line plan rather than attempting prose.
+
+## Relationship-health signals
+
+The agent flags anomalies in the Slack summary so the owner sees
+relationship deterioration without having to ask:
+
+- **Normally-prompt client suddenly late.** If the client's average
+  days-to-pay is < 7 across the last 6 invoices and the current invoice is
+  > 14 days late, flag as `relationship-health: payment cadence change`.
+- **Multiple clients of same vendor stack late simultaneously.** If ≥ 3
+  clients sharing a common AP provider / industry are simultaneously late,
+  flag as `market-signal: cohort-wide cash flow strain` — owner may want
+  to adjust terms for that segment.
+- **Client gone dark across multiple drafts.** If the same invoice has
+  cycled through 7/14/30-day drafts with zero client response in the
+  thread, flag as `relationship-health: client unresponsive` regardless
+  of whether escalation has hit 45 days.
+- **Disputed amount.** If `prior_threads` contains language disputing the
+  invoice amount or scope ("we never agreed to this charge", "this isn't
+  what we discussed"), flag as `relationship-health: disputed; owner
+  must intervene before next draft`.
+
+Flagged signals appear in the Slack summary but do NOT block draft
+writing — the owner reads the flag, then decides whether to send the
+draft as-is, edit, or pull the engagement.
+
+## Per-invoice draft file layout
+
+Drafts land in `customer_notes/drafts/ar/{client_slug}-{invoice_id}-{stage}.md`
+where `stage` is one of `7day`, `14day`, `30day`, `45day-escalation`. The
+45day-escalation file contains only the owner-facing Slack summary
+content; there is no email draft body in that file.
+
+Each draft file frontmatter records:
+
+```yaml
+client_slug: <slug>
+invoice_id: <qbo id>
+amount_usd: <numeric>
+due_date: <YYYY-MM-DD>
+days_overdue: <numeric>
+cadence_stage: <7day | 14day | 30day | 45day-escalation>
+payment_promise_detected: <bool>
+voice_match_source: <gmail_thread_id | default>
+flags: [<relationship-health-signals>]
+```
+
+## Summary Slack post (one per run)
+
+After all per-invoice drafts are written, the agent posts ONE summary
+thread to the agency's `ar-drafts` channel:
+
+```
+*AR drafts ready — {YYYY-MM-DD}*
+
+Drafts written (7-44 day band):
+- {Client Name} — INV-{id} — {amount} — {days} days overdue ({stage})
+- ...
+
+Escalations (45+ days; no draft):
+- @{owner} {Client Name} — INV-{id} — {amount} — {days} days
+  Cadence history: 7/14/30 drafts sent. Last client response: {date or "none"}.
+  Recommendation: {call | pause | escalate}
+
+Skipped (paid since snapshot):
+- {Client Name} — INV-{id}
+
+Relationship-health flags:
+- {Client Name}: payment cadence change (avg 5 → current 22 days)
+- {Client Name}: disputed amount — owner must intervene
+
+Could not verify payment status (owner check QBO):
+- {Client Name} — INV-{id}
+
+_Run finished {ISO timestamp} · skill version {hash}_
+```
+
+The summary is the owner's morning trigger — they read the escalations
+and disputed-amount flags first, then scan the 7-44 day drafts.
+
+## Why `execute_code` and not the original 6 sequential steps
+
+The original 6-step procedure (preserved in git history before this
+rewrite) executed every per-invoice QBO check and per-client Gmail thread
+read in the parent agent's conversation context. For a 20-client agency
+with ~5-15 overdue invoices the context bloat was ~10-25 separate tool
+result blocks before the agent could write the first draft. Each tool
+result entered the conversation as its own block.
+
+`execute_code` collapses the fetch loop into a single child process. The
+parent receives ONE JSON document — typically 30-50K tokens covering
+every overdue invoice with its payment-status cross-check and prior-
+thread context. The agent then iterates the payload in its reasoning
+context, producing one draft per 7-44-day invoice + one summary Slack
+post. Per-tool intermediate results never enter the conversation; only
+the final structured payload does.
+
+A meaningful side benefit: the per-invoice payment-status cross-check
+now runs at zero conversation-context cost. Pre-rewrite the cross-check
+was an N additional tool calls landing in context, which made it
+tempting to skip. Inside `execute_code` the check is just another
+function call in the loop — defending against the #1 AR pitfall
+(drafting a chase on an already-paid invoice) is no longer a cost
+tradeoff.
+
+## What this algorithm is NOT
+
+- **Not autonomous.** Trust ceiling stays `draft_for_review`. Drafts land
+  in `customer_notes/drafts/ar/` and the owner ships from their own inbox.
+  The agent never sends an email to a client.
+- **Not adversarial.** Even at the 30-44 day stage the draft assumes
+  good faith. References to legal action, late fees, or "collections"
+  are categorically refused. The owner adds those if they decide to —
+  it's a relationship call.
+- **Not silently chasing paid invoices.** The payment-status cross-check
+  inside `execute_code` is structural enforcement. An invoice that paid
+  between aging snapshot and run-time is skipped and surfaced in the
+  Slack summary so the owner sees the save.
+- **Not invented.** Every dollar amount, every invoice number, every
+  days-overdue figure traces to a QBO row. Where data is missing
+  (`parse_failed`), the invoice surfaces in the Slack summary as
+  "could not verify" — never with invented numbers.

--- a/ai-employee/skills/ar-chaser/references/algorithm.md
+++ b/ai-employee/skills/ar-chaser/references/algorithm.md
@@ -48,7 +48,7 @@ to check QBO manually."
 Before scoring cadence, the agent applies two filters:
 
 1. **Paid-since-snapshot skip.** Any payload entry with `skipped_reason:
-   paid_since_snapshot` is omitted from the day's drafts. These appear in
+paid_since_snapshot` is omitted from the day's drafts. These appear in
    the Slack summary as `"{client} — INV-{id}: skipped (paid since snapshot)"`
    so the owner can see the cross-check fired and saved them from sending
    a chase on a paid invoice.
@@ -110,7 +110,7 @@ calibrates:
 2. **Formality level.** Mirror sentence length and word choice from the
    most recent shipped agency message to this client.
 3. **Sign-off.** Use the agency's standard AR sign-off unless `customer.yaml:
-   clients.{slug}.report_voice.signoff` overrides.
+clients.{slug}.report_voice.signoff` overrides.
 4. **Reference framing.** If prior threads use ticket / project / matter
    numbers, the draft references them. If prior threads use service names
    ("the Q3 campaign"), use those.
@@ -138,7 +138,7 @@ relationship deterioration without having to ask:
 - **Disputed amount.** If `prior_threads` contains language disputing the
   invoice amount or scope ("we never agreed to this charge", "this isn't
   what we discussed"), flag as `relationship-health: disputed; owner
-  must intervene before next draft`.
+must intervene before next draft`.
 
 Flagged signals appear in the Slack summary but do NOT block draft
 writing — the owner reads the flag, then decides whether to send the


### PR DESCRIPTION
## Summary

- Wave 2, Stream A.4 of [ADR 0021](https://github.com/venturecrane/ss-console/pull/1048). Closes #1068.
- Rewrites `ai-employee/skills/ar-chaser/SKILL.md` `## Procedure` to a two-phase pattern matching A.1 (#1059) and A.3 (#1067).
- Phase 1: one `execute_code` block does the QBO aging fetch, per-invoice payment-status cross-check, and per-client prior-thread reads. Emits one JSON. Phase 2: agent picks cadence stage, detects payment-promise context, voice-matches, drafts per stage or Slack-escalates at 45+.
- Detailed cadence rules, voice-matching, payment-promise detection, and relationship-health heuristics preserved in new `references/algorithm.md` for graders.

## Why

Pre-rewrite the parent agent saw ~10-25 separate tool-call result blocks per run (QBO aging + per-invoice payment cross-checks + per-client thread reads + Slack post). `execute_code` collapses every per-tool result into the child process; only one ~30-50K-token JSON enters context.

**Side benefit:** the payment-status cross-check inside `execute_code` runs at zero conversation-context cost. Pre-rewrite, the cross-check was N additional tool calls landing in context — making it tempting to skip. Defending against the #1 AR pitfall (drafting a chase on a paid invoice) is no longer a cost tradeoff.

## What changed

| File | Change |
|---|---|
| `ai-employee/skills/ar-chaser/SKILL.md` | `## Procedure` rewritten to two-phase pattern; References list adds algorithm.md; cost estimate updated |
| `ai-employee/skills/ar-chaser/references/algorithm.md` | NEW — preserves detailed cadence-stage rules, payment-promise detection, voice-matching, relationship-health flags for graders |

Trust ceiling (`draft_for_review`) unchanged. 45+ day Slack-only escalation behavior unchanged. No new connectors. No new audit events. No frontmatter changes.

A QBO `parse_failed` on payment-status is a HARD STOP for that invoice — the agent does NOT draft when it cannot confirm unpaid. The flagged invoice surfaces in the Slack summary as "could not verify payment status."

## Test plan

- [x] `npm run typecheck` — 0 errors, 0 warnings on changed files (markdown-only change)
- [ ] Token-reduction grading on a 10-overdue-invoice synthetic fixture (acceptance criterion in ADR 0021 Stream A): ≥ 50% reduction vs. pre-rewrite baseline
- [ ] Paid-since-snapshot defense test: synthetic fixture where 2 of 10 invoices clear between aging snapshot and run; assert agent skips those 2 and surfaces them in Slack summary

## Refs

- Parent tracking: #1049
- ADR: #1048
- Pattern references: #1059 (A.1 inbox-triage), #1067 (A.3 status-report-assembler)

🤖 Generated with [Claude Code](https://claude.com/claude-code)