### PR TITLE
docs(adr-0023): correct citations, lock implementation decisions, add observability: schema block

### DIFF
--- a/docs/adr/0023-ai-employee-per-customer-observability.md
+++ b/docs/adr/0023-ai-employee-per-customer-observability.md
@@ -60,7 +60,7 @@ The per-customer observability stack is composed from existing specs (cited, not
 
 ### Introduced by this ADR
 
-**1. Sentry on AI Employee Machines.** One shared `smd-ai-employee` Sentry project; DSN pushed as a Fly secret at provision time (same mechanism as Anthropic / Composio per [ADR 0010](./0010-per-customer-oauth-token-storage.md)). The AI Employee bootstrap reads `customer.yaml` (via the same path used by `hermes-smd bootstrap` per [ADR 0019](./0019-customer-yaml-storage.md) / `0019` equivalent) and initializes the Sentry SDK with a scope tag `tenant=<slug>`.
+**1. Sentry on AI Employee Machines.** One shared `smd-ai-employee` Sentry project; DSN pushed as a Fly secret at provision time (same mechanism as Anthropic / Composio per [ADR 0010](./0010-per-customer-oauth-token-storage.md)). The AI Employee bootstrap reads `customer.yaml` (via the same path used by `hermes-smd bootstrap` per [ADR 0019](./0019-customer-yaml-to-profile-config-translation.md)) and initializes the Sentry SDK with a scope tag `tenant=<slug>`.
 
 The marketing-site reference pattern is `src/lib/observability/sentry.ts` (a `withSentryRequestHandler` wrapper using `@sentry/cloudflare@^10.51.0`), invoked from `src/middleware.ts:255`. **That is a TypeScript-for-Workers pattern; the AI Employee Machines are Python, so the implementation uses the `sentry-sdk` Python package, not `@sentry/cloudflare`.** The marketing site is conceptual reference, not code reuse. The Python init lives in `venturecrane/hermes-smd-overlay` per [ADR 0015](./0015-hermes-fork-vs-upstream.md) — that repo is not in the `ss-console` workspace; implementation lands in a separate PR there.
 
@@ -78,7 +78,7 @@ SMD ops configures Sentry alert rules in Sentry UI per customer. No auto-provisi
 }
 ```
 
-`heartbeat_ts` is written by a 30-second internal ticker, independent of any traffic. A background task on the Machine POSTs to its assigned healthchecks.io URL every 60 seconds. Healthchecks.io grace expiration fires a webhook to the alert-router.
+`heartbeat_ts` is written by a 30-second internal ticker, independent of any traffic. A background task on the Machine POSTs to its assigned healthchecks.io URL every 60 seconds. Healthchecks.io grace expiration fires a webhook to `/api/webhooks/healthchecks`, which writes a `cost_anomaly_alerts` row with `source='healthchecks'`.
 
 `/health` is reachable only via Fly's private network — it is not exposed publicly. The grace and period are configurable per customer via `customer.yaml.observability.health`.
 
@@ -94,15 +94,13 @@ Adds a new D1 table `fleet_status` in `ss-console`'s D1 (`env.DB`) — not per-c
 
 No separate `/admin/ai-employee/fleet` page.
 
-**4. Alert routing — composes with the existing cost-anomaly system.** A `customer.yaml.observability.alert_webhook` field (optional; SMD-default Telegram channel if absent — bot token stored in Infisical, populated at Worker deploy as a Cloudflare Worker secret). Telegram is the pinned default because it accepts arbitrary text payloads; alternative destinations (Slack / PagerDuty / email) would require shape negotiation in a follow-on.
+**4. Alert routing — composes with the existing cost-anomaly system.** All sources (cost-anomaly, Sentry, healthchecks, audit-integrity in Wave 2) write rows to the existing `cost_anomaly_alerts` table tagged by `source`. The admin dashboard at `/admin/ai-employee/costs/` surfaces them via the existing `listOpenAlerts()` reader (source-agnostic by design). The dashboard is the primary monitoring surface; push-channel escalation is deferred to a real-customer-demand follow-on per locked-decision #9.
 
 The router has two distinct surfaces:
 
-- **Push (webhook receiver Worker).** Sentry's native alert rules POST here; healthchecks.io POSTs on grace expiration. No custom Sentry threshold is invented in this ADR — Sentry's native rate-of-change and frequency rules are the configuration surface, owned per-customer by SMD ops in Sentry UI. **Operational gotcha at scale**: per-customer alert rules in Sentry are configured manually; manageable at five customers, painful at fifty. Auto-provisioning Sentry rules from `customer.yaml` is a follow-on triggered by customer-count scale.
+- **Push (webhook receiver — composes with `src/pages/api/webhooks/`, no new Worker).** Sentry's native alert rules POST to `/api/webhooks/sentry`; healthchecks.io POSTs to `/api/webhooks/healthchecks` on grace expiration. Each handler verifies HMAC against the source's signing secret and writes a `cost_anomaly_alerts` row with the appropriate `source` tag. No custom Sentry threshold is invented here — Sentry's native rate-of-change and frequency rules are the configuration surface, owned per-customer by SMD ops in Sentry UI. **Operational gotcha at scale**: per-customer alert rules in Sentry are configured manually; manageable at the first few customers, painful at ~20+. Auto-provisioning Sentry rules from `customer.yaml` is a follow-on triggered by customer-count scale.
 
-- **Pull (cron consumer Worker).** A scheduled Worker reads `audit_log_integrity` reports (post-rehome) and emits Captain alerts. The **existing cost-anomaly subsystem** (`src/lib/admin/cost-anomaly.ts` + `listOpenAlerts`) already handles COGS/MRR threshold detection and persists alert rows; this ADR adds an outbound-webhook step that posts unacknowledged anomalies to `alert_webhook`. The router does NOT reinvent the anomaly-detection logic.
-
-Both surfaces route outbound to the same `alert_webhook` destination via the same Worker entry, with a `source` field in the payload so Telegram messages are distinguishable.
+- **Pull (cron consumer — extends `workers/cost-anomaly`, no parallel router).** The existing daily cron at `workers/cost-anomaly` already handles COGS/MRR threshold detection and persists alert rows via `listOpenAlerts` / `upsertAlert`. This ADR adds (a) a 24h Sentry error-count sync that writes `fleet_status.sentry_errors_last_24h`, and (b) the `source='cost'` tag on cost-anomaly writes for the dashboard's source-agnostic banner. Captain ops escalation continues via the existing Resend path on this Worker. The router does NOT reinvent the anomaly-detection logic and does NOT introduce a parallel alert-router Worker.
 
 **5. Fly resource metrics (not new, named explicitly).** Per-Machine CPU, memory, disk, network, and restart count come from Fly's hosted Grafana + Prometheus endpoint. SMD ops bookmark the Fly Grafana view per Machine; nothing in SMD's stack duplicates these signals. Listed here as a layer of the observability stack so the ADR does not leave the resource-metrics gap silent.
 
@@ -110,7 +108,7 @@ Both surfaces route outbound to the same `alert_webhook` destination via the sam
 
 1. **SMD-managed vendor accounts** (Captain decision 2026-05-26). Single Sentry org, single healthchecks.io account, SMD-owned per-customer R2 buckets (Object Lock per `audit-log-immutability.md`). Customer-owned vendor accounts deferred to a follow-on ADR triggered by real demand (premium tier or compliance posture).
 
-2. **Alert-only on COGS/MRR breach** (Captain decision 2026-05-26). The existing > 0.40 / two-consecutive-month threshold from `cost-telemetry-events.md` is the trigger. This ADR adds: alerts route to `alert_webhook`; Captain decides per-incident (re-scope, eat cost, talk to client). No automatic disabling of the AI Employee. Auto-disable / soft-cap / hard-cap mechanisms are explicitly out of scope.
+2. **Alert-only on COGS/MRR breach** (Captain decision 2026-05-26). The existing > 0.40 / two-consecutive-month threshold from `cost-telemetry-events.md` is the trigger. This ADR adds: alert rows are written to `cost_anomaly_alerts` with `source='cost'` and surface in the admin dashboard banner; the existing Resend path on `workers/cost-anomaly` continues to email Captain. Captain decides per-incident (re-scope, eat cost, talk to client). No automatic disabling of the AI Employee. Auto-disable / soft-cap / hard-cap mechanisms are explicitly out of scope.
 
 3. **Shared Sentry project, tenant tag at SDK init** — not per-customer Sentry projects. Isolation comes from tag scoping; query filters on `tenant=<slug>` to surface per-customer error streams.
 
@@ -126,6 +124,12 @@ Both surfaces route outbound to the same `alert_webhook` destination via the sam
 
 8. **Healthchecks.io heartbeats are push-from-Machine, not pull.** The Machine emits an outbound POST to its assigned healthchecks.io URL every 60 seconds. Push direction means the Machine declares liveness; pull would require exposing `/health` publicly and trusting the responder.
 
+9. **Admin dashboard is the primary monitoring surface; push channels are escalation overlay.** All alert sources (cost, Sentry, healthchecks, audit-integrity in Wave 2) write rows to the existing `cost_anomaly_alerts` table tagged by `source`. The existing `/admin/ai-employee/costs/` page surfaces them via the existing `listOpenAlerts()` reader. Customer-configurable external destinations (`alert_webhook`) are a follow-on triggered by real customer demand — Wave 1 ships without the field because Telegram bot webhooks don't accept arbitrary JSON, Slack incoming webhooks accept only `{text}`, and shipping a "Telegram-compatible payload" that doesn't function against Telegram is worse than not shipping it. Captain ops escalation (fleet-wide critical alerts) reuses the existing Resend path on `workers/cost-anomaly`.
+
+10. **Machine-to-control-plane heartbeat auth — single shared secret in Wave 1.** A single `MACHINE_HEARTBEAT_KEY` Worker secret authenticates `POST /api/internal/heartbeat`; `X-Tenant-Slug` header identifies the tenant. No per-customer key DB lookup → no timing-oracle path on slug enumeration. **Upgrade path (customer #2 onboarding):** per-tenant secrets in a `machine_credentials` table with HMAC-SHA256 + per-row salt, dual-key rotation (current + prev with TTL), always-DB-roundtrip lookup with sentinel hash on miss for timing uniformity. Documented and gated on customer #2; not built now.
+
+11. **Sentry PII scrub is locked at SDK init.** `send_default_pii=False`; `before_send` + `before_breadcrumb` hooks strip: request bodies entirely; named headers (`cookie`, `authorization`, `x-api-key`, `x-machine-token`, `x-sentry-auth`, `x-tenant-slug`); email-shaped regex from messages and breadcrumbs; provider key shapes (`sk-[a-zA-Z0-9]{20,}`, `pk_(live|test)_[a-zA-Z0-9]{20,}`, AWS `AKIA[0-9A-Z]{16}`). The scrub list is a constant in the overlay's Sentry init module; a pytest regression suite gates every overlay PR so refactor-induced regressions surface in review, not after a leak.
+
 ### customer.yaml additions
 
 The existing `logging:` block (`level`, `ship_to`) handles application stdout/stderr destinations — it is unchanged and orthogonal to this addition. `memory.retention.audit_log_days`, `compliance_enabled`, role-related fields, and connector OAuth scope declarations also stay unchanged. The new `observability:` block is parallel to `logging:` and covers vendor wiring only:
@@ -137,10 +141,11 @@ observability:
   health:
     period_seconds: 60 # push cadence to healthchecks.io
     grace_minutes: 5 # late before alert fires
-  alert_webhook: <url> # optional; SMD-default Telegram bot channel if absent
 ```
 
 Sentry error-spike thresholds are NOT in `customer.yaml` — they are owned by Sentry's native alert rules, configured per-customer in Sentry UI by SMD ops. Auto-provisioning from `customer.yaml` is a follow-on triggered by customer-count scale.
