### PR TITLE
feat(ai-employee): skill body persistence substrate (ADR 0022 Stream 2)

### DIFF
--- a/ai-employee/bin/provision-customer.sh
+++ b/ai-employee/bin/provision-customer.sh
@@ -20,6 +20,15 @@
 #   R2_SECRET_ACCESS_KEY   — R2 secret (operator-local)
 #   R2_BUCKET_CONFIG       — R2 bucket holding customer.yaml + voice vaults
 #                            (defaults to "smd-customer-config" if unset)
+#   CF_API_TOKEN           — Cloudflare API token with "Workers R2 Storage: Edit"
+#                            scope at the account level. Used by ADR 0022 Stream 2
+#                            to create the per-customer skill-bodies R2 bucket
+#                            (ss-ai-employee-<slug>-skills). Optional in dev —
+#                            when unset, the script logs a warning and skips the
+#                            bucket-create step (the operator can create it via
+#                            the CF dashboard before re-running).
+#   CF_ACCOUNT_ID          — Cloudflare account ID (32-char hex). Required when
+#                            CF_API_TOKEN is set; ignored otherwise.
 #
 # Observability (ADR 0023 Wave 1) prerequisites:
 #   SENTRY_DSN                  — staged to Fly as a secret so the Machine's
@@ -156,6 +165,11 @@ log "R2 upload OK"
 # ---------- Step 3: render fly.toml ----------
 log "Rendering fly.toml..."
 mkdir -p "${RENDERED_DIR}"
+# Per-customer skill bodies bucket name (ADR 0022 Stream 2). One bucket per
+# customer; the bucket itself is the trust boundary. Bucket-scoped access
+# keys are entered via the secret-paste flow below; the bucket name is
+# rendered into fly.toml [env] (not a credential, just a string).
+R2_SKILL_BODIES_BUCKET="ss-ai-employee-${SLUG}-skills"
 sed -e "s/{{CUSTOMER_SLUG}}/${SLUG}/g" \
     -e "s/{{FLY_REGION}}/${FLY_REGION}/g" \
     -e "s/{{MACHINE_SIZE}}/${MACHINE_SIZE}/g" \
@@ -163,6 +177,7 @@ sed -e "s/{{CUSTOMER_SLUG}}/${SLUG}/g" \
     -e "s/{{HERMES_REF}}/${HERMES_REF}/g" \
     -e "s/{{HERMES_UPSTREAM_SHA}}/${HERMES_UPSTREAM_SHA}/g" \
     -e "s|{{R2_BUCKET_CONFIG}}|${R2_BUCKET_CONFIG}|g" \
+    -e "s|{{R2_SKILL_BODIES_BUCKET}}|${R2_SKILL_BODIES_BUCKET}|g" \
     "${TEMPLATE_DIR}/fly.toml.template" > "${RENDERED_DIR}/fly.toml"
 log "Rendered to ${RENDERED_DIR}/fly.toml"
 
@@ -189,6 +204,40 @@ if fly volumes list -a "${APP_NAME}" --json 2>/dev/null | python3 -c "import sys
   fi
 else
   fly volumes create hermes_state --size 10 --region "${FLY_REGION}" -a "${APP_NAME}" --yes || true
+fi
+
+# ---------- Step 5b: create per-customer skill-bodies R2 bucket (ADR 0022 Stream 2) ----------
+# Per Captain decision (2026-05-27): one R2 bucket per customer for agent-
+# authored skill body persistence. The bucket name is deterministic
+# (ss-ai-employee-<slug>-skills); creation is idempotent via CF API.
+#
+# If CF_API_TOKEN / CF_ACCOUNT_ID are unset, the script logs a warning and
+# skips the create step — the operator must create the bucket manually via
+# the CF dashboard before the Machine boots. Future agent-authored skills
+# would otherwise fail the write-ahead R2 PUT and surface as r2_status='failed'
+# in the per-customer agent_skills_inventory.
+if [ -n "${CF_API_TOKEN:-}" ] && [ -n "${CF_ACCOUNT_ID:-}" ]; then
+  log "Creating per-customer R2 bucket: ${R2_SKILL_BODIES_BUCKET}"
+  CF_BUCKET_RESPONSE=$(curl -sS -X POST \
+    "https://api.cloudflare.com/client/v4/accounts/${CF_ACCOUNT_ID}/r2/buckets" \
+    -H "Authorization: Bearer ${CF_API_TOKEN}" \
+    -H "Content-Type: application/json" \
+    -d "{\"name\":\"${R2_SKILL_BODIES_BUCKET}\"}" 2>&1 || true)
+  if echo "${CF_BUCKET_RESPONSE}" | grep -q '"success":true'; then
+    log "R2 bucket created: ${R2_SKILL_BODIES_BUCKET}"
+  elif echo "${CF_BUCKET_RESPONSE}" | grep -q '"code":10004'; then
+    # Cloudflare error 10004 = bucket already exists. Idempotent re-run is fine.
+    log "R2 bucket ${R2_SKILL_BODIES_BUCKET} already exists; skipping create"
+  else
+    # Any other error — log but don't die. The operator can create manually
+    # and re-run; the secret-paste prompts below will still capture the
+    # bucket-scoped credentials.
+    log "WARN: R2 bucket create did not succeed. Response: ${CF_BUCKET_RESPONSE}"
+    log "WARN: Create the bucket manually via the CF dashboard before the Machine boots."
+  fi
+else
+  log "WARN: CF_API_TOKEN or CF_ACCOUNT_ID not set; skipping R2 bucket auto-create."
+  log "WARN: Create '${R2_SKILL_BODIES_BUCKET}' via the CF dashboard before the Machine boots."
 fi
 
 # ---------- Step 6: set secrets (paste flow; never echo values) ----------
