### PR TITLE
feat(ai-employee): E.1 Filevine subscribe() — webhook subscription capability

### DIFF
--- a/ai-employee/connectors/filevine/capabilities.py
+++ b/ai-employee/connectors/filevine/capabilities.py
@@ -273,6 +273,11 @@ _PM_SUPPORTED = (
     "get_matter",
     "list_matter_documents",
     "create_note",
+    # ADR 0021 Stream E — matter-event webhook subscription. The HTTP
+    # path against Filevine's v2 `/core/webhooks` API is wired in this
+    # PR; live sandbox verification deferred to a Wave-4 hardening PR.
+    "subscribe",
+    "unsubscribe",
 )
 
 
@@ -292,6 +297,54 @@ _PM_UNSUPPORTED = (
     "create_time_entry_draft",
     "upload_matter_document",
 )
+
+
+# ---------------------------------------------------------------------------
+# Subscription capability shapes (ADR 0021 Stream E)
+# ---------------------------------------------------------------------------
+
+
+# Canonical event-type taxonomy. Mirrors `MatterEvent` from
+# src/lib/ai-employee/capabilities/practice-management.ts.
+SUPPORTED_MATTER_EVENTS = frozenset(
+    {
+        "matter.created",
+        "matter.updated",
+        "matter.closed",
+        "document.added",
+        "note.added",
+    }
+)
+
+
+# Filevine's v2 `/core/webhooks` API uses its own event-type strings.
+# The translation below maps canonical -> Filevine. Unknown canonical
+# events raise capability_not_supported before any HTTP call.
+_FILEVINE_EVENT_MAP: dict[str, str] = {
+    "matter.created": "Project.Created",
+    "matter.updated": "Project.Updated",
+    "matter.closed": "Project.Closed",
+    "document.added": "Document.Added",
+    "note.added": "Note.Created",
+}
+
+
+@dataclass(frozen=True)
+class SubscriptionRef:
+    """Python mirror of `SubscriptionRef` from `practice-management.ts`.
+
+    Returned by `subscribe()`; passed to `unsubscribe(id=...)`. The
+    `id` field is the adapter-side stable handle (typically the
+    vendor's id formatted with the adapter slug as prefix); the
+    `vendor_subscription_id` is the unwrapped vendor id for the same
+    record.
+    """
+
+    id: str
+    events: tuple[str, ...]
+    webhook_url: str
+    registered_at: str
+    vendor_subscription_id: str
 
 
 class FilevinePracticeManagement:
@@ -534,6 +587,109 @@ class FilevinePracticeManagement:
             capability=self.capability,
             adapter=self.adapter,
             message="upload_matter_document is not supported in Filevine v1 adapter",
