### PR TITLE
chore(ai-employee): bump overlay ref to v0.1.1 (go-live blockers)

### DIFF
--- a/ai-employee/templates/Dockerfile
+++ b/ai-employee/templates/Dockerfile
@@ -51,7 +51,7 @@ ARG HONCHO_PIP_SPEC="honcho-ai==1.0.0"
 # (`hermes-smd bootstrap`, `hermes-smd customer-sync`). Pinned to a tagged
 # release; bump in lockstep with overlay-side feature work.
 ARG OVERLAY_REPO="https://github.com/venturecrane/hermes-smd-overlay.git"
-ARG OVERLAY_REF="v0.1.0"
+ARG OVERLAY_REF="v0.1.1"
 
 ARG CUSTOMER_SLUG=customer-zero
 


### PR DESCRIPTION
## What

Bumps `OVERLAY_REF` in `ai-employee/templates/Dockerfile` from `v0.1.0` → `v0.1.1`.

## Why

`v0.1.0` (overlay commit `b61ead7`) **predates the fail-closed go-live blocker fixes** — overlay #12 (trust) and #13 (webhook), merged via #14 at `a413634`. Provisioning customer-zero on `v0.1.0` would `pip install` the overlay *without* those blockers, shipping the exact code the blockers were meant to gate.

`v0.1.1` was cut from current overlay `main` (`a413634`, CI `verify: success`) and is the first overlay release safe for customer-zero provisioning.

## Verification

- Overlay `main` HEAD `a413634`, CI green (`verify: success`)
- `v0.1.1` tag pushed → dereferences to `a413634`
- Only the Dockerfile ARG references the ref; no other call sites (grep clean)

Unblocks customer-zero (SMD) Fly provisioning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)