@@ -229,6 +278,15 @@ prompt_and_set AGENTMAIL_API_KEY  "AgentMail API key (Builder tier)"
 prompt_and_set R2_ACCESS_KEY_ID     "R2 access key ID (Machine-scoped, R/W on s3://${R2_BUCKET_CONFIG}/vaults/${SLUG}/)"
 prompt_and_set R2_SECRET_ACCESS_KEY "R2 secret access key (paired with R2_ACCESS_KEY_ID above)"
 prompt_and_set R2_ENDPOINT_URL      "R2 endpoint URL (Cloudflare account R2 endpoint)"
+
+# ADR 0022 Stream 2 — bucket-scoped R2 credentials for the per-customer
+# skill bodies bucket. Issue these via the CF dashboard with a policy
+# scoped to ${R2_SKILL_BODIES_BUCKET} only (Object Read + Write). The
+# bucket itself is the trust boundary per ADR 0007; a misconfigured token
+# scope would be the only path to cross-tenant leakage, so the operator
+# verifies the scope before pasting.
+prompt_and_set R2_SKILL_BODIES_ACCESS_KEY_ID "R2 access key ID scoped to bucket ${R2_SKILL_BODIES_BUCKET}"
+prompt_and_set R2_SKILL_BODIES_SECRET_ACCESS_KEY "R2 secret access key paired with R2_SKILL_BODIES_ACCESS_KEY_ID above"
 
 # HONCHO_API_KEY — generated locally, sent to Fly via stdin, never stored
 # anywhere else. Honcho is self-hosted in this Machine; this is the shared

