### PR TITLE
chore(llm): refresh QUALITY tier to current Sonnet (#1120)

### DIFF
--- a/src/lib/claude/assessment-to-quote.test.ts
+++ b/src/lib/claude/assessment-to-quote.test.ts
@@ -150,7 +150,7 @@ describe('generateQuoteLineItems', () => {
     expect(headers['anthropic-version']).toBe('2023-06-01')
 
     const body = JSON.parse((opts as RequestInit).body as string)
-    expect(body.model).toBe('claude-sonnet-4-20250514')
+    expect(body.model).toBe('claude-sonnet-4-6')
     expect(body.messages[0].content).toContain('process_design')
     expect(body.messages[0].content).toContain('entity context here')
   })

--- a/src/lib/llm/models.ts
+++ b/src/lib/llm/models.ts
@@ -37,7 +37,7 @@ export type ModelTier = 'QUALITY' | 'FAST'
  * Default model ID per tier. This is the one place a model version lives.
  */
 const TIER_DEFAULTS: Record<ModelTier, string> = {
-  QUALITY: 'claude-sonnet-4-20250514',
+  QUALITY: 'claude-sonnet-4-6',
   FAST: 'claude-haiku-4-5-20251001',
 }
 

--- a/tests/claude-extract.test.ts
+++ b/tests/claude-extract.test.ts
@@ -56,7 +56,7 @@ describe('claude extraction: client module', () => {
     expect(code).toContain('const MODEL = QUALITY_MODEL')
     expect(code).toContain('model: MODEL')
     // The literal model ID must live only in llm/models.ts, not at the call site.
-    expect(code).not.toContain('claude-sonnet-4-20250514')
+    expect(code).not.toContain('claude-sonnet-4-6')
   })
 
   it('sets max_tokens to 4096', () => {

--- a/tests/llm-models.test.ts
+++ b/tests/llm-models.test.ts
@@ -18,7 +18,7 @@ describe('llm/models: central model selection', () => {
   it('defines the current tier defaults', () => {
     // This is the ONE place model IDs live. Bumping a tier (e.g. the Opus 4.8-era
     // refresh) is a one-line change here plus this assertion.
-    expect(QUALITY_MODEL).toBe('claude-sonnet-4-20250514')
+    expect(QUALITY_MODEL).toBe('claude-sonnet-4-6')
     expect(FAST_MODEL).toBe('claude-haiku-4-5-20251001')
   })
 


### PR DESCRIPTION
## What

Bumps the `QUALITY` tier default from the stale 2025-era `claude-sonnet-4-20250514` to **`claude-sonnet-4-6`** (the current Sonnet, already used by the `workers/` qualifiers — this harmonizes the main app with them). Closes #1120.

## Why

The enrichment / lead-gen / assessment stack had been pinned to a 2025-era Sonnet. The #1119 centralization made this a one-line change in `TIER_DEFAULTS`.

## Scope of effect

Every QUALITY-tier surface moves to the newer model together: assessment extraction, quote line items, outreach drafting, dossier, deep-website, review synthesis. `enrichment-advanced` provenance labels track `QUALITY_MODEL` automatically, so they stay honest. FAST tier (Haiku) is unchanged.

## Diff

4 lines: the config default + the three matching test assertions (`llm-models`, `claude-extract` guardrail, `assessment-to-quote` runtime check).

## Verification

Full `npm run verify` ✓ — typecheck, typecheck:workers, format, lint (0 errors), build, test (2846), test:workers (9). All green.