### PR TITLE
feat(ai-employee): config governance — portal-side security boundary (ADR 0026/0030)

### DIFF
--- a/migrations/0046_config_change_audit.sql
+++ b/migrations/0046_config_change_audit.sql
@@ -1,0 +1,76 @@
+-- ============================================================================
+-- Migration 0046: config_change_audit table (ADR 0026 / ADR 0030)
+-- ============================================================================
+--
+-- The control-plane ledger for autonomy-config governance actions. ADR 0026
+-- requires every change to a trust ceiling / exposure setting to be
+-- principal-authenticated, immutably audited, and floor-checked. ADR 0030
+-- names the control plane as the principal's single governing surface, and
+-- §4 (Authority) is operated through this table.
+--
+-- WHY A NEW TABLE (not customer_config_history, migration 0045):
+--   0045 records git-sync EVENTS (git_sha-keyed; shouldRecordSync no-ops on
+--   identical SHA). A governance action is a different thing:
+--     * it has no git_sha — the git write-back leg is deferred (ADR 0025
+--       step 7), so the live config is not mutated by the portal (customer-
+--       config.ts is read-only on principle, ADR 0012 §2);
+--     * a REJECTED floor-violation attempt must be recorded (ADR 0026 §4)
+--       and produces no sync and no SHA, so it cannot live in 0045 at all.
+--   This table answers "who authorized which authority change, from what to
+--   what, and was it floor-rejected" — the compliance question ADR 0026 exists
+--   to answer.
+--
+-- HONEST SCOPING (`source` column):
+--   Rows are `portal_intent`: the principal's governance action recorded in
+--   the control plane. They are NOT the per-customer runtime audit log (which
+--   lives on the Machine, unreachable from the portal per ADR 0009). The
+--   value change reaches the runtime via the deferred git write-back path;
+--   correlating this ledger with the runtime audit is a tracked follow-on.
+--   The column exists so a future reader is never misled into treating an
+--   intent row as a runtime-confirmed fact.
+--
+-- Append-only by convention: no UPDATE/DELETE code path. Forward-only,
+-- additive. No drops.
+--
+-- Refers to: docs/adr/0026-config-surface-is-a-security-boundary.md
+--            docs/adr/0030-control-plane-human-principal-surface.md
+--            docs/adr/0025-autonomy-ceilings-configurable-exposure-vs-initiation.md (floors)
+--            docs/adr/0009-cross-machine-query-prohibition.md (control-plane carve-out)
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS config_change_audit (
+  id              INTEGER PRIMARY KEY AUTOINCREMENT,
+  customer_slug   TEXT NOT NULL,
+  entity_id       TEXT NOT NULL,
+  -- Provenance scope. 'portal_intent' = principal action in the control
+  -- plane (the only source today). Reserved for a future
+  -- 'runtime_confirmed' once the runtime->portal reconciliation lands.
+  source          TEXT NOT NULL DEFAULT 'portal_intent'
+                    CHECK (source IN ('portal_intent', 'runtime_confirmed')),
+  -- Who: the authenticated principal (principal-only per ADR 0011/0026).
+  actor_user_id   TEXT NOT NULL,
+  actor_email     TEXT NOT NULL,
+  actor_role      TEXT NOT NULL,
+  -- What changed.
+  change_type     TEXT NOT NULL
+                    CHECK (change_type IN ('trust_ceiling', 'action_ceiling', 'skill_toggle')),
+  persona_slug    TEXT,
+  skill_name      TEXT,
+  action_class    TEXT,           -- e.g. 'external_send', when change_type='action_ceiling'
+  -- Value transition.
+  old_value       TEXT,
+  new_value       TEXT,
+  -- Outcome — the immutable record of the decision, INCLUDING rejections.
+  outcome         TEXT NOT NULL
+                    CHECK (outcome IN ('accepted', 'rejected_floor', 'rejected_invalid')),
+  outcome_reason  TEXT,
+  -- Direction of a raise/lower relative to the restrictiveness ordering.
+  direction       TEXT NOT NULL DEFAULT 'n/a'
+                    CHECK (direction IN ('raise', 'lower', 'lateral', 'n/a')),
+  created_at      TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_cca_slug_created
+  ON config_change_audit (customer_slug, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_cca_entity_created
+  ON config_change_audit (entity_id, created_at DESC);

--- a/src/lib/portal/ai-employee/config-governance.ts
+++ b/src/lib/portal/ai-employee/config-governance.ts
@@ -1,0 +1,308 @@
+/**
+ * Config governance — the portal-side security boundary for autonomy config
+ * (ADR 0026 / ADR 0030 §4).
+ *
+ * A change to a trust ceiling or exposure setting is a privileged, principal-
+ * authenticated, immutably-audited, floor-checked act. This module holds the
+ * pure decision logic plus the append-only audit writer. It is imported ONLY
+ * by principal-gated portal POST handlers — never by agent/skill/tool code
+ * (the agent runs on the Machine in the overlay repo, physically unable to
+ * reach this module per the ADR 0009 isolation boundary; this is the portal-
+ * side statement of ADR 0026 §1 "the agent can never raise its own ceiling").
+ *
+ * This module does NOT mutate the live `customer_configs` replica: that table
+ * is read-only on principle (ADR 0012 §2 — only git -> CI writes it). The
+ * value change reaches the runtime via the deferred git write-back path
+ * (ADR 0025 step 7). What we persist here is the governance ACTION and its
+ * floor decision, in the `config_change_audit` ledger — that is ADR 0026's
+ * "immutably audited," honestly scoped `portal_intent`.
+ */
+
+import { ACCEPTED_ACTION_CLASSES, type ActionClass } from '../../ai-employee/customer-yaml/types'
+import type { D1Database } from '@cloudflare/workers-types'
+
+export type Ceiling = 'autonomous' | 'draft_for_review' | 'refused'
+
+/**
+ * Restrictiveness ordering — mirrors `ai-employee/adapter/trust_ceiling.py`
+ * `_RESTRICTIVENESS`. Higher = more restrictive. Single source for the
+ * raise/lower asymmetry and the floor comparison on the TS side.
+ */
+const RESTRICTIVENESS: Record<Ceiling, number> = {
+  autonomous: 0,
+  draft_for_review: 1,
+  refused: 2,
+}
+
+export function isCeiling(value: unknown): value is Ceiling {
+  return value === 'autonomous' || value === 'draft_for_review' || value === 'refused'
+}
+
+export function restrictiveness(c: Ceiling): number {
+  return RESTRICTIVENESS[c]
+}
+
+export type ChangeDirection = 'raise' | 'lower' | 'lateral' | 'n/a'
+
+/**
+ * Direction of a ceiling change. A "raise" moves toward LESS restrictive
+ * (more autonomy) — the privileged direction ADR 0026 §5 guards.
+ */
+export function changeDirection(oldValue: Ceiling, newValue: Ceiling): ChangeDirection {
+  const delta = RESTRICTIVENESS[newValue] - RESTRICTIVENESS[oldValue]
+  if (delta < 0) return 'raise'
+  if (delta > 0) return 'lower'
+  return 'lateral'
+}
+
+/**
+ * Non-raisable per-action-class vertical floors (ADR 0025 / ADR 0022
+ * compliance constraints). Seeded constant — the source of truth is the
+ * vertical pack manifest (`ai-employee/verticals/<v>/vertical.yaml`
+ * `trust_floors`); this mirror is kept tiny and the keys are asserted to be
+ * real action classes (see config-governance.test.ts) so the portal and the
+ * runtime can never drift on the identifier. CI projection of floors from the
+ * vertical manifests is a tracked follow-on; until then a Captain-reviewed
+ * constant is authored data, not fabrication.
+ *
+ * For a law firm, ABA Formal Opinion 512 / state AI-disclosure rules pin every
+ * outbound communication to reviewer-as-sender, so `external_send` is floored
+ * at `draft_for_review` and cannot be promoted to `autonomous`.
+ */
+export const VERTICAL_FLOORS: Readonly<Record<string, Partial<Record<ActionClass, Ceiling>>>> = {
+  'law-firm': { external_send: 'draft_for_review' },
+}
+
+/** Every action-class key used in VERTICAL_FLOORS, for the membership assertion. */
+export function verticalFloorActionClasses(): string[] {
+  const keys = new Set<string>()
+  for (const floors of Object.values(VERTICAL_FLOORS)) {
+    for (const k of Object.keys(floors)) keys.add(k)
+  }
+  return [...keys]
+}
+
+export function getVerticalFloor(vertical: string | null, action: ActionClass): Ceiling | null {
+  if (!vertical) return null
+  return VERTICAL_FLOORS[vertical]?.[action] ?? null
+}
+
+export interface FloorCheck {
+  allowed: boolean
+  reason: string | null
+}
+
+/**
+ * A requested ceiling may not be LESS restrictive than the floor. Returns
+ * disallowed for a raise above the floor; allowed when at/below the floor or
+ * when no floor applies.
+ */
+export function checkFloor(floor: Ceiling | null, requested: Ceiling): FloorCheck {
+  if (floor === null) return { allowed: true, reason: null }
+  if (RESTRICTIVENESS[requested] < RESTRICTIVENESS[floor]) {
+    return {
+      allowed: false,
+      reason: `vertical floor requires '${floor}' for this action class; '${requested}' would raise above it`,
+    }
+  }
+  return { allowed: true, reason: null }
+}
+
+export type ConfigChangeType = 'trust_ceiling' | 'action_ceiling' | 'skill_toggle'
+export type ConfigChangeOutcome = 'accepted' | 'rejected_floor' | 'rejected_invalid'
+
+export interface ConfigChangeAuditEvent {
+  customer_slug: string
+  entity_id: string
+  actor_user_id: string
+  actor_email: string
+  actor_role: string
+  change_type: ConfigChangeType
+  persona_slug: string | null
+  skill_name: string | null
+  action_class: string | null
+  old_value: string | null
+  new_value: string | null
+  outcome: ConfigChangeOutcome
+  outcome_reason: string | null
+  direction: ChangeDirection
+}
+
+/**
+ * Append a governance action to the immutable control-plane ledger. Always
+ * writes `source='portal_intent'`. Records accepted AND rejected outcomes —
+ * a floor-rejected raise is itself a compliance-relevant event (ADR 0026 §4).
+ */
+export async function recordConfigChangeAudit(
+  db: D1Database,
+  event: ConfigChangeAuditEvent
+): Promise<void> {
+  await db
+    .prepare(
+      'INSERT INTO config_change_audit ' +
+        '(customer_slug, entity_id, source, actor_user_id, actor_email, actor_role, ' +
+        'change_type, persona_slug, skill_name, action_class, old_value, new_value, ' +
+        'outcome, outcome_reason, direction) ' +
+        "VALUES (?, ?, 'portal_intent', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+    )
+    .bind(
+      event.customer_slug,
+      event.entity_id,
+      event.actor_user_id,
+      event.actor_email,
+      event.actor_role,
+      event.change_type,
+      event.persona_slug,
+      event.skill_name,
+      event.action_class,
+      event.old_value,
+      event.new_value,
+      event.outcome,
+      event.outcome_reason,
+      event.direction
+    )
+    .run()
+}
+
+export interface Actor {
+  user_id: string
+  email: string
+  role: string
+}
+
+export interface ApplyCeilingChangeInput {
+  customer_slug: string
+  entity_id: string
+  actor: Actor
+  persona_slug: string | null
+  skill_name: string
+  /** Present for an exposure (action-class) change; null for a skill scalar. */
+  action_class: ActionClass | null
+  /** The customer's vertical, for the floor lookup. Null when unknown. */
+  vertical: string | null
+  old_value: Ceiling
+  new_value: Ceiling
+}
+
+export interface ApplyResult {
+  outcome: ConfigChangeOutcome
+  reason: string | null
+}
+
+/**
+ * Orchestrate a trust-ceiling / action-ceiling change: compute direction,
+ * floor-check a raise on an action class, and record the outcome (accepted or
+ * rejected) to the ledger. Does not write the live config (deferred git
+ * write-back). The caller is responsible for being principal-gated.
+ */
+export async function applyCeilingChange(
+  db: D1Database,
+  input: ApplyCeilingChangeInput
+): Promise<ApplyResult> {
+  const direction = changeDirection(input.old_value, input.new_value)
+  const floor = input.action_class ? getVerticalFloor(input.vertical, input.action_class) : null
+  const floorCheck = checkFloor(floor, input.new_value)
+  const outcome: ConfigChangeOutcome = floorCheck.allowed ? 'accepted' : 'rejected_floor'
+
+  await recordConfigChangeAudit(db, {
+    customer_slug: input.customer_slug,
+    entity_id: input.entity_id,
+    actor_user_id: input.actor.user_id,
+    actor_email: input.actor.email,
+    actor_role: input.actor.role,
+    change_type: input.action_class ? 'action_ceiling' : 'trust_ceiling',
+    persona_slug: input.persona_slug,
+    skill_name: input.skill_name,
+    action_class: input.action_class,
+    old_value: input.old_value,
+    new_value: input.new_value,
+    outcome,
+    outcome_reason: floorCheck.reason,
+    direction,
+  })
+
+  return { outcome, reason: floorCheck.reason }
+}
+
+export interface ApplySkillToggleInput {
+  customer_slug: string
+  entity_id: string
+  actor: Actor
+  persona_slug: string | null
+  skill_name: string
+  next_enabled: boolean
+  /** Current skill ceiling, for the old_value. */
+  old_value: Ceiling
+}
+
+/**
+ * Record a skill enable/disable. Disabling maps to `refused` (a lower — more
+ * restrictive, always allowed); enabling maps back to `draft_for_review` (the
+ * safe default, never a raise above a floor since draft_for_review is itself
+ * the most permissive value any floor allows). Always `accepted`; audited.
+ */
+export async function applySkillToggle(
+  db: D1Database,
+  input: ApplySkillToggleInput
+): Promise<ApplyResult> {
+  const newValue: Ceiling = input.next_enabled ? 'draft_for_review' : 'refused'
+  const direction = changeDirection(input.old_value, newValue)
+
+  await recordConfigChangeAudit(db, {
+    customer_slug: input.customer_slug,
+    entity_id: input.entity_id,
+    actor_user_id: input.actor.user_id,
+    actor_email: input.actor.email,
+    actor_role: input.actor.role,
+    change_type: 'skill_toggle',
+    persona_slug: input.persona_slug,
+    skill_name: input.skill_name,
+    action_class: null,
+    old_value: input.old_value,
+    new_value: newValue,
+    outcome: 'accepted',
+    outcome_reason: null,
+    direction,
+  })
+
+  return { outcome: 'accepted', reason: null }
+}
+
+/** Action classes accepted on the action-ceiling path, re-exported for callers. */
+export const ACTION_CLASSES: readonly ActionClass[] = ACCEPTED_ACTION_CLASSES
+
+export interface ConfigChangeAuditRow {
+  id: number
+  created_at: string
+  source: string
+  actor_email: string
+  change_type: ConfigChangeType
+  persona_slug: string | null
+  skill_name: string | null
+  action_class: string | null
+  old_value: string | null
+  new_value: string | null
+  outcome: ConfigChangeOutcome
+  outcome_reason: string | null
+  direction: ChangeDirection
+}
+
+/**
+ * Read the most-recent N governance actions for an entity, newest first.
+ * Powers the control-plane authority-audit pane (ADR 0030 §4). Read-only.
+ */
+export async function listConfigChangeAudit(
+  db: D1Database,
+  entityId: string,
+  limit = 50
+): Promise<ConfigChangeAuditRow[]> {
+  const result = await db
+    .prepare(
+      'SELECT id, created_at, source, actor_email, change_type, persona_slug, skill_name, ' +
+        'action_class, old_value, new_value, outcome, outcome_reason, direction ' +
+        'FROM config_change_audit WHERE entity_id = ? ORDER BY created_at DESC, id DESC LIMIT ?'
+    )
+    .bind(entityId, limit)
+    .all<ConfigChangeAuditRow>()
+  return result.results ?? []
+}

--- a/src/pages/api/portal/ai-employee/settings/skill-toggle.ts
+++ b/src/pages/api/portal/ai-employee/settings/skill-toggle.ts
@@ -1,39 +1,37 @@
 import type { APIRoute } from 'astro'
 import { resolveAiEmployeeAccess } from '../../../../../lib/portal/ai-employee-access'
+import { getCustomerConfig, getActivePersona } from '../../../../../lib/portal/customer-config'
+import {
+  applySkillToggle,
+  isCeiling,
+  type Ceiling,
+} from '../../../../../lib/portal/ai-employee/config-governance'
 import { env } from 'cloudflare:workers'
 
 /**
  * POST /api/portal/ai-employee/settings/skill-toggle
  *
- * Enables or disables a single skill on the active persona.
+ * Enables or disables a single skill on the active persona (ADR 0026 / 0030 §4).
  *
  * Form fields:
  *   skillName     — slug of the skill being toggled
  *   personaSlug   — slug of the persona owning the skill (optional)
- *   nextEnabled   — 'true' or 'false' (the target state). Sent by
- *                   the form, not derived server-side, so a slow
- *                   reviewer cannot double-click and flip past
- *                   their intent.
+ *   nextEnabled   — 'true' or 'false' (the target state)
  *
- * Auth: principal on the active AI Employee subscription.
- *
- * Today this endpoint logs intent. The write back to
- * customer.yaml's `personas[].skills[].trust_ceiling` (where
- * disabling maps to `refused` and enabling maps back to
- * `draft_for_review`) lands once the configs-repo write path
- * ships. The page renders an info banner via the `?status=ack`
- * query param so a principal does not assume their click has
- * propagated.
+ * Auth: principal only. Disabling maps to `refused` (a lower / more
+ * restrictive change, always allowed); enabling maps to `draft_for_review`
+ * (the safe default). Records the governance action to the immutable
+ * `config_change_audit` ledger; does not mutate the live config replica
+ * (ADR 0012 §2 — value applies on the next git sync). Status banner:
+ *   ?status=saved      — recorded
+ *   ?status=invalid_*  — malformed request
  */
 
 const SETTINGS_PAGE_URL = '/portal/products/ai-employee/settings'
 
 function redirectWithStatus(status: string): Response {
   const target = `${SETTINGS_PAGE_URL}?status=${encodeURIComponent(status)}`
-  return new Response(null, {
-    status: 303,
-    headers: { Location: target },
-  })
+  return new Response(null, { status: 303, headers: { Location: target } })
 }
 
 function jsonError(status: number, message: string): Response {
@@ -43,10 +41,16 @@ function jsonError(status: number, message: string): Response {
   })
 }
 
+function currentSkillCeiling(
+  persona: { skills: { name: string; trust_ceiling: string }[] } | null,
+  skillName: string
+): Ceiling {
+  const skill = persona?.skills.find((s) => s.name === skillName)
+  return skill && isCeiling(skill.trust_ceiling) ? skill.trust_ceiling : 'draft_for_review'
+}
+
 export const POST: APIRoute = async ({ locals, request }) => {
-  const access = await resolveAiEmployeeAccess(env.DB, locals, {
-    allowedRoles: ['principal'],
-  })
+  const access = await resolveAiEmployeeAccess(env.DB, locals, { allowedRoles: ['principal'] })
   if (access.kind === 'redirect') {
     return jsonError(403, 'Forbidden')
   }
@@ -54,6 +58,8 @@ export const POST: APIRoute = async ({ locals, request }) => {
   const formData = await request.formData()
   const skillName = formData.get('skillName')
   const nextEnabled = formData.get('nextEnabled')
+  const personaSlug = formData.get('personaSlug')
+
   if (typeof skillName !== 'string' || skillName === '') {
     return redirectWithStatus('invalid_skill')
   }
@@ -61,12 +67,19 @@ export const POST: APIRoute = async ({ locals, request }) => {
     return redirectWithStatus('invalid_state')
   }
 
-  console.info('settings.skill_toggle.intent', {
+  const config = await getCustomerConfig(env.DB, access.client.id)
+  const persona = await getActivePersona(env.DB, access.client.id)
+  const oldValue = currentSkillCeiling(persona, skillName)
+
+  await applySkillToggle(env.DB, {
+    customer_slug: config?.customer_slug ?? access.client.id,
     entity_id: access.client.id,
-    user_id: access.user.id,
-    skill: skillName,
+    actor: { user_id: access.user.id, email: access.user.email, role: 'principal' },
+    persona_slug: typeof personaSlug === 'string' && personaSlug !== '' ? personaSlug : null,
+    skill_name: skillName,
     next_enabled: nextEnabled === 'true',
+    old_value: oldValue,
   })
 
-  return redirectWithStatus('ack')
+  return redirectWithStatus('saved')
 }

--- a/src/pages/api/portal/ai-employee/settings/trust-ceiling.ts
+++ b/src/pages/api/portal/ai-employee/settings/trust-ceiling.ts
@@ -1,41 +1,47 @@
 import type { APIRoute } from 'astro'
 import { resolveAiEmployeeAccess } from '../../../../../lib/portal/ai-employee-access'
-import { isTrustCeilingLevel } from '../../../../../lib/portal/ai-employee/settings'
+import { getCustomerConfig, getActivePersona } from '../../../../../lib/portal/customer-config'
+import {
+  applyCeilingChange,
+  isCeiling,
+  type Ceiling,
+} from '../../../../../lib/portal/ai-employee/config-governance'
+import {
+  ACCEPTED_ACTION_CLASSES,
+  type ActionClass,
+} from '../../../../../lib/ai-employee/customer-yaml/types'
 import { env } from 'cloudflare:workers'
 
 /**
  * POST /api/portal/ai-employee/settings/trust-ceiling
  *
- * Updates a single skill's trust ceiling on the active persona.
+ * Changes a skill's trust ceiling on the active persona (ADR 0026 / ADR 0030 §4).
  *
  * Form fields:
  *   skillName     — slug of the skill being edited
- *   personaSlug   — slug of the persona owning the skill (optional;
- *                   single-persona customers omit it)
- *   level         — one of TRUST_CEILING_LEVELS
- *                   (`autonomous` / `draft_for_review` / `refused`)
+ *   personaSlug   — slug of the persona owning the skill (optional)
+ *   level         — one of 'autonomous' | 'draft_for_review' | 'refused'
+ *   actionClass   — optional. When present (e.g. 'external_send'), this is an
+ *                   exposure (action-class) change and is floor-checked against
+ *                   the customer's vertical floor (ADR 0025). Absent = a skill
+ *                   scalar change (governs internal_write; no floor applies).
  *
- * Auth: principal on the active AI Employee subscription. Operators
- * and compliance are forbidden — trust ceiling is a principal-only
- * configuration surface per ADR 0011.
+ * Auth: principal only (ADR 0011). The agent can never reach this surface.
  *
- * Today this endpoint logs the intent and returns. The write back
- * to customer.yaml (and therefore the projection in
- * `customer_configs`) lands once the configs-repo write path
- * ships. Until then the dropdown contract is locked but the value
- * is not yet persisted. The page renders an info banner via the
- * `?status=ack` query param so a principal does not assume their
- * click has propagated.
+ * This endpoint records the governance ACTION + its floor decision to the
+ * immutable `config_change_audit` ledger. It does NOT mutate the live config
+ * replica (read-only on principle, ADR 0012 §2); the value reaches the runtime
+ * via the deferred git write-back path (ADR 0025 step 7). Status banner:
+ *   ?status=saved         — accepted (recorded; applies on next sync)
+ *   ?status=floor_blocked — rejected by the vertical compliance floor
+ *   ?status=invalid_*     — malformed request
  */
 
 const SETTINGS_PAGE_URL = '/portal/products/ai-employee/settings'
 
 function redirectWithStatus(status: string): Response {
   const target = `${SETTINGS_PAGE_URL}?status=${encodeURIComponent(status)}`
-  return new Response(null, {
-    status: 303,
-    headers: { Location: target },
-  })
+  return new Response(null, { status: 303, headers: { Location: target } })
 }
 
 function jsonError(status: number, message: string): Response {
@@ -45,32 +51,78 @@ function jsonError(status: number, message: string): Response {
   })
 }
 
+function optionalString(raw: FormDataEntryValue | null): string | null {
+  return typeof raw === 'string' && raw !== '' ? raw : null
+}
+
+function currentSkillCeiling(
+  persona: { skills: { name: string; trust_ceiling: string }[] } | null,
+  skillName: string
+): Ceiling {
+  const skill = persona?.skills.find((s) => s.name === skillName)
+  return skill && isCeiling(skill.trust_ceiling) ? skill.trust_ceiling : 'draft_for_review'
+}
+
+interface ParsedRequest {
+  skillName: string
+  level: Ceiling
+  personaSlug: string | null
+  actionClass: ActionClass | null
+}
+
+/** Validate the form. Returns an error status string, or the parsed inputs. */
+function parseRequest(formData: FormData): { error: string } | { parsed: ParsedRequest } {
+  const skillName = formData.get('skillName')
+  if (typeof skillName !== 'string' || skillName === '') return { error: 'invalid_skill' }
+
+  const level = formData.get('level')
+  if (typeof level !== 'string' || !isCeiling(level)) return { error: 'invalid_level' }
+
+  // A present-but-unrecognized actionClass is malformed — fail rather than
+  // silently treating it as a skill-scalar change.
+  const rawActionClass = optionalString(formData.get('actionClass'))
+  let actionClass: ActionClass | null = null
+  if (rawActionClass !== null) {
+    if (!(ACCEPTED_ACTION_CLASSES as readonly string[]).includes(rawActionClass)) {
+      return { error: 'invalid_action_class' }
+    }
+    actionClass = rawActionClass as ActionClass
+  }
+
+  return {
+    parsed: {
+      skillName,
+      level,
+      personaSlug: optionalString(formData.get('personaSlug')),
+      actionClass,
+    },
+  }
+}
+
 export const POST: APIRoute = async ({ locals, request }) => {
-  const access = await resolveAiEmployeeAccess(env.DB, locals, {
-    allowedRoles: ['principal'],
-  })
+  const access = await resolveAiEmployeeAccess(env.DB, locals, { allowedRoles: ['principal'] })
   if (access.kind === 'redirect') {
     return jsonError(403, 'Forbidden')
   }
 
-  const formData = await request.formData()
-  const skillName = formData.get('skillName')
-  const level = formData.get('level')
-  if (typeof skillName !== 'string' || skillName === '') {
-    return redirectWithStatus('invalid_skill')
-  }
-  if (typeof level !== 'string' || !isTrustCeilingLevel(level)) {
-    return redirectWithStatus('invalid_level')
-  }
+  const result = parseRequest(await request.formData())
+  if ('error' in result) return redirectWithStatus(result.error)
+  const { skillName, level, personaSlug, actionClass } = result.parsed
 
-  // Intent log only. Real write lands when the configs-repo write
-  // path ships; see src/lib/portal/customer-config.ts header.
-  console.info('settings.trust_ceiling.intent', {
+  const config = await getCustomerConfig(env.DB, access.client.id)
+  const persona = await getActivePersona(env.DB, access.client.id)
+
+  const applied = await applyCeilingChange(env.DB, {
+    customer_slug: config?.customer_slug ?? access.client.id,
     entity_id: access.client.id,
-    user_id: access.user.id,
-    skill: skillName,
-    level,
+    actor: { user_id: access.user.id, email: access.user.email, role: 'principal' },
+    persona_slug: personaSlug,
+    skill_name: skillName,
+    action_class: actionClass,
+    vertical: config?.vertical ?? null,
+    old_value: currentSkillCeiling(persona, skillName),
+    new_value: level,
   })
 
-  return redirectWithStatus('ack')
+  return redirectWithStatus(applied.outcome === 'accepted' ? 'saved' : 'floor_blocked')
 }

--- a/src/pages/portal/products/ai-employee/settings/index.astro
+++ b/src/pages/portal/products/ai-employee/settings/index.astro
@@ -44,10 +44,13 @@ import { env } from 'cloudflare:workers'
  *     docs/style/empty-state-pattern.md.
  *
  * Mutations are HTML-form POSTs to the per-section endpoints
- * under /api/portal/ai-employee/settings/*. Each endpoint logs
- * intent today; real propagation to customer.yaml lands once
- * the configs-repo write path ships. The page surfaces a
- * confirmation banner on `?status=ack` per UI-PATTERNS R1.
+ * under /api/portal/ai-employee/settings/*. The trust-ceiling and
+ * skill-toggle endpoints persist the governance action + its floor
+ * decision to the immutable `config_change_audit` ledger and
+ * floor-check raises (ADR 0026 / ADR 0030). The value reaches the
+ * runtime via the deferred git write-back path (ADR 0025 step 7);
+ * the page surfaces a confirmation banner on `?status=saved` (or
+ * `?status=floor_blocked` for a rejected raise) per UI-PATTERNS R1.
  */
 
 const access = await resolveAiEmployeeAccess(env.DB, Astro.locals, {
@@ -69,6 +72,18 @@ const banner: { kind: 'ok' | 'error'; text: string } | null = (() => {
   switch (statusParam) {
     case 'ack':
       return { kind: 'ok', text: 'Saved.' }
+    case 'saved':
+      return {
+        kind: 'ok',
+        text: 'Saved. Your change is recorded and takes effect on the next sync.',
+      }
+    case 'floor_blocked':
+      return {
+        kind: 'error',
+        text: 'Your vertical requires this kind of message to be reviewed before sending, so this setting cannot be raised.',
+      }
+    case 'invalid_action_class':
+      return { kind: 'error', text: 'That action class is not valid.' }
     case 'voice_added':
       return { kind: 'ok', text: 'Voice sample queued.' }
     case 'voice_removed':

--- a/tests/config-governance.test.ts
+++ b/tests/config-governance.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Tests for the config-governance module (ADR 0026 / ADR 0030 §4).
+ *
+ * Pure-logic coverage of the restrictiveness ordering, raise/lower asymmetry,
+ * and floor check, plus a real-D1 integration that exercises the immutable
+ * ledger: an accepted lower, a floor-rejected raise (recorded as
+ * rejected_floor), and a skill toggle. Also asserts that every action-class
+ * key used in the seeded vertical floors is a real ActionClass — the guard
+ * against portal<->runtime identifier drift.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  createTestD1,
+  runMigrations,
+  discoverNumericMigrations,
+} from '@venturecrane/crane-test-harness'
+import { resolve } from 'path'
+import type { D1Database } from '@cloudflare/workers-types'
+import {
+  restrictiveness,
+  changeDirection,
+  checkFloor,
+  getVerticalFloor,
+  verticalFloorActionClasses,
+  applyCeilingChange,
+  applySkillToggle,
+  listConfigChangeAudit,
+  isCeiling,
+} from '../src/lib/portal/ai-employee/config-governance'
+import { ACCEPTED_ACTION_CLASSES } from '../src/lib/ai-employee/customer-yaml/types'
+
+const migrationsDir = resolve(process.cwd(), 'migrations')
+
+async function freshDb(): Promise<D1Database> {
+  const db = createTestD1()
+  await runMigrations(db, { files: discoverNumericMigrations(migrationsDir) })
+  return db
+}
+
+const ACTOR = { user_id: 'user-1', email: 'owner@firm.test', role: 'principal' }
+
+describe('restrictiveness ordering', () => {
+  it('orders autonomous < draft_for_review < refused', () => {
+    expect(restrictiveness('autonomous')).toBeLessThan(restrictiveness('draft_for_review'))
+    expect(restrictiveness('draft_for_review')).toBeLessThan(restrictiveness('refused'))
+  })
+
+  it('isCeiling accepts only the three ceilings', () => {
+    expect(isCeiling('autonomous')).toBe(true)
+    expect(isCeiling('draft_for_review')).toBe(true)
+    expect(isCeiling('refused')).toBe(true)
+    expect(isCeiling('disabled')).toBe(false)
+    expect(isCeiling('')).toBe(false)
+  })
+})
+
+describe('changeDirection (raise = toward less restrictive)', () => {
+  it('classifies a move toward autonomy as a raise', () => {
+    expect(changeDirection('draft_for_review', 'autonomous')).toBe('raise')
+    expect(changeDirection('refused', 'draft_for_review')).toBe('raise')
+  })
+  it('classifies a move toward refused as a lower', () => {
+    expect(changeDirection('autonomous', 'draft_for_review')).toBe('lower')
+    expect(changeDirection('draft_for_review', 'refused')).toBe('lower')
+  })
+  it('classifies an unchanged value as lateral', () => {
+    expect(changeDirection('autonomous', 'autonomous')).toBe('lateral')
+  })
+})
+
+describe('checkFloor', () => {
+  it('allows when no floor applies', () => {
+    expect(checkFloor(null, 'autonomous')).toEqual({ allowed: true, reason: null })
+  })
+  it('rejects a raise above the floor', () => {
+    const r = checkFloor('draft_for_review', 'autonomous')
+    expect(r.allowed).toBe(false)
+    expect(r.reason).toContain('draft_for_review')
+  })
+  it('allows at or below the floor', () => {
+    expect(checkFloor('draft_for_review', 'draft_for_review').allowed).toBe(true)
+    expect(checkFloor('draft_for_review', 'refused').allowed).toBe(true)
+  })
+})
+
+describe('vertical floors', () => {
+  it('pins law-firm external_send at draft_for_review', () => {
+    expect(getVerticalFloor('law-firm', 'external_send')).toBe('draft_for_review')
+  })
+  it('has no floor for an unknown vertical', () => {
+    expect(getVerticalFloor('marketing-agency', 'external_send')).toBeNull()
+    expect(getVerticalFloor(null, 'external_send')).toBeNull()
+  })
+  it('every floor action-class key is a real ActionClass (no portal<->runtime drift)', () => {
+    for (const key of verticalFloorActionClasses()) {
+      expect(ACCEPTED_ACTION_CLASSES as readonly string[]).toContain(key)
+    }
+  })
+})
+
+describe('applyCeilingChange (D1)', () => {
+  let db: D1Database
+  beforeEach(async () => {
+    db = await freshDb()
+  })
+
+  it('rejects and audits a law-firm external_send raise to autonomous', async () => {
+    const result = await applyCeilingChange(db, {
+      customer_slug: 'smith-pi-firm',
+      entity_id: 'entity-1',
+      actor: ACTOR,
+      persona_slug: 'marcus',
+      skill_name: 'ar-chaser',
+      action_class: 'external_send',
+      vertical: 'law-firm',
+      old_value: 'draft_for_review',
+      new_value: 'autonomous',
+    })
+    expect(result.outcome).toBe('rejected_floor')
+
+    const rows = await listConfigChangeAudit(db, 'entity-1')
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({
+      source: 'portal_intent',
+      change_type: 'action_ceiling',
+      action_class: 'external_send',
+      old_value: 'draft_for_review',
+      new_value: 'autonomous',
+      outcome: 'rejected_floor',
+      direction: 'raise',
+      actor_email: 'owner@firm.test',
+    })
+    expect(rows[0].outcome_reason).toContain('draft_for_review')
+  })
+
+  it('accepts and audits a lower (autonomous -> draft) with no floor', async () => {
+    const result = await applyCeilingChange(db, {
+      customer_slug: 'shop',
+      entity_id: 'entity-2',
+      actor: ACTOR,
+      persona_slug: null,
+      skill_name: 'inbox-triage',
+      action_class: 'external_send',
+      vertical: 'marketing-agency',
+      old_value: 'autonomous',
+      new_value: 'draft_for_review',
+    })
+    expect(result.outcome).toBe('accepted')
+
+    const rows = await listConfigChangeAudit(db, 'entity-2')
+    expect(rows[0]).toMatchObject({ outcome: 'accepted', direction: 'lower' })
+  })
+
+  it('accepts a non-action-class (skill scalar) change with no floor', async () => {
+    const result = await applyCeilingChange(db, {
+      customer_slug: 'smith-pi-firm',
+      entity_id: 'entity-3',
+      actor: ACTOR,
+      persona_slug: 'marcus',
+      skill_name: 'inbox-triage',
+      action_class: null,
+      vertical: 'law-firm',
+      old_value: 'draft_for_review',
+      new_value: 'autonomous',
+    })
+    expect(result.outcome).toBe('accepted')
+    const rows = await listConfigChangeAudit(db, 'entity-3')
+    expect(rows[0]).toMatchObject({ change_type: 'trust_ceiling', action_class: null })
+  })
+})
+
+describe('applySkillToggle (D1)', () => {
+  let db: D1Database
+  beforeEach(async () => {
+    db = await freshDb()
+  })
+
+  it('records disable as refused (a lower) and enable as draft_for_review', async () => {
+    await applySkillToggle(db, {
+      customer_slug: 'smith-pi-firm',
+      entity_id: 'entity-4',
+      actor: ACTOR,
+      persona_slug: 'marcus',
+      skill_name: 'ar-chaser',
+      next_enabled: false,
+      old_value: 'draft_for_review',
+    })
+    const rows = await listConfigChangeAudit(db, 'entity-4')
+    expect(rows[0]).toMatchObject({
+      change_type: 'skill_toggle',
+      new_value: 'refused',
+      direction: 'lower',
+      outcome: 'accepted',
+    })
+  })
+})


### PR DESCRIPTION
First of the harness-pivot implementation PRs. Turns the two config **stubs** (`trust-ceiling.ts:68`, `skill-toggle.ts:64` — `console.info` intent only) into the real, audited, floor-checked **config security boundary** on portal-side D1. Closes the only STUB-grade gap on the highest-privilege surface (the audit's keystone).

## What

- **`migrations/0046_config_change_audit.sql`** — ONE append-only control-plane ledger. Records governance actions (ceiling change, skill toggle) **and rejected floor attempts** (which have no `git_sha` and genuinely can't live in `customer_config_history`). `source` defaults `'portal_intent'` — **honestly scoped** as control-plane intent, *not* the runtime audit log (unreachable from the portal per ADR 0009). Runtime correlation is a tracked follow-on.
- **`src/lib/portal/ai-employee/config-governance.ts`** — `restrictiveness` (mirrors `trust_ceiling.py::_RESTRICTIVENESS`), `changeDirection` (raise = toward less restrictive), `checkFloor`, `applyCeilingChange`, `applySkillToggle`, `recordConfigChangeAudit`, `listConfigChangeAudit`. Vertical floors are a **seeded constant keyed by the shared `ACCEPTED_ACTION_CLASSES`** (#1145) so portal↔runtime identifiers can't drift (asserted in a test). Law-firm `external_send` pinned at `draft_for_review`.
- **Does NOT mutate `customer_configs`** (read-only on principle, ADR 0012 §2). The value reaches the runtime via the deferred git write-back (ADR 0025 step 7); what persists here is the governance action + floor decision.
- **Both endpoints rewritten**: principal-gated, persist+audit+floor-check. `trust-ceiling` gains an optional `actionClass` field so an `external_send` raise is floor-checked — a law-firm `external_send=autonomous` → `rejected_floor`, audited. Status banners `saved` / `floor_blocked`.

## Deliberately omitted (per a 3-critic review)
- **No grep-gate ceremony** — the portal/Machine repo split enforces agent-can't-raise *physically*.
- **No `lifecycle/pause` stub** — a pause that doesn't halt the runtime is a fail-open; deferred with the runtime-halt it needs.
- **No second table** — floors are a shared constant, not a 1-row table.

## Verification
`tests/config-governance.test.ts` (15): restrictiveness/direction/floor logic + **real-D1 integration** — a law-firm `external_send=autonomous` raise is rejected and audited as `rejected_floor`; skill-toggle records `refused`; the action-class-key membership guard. No regression in settings/customer-config suites (65 tests green). ESLint/prettier/typecheck clean.

## Scope boundary
This is the unblocked, ss-console-only keystone. The inbound boundary (0027), outbound gates (0028 — in the `hermes-smd-overlay` repo), and the #821 read-bridge proceed as their own PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)