### PR TITLE
fix(auth): resolve portal entity by users.entity_id; SignOutButton asChild

### DIFF
--- a/src/lib/portal/session.ts
+++ b/src/lib/portal/session.ts
@@ -3,23 +3,23 @@
  *
  * Resolves the local user + entity for an authenticated portal request.
  * Identity is owned by Clerk (see src/lib/auth/clerk-bridge.ts); SS
- * stores shadow rows keyed by clerk_user_id / clerk_org_id and JIT-
- * creates the local users row on first login. The local entity is NOT
- * JIT-created — a Clerk Organization without a matching
- * `entities.clerk_org_id` returns `client: null`, and the caller renders
+ * stores shadow rows keyed by clerk_user_id / clerk_org_id. The bridge
+ * JIT-creates the local users row (or auto-links a pre-Clerk row by
+ * email) on first login. The local entity is NOT JIT-created — a Clerk
+ * user with no binding returns `client: null`, and the caller renders
  * the "no portal access yet" state.
  *
- * Magic-link auth on src/lib/auth/session.ts is retained for the admin
- * console only. Portal auth runs through Clerk.
+ * Entity resolution order (handled in resolveClerkPortalContext):
+ *   1. users.entity_id  — direct binding (admin-provisioned single-user)
+ *   2. entities.clerk_org_id — via active Clerk Organization (AI Employee)
+ *
+ * Magic-link auth on src/lib/auth/session.ts is retained for client
+ * invitation acceptance only.
  */
 
-import type { Entity } from '../db/entities'
-import { ensureLocalUser, resolveClerkEntity, type PortalUserRow } from '../auth/clerk-bridge'
+import { resolveClerkPortalContext, type PortalContext } from '../auth/clerk-bridge'
 