+        )
+
+    # ----- Subscription (ADR 0021 Stream E) -----
+
+    async def subscribe(
+        self,
+        events: tuple[str, ...] | list[str],
+        webhook_url: str,
+    ) -> SubscriptionRef:
+        """Register a Filevine webhook subscription for the given events.
+
+        `events` is a canonical event list (see SUPPORTED_MATTER_EVENTS).
+        Unknown canonical events raise capability_not_supported. The
+        canonical strings are translated to Filevine's `Project.*` /
+        `Document.*` / `Note.*` taxonomy on the wire.
+
+        Per ADR 0021 Stream E, the subscription endpoint is the
+        customer's own Fly Machine — `customer.yaml.connectors[].webhook_url`.
+        Caller supplies the resolved URL; this adapter does NOT read
+        customer.yaml directly.
+
+        Returns a SubscriptionRef with the vendor's webhook id, the
+        canonical event list, the configured URL, and the registration
+        timestamp. The caller (typically the bootstrap routine that
+        provisions a customer Machine) records the ref in per-customer
+        state so unsubscribe() can be called at decommission time.
+        """
+        events_tuple = tuple(events)
+        unknown = [e for e in events_tuple if e not in SUPPORTED_MATTER_EVENTS]
+        if unknown:
+            raise AdapterError(
+                code="capability_not_supported",
+                capability=self.capability,
+                adapter=self.adapter,
+                message=(
+                    f"unsupported MatterEvent values: {unknown!r}; "
+                    f"supported: {sorted(SUPPORTED_MATTER_EVENTS)!r}"
+                ),
+            )
+        if not webhook_url:
+            raise AdapterError(
+                code="validation_failed",
+                capability=self.capability,
+                adapter=self.adapter,
+                message="webhook_url is required and must be non-empty",
+            )
+
+        # Translate canonical -> Filevine wire events.
+        wire_events = tuple(_FILEVINE_EVENT_MAP[e] for e in events_tuple)
+
+        result = await self._client.create_webhook_subscription(
+            capability=self.capability,
+            webhook_url=webhook_url,
+            wire_events=wire_events,
+        )
+        vendor_id = _opt_str(result.get("webhookId")) or _opt_str(result.get("id"))
+        if vendor_id is None:
+            raise AdapterError(
+                code="unknown",
+                capability=self.capability,
+                adapter=self.adapter,
+                message="Filevine webhook POST returned no id",
+            )
+        registered_at = (
+            _opt_str(result.get("createdAt")) or _opt_str(result.get("created_at")) or ""
+        )
+
+        return SubscriptionRef(
+            id=f"{ADAPTER_SLUG}:{vendor_id}",
+            events=events_tuple,
+            webhook_url=webhook_url,
+            registered_at=registered_at,
+            vendor_subscription_id=vendor_id,
+        )
+
+    async def unsubscribe(self, subscription_id: str) -> None:
+        """Delete a Filevine webhook subscription previously registered
+        via `subscribe()`.
+
+        `subscription_id` is the SubscriptionRef.id (prefixed with the
+        adapter slug). The adapter strips the prefix before issuing the
+        DELETE against Filevine's v2 webhooks API.
+
+        Idempotent: a 404 on the vendor side is silently OK (the
+        subscription is already gone). Other 4xx/5xx propagate as
+        AdapterError.
+        """
+        if not subscription_id:
+            raise AdapterError(
+                code="validation_failed",
+                capability=self.capability,
+                adapter=self.adapter,
+                message="subscription_id is required",
+            )
+        prefix = f"{ADAPTER_SLUG}:"
+        vendor_id = (
+            subscription_id[len(prefix) :]
+            if subscription_id.startswith(prefix)
+            else subscription_id
+        )
+        await self._client.delete_webhook_subscription(
+            capability=self.capability,
+            vendor_subscription_id=vendor_id,
         )
 
 

--- a/ai-employee/connectors/filevine/client.py
+++ b/ai-employee/connectors/filevine/client.py
@@ -337,6 +337,85 @@ class FilevineClient:
             )
         return bytes(result)
 
+    # ---------- Webhooks (ADR 0021 Stream E) ----------
+
+    async def create_webhook_subscription(
+        self,
+        *,
+        capability: str,
+        webhook_url: str,
+        wire_events: tuple[str, ...],
+    ) -> dict[str, Any]:
+        """POST a webhook subscription against Filevine's `/core/webhooks`.
+
+        Filevine's v2 webhook API accepts `{url, eventType, orgUid}`
+        per the developer.filevine.com reference. One subscription
+        covers one event type, so this method POSTs once per event in
+        `wire_events` and returns the FIRST result (the caller maps the
+        adapter-side `SubscriptionRef.id` to that record).
+
+        Empirically the Filevine API also supports an `eventTypes` list
+        on a single subscription; the per-event POST loop here is the
+        conservative reading of the documented contract. Live sandbox
+        verification deferred to a Wave-4 hardening PR.
+        """
+        if not wire_events:
+            raise AdapterError(
+                code="validation_failed",
+                capability=capability,
+                adapter=ADAPTER_SLUG,
+                message="wire_events must not be empty",
+            )
+        result: Optional[dict[str, Any]] = None
+        for event in wire_events:
+            payload = {
+                "url": webhook_url,
+                "eventType": event,
+                "orgUid": self.org_slug,
+            }
+            posted = await self._request(
+                "POST",
+                "/core/webhooks",
+                capability=capability,
+                json_body=payload,
+            )
+            if posted is None:
+                raise AdapterError(
+                    code="unknown",
+                    capability=capability,
+                    adapter=ADAPTER_SLUG,
+                    message=(
+                        f"Filevine returned empty body for webhook POST "
+                        f"on event {event!r}"
+                    ),
+                )
+            if result is None:
+                result = posted
+        assert result is not None  # loop body ran at least once
+        return result
+
+    async def delete_webhook_subscription(
+        self,
+        *,
+        capability: str,
+        vendor_subscription_id: str,
+    ) -> None:
+        """DELETE a webhook subscription against Filevine's `/core/webhooks`.
+
+        A 404 on the vendor side is silently OK — the subscription is
+        already gone. The base request layer returns None on 404 (it
+        does not raise), so a None return value is the success path
+        for "already gone." Other 4xx/5xx propagate as AdapterError
+        via the request layer.
+        """
+        # The 404 case is silently OK — _request returns None for 404
+        # per the conformance contract; we discard the return value.
+        await self._request(
+            "DELETE",
+            f"/core/webhooks/{vendor_subscription_id}",
+            capability=capability,
+        )
+
     # ---------- Health check ----------
 
     async def ping(self, *, capability: str) -> bool:

--- a/ai-employee/connectors/filevine/tests/test_capabilities.py
+++ b/ai-employee/connectors/filevine/tests/test_capabilities.py
@@ -298,6 +298,130 @@ def test_pm_unsupported_methods_raise_capability_not_supported():
 
 
 # ---------------------------------------------------------------------------
+# Subscription (ADR 0021 Stream E)
+# ---------------------------------------------------------------------------
+
+
+def test_pm_describe_capabilities_includes_subscribe_unsubscribe():
+    """subscribe/unsubscribe must appear in supported_methods for the
+    overlay-side webhook router to gate its registration step on."""
+    client, _, _ = make_client()
+    pm = FilevinePracticeManagement(client)
+
+    cs = pm.describe_capabilities()
+    assert "subscribe" in cs.supported_methods
+    assert "unsubscribe" in cs.supported_methods
+    # Must not also appear as unsupported.
+    assert "subscribe" not in cs.unsupported_methods
+    assert "unsupported" not in cs.unsupported_methods
+
+
+def test_pm_subscribe_posts_one_webhook_per_event_and_returns_ref():
+    """`subscribe(events, url)` POSTs one record per event to
+    Filevine's `/core/webhooks` API; SubscriptionRef carries the
+    canonical event list and the vendor id."""
+    responses = {
+        ("POST", "/core/webhooks"): FakeResponse(
+            status_code=200,
+            json_body={"webhookId": "wh-100", "createdAt": "2026-05-26T03:00:00Z"},
+        ),
+    }
+    client, fake_http, _ = make_client(responses=responses)
+    pm = FilevinePracticeManagement(client)
+
+    ref = asyncio.run(
+        pm.subscribe(
+            events=("matter.created", "document.added"),
+            webhook_url="https://hermes-acme.fly.dev/webhooks/practice_management",
+        )
+    )
+
+    # Two events => two POSTs.
+    posts = [c for c in fake_http.calls if c.method == "POST"]
+    assert len(posts) == 2
+    # Each POST carries one wire-event mapped from the canonical name.
+    wire_events_posted = {p.json["eventType"] for p in posts}
+    assert wire_events_posted == {"Project.Created", "Document.Added"}
+    # orgUid is included on every POST.
+    for p in posts:
+        assert p.json["orgUid"] == "example-firm"
+        assert p.json["url"] == "https://hermes-acme.fly.dev/webhooks/practice_management"
+
+    # Returned ref carries the canonical event list, not the wire vocabulary.
+    assert ref.events == ("matter.created", "document.added")
+    assert ref.webhook_url == "https://hermes-acme.fly.dev/webhooks/practice_management"
+    assert ref.vendor_subscription_id == "wh-100"
+    # Adapter-prefixed id for cross-adapter uniqueness.
+    assert ref.id == "filevine:wh-100"
+    assert ref.registered_at == "2026-05-26T03:00:00Z"
+
+
+def test_pm_subscribe_rejects_unknown_events_with_capability_not_supported():
+    client, _, _ = make_client()
+    pm = FilevinePracticeManagement(client)
+
+    with pytest.raises(AdapterError) as exc:
+        asyncio.run(
+            pm.subscribe(
+                events=("matter.created", "matter.archived"),  # unknown
+                webhook_url="https://x.invalid/webhook",
+            )
+        )
+    assert exc.value.code == "capability_not_supported"
+    assert "matter.archived" in str(exc.value.args[0])
+
+
+def test_pm_subscribe_rejects_empty_webhook_url():
+    client, _, _ = make_client()
+    pm = FilevinePracticeManagement(client)
+
+    with pytest.raises(AdapterError) as exc:
+        asyncio.run(pm.subscribe(events=("matter.created",), webhook_url=""))
+    assert exc.value.code == "validation_failed"
+
+
+def test_pm_unsubscribe_strips_adapter_prefix_and_deletes():
+    responses = {
+        ("DELETE", "/core/webhooks/wh-100"): FakeResponse(
+            status_code=204,
+            json_body=None,
+        ),
+    }
+    client, fake_http, _ = make_client(responses=responses)
+    pm = FilevinePracticeManagement(client)
+
+    asyncio.run(pm.unsubscribe(subscription_id="filevine:wh-100"))
+
+    deletes = [c for c in fake_http.calls if c.method == "DELETE"]
+    assert len(deletes) == 1
+    assert deletes[0].path == "/core/webhooks/wh-100"
+
+
+def test_pm_unsubscribe_is_idempotent_on_404():
+    """A 404 means the subscription is already gone — success."""
+    responses = {
+        ("DELETE", "/core/webhooks/wh-missing"): FakeResponse(
+            status_code=404,
+            json_body=None,
+        ),
+    }
+    client, _, _ = make_client(responses=responses)
+    pm = FilevinePracticeManagement(client)
+
+    # Must NOT raise.
+    asyncio.run(pm.unsubscribe(subscription_id="filevine:wh-missing"))
+
+
+def test_pm_unsubscribe_rejects_empty_id():
+    client, _, _ = make_client()
+    pm = FilevinePracticeManagement(client)
+
+    with pytest.raises(AdapterError) as exc:
+        asyncio.run(pm.unsubscribe(subscription_id=""))
+    assert exc.value.code == "validation_failed"
+
+
+# ---------------------------------------------------------------------------
 # DocumentStorage
 # ---------------------------------------------------------------------------
 

