### PR TITLE
feat(portal): customer.yaml materialization history substrate (ADR 0022 Stream 3)

### DIFF
--- a/migrations/0045_customer_config_history.sql
+++ b/migrations/0045_customer_config_history.sql
@@ -1,0 +1,97 @@
+-- ============================================================================
+-- Migration 0045: customer_config_history table (ADR 0022 Stream 3)
+-- ============================================================================
+--
+-- Closes the second substrate gap that ADR 0022 §"Time-machine substrate
+-- commitment" flagged as production-blocking: every CI / drift-repair /
+-- manual / bootstrap sync of customer.yaml records a versioned event row
+-- here so the materialization history is queryable independent of git.
+--
+-- Posture (pointer-only — Simplifier critique #2):
+--   Rows are pointers, not snapshots. git_sha references the commit; the
+--   full byte-level snapshot lives in git itself (the source-of-truth per
+--   ADR 0012) and, optionally, in an R2 shadow at
+--   `r2://customers/<slug>/history/<git_sha>.yaml` for durability insurance
+--   against repo loss + post-transformation byte capture. The shadow
+--   column is nullable: PR 3 ships the substrate; the actual shadow-write
+--   path lives wherever the CI sync code lands.
+--
+-- Why a separate table from customer_configs:
+--   customer_configs is single-row-per-customer (a read replica for the
+--   live config). It answers "what is config NOW." The history table
+--   answers "when did config CHANGE, and how was it sourced." Git knows
+--   the commit timeline; the portal needs the sync-event timeline (which
+--   includes drift-repair re-syncs at the same SHA, manual overrides at
+--   the portal, and bootstrap events tied to Machine provisioning).
+--
+-- Write contract (the sync code path — wherever it lives — calls
+-- `recordCustomerConfigSync` from src/lib/portal/customer-config.ts):
+--   1. Load the latest history row for the slug.
+--   2. shouldRecordSync(prev, current_git_sha, source) decides no-op.
+--      The only case that records on identical git_sha is source =
+--      'drift-repair' (re-sync recovering from out-of-band edits).
+--   3. INSERT the history row.
+--   4. (Optionally) PUT the R2 shadow at the documented key; failure
+--      leaves r2_shadow_key = NULL and surfaces as a P2 admin alert.
+--   5. UPSERT customer_configs (unchanged behavior).
+--
+-- Read contract:
+--   /admin/ai-employee/config-history/<customer_slug>.astro reads the last
+--   20 rows ORDER BY synced_at DESC. Snapshot bytes are resolved on demand
+--   via the GitHub API (`git show <sha>:<path>`) or, when the shadow
+--   exists, via the R2 shadow URL.
+--
+-- Forward-only, additive. No drops.
+--
+-- Source spec: docs/specs/ai-employee/customer-config-history.md
+-- Refers to:   docs/adr/0022-vertical-pack-architecture.md §"Time-machine substrate commitment"
+--              docs/adr/0012-customer-yaml-storage.md (the customer.yaml storage model this layers on)
+--              docs/adr/0016-honcho-disposition.md (mirror-don't-gate posture)
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS customer_config_history (
+  id                   INTEGER PRIMARY KEY AUTOINCREMENT,
+  customer_slug        TEXT NOT NULL,
+
+  -- The commit the projection was built from. Joining this back to git
+  -- reconstructs the customer.yaml bytes that were live at that sync.
+  git_sha              TEXT NOT NULL,
+
+  -- When the sync event landed in this database. May differ from the git
+  -- commit time (CI is typically minutes behind merge; manual/bootstrap
+  -- syncs are not tied to a commit time at all).
+  synced_at            TEXT NOT NULL,
+
+  -- Which sync code path produced the row. Enforced as a CHECK so the
+  -- substrate is structurally aligned with the SyncSource enum exported
+  -- from src/lib/ai-employee/customer-yaml (added in PR 1).
+  synced_by            TEXT NOT NULL CHECK (synced_by IN (
+    'manual', 'ci', 'drift-repair', 'bootstrap'
+  )),
+
+  -- Who initiated the sync, when known. NULL for fully automated sources
+  -- (ci, bootstrap); populated as 'system:<job-name>' or '<user-email>'
+  -- for manual and drift-repair. Distinct from synced_by because two
+  -- different actors can both be flavor 'manual'.
+  actor                TEXT,
+
+  -- The git_sha of the immediately preceding history row for this slug,
+  -- or NULL for the first sync. Lets the admin page walk the chain
+  -- without a second query.
+  prev_git_sha         TEXT,
+
+  -- Optional R2 shadow key at `customers/<slug>/history/<git_sha>.yaml`.
+  -- NULL when the shadow write was skipped or failed; admin page falls
+  -- back to GitHub API for snapshot reconstruction in that case.
+  r2_shadow_key        TEXT,
+
+  created_at           TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- Most-recent-first scan for the admin config-history page.
+CREATE INDEX IF NOT EXISTS idx_cch_slug_synced
+  ON customer_config_history (customer_slug, synced_at DESC);
+
+-- Direct lookup by SHA (for snapshot-bytes resolution and drift-cron joins).
+CREATE INDEX IF NOT EXISTS idx_cch_slug_sha
+  ON customer_config_history (customer_slug, git_sha);

--- a/src/lib/portal/customer-config.ts
+++ b/src/lib/portal/customer-config.ts
@@ -179,3 +179,195 @@ export async function getActivePersona(
   const active = config.personas.find((p) => p.status === 'active')
   return active ?? null
 }
+
+// ===========================================================================
+// customer_config_history — ADR 0022 Stream 3 (substrate gap B)
+// ===========================================================================
+//
+// The history table records materialization events independently of git.
+// Wherever the actual sync code path lives (CI workflow, drift-repair cron,
+// manual portal action, bootstrap script), it should call
+// `recordCustomerConfigSync` after writing customer_configs so the audit
+// trail accumulates from day one.
+//
+// PR 3 ships the substrate (table + helpers + admin page). The sync code
+// path itself lives where it already lives — this module does not own it.
+
+/**
+ * Source of a customer_config_history event. Mirrors the SyncSource enum
+ * exported from src/lib/ai-employee/customer-yaml (added in PR 1). Kept as
+ * a literal-union here so the portal-side modules don't need to pull in
+ * the validator just for the enum.
+ */
+export type SyncSource = 'manual' | 'ci' | 'drift-repair' | 'bootstrap'
+
+export interface CustomerConfigHistoryRow {
+  id: number
+  customer_slug: string
+  git_sha: string
+  synced_at: string
+  synced_by: SyncSource
+  actor: string | null
+  prev_git_sha: string | null
+  r2_shadow_key: string | null
+  created_at: string
+}
+
+interface PreviousSyncMeta {
+  git_sha: string
+  synced_by: SyncSource
+}
+
+/**
+ * Decide whether a new sync event should record a history row.
+ *
+ * Rule (per ADR 0022 Stream 3 plan §"shouldRecordSync"):
+ *   - First sync for the slug: always record.
+ *   - SHA differs from previous: always record (the customer.yaml content changed).
+ *   - SHA is identical AND source === 'drift-repair': record. The drift-cron
+ *     is allowed to recover from out-of-band edits, and we want the audit
+ *     trail of that recovery.
+ *   - SHA is identical AND source !== 'drift-repair': no-op. Re-running CI
+ *     against an already-synced commit shouldn't pollute the audit trail.
+ *
+ * Pure function — own unit test. The caller passes the previous row's
+ * pointer fields; this module never touches D1 for the decision.
+ */
+export function shouldRecordSync(
+  prev: PreviousSyncMeta | null,
+  currentSha: string,
+  source: SyncSource
+): boolean {
+  if (prev === null) return true
+  if (prev.git_sha !== currentSha) return true
+  return source === 'drift-repair'
+}
+
+interface PreviousSyncDbRow {
+  git_sha: string
+  synced_by: string
+}
+
+/**
+ * Load the most-recent prior sync's pointer fields for the slug. Used by
+ * recordCustomerConfigSync to feed shouldRecordSync.
+ */
+export async function getLatestSyncMeta(
+  db: D1Database,
+  customerSlug: string
+): Promise<PreviousSyncMeta | null> {
+  const row = await db
+    .prepare(
+      'SELECT git_sha, synced_by FROM customer_config_history ' +
+        'WHERE customer_slug = ? ORDER BY synced_at DESC LIMIT 1'
+    )
+    .bind(customerSlug)
+    .first<PreviousSyncDbRow>()
+  if (!row) return null
+  return { git_sha: row.git_sha, synced_by: row.synced_by as SyncSource }
+}
+
+export interface RecordSyncOptions {
+  customer_slug: string
+  git_sha: string
+  /**
+   * ISO-8601 timestamp the sync code was executed. Distinct from
+   * created_at (which is set by the DB on INSERT) and from the git commit
+   * timestamp (which is opaque to D1).
+   */
+  synced_at: string
+  synced_by: SyncSource
+  /**
+   * Actor handle: email for `manual`, `'system:<job>'` for `drift-repair`,
+   * `null` for fully-automated sources (`ci`, `bootstrap`).
+   */
+  actor: string | null
+  /**
+   * Optional R2 shadow key produced by the sync code path. The substrate
+   * accepts but does not produce — the actual shadow write lives in the
+   * sync code path, which can pass the key it produced or pass `null`
+   * when no shadow was written.
+   */
+  r2_shadow_key: string | null
+}
+
+export interface RecordSyncResult {
+  recorded: boolean
+  /**
+   * Reason the helper no-op'd. `null` when recorded === true. Useful for
+   * the caller's logs without re-deriving the policy.
+   */
+  skipped_reason: string | null
+}
+
+/**
+ * Record a sync event. No-ops cleanly when the policy says skip
+ * (shouldRecordSync returned false). The helper does NOT UPSERT
+ * customer_configs — that's the caller's responsibility, and it must
+ * happen AFTER this helper so a corrupted live row always has a clean
+ * predecessor history row at the prior git_sha.
+ *
+ * Caller flow:
+ *   ```ts
+ *   const prev = await getLatestSyncMeta(db, slug)
+ *   const result = await recordCustomerConfigSync(db, {
+ *     customer_slug: slug, git_sha: newSha, synced_at: now,
+ *     synced_by: 'ci', actor: null, r2_shadow_key: shadowKey,
+ *   })
+ *   if (result.recorded) {
+ *     // UPSERT customer_configs here
+ *   }
+ *   ```
+ */
+export async function recordCustomerConfigSync(
+  db: D1Database,
+  opts: RecordSyncOptions
+): Promise<RecordSyncResult> {
+  const prev = await getLatestSyncMeta(db, opts.customer_slug)
+  if (!shouldRecordSync(prev, opts.git_sha, opts.synced_by)) {
+    return {
+      recorded: false,
+      skipped_reason:
+        `identical git_sha=${opts.git_sha} as previous sync ` +
+        `(synced_by=${prev?.synced_by ?? 'unknown'}); only drift-repair re-records on identical SHA`,
+    }
+  }
+  await db
+    .prepare(
+      'INSERT INTO customer_config_history ' +
+        '(customer_slug, git_sha, synced_at, synced_by, actor, prev_git_sha, r2_shadow_key) ' +
+        'VALUES (?, ?, ?, ?, ?, ?, ?)'
+    )
+    .bind(
+      opts.customer_slug,
+      opts.git_sha,
+      opts.synced_at,
+      opts.synced_by,
+      opts.actor,
+      prev?.git_sha ?? null,
+      opts.r2_shadow_key
+    )
+    .run()
+  return { recorded: true, skipped_reason: null }
+}
+
+/**
+ * List the most-recent N history rows for a customer slug. Powers the
+ * admin /admin/ai-employee/config-history/<slug>.astro page.
+ */
+export async function listCustomerConfigHistory(
+  db: D1Database,
+  customerSlug: string,
+  limit = 20
+): Promise<CustomerConfigHistoryRow[]> {
+  const { results } = await db
+    .prepare(
+      'SELECT id, customer_slug, git_sha, synced_at, synced_by, actor, ' +
+        'prev_git_sha, r2_shadow_key, created_at ' +
+        'FROM customer_config_history ' +
+        'WHERE customer_slug = ? ORDER BY synced_at DESC LIMIT ?'
+    )
+    .bind(customerSlug, limit)
+    .all<CustomerConfigHistoryRow>()
+  return results ?? []
+}

--- a/src/pages/admin/ai-employee/config-history/[customer_slug].astro
+++ b/src/pages/admin/ai-employee/config-history/[customer_slug].astro
@@ -1,0 +1,153 @@
+---
+import AdminLayout from '../../../../layouts/AdminLayout.astro'
+import { listCustomerConfigHistory } from '../../../../lib/portal/customer-config'
+import { env } from 'cloudflare:workers'
+
+/**
+ * Captain customer.yaml materialization-history view — per-customer drill-down.
+ *
+ * ADR 0022 Stream 3 (substrate gap B). Shows the most recent 20 sync events
+ * for one customer's customer.yaml projection. Each row is a pointer into
+ * git: `git_sha` reconstructs the customer.yaml bytes that were live at the
+ * time of the sync via `git show <sha>:<path>` or via the R2 shadow when it
+ * exists.
+ *
+ * The page is intentionally narrow in v1:
+ *   - No filtering (default order: most recent first).
+ *   - No diff view between adjacent rows (deferred per the plan §"Time-machine UX").
+ *   - No surgical revert handler (also deferred).
+ * The substrate is the value; the UX is additive.
+ */
+
+const session = Astro.locals.session!
+if (session.role !== 'admin') {
+  return Astro.redirect('/auth/sign-in')
+}
+
+const { customer_slug } = Astro.params
+if (!customer_slug) {
+  return new Response('Customer slug required', { status: 400 })
+}
+
+const rows = await listCustomerConfigHistory(env.DB, customer_slug, 20)
+
+function formatSyncedAt(iso: string): string {
+  // Stable, locale-agnostic rendering — Captain reads logs in UTC.
+  return iso
+    .replace('T', ' ')
+    .replace(/\.\d+Z?$/, '')
+    .replace(/Z$/, ' UTC')
+}
+
+function shortSha(sha: string): string {
+  return sha.slice(0, 12)
+}
+---
+
+<AdminLayout
+  title={`Config history — ${customer_slug}`}
+  breadcrumbs={[
+    { label: 'Dashboard', href: '/admin' },
+    { label: 'AI Employee' },
+    { label: 'Config history' },
+    { label: customer_slug },
+  ]}
+>
+  <div class="space-y-card">
+    <header class="flex items-end justify-between gap-4">
+      <div>
+        <h2 class="text-xl font-semibold text-[color:var(--ss-color-text-primary)]">
+          customer.yaml sync history
+        </h2>
+        <p class="text-sm text-[color:var(--ss-color-text-secondary)] mt-1">
+          <code>{customer_slug}</code> · most recent {rows.length} event(s)
+        </p>
+      </div>
+    </header>
+
+    {
+      rows.length === 0 ? (
+        <div class="rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-white p-card">
+          <p class="text-sm text-[color:var(--ss-color-text-secondary)]">
+            No sync events recorded for this customer yet. The first sync event lands when the CI
+            sync code path, the bootstrap script, or a manual portal action calls{' '}
+            <code>recordCustomerConfigSync</code> from{' '}
+            <code>src/lib/portal/customer-config.ts</code>. The substrate is in place (migration
+            0045); waiting on the sync code path itself.
+          </p>
+        </div>
+      ) : (
+        <div class="rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-white overflow-hidden">
+          <table class="w-full text-sm">
+            <thead class="bg-[color:var(--ss-color-border-subtle)]">
+              <tr>
+                <th class="text-left px-card py-2 font-medium text-[color:var(--ss-color-text-primary)]">
+                  Synced at
+                </th>
+                <th class="text-left px-card py-2 font-medium text-[color:var(--ss-color-text-primary)]">
+                  Source
+                </th>
+                <th class="text-left px-card py-2 font-medium text-[color:var(--ss-color-text-primary)]">
+                  Actor
+                </th>
+                <th class="text-left px-card py-2 font-medium text-[color:var(--ss-color-text-primary)]">
+                  git_sha
+                </th>
+                <th class="text-left px-card py-2 font-medium text-[color:var(--ss-color-text-primary)]">
+                  prev
+                </th>
+                <th class="text-left px-card py-2 font-medium text-[color:var(--ss-color-text-primary)]">
+                  R2 shadow
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row) => (
+                <tr class="border-t border-[color:var(--ss-color-border)]">
+                  <td class="px-card py-2 text-[color:var(--ss-color-text-primary)] font-mono">
+                    {formatSyncedAt(row.synced_at)}
+                  </td>
+                  <td class="px-card py-2 text-[color:var(--ss-color-text-secondary)]">
+                    {row.synced_by}
+                  </td>
+                  <td class="px-card py-2 text-[color:var(--ss-color-text-secondary)]">
+                    {row.actor ?? <span class="opacity-60">—</span>}
+                  </td>
+                  <td class="px-card py-2 text-[color:var(--ss-color-text-primary)] font-mono">
+                    <code title={row.git_sha}>{shortSha(row.git_sha)}</code>
+                  </td>
+                  <td class="px-card py-2 text-[color:var(--ss-color-text-secondary)] font-mono">
+                    {row.prev_git_sha ? (
+                      <code title={row.prev_git_sha}>{shortSha(row.prev_git_sha)}</code>
+                    ) : (
+                      <span class="opacity-60">first sync</span>
+                    )}
+                  </td>
+                  <td class="px-card py-2 text-[color:var(--ss-color-text-secondary)]">
+                    {row.r2_shadow_key ? (
+                      <code class="text-xs">{row.r2_shadow_key}</code>
+                    ) : (
+                      <span class="opacity-60">—</span>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )
+    }
+
+    <p class="text-xs text-[color:var(--ss-color-text-secondary)]">
+      Snapshot bytes are not stored in the history table itself — each row points into git via <code
+        >git_sha</code
+      >. The R2 shadow column, when populated, contains a backup of the post-transformation bytes at{
+        ' '
+      }
+      <code>customers/&lt;slug&gt;/history/&lt;git_sha&gt;.yaml</code>. See{' '}
+      <code>docs/adr/0022-vertical-pack-architecture.md</code> §"Time-machine substrate commitment" for
+      the substrate model and{' '}
+      <code>src/lib/portal/customer-config.ts</code> for the read helper.
+    </p>
+  </div>
+</AdminLayout>

--- a/tests/customer-config.test.ts
+++ b/tests/customer-config.test.ts
@@ -24,6 +24,10 @@ import { ORG_ID } from '../src/lib/constants'
 import {
   getCustomerConfig,
   getActivePersona,
+  getLatestSyncMeta,
+  listCustomerConfigHistory,
+  recordCustomerConfigSync,
+  shouldRecordSync,
   type PersonaConfig,
 } from '../src/lib/portal/customer-config'
 
@@ -262,5 +266,251 @@ describe('customer_configs schema integrity', () => {
     await expect(
       seedConfig(db, { entity_id: 'entity-other', customer_slug: 'same-slug' })
     ).rejects.toThrow()
+  })
+})
+
+// ===========================================================================
+// customer_config_history — ADR 0022 Stream 3 substrate
+// ===========================================================================
+
+describe('shouldRecordSync (pure policy)', () => {
+  it('records the first sync (prev is null)', () => {
+    expect(shouldRecordSync(null, 'sha-aaa', 'ci')).toBe(true)
+  })
+
+  it('records when git_sha differs from previous', () => {
+    expect(shouldRecordSync({ git_sha: 'sha-aaa', synced_by: 'ci' }, 'sha-bbb', 'ci')).toBe(true)
+  })
+
+  it('no-ops when sha matches and source is ci', () => {
+    expect(shouldRecordSync({ git_sha: 'sha-aaa', synced_by: 'ci' }, 'sha-aaa', 'ci')).toBe(false)
+  })
+
+  it('no-ops when sha matches and source is manual', () => {
+    expect(shouldRecordSync({ git_sha: 'sha-aaa', synced_by: 'manual' }, 'sha-aaa', 'manual')).toBe(
+      false
+    )
+  })
+
+  it('no-ops when sha matches and source is bootstrap', () => {
+    expect(shouldRecordSync({ git_sha: 'sha-aaa', synced_by: 'ci' }, 'sha-aaa', 'bootstrap')).toBe(
+      false
+    )
+  })
+
+  it('records when sha matches and source is drift-repair (the recovery exception)', () => {
+    expect(
+      shouldRecordSync({ git_sha: 'sha-aaa', synced_by: 'ci' }, 'sha-aaa', 'drift-repair')
+    ).toBe(true)
+  })
+})
+
+describe('customer_config_history helpers', () => {
+  let db: D1Database
+
+  beforeEach(async () => {
+    db = await freshDb()
+  })
+
+  it('returns empty list when no history exists', async () => {
+    const rows = await listCustomerConfigHistory(db, 'smith-pi-firm')
+    expect(rows).toEqual([])
+  })
+
+  it('records the first sync with prev_git_sha=null', async () => {
+    const result = await recordCustomerConfigSync(db, {
+      customer_slug: 'smith-pi-firm',
+      git_sha: 'sha-aaa',
+      synced_at: '2026-05-27T00:00:00Z',
+      synced_by: 'ci',
+      actor: null,
+      r2_shadow_key: null,
+    })
+    expect(result.recorded).toBe(true)
+    expect(result.skipped_reason).toBeNull()
+
+    const rows = await listCustomerConfigHistory(db, 'smith-pi-firm')
+    expect(rows).toHaveLength(1)
+    expect(rows[0].git_sha).toBe('sha-aaa')
+    expect(rows[0].prev_git_sha).toBeNull()
+    expect(rows[0].synced_by).toBe('ci')
+    expect(rows[0].actor).toBeNull()
+  })
+
+  it('chains prev_git_sha across consecutive syncs', async () => {
+    await recordCustomerConfigSync(db, {
+      customer_slug: 'smith-pi-firm',
+      git_sha: 'sha-aaa',
+      synced_at: '2026-05-27T00:00:00Z',
+      synced_by: 'ci',
+      actor: null,
+      r2_shadow_key: null,
+    })
+    await recordCustomerConfigSync(db, {
+      customer_slug: 'smith-pi-firm',
+      git_sha: 'sha-bbb',
+      synced_at: '2026-05-27T00:01:00Z',
+      synced_by: 'ci',
+      actor: null,
+      r2_shadow_key: null,
+    })
+    const rows = await listCustomerConfigHistory(db, 'smith-pi-firm')
+    expect(rows).toHaveLength(2)
+    // listCustomerConfigHistory returns most-recent-first.
+    expect(rows[0].git_sha).toBe('sha-bbb')
+    expect(rows[0].prev_git_sha).toBe('sha-aaa')
+    expect(rows[1].git_sha).toBe('sha-aaa')
+    expect(rows[1].prev_git_sha).toBeNull()
+  })
+
+  it('no-ops a CI re-sync at identical git_sha', async () => {
+    await recordCustomerConfigSync(db, {
+      customer_slug: 'smith-pi-firm',
+      git_sha: 'sha-aaa',
+      synced_at: '2026-05-27T00:00:00Z',
+      synced_by: 'ci',
+      actor: null,
+      r2_shadow_key: null,
+    })
+    const result = await recordCustomerConfigSync(db, {
+      customer_slug: 'smith-pi-firm',
+      git_sha: 'sha-aaa',
+      synced_at: '2026-05-27T00:01:00Z',
+      synced_by: 'ci',
+      actor: null,
+      r2_shadow_key: null,
+    })
+    expect(result.recorded).toBe(false)
+    expect(result.skipped_reason).toContain('identical git_sha')
+    const rows = await listCustomerConfigHistory(db, 'smith-pi-firm')
+    expect(rows).toHaveLength(1)
+  })
+
+  it('records a drift-repair re-sync at identical git_sha', async () => {
+    await recordCustomerConfigSync(db, {
+      customer_slug: 'smith-pi-firm',
+      git_sha: 'sha-aaa',
+      synced_at: '2026-05-27T00:00:00Z',
+      synced_by: 'ci',
+      actor: null,
+      r2_shadow_key: null,
+    })
+    const result = await recordCustomerConfigSync(db, {
+      customer_slug: 'smith-pi-firm',
+      git_sha: 'sha-aaa',
+      synced_at: '2026-05-27T00:30:00Z',
+      synced_by: 'drift-repair',
+      actor: 'system:drift-cron',
+      r2_shadow_key: null,
+    })
+    expect(result.recorded).toBe(true)
+    const rows = await listCustomerConfigHistory(db, 'smith-pi-firm')
+    expect(rows).toHaveLength(2)
+    expect(rows[0].synced_by).toBe('drift-repair')
+    expect(rows[0].actor).toBe('system:drift-cron')
+    // prev_git_sha on the drift-repair row points at the original ci row's
+    // sha — which IS the same sha. That's correct: the chain reflects the
+    // last sync we materialized, not the last unique sha.
+    expect(rows[0].prev_git_sha).toBe('sha-aaa')
+  })
+
+  it('persists r2_shadow_key when the caller passes it', async () => {
+    await recordCustomerConfigSync(db, {
+      customer_slug: 'smith-pi-firm',
+      git_sha: 'sha-aaa',
+      synced_at: '2026-05-27T00:00:00Z',
+      synced_by: 'ci',
+      actor: null,
+      r2_shadow_key: 'customers/smith-pi-firm/history/sha-aaa.yaml',
+    })
+    const rows = await listCustomerConfigHistory(db, 'smith-pi-firm')
+    expect(rows[0].r2_shadow_key).toBe('customers/smith-pi-firm/history/sha-aaa.yaml')
+  })
+
+  it('CHECK constraint rejects an unknown synced_by value', async () => {
+    await expect(
+      db
+        .prepare(
+          'INSERT INTO customer_config_history (customer_slug, git_sha, synced_at, synced_by) ' +
+            'VALUES (?, ?, ?, ?)'
+        )
+        .bind('smith-pi-firm', 'sha-bogus', '2026-05-27T00:00:00Z', 'not-a-valid-source')
+        .run()
+    ).rejects.toThrow()
+  })
+
+  it('isolates history per customer_slug', async () => {
+    await recordCustomerConfigSync(db, {
+      customer_slug: 'smith-pi-firm',
+      git_sha: 'sha-aaa',
+      synced_at: '2026-05-27T00:00:00Z',
+      synced_by: 'ci',
+      actor: null,
+      r2_shadow_key: null,
+    })
+    await recordCustomerConfigSync(db, {
+      customer_slug: 'jones-pi-firm',
+      git_sha: 'sha-xxx',
+      synced_at: '2026-05-27T00:00:00Z',
+      synced_by: 'ci',
+      actor: null,
+      r2_shadow_key: null,
+    })
+    const smith = await listCustomerConfigHistory(db, 'smith-pi-firm')
+    const jones = await listCustomerConfigHistory(db, 'jones-pi-firm')
+    expect(smith).toHaveLength(1)
+    expect(jones).toHaveLength(1)
+    expect(smith[0].git_sha).toBe('sha-aaa')
+    expect(jones[0].git_sha).toBe('sha-xxx')
+  })
+
+  it('listCustomerConfigHistory respects the limit argument', async () => {
+    for (let i = 0; i < 5; i++) {
+      await recordCustomerConfigSync(db, {
+        customer_slug: 'smith-pi-firm',
+        git_sha: `sha-${i}`,
+        synced_at: `2026-05-27T00:0${i}:00Z`,
+        synced_by: 'ci',
+        actor: null,
+        r2_shadow_key: null,
+      })
+    }
+    const limited = await listCustomerConfigHistory(db, 'smith-pi-firm', 3)
+    expect(limited).toHaveLength(3)
+    expect(limited[0].git_sha).toBe('sha-4')
+  })
+})
+
+describe('getLatestSyncMeta', () => {
+  let db: D1Database
+
+  beforeEach(async () => {
+    db = await freshDb()
+  })
+
+  it('returns null when no history exists', async () => {
+    const meta = await getLatestSyncMeta(db, 'smith-pi-firm')
+    expect(meta).toBeNull()
+  })
+
+  it('returns the most recent row by synced_at', async () => {
+    await recordCustomerConfigSync(db, {
+      customer_slug: 'smith-pi-firm',
+      git_sha: 'sha-aaa',
+      synced_at: '2026-05-27T00:00:00Z',
+      synced_by: 'ci',
+      actor: null,
+      r2_shadow_key: null,
+    })
+    await recordCustomerConfigSync(db, {
+      customer_slug: 'smith-pi-firm',
+      git_sha: 'sha-bbb',
+      synced_at: '2026-05-27T00:01:00Z',
+      synced_by: 'manual',
+      actor: 'partner@smith-pi-firm.example',
+      r2_shadow_key: null,
+    })
+    const meta = await getLatestSyncMeta(db, 'smith-pi-firm')
+    expect(meta).toEqual({ git_sha: 'sha-bbb', synced_by: 'manual' })
   })
 })


### PR DESCRIPTION
## Summary

PR 3 of 4 for [ADR 0022](../blob/main/docs/adr/0022-vertical-pack-architecture.md). Closes the second substrate gap flagged in §"Time-machine substrate commitment": every CI / drift-repair / manual / bootstrap sync of `customer.yaml` now records a versioned event row in `customer_config_history` so the materialization history is queryable independent of git.

- Closes #1113
- Parent: #1091
- Unblocked by PR 2 (#1117) landing

## Pointer-only design (Simplifier critique #2)

Rows reference `git_sha`, not snapshot bytes. Git itself is the durable copy (per ADR 0012); an optional `r2_shadow_key` column captures post-transformation bytes when the sync code path produces one. Three storage locations collapse to two with negligible loss of recovery surface.

## What ships

| File | Purpose |
|---|---|
| `migrations/0045_customer_config_history.sql` | Pointer-only table. `synced_by` CHECK enum (`manual`/`ci`/`drift-repair`/`bootstrap`). Indexes on `(customer_slug, synced_at DESC)` and `(customer_slug, git_sha)`. |
| `src/lib/portal/customer-config.ts` | `shouldRecordSync` (pure policy: drift-repair is the only source that records on identical SHA), `getLatestSyncMeta`, `recordCustomerConfigSync`, `listCustomerConfigHistory`, `SyncSource` type. |
| `src/pages/admin/ai-employee/config-history/[customer_slug].astro` | Admin page showing the last 20 sync events. Empty state explicitly references the substrate-vs-wired gap. |
| `tests/customer-config.test.ts` | +17 cases covering policy edges, chain integrity, CHECK constraint, per-slug isolation, limit param. |

## Substrate vs. wiring

The CI sync code path that calls `recordCustomerConfigSync` doesn't live in this repo yet (the existing `customer-config.ts` header says: _"CI sync … lands in a follow-on PR"_). PR 3 ships the substrate so that when CI sync IS wired up — whether next week or next quarter — the audit trail accumulates from day one. Until then, the table sits empty and the admin page surfaces an explicit empty-state message pointing at the unimplemented sync path. This is per the approved plan §Stream 3.

## Migration number

The plan reserved `0044` but ADR 0023 used it before this branch was cut. Bumped to `0045_customer_config_history.sql`.

## Out of scope (per plan)
- Wiring `recordCustomerConfigSync` into the CI sync code path (separate concern, follows when CI sync code lands)
- R2 shadow write helper (the sync code path produces shadow keys; the helper just persists what it's given)
- Time-machine UX — diff view, surgical revert (ADR 0022 §"Out of Scope" defers until first real customer-support case)

## Test plan

- [x] `npm run verify` green (lint + typecheck + format + build + JS tests)
- [x] 31 customer-config tests pass (14 existing + 17 new)
- [x] Migration 0045 verified via in-test schema seed against fresh D1
- [ ] CI green

## Plan reference
`~/.claude/plans/write-a-plan-to-valiant-plum.md` §Stream 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)