### PR TITLE
feat(ai-employee): D bundle catalog — pi-intake, pi-matter-prep, weekly-client-pulse

### DIFF
--- a/ai-employee/bundles/README.md
+++ b/ai-employee/bundles/README.md
@@ -1,0 +1,86 @@
+# Skill Bundles Catalog
+
+Three reference bundle definitions for the SMD AI Employee. Each catalog
+entry combines two or more skills under a single slash command so a
+common multi-step workflow becomes one user-facing invocation.
+
+| Bundle                     | Slash command          | Skills                                                  | Vertical         |
+| -------------------------- | ---------------------- | ------------------------------------------------------- | ---------------- |
+| `pi-intake.yaml`           | `/pi-intake`           | `law-pi-intake-triage` + `law-conflict-check`           | law-firm-pi      |
+| `pi-matter-prep.yaml`      | `/pi-matter-prep`      | `law-pi-demand-letter-draft` + `law-pi-settlement-prep` | law-firm-pi      |
+| `weekly-client-pulse.yaml` | `/weekly-client-pulse` | `status-report-assembler` + `retainer-hours-reconciler` | marketing-agency |
+
+## How bundles flow from catalog to runtime
+
+The catalog is a reference. Bundles only activate for a customer when
+their `customer.yaml.personas[<n>].bundles[]` block declares one — the
+catalog file isn't loaded directly at boot.
+
+```
+ai-employee/bundles/<slug>.yaml          (this catalog — reference shape)
+                  ↓ author copies from
+customer.yaml personas[<n>].bundles[]    (per-customer customer.yaml)
+                  ↓ validator enforces skills[] match enabled skills
+                  ↓ `hermes-smd bootstrap` (overlay-repo) reads at Machine boot
+~/.hermes/skill-bundles/<slug>.yaml      (Hermes-native bundle file, per profile)
+                  ↓ Hermes loads
+                  ↓ `/<slug>` invocation triggers each skill listed
+```
+
+The translation step (customer.yaml → per-profile bundle YAML) lives in
+`venturecrane/hermes-smd-overlay` per ADR 0021 Wave 3 (Overlay-3). It is
+NOT in this repo.
+
+## Catalog entry shape
+
+Each catalog file matches the customer.yaml `personas[].bundles[]` schema:
+
+```yaml
+slug: <kebab-case identifier, matches SLUG_PATTERN>
+description: <one-line summary, max 200 chars>
+skills:
+  - <skill-name-1>
+  - <skill-name-2>
+instruction: |
+  <Optional shared context prepended to every bundled skill invocation.
+   See the Hermes-native `instruction:` field. Carry intent that
+   applies across all skills in the bundle; per-skill rules stay in the
+   individual SKILL.md files.>
+```
+
+The schema is canonical in
+[`docs/specs/ai-employee/customer-yaml-schema.md`](../../docs/specs/ai-employee/customer-yaml-schema.md)
+(see "Skill bundles (ADR 0021 Stream D)").
+
+## Adding a new bundle to the catalog
+
+1. Identify the multi-step workflow that fires often enough to deserve
+   a slash command. A workflow that fires once a quarter is probably
+   not worth a bundle.
+2. Confirm both (or more) skills already exist in
+   `ai-employee/skills/<skill-name>/`.
+3. Author the catalog file at `ai-employee/bundles/<slug>.yaml` matching
+   the schema above.
+4. Update this README's catalog table.
+5. Customers that want the bundle then copy the block into their
+   `customer.yaml.personas[<n>].bundles[]` and ensure the skills are
+   listed in the same persona's `skills[]` with `enabled: true`.
+
+## What the catalog is NOT
+
+- **Not a registry.** Hermes doesn't load this directory. The customer.yaml
+  block is the source of truth at runtime.
+- **Not a sandbox.** Bundles in `customer.yaml.personas[].bundles[]` may
+  cite skills NOT in this catalog — the catalog is a curation of
+  reference combinations, not the limit of what can be bundled.
+- **Not multi-tenant.** Each customer Machine reads its own
+  `customer.yaml`. The catalog has no tenant context.
+
+## ADR references
+
+- [ADR 0021](../../docs/adr/0021-leverage-hermes-native-primitives.md)
+  Stream D — Skill bundles for multi-step workflows.
+- [ADR 0017](../../docs/adr/0017-skill-curator-disposition.md) — Hermes-
+  native skill management surface (`skill_manage`).
+- [ADR 0005](../../docs/adr/0005-reviewer-as-sender.md) — Email drafts
+  land in the partner's drafts folder; no agent send path.