--- a/ai-employee/contracts/skill_capture_v1.json
+++ b/ai-employee/contracts/skill_capture_v1.json
@@ -1,0 +1,150 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://smd.services/contracts/skill_capture/v1",
+  "title": "Skill Capture Contract v1 — ADR 0022 Stream 2",
+  "description": "Contract between the SS-side schema (per-customer D1 agent_skills_inventory + R2 bucket) and the overlay-side writer (venturecrane/hermes-smd-overlay hermes-smd-audit plugin). Both repos consume this file as the source of truth for the write-ahead pattern that persists agent-authored skill bodies. See docs/specs/ai-employee/skill-body-persistence.md for the prose contract.",
+  "version": "1.0.0",
+
+  "definitions": {
+    "skillSlug": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9-]{0,63}$",
+      "description": "Skill identifier (matches SKILL.md frontmatter `name:` field). Path provenance: vertical-pack skills carry the slug only — no `<vertical>-<addon>-` prefix (per ADR 0022 Stream 4 rename)."
+    },
+    "personaSlug": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9-]{0,31}$"
+    },
+    "customerSlug": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9-]{0,31}$"
+    },
+    "contentHash": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$",
+      "description": "SHA-256 hex digest of the SKILL.md body bytes. Lowercase."
+    },
+    "r2Key": {
+      "type": "string",
+      "pattern": "^skills/[a-z0-9][a-z0-9-]{0,31}/[a-z0-9][a-z0-9-]{0,63}/[a-f0-9]{64}\\.md$",
+      "description": "skills/<persona_slug>/<skill_name>/<content_hash>.md — derived deterministically from the input fields. The bucket itself encodes the customer (one bucket per customer)."
+    },
+    "r2Status": {
+      "type": "string",
+      "enum": ["unknown", "pending", "persisted", "failed"]
+    },
+    "r2WriteError": {
+      "type": ["string", "null"],
+      "description": "Reason string when r2_status='failed'. Stable enough to alert on (e.g. AccessDenied, BucketNotFound, ThrottledByR2, BodyMissingOnVolume). Null otherwise."
+    }
+  },
+
+  "events": {
+    "skill_manage_post_tool_call": {
+      "description": "Fires from Hermes' post_tool_call hook surface for skill_manage actions `create` or `write_file`. The overlay plugin is the subscriber; SS-side D1 + R2 are the destinations.",
+      "input": {
+        "type": "object",
+        "required": [
+          "customer_slug",
+          "persona_slug",
+          "skill_name",
+          "skill_content_hash",
+          "source_turn_id",
+          "skill_body_bytes"
+        ],
+        "properties": {
+          "customer_slug": { "$ref": "#/definitions/customerSlug" },
+          "persona_slug": { "$ref": "#/definitions/personaSlug" },
+          "skill_name": { "$ref": "#/definitions/skillSlug" },
+          "skill_content_hash": { "$ref": "#/definitions/contentHash" },
+          "source_turn_id": {
+            "type": "string",
+            "description": "The conversation turn that produced the skill_manage call."
+          },
+          "skill_body_bytes": {
+            "type": "string",
+            "contentEncoding": "base64",
+            "description": "Raw SKILL.md body. Plugin verifies sha256(decode(skill_body_bytes)) == skill_content_hash before writing."
+          }
+        }
+      }
+    }
+  },
+
+  "writes": {
+    "d1_inventory_row": {
+      "description": "INSERT into per-customer agent_skills_inventory. Performed BEFORE the R2 PUT (write-ahead) so the row is always visible to the admin portal even if R2 is unreachable.",
+      "table": "agent_skills_inventory",
+      "columns": {
+        "customer_slug": { "$ref": "#/definitions/customerSlug" },
+        "persona_slug": { "$ref": "#/definitions/personaSlug" },
+        "skill_name": { "$ref": "#/definitions/skillSlug" },
+        "skill_content_hash": { "$ref": "#/definitions/contentHash" },
+        "source_turn_id": { "type": "string" },
+        "r2_key": { "$ref": "#/definitions/r2Key" },
+        "r2_status": { "const": "pending", "description": "Initial state before R2 PUT." },
+        "r2_write_error": { "const": null }
+      }
+    },
+    "r2_put": {
+      "description": "R2 PUT body bytes at r2_key. S3-compatible PutObject. ContentType=text/markdown; charset=utf-8.",
+      "bucket_env": "R2_SKILL_BODIES_BUCKET",
+      "endpoint_env": "R2_ENDPOINT_URL",
+      "access_key_env": "R2_SKILL_BODIES_ACCESS_KEY_ID",
+      "secret_key_env": "R2_SKILL_BODIES_SECRET_ACCESS_KEY",
+      "key_template": "skills/{persona_slug}/{skill_name}/{skill_content_hash}.md",
+      "idempotency": "Hash-addressed key + identical body = identical R2 PUT. Re-attempts on retry are safe."
+    },
+    "d1_status_update": {
+      "description": "UPDATE the row's r2_status after the R2 PUT attempt.",
+      "table": "agent_skills_inventory",
+      "where_columns": ["customer_slug", "persona_slug", "skill_name", "skill_content_hash"],
+      "set_on_success": {
+        "r2_status": "persisted",
+        "r2_write_error": null
+      },
+      "set_on_failure": {
+        "r2_status": "failed",
+        "r2_write_error": { "$ref": "#/definitions/r2WriteError" }
+      }
+    },
+    "audit_log_emit": {
+      "description": "Emit AGENT_SKILL_CREATED row to the per-customer audit_log. Body bytes are NEVER in metadata — only the r2_key reference. The audit row writes AFTER the D1 INSERT but is independent of the R2 PUT outcome (the event is still durable in the audit log even if the body PUT failed).",
+      "action_type": "AGENT_SKILL_CREATED",
+      "metadata_keys": [
+        "persona_slug",
+        "skill_name",
+        "skill_content_hash",
+        "r2_key",
+        "source_turn_id"
+      ],
+      "forbidden_metadata_keys": ["skill_body", "body", "skill_body_bytes", "content"]
+    }
+  },
+
+  "reconciler": {
+    "description": "Boot-time pass on every Machine start. Retries pending/failed rows by re-reading the body from the per-profile skills directory on the Fly volume.",
+    "query": "SELECT customer_slug, persona_slug, skill_name, skill_content_hash, r2_key FROM agent_skills_inventory WHERE r2_status IN ('pending', 'failed') ORDER BY created_at ASC",
+    "per_row_steps": [
+      "Read SKILL.md from $HERMES_HOME/profiles/{persona_slug}/skills/{skill_name}/SKILL.md",
+      "Recompute SHA-256 of the body; verify matches skill_content_hash. On mismatch: row is FAILED with r2_write_error='BodyHashMismatch'.",
+      "If body file missing: row stays FAILED with r2_write_error='BodyMissingOnVolume'.",
+      "Otherwise: re-attempt R2 PUT and run the d1_status_update write above."
+    ],
+    "exit_criteria": "Reconciler completes when no rows match the query OR the iteration encounters the same row twice with no state change (livelock guard)."
+  },
+
+  "read": {
+    "description": "Admin portal endpoint. SS-side; consumed by ss-console only.",
+    "endpoint": "GET /admin/ai-employee/{customer_slug}/skills/{skill_content_hash}/body",
+    "auth": "admin session (host-scoped cookie on admin.smd.services)",
+    "behavior": [
+      "Look up row by (customer_slug, skill_content_hash) in per-customer D1.",
+      "If r2_status != 'persisted': return 404. The admin portal surfaces the gap via the r2_status indicator on the skill list view.",
+      "Resolve customer's R2 bucket name + credentials from SS Worker secrets store.",
+      "Generate short-lived (15 min) presigned GET via S3-compatible R2 API.",
+      "Return 302 to the presigned URL. The Worker never streams body bytes."
+    ],
+    "scope_note": "Endpoint implementation deferred to a follow-on PR — PR 2 ships the write substrate so customer-zero can onboard without losing data."
+  }
+}

