### PR TITLE
feat(ai-employee): configurable autonomy ceilings — action-class exposure axis (ADR 0025, #1145)

### DIFF
--- a/ai-employee/adapter/trust_ceiling.py
+++ b/ai-employee/adapter/trust_ceiling.py
@@ -14,12 +14,20 @@ the customer's audit log and surfaced in the per-fixture grading trail.
 The enforcement runs in code, not in prompt. Prompt drift cannot escalate
 a skill — the model can ask all it wants; the adapter says no.
 
-For Phase A this module is a stub; Phase A.5 fills in real enforcement.
+Per ADR 0025, autonomy is enforced as a configurable ceiling **per action
+class**, not one scalar applied to the whole skill. `enforce()` resolves the
+effective ceiling for an action as the most restrictive of {vertical floor,
+the customer's explicit per-action override, the safe class default}. The
+`external_send` class defaults to `draft_for_review` (reviewer-as-sender) and
+must be *explicitly* raised to `autonomous` in `action_ceilings` to permit an
+autonomous send — and can never be raised above a vertical-pack floor. The
+agent can never raise its own ceiling (that is a control-plane act, ADR 0026).
 """
 
 from __future__ import annotations
 
 import enum
+from collections.abc import Mapping
 from dataclasses import dataclass
 
 
@@ -46,6 +54,58 @@ class EnforcementDecision:
     audit_action: str  # "allow" | "draft" | "refuse"
 
 
+# Restrictiveness ordering: higher number == more restrictive. Used to pick
+# the most-restrictive ceiling when combining a configured value with a
+# vertical-pack floor (a floor can only narrow, never widen — ADR 0025).
+_RESTRICTIVENESS: dict[Ceiling, int] = {
+    Ceiling.AUTONOMOUS: 0,
+    Ceiling.DRAFT_FOR_REVIEW: 1,
+    Ceiling.REFUSED: 2,
+}
+
+
+def _most_restrictive(a: Ceiling, b: Ceiling) -> Ceiling:
+    return a if _RESTRICTIVENESS[a] >= _RESTRICTIVENESS[b] else b
+
+
+def _class_default(action: ActionClass, skill_ceiling: Ceiling) -> Ceiling:
+    """The safe default ceiling for an action class when no explicit override
+    is authored. `external_send` defaults to draft_for_review regardless of
+    the skill's scalar, so an autonomous skill does not silently gain the
+    ability to send externally — it must be granted explicitly (ADR 0025)."""
+    if action == ActionClass.READ:
+        return Ceiling.AUTONOMOUS
+    if action == ActionClass.INTERNAL_WRITE:
+        return skill_ceiling
+    if action == ActionClass.EXTERNAL_SEND:
+        return Ceiling.DRAFT_FOR_REVIEW
+    # COMMITMENT / DESTRUCTIVE keep their own reversibility floors in enforce();
+    # this default only matters if those branches ever consult it.
+    return Ceiling.DRAFT_FOR_REVIEW
+
+
+def resolve_ceiling(
+    action: ActionClass,
+    skill_ceiling: Ceiling,
+    action_ceilings: Mapping[ActionClass, Ceiling] | None = None,
+    vertical_floors: Mapping[ActionClass, Ceiling] | None = None,
+) -> Ceiling:
+    """Resolve the effective ceiling for one action class.
+
+    Effective = most restrictive of:
+      - the customer's explicit per-action override (if present), else the
+        safe class default; and
+      - the vertical-pack floor for that class (if present).
+
+    A vertical floor can only make the result *more* restrictive — customer
+    config can never raise above it (ADR 0025 / ADR 0022 compliance floors).
+    """
+    explicit = action_ceilings.get(action) if action_ceilings else None
+    base = explicit if explicit is not None else _class_default(action, skill_ceiling)
+    floor = vertical_floors.get(action) if vertical_floors else None
+    return _most_restrictive(base, floor) if floor is not None else base
+
+
 def enforce(
     *,
     ceiling: Ceiling,
@@ -53,17 +113,23 @@ def enforce(
     skill_name: str,
     tool_name: str,
     current_turn_approval: bool = False,
+    action_ceilings: Mapping[ActionClass, Ceiling] | None = None,
+    vertical_floors: Mapping[ActionClass, Ceiling] | None = None,
 ) -> EnforcementDecision:
-    """Return whether this tool call is allowed under the current trust ceiling.
+    """Return whether this tool call is allowed under the configured ceilings.
 
-    `current_turn_approval` is True iff the operator explicitly approved
-    this specific action in the current invocation. Approvals from prior
-    turns or prior sessions are NOT valid (per safety invariant #1).
+    `ceiling` is the skill-level scalar (governs `internal_write` and acts as
+    the cap). `action_ceilings` are the customer's explicit per-action-class
+    overrides; `vertical_floors` are non-raisable per-class floors from the
+    vertical pack. Both optional — when omitted, the safe class defaults apply
+    (notably `external_send` → draft_for_review), preserving reviewer-as-sender
+    as the default until a customer explicitly raises the exposure ceiling.
 
-    Phase A: this is a stub — returns allow for READ + INTERNAL_WRITE, draft
-    for EXTERNAL_SEND, refuse for COMMITMENT + DESTRUCTIVE. Phase A.5 wires
-    this into Hermes' tool dispatch and runs it against five invariant
-    fixtures.
+    `current_turn_approval` is True iff the operator explicitly approved this
+    specific action in the current invocation. Approvals from prior turns or
+    prior sessions are NOT valid (safety invariant #1). It gates the
+    reversibility classes (COMMITMENT, DESTRUCTIVE); `external_send` autonomy is
+    governed by the configured ceiling, not by an in-turn approval (ADR 0025).
     """
     # REFUSED ceiling: nothing executes
     if ceiling == Ceiling.REFUSED:
@@ -114,28 +180,44 @@ def enforce(
             )
         return EnforcementDecision(allowed=True, reason="destructive with current-turn approval", audit_action="allow")
 
-    # EXTERNAL_SEND requires current-turn approval unless skill is autonomous (invariant #2)
+    # EXTERNAL_SEND: governed by the resolved per-action ceiling (ADR 0025).
+    # autonomous → send; draft_for_review (the default) → draft; refused → block.
+    # No in-turn-approval escape: exposure autonomy is configured, not approved
+    # per message. The hardcoded "always require approval" refusal is gone.
     if action == ActionClass.EXTERNAL_SEND:
-        if ceiling == Ceiling.AUTONOMOUS and current_turn_approval:
-            return EnforcementDecision(allowed=True, reason="autonomous send with approval", audit_action="allow")
-        if ceiling == Ceiling.AUTONOMOUS:
-            # Even autonomous skills don't send to external parties without explicit approval
+        eff = resolve_ceiling(action, ceiling, action_ceilings, vertical_floors)
+        if eff == Ceiling.AUTONOMOUS:
+            return EnforcementDecision(
+                allowed=True,
+                reason="external_send permitted: configured ceiling is autonomous",
+                audit_action="allow",
+            )
+        if eff == Ceiling.REFUSED:
             return EnforcementDecision(
                 allowed=False,
-                reason="external_send requires explicit current-turn approval even for autonomous skills",
+                reason="external_send refused: configured ceiling (or vertical floor) is refused",
                 audit_action="refuse",
             )
-        # draft_for_review: produce the draft, don't send
+        # draft_for_review — the safe default and the reviewer-as-sender path
         return EnforcementDecision(
             allowed=False,
-            reason="skill is draft_for_review; produce draft to notes folder instead of sending",
+            reason="external_send below autonomous ceiling; routing to draft (reviewer-as-sender)",
             audit_action="draft",
         )
 
-    # INTERNAL_WRITE: autonomous OK, draft_for_review writes to notes folder
+    # INTERNAL_WRITE: governed by the resolved per-action ceiling (defaults to
+    # the skill scalar). autonomous → write; draft_for_review → route to draft;
+    # refused (only if explicitly set) → block.
     if action == ActionClass.INTERNAL_WRITE:
-        if ceiling == Ceiling.AUTONOMOUS:
+        eff = resolve_ceiling(action, ceiling, action_ceilings, vertical_floors)
+        if eff == Ceiling.AUTONOMOUS:
             return EnforcementDecision(allowed=True, reason="autonomous internal write", audit_action="allow")
+        if eff == Ceiling.REFUSED:
+            return EnforcementDecision(
+                allowed=False,
+                reason="internal_write refused by configured ceiling",
+                audit_action="refuse",
+            )
         # draft_for_review: allow write but route to notes folder
         return EnforcementDecision(allowed=True, reason="internal write routed to draft folder", audit_action="draft")
 

--- a/ai-employee/safety-substrate/tests/test_invariant_2_no_external_send_without_confirmation.py
+++ b/ai-employee/safety-substrate/tests/test_invariant_2_no_external_send_without_confirmation.py
@@ -1,13 +1,25 @@
-"""Invariant 2: no outbound external send without explicit current-turn confirmation.
+"""Invariant 2: external send is gated by the CONFIGURED ceiling and the
+vertical floor — and the agent can never exceed either.
 
-Email send, SMS send, social post, calendar invite to external attendees,
-draft committed to a public surface — all gated. Even autonomous skills
-cannot fire an external send without the operator's approval in the
-current invocation.
+Reshaped per ADR 0025. The old invariant asserted "no external send without
+current-turn confirmation" — a hardcoded refusal of every autonomous send.
+ADR 0025 makes exposure a configurable ceiling per action class, so the
+invariant is now:
 
-Failure mode this protects against: a misconfigured prompt or compromised
-tool result causing a skill to fire an outbound message to a customer
-or third party.
+  - `external_send` defaults to draft_for_review (reviewer-as-sender). An
+    autonomous *skill scalar* does NOT grant autonomous send; it must be
+    raised explicitly via `action_ceilings[external_send] = autonomous`.
+  - An explicit autonomous override permits the send (the new capability).
+  - A vertical-pack floor can only narrow: a floor of draft_for_review beats a
+    customer override of autonomous, so a regulated vertical (e.g. law) keeps
+    reviewer-as-sender even if the customer tries to raise it.
+  - A skill whose scalar ceiling is `refused` runs nothing at all.
+
+Failure mode this still protects against: a misconfigured prompt or
+compromised tool result causing a skill to fire an outbound message it was
+not configured to send autonomously. Authorization comes from authored config
+(customer.yaml + vertical floor), never from model claims or the in-turn
+approval flag (that flag governs the reversibility classes; see invariant 5).
 """
 
 from __future__ import annotations
@@ -21,7 +33,7 @@ from adapter.trust_ceiling import ActionClass, Ceiling, enforce
 
 
 def run() -> tuple[bool, str]:
-    # Scenario A: draft_for_review skill, external send, no approval — drafted, not sent
+    # Scenario A: default external_send (no override) drafts, never sends.
     decision = enforce(
         ceiling=Ceiling.DRAFT_FOR_REVIEW,
         action=ActionClass.EXTERNAL_SEND,
@@ -29,18 +41,15 @@ def run() -> tuple[bool, str]:
         tool_name="gmail.send",
         current_turn_approval=False,
     )
-    if decision.allowed:
+    if decision.allowed or decision.audit_action != "draft":
         return (
             False,
-            f"FAIL: draft_for_review external_send was allowed, should route to draft (audit={decision.audit_action})",
-        )
-    if decision.audit_action != "draft":
-        return (
-            False,
-            f"FAIL: draft_for_review external_send should audit as 'draft', got '{decision.audit_action}'",
+            f"FAIL: default external_send should draft, got allowed={decision.allowed} "
+            f"audit={decision.audit_action}",
         )
 
-    # Scenario B: autonomous skill, external send, no approval — refused
+    # Scenario B: an autonomous SKILL scalar does NOT auto-grant external send.
+    # Without an explicit action_ceilings override, external_send still drafts.
     decision = enforce(
         ceiling=Ceiling.AUTONOMOUS,
         action=ActionClass.EXTERNAL_SEND,
@@ -48,46 +57,85 @@ def run() -> tuple[bool, str]:
         tool_name="gmail.send",
         current_turn_approval=False,
     )
-    if decision.allowed:
+    if decision.allowed or decision.audit_action != "draft":
         return (
             False,
-            f"FAIL: autonomous external_send WITHOUT approval was allowed (audit={decision.audit_action})",
-        )
-    if decision.audit_action != "refuse":
-        return (
-            False,
-            f"FAIL: autonomous external_send no approval should refuse, got '{decision.audit_action}'",
+            f"FAIL: autonomous skill scalar must NOT silently grant external send; "
+            f"expected draft, got allowed={decision.allowed} audit={decision.audit_action}",
         )
 
-    # Scenario C: autonomous skill, external send, WITH approval — allowed
+    # Scenario C: explicit action_ceilings override permits autonomous send.
+    decision = enforce(
+        ceiling=Ceiling.DRAFT_FOR_REVIEW,
+        action=ActionClass.EXTERNAL_SEND,
+        skill_name="ar-chaser",
+        tool_name="gmail.send",
+        current_turn_approval=False,
+        action_ceilings={ActionClass.EXTERNAL_SEND: Ceiling.AUTONOMOUS},
+    )
+    if not decision.allowed or decision.audit_action != "allow":
+        return (
+            False,
+            f"FAIL: explicit external_send=autonomous should send, got allowed={decision.allowed} "
+            f"audit={decision.audit_action} ({decision.reason})",
+        )
+
+    # Scenario D: explicit external_send=refused blocks the send outright.
     decision = enforce(
         ceiling=Ceiling.AUTONOMOUS,
         action=ActionClass.EXTERNAL_SEND,
         skill_name="ar-chaser",
         tool_name="gmail.send",
-        current_turn_approval=True,
+        current_turn_approval=False,
+        action_ceilings={ActionClass.EXTERNAL_SEND: Ceiling.REFUSED},
     )
-    if not decision.allowed:
+    if decision.allowed or decision.audit_action != "refuse":
         return (
             False,
-            f"FAIL: autonomous external_send WITH approval should be allowed ({decision.reason})",
+            f"FAIL: external_send=refused should refuse, got allowed={decision.allowed} "
+            f"audit={decision.audit_action}",
         )
 
-    # Scenario D: refused-ceiling skill, external send, with approval — still refused
+    # Scenario E: a vertical floor can only NARROW. A floor of draft_for_review
+    # beats a customer override of autonomous — the regulated-vertical guarantee.
+    decision = enforce(
+        ceiling=Ceiling.AUTONOMOUS,
+        action=ActionClass.EXTERNAL_SEND,
+        skill_name="ar-chaser",
+        tool_name="gmail.send",
+        current_turn_approval=False,
+        action_ceilings={ActionClass.EXTERNAL_SEND: Ceiling.AUTONOMOUS},
+        vertical_floors={ActionClass.EXTERNAL_SEND: Ceiling.DRAFT_FOR_REVIEW},
+    )
+    if decision.allowed or decision.audit_action != "draft":
+        return (
+            False,
+            f"FAIL: vertical floor draft_for_review must beat customer override autonomous; "
+            f"expected draft, got allowed={decision.allowed} audit={decision.audit_action}",
+        )
+
+    # Scenario F: a skill whose scalar ceiling is refused runs nothing — even an
+    # external_send=autonomous override cannot revive a disabled skill.
     decision = enforce(
         ceiling=Ceiling.REFUSED,
         action=ActionClass.EXTERNAL_SEND,
         skill_name="never-runs",
         tool_name="gmail.send",
         current_turn_approval=True,
+        action_ceilings={ActionClass.EXTERNAL_SEND: Ceiling.AUTONOMOUS},
     )
     if decision.allowed:
         return (
             False,
-            f"FAIL: refused-ceiling skill should never execute anything, got allowed ({decision.reason})",
+            f"FAIL: refused-scalar skill should never execute anything, got allowed ({decision.reason})",
         )
 
-    return (True, "PASS: invariant 2 holds — external send gated by approval; draft routes to folder; refused blocks all")
+    return (
+        True,
+        "PASS: invariant 2 holds — external send gated by configured ceiling; "
+        "autonomous skill scalar does not auto-grant send; explicit override sends; "
+        "vertical floor narrows; refused scalar blocks all",
+    )
 
 
 if __name__ == "__main__":

--- a/ai-employee/safety-substrate/tests/test_invariant_5_ceiling_enforced_in_code_not_prompt.py
+++ b/ai-employee/safety-substrate/tests/test_invariant_5_ceiling_enforced_in_code_not_prompt.py
@@ -55,31 +55,32 @@ def run() -> tuple[bool, str]:
         tool_name="gmail.send",
         current_turn_approval=True,  # would be set by a malicious injection
     )
-    # Current implementation: draft + external_send routes to draft regardless
-    # of approval flag. The approval flag matters only for autonomous skills.
+    # external_send routes to draft regardless of the approval flag (ADR 0025):
+    # exposure autonomy is governed by the authored ceiling, not an in-turn
+    # approval, so a prompt-injected approval cannot escalate a draft skill.
     if decision.allowed:
         return (
             False,
             "FAIL: draft skill with prompt-injected approval was allowed to send",
         )
 
-    # Final test: ceiling=AUTONOMOUS, current_turn_approval=True, external_send.
-    # The model's prompt claims autonomy AND approval — and indeed if the
-    # SKILL.md was authored autonomous and the operator approved in this turn,
-    # the action should fire. The substrate doesn't refuse here — it allows.
-    # This is the boundary: code reads SKILL.md authoring (not model claims),
-    # and operator approval is a real signal IF the ceiling permits it.
+    # Final test: external_send authorized for autonomy via the authored
+    # action-class ceiling (action_ceilings), NOT via a model-claimed approval.
+    # When the customer.yaml authoring sets external_send=autonomous, the send
+    # fires. This is the boundary: code reads authored config (not model
+    # claims), and the configured exposure ceiling is what permits the send.
     decision = enforce(
-        ceiling=Ceiling.AUTONOMOUS,  # authored
+        ceiling=Ceiling.DRAFT_FOR_REVIEW,  # skill scalar; irrelevant to external_send
         action=ActionClass.EXTERNAL_SEND,
         skill_name="autonomous-sender",
         tool_name="gmail.send",
-        current_turn_approval=True,
+        current_turn_approval=False,  # approval flag is NOT the lever here
+        action_ceilings={ActionClass.EXTERNAL_SEND: Ceiling.AUTONOMOUS},  # authored
     )
     if not decision.allowed:
         return (
             False,
-            f"FAIL: legitimate autonomous + approved send was blocked ({decision.reason})",
+            f"FAIL: legitimate authored-autonomous send was blocked ({decision.reason})",
         )
 
     return (True, "PASS: invariant 5 holds — ceiling read from authoring, prompt cannot escalate; legitimate flows still work")

--- a/ai-employee/verticals/law-firm/vertical.yaml
+++ b/ai-employee/verticals/law-firm/vertical.yaml
@@ -19,6 +19,22 @@ compliance:
   - privilege
   - upl-boundary
 
+# Non-raisable per-action-class trust floors (ADR 0025 / ADR 0022 compliance
+# constraints). Customer configuration and skill promotion can never raise an
+# action class above its floor here. The overlay's `hermes-smd-trust` plugin
+# loads these into `vertical_floors` and passes them to
+# `adapter/trust_ceiling.py::enforce()`, which takes the most restrictive of
+# {floor, customer override, safe default}.
+#
+# For a law firm, every outbound communication ships under the reviewer's
+# identity per ABA Formal Opinion 512 / state AI-disclosure rules — so
+# external_send is pinned at draft_for_review and cannot be promoted to
+# autonomous, preserving reviewer-as-sender as a hard floor for this vertical
+# (the moat ADR 0005 protects, expressed as a floor rather than a global
+# absolute per ADR 0025).
+trust_floors:
+  external_send: draft_for_review
+
 # Reference persona archetypes. Empty in v1 — customer-zero is the first
 # concrete persona shape and lives in customer.yaml directly. Promote
 # reusable archetypes here as multi-customer patterns emerge.

--- a/docs/adr/0025-autonomy-ceilings-configurable-exposure-vs-initiation.md
+++ b/docs/adr/0025-autonomy-ceilings-configurable-exposure-vs-initiation.md
@@ -96,6 +96,15 @@ The hardcoded refusal at `trust_ceiling.py:117-127` is removed. `enforce()` cons
 
 ADR 0005's internal/external persona split (the persona is fully visible internally; external presence is the reviewer) stands as the **default**. A customer who configures autonomous external send may also configure an agent-as-sender identity for that channel; doing so is the same kind of privileged, audited config act as raising the exposure ceiling, and is subject to any vertical floor. ADR 0005's drafts mechanism, audit-trail preamble, and internal-persona rules are otherwise preserved.
 
+### 7. Two enforcement layers — this ADR governs the gate, not the adapter surface
+
+There are **two** code layers that today encode "no autonomous external send," and this ADR addresses only the first:
+
+1. **The trust-ceiling gate** (`adapter/trust_ceiling.py::enforce()`, run live by the overlay `hermes-smd-trust` `pre_tool_call` hook). This is the configurable authority layer — the subject of this ADR. After implementation, the gate consults the configured per-action ceiling and permits a send tool to fire when `external_send` is raised to `autonomous` (floored by the vertical).
+2. **The capability-adapter surface ban** (`src/lib/ai-employee/capabilities/conformance.ts` `NO_AUTONOMOUS_EXTERNAL_SEND` + `BANNED_METHOD_NAMES`). Our own `build:` capability adapters are _structurally_ forbidden from exposing a send method at all — the `Email` adapter has no `send`, only draft. This is the deeper, structural form of reviewer-as-sender (ADR 0005 / ADR 0006).
+
+The consequence: raising the ceiling makes autonomous send real on the **MCP-connector path** (ADR 0020's primary path — an MCP server exposes a `send` tool the gate governs). It does **not** make our `build:` adapters send, because those have no send method to call regardless of ceiling. That is the intended conservative posture: build adapters stay structurally draft-only; autonomous send is reached through a ceiling-gated MCP tool, never by an adapter that smuggles in a `send`. Whether to ever lift the `build:`-adapter ban is a separate, genuinely ADR-0005-architectural decision, deliberately **not** decided here.
+
 ---
 
 ## Alternatives Considered

--- a/docs/pm/ai-employee/platform-prd.md
+++ b/docs/pm/ai-employee/platform-prd.md
@@ -423,7 +423,7 @@ Skills live in `ai-employee/skills/{skill-name}/SKILL.md` plus a `references/` f
 Eight base invariants gate every Hermes container boot:
 
 1. No destructive operations without approval
-2. No external send without approval (architectural — the reviewer-as-sender pattern)
+2. External send obeys the **configured** per-action ceiling, floored by the vertical pack; the agent can never raise its own ceiling (**[ADR 0025](../../adr/0025-autonomy-ceilings-configurable-exposure-vs-initiation.md)**). `external_send` defaults to `draft_for_review` (reviewer-as-sender) and is promotable to `autonomous` only where no vertical floor forbids it. Reviewer-as-sender remains the default and the structural form for our `build:` capability adapters (the `Email` interface still has no `send` method — §3 / [ADR 0005](../../adr/0005-reviewer-as-sender.md)); autonomous send is reached via a ceiling-gated send tool (e.g. an MCP connector), never by an adapter that smuggles in a `send`.
 3. No commitment execution (no autonomous contract signing, no autonomous payments)
 4. Sticky stop instructions (an "agent off" command persists across context compaction)
 5. Code-enforced trust ceilings (skill-declared trust levels override prompt-injection attempts)
@@ -717,13 +717,13 @@ The product's safety architecture and the principal's confidence dial.
 | **draft_for_review** | Agent drafts; named human reviewer must approve before any external action. | All external communications, all transactions, all matter writes, all signing requests                                  |
 | **disabled**         | Agent does not run this skill at all.                                       | Customer-disabled or trust-revoked skills                                                                               |
 
-### 11.2 The default ceiling per skill
+### 11.2 The default ceiling per action class
 
-Every skill ships with a default trust ceiling. The defaults are conservative:
+Per **[ADR 0025](../../adr/0025-autonomy-ceilings-configurable-exposure-vs-initiation.md)**, the trust ceiling is resolved **per action class** (`read` / `internal_write` / `external_send` / `commitment` / `destructive`), not as one scalar applied to the whole skill. The defaults are conservative, and the exposure axis (`external_send`) is the one a customer can deliberately raise:
 
-- **Read-only / monitoring / internal**: `autonomous` allowed by default
-- **External communication, drafts, transactions, writes to matters**: `draft_for_review` mandatory
-- **Anything touching trust accounting, court filing, settlement authority, judgment-bearing work**: `draft_for_review` permanently; cannot be promoted to autonomous
+- **Read-only / monitoring / internal_write**: `autonomous` allowed by default
+- **External communication (`external_send`)**: `draft_for_review` **by default** (reviewer-as-sender). This is the secure default, not a permanent lock — it is promotable to `autonomous` per §11.3 where no vertical floor forbids it. Raising it is what authorizes the agent to send without per-message review.
+- **Trust accounting, court filing, settlement authority, judgment-bearing work**: a **non-raisable vertical-pack floor** ([ADR 0022](../../adr/0022-vertical-pack-architecture.md) compliance constraints). Customer configuration and promotion can never raise above the floor; the law pack pins these permanently at `draft_for_review`. `commitment` and `destructive` retain their current-turn-approval floors regardless of configuration (safety invariants 1 & 3).
 
 ### 11.3 Promotion mechanics
 

--- a/src/lib/ai-employee/customer-yaml/sections-personas.ts
+++ b/src/lib/ai-employee/customer-yaml/sections-personas.ts
@@ -5,10 +5,12 @@
  */
 
 import {
+  ACCEPTED_ACTION_CLASSES,
   ACCEPTED_PERSONA_STATUSES,
   ACCEPTED_PRONOUNS,
   ACCEPTED_TRUST_CEILINGS,
   SLUG_PATTERN,
+  type ActionClass,
   type CostEstimate,
   type Persona,
   type PersonaChannelBinding,
@@ -221,6 +223,7 @@ function checkOneSkill(raw: unknown, path: string, errors: ValidationError[]): P
   }
   checkSkillName(raw['name'], path, errors)
   checkSkillCeiling(raw['trust_ceiling'], path, errors)
+  checkSkillActionCeilings(raw['action_ceilings'], path, errors)
   checkSkillVersion(raw['version'], path, errors)
   checkSkillEnabled(raw['enabled'], path, errors)
   const cost = checkCostEstimate(raw['cost_estimate'], `${path}.cost_estimate`, errors)
@@ -248,6 +251,47 @@ function checkSkillCeiling(ceiling: unknown, path: string, errors: ValidationErr
       path: `${path}.trust_ceiling`,
       message: `trust_ceiling must be one of: ${ACCEPTED_TRUST_CEILINGS.join(', ')}`,
     })
+  }
+}
+
+/**
+ * Validate the optional per-action-class ceiling override map (ADR 0025).
+ * Absent/null is valid (skill uses safe class defaults). When present it must
+ * be an object whose keys are known ActionClasses and whose values are
+ * accepted TrustCeilings. The floor check (cannot raise above a vertical
+ * floor) is a runtime/enforcement concern, not a static-shape concern, so it
+ * is not done here.
+ */
+function checkSkillActionCeilings(raw: unknown, path: string, errors: ValidationError[]): void {
+  if (raw === undefined || raw === null) return
+  const fieldPath = `${path}.action_ceilings`
+  if (!isPlainObject(raw)) {
+    errors.push({
+      code: 'TypeMismatch',
+      path: fieldPath,
+      message: `${fieldPath} must be an object`,
+    })
+    return
+  }
+  for (const [key, value] of Object.entries(raw)) {
+    if (!(ACCEPTED_ACTION_CLASSES as readonly string[]).includes(key)) {
+      errors.push({
+        code: 'InvalidActionClass',
+        path: `${fieldPath}.${key}`,
+        message: `action_ceilings key must be one of: ${ACCEPTED_ACTION_CLASSES.join(', ')}`,
+      })
+      continue
+    }
+    if (
+      typeof value !== 'string' ||
+      !(ACCEPTED_TRUST_CEILINGS as readonly string[]).includes(value)
+    ) {
+      errors.push({
+        code: 'InvalidActionCeiling',
+        path: `${fieldPath}.${key}`,
+        message: `action_ceilings.${key} must be one of: ${ACCEPTED_TRUST_CEILINGS.join(', ')}`,
+      })
+    }
   }
 }
 
@@ -288,10 +332,31 @@ function assembleSkill(
       (ACCEPTED_TRUST_CEILINGS as readonly string[]).includes(ceiling)
         ? (ceiling as TrustCeiling)
         : 'refused',
+    action_ceilings: extractActionCeilings(raw['action_ceilings']),
     enabled: typeof enabled === 'boolean' ? enabled : true,
     cost_estimate: cost,
     scope,
   }
+}
+
+/**
+ * Build the validated per-action-class ceiling map, keeping only well-formed
+ * entries. Returns null when no overrides are authored (the common case),
+ * so consumers can treat null as "use safe class defaults."
+ */
+function extractActionCeilings(raw: unknown): Partial<Record<ActionClass, TrustCeiling>> | null {
+  if (!isPlainObject(raw)) return null
+  const out: Partial<Record<ActionClass, TrustCeiling>> = {}
+  for (const [key, value] of Object.entries(raw)) {
+    if (
+      (ACCEPTED_ACTION_CLASSES as readonly string[]).includes(key) &&
+      typeof value === 'string' &&
+      (ACCEPTED_TRUST_CEILINGS as readonly string[]).includes(value)
+    ) {
+      out[key as ActionClass] = value as TrustCeiling
+    }
+  }
+  return Object.keys(out).length > 0 ? out : null
 }
 
 function checkCostEstimate(

--- a/src/lib/ai-employee/customer-yaml/types.ts
+++ b/src/lib/ai-employee/customer-yaml/types.ts
@@ -118,6 +118,26 @@ export const AUDIT_LOG_DAYS_MAX = 36500
 export const ACCEPTED_TRUST_CEILINGS = ['autonomous', 'draft_for_review', 'refused'] as const
 export type TrustCeiling = (typeof ACCEPTED_TRUST_CEILINGS)[number]
 
+/**
+ * Action classes a tool call is categorized into, mirroring the Python
+ * `ActionClass` enum in `ai-employee/adapter/trust_ceiling.py`. Per ADR 0025,
+ * autonomy is enforced as a configurable ceiling **per action class** rather
+ * than one scalar applied to the whole skill — splitting the exposure axis
+ * (external_send) from the initiation and internal axes.
+ *
+ * The values must stay byte-identical to the Python enum's `.value` strings;
+ * the overlay materializer (`hermes-smd bootstrap`) carries this map across
+ * the seam to the runtime `enforce()` call.
+ */
+export const ACCEPTED_ACTION_CLASSES = [
+  'read',
+  'internal_write',
+  'external_send',
+  'commitment',
+  'destructive',
+] as const
+export type ActionClass = (typeof ACCEPTED_ACTION_CLASSES)[number]
+
 export const ACCEPTED_USER_ROLES = ['principal', 'operator', 'compliance'] as const
 export type UserRole = (typeof ACCEPTED_USER_ROLES)[number]
 
@@ -214,7 +234,25 @@ export interface CostEstimate {
 export interface PersonaSkill {
   name: string
   version: string
+  /**
+   * Skill-level scalar ceiling. Governs `internal_write` and acts as the
+   * cap the per-action overrides resolve under. Retained from the
+   * pre-ADR-0025 schema for back-compat: a skill with only `trust_ceiling`
+   * set keeps its previous meaning, and `external_send` stays at the safe
+   * `draft_for_review` default (reviewer-as-sender) unless explicitly raised
+   * in `action_ceilings`.
+   */
   trust_ceiling: TrustCeiling
+  /**
+   * Per-action-class ceiling overrides (ADR 0025). Optional and sparse —
+   * only the classes a customer wants to set explicitly appear. The runtime
+   * `enforce()` resolves the effective ceiling for an action as the most
+   * restrictive of {vertical floor, this override if present, the safe
+   * class default}. Setting `external_send: autonomous` here is what grants
+   * autonomous external send; it can never raise above a vertical-pack floor.
+   * `null`/absent means "no overrides — use safe class defaults."
+   */
+  action_ceilings: Partial<Record<ActionClass, TrustCeiling>> | null
   enabled: boolean
   cost_estimate: CostEstimate | null
   scope: string[]
@@ -601,6 +639,8 @@ export type ValidationErrorCode =
   | 'InvalidVerticalSpec'
   | 'InvalidAddonSpec'
   | 'UnknownAddon'
+  | 'InvalidActionClass'
+  | 'InvalidActionCeiling'
 
 export interface ValidationError {
   code: ValidationErrorCode


### PR DESCRIPTION
Implements **[ADR 0025](https://github.com/venturecrane/ss-console/blob/main/docs/adr/0025-autonomy-ceilings-configurable-exposure-vs-initiation.md)**. Closes #1145.

Turns exposure-as-config doctrine into a working switch: `EXTERNAL_SEND` (and the other action classes) become **configurable per-action ceilings** instead of a hardcoded refusal. **Safe by default** — existing customers do not silently gain autonomous send.

## The model

`enforce()` resolves the effective ceiling for `(skill, action_class)` = **most restrictive of** {vertical floor, explicit `action_ceilings` override, safe class default}. `EXTERNAL_SEND` defaults to `draft_for_review` regardless of the skill scalar, so autonomous send must be **explicitly raised** and can never exceed a vertical floor.

## Changes

**Schema (TS)** — `types.ts`: `ACCEPTED_ACTION_CLASSES` + `ActionClass` (mirrors the Python enum), optional `action_ceilings` map on `PersonaSkill`, two new error codes. Scalar `trust_ceiling` retained for back-compat. `sections-personas.ts`: validate + assemble the sparse override map.

**Enforcement (Python)** — `trust_ceiling.py`: new `resolve_ceiling()`; removed the `:117-127` hardcoded refusal; `enforce()` gains optional `action_ceilings` + `vertical_floors` params (**backward-compatible** — the overlay keeps working and shifts to the safe `draft_for_review` default until it passes the new args).

**Tests (Python)** — invariant 2 reshaped from "always refuse autonomous external send" to six per-ceiling scenarios: default drafts · autonomous-scalar does NOT auto-grant send · explicit override sends · `refused` blocks · **vertical floor narrows an autonomous override** · refused-scalar disables the skill. Invariant 5's legitimate-send scenario now authorizes via authored `action_ceilings` (not the approval flag); its prompt-can't-escalate core is unchanged.

**Vertical floor** — `law-firm/vertical.yaml`: `trust_floors.external_send = draft_for_review` pins reviewer-as-sender as a **non-raisable floor** for the law vertical (the ADR 0005 moat, now a floor rather than a global absolute).

**Docs** — ADR 0025 §7 documents the **two enforcement layers** discovered during implementation: the trust-ceiling gate (this change, configurable) and the `conformance.ts` `build:`-adapter surface ban (structural, unchanged). Autonomous send is real on the **MCP-connector path**; `build:` adapters stay draft-only. Whether to ever lift the build-adapter ban → **#1146** (Captain decision, my rec: keep the ban). PRD §11.2 + safety-invariant 2 amended to the default-plus-floor model.

## What this does and doesn't enable

- ✅ A git-authored `customer.yaml` with `action_ceilings: {external_send: autonomous}` lets the agent send without per-message approval **on the MCP-tool path**, floored by the vertical.
- ⏸️ **Deferred (safety chain, per ADR 0025):** self-serve portal raise waits on ADR 0026; **no customer configured for autonomous send until ADR 0027 (inbound boundary) + ADR 0028 (outbound gates) ship.** Overlay `hermes-smd-trust` passing the new args is the cross-repo follow-up.

## Verification

`npm run verify` green (typecheck · workers typecheck · format · lint · build · test · test:workers). All 7 safety invariants pass; skill-regression goldens pass. Every file:line claim verified against live code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)