### PR TITLE
fix(ai-employee): first real boot of customer-zero — Honcho deferred, gateway live (ADR 0016 revised)

### DIFF
--- a/ai-employee/bin/boot-smoke-test.sh
+++ b/ai-employee/bin/boot-smoke-test.sh
@@ -5,9 +5,11 @@
 #   ai-employee/bin/boot-smoke-test.sh <customer-slug>
 #
 # Scope: this is a SMOKE TEST, not an end-to-end test. It verifies that
-# bootstrap.sh's sequenced startup (Postgres → Redis → Honcho → customer.yaml
-# fetched from R2 → Hermes profiles materialized → overlay plugins installed)
-# came up cleanly. It does NOT exercise a real agent turn, a real LLM call,
+# bootstrap.sh's sequenced startup (customer.yaml fetched from R2 → Hermes
+# profiles materialized → overlay plugins installed → curator disabled) came
+# up cleanly. The Postgres/Redis/Honcho checks were removed when the Honcho
+# data plane was deferred to Phase 2 (ADR 0016 revised). It does NOT exercise
+# a real agent turn, a real LLM call,
 # or a real D1 write through a connector. Those require live external
 # credentials (MCP servers, Anthropic API, customer's OAuth tokens) and are
 # the job of the per-connector prod smoke test in run_prod_smoke_test.py and,
@@ -63,14 +65,10 @@ except Exception:
 done
 [ "${STATE}" = "started" ] || fail "machine-state-started — state=${STATE} after 60s"
 
-# ---------- Step 2: Postgres reachable ----------
-ssh_exec "postgres-ready" "pg_isready -h localhost -p 5432 -U honcho"
-
-# ---------- Step 3: Redis reachable ----------
-ssh_exec "redis-ping" "redis-cli ping | grep -q PONG"
-
-# ---------- Step 4: Honcho health endpoint ----------
-ssh_exec "honcho-health" "curl -fsS http://localhost:8000/health"
+# ---------- Steps 2-4: Postgres / Redis / Honcho — DEFERRED (Phase 2) ----------
+# The Honcho data plane is deferred to Phase 2 (ADR 0016 revised); Phase 1 boots
+# on Hermes' flat-file memory core, so there is no Postgres/Redis/Honcho to
+# probe here. These checks return when Phase 2 vendors the real Honcho source.
 
 # ---------- Step 5: customer.yaml present on volume ----------
 ssh_exec "customer-yaml-present" "test -s /opt/data/customer.yaml"

--- a/ai-employee/bin/provision-customer.sh
+++ b/ai-employee/bin/provision-customer.sh
@@ -8,11 +8,11 @@
 # customer.yaml to R2 (so bootstrap.sh can fetch it on first boot — no more
 # baking into the image per §6 of the build plan), renders
 # ai-employee/.rendered/<slug>/fly.toml (gitignored), creates the Fly app,
-# provisions the volume (10GB — hosts Postgres + Redis + customer.yaml +
-# SQLite + voice cache), prompts Captain for secrets (pasted via pbpaste —
-# values never appear in the chat transcript), deploys, then runs the boot
-# smoke test (boot-smoke-test.sh) to verify the Postgres/Redis/Honcho/Hermes
-# dependency chain came up cleanly.
+# provisions the volume (10GB — hosts customer.yaml + SQLite + voice cache;
+# Phase 2 adds Postgres + Redis for Honcho), prompts Captain for secrets
+# (pasted via pbpaste — values never appear in the chat transcript), deploys,
+# then runs the boot smoke test (boot-smoke-test.sh) to verify the Hermes
+# profile + plugin chain came up cleanly.
 #
 # Operator prerequisites (set in your shell / .envrc / direnv before running):
 #   R2_ENDPOINT_URL        — Cloudflare R2 endpoint (https://<account>.r2.cloudflarestorage.com)
@@ -95,7 +95,6 @@ R2_BUCKET_CONFIG="${R2_BUCKET_CONFIG:-smd-customer-config}"
 [ -n "${R2_ACCESS_KEY_ID:-}" ] || die "R2_ACCESS_KEY_ID not set in operator env"
 [ -n "${R2_SECRET_ACCESS_KEY:-}" ] || die "R2_SECRET_ACCESS_KEY not set in operator env"
 command -v aws >/dev/null 2>&1 || die "aws CLI not found (required for R2 customer.yaml upload)"
-command -v openssl >/dev/null 2>&1 || die "openssl not found (required for HONCHO_API_KEY generation)"
 command -v pbpaste >/dev/null 2>&1 || die "pbpaste not found (macOS-only; required for secret entry flow)"
 
 # ---------- Step 1: validate customer.yaml ----------
@@ -202,11 +201,11 @@ else
 fi
 
 # ---------- Step 5: create volume (idempotent, 10GB) ----------
-# Volume hosts: Postgres data (Honcho), Redis AOF (Honcho), customer.yaml
-# (R2-mirrored copy), audit.db + observations.db SQLite, Hermes profiles
-# under /opt/data/profiles/, voice samples cache, OAuth token files (ADR
-# 0010). 10GB is the new floor (was 1GB pre-§6); per-customer fixed disk
-# pressure should not be a thing we manage on a per-customer basis.
+# Volume hosts: customer.yaml (R2-mirrored copy), audit.db SQLite, Hermes
+# profiles + flat-file memory (MEMORY.md/USER.md) under /opt/data/profiles/,
+# voice samples cache, OAuth token files (ADR 0010). Phase 2 adds Postgres +
+# Redis (Honcho) + observations.db. 10GB is the floor (was 1GB pre-§6);
+# per-customer fixed disk pressure should not be a thing we manage per customer.
 log "Creating persistent volume (idempotent, 10GB)..."
 if fly volumes list -a "${APP_NAME}" --json 2>/dev/null | python3 -c "import sys, json; data = json.load(sys.stdin) if sys.stdin.read else []" 2>/dev/null; then
   if ! fly volumes list -a "${APP_NAME}" --json | grep -q '"name":"hermes_state"'; then
@@ -307,17 +306,9 @@ prompt_and_set R2_ENDPOINT_URL      "R2 endpoint URL (Cloudflare account R2 endp
 prompt_and_set R2_SKILL_BODIES_ACCESS_KEY_ID "R2 access key ID scoped to bucket ${R2_SKILL_BODIES_BUCKET}"
 prompt_and_set R2_SKILL_BODIES_SECRET_ACCESS_KEY "R2 secret access key paired with R2_SKILL_BODIES_ACCESS_KEY_ID above"
 
-# HONCHO_API_KEY — generated locally, sent to Fly via stdin, never stored
-# anywhere else. Honcho is self-hosted in this Machine; this is the shared
-# secret between the Hermes process and the in-Machine Honcho FastAPI server.
-# Rotating it means re-running provisioning (Captain-initiated restart per
-# ADR 0010 to preserve OAuth tokens on the volume).
-log "Generating HONCHO_API_KEY (openssl rand -hex 32) and staging directly to Fly..."
-openssl rand -hex 32 \
-  | { read -r _val; printf 'HONCHO_API_KEY=%s\n' "${_val}"; } \
-  | fly secrets import --stage -a "${APP_NAME}" >/dev/null
-log "Staged HONCHO_API_KEY (value never logged)"
-unset _val 2>/dev/null || true
+# HONCHO_API_KEY — DEFERRED to Phase 2 (ADR 0016 revised). No in-Machine Honcho
+# server is provisioned in Phase 1, so there is no shared secret to generate.
+# Phase 2 reintroduces this when it vendors the real plastic-labs/honcho source.
 
 # ---------- Step 6b: observability secrets (ADR 0023 Wave 1) ----------
 # These come from operator env (Infisical-staged in Captain's shell), not
@@ -434,9 +425,10 @@ log "Deploying ${APP_NAME}..."
   --build-arg CUSTOMER_SLUG="${SLUG}")
 
 # ---------- Step 8: boot smoke test ----------
-# The boot-smoke-test.sh script exercises the Postgres → Redis → Honcho →
-# customer.yaml → profiles → Hermes plugins dependency chain. It is the real
-# verification that bootstrap.sh's sequenced startup came up cleanly.
+# The boot-smoke-test.sh script exercises the customer.yaml → profiles → Hermes
+# plugins → curator-disabled dependency chain. It is the real verification that
+# bootstrap.sh's sequenced startup came up cleanly. (Postgres/Redis/Honcho
+# checks return in Phase 2 — ADR 0016 revised.)
 log "Running boot smoke test..."
 if [ -x "${BIN_DIR}/boot-smoke-test.sh" ]; then
   "${BIN_DIR}/boot-smoke-test.sh" "${SLUG}" \

--- a/ai-employee/customers/smd/customer.yaml
+++ b/ai-employee/customers/smd/customer.yaml
@@ -100,6 +100,9 @@ voice_library:
   samples_path: 'r2://vaults/smd/voice/samples/'
 
 # ---- MEMORY (per-customer isolation invariants; must match customer_id) ----
