### PR TITLE
feat(ai-employee): pull published $5,000/mo price from marketing page

### DIFF
--- a/src/pages/ai-employee.astro
+++ b/src/pages/ai-employee.astro
@@ -15,14 +15,6 @@ const productSchema = {
   brand: { '@type': 'Brand', name: 'SMD Services' },
   offers: {
     '@type': 'Offer',
-    priceCurrency: 'USD',
-    price: '5000.00',
-    priceSpecification: {
-      '@type': 'UnitPriceSpecification',
-      price: '5000.00',
-      priceCurrency: 'USD',
-      referenceQuantity: { '@type': 'QuantitativeValue', value: '1', unitCode: 'MON' },
-    },
     availability: 'https://schema.org/InStock',
     seller: { '@type': 'Organization', name: 'SMD Services' },
   },
@@ -107,7 +99,7 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 03 Pricing -->
+    <!-- § 03 What it's worth -->
     <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
@@ -117,23 +109,18 @@ const roleLenses = [
         <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
         >
-          Pricing.
+          What It's Worth.
         </h2>
-        <div class="border-[3px] border-[color:var(--ss-color-text-primary)] bg-white p-10 md:p-12">
-          <p
-            class="font-['JetBrains_Mono'] text-sm font-semibold uppercase tracking-[0.14em] text-[color:var(--ss-color-primary)] mb-4"
-          >
-            Monthly subscription
+        <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
+          <p>
+            Add up the hours your team spends on the work that repeats. The inquiries answered the
+            same way, the follow-ups that slip, the status updates typed out one more time. That is
+            the work the agent takes on, and the time it gives back is the return.
           </p>
-          <p
-            class="font-['Archivo'] text-6xl md:text-7xl font-black tracking-[-0.03em] text-[color:var(--ss-color-text-primary)]"
-          >
-            $5,000<span class="text-2xl md:text-3xl font-bold tracking-normal">&nbsp;/ month</span>
-          </p>
-          <p
-            class="mt-6 font-['Archivo'] text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]"
-          >
-            Flat. Setup and ongoing operation included. No additional fees.
+          <p>
+            Pricing is a flat monthly subscription, scoped to the role we build together. We walk
+            through it in the first conversation, before any setup begins. No hourly billing, no
+            usage meter, no surprise line items.
           </p>
         </div>
       </div>

--- a/tests/landing-page.test.ts
+++ b/tests/landing-page.test.ts
@@ -25,16 +25,16 @@ function readAllSrcFiles(): string[] {
   return files
 }
 
-// Marketing surfaces for the scope-based consulting funnel. The "no dollar
-// amounts" check below applies to these files. Productized SKU detail pages
-// (e.g. src/pages/ai-employee.astro for the AI Employee subscription) are
-// intentionally EXCLUDED from this list — those surfaces may publish a
-// price because the offering is a fixed product, not a custom scope. New
-// home-page sections SHOULD be added here so a future edit cannot
-// accidentally publish a price on the home funnel.
+// Marketing surfaces. The "no dollar amounts" check below applies to these
+// files. The AI Employee SKU page (src/pages/ai-employee.astro) is included:
+// as of 2026-05-30 we pulled the published $5,000/mo price and route pricing
+// to the first conversation, so no dollar amount may appear on that surface
+// either. New marketing sections SHOULD be added here so a future edit cannot
+// accidentally publish a price.
 function readMarketingFiles(): string[] {
   return [
     resolve('src/pages/index.astro'),
+    resolve('src/pages/ai-employee.astro'),
     join(componentsDir, 'Hero.astro'),
     join(componentsDir, 'ProblemCards.astro'),
     join(componentsDir, 'RoiMath.astro'),


### PR DESCRIPTION
## What

Pivot on the AI Employee marketing page (`/ai-employee`): we originally published the subscription price, but we're pulling it for now and alluding to the ROI instead. Pricing moves to the first conversation.

## Changes

- **§03 "Pricing" → "What It's Worth"** — replaces the `$5,000 / month` block with value framing: alludes to the return (the time the agent gives back), keeps the flat-monthly-subscription *model*, and routes the actual figure to the scoping conversation. No dollar amount on the page.
- **Product JSON-LD** — strips `price` / `priceSpecification` from `offers` (keeps `availability` + `seller`), so the price isn't published in structured data either.
- **`landing-page.test.ts`** — moves `ai-employee.astro` into the enforced no-dollar-amounts list (it was *intentionally excluded* while we published the price). This makes the guardrail prevent the number creeping back and brings the page in line with CLAUDE.md rule #4 ("No published dollar amounts").

The meta description's "Flat monthly subscription" phrasing is retained — it describes the pricing *model*, not an amount.

## Verification

- `npm run verify` — green (2870 tests + all worker suites, EXIT=0)
- `tests/landing-page.test.ts` + `tests/forbidden-strings.test.ts` — pass, including the now-enforced no-dollar check on `ai-employee.astro`

🤖 Generated with [Claude Code](https://claude.com/claude-code)