### PR TITLE
chore(ai-employee): remove Composio prompt from provision-customer.sh

### DIFF
--- a/ai-employee/bin/provision-customer.sh
+++ b/ai-employee/bin/provision-customer.sh
@@ -198,9 +198,13 @@ prompt_and_set() {
   log "Staged ${secret_name}"
 }
 
-# Required secrets per bootstrap.sh
+# Required secrets per bootstrap.sh.
+# COMPOSIO_API_KEY removed 2026-05-26: Composio is doctrine-dropped per the
+# ADR 0020 revision dated 2026-05-24 ("As of this revision, no currently
+# planned binding uses composio"). The schema validator and runtime guard
+# still accept `composio:` backend prefixes for future long-tail vendors;
+# this prompt was dead provisioning ceremony.
 prompt_and_set ANTHROPIC_API_KEY  "Anthropic API key for hermes-${SLUG}"
-prompt_and_set COMPOSIO_API_KEY   "Composio API key (Standard tier)"
 prompt_and_set AGENTMAIL_API_KEY  "AgentMail API key (Builder tier)"
 
 # R2 access for bootstrap.sh's customer.yaml fetch + customer-sync sidecar's


### PR DESCRIPTION
## Summary

- Removes the dead `COMPOSIO_API_KEY` prompt from `ai-employee/bin/provision-customer.sh`
- Composio was dropped from the connector decision table per the [ADR 0020 revision dated 2026-05-24](docs/adr/0020-connector-strategy.md): *"As of this revision, no currently planned binding uses composio — every prior composio row in the table above migrated to a vendor-direct MCP."*
- Schema validator and runtime guard still accept `composio:` backend prefixes for future long-tail vendors; this change only removes provisioning ceremony.

## Why

Surfaced during the 2026-05-26 customer-zero standup audit. `provision-customer.sh` would prompt Captain for a Composio key on every new customer provision, even though no connector binding in the current decision table uses it. Dead step.

## Test plan

- [x] `bash -n ai-employee/bin/provision-customer.sh` passes
- [ ] Visual diff review — confirm only the Composio prompt is removed; rationale comment is captured
- [ ] No downstream references to `COMPOSIO_API_KEY` in `bootstrap.sh` / overlay bootstrap that this removal would break (per ADR 0020, the prefix substrate is preserved — only the provision-time prompt was removed)

## Related

- #776 (Build first SMD AI Employee — surfaces during prereq audit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)