+# Phase 1 runs on Hermes' flat-file memory core (MEMORY.md/USER.md). Inferred
+# memory (Honcho) is deferred to Phase 2 — see ADR 0016 (revised 2026-05-30).
+# The fields below are the customer-owned D1/R2 memory file's isolation anchors.
 memory:
   d1_namespace: smd
   r2_vault_path: 'vaults/smd/'

--- a/ai-employee/templates/Dockerfile
+++ b/ai-employee/templates/Dockerfile
@@ -2,12 +2,19 @@
 #
 # Builds Hermes from upstream at a pinned ref, installs the hermes-smd
 # overlay plugins + companion CLI, layers in our AIEmployee adapter / skill
-# library / connectors / safety-substrate tests, and bundles Postgres + Redis
-# + Honcho (Plastic Labs, AGPL-3.0) as in-container memory infrastructure.
+# library / connectors / safety-substrate tests.
+#
+# Memory (ADR 0016, revised 2026-05-30): Phase 1 runs on Hermes' always-on
+# flat-file core (MEMORY.md/USER.md). Honcho — the inferred-memory engine —
+# is deferred to Phase 2, when it is vendored as the real plastic-labs/honcho
+# v3.0.7 source (api + deriver, pgvector). The earlier in-container `honcho-ai`
+# server install was fictional (that package is the client SDK, not the server)
+# and is removed. Postgres + Redis remain installed below but are NOT started
+# at boot in Phase 1 — they exist only to serve Honcho and are reused in Phase 2.
 #
 # The container runs a multi-process startup under tini (PID 1, zombie
-# reaper). bootstrap.sh launches Postgres, Redis, Honcho, the customer-sync
-# sidecar, and finally execs Hermes. See bootstrap.sh for the full sequence.
+# reaper). bootstrap.sh fetches customer.yaml, materializes profiles, runs the
+# safety substrate, and execs the Hermes gateway. See bootstrap.sh.
 #
 # Per §6 of the locked build plan and ADR 0019: customer.yaml is NOT baked
 # into the image. Provisioning writes it to R2 at vaults/<slug>/customer.yaml;
@@ -41,24 +48,22 @@ ARG HERMES_UPSTREAM_TAG=v2026.5.16
 # upstream Hermes.
 ARG HERMES_UPSTREAM_SHA=a91a57fa5a13d516c38b07a141a9ce8a3daabeb0
 
-# Honcho upstream is plastic-labs/honcho (AGPL-3.0). Pinned via the pip
-# package version below. TODO(ci): add a CI assertion that the installed
-# Honcho commit hash matches upstream — mirroring the HERMES_SHA check
-# pattern so a transparent version drift is caught at build time.
-ARG HONCHO_PIP_SPEC="honcho-ai==1.0.0"
-
 # hermes-smd overlay (venturecrane/hermes-smd-overlay): plugin pack + CLI
 # (`hermes-smd bootstrap`, `hermes-smd customer-sync`) + the importable
 # `shared` policy core the runtime plugins depend on. Pinned to a tagged
 # release; bump in lockstep with overlay-side feature work.
 #
-# v0.2.0 is the FLOOR for a harness-complete Machine: the trust plugin does
+# v0.2.0 was the FLOOR for a harness-complete Machine: the trust plugin does
 # `from shared.outbound_gate import evaluate`, and that module first shipped
-# after v0.1.1 (overlay #15). Pinning at v0.1.1 builds a Machine whose trust
-# plugin cannot import its own policy core. See ADR 0028 + the import assert
-# below.
+# after v0.1.1 (overlay #15). The import assert below still guards it.
+#
+# v0.3.0 restores Hermes' flat-file memory core (stops the MEMORY.md/USER.md
+# tombstoning) and defers Honcho (ADR 0016 revised). Customer-zero booted end
+# to end on this overlay; the gateway ran with 8/8 safety invariants passing.
+# (The first-boot proof built from the pre-tag commit 0127331, which is
+# behaviorally identical to v0.3.0 — the only delta is the version string.)
 ARG OVERLAY_REPO="https://github.com/venturecrane/hermes-smd-overlay.git"
-ARG OVERLAY_REF="v0.2.0"
+ARG OVERLAY_REF="v0.3.0"
 
 ARG CUSTOMER_SLUG=customer-zero
 
@@ -84,7 +89,6 @@ FROM ghcr.io/astral-sh/uv:0.11.6-python3.13-trixie AS uv_source
 FROM debian:13.4
 
 ARG CUSTOMER_SLUG
-ARG HONCHO_PIP_SPEC
 ARG OVERLAY_REPO
 ARG OVERLAY_REF
 
@@ -92,19 +96,21 @@ ENV CUSTOMER_SLUG=${CUSTOMER_SLUG}
 ENV PYTHONUNBUFFERED=1
 ENV PLAYWRIGHT_BROWSERS_PATH=/opt/hermes/.playwright
 ENV HERMES_HOME=/opt/data
-ENV PATH="/opt/data/.local/bin:/usr/lib/postgresql/16/bin:${PATH}"
+ENV PATH="/opt/data/.local/bin:/usr/lib/postgresql/17/bin:${PATH}"
 
 # ---------- System packages ----------
 # tini: PID 1 zombie reaper (signals + orphaned MCP stdio subprocesses).
-# postgresql-16 + redis: in-container Honcho data plane (Debian 13 defaults).
-# awscli: needed by bootstrap.sh to fetch customer.yaml from R2 (S3-compat).
-# curl + ca-certificates: health checks against the Honcho FastAPI server.
+# postgresql-17 + redis: installed for Phase 2 Honcho's data plane but NOT
+# started at boot in Phase 1 (Debian 13 trixie ships PostgreSQL 17 as default;
+# postgresql-16 is not in trixie's repos — keep 17 so the Phase-2 vendor lands
+# cleanly). awscli: bootstrap.sh fetches customer.yaml from R2 (S3-compat).
+# curl + ca-certificates: R2 fetch + general TLS.
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
       build-essential curl nodejs npm python3 python3-pip python3-venv \
       ripgrep ffmpeg gcc python3-dev libffi-dev procps git openssh-client \
       docker-cli tini ca-certificates \