--- a/ai-employee/bundles/pi-intake.yaml
+++ b/ai-employee/bundles/pi-intake.yaml
@@ -1,0 +1,38 @@
+# PI Intake — bundle catalog entry
+#
+# Combines intake triage + conflict screen so the assessment call from a
+# new prospect produces both an intake triage doc AND the conflict-of-
+# interest screen in one `/pi-intake` invocation.
+#
+# This file is a reference shape. To activate this bundle for a customer,
+# copy the block below into `customer.yaml.personas[<n>].bundles[]` and
+# ensure both referenced skills are enabled on the same persona's
+# `skills[]` list (the validator enforces this at customer.yaml load time).
+#
+# At Machine boot, `hermes-smd bootstrap` (overlay-repo) reads the
+# customer.yaml block and writes the bundle YAML into the per-profile
+# `~/.hermes/skill-bundles/pi-intake.yaml` per ADR 0021 Stream D.
+
+slug: pi-intake
+description: 'Intake triage + conflict screen for a new PI prospect'
+skills:
+  - law-pi-intake-triage
+  - law-conflict-check
+instruction: |
+  Treat both skills as one /pi-intake invocation against the same prospect.
+  Each skill writes its own draft into the supervising partner's drafts
+  folder per ADR 0005 (reviewer-as-sender); the partner reviews both
+  drafts before any external action. Neither skill sends mail.
+
+  Shared context to carry across both skill invocations:
+  - The prospect's matter-creation request (intake form, voicemail
+    transcript, email body — whichever surfaced the lead).
+  - The firm's conflict-check memory rule corpus
+    (`customer.yaml.memory_rules.conflict_check`) — read by
+    law-conflict-check but referenced in the triage doc for partner
+    visibility.
+
+  Order of skill execution is intentionally unspecified — Hermes' bundle
+  runtime determines ordering. The intake triage doc may flag fields the
+  conflict check then catches, or vice versa; the partner reviews both
+  drafts together and acts on the combined picture.

--- a/ai-employee/bundles/pi-matter-prep.yaml
+++ b/ai-employee/bundles/pi-matter-prep.yaml
@@ -1,0 +1,49 @@
+# PI Matter Prep — bundle catalog entry
+#
+# Combines demand-letter assembly + settlement-prep memo so a matter
+# heading into settlement-conference work can pull both the demand-letter
+# draft and the prep memo under one `/pi-matter-prep` invocation while
+# sharing matter-loaded context (matter facts, custom_fields, document
+# folder) across both skills.
+#
+# This file is a reference shape. To activate this bundle for a customer,
+# copy the block below into `customer.yaml.personas[<n>].bundles[]` and
+# ensure both referenced skills are enabled on the same persona's
+# `skills[]` list.
+#
+# At Machine boot, `hermes-smd bootstrap` (overlay-repo) reads the
+# customer.yaml block and writes the bundle YAML into the per-profile
+# `~/.hermes/skill-bundles/pi-matter-prep.yaml` per ADR 0021 Stream D.
+
+slug: pi-matter-prep
+description: 'Demand-letter draft + settlement-prep memo for one PI matter'
+skills:
+  - law-pi-demand-letter-draft
+  - law-pi-settlement-prep
+instruction: |
+  Treat both skills as one /pi-matter-prep invocation against the same
+  matter. Each skill writes its own draft per ADR 0005 (reviewer-as-
+  sender): the demand letter lands in the partner's outbound drafts
+  folder; the prep memo lands as an internal-recipient draft in the
+  partner's own inbox. Both remain `draft_for_review (locked)` — the
+  partner reviews, fills the TBD sections, and ships from their own
+  client.
+
+  Shared context to carry across both skill invocations:
+  - The matter id (--matter-id flag) and the matter's `custom_fields`
+    block from PracticeManagement.
+  - The matter's documents folder (DocumentStorage).
+  - The supervising partner's voice samples (Layer 2) — both skills
+    voice-match against the same partner corpus.
+
+  Both skills use `delegate_task` to spawn three parallel subagents per
+  ADR 0021 Stream C. Bundle invocation does NOT change the subagent
+  topology — each skill's subagent set runs in its own isolated context
+  per Hermes' delegation contract. Audit emissions
+  (SUBAGENT_STOPPED × 3 per skill = 6 total per bundle run) land
+  separately per skill.
+
+  Order of skill execution is intentionally unspecified. Demand-letter
+  assembly typically completes first because the prep memo's
+  comparable-verdict lookup uses the demand's damages summary as an
+  input signal; Hermes' bundle scheduler may parallelize.