+
+`alert_webhook` is deferred per locked-decision #9 — Wave 1 has no customer-configurable external destination. The Captain ops escalation path is the existing Resend channel on `workers/cost-anomaly`; customer-facing escalation is the admin dashboard. Reintroduction is a follow-on driven by real customer demand, with per-destination adapter shape (Telegram bot API / Slack incoming webhook / raw HTTPS) — not a single "Telegram-compatible" payload that doesn't actually work against Telegram.
 
 No customer-owned vendor fields. Adding them is a follow-on ADR.
 
@@ -153,15 +158,15 @@ No customer-owned vendor fields. Adding them is a follow-on ADR.
 - Wave-1 work ships independently of the audit-log rehome; the ADR does not block Sentry, `/health`, fleet view, or alert routing on out-of-tree work.
 - The fleet view drops into the existing customer-list page, preserving the drill-down and avoiding a new admin surface that would have its own auth and IA decisions.
 - Alert routing composes with the existing `listOpenAlerts` system rather than duplicating cost-anomaly detection logic.
-- Telegram as the default `alert_webhook` keeps the SMD-side mechanic single-channel and Captain-readable on mobile; the field stays optional so customers who want their own destination can override.
+- Admin dashboard is the single always-on monitoring surface across all customers; Captain's mobile / inbox escalation goes through the existing Resend path (no new channel for Wave 1). Customer-configurable external destinations are deferred until a real customer asks for one — at which point the design lands as per-destination adapters, not a single shape that doesn't fit any real webhook target.
 
 **Negative / accepted.**
 
