### PR TITLE
fix(ai-employee): unblock boot — move Composio + AgentMail to OPTIONAL_ENV

### DIFF
--- a/ai-employee/bin/provision-customer.sh
+++ b/ai-employee/bin/provision-customer.sh
@@ -281,8 +281,15 @@ prompt_and_set() {
 # planned binding uses composio"). The schema validator and runtime guard
 # still accept `composio:` backend prefixes for future long-tail vendors;
 # this prompt was dead provisioning ceremony.
+# AGENTMAIL_API_KEY removed 2026-05-29: the persona's own outbound mailbox
+# identity (ADR 0005 reviewer-as-sender / ADR 0008) is deferred to Phase 2
+# multi-persona (ADR 0011) and not yet implemented — no connector, OAuth flow,
+# plugin, or skill code reads it (cost_rollup.py only maps it as a future
+# cost-driver category). bootstrap.sh moved it to OPTIONAL_ENV in lockstep.
+# Like the Composio removal above, this prompt was dead provisioning ceremony;
+# customers act on real mailboxes via mcp:google-gmail / ms-graph, not an agent
+# mailbox. Re-add when a persona email identity is actually wired.
 prompt_and_set ANTHROPIC_API_KEY  "Anthropic API key for hermes-${SLUG}"
-prompt_and_set AGENTMAIL_API_KEY  "AgentMail API key (Builder tier)"
 
 # R2 access for bootstrap.sh's customer.yaml fetch + customer-sync sidecar's
 # polling for non-structural config changes. R2_BUCKET_CONFIG is in fly.toml

--- a/ai-employee/templates/bootstrap.sh
+++ b/ai-employee/templates/bootstrap.sh
@@ -103,8 +103,6 @@ log "Hermes SHA: $(cat /opt/hermes/HERMES_SHA 2>/dev/null || echo unknown)"
 # values; only check presence.
 REQUIRED_ENV=(
   ANTHROPIC_API_KEY
-  COMPOSIO_API_KEY
-  AGENTMAIL_API_KEY
   # R2 access for customer.yaml fetch (vaults/<slug>/customer.yaml).
   R2_BUCKET_CONFIG
   R2_ACCESS_KEY_ID
@@ -138,6 +136,21 @@ OPTIONAL_ENV=(
   GOOGLE_CLIENT_SECRET_JSON
   # R2 endpoint URL override (defaults to the Cloudflare R2 S3 endpoint).
   R2_ENDPOINT_URL
+  # COMPOSIO_API_KEY — doctrine-dropped per ADR 0020 (revision 2026-05-24: "no
+  # currently planned binding uses composio"). provision-customer.sh stopped
+  # staging it on 2026-05-26, so requiring it here was a guaranteed fail-closed
+  # boot crashloop. Kept as optional for forward-compat: a future customer.yaml
+  # with a composio: connector backend can stage it, and the runtime guard still
+  # accepts the prefix. No customer-zero code path consumes it.
+  COMPOSIO_API_KEY
+  # AGENTMAIL_API_KEY — the persona's own outbound mailbox identity (ADR 0005
+  # reviewer-as-sender; ADR 0008). Deferred to Phase 2 multi-persona (ADR 0011)
+  # and not yet implemented: no connector, OAuth flow, plugin, or skill code
+  # reads it (cost_rollup.py only maps it as a future cost-driver category).
+  # SMD customer-zero acts on the principal's Gmail via mcp:google-gmail, not an
+  # agent mailbox, so requiring it blocked boot for no functional reason. Re-
+  # require when a persona email identity is actually wired.
+  AGENTMAIL_API_KEY
 )
 
 for var in "${OPTIONAL_ENV[@]}"; do


### PR DESCRIPTION
## What

Moves `COMPOSIO_API_KEY` and `AGENTMAIL_API_KEY` from `REQUIRED_ENV` → `OPTIONAL_ENV` in `bootstrap.sh`, and removes the dead AgentMail `pbpaste` prompt from `provision-customer.sh`.

## Why — guaranteed boot crashloop

`bootstrap.sh` fails closed if any `REQUIRED_ENV` var is unset (step-1 check, lines 127-132). Two listed vars can never be satisfied, so **every provisioned Machine would crashloop**:

| Var | Required at | Reality |
|---|---|---|
| `COMPOSIO_API_KEY` | bootstrap.sh:106 | `provision-customer.sh` **stopped staging it** 2026-05-26 — Composio doctrine-dropped (ADR 0020 revision 2026-05-24). Required but never provided. |
| `AGENTMAIL_API_KEY` | bootstrap.sh:107 | Persona's own mailbox identity (ADR 0005/0008), **deferred to Phase 2 multi-persona** (ADR 0011), **zero runtime consumers** — only `cost_rollup.py` maps it as a future cost-driver category. SMD acts on the principal's Gmail via `mcp:google-gmail`, not an agent mailbox. |

This is the fail-open→fail-closed antipattern flagged in enterprise memory: the boot gate drifted out of sync with provisioning doctrine.

## Scope / safety

- Both moved to `OPTIONAL_ENV` with ADR-cited rationale (not deleted) — forward-compatible: a future `customer.yaml` with a `composio:`/`agentmail` backend can stage them, and the runtime guards still accept the prefixes.
- AgentMail prompt removal mirrors the prior Composio prompt removal (same file, line 279).
- No tests pin these as required boot vars (`cost_rollup` tests only assert cost-category mappings, unchanged).
- `bash -n` clean on both files.

Unblocks customer-zero (SMD) Fly provisioning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)