### PR TITLE
feat(ai-employee): F migration — DocumentStorage to mcp:softeria/ms-365-mcp-server

### DIFF
--- a/ai-employee/customers/_template/customer.yaml
+++ b/ai-employee/customers/_template/customer.yaml
@@ -88,8 +88,19 @@ connectors:
     backend: '[mcp:m365-mail / mcp:google-gmail / synthetic:fixture]'
     enabled: true
   Calendar:
-    adapter: '[gmail / microsoft-graph / synthetic]'
-    backend: '[composio:gmail / build:ms-graph / synthetic:fixture]'
+    # ADR 0021 Stream F migration (PR #1080): M365 calendar shipped as
+    # first-party MCP. Per ADR 0020 the MCP-first ordering applies.
+    adapter: '[m365-calendar / google-calendar / synthetic]'
+    backend: '[mcp:m365-calendar / mcp:google-calendar / synthetic:fixture]'
+    enabled: true
+  DocumentStorage:
+    # ADR 0021 Stream F migration (PR #1080): Microsoft has not shipped a
+    # first-party OneDrive/SharePoint MCP. The community MIT
+    # `mcp:softeria/ms-365-mcp-server` covers the Files surface; the
+    # retired BUILD adapter at `ai-employee/connectors/ms_graph/` is
+    # removed in the Wave-4 removal PR.
+    adapter: '[ms-365 / google-drive / synthetic]'
+    backend: '[mcp:softeria/ms-365-mcp-server / mcp:google-drive / synthetic:fixture]'
     enabled: true
 
 # ---- OPTIONAL: webhook triggers (ADR 0021 Stream E) ----

--- a/ai-employee/templates/customer-no-pm-system.yaml
+++ b/ai-employee/templates/customer-no-pm-system.yaml
@@ -119,16 +119,30 @@ connectors:
     token_ref: 'infisical:/ai-employee/[FIRM-SLUG]/email/microsoft-entra-tenant-id'
 
   DocumentStorage:
-    # ADR 0020: Microsoft has NOT shipped an M365 MCP for OneDrive/SharePoint
-    # yet (Mail/Calendar/Teams/User/Copilot Chat only as of the rewrite).
-    # Keep build:microsoft_graph for OneDrive; revisit when MS ships one.
-    adapter: microsoft_graph
-    backend: build:microsoft_graph
+    # ADR 0020 / ADR 0021 Stream F (decision packet at
+    # docs/strategy/mcp-vs-build-ms-graph-2026-05-25.md): Microsoft has
+    # not shipped a first-party M365 MCP for OneDrive/SharePoint
+    # (Mail/Calendar/Teams/User/Copilot Chat only). The community
+    # mcp:softeria/ms-365-mcp-server (MIT) covers the OneDrive Files
+    # surface (read + read/write inside the agent's AppFolder).
+    # Migrated 2026-05-25 — see PR #1080. The BUILD adapter at
+    # ai-employee/connectors/ms_graph/ is retired in the Wave-4 removal
+    # PR.
+    #
+    # Fallback: if the community MCP turns out unsuitable for a specific
+    # customer, document the regression with a Captain decision and
+    # bind backend: build:microsoft_graph instead. The BUILD adapter is
+    # removed from the tree in Wave 4 so any fallback must restore it
+    # from git history; that is the desired friction.
+    adapter: ms-365
+    backend: mcp:softeria/ms-365-mcp-server
     enabled: true
     scopes:
       - 'Files.Read'
-      - 'Files.ReadWrite'
+      - 'Files.ReadWrite.AppFolder'
     # OneDrive uses the standard Microsoft Graph OAuth refresh-token path.
+    # The community MCP server reads from the same token surface as the
+    # retired BUILD adapter; the token_ref name stays for continuity.
     token_ref: 'infisical:/ai-employee/[FIRM-SLUG]/document-storage/microsoft-graph-oauth-refresh'
 
   ESign:


### PR DESCRIPTION
## Summary

- Wave 3, Stream F migration of [ADR 0021](https://github.com/venturecrane/ss-console/blob/main/docs/adr/0021-leverage-hermes-native-primitives.md). Closes #1080.
- Implements the recommendation from the F decision packet shipped in #1054.

## What changed

| File | Change |
|---|---|
| \`ai-employee/templates/customer-no-pm-system.yaml\` | DocumentStorage backend flipped from \`build:microsoft_graph\` to \`mcp:softeria/ms-365-mcp-server\`. Scope tightened to \`Files.ReadWrite.AppFolder\`. |
| \`ai-employee/customers/_template/customer.yaml\` | Calendar placeholder updated (\`build:ms-graph\` → \`mcp:m365-calendar\`). New DocumentStorage placeholder added (was missing). |

## Connector matrix after this PR

| Capability | customer-no-pm-system.yaml binding |
|---|---|
| Email | \`mcp:m365-mail\` (Microsoft first-party MCP) |
| Calendar | \`mcp:m365-calendar\` (Microsoft first-party MCP) |
| DocumentStorage | \`mcp:softeria/ms-365-mcp-server\` (community MIT) |

Microsoft has not shipped a first-party OneDrive/SharePoint MCP yet (Mail/Calendar/Teams/User/Copilot Chat only). The community MCP covers the OneDrive Files surface; the retired BUILD adapter at \`ai-employee/connectors/ms_graph/\` is removed in the Wave-4 removal PR (separate).

## Customer-zero

No migration needed — \`ai-employee/bin/fixtures/smd/customer.yaml\` binds Email to \`synthetic:fixture\` per the decision packet. There is no production usage of \`build:ms-graph\` to coordinate around.

## Fallback

Documented in the new \`customer-no-pm-system.yaml\` comment: if the community MCP turns out unsuitable for a specific customer, bind \`backend: build:microsoft_graph\` instead. The BUILD adapter is removed in Wave 4, so any fallback must restore it from git history — that is the desired friction.

## Test plan

- [x] \`npm run typecheck\` — 0 errors, 0 warnings
- [x] \`npx prettier --check\` clean
- [x] Pre-existing template validator errors (SecretDetected on placeholders, InvalidSlug on \`[PERSONA SLUG]\`) confirmed NOT introduced by this PR — git stash + re-run shows same errors on main.

## Refs

- Parent tracking: #1049
- ADR: ADR 0021 / ADR 0020
- Decision packet: docs/strategy/mcp-vs-build-ms-graph-2026-05-25.md (#1054)
- Wave-4 removal PR will delete \`ai-employee/connectors/ms_graph/\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)