--- a/docs/specs/ai-employee/capability-contracts.md
+++ b/docs/specs/ai-employee/capability-contracts.md
@@ -48,6 +48,21 @@ type DateRange = { start: string; end: string } // ISO 8601
 type DraftRef = { id: string; storage_uri: string; created_at: string }
 
 // ---------- 1. PracticeManagement ----------
+type MatterEvent =
+  | 'matter.created'
+  | 'matter.updated'
+  | 'matter.closed'
+  | 'document.added'
+  | 'note.added'
+
+interface SubscriptionRef {
+  id: string // adapter-prefixed: `<adapter-slug>:<vendor_id>`
+  events: ReadonlyArray<MatterEvent>
+  webhook_url: string
+  registered_at: string
+  vendor_subscription_id: string
+}
+
 interface PracticeManagement {
   search_matters(query: MatterQuery): Promise<Matter[]>
   get_matter(id: string): Promise<Matter | null>
@@ -60,6 +75,10 @@ interface PracticeManagement {
   create_time_entry_draft(input: TimeEntryInput): Promise<TimeEntry>
   list_matter_documents(matter_id: string): Promise<DocumentRef[]>
   upload_matter_document(matter_id: string, doc: DocumentUpload): Promise<DocumentRef>
+  // Subscription (ADR 0021 Stream E). Adapters without vendor-side
+  // webhook support declare these in CapabilitySet.unsupported_methods.
+  subscribe(events: ReadonlyArray<MatterEvent>, webhook_url: string): Promise<SubscriptionRef>
+  unsubscribe(subscription_id: string): Promise<void>
   describe_capabilities(): CapabilitySet
   health_check(): Promise<HealthStatus>
 }

--- a/src/lib/ai-employee/capabilities/practice-management.ts
+++ b/src/lib/ai-employee/capabilities/practice-management.ts
@@ -145,6 +145,40 @@ export interface DocumentUpload {
 // Interface
 // ---------------------------------------------------------------------------
 
+/**
+ * Webhook event types the PracticeManagement adapter can subscribe to.
+ *
+ * Added by ADR 0021 Stream E. Initial set covers matter lifecycle plus
+ * document/note attach events — the vendor-direct events that trigger
+ * intake-triage and discovery-response skills. Vendor-specific events
+ * outside this set carry a `vendor_event_type` field in metadata.
+ */
+export type MatterEvent =
+  | 'matter.created'
+  | 'matter.updated'
+  | 'matter.closed'
+  | 'document.added'
+  | 'note.added'
+
+/**
+ * Returned by `subscribe()` — the per-customer record of a webhook
+ * subscription registered with the underlying PM system. The id is the
+ * adapter-side handle (used to unsubscribe); the `vendor_subscription_id`
+ * is the vendor's own id for the same record.
+ *
+ * Per ADR 0021 Stream E. The overlay's `hermes-smd-webhook-router`
+ * plugin reads inbound webhook payloads, matches them against
+ * `customer.yaml.webhook_triggers` (schema in #1052), and dispatches
+ * the configured skill.
+ */
+export interface SubscriptionRef {
+  id: string
+  events: ReadonlyArray<MatterEvent>
+  webhook_url: string
+  registered_at: string
+  vendor_subscription_id: string
+}
+
 export interface PracticeManagement extends AdapterBase {
   // Matter operations
   search_matters(query: MatterQuery): Promise<Matter[]>
@@ -165,4 +199,11 @@ export interface PracticeManagement extends AdapterBase {
   // Document operations within the PM system
   list_matter_documents(matter_id: string): Promise<DocumentRef[]>
   upload_matter_document(matter_id: string, doc: DocumentUpload): Promise<DocumentRef>
+
+  // Subscription operations (ADR 0021 Stream E). Adapters that do not
+  // support vendor-side webhooks declare `subscribe` / `unsubscribe`
+  // in `CapabilitySet.unsupported_methods` and raise
+  // `capability_not_supported` at call time.
+  subscribe(events: ReadonlyArray<MatterEvent>, webhook_url: string): Promise<SubscriptionRef>
+  unsubscribe(subscription_id: string): Promise<void>
 }


### PR DESCRIPTION
## Summary

- Wave 3, Stream E.1 of [ADR 0021](https://github.com/venturecrane/ss-console/blob/main/docs/adr/0021-leverage-hermes-native-primitives.md). Closes #1082.
- Adds the matter-event webhook subscription capability to the Filevine BUILD adapter. Companion to the customer.yaml \`connectors[].webhook_url\` schema field landed in #1052, and to the Wave-4 overlay-4 \`hermes-smd-webhook-router\` plugin that consumes the events.

## TypeScript additions

| Type | Purpose |
|---|---|
| \`MatterEvent\` | Canonical event-type union (\`matter.created\`, \`matter.updated\`, \`matter.closed\`, \`document.added\`, \`note.added\`) |
| \`SubscriptionRef\` | \`{id, events, webhook_url, registered_at, vendor_subscription_id}\` — id is adapter-prefixed for cross-adapter uniqueness |
| \`PracticeManagement.subscribe()\` / \`unsubscribe()\` | New methods on the interface — adapters without vendor-side webhook support declare these in \`CapabilitySet.unsupported_methods\` |

## Filevine implementation

- Canonical events translate to Filevine's \`Project.*\` / \`Document.*\` / \`Note.*\` wire vocabulary; one POST per event against \`/core/webhooks\`.
- DELETE strips the adapter prefix from the SubscriptionRef.id and is idempotent on 404.
- Validation: unknown canonical events → \`capability_not_supported\`; empty webhook_url or subscription_id → \`validation_failed\`.

## What changed

| File | Change |
|---|---|
| \`src/lib/ai-employee/capabilities/practice-management.ts\` | New \`MatterEvent\`, \`SubscriptionRef\`, \`subscribe()\`, \`unsubscribe()\` on the interface |
| \`ai-employee/connectors/filevine/capabilities.py\` | \`SUPPORTED_MATTER_EVENTS\`, \`_FILEVINE_EVENT_MAP\`, \`SubscriptionRef\` dataclass, \`subscribe()\` + \`unsubscribe()\` on \`FilevinePracticeManagement\`; added to \`_PM_SUPPORTED\` |
| \`ai-employee/connectors/filevine/client.py\` | \`create_webhook_subscription()\` + \`delete_webhook_subscription()\` HTTP methods |
| \`ai-employee/connectors/filevine/tests/test_capabilities.py\` | 7 new tests |
| \`docs/specs/ai-employee/capability-contracts.md\` | Adds the new types + methods to PracticeManagement |

## Test plan

- [x] \`python3 -m pytest tests/\` in filevine — 64 / 64 pass (7 new)
- [x] \`npm run typecheck\` — 0 errors, 0 warnings
- [x] \`npx prettier --check\` — clean
- [ ] **Live sandbox verification deferred to Wave-4 hardening PR.** The HTTP path is tested against a mocked client only; Filevine v2's webhook API contract is documented but not exercised against a real sandbox here.

## E.2 (Clio) status

\`venturecrane/ss-console\` does NOT currently ship a Clio BUILD connector — only \`filevine\`, \`lawpay\`, and \`no_pm\` exist in \`ai-employee/connectors/\`. The original ADR 0021 plan assumed Clio would have a BUILD adapter; the gap is documented in #1082 and Clio's \`subscribe()\` ships alongside the Clio connector when that lands.

## Refs

- Parent tracking: #1049
- ADR: ADR 0021 Stream E
- Schema dependency: #1052 (\`customer.yaml.connectors[].webhook_url\`)
- Consumer: Wave-4 overlay-4 \`hermes-smd-webhook-router\` (separate, in overlay repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)