--- a/ai-employee/migrations/0009_skill_inventory_r2_capture.sql
+++ b/ai-employee/migrations/0009_skill_inventory_r2_capture.sql
@@ -1,0 +1,73 @@
+-- ============================================================================
+-- Migration 0009: agent_skills_inventory R2 capture columns (ADR 0022 Stream 2)
+-- ============================================================================
+--
+-- Adds the substrate gap closure from ADR 0022 §"Time-machine substrate
+-- commitment": every agent-authored skill the `skill_manage` tool creates
+-- gets its body bytes persisted to R2 so the historical content is
+-- recoverable, not just the AGENT_SKILL_CREATED audit event.
+--
+-- Write contract (write-ahead pattern):
+--   1. Overlay plugin INSERTs the row inline with r2_status='pending' and
+--      r2_key=<predictable hash-addressed key>, r2_write_error=NULL.
+--   2. Same plugin (or a sidecar reconciler) attempts the R2 PUT; on success
+--      UPDATEs r2_status='persisted'; on failure UPDATEs r2_status='failed'
+--      with the error reason in r2_write_error.
+--   3. On Machine boot, the reconciler re-attempts any row with
+--      r2_status IN ('pending','failed').
+--
+-- The write happens inside the customer Machine (mirror-don't-gate per
+-- ADR 0016) — no HTTP bridge from Machine to ss-console Worker.
+--
+-- Captain isolation decision (2026-05-26, reconfirmed 2026-05-27):
+--   One R2 bucket per customer (`ss-ai-employee-<slug>-skills`). Per-Machine
+--   credentials scoped to that bucket. The bucket itself is the trust
+--   boundary, not the IAM policy. See approved plan §"R2 bucket model"
+--   for the constraint analysis behind the choice.
+--
+-- R2 key shape (per-customer bucket model):
+--   skills/<persona_slug>/<skill_name>/<skill_content_hash>.md
+--
+-- Content-addressed: identical bodies dedupe at the R2 layer; rename of
+-- skill_name leaves the prior hash intact (skills can be re-discovered by
+-- joining inventory rows on skill_content_hash).
+--
+-- Read path: admin portal looks up r2_key from D1 by hash, generates a
+-- short-lived presigned GET via the per-customer bucket credentials.
+-- Returns 404 when r2_status != 'persisted' (surfaces the gap rather than
+-- serving stale or absent content).
+--
+-- Backfill posture: legacy rows (created before this migration) leave the
+-- new columns NULL. The reconciler does not back-populate historical
+-- bodies — those were never persisted and are not recoverable. The
+-- substrate gap closes for new agent-authored skills from this point
+-- forward.
+--
+-- Source spec: docs/specs/ai-employee/skill-body-persistence.md
+-- Refers to:   docs/adr/0022-vertical-pack-architecture.md §"Time-machine substrate commitment"
+--              docs/adr/0007-per-customer-machine-isolation.md (bucket-per-customer rationale)
+--              docs/adr/0016-honcho-disposition.md (mirror-don't-gate posture)
+--              docs/adr/0017-skill-curator-disposition.md (the inventory table this extends)
+-- ============================================================================
+
+-- ---------- New columns: R2 capture metadata ----------
+ALTER TABLE agent_skills_inventory ADD COLUMN r2_key TEXT;
+ALTER TABLE agent_skills_inventory ADD COLUMN r2_status TEXT NOT NULL DEFAULT 'unknown'
+  CHECK (r2_status IN ('unknown', 'pending', 'persisted', 'failed'));
+ALTER TABLE agent_skills_inventory ADD COLUMN r2_write_error TEXT;
+
+-- ---------- New index: content-hash lookup ----------
+-- Powers the admin portal's "view body by hash" endpoint and the
+-- decommission export's hash-to-row mapping.
+CREATE INDEX agent_skills_inventory_by_hash
+  ON agent_skills_inventory (skill_content_hash);
+
+-- ---------- New partial index: pending/failed surface ----------
+-- Powers the reconciler's boot-time retry pass and the admin sidebar's
+-- "skills missing R2 body" indicator. Partial index keeps it cheap.
+CREATE INDEX agent_skills_inventory_r2_pending
+  ON agent_skills_inventory (r2_status, created_at)
+  WHERE r2_status IN ('pending', 'failed');
+
+-- ---------- Schema version ----------
+PRAGMA user_version = 9;

--- a/ai-employee/templates/bootstrap.sh
+++ b/ai-employee/templates/bootstrap.sh
@@ -113,6 +113,14 @@ REQUIRED_ENV=(
   SMD_D1_OBSERVATIONS_BINDING
   # Honcho FastAPI access token, generated per-Machine at provisioning.
   HONCHO_API_KEY
+  # ADR 0022 Stream 2 — per-customer skill bodies bucket. Bucket name
+  # comes from fly.toml [env] (R2_SKILL_BODIES_BUCKET); the bucket-scoped
+  # access key + secret are Fly secrets set by provision-customer.sh. The
+  # hermes-smd-audit plugin writes SKILL.md bodies here on skill_manage
+  # events (write-ahead pattern; see docs/specs/ai-employee/skill-body-persistence.md).
+  R2_SKILL_BODIES_BUCKET
+  R2_SKILL_BODIES_ACCESS_KEY_ID
+  R2_SKILL_BODIES_SECRET_ACCESS_KEY
 )
 
 for var in "${REQUIRED_ENV[@]}"; do

--- a/ai-employee/templates/fly.toml.template
+++ b/ai-employee/templates/fly.toml.template
@@ -52,6 +52,14 @@ primary_region = "{{FLY_REGION}}"
   # on first boot and the customer-sync sidecar polls the same key.
   R2_BUCKET_CONFIG = "{{R2_BUCKET_CONFIG}}"
 
+  # ADR 0022 Stream 2 — per-customer skill bodies bucket. One R2 bucket per
+  # customer; the bucket itself is the trust boundary (per ADR 0007). The
+  # overlay's hermes-smd-audit plugin writes SKILL.md bodies here when the
+  # skill_manage tool creates an agent-authored skill. Keys: skills/<persona>/<skill>/<hash>.md.
+  # Bucket name is not a credential; the bucket-scoped R2 access key + secret
+  # are in fly secrets (R2_SKILL_BODIES_ACCESS_KEY_ID, R2_SKILL_BODIES_SECRET_ACCESS_KEY).
+  R2_SKILL_BODIES_BUCKET = "{{R2_SKILL_BODIES_BUCKET}}"
+
   # Per-customer SQLite paths. The hermes-smd-audit and hermes-smd-memory-mirror
   # plugins resolve these to absolute file paths under the mounted volume.
   SMD_D1_AUDIT_BINDING = "/opt/data/audit.db"

--- a/ai-employee/tests/test_migration_0009_skill_inventory_r2_capture.py
+++ b/ai-employee/tests/test_migration_0009_skill_inventory_r2_capture.py
@@ -1,0 +1,169 @@
+"""Migration 0009 — agent_skills_inventory R2 capture columns (ADR 0022 Stream 2).
+
+Verifies the migration applied against a clean SQLite database that previously
+ran migration 0008 (the table-creation migration). Tests live as pytest cases
+under ai-employee/tests/ alongside the other Python-side regression tests.
+
+What this test locks in:
+  1. The three new columns exist (r2_key, r2_status, r2_write_error) with the
+     correct types and the r2_status DEFAULT 'unknown' + CHECK constraint.
+  2. The two new indexes exist (agent_skills_inventory_by_hash and the partial
+     agent_skills_inventory_r2_pending on r2_status IN ('pending','failed')).
+  3. Legacy rows from migration 0008 (those that exist prior to ALTER) remain
+     readable with NULL r2_key / r2_write_error and r2_status='unknown' (the
+     CHECK constraint accepts the default).
+  4. The CHECK constraint rejects unknown r2_status values.
+  5. The partial index does not match rows in r2_status='persisted' (cost
+     control — the index is meant to bound the reconciler's work).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MIGRATIONS_DIR = REPO_ROOT / "ai-employee" / "migrations"
+
+
+def _connect_with_migrations(through: int) -> sqlite3.Connection:
+    """Connect to in-memory SQLite and apply migrations 0001..through inclusive."""
+    conn = sqlite3.connect(":memory:")
+    for n in range(1, through + 1):
+        path = next(MIGRATIONS_DIR.glob(f"{n:04d}_*.sql"))
+        conn.executescript(path.read_text(encoding="utf-8"))
+    conn.commit()
+    return conn
+
+
+def _columns(conn: sqlite3.Connection) -> dict[str, dict]:
+    """Return agent_skills_inventory columns keyed by name."""
+    # PRAGMA statements do not accept bind parameters; use a literal table
+    # name (the only table this test inspects) to satisfy the SAST lint.
+    rows = conn.execute("PRAGMA table_info(agent_skills_inventory)").fetchall()
+    return {
+        r[1]: {"type": r[2], "notnull": bool(r[3]), "dflt": r[4]}
+        for r in rows
+    }
+
+
+def _indexes(conn: sqlite3.Connection) -> set[str]:
+    rows = conn.execute("PRAGMA index_list(agent_skills_inventory)").fetchall()
+    return {r[1] for r in rows}
+
+
+def test_legacy_row_survives_with_unknown_status() -> None:
+    """A row inserted under migration 0008 (no new columns) becomes a row with
+    r2_status='unknown' + NULL r2_key + NULL r2_write_error after 0009 applies."""
+    conn = _connect_with_migrations(8)
+    conn.execute(
+        """
+        INSERT INTO agent_skills_inventory
+          (customer_slug, persona_slug, skill_name, skill_content_hash, source_turn_id)
+        VALUES (?, ?, ?, ?, ?)
+        """,
+        ("smith-pi-firm", "marcus", "demand-letter-draft", "a" * 64, "turn_001"),
+    )
+    conn.commit()
+
+    # Apply migration 0009.
+    path = next(MIGRATIONS_DIR.glob("0009_*.sql"))
+    conn.executescript(path.read_text(encoding="utf-8"))
+    conn.commit()
+
+    row = conn.execute(
+        "SELECT r2_key, r2_status, r2_write_error FROM agent_skills_inventory"
+    ).fetchone()
+    assert row == (None, "unknown", None)
+
+
+def test_new_columns_present_with_correct_defaults() -> None:
+    conn = _connect_with_migrations(9)
+    cols = _columns(conn)
+    assert "r2_key" in cols
+    assert cols["r2_key"]["type"] == "TEXT"
+    assert cols["r2_key"]["notnull"] is False
+    assert cols["r2_status"]["type"] == "TEXT"
+    assert cols["r2_status"]["notnull"] is True
+    assert cols["r2_status"]["dflt"] == "'unknown'"
+    assert cols["r2_write_error"]["type"] == "TEXT"
+    assert cols["r2_write_error"]["notnull"] is False
+
+
+def test_indexes_added() -> None:
+    conn = _connect_with_migrations(9)
+    idx = _indexes(conn)
+    assert "agent_skills_inventory_by_hash" in idx
+    assert "agent_skills_inventory_r2_pending" in idx
+
+
+def test_check_constraint_rejects_unknown_status() -> None:
+    conn = _connect_with_migrations(9)
+    try:
+        conn.execute(
+            """
+            INSERT INTO agent_skills_inventory
+              (customer_slug, persona_slug, skill_name, skill_content_hash,
+               source_turn_id, r2_status)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            ("smith", "marcus", "demand", "b" * 64, "turn_002", "bogus_status"),
+        )
+        conn.commit()
+        raise AssertionError("expected CHECK constraint violation for bogus_status")
+    except sqlite3.IntegrityError as e:
+        assert "CHECK" in str(e) or "constraint" in str(e).lower()
+
+
+def test_each_valid_status_accepted() -> None:
+    conn = _connect_with_migrations(9)
+    for status in ("unknown", "pending", "persisted", "failed"):
+        conn.execute(
+            """
+            INSERT INTO agent_skills_inventory
+              (customer_slug, persona_slug, skill_name, skill_content_hash,
+               source_turn_id, r2_status)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            ("smith", "marcus", f"skill-{status}", "c" * 64, f"turn-{status}", status),
+        )
+    conn.commit()
+    n = conn.execute(
+        "SELECT COUNT(*) FROM agent_skills_inventory"
+    ).fetchone()[0]
+    assert n == 4
+
+
+def test_partial_index_excludes_persisted_rows() -> None:
+    """The partial index agent_skills_inventory_r2_pending is meant to bound
+    reconciler work — it MUST NOT match rows in 'persisted' state."""
+    conn = _connect_with_migrations(9)
+    conn.executemany(
+        """
+        INSERT INTO agent_skills_inventory
+          (customer_slug, persona_slug, skill_name, skill_content_hash,
+           source_turn_id, r2_status)
+        VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        [
+            ("smith", "marcus", "s-persisted", "d" * 64, "t-p", "persisted"),
+            ("smith", "marcus", "s-pending",   "e" * 64, "t-pe", "pending"),
+            ("smith", "marcus", "s-failed",    "f" * 64, "t-f", "failed"),
+        ],
+    )
+    conn.commit()
+    # The query the reconciler runs.
+    rows = conn.execute(
+        """
+        SELECT skill_name FROM agent_skills_inventory
+        WHERE r2_status IN ('pending', 'failed')
+        ORDER BY skill_name
+        """
+    ).fetchall()
+    assert [r[0] for r in rows] == ["s-failed", "s-pending"]
+
+
+def test_schema_version_bumped_to_9() -> None:
+    conn = _connect_with_migrations(9)
+    v = conn.execute("PRAGMA user_version").fetchone()[0]
+    assert v == 9

