### PR TITLE
chore(ci): bump GitHub Actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/adr-0022-pi-prefix-gate.yml
+++ b/.github/workflows/adr-0022-pi-prefix-gate.yml
@@ -28,7 +28,7 @@ jobs:
     name: Block law-pi- prefix in active paths
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install ripgrep
         run: |

--- a/.github/workflows/ai-employee-skill-regression.yml
+++ b/.github/workflows/ai-employee-skill-regression.yml
@@ -39,10 +39,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '>=3.11'
 
@@ -56,7 +56,7 @@ jobs:
 
       - name: Upload regression report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ai-employee-skill-regression
           path: regression-report.md
@@ -64,7 +64,7 @@ jobs:
 
       - name: Comment on PR
         if: github.event_name == 'pull_request' && always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/ai-employee-substrate.yml
+++ b/.github/workflows/ai-employee-substrate.yml
@@ -33,10 +33,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '>=3.11'
 

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@v3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,10 +18,10 @@ jobs:
       packages: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'npm'
@@ -38,14 +38,14 @@ jobs:
 
       # Dry-run catches wrangler config / binding errors before they hit prod.
       - name: Wrangler deploy (dry-run)
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: deploy --dry-run
 
       - name: Deploy to Cloudflare Workers
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -59,7 +59,7 @@ jobs:
 
       - name: Run D1 migrations
         if: ${{ vars.D1_MIGRATIONS_ENABLED == 'true' }}
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -77,7 +77,7 @@ jobs:
         run: cd workers/job-monitor && npm ci
 
       - name: Deploy Job Monitor Worker
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -88,7 +88,7 @@ jobs:
         run: cd workers/new-business && npm ci
 
       - name: Deploy New Business Worker
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -99,7 +99,7 @@ jobs:
         run: cd workers/review-mining && npm ci
 
       - name: Deploy Review Mining Worker
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -110,7 +110,7 @@ jobs:
         run: cd workers/social-listening && npm ci
 
       - name: Deploy Social Listening Worker
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/scope-deferred-todo.yml
+++ b/.github/workflows/scope-deferred-todo.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Inspect PR diff for TODO(#NNN) introductions
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const SOURCE_EXTS = /\.(ts|tsx|js|jsx|astro|mjs|cjs|svelte|vue|py|go|rs|java|kt)$/i;

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -27,10 +27,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'npm'
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -107,10 +107,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'npm'
@@ -134,7 +134,7 @@ jobs:
       # .github/workflows/dependabot-auto-merge.yml when safe).
       image: returntocorp/semgrep:1.157.0
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Run Semgrep
         # POSIX-compatible shell script — the returntocorp/semgrep container
         # uses Alpine ash, not bash, so ${PIPESTATUS[n]} is unavailable.
@@ -173,7 +173,7 @@ jobs:
     name: nosemgrep Justification Audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Require substantive justification on every nosemgrep
         # Every `// nosemgrep` annotation must be followed by ` — ` or `: ` and
         # at least 20 characters of justification prose. Without this audit,

--- a/.github/workflows/ui-drift-audit.yml
+++ b/.github/workflows/ui-drift-audit.yml
@@ -32,14 +32,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Sync canonical skills from crane-console
         # The audit script lives in crane-console/.agents/skills/ui-drift-audit/.
         # Locally, the launcher (crane-console/packages/crane-mcp/src/cli/launch-lib.ts:1185
         # syncVentureSkills) mirrors it on every `crane <venture>` launch. CI has no
         # launcher, so we sparse-clone canon and stage the script into the expected path.
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: venturecrane/crane-console
           sparse-checkout: |
@@ -54,7 +54,7 @@ jobs:
           rm -rf .crane-canon
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '>=3.11'
 
@@ -111,13 +111,13 @@ jobs:
 
       - name: Comment on PR
         if: github.event_name == 'pull_request'
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@v3
         with:
           header: ui-drift-audit
           path: comment.md
 
       - name: Upload audit JSON
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ui-drift-audit
           path: audit.json

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -17,10 +17,10 @@ jobs:
       packages: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'npm'


### PR DESCRIPTION
## Why

GitHub forces Node 20 actions to Node 24 on **2026-06-16** and removes the Node 20 runner on 2026-09-16 ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). The 2026-05-31 deploy run flagged it. Every pinned action in `.github/workflows/` was on a Node 20 release.

## What changed

Bumped each action to the lowest major that ships a `node24` runtime (verified against each `action.yml` `runs.using` at the target tag, not assumed):

| Action | From | To |
|---|---|---|
| actions/checkout | v4 | v5 |
| actions/setup-node | v4 | v5 |
| actions/setup-python | v5 | v6 |
| actions/upload-artifact | v4 | v6 (v5 is still node20) |
| actions/github-script | v7 | v8 |
| cloudflare/wrangler-action | v3 | v4 |
| dependabot/fetch-metadata | v2 | v3 |
| marocchino/sticky-pull-request-comment | v2 | v3 |

## Compatibility

No input contracts changed for our usage, verified against each target's declared inputs:
- `wrangler-action@v4` still accepts `apiToken` / `accountId` / `command` / `workingDirectory` (the deploy-gating one).
- `setup-node`/`setup-python` `node-version`/`python-version`, `upload-artifact` `name`/`path`/`if-no-files-found`, `github-script` `script:` all unchanged.

The real validation is this PR's own CI running green on the new versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)