-      postgresql-16 postgresql-client-16 redis-server awscli \
+      postgresql-17 postgresql-client-17 redis-server awscli \
  && rm -rf /var/lib/apt/lists/*
 
 # ---------- hermes user ----------
@@ -129,18 +135,20 @@ RUN uv sync --frozen --no-install-project --extra all
 RUN cd web && npm run build && cd ../ui-tui && npm run build
 RUN uv pip install --no-cache-dir --no-deps -e "."
 
-# ---------- Honcho (memory service) ----------
-# Installed into Hermes' venv so the migration runner + FastAPI server share
-# the same Python. Upstream: github.com/plastic-labs/honcho (AGPL-3.0).
-# Postgres + Redis are managed by bootstrap.sh; Honcho talks to 127.0.0.1.
-RUN /opt/hermes/.venv/bin/pip install --no-cache-dir "${HONCHO_PIP_SPEC}"
+# ---------- Honcho: deferred to Phase 2 (ADR 0016, revised 2026-05-30) ----------
+# No in-container Honcho server is installed. The prior `honcho-ai` pip install
+# was fictional — that package is the Honcho CLIENT SDK, not the server; the
+# real server is the plastic-labs/honcho v3.0.7 SOURCE repo (fastapi api +
+# `python -m src.deriver` worker, pgvector, mandatory LLM provider). Phase 2
+# vendors it the same way upstream Hermes is vendored above (clone at a pinned
+# tag, own venv). Phase 1 runs on Hermes' flat-file memory core.
 
 # ---------- hermes-smd overlay (plugins + CLI) ----------
 # Pip-install the overlay (provides `hermes-smd` console script for the
 # bootstrap translator and customer-sync sidecar) and then register the
 # plugin pack with Hermes. Plugins land under ~/.hermes/plugins/ where the
 # Hermes plugin loader discovers them at runtime.
-RUN /opt/hermes/.venv/bin/pip install --no-cache-dir \
+RUN uv pip install --no-cache-dir \
       "git+${OVERLAY_REPO}@${OVERLAY_REF}"
 
 # Register the plugin pack with Hermes' loader. `hermes plugins install` clones
@@ -225,13 +233,12 @@ ENV HERMES_WEB_DIST=/opt/hermes/hermes_cli/web_dist
 VOLUME [ "/opt/data" ]
 
 # Drop to non-root for runtime. bootstrap.sh does no root-requiring work:
-# env validation, R2 fetch, Postgres/Redis startup (data dirs pre-owned by
-# hermes), Honcho migrations + serve, safety-substrate python run, and
-# hermes-smd bootstrap all run as the hermes user.
+# env validation, R2 fetch, safety-substrate python run, hermes-smd bootstrap,
+# and the Hermes gateway all run as the hermes user.
 # Closes semgrep dockerfile.security.last-user-is-root.
 USER hermes
 
 # tini as PID 1: reaps zombies, forwards signals to the foreground child
-# (Hermes via `exec` in bootstrap.sh) and to the supervised background
-# children (Postgres, Redis, Honcho, customer-sync sidecar).
+# (the Hermes gateway via `exec` in bootstrap.sh) and to any supervised
+# background children (the customer-sync sidecar; Phase 2 adds Honcho).
 ENTRYPOINT [ "/usr/bin/tini", "-g", "--", "/app/bootstrap.sh" ]

--- a/ai-employee/templates/README.md
+++ b/ai-employee/templates/README.md
@@ -7,17 +7,15 @@ Templates an operator copies during provisioning. Each file is read once at prov
 A customer Machine is a single Fly.io Machine running one container that supervises multiple processes under `tini`. Inside that container:
 
 - **Hermes Agent** — the substrate. Skills, profiles, the tool registry, the plugin hook surface, and MCP integration are all Hermes-native. We do not modify core files (ADR 0015, plugin-only overlay). Pinned via `customer.yaml.hermes_ref` to an upstream release (`vYYYY.M.D@<40-hex-sha>`) on `NousResearch/hermes-agent` directly — ADR 0024 retired the `venturecrane/hermes-agent` fork. The Dockerfile's stage-1 clone fetches the pinned upstream tag and asserts the cloned commit SHA matches the SHA carried in `hermes_ref`; divergence (an upstream re-tag, or a stale pin) fails the build. This is the integrity check that proves we ship unmodified upstream Hermes (ADR 0024).
-- **Honcho** — self-hosted from the upstream image, stock binary, configuration-only customization. Honcho's data store is the in-container Postgres; Redis is its cache.
-- **Postgres** — local data store for Honcho.
-- **Redis** — local cache for Honcho (AOF-persisted on the volume).
-- **hermes-smd-overlay plugins** — four narrow plugins installed at image-build time from `venturecrane/hermes-smd-overlay`:
+- **Memory (ADR 0016, revised 2026-05-30)** — Phase 1 runs on Hermes' always-on flat-file core (`MEMORY.md`/`USER.md`), which Hermes auto-creates and maintains at profile boot. The customer-owned memory file lives in D1/R2. **Honcho** — the inferred-memory engine — is a swappable provider that sits behind that file and is **deferred to Phase 2**; the earlier in-container `honcho-ai` server install was fictional (that package is the client SDK, not the server). **Postgres** and **Redis** remain installed in the image for the Phase-2 Honcho data plane but are **not started** in Phase 1.
+- **hermes-smd-overlay plugins** — narrow plugins installed at image-build time from `venturecrane/hermes-smd-overlay`:
   - `hermes-smd-audit` — per-tool / per-LLM audit emission to per-customer SQLite.
   - `hermes-smd-trust` — trust-ceiling enforcement + Composio per-connection guard.
   - `hermes-smd-voice` — sample-driven voice transformation.
-  - `hermes-smd-memory-mirror` — mirrors Honcho conclusions to per-customer SQLite with provenance.
+  - `hermes-smd-memory-mirror` — mirrors Honcho conclusions to per-customer SQLite with provenance. Inert in Phase 1 (no Honcho to poll); active in Phase 2.
 - **customer-sync sidecar** (from the overlay's `bootstrap/` package) — polls R2 for non-structural `customer.yaml` changes at a 5-minute cadence.
 
-No public HTTP. Honcho's FastAPI binds localhost only. All inbound traffic is SSH via `fly ssh console -a hermes-<slug>`.
+No public HTTP. All inbound traffic is SSH via `fly ssh console -a hermes-<slug>`.
 
 ## Runtime templates
 
@@ -42,7 +40,7 @@ Set these in your local shell (e.g., via `.envrc` + `direnv`) before running pro
 | `R2_SECRET_ACCESS_KEY` | R2 secret paired with the access key                                                          |
 | `R2_BUCKET_CONFIG`     | R2 bucket holding `customer.yaml` + voice vaults (defaults to `smd-customer-config` if unset) |
 
-Tools required on the operator machine: `fly`, `aws` (any version with S3-compatible `--endpoint-url`), `openssl`, `pbpaste` (macOS), `python3`, `uv`.
+Tools required on the operator machine: `fly`, `aws` (any version with S3-compatible `--endpoint-url`), `pbpaste` (macOS), `python3`, `uv`.
 
 ### Provisioning steps
 
@@ -52,13 +50,13 @@ Tools required on the operator machine: `fly`, `aws` (any version with S3-compat
 2. **Upload `customer.yaml` to R2** at `s3://${R2_BUCKET_CONFIG}/vaults/<slug>/customer.yaml`. This happens BEFORE the Fly deploy so the first Machine boot can fetch it. The customer-sync sidecar polls this same key for non-structural updates.
 3. **Render `fly.toml`** from `fly.toml.template` to `ai-employee/.rendered/<slug>/fly.toml` (gitignored).
 4. **Create the Fly app** `hermes-<slug>` (skipped if it exists).
-5. **Create the 10GB volume** `hermes_state` in the customer's region (skipped if it exists). 10GB hosts Postgres + Redis + customer.yaml + audit/observations SQLite + voice cache + OAuth tokens with headroom.
+5. **Create the 10GB volume** `hermes_state` in the customer's region (skipped if it exists). 10GB hosts customer.yaml + audit SQLite + Hermes profiles (incl. flat-file memory) + voice cache + OAuth tokens with headroom (Phase 2 adds Postgres + Redis + observations SQLite).
 6. **Stage secrets via the pbpaste flow.** For each secret, the operator copies the value to clipboard and presses Enter; the value flows from `pbpaste` directly into `fly secrets import --stage` over stdin. Values never appear on the command line, in the terminal, or in any chat transcript. The set of staged secrets:
    - `ANTHROPIC_API_KEY` — model access for Hermes.
    - `COMPOSIO_API_KEY` — long-tail connector access.
    - `AGENTMAIL_API_KEY` — agent-side mailbox.
    - `R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` / `R2_ENDPOINT_URL` — Machine-scoped R2 credentials used by `bootstrap.sh` and the customer-sync sidecar.
-   - `HONCHO_API_KEY` — generated locally via `openssl rand -hex 32`, piped straight to `fly secrets import --stage` over stdin. Never logged, never stored elsewhere. Rotating it requires a Captain-initiated re-provision.
+   - `HONCHO_API_KEY` — **deferred to Phase 2** (no in-Machine Honcho server in Phase 1; nothing generated).
 7. **Deploy** with `fly deploy` against the rendered `fly.toml`.
 8. **Boot smoke test** (`bin/boot-smoke-test.sh <slug>`) — see the section below.
 9. **Per-connector prod smoke tests** (`run_prod_smoke_test.py`) — one read-only call per enabled BUILD or COMPOSIO connector against the customer's tenant. Surfaces auth / scope / shape issues before any write capability is exercised.
@@ -69,9 +67,7 @@ These are set as `[env]` entries in `fly.toml.template` (rendered per-customer):
 
 - `R2_BUCKET_CONFIG` — the bucket name (NOT a credential).
 - `SMD_D1_AUDIT_BINDING` — defaults to `/opt/data/audit.db`.
-- `SMD_D1_OBSERVATIONS_BINDING` — defaults to `/opt/data/observations.db`.
-- `HONCHO_BASE_URL` — `http://localhost:8000` (Honcho FastAPI binds localhost only).
-- `HONCHO_DATABASE_URL` — `postgresql://honcho@localhost:5432/honcho` (in-container Postgres).
+- `SMD_D1_OBSERVATIONS_BINDING` / `HONCHO_BASE_URL` / `HONCHO_DATABASE_URL` — **deferred to Phase 2** (no Honcho in Phase 1; these env entries are not rendered).
 - `HERMES_HOME` — `/opt/data`.
 - `CUSTOMER_SLUG` — the slug, propagated for log filtering and skill resolution.
 
@@ -79,46 +75,37 @@ These are set as `[env]` entries in `fly.toml.template` (rendered per-customer):
 
 The 10GB Fly volume mounts at `/opt/data` and hosts everything stateful. `customer.yaml` is volume-write at provisioning and R2-mirrored for non-structural updates (ADR 0019).
 
-| Path                         | Contents                                                                          |
-| ---------------------------- | --------------------------------------------------------------------------------- |
-| `/opt/data/customer.yaml`    | Live customer config. Fetched from R2 at first boot; refreshed by sidecar.        |
-| `/opt/data/honcho/pg/`       | Postgres data dir (Honcho's primary store).                                       |
-| `/opt/data/honcho/redis/`    | Redis AOF (Honcho's cache).                                                       |
-| `/opt/data/audit.db`         | Per-customer audit log SQLite (`hermes-smd-audit` writes).                        |
-| `/opt/data/observations.db`  | Honcho-mirror SQLite (`hermes-smd-memory-mirror` writes). ADR 0016.               |
-| `/opt/data/profiles/<slug>/` | Hermes per-persona profiles (one per `customer.yaml.personas[]`). ADR 0011, 0019. |
-| `/opt/data/oauth/`           | Per-provider OAuth token files. ADR 0010.                                         |
-| `/opt/data/voice/`           | Voice samples warm cache (R2-backed).                                             |
+| Path                         | Contents                                                                                                                    |
+| ---------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `/opt/data/customer.yaml`    | Live customer config. Fetched from R2 at first boot; refreshed by sidecar.                                                  |
+| `/opt/data/honcho/pg/`       | Postgres data dir — **Phase 2** (Honcho's store; unused in Phase 1).                                                        |
+| `/opt/data/honcho/redis/`    | Redis AOF — **Phase 2** (Honcho's cache; unused in Phase 1).                                                                |
+| `/opt/data/audit.db`         | Per-customer audit log SQLite (`hermes-smd-audit` writes).                                                                  |
+| `/opt/data/observations.db`  | Honcho-mirror SQLite (`hermes-smd-memory-mirror` writes) — **Phase 2**. ADR 0016.                                           |
+| `/opt/data/profiles/<slug>/` | Hermes per-persona profiles + flat-file memory (`MEMORY.md`/`USER.md`), one per `customer.yaml.personas[]`. ADR 0011, 0019. |
+| `/opt/data/oauth/`           | Per-provider OAuth token files. ADR 0010.                                                                                   |
+| `/opt/data/voice/`           | Voice samples warm cache (R2-backed).                                                                                       |
 
 ## Boot sequence (summary)
 
-`bootstrap.sh` runs as the container entrypoint under `tini`. Eleven sequenced steps; each waits on the previous and fail-fasts on timeout:
+`bootstrap.sh` runs as the container entrypoint under `tini`. The Phase-1 sequence (steps 3–6, the Honcho data plane, are deferred to Phase 2 — see ADR 0016 revised):
 
 1. Validate required env vars.
 2. Fetch `customer.yaml` from R2 if `/opt/data/customer.yaml` is missing; otherwise use the volume copy.
-3. Start Postgres (mounted on `/opt/data/honcho/pg/`); wait on `pg_isready`.
-4. Start Redis (mounted on `/opt/data/honcho/redis/`); wait on `redis-cli ping`.
-5. Run Honcho schema migrations (idempotent).
-6. Start Honcho FastAPI; wait on `curl -fsS http://localhost:8000/health`.
-7. Run `hermes-smd bootstrap` from the overlay repo — translates `customer.yaml.personas[]` into N profile directories under `/opt/data/profiles/`, writes each profile's `config.yaml` and `SOUL.md`.
-8. Run the safety-substrate invariant checks (`/app/safety-substrate/run_invariants.py`).
-9. Pause-guard check.
-10. Start the `hermes-smd customer-sync` sidecar in the background (R2 polling).
-11. Launch Hermes with the four overlay plugins discovered from `~/.hermes/plugins/`.
+   3–6. **Honcho data plane (Postgres / Redis / migrations / FastAPI) — deferred to Phase 2.** Phase 1 runs on Hermes' flat-file memory core.
+3. Run `hermes-smd bootstrap` from the overlay repo — translates `customer.yaml.personas[]` into N profile directories under `/opt/data/profiles/`, writes each profile's `config.yaml` and `SOUL.md`.
+4. Run the safety-substrate invariant checks (`/app/safety-substrate/run_invariants.py`).
+5. Pause-guard check.
+6. Start the `hermes-smd customer-sync` sidecar in the background (R2 polling).
+7. `exec hermes gateway run` — the unattended gateway daemon (listens for cron + webhook triggers and drives them through the agent + overlay plugins). NOT `hermes chat`, which is an interactive REPL that would exit on EOF as PID-1's child.
 
 The full step list and the exact failure-handling lives in `bootstrap.sh` itself; this section is a summary.
 
-## Honcho failure semantics
+## Memory semantics (Phase 1)
 
-If Honcho's FastAPI server becomes unresponsive mid-session (process crash, OOM, Postgres connection failure), Hermes degrades gracefully:
+Phase 1 runs on Hermes' always-on flat-file memory core (`MEMORY.md`/`USER.md`), which Hermes auto-creates and maintains per profile. This is in-session memory only: the customer-owned explicit memory (D1/R2 rules, person-mappings, voice) is **not on the runtime read path** until the tail-log drain (#821), and inferred memory (Honcho) is **deferred to Phase 2**. A first inbound message proves the harness (quarantine → draft → reviewer), not the product memory.
 
-- The agent continues to function without Honcho writes for that turn.
-- `hermes-smd-audit` emits a `MEMORY_PROVIDER_DEGRADED` audit row with the timestamp and last-known Honcho status.
-- The admin portal surfaces this as a yellow-state Machine.
-- `tini` reaps the dead Honcho process and the bootstrap sequencer restarts it.
-- On reconnect, `hermes-smd-audit` emits a `MEMORY_PROVIDER_RECOVERED` audit row.
-
-We do not fail-closed because a memory-system bug should not brick the customer's AI Employee. The per-draft reviewer-as-sender pattern catches any single bad draft regardless of memory state. ADR 0016 governs the mirror, the dismissal flow, and TTL archival.
+When Honcho lands in Phase 2, it degrades gracefully if unresponsive mid-session: the agent continues without Honcho writes for that turn, `hermes-smd-audit` emits `MEMORY_PROVIDER_DEGRADED`, and `MEMORY_PROVIDER_RECOVERED` on reconnect. We do not fail-closed — a memory-system bug should not brick the AI Employee, and reviewer-as-sender catches any single bad draft regardless of memory state. ADR 0016 governs the mirror, the dismissal flow, and TTL archival.
 
 ## Updating customer.yaml
 
@@ -156,7 +143,7 @@ The most common state at the target-buyer profile is no working PM system at all
 | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | Pause a Machine                | `fly machine stop -a hermes-<slug> <machine-id>`                                                                                                             |
 | Decommission a customer        | `fly apps destroy hermes-<slug>` (irreversible; volume contents are lost)                                                                                    |
-| Run the boot smoke test        | `ai-employee/bin/boot-smoke-test.sh <slug>` (Postgres → Redis → Honcho → customer.yaml → profiles → plugins)                                                 |
+| Run the boot smoke test        | `ai-employee/bin/boot-smoke-test.sh <slug>` (customer.yaml → profiles → plugins → curator-disabled; Postgres/Redis/Honcho are Phase 2)                       |
 | Run connector prod smoke tests | `uv run python3 ai-employee/adapter/run_prod_smoke_test.py --customer <slug> --app hermes-<slug> --customer-yaml ai-employee/customers/<slug>/customer.yaml` |
 | Inspect logs                   | `fly logs -a hermes-<slug>`                                                                                                                                  |
 | Interactive shell              | `fly ssh console -a hermes-<slug>`                                                                                                                           |
@@ -165,7 +152,7 @@ The most common state at the target-buyer profile is no working PM system at all
 
 ### Boot smoke test scope
 
-`boot-smoke-test.sh` exercises the dependency chain only: Machine state, Postgres readiness, Redis readiness, Honcho health, `customer.yaml` presence, profiles directory presence, and overlay plugins installation. It does **not** run a real agent turn or exercise live MCP / Anthropic credentials. Those are the job of `run_prod_smoke_test.py` (per-connector) and the end-to-end test described in §6 of the build plan.
+`boot-smoke-test.sh` exercises the dependency chain only: Machine state, `customer.yaml` presence, profiles directory presence, overlay plugins installation, and curator-disabled. (The Postgres/Redis/Honcho-health checks are deferred to Phase 2 — ADR 0016 revised.) It does **not** run a real agent turn or exercise live MCP / Anthropic credentials. Those are the job of `run_prod_smoke_test.py` (per-connector) and the end-to-end test described in §6 of the build plan.
 
 ## ADR references
 

--- a/ai-employee/templates/bootstrap.sh
+++ b/ai-employee/templates/bootstrap.sh
@@ -2,20 +2,24 @@
 # bootstrap.sh — container entrypoint for the AI Employee customer Machine
 #
 # Per §6 of the locked build plan and ADRs 0007/0010/0016/0019, this script
-# runs an 11-step sequenced startup under tini (PID 1, zombie reaper):
+# runs a sequenced startup under tini (PID 1, zombie reaper). Steps 3-6 (the
+# Honcho data plane) are DEFERRED to Phase 2 per the revised ADR 0016 — see
+# that block below — so the Phase-1 sequence is:
 #
 #   1.  Validate required env vars.
 #   2.  Verify (or fetch from R2) /opt/data/customer.yaml.
-#   3.  Start Postgres (Honcho's data store) as a supervised child.
-#   4.  Start Redis (Honcho's queue/cache) as a supervised child.
-#   5.  Run Honcho schema migrations (idempotent).
-#   6.  Start Honcho FastAPI server as a supervised child.
+#   3-6. Honcho data plane — deferred to Phase 2 (no Postgres/Redis/Honcho).
 #   7.  Run `hermes-smd bootstrap` (customer.yaml -> per-profile config + SOUL.md).
 #   7b. Disable the Hermes curator in each profile config (ADR 0017).
 #   8.  Run the safety-substrate invariant checks (Phase A.5 gate).
 #   9.  Pause guard.
-#   10. Start `hermes-smd customer-sync` sidecar (R2 poller).
-#   11. exec Hermes (becomes the foreground child of tini).
+#   10. customer-sync sidecar (R2 poller) — NOT launched in Phase 1 (the overlay
+#       reload path is unimplemented; see that step).
+#   11. exec the Hermes gateway (becomes the foreground child of tini).
+#
+# Memory (ADR 0016, revised 2026-05-30): Phase 1 runs on Hermes' always-on
+# flat-file core (MEMORY.md/USER.md). Honcho (inferred memory) is a swappable
+# provider deferred to Phase 2; the customer-owned memory file lives in D1/R2.
 #
 # Storage model:
 #   - customer.yaml is volume-mounted, NOT baked into the image.
@@ -25,21 +29,22 @@
 #
 # Process supervision:
 #   - tini (PID 1) reaps zombies and forwards signals.
-#   - Postgres, Redis, Honcho, and the customer-sync sidecar are launched
-#     under restart wrappers so a crashed dependency self-heals.
-#   - The memory-mirror plugin handles graceful degradation when Honcho is
-#     unhealthy mid-session; this script does not health-monitor Honcho at
-#     runtime (only at startup).
+#   - The gateway runs as the foreground (exec) child.
 #
 # Fails fast on any of:
 #   - missing required env vars
 #   - customer.yaml missing AND not fetchable from R2
-#   - Postgres/Redis/Honcho not healthy within bounded retries
-#   - Honcho schema migration error
 #   - `hermes-smd bootstrap` error (bad customer.yaml structure)
 #   - safety-substrate invariant test failures
 
 set -euo pipefail
+
+# Activate the Hermes venv for the whole entrypoint. The overlay CLI
+# (hermes-smd) and the hermes gateway are installed ONLY in /opt/hermes/.venv;
+# bootstrap.sh invokes `hermes-smd` and `hermes` as bare commands. Without the
+# venv on PATH, a bare `hermes`/`hermes-smd` would not resolve and the Machine
+# would crash at step 7 / step 11.
+export PATH="/opt/hermes/.venv/bin:${PATH}"
 
 log() {
   echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [bootstrap] $*"
@@ -50,45 +55,10 @@ die() {
   exit 1
 }
 
-# Bounded retry helper: wait_for <description> <max_attempts> <sleep_seconds> <check_command...>
-wait_for() {
-  local desc="$1"
-  local max="$2"
-  local delay="$3"
-  shift 3
-  local attempt=1
-  while (( attempt <= max )); do
-    if "$@" >/dev/null 2>&1; then
-      log "${desc} ready (attempt ${attempt}/${max})"
-      return 0
-    fi
-    log "${desc} not ready, retry ${attempt}/${max} in ${delay}s..."
-    sleep "${delay}"
-    attempt=$(( attempt + 1 ))
-  done
-  return 1
-}
-
-# Restart-on-crash wrapper for foundational child processes. Logs a
-# fatal-style line on each crash so the audit plugin / operator sees the
-# transition; tini still reaps the dying child.
-supervise() {
-  local name="$1"
-  shift
-  (
-    while true; do
-      log "supervisor: starting ${name}"
-      if "$@"; then
-        log "supervisor: ${name} exited 0; restarting in 5s"
-      else
-        local rc=$?
-        log "supervisor: ${name} exited ${rc}; restarting in 5s"
-      fi
-      sleep 5
-    done
-  ) &
-  log "supervisor: ${name} pid=$!"
-}
+# NOTE: the wait_for() bounded-retry helper and supervise() restart wrapper
+# were removed with the Honcho data plane (steps 3-6); Postgres/Redis/Honcho
+# were their only callers. Phase 2 reintroduces supervision when it vendors the
+# real Honcho api + deriver processes.
 
 CUSTOMER_SLUG="${CUSTOMER_SLUG:-}"
 [ -n "${CUSTOMER_SLUG}" ] || die "CUSTOMER_SLUG env var is unset"
@@ -107,11 +77,10 @@ REQUIRED_ENV=(
   R2_BUCKET_CONFIG
   R2_ACCESS_KEY_ID
   R2_SECRET_ACCESS_KEY
-  # D1 bindings for the audit + observations mirror tables (ADR 0016/0017).
+  # D1 binding for the audit log (ADR 0017). The observations-mirror binding
+  # (SMD_D1_OBSERVATIONS_BINDING) and HONCHO_API_KEY are optional in Phase 1 —
+  # they only matter once Honcho is wired (Phase 2; ADR 0016 revised).
   SMD_D1_AUDIT_BINDING
-  SMD_D1_OBSERVATIONS_BINDING
-  # Honcho FastAPI access token, generated per-Machine at provisioning.
-  HONCHO_API_KEY
   # ADR 0022 Stream 2 — per-customer skill bodies bucket. Bucket name
   # comes from fly.toml [env] (R2_SKILL_BODIES_BUCKET); the bucket-scoped
   # access key + secret are Fly secrets set by provision-customer.sh. The
@@ -134,6 +103,11 @@ done
 OPTIONAL_ENV=(
   GOOGLE_TOKEN_JSON
   GOOGLE_CLIENT_SECRET_JSON
+  # Honcho (inferred memory) is deferred to Phase 2 (ADR 0016 revised). These
+  # are unused at boot in Phase 1; kept optional for forward-compat so the
+  # Phase-2 vendor can stage them without a bootstrap change.
+  SMD_D1_OBSERVATIONS_BINDING
+  HONCHO_API_KEY
   # R2 endpoint URL override (defaults to the Cloudflare R2 S3 endpoint).
   R2_ENDPOINT_URL
   # COMPOSIO_API_KEY — doctrine-dropped per ADR 0020 (revision 2026-05-24: "no
@@ -188,117 +162,34 @@ else
 fi
 
 # ============================================================================
-# Step 3: start Postgres (Honcho data store)
+# Steps 3-6: Honcho data plane — DEFERRED to Phase 2 (ADR 0016, revised)
 # ============================================================================
-# Honcho stores conclusions/observations in Postgres. Data dir lives on the
-# volume so it survives Machine restarts. Initialize on first boot; subsequent
-# boots reuse the cluster. Postgres runs as the hermes user (uid 10000) — the
-# image creates the data dir with hermes ownership.
-PGDATA="/opt/data/honcho/pg"
-PG_BIN="/usr/lib/postgresql/16/bin"
-export PGDATA
-
-if [ ! -s "${PGDATA}/PG_VERSION" ]; then
-  log "Postgres data dir empty; running initdb (first boot)"
-  mkdir -p "${PGDATA}"
-  "${PG_BIN}/initdb" \
-    --pgdata "${PGDATA}" \
-    --username "honcho" \
-    --auth-local "trust" \
-    --auth-host "trust" \
-    --encoding "UTF8" \
-    --locale "C" \
-    || die "Postgres initdb failed"
-  # Listen on localhost only; no external exposure.
-  cat >> "${PGDATA}/postgresql.conf" <<EOF
-listen_addresses = '127.0.0.1'
-port = 5432
-unix_socket_directories = '/tmp'
-EOF
-  log "Postgres cluster initialized"
-fi
-
-# Supervised start. pg_ctl backgrounds itself; we use postgres directly so
-# tini sees the process. The supervise() wrapper keeps it alive.
-supervise "postgres" "${PG_BIN}/postgres" -D "${PGDATA}"
-
-# Health-wait. 30 attempts × 1s = 30s ceiling.
-if ! wait_for "Postgres" 30 1 "${PG_BIN}/pg_isready" -h 127.0.0.1 -p 5432 -U honcho; then
-  die "Postgres did not become ready within 30s"
-fi
-
-# Ensure the honcho database exists (createdb is idempotent via DO block).
-"${PG_BIN}/psql" -h 127.0.0.1 -U honcho -d postgres -tAc \
-  "SELECT 1 FROM pg_database WHERE datname='honcho'" | grep -q 1 \
-  || "${PG_BIN}/createdb" -h 127.0.0.1 -U honcho honcho \
-  || die "Failed to create honcho database"
-log "Postgres ready (database=honcho)"
-
-# ============================================================================
-# Step 4: start Redis (Honcho cache/queue)
-# ============================================================================
-# AOF persistence keeps Honcho's queue durable across restarts. Data dir lives
-# on the volume.
-REDIS_DIR="/opt/data/honcho/redis"
-mkdir -p "${REDIS_DIR}"
-
-supervise "redis" redis-server \
-  --bind 127.0.0.1 \
-  --port 6379 \
-  --appendonly yes \
-  --dir "${REDIS_DIR}" \
-  --protected-mode no \
-  --save ""
-
-if ! wait_for "Redis" 30 1 redis-cli -h 127.0.0.1 -p 6379 ping; then
-  die "Redis did not become ready within 30s"
-fi
-log "Redis ready"
-
-# ============================================================================
-# Step 5: Honcho schema migrations
-# ============================================================================
-# Idempotent — Honcho's migration runner is safe to re-run on every boot.
-# Tuned config knobs from ADR 0016 are applied via env vars consumed by the
-# Honcho process itself (set in step 6) and via the hermes-smd bootstrap
-# translator in step 7 (writes them into each profile's memory-provider
-# config). We export DB/Redis URLs here so the migration runner can find them.
-export HONCHO_DB_URL="postgresql://honcho@127.0.0.1:5432/honcho"
-export HONCHO_REDIS_URL="redis://127.0.0.1:6379/0"
-
-log "Running Honcho schema migrations..."
-python3 -m honcho.migrations \
-  || die "Honcho schema migration failed"
-log "Honcho migrations applied"
-
-# ============================================================================
-# Step 6: start Honcho FastAPI server
-# ============================================================================
-# Local-only on port 8000; the memory-mirror plugin in Hermes talks to it via
-# 127.0.0.1.
-supervise "honcho" python3 -m honcho.server \
-  --host 127.0.0.1 \
-  --port 8000
-
-if ! wait_for "Honcho FastAPI" 60 1 curl -fsS http://127.0.0.1:8000/health; then
-  die "Honcho FastAPI did not become healthy within 60s"
-fi
-log "Honcho FastAPI ready"
+# Previously: start Postgres, start Redis, run `python -m honcho.migrations`,
+# start `python -m honcho.server`. That integration was fictional — `honcho-ai`
+# is the Honcho CLIENT SDK, not the server, so those module invocations never
+# existed and the Machine died here at every boot. Real Honcho v3.0.7 is the
+# plastic-labs/honcho SOURCE repo (fastapi api + `python -m src.deriver`,
+# pgvector, mandatory LLM provider).
+#
+# Per the revised ADR 0016 (Option 2): the customer-owned memory file lives in
+# our D1/R2; Honcho is a swappable INFERRED-memory provider that sits behind it
+# and is deferred to Phase 2. Phase 1 runs on Hermes' always-on flat-file core
+# (MEMORY.md/USER.md), which Hermes auto-creates at profile boot. Postgres +
+# Redis remain installed in the image (for Phase 2) but are not started here.
 
 # ============================================================================
 # Step 7: hermes-smd bootstrap (customer.yaml -> per-profile config)
 # ============================================================================
 # Installed at image build time via `pip install hermes-smd-overlay`. Reads
 # /opt/data/customer.yaml, writes N profile directories under
-# $HERMES_HOME/profiles/<slug>/ with config.yaml and SOUL.md. Each profile's
-# memory-provider block is configured to talk to the local Honcho FastAPI
-# with the ADR 0016 tuned knobs.
+# $HERMES_HOME/profiles/<slug>/ with config.yaml and SOUL.md. Phase 1 emits no
+# memory-provider block (flat-file core); the `hermes-smd bootstrap` CLI takes
+# no --honcho-* flags (those were never valid args — passing them aborted the
+# step). Honcho wiring returns in Phase 2 (ADR 0016 revised).
 log "Running hermes-smd bootstrap (customer.yaml -> profiles)..."
 hermes-smd bootstrap \
   --customer-yaml "${CUSTOMER_YAML}" \
   --hermes-home "${HERMES_HOME}" \
-  --honcho-url "http://127.0.0.1:8000" \
-  --honcho-api-key "${HONCHO_API_KEY}" \
   || die "hermes-smd bootstrap failed; check customer.yaml structure"
 log "Profile config(s) generated under ${HERMES_HOME}/profiles/"
 
@@ -356,38 +247,42 @@ if [ -f /opt/data/.paused ]; then
 fi
 
 # ============================================================================
-# Step 10: customer-sync sidecar (R2 poller)
+# Step 10: customer-sync sidecar (R2 poller) — NOT launched (unimplemented)
 # ============================================================================
-# Polls R2 at vaults/<slug>/customer.yaml every 5 minutes. On non-structural
-# change: rewrites /opt/data/customer.yaml and signals Hermes (SIGHUP) to
-# reload profile config. On structural change: logs warning + posts to admin
-# portal, but does NOT restart (preserves OAuth tokens per ADR 0010).
-log "Starting customer-sync sidecar (R2 polling every 300s)..."
-AWS_ACCESS_KEY_ID="${R2_ACCESS_KEY_ID}" \
-AWS_SECRET_ACCESS_KEY="${R2_SECRET_ACCESS_KEY}" \
-  hermes-smd customer-sync \
-    --customer-yaml "${CUSTOMER_YAML}" \
-    --r2-bucket "${R2_BUCKET_CONFIG}" \
-    --r2-endpoint "${R2_ENDPOINT_URL}" \
-    --interval 300 \
-    &
-SIDECAR_PID=$!
-log "customer-sync sidecar pid=${SIDECAR_PID}"
+# The sidecar's purpose is to poll R2 at vaults/<slug>/customer.yaml and apply
+# non-structural changes in place (SIGHUP reload). It is NOT launched in Phase 1
+# for two reasons: (1) the overlay's `start_customer_sync` raises
+# NotImplementedError (the reload path is a tracked follow-on), and (2) the
+# `hermes-smd customer-sync` CLI does not accept the `--r2-endpoint` flag this
+# script previously passed, so argparse aborted it immediately. Launching it
+# backgrounded only spammed a guaranteed crash into the logs on every boot.
+# Structural changes already require a Captain re-provision (ADR 0019); until
+# the reload path is implemented, non-structural edits also go through a
+# re-provision. Re-enable here once the overlay ships the sidecar.
 
 # ============================================================================
-# Step 11: launch Hermes (foreground under tini)
+# Step 11: launch the Hermes gateway (foreground under tini)
 # ============================================================================
-# Overlay plugins were installed at image build time and live under
-# ~/.hermes/plugins/. The first profile in personas[] (the only one in v1 per
-# the §7 validator) becomes the active session. `exec` so Hermes inherits
-# PID-1-ish ownership under tini cleanly — tini still reaps the foundational
-# children (Postgres, Redis, Honcho, sidecar) launched above.
+# The unattended runtime is `hermes gateway run`, NOT `hermes chat`. `chat` is
+# an interactive REPL — as PID-1's foreground child with no TTY it would hit
+# EOF on stdin and exit, never staying up. The gateway is the long-lived daemon
+# that listens for cron triggers (e.g. the daily inbox-triage run) and inbound
+# webhook events and drives them through the agent + overlay plugin surface
+# (audit / trust / inbound / outbound / voice). `gateway run` is the upstream-
+# documented foreground mode for containers.
 #
-# The legacy `PYTHONPATH=/app/adapter:...` export and AIE_* env vars were
-# removed when the in-tree adapter retired. The overlay plugin surface
-# (audit / trust / voice / memory-mirror / hook-probe) is the runtime path;
-# customer.yaml + skills + connector wiring all resolve through the
-# overlay's bootstrap CLI invoked above.
-log "Launching Hermes (overlay plugins enabled)..."
+# `exec` so the gateway inherits the foreground slot under tini cleanly.
+#
+# Overlay plugins were installed at image build time under ~/.hermes/plugins/.
+# customer.yaml + skills + connector wiring resolve through the overlay's
+# bootstrap CLI invoked in step 7.
+#
+# Ensure the gateway's log directory exists and is writable by the hermes user.
+# Hermes writes a rotating log to $HERMES_HOME/logs/agent.log and does NOT create
+# the parent dir itself — on a fresh volume the open() would fail. The volume
+# root is hermes-owned, so this mkdir creates a hermes-owned, writable dir.
+mkdir -p "${HERMES_HOME}/logs"
 
-exec /opt/hermes/.venv/bin/hermes chat
+log "Launching Hermes gateway (overlay plugins enabled)..."
+
+exec /opt/hermes/.venv/bin/hermes gateway run

--- a/ai-employee/templates/fly.toml.template
+++ b/ai-employee/templates/fly.toml.template
@@ -61,16 +61,15 @@ primary_region = "{{FLY_REGION}}"
   # are in fly secrets (R2_SKILL_BODIES_ACCESS_KEY_ID, R2_SKILL_BODIES_SECRET_ACCESS_KEY).
   R2_SKILL_BODIES_BUCKET = "{{R2_SKILL_BODIES_BUCKET}}"
 
-  # Per-customer SQLite paths. The hermes-smd-audit and hermes-smd-memory-mirror
-  # plugins resolve these to absolute file paths under the mounted volume.
+  # Per-customer SQLite paths. The hermes-smd-audit plugin resolves the audit
+  # binding to an absolute file path under the mounted volume. The observations
+  # binding (hermes-smd-memory-mirror) is set only when Honcho is wired in
+  # Phase 2 (ADR 0016 revised); Phase 1 boots without it.
   SMD_D1_AUDIT_BINDING = "/opt/data/audit.db"
-  SMD_D1_OBSERVATIONS_BINDING = "/opt/data/observations.db"
 
-  # Honcho is in-container. The plugin code reaches it on localhost; the
-  # Postgres database URL points at the in-container Postgres that bootstrap.sh
-  # starts before Honcho. Per ADR 0016, Honcho runs unmodified, stock binary.
-  HONCHO_BASE_URL = "http://localhost:8000"
-  HONCHO_DATABASE_URL = "postgresql://honcho@localhost:5432/honcho"
+  # Honcho (inferred memory) is deferred to Phase 2 (ADR 0016 revised). No
+  # HONCHO_BASE_URL / HONCHO_DATABASE_URL env in Phase 1 — there is no
+  # in-container Honcho server. Phase 2 adds them with the real source vendor.
 
 # Smallest sensible machine class. Postgres + Redis + Honcho + Hermes need
 # more memory than the pre-§6 1024MB single-process Hermes did. Per-customer

--- a/docs/adr/0016-honcho-disposition.md
+++ b/docs/adr/0016-honcho-disposition.md
@@ -11,6 +11,27 @@ related-issue: TBD (filed as follow-on to the locked Hermes-alignment plan dated
 
 # ADR 0016 — Honcho Disposition
 
+**Status:** Accepted (Captain decision, 2026-05-24); **amended 2026-05-30** — see Revision below.
+
+## Revision (2026-05-30) — Honcho deferred behind the owned-memory file; flat-file core restored
+
+The first real boot of customer-zero exposed that the in-container Honcho integration was **fictional**: `bootstrap.sh` ran `python -m honcho.migrations` / `python -m honcho.server` against the pip package `honcho-ai`, which is the Honcho **client SDK**, not the server. Real Honcho v3.0.7 ([plastic-labs/honcho](https://github.com/plastic-labs/honcho)) is a uv **source repo** — `fastapi run src/main.py` (api) plus a **separate `python -m src.deriver`** worker (the deriver is what produces the conclusions this ADR's mirror depends on), alembic migrations via `scripts/provision_db.py`, requiring **pgvector** Postgres and a **mandatory LLM provider**. The Machine had never booted; it died at the fictional migration step.
+
+Reviewing the Hermes docs + our harness intent (PRD §10) resolved the posture (Captain, 2026-05-30):
+
+- **Memory is two layers.** The customer-owned, editable, exportable memory file (rules, person-mappings, voice — PRD §10) lives in **our D1/R2**; that is the product and the trust mechanism. Honcho is the **inferred-memory engine** that sits **behind** that file and feeds it — a _swappable provider_, not the substrate. This is the "you own the memory; we can swap the tech underneath" promise, delivered by the architecture, not a config knob.
+- **Hermes agrees.** Honcho is 1 of 8 _optional_ memory providers that run **alongside** an always-on flat-file core (`MEMORY.md`/`USER.md`), never replacing it. Boot never depends on Honcho.
+- **Phase 1 (now):** boot on the flat-file core with Honcho **removed** from the boot path. The `hermes-smd-overlay` `translate.py` no longer tombstones `MEMORY.md`/`USER.md` or emits a Honcho config block; Postgres/Redis/Honcho are not started; the Honcho secrets are optional. This is implemented in ss-console (`ai-employee/templates/*`, `bin/*`) + overlay (`bootstrap/translate.py`).
+- **Phase 2 (deferred, demand-gated):** vendor the **real** `plastic-labs/honcho@v3.0.7` source (api + deriver, pgvector, localhost-bound, `AUTH_USE_AUTH=false`) the same way upstream Hermes is vendored; rewrite `memory-mirror/honcho_client.py` against the real API (its assumed `/conclusions` endpoints likely do not match v3.0.7); build the admin `persona_observations` viewer/dismiss UI; bump `machine.memory_mb` and price the deriver's continuous LLM spend (ADR 0004).
+
+**What the Decision below still means, and what changed.** The decision to _keep_ Honcho as the inferred-memory provider stands; the mirror/dismissal/evidence-status/TTL machinery is the right shape for Phase 2. What is **reversed** is the disposition that Honcho is the _sole_ memory provider with the flat-file core **tombstoned** — the flat-file core is always-on (Hermes' own model), and Honcho runs alongside and feeds the owned D1 file. The "in-container unmodified Honcho image" wiring (and Verification #6's `docker image inspect plasticlabs/honcho`) is replaced by **vendored source at a pinned tag** in Phase 2.
+
+**Loud caveat.** With Honcho off and the explicit D1/R2 memory not yet on the runtime read path (the tail-log drain, #821), the Phase-1 agent has **in-session flat-file memory only**. The first real boot proves the **harness** (quarantine → draft → reviewer-as-sender), not the product memory.
+
+---
+
+_Original decision (2026-05-24), preserved below with the amendments above governing._
+
 **Status:** Accepted (Captain decision, 2026-05-24).
 
 **Source:** The locked Hermes-alignment build plan dated 2026-05-24, following a focused Honcho deep-dive (architecture, configurable behaviors, native deferred/proposer capabilities, real-world failure modes) and Captain's directional reframe of the gating question. This rewrite replaces the prior version which proposed a "proposer-only" interception of Honcho writes — that posture had no native surface to land on, addressed a real concern (voice drift, hallucinated facts) with the wrong mechanism, and was framed against the wrong risk (lawyer malpractice).
@@ -149,7 +170,7 @@ Selected. Self-host preserves the product story and the AGPL safe harbor; the mi
 3. **D1 `persona_observations` accumulates evidenced + unevidenced rows.** A first-session smoke test against `_template` customer produces measurable rows with correct `evidence_status` classification.
 4. **Captain dismissal physically deletes from Honcho.** Smoke test: insert a synthetic conclusion via Honcho API, mirror to D1, dismiss in the admin portal, verify Honcho's `GET /conclusions/{id}` returns 404.
 5. **TTL archival sweeps run daily.** The plugin's daily job logs the sweep and writes archive rows. A back-dated synthetic conclusion (`mirrored_at` set 200 days ago) gets archived on the next sweep.
-6. **No patches to Honcho.** CI on Machine image build runs `docker image inspect plasticlabs/honcho:<pinned-tag>` and compares the layer hash to the recorded upstream hash. Mismatch fails the build.
+6. **No patches to Honcho.** _(Superseded by the 2026-05-30 Revision: Phase 2 vendors `plastic-labs/honcho@v3.0.7` **source** at a pinned tag — the same clone-and-assert-SHA discipline used for upstream Hermes — not a prebuilt `plasticlabs/honcho` image. The integrity check is the SHA assertion on the cloned tag, not a `docker image inspect` layer-hash compare.)_
 7. **No interceptor code.** `rg -i "HonchoInterceptor|honcho_interceptor|verify_honcho_intercepted|proposer_only" ai-employee/ src/ venturecrane/` returns zero matches.
 
 ## References

--- a/tests/ai-employee-dockerfile.test.ts
+++ b/tests/ai-employee-dockerfile.test.ts
@@ -24,19 +24,35 @@ import { readFileSync } from 'fs'
 import { resolve } from 'path'
 
 const DOCKERFILE = readFileSync(resolve('ai-employee/templates/Dockerfile'), 'utf8')
+const BOOTSTRAP = readFileSync(resolve('ai-employee/templates/bootstrap.sh'), 'utf8')
+
+// Strip `#`-comment lines so NEGATIVE assertions (e.g. "no honcho.server")
+// match executable content only — the Honcho-deferral comments deliberately
+// NAME the removed commands to explain why they are gone.
+const stripHashComments = (s: string): string =>
+  s
+    .split('\n')
+    .filter((l) => !/^\s*#/.test(l))
+    .join('\n')
+const DOCKERFILE_CODE = stripHashComments(DOCKERFILE)
+const BOOTSTRAP_CODE = stripHashComments(BOOTSTRAP)
 
 describe('AI Employee customer Machine Dockerfile', () => {
-  it('pins OVERLAY_REF to a semver release tag, never a branch', () => {
-    const m = DOCKERFILE.match(/ARG\s+OVERLAY_REF=["']?(v\d+\.\d+\.\d+)["']?/)
-    expect(m, 'OVERLAY_REF must be pinned to a vX.Y.Z release tag').not.toBeNull()
-  })
-
-  it('pins the overlay at >= v0.2.0 (the floor that contains shared/outbound_gate.py)', () => {
-    const m = DOCKERFILE.match(/ARG\s+OVERLAY_REF=["']?v(\d+)\.(\d+)\.(\d+)["']?/)
-    expect(m).not.toBeNull()
-    const [major, minor] = [Number(m![1]), Number(m![2])]
-    // v0.1.1 lacked the outbound gate / inbound spine; v0.2.0 is the floor.
-    expect(major > 0 || minor >= 2, 'OVERLAY_REF must be >= v0.2.0').toBe(true)
+  it('pins OVERLAY_REF to a release tag or a full commit SHA, never a branch', () => {
+    // During a first-boot proof OVERLAY_REF is a 40-hex commit SHA on a feature
+    // branch; after the boot is green it is repointed to a vX.Y.Z release tag
+    // (see the plan's "tag last" sequencing). A bare branch name (e.g. `main`)
+    // is never acceptable — it would let the pip-installed `shared` policy core
+    // drift silently. The import assert below is the real harness-present gate.
+    const m = DOCKERFILE.match(/ARG\s+OVERLAY_REF=["']?([^"'\s]+)["']?/)
+    expect(m, 'OVERLAY_REF must be set').not.toBeNull()
+    const ref = m![1]
+    const isSemver = /^v\d+\.\d+\.\d+$/.test(ref)
+    const isSha = /^[0-9a-f]{40}$/.test(ref)
+    expect(
+      isSemver || isSha,
+      `OVERLAY_REF must be a vX.Y.Z tag or a 40-hex commit SHA, got "${ref}"`
+    ).toBe(true)
   })
 
   it('does NOT swallow a failed plugin install (no fail-open `|| echo ... continuing`)', () => {
@@ -56,5 +72,97 @@ describe('AI Employee customer Machine Dockerfile', () => {
       'Dockerfile must assert `import shared.outbound_gate` succeeds in the venv'
     ).toBe(true)
     expect(DOCKERFILE).toMatch(/from shared\.outbound_gate import evaluate/)
+  })
+})
+
+/**
+ * Regression guard: the first-boot build/runtime fixes (first real boot,
+ * 2026-05-30). Three stacked defects meant the Machine had never booted:
+ *   1. `postgresql-16` is not in Debian 13 (trixie ships PG 17) — build exit 100.
+ *   2. The uv-created venv has no `pip` binary; `.venv/bin/pip install` exits 127.
+ *   3. The venv was not on PATH, so bare `python3 -m honcho.*` / `hermes-smd`
+ *      resolved to /usr/bin and crashlooped at boot.
+ */
+describe('AI Employee Machine first-boot build/runtime fixes', () => {
+  it('installs postgresql-17 (Debian 13 default), never postgresql-16', () => {
+    expect(
+      /apt-get install[\s\S]*?postgresql-17 postgresql-client-17/.test(DOCKERFILE),
+      'apt must install postgresql-17 / postgresql-client-17'
+    ).toBe(true)
+    expect(
+      /apt-get install[\s\S]*?postgresql-16 postgresql-client-16/.test(DOCKERFILE),
+      'postgresql-16 is not in Debian 13 trixie repos — build fails with exit 100'
+    ).toBe(false)
+    expect(DOCKERFILE, 'Postgres bin PATH must target /17/, not /16/').not.toMatch(
+      /usr\/lib\/postgresql\/16\/bin/
+    )
+  })
+
+  it('installs into the venv via `uv pip`, never the absent `.venv/bin/pip`', () => {
+    expect(
+      /\.venv\/bin\/pip install/.test(DOCKERFILE),
+      'uv venvs ship no pip binary; `.venv/bin/pip install` exits 127 — use `uv pip install`'
+    ).toBe(false)
+  })
+
+  it('bootstrap.sh puts the Hermes venv on PATH', () => {
+    expect(
+      /export PATH="\/opt\/hermes\/\.venv\/bin:/.test(BOOTSTRAP),
+      'bootstrap.sh must prepend the venv to PATH so bare hermes/hermes-smd resolve to it'
+    ).toBe(true)
+    // Postgres is no longer started in bootstrap (Honcho deferred), so the
+    // PG_BIN/17 reference moved out of bootstrap.sh — see the Honcho-deferral
+    // suite below. Postgres 17 stays INSTALLED in the Dockerfile (asserted above).
+  })
+})
+
+/**
+ * Regression guard: Honcho is deferred to Phase 2 (ADR 0016, revised
+ * 2026-05-30). The never-booted Machine died at the fictional Honcho steps —
+ * `python -m honcho.{migrations,server}` against `honcho-ai`, which is the
+ * client SDK, not the server. These lock the deletion + the correct launch
+ * verb so the boot path can't regress back into the fiction.
+ *
+ * Assertions run against comment-stripped content: the deferral comments
+ * intentionally name the removed commands.
+ */
+describe('AI Employee Machine: Honcho deferred, flat-file core (ADR 0016 revised)', () => {
+  it('Dockerfile does not install the fictional honcho-ai client SDK', () => {
+    expect(
+      /honcho-ai/.test(DOCKERFILE_CODE),
+      'honcho-ai is the Honcho CLIENT SDK, not the server — it must not be installed'
+    ).toBe(false)
+    expect(/HONCHO_PIP_SPEC/.test(DOCKERFILE_CODE)).toBe(false)
+  })
+
+  it('bootstrap.sh does not run the fictional honcho migrations/server', () => {
+    expect(
+      /python3?\s+-m\s+honcho\.(migrations|server)/.test(BOOTSTRAP_CODE),
+      '`python -m honcho.{migrations,server}` never existed — the boot died here'
+    ).toBe(false)
+  })
+
+  it('bootstrap.sh launches the gateway daemon, not the interactive chat REPL', () => {
+    expect(
+      /exec\s+\S*hermes\s+gateway\s+run/.test(BOOTSTRAP_CODE),
+      'an unattended Machine must `exec hermes gateway run`'
+    ).toBe(true)
+    expect(
+      /exec\s+\S*hermes\s+chat\b/.test(BOOTSTRAP_CODE),
+      '`hermes chat` is an interactive REPL — wrong for PID-1 with no TTY'
+    ).toBe(false)
+  })
+
+  it('bootstrap.sh does not require the Honcho secrets at boot', () => {
+    // HONCHO_API_KEY / SMD_D1_OBSERVATIONS_BINDING moved to OPTIONAL_ENV; a
+    // Phase-1 boot must not fail-closed on their absence.
+    const required = stripHashComments(BOOTSTRAP.match(/REQUIRED_ENV=\(([\s\S]*?)\n\)/)?.[1] ?? '')
+    expect(/HONCHO_API_KEY/.test(required), 'HONCHO_API_KEY must not be required in Phase 1').toBe(
+      false
+    )
+    expect(
+      /SMD_D1_OBSERVATIONS_BINDING/.test(required),
+      'SMD_D1_OBSERVATIONS_BINDING must not be required in Phase 1'
+    ).toBe(false)
   })
 })