-- SMD operates more vendor accounts (Sentry, healthchecks.io, per-customer R2 buckets, Telegram bot). Vendor sprawl is real; the trade is centralized account hygiene vs. per-customer provisioning complexity. We accept.
+- SMD operates more vendor accounts (Sentry, healthchecks.io, per-customer R2 buckets). Vendor sprawl is real; the trade is centralized account hygiene vs. per-customer provisioning complexity. We accept.
 - Sentry alert rules are configured manually per customer in Sentry UI. Manageable for the first few customers; at ~50 customers this becomes an operational burden, triggering an auto-provisioning follow-on.
 - The fleet view depends on a Machine-to-control-plane HTTP write per heartbeat. A control-plane outage degrades the fleet view but does not affect Machine operation. We accept.
 - `fleet_status` is a control-plane table that crosses customer boundaries by design. [ADR 0009](./0009-cross-machine-query-prohibition.md) explicitly permits this for fleet health; the choice is auditable but worth re-stating loudly here.
-- Wave 1 ships without audit-log Logpush. The audit log still writes to per-customer D1 (the immutability invariant in `audit-log-immutability.md` Layer 1 holds via the Worker wrapper), but the tamper-resistant R2 mirror is deferred to Wave 2. We accept; the marginal compliance posture between "D1-only" and "D1 + Logpush mirror" is small for the pre-customer-zero window.
+- Wave 1 ships without audit-log Logpush. The audit log still writes to per-customer D1 (the immutability invariant in `audit-log-immutability.md` Layer 1 holds via the Worker wrapper), but the tamper-resistant R2 mirror is deferred to Wave 2. We accept; the compliance posture between "D1-only" and "D1 + Logpush mirror" is acceptable for the pre-customer-zero window. The delta is real (the Worker wrapper defends against application-level mistakes but not against privileged D1 manipulation), so Wave 2 is on the critical path before the first paying regulated-vertical customer.
 
 **Out of scope.**
 