--- a/docs/specs/ai-employee/skill-body-persistence.md
+++ b/docs/specs/ai-employee/skill-body-persistence.md
@@ -1,0 +1,129 @@
+# Skill Body Persistence
+
+**Status:** Active — landed by ADR 0022 Stream 2.
+**Governing ADR:** [`docs/adr/0022-vertical-pack-architecture.md`](../../adr/0022-vertical-pack-architecture.md) §"Time-machine substrate commitment".
+**Related issues:** [#1091](https://github.com/venturecrane/ss-console/issues/1091) (parent), [#1112](https://github.com/venturecrane/ss-console/issues/1112) (PR 2 child).
+
+## Purpose
+
+Close the substrate gap that ADR 0022 flagged as production-blocking: when the Hermes `skill_manage` tool creates an agent-authored skill at runtime, the SS-side audit emits an `AGENT_SKILL_CREATED` event but the actual SKILL.md body bytes are not persisted anywhere durable. After this spec lands, every body lives in R2 and is recoverable by the admin portal indefinitely.
+
+Skipping this is unrecoverable: agent-evolution history is lost retroactively if any customer Machine boots before the substrate is in place.
+
+## Architecture
+
+### Isolation model
+
+**One R2 bucket per customer.** Bucket name: `ss-ai-employee-<customer_slug>-skills`. Per-Machine R2 credentials are scoped to that bucket. The bucket is the trust boundary; a misconfigured token in one Machine cannot reach another customer's content.
+
+This is Captain's reconfirmed decision (2026-05-27) after a critique surfaced Cloudflare account-level bucket cap (~1000 on Standard plan), Fly's S3-compatible-only access (no native R2 binding), and the provisioning ops cost. For the SS venture's realistic growth path (consulting firm, not SaaS), the isolation strength wins; the alternative (shared bucket + prefix isolation) stays available behind the same key shape if a future scaling event forces the swap.
+
+### Key shape
+
+```
+skills/<persona_slug>/<skill_name>/<skill_content_hash>.md
+```
+
+Content-addressed: identical bodies dedupe (`r2.put` is idempotent on identical key). Skill rename leaves the prior hash intact — skills can be re-discovered by joining `agent_skills_inventory` rows on `skill_content_hash`.
+
+### D1 columns (added in migration 0009)
+
+| Column           | Type                            | Notes                                                                                                                                                                           |
+| ---------------- | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `r2_key`         | TEXT                            | The full R2 key, computed before R2 PUT. NULL only for legacy rows from before this migration.                                                                                  |
+| `r2_status`      | TEXT NOT NULL DEFAULT 'unknown' | One of: `unknown` (legacy backfill), `pending` (D1 row written, R2 PUT not yet attempted or in-flight), `persisted` (R2 PUT succeeded), `failed` (R2 PUT attempted and failed). |
+| `r2_write_error` | TEXT                            | Populated when `r2_status='failed'`. Reason string (e.g. "AccessDenied", "BucketNotFound").                                                                                     |
+
+### Write contract (write-ahead pattern)
+
+```
+[skill_manage fires]
+       │
+       ▼
+[overlay plugin: compute content hash + r2_key]
+       │
+       ▼
+[INSERT D1 row: r2_status='pending', r2_key=<key>, r2_write_error=NULL]   ← (1)
+       │
+       ▼
+[R2 PUT body bytes at r2_key]                                              ← (2)
+       │
+       ├─ success ─▶ [UPDATE r2_status='persisted']                        ← (3a)
+       │
+       └─ failure ─▶ [UPDATE r2_status='failed', r2_write_error=<reason>]  ← (3b)
+       │
+       ▼
+[overlay plugin emits AGENT_SKILL_CREATED audit row referencing r2_key]   ← (4)
+```
+
+Step (1) commits before step (2), so the row is always visible to the admin portal even when R2 is unreachable — the operator sees the gap and can investigate. Step (3a/3b) is best-effort; if the Machine crashes between (1) and (3), the row stays `pending` and the boot-time reconciler picks it up.
+
+### Boot-time reconciler
+
+On Machine boot the audit plugin runs a reconciler pass:
+
+```sql
+SELECT customer_slug, persona_slug, skill_name, skill_content_hash, r2_key
+FROM agent_skills_inventory
+WHERE r2_status IN ('pending', 'failed')
+ORDER BY created_at ASC
+```
+
+For each row, the plugin reads the SKILL.md body from the Fly volume's per-profile skills directory (the path Hermes wrote during `skill_manage`), recomputes the hash to verify, and re-attempts the R2 PUT. On success, the row moves to `persisted`; on persistent failure (e.g. the skill was deleted from the volume), the row stays `failed` with the latest `r2_write_error` and surfaces as a P1 admin alert.
+
+### Audit-log boundary
+
+**Skill body bytes never land in `audit_log.metadata`.** The audit row references the R2 key, not the content. D1 row size pressure is real (skill bodies are 2–10 KB; metadata is intended for a few hundred bytes per event). The `consumer-side contract` guardrail test in `tests/forbidden-strings.test.ts` (PR 2 follow-on) asserts no SS-side code path violates this — the overlay producer-side test is in the overlay repo.
+
+### Read path (admin portal)
+
+`GET /admin/ai-employee/<customer_slug>/skills/<skill_content_hash>/body`
+
+1. Look up the row by `(customer_slug, skill_content_hash)` in the per-customer D1.
+2. If `r2_status != 'persisted'`, return 404 — the body either has not been written yet or failed to persist. The admin portal surfaces the gap separately via the `r2_status` indicator on the skill list view.
+3. Resolve the customer's R2 bucket name + credentials from the SS Worker's secrets store.
+4. Generate a short-lived (15 min) presigned GET via the S3-compatible R2 API.
+5. Return `302` to the presigned URL.
+
+Admin auth is required (per host-scoped cookie boundary at `admin.smd.services`, see CLAUDE.md §"Cookie boundaries"). The endpoint never streams body bytes through the Worker — presigned URL only — to keep Worker CPU bounded.
+
+The admin endpoint and the Worker-side R2 credential lookup ship in a follow-on PR — PR 2's scope is the substrate (D1 + R2 + write contract) so customer-zero can onboard without losing data. The view-body affordance is a UX nicety that can land after.
+
+## Repo split
+
+| Layer                        | Repo                            | Components                                                                                                                                           |
+| ---------------------------- | ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **D1 schema**                | ss-console                      | Migration 0009 (this spec)                                                                                                                           |
+| **customer.yaml fields**     | ss-console                      | `memory.r2_skill_bodies_bucket` (declared optional in PR 1)                                                                                          |
+| **Bootstrap + provisioning** | ss-console                      | `provision-customer.sh` creates bucket + scoped creds; `bootstrap.sh` validates R2*SKILL_BODIES*\* env; `fly.toml.template` declares the bucket name |
+| **Audit plugin (writer)**    | venturecrane/hermes-smd-overlay | `hermes-smd-audit` post-tool-call hook on `skill_manage` events; boot-time reconciler                                                                |
+| **Contract**                 | both                            | `ai-employee/contracts/skill_capture_v1.json` mirrored in both repos for contract test                                                               |
+| **Admin endpoint**           | ss-console                      | `src/pages/api/admin/ai-employee/[slug]/skills/[hash]/body.ts` (follow-on)                                                                           |
+
+The ss-console and overlay PRs file and merge in lockstep so the contract is exercised end-to-end before either lands.
+
+## Failure modes
+
+| Failure                                                  | Detection                                                                                                                           | Recovery                                                                                             |
+| -------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| R2 PUT fails (network, throttle)                         | `r2_status='failed'` + `r2_write_error` populated                                                                                   | Boot-time reconciler retries. Admin alert surfaces persistent failures.                              |
+| Machine crashes between D1 INSERT and R2 PUT             | `r2_status='pending'` row exists                                                                                                    | Boot-time reconciler retries by re-reading body from volume.                                         |
+| Skill body deleted from volume before reconciler runs    | Reconciler logs "body bytes missing" + leaves row `failed`                                                                          | Captain decision per-case. Hash is in D1; body is lost. Surfaced as a P1 alert.                      |
+| Bucket credentials revoked / wrong                       | All writes fail; reconciler keeps trying                                                                                            | Provisioning script re-runs (rotates scoped token, no data loss since hash + key are deterministic). |
+| Bucket exists but is wrong customer's (provisioning bug) | Defensive check: object key includes no customer slug, but the BUCKET enforces tenancy. Cross-tenant write structurally impossible. | N/A — caught at provisioning time.                                                                   |
+
+## Out of scope (PR 2)
+
+- Admin portal "view body" endpoint and signed-URL plumbing (follow-on; D1 substrate first so customer-zero can onboard).
+- Admin sidebar "skills missing R2 body" indicator (follow-on; just a D1 read).
+- Backfill of legacy `AGENT_SKILL_CREATED` rows whose bodies were never persisted — those bodies are unrecoverable. Future agent-authored skills are captured from this point forward.
+- Cross-bucket migration tooling. If the per-customer-bucket model ever needs to consolidate into shared-bucket-plus-prefix, the migration is mechanical (same key shape) but the tooling ships when the need exists.
+
+## References
+
+- ADR 0022 — Vertical Pack Architecture and Time-Machine Substrate (§"Time-machine substrate commitment")
+- ADR 0007 — Per-customer Machine isolation
+- ADR 0016 — Honcho disposition (mirror-don't-gate principle)
+- ADR 0017 — Skill Curator disposition (the `agent_skills_inventory` table)
+- [Approved plan](../../../.claude/plans/write-a-plan-to-valiant-plum.md) §Stream 2
+- `ai-employee/contracts/skill_capture_v1.json` — JSON contract shared with overlay repo


### PR DESCRIPTION
## Summary

PR 2 of 4 for [ADR 0022](../blob/main/docs/adr/0022-vertical-pack-architecture.md). Closes the substrate gap flagged in §"Time-machine substrate commitment" as production-blocking: every agent-authored skill body now lands in per-customer R2 via a write-ahead pattern, indexed by `r2_key` + `r2_status` in the per-customer `agent_skills_inventory` table.

- Closes #1112
- Parent: #1091
- Captain reconfirmed (2026-05-27) per-customer-bucket isolation after weighing critique-surfaced constraints. See `docs/specs/ai-employee/skill-body-persistence.md` §"Isolation model" for the rationale.

## What ships in this PR

### ss-console side

| File | Purpose |
|---|---|
| `ai-employee/migrations/0009_skill_inventory_r2_capture.sql` | ALTER TABLE adds `r2_key`, `r2_status` (CHECK enum `unknown`/`pending`/`persisted`/`failed`), `r2_write_error`. Adds index on `skill_content_hash` and partial index on `r2_status IN ('pending','failed')` for the reconciler. |
| `ai-employee/templates/fly.toml.template` | `R2_SKILL_BODIES_BUCKET` in `[env]`. |
| `ai-employee/templates/bootstrap.sh` | `R2_SKILL_BODIES_{BUCKET,ACCESS_KEY_ID,SECRET_ACCESS_KEY}` added to `REQUIRED_ENV`. |
| `ai-employee/bin/provision-customer.sh` | Idempotent bucket auto-create via CF API (skipped with warning if `CF_API_TOKEN` unset; operator can create via dashboard); prompt-and-set for bucket-scoped credentials; renders `ss-ai-employee-<slug>-skills` into fly.toml. |
| `docs/specs/ai-employee/skill-body-persistence.md` | Authoritative prose contract (write-ahead pattern, reconciler, failure modes, read path). |
| `ai-employee/contracts/skill_capture_v1.json` | JSON contract shared with overlay repo (event input shape, D1/R2 write shapes, audit boundary). |
| `ai-employee/tests/test_migration_0009_skill_inventory_r2_capture.py` | 6 pytest cases — legacy row survival, column types, indexes, CHECK enum, partial-index logic, schema version. |

### Coordinated overlay PR (`venturecrane/hermes-smd-overlay`)

`hermes-smd-audit` plugin gains the `post_tool_call` hook on `skill_manage` events + boot-time reconciler. Files and merges **in lockstep** with this PR via the shared contract JSON. No Hermes core file modified (ADR 0015).

## Write contract (write-ahead pattern)

```
[skill_manage fires]
  → [INSERT D1 row: r2_status='pending', r2_key=<key>]   ← (1) durable first
  → [R2 PUT body at r2_key]                              ← (2)
  → success: [UPDATE r2_status='persisted']              ← (3a)
  → failure: [UPDATE r2_status='failed', r2_write_error] ← (3b)
  → [audit log: AGENT_SKILL_CREATED references r2_key]   ← (4)
```

Step (1) commits before (2) so the row is always visible to admin even when R2 is unreachable. Crash between (1) and (3) is reconciled at next Machine boot (re-reads body from volume, retries PUT). Skill body bytes never land in `audit_log.metadata`.

## Out of scope (per plan)

- Admin endpoint `/admin/ai-employee/<slug>/skills/<hash>/body` (follow-on; D1 substrate first so customer-zero can onboard).
- Admin sidebar "skills missing R2 body" indicator (follow-on; just a D1 read).
- Backfill of legacy `AGENT_SKILL_CREATED` rows whose bodies were never persisted (unrecoverable; future skills captured from this point forward).

## Test plan

- [x] `npm run verify` green (lint + typecheck + format + build + JS tests)
- [x] All 6 migration tests pass inline against fresh SQLite (`test_migration_0009_*.py`)
- [ ] CI green
- [ ] Reviewer confirms the contract JSON matches what the overlay PR consumes
- [ ] Reviewer confirms the per-customer-bucket model is correctly reflected in fly.toml + bootstrap.sh + provision-customer.sh

## Plan reference
`~/.claude/plans/write-a-plan-to-valiant-plum.md` §Stream 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)