--- a/ai-employee/bundles/weekly-client-pulse.yaml
+++ b/ai-employee/bundles/weekly-client-pulse.yaml
@@ -1,0 +1,53 @@
+# Weekly Client Pulse — bundle catalog entry
+#
+# Combines status-report assembly + retainer-hours reconciliation so the
+# marketing agency's Friday-morning client reporting produces both
+# artifacts under one `/weekly-client-pulse` invocation.
+#
+# This file is a reference shape. To activate this bundle for a customer,
+# copy the block below into `customer.yaml.personas[<n>].bundles[]` and
+# ensure both referenced skills are enabled on the same persona's
+# `skills[]` list.
+#
+# At Machine boot, `hermes-smd bootstrap` (overlay-repo) reads the
+# customer.yaml block and writes the bundle YAML into the per-profile
+# `~/.hermes/skill-bundles/weekly-client-pulse.yaml` per ADR 0021 Stream D.
+
+slug: weekly-client-pulse
+description: 'Weekly status drafts + retainer-hours report for marketing-agency clients'
+skills:
+  - status-report-assembler
+  - retainer-hours-reconciler
+instruction: |
+  Treat both skills as one /weekly-client-pulse invocation. The status-
+  report-assembler produces per-client draft notes for the owner to ship;
+  the retainer-hours-reconciler posts an internal utilization report to
+  the agency's `retainer-ops` Slack channel.
+
+  Trust ceiling differs across the two: status-report-assembler runs at
+  `draft_for_review` (the owner ships per-client drafts from their own
+  inbox); retainer-hours-reconciler runs at `autonomous` for the read +
+  internal Slack post (the report never reaches clients).
+
+  Shared context to carry across both skill invocations:
+  - The agency's active retainer client roster (read from
+    `customer.yaml.clients[]` and the PM connector).
+  - The reporting window (default: current ISO week; both skills honor
+    a --window override).
+  - The agency-wide voice samples (Layer 2) for the status drafts.
+
+  Both skills use `execute_code` per ADR 0021 Stream A — the per-client
+  fetch loops run in child processes and emit single structured JSON
+  documents to the parent agent. Per-tool intermediate results never
+  enter the conversation context.
+
+  retainer-hours-reconciler also wires `pre_run.py` per ADR 0021 Stream
+  B. When invoked through this bundle the pre-run gate does NOT run —
+  bundle invocations are user-driven, not cron-scheduled — so the
+  reconciler runs every time the bundle fires.
+
+  Order of skill execution is intentionally unspecified. If
+  retainer-hours-reconciler surfaces an OVER_CRITICAL or UNDER_CRITICAL
+  flag for a client, the owner reviews that signal alongside that
+  client's status draft to decide whether to address utilization in the
+  client-facing note or in a separate conversation.


### PR DESCRIPTION
## Summary

- Wave 3, Stream D bundle authoring of [ADR 0021](https://github.com/venturecrane/ss-console/blob/main/docs/adr/0021-leverage-hermes-native-primitives.md). Closes #1078.
- Adds three reference bundle YAMLs under a new \`ai-employee/bundles/\` catalog directory.
- Catalog is reference-only — bundles activate per-customer via \`customer.yaml.personas[].bundles[]\` (schema landed in #1052).

## Bundles

| File | Slash command | Skills | Vertical |
|---|---|---|---|
| \`pi-intake.yaml\` | \`/pi-intake\` | \`law-pi-intake-triage\` + \`law-conflict-check\` | law-firm-pi |
| \`pi-matter-prep.yaml\` | \`/pi-matter-prep\` | \`law-pi-demand-letter-draft\` + \`law-pi-settlement-prep\` | law-firm-pi |
| \`weekly-client-pulse.yaml\` | \`/weekly-client-pulse\` | \`status-report-assembler\` + \`retainer-hours-reconciler\` | marketing-agency |

## What changed

| File | Change |
|---|---|
| \`ai-employee/bundles/pi-intake.yaml\` | NEW — intake + conflict screen bundle |
| \`ai-employee/bundles/pi-matter-prep.yaml\` | NEW — demand + settlement-prep bundle (preserves delegate_task isolation) |
| \`ai-employee/bundles/weekly-client-pulse.yaml\` | NEW — status report + retainer-hours bundle (mixed trust-ceiling instruction) |
| \`ai-employee/bundles/README.md\` | NEW — catalog purpose, flow from catalog to runtime, schema reference |

## Why now

#1052 (D.0 schema) landed the \`personas[].bundles[]\` shape. The overlay's \`hermes-smd bootstrap\` (Overlay-3 PR, separate) will read \`customer.yaml.personas[].bundles[]\` at Machine boot and translate each entry into \`~/.hermes/skill-bundles/<slug>.yaml\`. This PR ships the canonical catalog so customer.yaml authors don't reinvent the same shapes.

## Test plan

- [x] \`npx prettier --check ai-employee/bundles/\` — clean
- [x] \`npm run typecheck\` — 0 errors, 0 warnings
- [x] Every referenced skill exists under \`ai-employee/skills/<skill-name>/\` (verified by directory existence)

## Refs

- Parent tracking: #1049
- ADR: ADR 0021
- Schema: #1052 (D.0)
- Overlay companion: Overlay-3 (separate PR in \`venturecrane/hermes-smd-overlay\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)