### PR DESCRIPTION
## Customer-zero (`smd`) now boots end to end to a live agent gateway 🎉

Standing up customer-zero on Fly surfaced that the Machine **had never actually booted**. This PR carries the full set of fixes that get it from "dies at step 5" to a **stable `hermes gateway run` daemon**, plus the Honcho architecture correction (ADR 0016 revised) that was the root blocker.

### What was wrong, and what's fixed

| # | Defect | Stage | Status |
|---|--------|-------|--------|
| 1 | `postgresql-16` not in Debian 13 (trixie ships PG 17) → apt exit 100 | build | ✅ |
| 2 | uv venv has no `pip` → `.venv/bin/pip install` exit 127 | build | ✅ |
| 3 | venv not on PATH → bare `hermes-smd`/`hermes` crashloop | boot | ✅ |
| 4 | **`honcho-ai` is the client SDK, not the server** — `python -m honcho.{migrations,server}` never existed; the Machine died here every boot | boot | ✅ deleted + deferred (ADR 0016 revised) |
| 5 | `bootstrap.sh` passed `--honcho-url`/`--honcho-api-key` to a CLI that has no such args → argparse abort at step 7 | boot | ✅ |
| 6 | step 11 ran `hermes chat` (interactive REPL) — exits on EOF as PID-1's child; the unattended verb is `hermes gateway run` | boot | ✅ |
| 7 | gateway crashed on `PermissionError: /opt/data/logs/agent.log` (Hermes doesn't create the log dir) | boot | ✅ `mkdir` in bootstrap |
| 8 | customer-sync sidecar launched with a rejected `--r2-endpoint` flag and is `NotImplementedError` upstream → guaranteed crash spam | boot | ✅ not launched in Phase 1 |

### The Honcho correction (ADR 0016 revised)

The in-container Honcho integration was fictional. Real Honcho v3.0.7 is a uv **source repo** (`fastapi run src/main.py` + a separate `python -m src.deriver` worker, alembic, pgvector, mandatory LLM provider) — none of which matched what bootstrap ran.

Per the revised ADR 0016 (Option 2): the **customer-owned memory file lives in our D1/R2**; Honcho is a **swappable inferred-memory provider that sits behind it**, deferred to Phase 2. **Phase 1 boots on Hermes' always-on flat-file core** (`MEMORY.md`/`USER.md`). The overlay (`venturecrane/hermes-smd-overlay` **v0.3.0**, `OVERLAY_REF`) stops tombstoning the flat-file core.

**Loud caveat:** Phase 1 is in-session flat-file memory only. The explicit customer-owned memory (D1/R2) is **not on the runtime read path until #821**; inferred memory (Honcho) is Phase 2. This boot proves the **harness**, not the product memory.

### Verified live on Fly (customer-zero, version 9, clean image, no manual intervention)

- `hermes-smd bootstrap` → profile `crane` materialized, **no tombstones**
- curator disabled (ADR 0017)
- **Safety-substrate invariants: 8 pass / 0 fail** under `--strict` on real infra
- `hermes gateway run` live and stable: cron ticker (60s) + kanban dispatcher running; flat-file core; **zero Honcho/Postgres/Redis started**
- Machine reaches and holds `started`; no crashloop

### Phase 2 (tracked, deferred)
Vendor real `plastic-labs/honcho@v3.0.7` source (api + deriver, pgvector); rewrite the mirror's `honcho_client` against the real API; admin `persona_observations` viewer/dismiss UI; `memory_mb` bump + deriver pricing (ADR 0004).

### Note on scope
This branch also carries prior-session AI-Employee first-boot/harness commits (inbound trust-boundary spine + `fabrication_markers.json` + substrate CI, ADR 0027). They predate this session's Honcho work and ride along in the same "first-boot readiness" PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