@@ -197,7 +202,8 @@ No customer-owned vendor fields. Adding them is a follow-on ADR.
 - `ai-employee/bin/decommission-customer.sh` + `ai-employee/bin/lib/decommission.py` — unstub: cancel healthchecks.io check; remove `fleet_status` row.
 - New: D1 migration adding `fleet_status` table (control-plane, in `env.DB`).
 - Extend: `src/pages/admin/ai-employee/costs/index.astro` — add three new columns (heartbeat status, Sentry errors last hour, uptime).
-- New: alert-router Worker — push-surface webhook receiver (Sentry + healthchecks.io inbound); pull-surface cron consumer composing with `listOpenAlerts` from `src/lib/admin/cost-anomaly.ts`. Outbound to `alert_webhook` (Telegram default).
+- New: Sentry + healthchecks.io webhook receivers in `src/pages/api/webhooks/` (no new Worker). Each receiver verifies HMAC and writes a `cost_anomaly_alerts` row with the appropriate `source` tag.
+- Extend `workers/cost-anomaly` with a daily 24h Sentry error-count sync (writes `fleet_status.sentry_errors_last_24h` + `sentry_errors_synced_at`). Existing Resend escalation path unchanged. Cost-anomaly writes get `source='cost'` for the dashboard banner.
 
 ### Wave 2 — post-rehome (gates on audit-log-immutability rehome)
 
@@ -224,15 +230,15 @@ No customer-owned vendor fields. Adding them is a follow-on ADR.
 3. **Error tagging** — fire a deliberate unhandled exception; Sentry event arrives scope-tagged `tenant=synthetic-test`; filter by another tenant shows nothing.
 4. **Resource metrics** — Fly Grafana view for the Machine renders CPU / memory / disk / network; SMD ops bookmark URL works.
 5. **Cost emission** — drive 100 mocked Anthropic calls per `cost-telemetry-events.md` verification suite; `cost_telemetry` rows appear; `compute_monthly_rollup` reads them back; COGS/MRR computation matches expected.
-6. **Alert routing — pull surface** — synthetic COGS/MRR breach (seeded cost rows + rollup) fires alert to the configured `alert_webhook`.
-7. **Alert routing — push surface** — Sentry alert rule fires test webhook; healthchecks.io test-fail fires webhook; both land at `alert_webhook` with distinguishable `source` payloads.
+6. **Alert routing — pull surface** — synthetic COGS/MRR breach (seeded cost rows + rollup) writes a `cost_anomaly_alerts` row with `source='cost'`; admin dashboard banner surfaces it; existing Resend Captain notification fires.
+7. **Alert routing — push surface** — Sentry alert rule fires test webhook; healthchecks.io test-fail fires webhook; each handler verifies HMAC and writes a `cost_anomaly_alerts` row with `source='sentry'` and `source='healthchecks'` respectively; admin dashboard banner surfaces both.
 8. **Fleet view** — extended `/admin/ai-employee/costs/` page shows synthetic-test with new heartbeat / error / uptime columns; kill Machine; heartbeat column flips to red within grace window; drill-down to existing `/admin/ai-employee/costs/{customer_slug}` works unchanged.
 9. **Decommission** — `bin/decommission-customer.sh synthetic-test` completes all nine steps; healthchecks check cancelled; `fleet_status` row removed.
 
 ### Wave 2
 
 10. **Audit immutability** — insert audit row via writer; R2 Object Lock bucket contains the mirror row within Logpush window; UPDATE / DELETE against `audit_log` raises `AuditLogImmutabilityError`; periodic integrity check reports clean.
-11. **Audit-immutability alert routing** — seed an `IN_MIRROR_NOT_IN_D1` finding; alert fires to `alert_webhook`.
+11. **Audit-immutability alert routing** — seed an `IN_MIRROR_NOT_IN_D1` finding; writer emits a `cost_anomaly_alerts` row with `source='audit_integrity'`; admin dashboard banner surfaces it.
 12. **Decommission audit carve-out** — `bin/decommission-customer.sh` preserves audit log per `audit-retention.md` carve-out; R2 audit bucket retained per retention policy.
 
 ## References

--- a/docs/specs/ai-employee/customer-yaml-schema.md
+++ b/docs/specs/ai-employee/customer-yaml-schema.md
@@ -137,6 +137,13 @@ pause: # OPTIONAL
   active: <boolean> # default false
   reason: <string> # required if active=true
 