-export interface PortalContext {
-  user: PortalUserRow
-  client: Entity | null
-}
+export type { PortalContext } from '../auth/clerk-bridge'
 
 /**
  * Resolve the portal context for the current Astro request.
@@ -47,10 +47,5 @@ export async function getPortalClient(
     clerkUser.username ||
     email
 
-  const user = await ensureLocalUser(db, auth.userId, { email, name })
-
-  if (!auth.orgId) return { user, client: null }
-
-  const client = await resolveClerkEntity(db, auth.orgId)
-  return { user, client }
+  return resolveClerkPortalContext(db, { userId: auth.userId, orgId: auth.orgId }, { email, name })
 }

--- a/src/pages/auth/sign-in.astro
+++ b/src/pages/auth/sign-in.astro
@@ -70,7 +70,7 @@ const message = status ? statusMessages[status] : null
         {
           status === 'no_subscription' && (
             <div class="mb-6 text-center">
-              <SignOutButton redirectUrl="/auth/sign-in">
+              <SignOutButton asChild redirectUrl="/auth/sign-in">
                 <button
                   type="button"
                   class="inline-flex items-center min-h-11 px-3 font-['Archivo_Narrow'] text-sm font-semibold uppercase tracking-[0.12em] text-[color:var(--ss-color-text-secondary)] hover:text-[color:var(--ss-color-text-primary)] active:text-[color:var(--ss-color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2 underline underline-offset-4"

--- a/tests/clerk-bridge.test.ts
+++ b/tests/clerk-bridge.test.ts
@@ -7,7 +7,7 @@ import {
 import { resolve } from 'path'
 import type { D1Database } from '@cloudflare/workers-types'
 
-import { ensureLocalUser } from '../src/lib/auth/clerk-bridge'
+import { ensureLocalUser, resolveClerkPortalContext } from '../src/lib/auth/clerk-bridge'
 import { ORG_ID } from '../src/lib/constants'
 
 const migrationsDir = resolve(process.cwd(), 'migrations')
@@ -144,5 +144,82 @@ describe('ensureLocalUser', () => {
     expect(result.role).toBe('client')
     expect(result.entity_id).toBeNull()
     expect(result.id).not.toBe(PRE_CLERK_USER_ID)
+  })
+})
+
+describe('resolveClerkPortalContext', () => {
+  let db: D1Database
+  const BOUND_CLERK_ID = 'user_bound_clerk'
+
+  beforeEach(async () => {
+    db = createTestD1()
+    await runMigrations(db, { files: discoverNumericMigrations(migrationsDir) })
+
+    await db
+      .prepare('INSERT OR IGNORE INTO organizations (id, name, slug) VALUES (?, ?, ?)')
+      .bind(ORG_ID, 'SMD Services', 'smd-services')
+      .run()
+    await db
+      .prepare(
+        `INSERT INTO entities (id, org_id, name, slug)
+         VALUES (?, ?, ?, ?)`
+      )
+      .bind(PRE_CLERK_ENTITY_ID, ORG_ID, 'Pre-Clerk Entity', 'pre-clerk-entity')
+      .run()
+    // Bind a users row directly to an entity (no Clerk Organization
+    // involved). This is the common single-user-portal case.
+    await db
+      .prepare(
+        `INSERT INTO users (id, org_id, email, name, role, entity_id, clerk_user_id)
+         VALUES (?, ?, ?, ?, 'client', ?, ?)`
+      )
+      .bind(
+        PRE_CLERK_USER_ID,
+        ORG_ID,
+        PRE_CLERK_EMAIL,
+        'Pre Clerk Client',
+        PRE_CLERK_ENTITY_ID,
+        BOUND_CLERK_ID
+      )
+      .run()
+  })
+
+  it('resolves the entity via users.entity_id when no Clerk org is active', async () => {
+    // The regression this guards: getPortalClient used to skip the
+    // entity_id path and only try auth.orgId. A user with no active
+    // Clerk org but a direct entity binding would land at no_subscription.
+    const ctx = await resolveClerkPortalContext(
+      db,
+      { userId: BOUND_CLERK_ID, orgId: null },
+      { email: PRE_CLERK_EMAIL, name: 'Pre Clerk Client' }
+    )
+
+    expect(ctx).not.toBeNull()
+    expect(ctx!.user.id).toBe(PRE_CLERK_USER_ID)
+    expect(ctx!.client).not.toBeNull()
+    expect(ctx!.client!.id).toBe(PRE_CLERK_ENTITY_ID)
+  })
+
+  it('returns client:null when neither entity_id nor a matching clerk_org_id exists', async () => {
+    // A JIT-created user with no binding lands here. Caller renders
+    // the "no portal access yet" state.
+    const ctx = await resolveClerkPortalContext(
+      db,
+      { userId: 'user_unbound', orgId: null },
+      { email: 'unbound@example.com', name: 'Unbound' }
+    )
+
+    expect(ctx).not.toBeNull()
+    expect(ctx!.user.entity_id).toBeNull()
+    expect(ctx!.client).toBeNull()
+  })
+
+  it('returns null when no Clerk session is present', async () => {
+    const ctx = await resolveClerkPortalContext(
+      db,
+      { userId: null, orgId: null },
+      { email: '', name: '' }
+    )
+    expect(ctx).toBeNull()
   })
 })

--- a/tests/portal-quotes.test.ts
+++ b/tests/portal-quotes.test.ts
@@ -56,14 +56,20 @@ describe('portal quotes: session helper', () => {
   })
 
   it('resolves portal user via the Clerk identity bridge', () => {
-    // Portal auth migrated to Clerk (PR #906). getPortalClient now reads
-    // Astro.locals.auth() / locals.currentUser() and bridges to local
-    // rows via ensureLocalUser / resolveClerkEntity in clerk-bridge.ts.
+    // Portal auth migrated to Clerk (PR #906). getPortalClient reads
+    // Astro.locals.auth() / locals.currentUser() and delegates the
+    // entity-resolution chain to resolveClerkPortalContext in
+    // clerk-bridge.ts. That function (not getPortalClient inline)
+    // owns the resolution order:
+    //   1. users.entity_id  (direct binding)
+    //   2. entities.clerk_org_id via active Clerk org
+    // The post-2026-05-26 regression: getPortalClient used to skip
+    // step 1, returning client:null for any user without an active
+    // Clerk org even when their users.entity_id was set.
     const code = readFileSync(resolve('src/lib/portal/session.ts'), 'utf-8')
     expect(code).toContain('locals.auth()')
     expect(code).toContain('locals.currentUser()')
-    expect(code).toContain('ensureLocalUser')
-    expect(code).toContain('resolveClerkEntity')
+    expect(code).toContain('resolveClerkPortalContext')
   })
 
   it('scopes the entity lookup by org_id for defense-in-depth (#399)', () => {


### PR DESCRIPTION
## Summary

Follow-up to #1077. The email-link fix worked (users row for \`smdurgan@venturecrane.com\` now has \`clerk_user_id\` bound to the Clerk identity), but Captain still hit no_subscription and the recovery SignOutButton didn't fire. Two bugs:

1. **\`getPortalClient\` ignored \`users.entity_id\`.** \`resolveClerkPortalContext\` in \`clerk-bridge.ts\` already had the right entity_id-first resolution chain — but no caller used it. \`getPortalClient\` had its own inline implementation that only tried \`auth.orgId → entities.clerk_org_id\`. Single-user portal clients (direct entity binding, no Clerk Organization) always returned \`client: null\`.
2. **Clerk \`<SignOutButton />\` on sign-in.astro lacked \`asChild\`.** Without it, the custom \`<button>\` child isn't wired to Clerk's click handler. AdminLayout uses \`asChild\` correctly; sign-in.astro didn't.

## Fix

- \`getPortalClient\` delegates to \`resolveClerkPortalContext\` (entity_id-first, then Clerk-org fallback).
- \`sign-in.astro\` recovery button now matches AdminLayout's pattern.

## Tests

- 3 new \`resolveClerkPortalContext\` cases in \`tests/clerk-bridge.test.ts\`: entity_id resolution without Clerk org, fully-unbound returns \`client:null\`, no Clerk session returns null.
- \`tests/portal-quotes.test.ts\` session-helper assertion updated: \`getPortalClient\` must reference \`resolveClerkPortalContext\`.

## Test plan
- [x] \`npm run verify\` passes (2755 tests + sub-Worker suites)
- [ ] After deploy: Captain hits \`portal.smd.services/\` while signed in as \`smdurgan@venturecrane.com\` → lands on \`/portal\` (renders the dashboard against \`entity_id=dc5653cf...\`)
- [ ] After deploy: Captain hits \`/auth/sign-in?status=no_subscription\` with an unbound identity → \"Sign out and try a different account\" button signs him out and reloads the page clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)