+observability: # OPTIONAL — added by ADR 0023 Wave 1
+  sentry: # OPTIONAL
+    enabled: <boolean> # default true; shared SMD project, tenant-tagged at SDK init
+  health: # OPTIONAL
+    period_seconds: <int> # default 60; heartbeat push cadence to healthchecks.io
+    grace_minutes: <int> # default 5; late before healthchecks.io fires a webhook
+
 # ---- COMPLIANCE DASHBOARD VIEW (OPTIONAL; added by #895) ----
 # See dashboard-roles.md §"Dedicated Compliance dashboard view (#895)".
 # Defaults to false when omitted. RBAC on the existing audit surface is
@@ -411,6 +418,31 @@ Validation rules:
 The fallback is enforced in `VoiceProfileBundle.select(reviewer_user_id, recipient_cohort)`. Each step's outcome is recorded in `TransformResult.selected_voice_user_id` and `TransformResult.selected_voice_cohort` so the audit row and dashboard surface know which profile actually shaped the draft.
 
 **Blind-test gate scoping.** The voice-gate harness (`runVoiceGate({ ..., cohort })`) already scopes per cohort; the blind-test gate (#823) is exercised per cohort separately. The schema additions in this PR feed the harness's cohort vocabulary; the harness's three-state contract (pass / near-pass / fail) is unchanged.
+
+## Observability (ADR 0023)
+
+**Added by [ADR 0023](../../adr/0023-ai-employee-per-customer-observability.md) Wave 1.** Optional block parallel to `logging:` and `pause:`. Covers vendor wiring for the per-customer observability stack (Sentry on Machine, healthchecks.io push heartbeat).
+
+```yaml
+observability: # OPTIONAL
+  sentry: # OPTIONAL
+    enabled: <boolean> # default true
+  health: # OPTIONAL
+    period_seconds: <int> # default 60
+    grace_minutes: <int> # default 5
+```
+
+Field rules:
+
+- The entire `observability:` block is optional. Missing fields fall back to documented defaults. Setting `observability:` to an empty object is equivalent to omitting it.
+- `sentry.enabled` defaults to `true`. The Machine initializes the Sentry SDK with a `tenant=<customer_id>` scope tag at boot (Python `sentry-sdk` package in the overlay). Setting to `false` disables Sentry init at boot — used for synthetic-customer fixtures and CI smoke runs that should not emit to the shared `smd-ai-employee` project.
+- `sentry.send_default_pii` and `sentry.before_send` scrub list are NOT in `customer.yaml` — they are locked in the overlay's Sentry init module per ADR 0023 §"Cross-cutting calls" #11 and gated by a pytest regression suite. Per-customer scrub overrides are a deliberate follow-on; no compliance posture allows weakening the default scrub.
+- `health.period_seconds` is the cadence of the Machine's outbound POST to its assigned healthchecks.io URL. Defaults to 60.
+- `health.grace_minutes` is the late-window before healthchecks.io fires its grace-expired webhook. Defaults to 5.
+
+**Sentry error-spike thresholds are NOT in `customer.yaml`.** They are owned by Sentry's native alert rules, configured per-customer in Sentry UI by SMD ops. Auto-provisioning from `customer.yaml` is a follow-on triggered by customer-count scale (~20+ customers).
+
+**No `alert_webhook` field in Wave 1.** Customer-configurable external destinations are deferred per ADR 0023 §"Cross-cutting calls" #9. The admin dashboard at `/admin/ai-employee/costs/` is the always-on monitoring surface across all customers; Captain ops escalation uses the existing Resend path on `workers/cost-anomaly`. Reintroduction is a follow-on driven by real customer demand with per-destination adapters, not a single shape that doesn't fit any real webhook target.
 
 ## Failure modes
 

--- a/src/lib/ai-employee/customer-yaml/sections-observability.ts
+++ b/src/lib/ai-employee/customer-yaml/sections-observability.ts
@@ -1,0 +1,104 @@
+/**
+ * Validator for the `observability:` block.
+ *
+ * Added by ADR 0023 Wave 1. Optional; partial. Returns a fully-populated
+ * Observability with defaults filled for any missing field. Consumers can
+ * always read `result.sentry.enabled`, `result.health.period_seconds`, etc.
+ * without null-checking.
+ *
+ * Validation is structural only — TypeMismatch when fields are present
+ * with wrong types. No `alert_webhook` field in Wave 1; see ADR 0023
+ * §"Cross-cutting calls" #9 for deferral rationale.
+ *
+ * Lives in its own file (not `sections-other.ts`) so the per-block check
+ * logic can split into helpers without bumping the orchestrator file
+ * past the 500-line ceiling.
+ */
+
+import { OBSERVABILITY_DEFAULTS, type Observability, type ValidationError } from './types'
+import { isPlainObject } from './helpers'
+
+export function checkObservability(
+  root: Record<string, unknown>,
+  errors: ValidationError[]
+): Observability {
+  const raw = root['observability']
+  if (raw === undefined || raw === null) return cloneDefaults()
+  if (!isPlainObject(raw)) {
+    errors.push({
+      code: 'TypeMismatch',
+      path: 'observability',
+      message: 'observability must be an object when present',
+    })
+    return cloneDefaults()
+  }
+
+  const result = cloneDefaults()
+  applySentry(raw['sentry'], result, errors)
+  applyHealth(raw['health'], result, errors)
+  return result
+}
+
+function cloneDefaults(): Observability {
+  return {
+    sentry: { ...OBSERVABILITY_DEFAULTS.sentry },
+    health: { ...OBSERVABILITY_DEFAULTS.health },
+  }
+}
+
+function applySentry(raw: unknown, result: Observability, errors: ValidationError[]): void {
+  if (raw === undefined || raw === null) return
+  if (!isPlainObject(raw)) {
+    errors.push({
+      code: 'TypeMismatch',
+      path: 'observability.sentry',
+      message: 'observability.sentry must be an object when present',
+    })
+    return
+  }
+  const enabled = raw['enabled']
+  if (enabled === undefined) return
+  if (typeof enabled !== 'boolean') {
+    errors.push({
+      code: 'TypeMismatch',
+      path: 'observability.sentry.enabled',
+      message: 'observability.sentry.enabled must be a boolean',
+    })
+    return
+  }
+  result.sentry.enabled = enabled
+}
+
+function applyHealth(raw: unknown, result: Observability, errors: ValidationError[]): void {
+  if (raw === undefined || raw === null) return
+  if (!isPlainObject(raw)) {
+    errors.push({
+      code: 'TypeMismatch',
+      path: 'observability.health',
+      message: 'observability.health must be an object when present',
+    })
+    return
+  }
+  applyPositiveIntField(raw, 'period_seconds', result.health, 'period_seconds', errors)
+  applyPositiveIntField(raw, 'grace_minutes', result.health, 'grace_minutes', errors)
+}
+
+function applyPositiveIntField(
+  raw: Record<string, unknown>,
+  rawKey: string,
+  target: { period_seconds: number; grace_minutes: number },
+  targetKey: 'period_seconds' | 'grace_minutes',
+  errors: ValidationError[]
+): void {
+  const value = raw[rawKey]
+  if (value === undefined) return
+  if (typeof value !== 'number' || !Number.isInteger(value) || value <= 0) {
+    errors.push({
+      code: 'TypeMismatch',
+      path: `observability.health.${rawKey}`,
+      message: `observability.health.${rawKey} must be a positive integer`,
+    })
+    return
+  }
+  target[targetKey] = value
+}

--- a/src/lib/ai-employee/customer-yaml/sections-other.ts
+++ b/src/lib/ai-employee/customer-yaml/sections-other.ts
@@ -1,6 +1,7 @@
 /**
  * Remaining section validators: scope, escalation, memory, and the
- * optional voice_library / business_hours / logging / pause blocks.
+ * optional voice_library / business_hours / logging / pause / observability
+ * blocks.
  */
 
 import {

--- a/src/lib/ai-employee/customer-yaml/types.ts
+++ b/src/lib/ai-employee/customer-yaml/types.ts
@@ -393,6 +393,23 @@ export interface Pause {
   reason: string | null
 }
 
+/**
+ * Observability block — added by ADR 0023 Wave 1.
+ *
+ * All fields are optional with documented defaults. Defaults are filled in
+ * by `checkObservability` on read so consumers can always assume the full
+ * shape is present.
+ */
+export interface Observability {
+  sentry: { enabled: boolean }
+  health: { period_seconds: number; grace_minutes: number }
+}
+
+export const OBSERVABILITY_DEFAULTS: Observability = {
+  sentry: { enabled: true },
+  health: { period_seconds: 60, grace_minutes: 5 },
+}
+
 export interface MachineSpec {
   size: string
   memory_mb: number
@@ -419,6 +436,12 @@ export interface CustomerYaml {
   memory: Memory
   logging: Logging | null
   pause: Pause | null
+  /**
+   * Observability block — added by ADR 0023 Wave 1. Always non-null on a
+   * validated CustomerYaml; defaults are filled in by `checkObservability`
+   * when the block is absent or partially populated.
+   */
+  observability: Observability
   /**
    * Inbound webhook → skill trigger map — ADR 0021 Stream E. Empty array
    * when no connector exposes a webhook_url.

--- a/src/lib/ai-employee/customer-yaml/validator.ts
+++ b/src/lib/ai-employee/customer-yaml/validator.ts
@@ -32,6 +32,7 @@ import {
   type CustomerYaml,
   type MachineSpec,
   type Memory,
+  type Observability,
   type SchemaVersion,
   type ValidationError,
   type ValidationResult,
@@ -56,6 +57,7 @@ import {
   checkScope,
   checkVoiceLibrary,
 } from './sections-other'
+import { checkObservability } from './sections-observability'
 import { checkVoiceCohorts } from './sections-voice'
 import { checkWebhookTriggers } from './sections-webhook-triggers'
 
@@ -88,6 +90,7 @@ export type {
   Pause,
   MachineSpec,
   CostEstimate,
+  Observability,
   Vertical,
   TrustCeiling,
   Pronouns,
@@ -108,6 +111,7 @@ export {
   ACCEPTED_WAKE_POLICIES,
   AUDIT_LOG_DAYS_MAX,
   BASE_VOICE_COHORTS,
+  OBSERVABILITY_DEFAULTS,
   VERTICAL_AUDIT_LOG_DAYS_DEFAULTS,
   WEBHOOK_URL_PATTERN,
   isAcceptedCronSchedule,
@@ -175,6 +179,7 @@ interface ParsedSections {
   businessHours: ReturnType<typeof checkBusinessHours>
   logging: ReturnType<typeof checkLogging>
   pause: ReturnType<typeof checkPause>
+  observability: Observability
   webhookTriggers: ReturnType<typeof checkWebhookTriggers>
   complianceEnabled: boolean
 }
@@ -217,6 +222,7 @@ function validateSections(
     businessHours: checkBusinessHours(root, errors),
     logging: checkLogging(root, errors),
     pause: checkPause(root, errors),
+    observability: checkObservability(root, errors),
     webhookTriggers,
     complianceEnabled: checkComplianceEnabled(root, errors),
   }
@@ -246,6 +252,7 @@ function assembleCustomerYaml(root: Record<string, unknown>, p: ParsedSections):
     memory: p.memory as Memory,
     logging: p.logging,
     pause: p.pause,
+    observability: p.observability,
     webhook_triggers: p.webhookTriggers,
     compliance_enabled: p.complianceEnabled,
   }

--- a/src/lib/portal/ai-employee/customer-yaml-editor.ts
+++ b/src/lib/portal/ai-employee/customer-yaml-editor.ts
@@ -419,6 +419,11 @@ export function applyEditableChanges(
         }
       : null,
     pause: changes.pause ? { active: changes.pause.active, reason: changes.pause.reason } : null,
+    // observability is not user-editable in the portal yet (ADR 0023 Wave 1
+    // lands the schema field; in-product editor is a follow-on if customer
+    // demand surfaces). Preserve the current value verbatim — the validator
+    // default-fills on read so `current.observability` is always non-null.
+    observability: current.observability,
     // webhook_triggers is not user-editable in the portal yet (ADR 0021
     // Stream E lands the field; in-product editor is a follow-on).
     // Preserve the current value verbatim.

--- a/tests/customer-yaml-validator.test.ts
+++ b/tests/customer-yaml-validator.test.ts
@@ -232,6 +232,113 @@ describe('validate — MissingField', () => {
 })
 
 // -----------------------------------------------------------------------------
+// Observability (ADR 0023 Wave 1)
+// -----------------------------------------------------------------------------
+
+describe('validate — observability block (ADR 0023)', () => {
+  it('fills defaults when block is absent', () => {
+    const r = validate(validFixture())
+    if (!r.ok) throw new Error('expected ok')
+    expect(r.value.observability.sentry.enabled).toBe(true)
+    expect(r.value.observability.health.period_seconds).toBe(60)
+    expect(r.value.observability.health.grace_minutes).toBe(5)
+  })
+
+  it('fills defaults when block is an empty object', () => {
+    const f = validFixture()
+    f['observability'] = {}
+    const r = validate(f)
+    if (!r.ok) throw new Error('expected ok')
+    expect(r.value.observability).toEqual({
+      sentry: { enabled: true },
+      health: { period_seconds: 60, grace_minutes: 5 },
+    })
+  })
+
+  it('accepts a fully populated observability block', () => {
+    const f = validFixture()
+    f['observability'] = {
+      sentry: { enabled: false },
+      health: { period_seconds: 30, grace_minutes: 10 },
+    }
+    const r = validate(f)
+    if (!r.ok) throw new Error('expected ok')
+    expect(r.value.observability.sentry.enabled).toBe(false)
+    expect(r.value.observability.health.period_seconds).toBe(30)
+    expect(r.value.observability.health.grace_minutes).toBe(10)
+  })
+
+  it('partial population fills only missing fields', () => {
+    const f = validFixture()
+    f['observability'] = { health: { period_seconds: 120 } }
+    const r = validate(f)
+    if (!r.ok) throw new Error('expected ok')
+    expect(r.value.observability.sentry.enabled).toBe(true) // default
+    expect(r.value.observability.health.period_seconds).toBe(120) // overridden
+    expect(r.value.observability.health.grace_minutes).toBe(5) // default
+  })
+
+  it('rejects non-boolean sentry.enabled', () => {
+    const f = validFixture()
+    f['observability'] = { sentry: { enabled: 'yes' } }
+    const r = validate(f)
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(
+      r.errors.some((e) => e.path === 'observability.sentry.enabled' && e.code === 'TypeMismatch')
+    ).toBe(true)
+  })
+
+  it('rejects non-positive-integer health.period_seconds', () => {
+    const f = validFixture()
+    f['observability'] = { health: { period_seconds: 0 } }
+    const r = validate(f)
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(
+      r.errors.some(
+        (e) => e.path === 'observability.health.period_seconds' && e.code === 'TypeMismatch'
+      )
+    ).toBe(true)
+  })
+
+  it('rejects non-positive-integer health.grace_minutes', () => {
+    const f = validFixture()
+    f['observability'] = { health: { grace_minutes: -1 } }
+    const r = validate(f)
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(
+      r.errors.some(
+        (e) => e.path === 'observability.health.grace_minutes' && e.code === 'TypeMismatch'
+      )
+    ).toBe(true)
+  })
+
+  it('rejects non-object observability', () => {
+    const f = validFixture()
+    f['observability'] = 'invalid'
+    const r = validate(f)
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(r.errors.some((e) => e.path === 'observability' && e.code === 'TypeMismatch')).toBe(true)
+  })
+
+  it('does not accept an alert_webhook field (deferred per ADR 0023 §9)', () => {
+    const f = validFixture()
+    // Including alert_webhook is silently ignored — validator doesn't gate on
+    // unknown keys, but the field doesn't appear in the typed output.
+    f['observability'] = { alert_webhook: 'https://example.com/webhook' }
+    const r = validate(f)
+    if (!r.ok) throw new Error('expected ok (unknown keys ignored)')
+    // The typed shape has no alert_webhook field.
+    expect('alert_webhook' in (r.value.observability as unknown as Record<string, unknown>)).toBe(
+      false
+    )
+  })
+})
+
+// -----------------------------------------------------------------------------
 // Enum violations
 // -----------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

ADR 0023 Wave 1 PR 1/5. Doc + schema + validator wiring; no runtime behavior change yet (wired pieces land in PRs 2-5 + overlay PR O1).

**ADR 0023 corrections:**
- Fix broken link target on §"Introduced by this ADR" §1 (was `0019-customer-yaml-storage.md`, actual file is `0019-customer-yaml-to-profile-config-translation.md`); remove leftover `/ 0019 equivalent` author note.
- Soften compliance-posture language in negative consequences (drop "small" on the D1-only vs D1+Logpush gap). Worker wrapper defends against application-level mistakes but not privileged D1 manipulation, so Wave 2 stays on the critical path before first paying regulated-vertical customer.
- Add three new locked cross-cutting decisions (#9-#11) capturing Wave 1 implementation choices instead of leaving them for the implementer: admin dashboard as primary monitoring surface (push channels are escalation overlay); single shared `MACHINE_HEARTBEAT_KEY` Worker secret with documented per-tenant upgrade path; Sentry PII scrub list locked at SDK init with pytest regression suite gating overlay CI.
- Rework §"Introduced by this ADR" §4 to match implementation: webhook receivers compose with `src/pages/api/webhooks/` (no new Worker), pull-surface extends `workers/cost-anomaly` (no parallel router), all sources tag rows in `cost_anomaly_alerts` via new `source` column.
- Drop `alert_webhook` from `customer.yaml` additions; document deferral. Telegram bot webhooks don't accept arbitrary JSON, Slack incoming webhooks accept only `{text}` — shipping a "Telegram-compatible" payload that doesn't function against Telegram is worse than not shipping it.

**Schema spec:**
- New optional `observability:` block parallel to `logging:` and `pause:`. Fields: `sentry.enabled` (default `true`), `health.period_seconds` (default `60`), `health.grace_minutes` (default `5`).
- Dedicated `## Observability (ADR 0023)` section with field rules, defaults, and rationale for what is NOT in `customer.yaml`.
- Schema_version not bumped — additive optional block per ADR 0012 §8.

**Validator:**
- New `Observability` type + `OBSERVABILITY_DEFAULTS` constant in `types.ts`.
- New `checkObservability` in `sections-observability.ts` (own file to keep `sections-other.ts` under 500-line ceiling; split into helpers to stay under complexity-15).
- Wired through `validateSections` → `ParsedSections` → `assembleCustomerYaml`.
- Portal `applyEditableChanges` passes `observability` through verbatim (not editable in portal in Wave 1; in-product editor is a follow-on if customer demand surfaces).

## Test plan

- [x] `npm run typecheck` — green across all 8 packages
- [x] `npm run lint` — 0 errors (warnings unchanged)
- [x] `npm run format:check` — clean
- [x] `npm run build` — clean
- [x] `npx vitest run tests/customer-yaml-validator.test.ts` — 147 / 147 pass, including 8 new `observability:` cases (defaults on absent/empty/partial, positive populated, type rejection per field, unknown `alert_webhook` silently dropped)
- [x] `npm run verify` end-to-end — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)