### PR TITLE
feat(ai-employee): wire Crane's AgentMail inbox + run the persona-profile gateway

### DIFF
--- a/ai-employee/customers/smd/customer.yaml
+++ b/ai-employee/customers/smd/customer.yaml
@@ -59,12 +59,19 @@ personas:
         wake_policy: always
 
 # ---- CONNECTORS ----
-# "We run everything in Google — Gmail, Google Calendar, and Google Drive." All three
-# named explicitly → vendor-direct Google MCPs per ADR 0020. No composio.
+# Email is Crane's OWN AgentMail inbox, not the principal's Gmail (Captain
+# decision 2026-05-31): AgentMail is API-first email built for AI agents, and
+# its native create_draft / send separation maps onto reviewer-as-sender
+# (ADR 0005) exactly — the agent drafts from its own identity and a human
+# sends. Backend mcp:agentmail is materialized by the overlay translator into
+# the profile's mcp_servers block (key from the AGENTMAIL_API_KEY Fly secret).
+# The autonomous-send tools are blocked at the trust layer + excluded from the
+# toolset. Calendar + DocumentStorage remain the principal's Google services
+# ("We run everything in Google") via vendor-direct MCPs per ADR 0020.
 connectors:
   Email:
-    adapter: google-gmail
-    backend: mcp:google-gmail
+    adapter: agentmail
+    backend: mcp:agentmail
     enabled: true
   Calendar:
     adapter: google-calendar

--- a/ai-employee/templates/Dockerfile
+++ b/ai-employee/templates/Dockerfile
@@ -61,9 +61,12 @@ ARG HERMES_UPSTREAM_SHA=a91a57fa5a13d516c38b07a141a9ce8a3daabeb0
 # tombstoning) and deferred Honcho (ADR 0016 revised); customer-zero booted end
 # to end on it with 8/8 safety invariants passing. v0.3.1 retires the (dormant)
 # composio per-connection isolation guard — composio is dropped, we connect to
-# MCPs directly (ADR 0020 revised).
+# MCPs directly (ADR 0020 revised). v0.3.2 materializes customer.yaml `mcp:`
+# connectors into the profile's mcp_servers block (AgentMail is the first
+# vendor), bans the agentmail autonomous-send tools at the trust layer, and
+# makes the profile-config write atomic (recovers a root-owned config.yaml).
 ARG OVERLAY_REPO="https://github.com/venturecrane/hermes-smd-overlay.git"
-ARG OVERLAY_REF="v0.3.1"
+ARG OVERLAY_REF="v0.3.2"
 
 ARG CUSTOMER_SLUG=customer-zero
 

--- a/ai-employee/templates/bootstrap.sh
+++ b/ai-employee/templates/bootstrap.sh
@@ -15,7 +15,8 @@
 #   9.  Pause guard.
 #   10. customer-sync sidecar (R2 poller) — NOT launched in Phase 1 (the overlay
 #       reload path is unimplemented; see that step).
-#   11. exec the Hermes gateway (becomes the foreground child of tini).
+#   11. exec the Hermes gateway for the active persona profile (`-p <slug>`;
+#       becomes the foreground child of tini).
 #
 # Memory (ADR 0016, revised 2026-05-30): Phase 1 runs on Hermes' always-on
 # flat-file core (MEMORY.md/USER.md). Honcho (inferred memory) is a swappable
@@ -111,12 +112,13 @@ OPTIONAL_ENV=(
   # R2 endpoint URL override (defaults to the Cloudflare R2 S3 endpoint).
   R2_ENDPOINT_URL
   # AGENTMAIL_API_KEY — the persona's own outbound mailbox identity (ADR 0005
-  # reviewer-as-sender; ADR 0008). Deferred to Phase 2 multi-persona (ADR 0011)
-  # and not yet implemented: no connector, OAuth flow, plugin, or skill code
-  # reads it (cost_rollup.py only maps it as a future cost-driver category).
-  # SMD customer-zero acts on the principal's Gmail via mcp:google-gmail, not an
-  # agent mailbox, so requiring it blocked boot for no functional reason. Re-
-  # require when a persona email identity is actually wired.
+  # reviewer-as-sender). NOW CONSUMED: a customer.yaml `Email` connector with
+  # backend `mcp:agentmail` is materialized by the overlay translator
+  # (bootstrap.translate._materialize_mcp_servers) into the profile's
+  # `mcp_servers` block, injecting this key as the `x-api-key` header. Kept
+  # OPTIONAL on purpose — if it is unset the translator logs and skips the
+  # agentmail server (the Machine still boots; the Email connector is simply
+  # not wired) rather than crashlooping on a missing key.
   AGENTMAIL_API_KEY
 )
 
@@ -254,7 +256,7 @@ fi
 # re-provision. Re-enable here once the overlay ships the sidecar.
 
 # ============================================================================
-# Step 11: launch the Hermes gateway (foreground under tini)
+# Step 11: launch the Hermes gateway for the active persona (foreground/tini)
 # ============================================================================
 # The unattended runtime is `hermes gateway run`, NOT `hermes chat`. `chat` is
 # an interactive REPL — as PID-1's foreground child with no TTY it would hit
@@ -264,18 +266,45 @@ fi
 # (audit / trust / inbound / outbound / voice). `gateway run` is the upstream-
 # documented foreground mode for containers.
 #
+# The gateway MUST target the persona profile, not the bare default profile.
+# A plain `hermes gateway run` runs Hermes' built-in `default` profile, which
+# has no model, no SOUL.md, no skills, and no connector wiring — i.e. NOT the
+# customer's agent. Step 7 wrote the persona profiles under
+# $HERMES_HOME/profiles/<slug>/; we select the active one with `-p <slug>`
+# (a global flag that works in any position; the profile dir is sufficient,
+# no separate `hermes profile create` needed).
+#
+# Active persona = the first persona with `status: active` (else the first
+# persona). Phase 1 customers run a single active persona, so one gateway. The
+# multi-active-persona case (one gateway per persona) is an ADR 0011 Phase-2
+# concern; until then we launch the single active persona's gateway.
+ACTIVE_PROFILE="$(/opt/hermes/.venv/bin/python3 - "${CUSTOMER_YAML}" <<'PY'
+import sys
+import yaml
+
+data = yaml.safe_load(open(sys.argv[1])) or {}
+personas = data.get("personas") or []
+active = [p for p in personas if p.get("status") == "active" and p.get("slug")]
+fallback = [p for p in personas if p.get("slug")]
+chosen = (active or fallback or [None])[0]
+print(chosen["slug"] if chosen else "")
+PY
+)" || die "failed to read active persona from customer.yaml"
+[ -n "${ACTIVE_PROFILE}" ] || die "no active persona with a slug in customer.yaml"
+log "Active persona profile: ${ACTIVE_PROFILE}"
+
 # `exec` so the gateway inherits the foreground slot under tini cleanly.
 #
 # Overlay plugins were installed at image build time under ~/.hermes/plugins/.
 # customer.yaml + skills + connector wiring resolve through the overlay's
 # bootstrap CLI invoked in step 7.
 #
-# Ensure the gateway's log directory exists and is writable by the hermes user.
-# Hermes writes a rotating log to $HERMES_HOME/logs/agent.log and does NOT create
-# the parent dir itself — on a fresh volume the open() would fail. The volume
-# root is hermes-owned, so this mkdir creates a hermes-owned, writable dir.
-mkdir -p "${HERMES_HOME}/logs"
+# Ensure the gateway's log directories exist and are writable by the hermes
+# user. Hermes writes a rotating log and does NOT create the parent dir itself
+# — on a fresh volume the open() would fail. The volume root and the profile
+# dir are hermes-owned, so these mkdirs create hermes-owned, writable dirs.
+mkdir -p "${HERMES_HOME}/logs" "${HERMES_HOME}/profiles/${ACTIVE_PROFILE}/logs"
 
-log "Launching Hermes gateway (overlay plugins enabled)..."
+log "Launching Hermes gateway for profile '${ACTIVE_PROFILE}' (overlay plugins enabled)..."
 
-exec /opt/hermes/.venv/bin/hermes gateway run
+exec /opt/hermes/.venv/bin/hermes -p "${ACTIVE_PROFILE}" gateway run

--- a/tests/ai-employee-dockerfile.test.ts
+++ b/tests/ai-employee-dockerfile.test.ts
@@ -142,10 +142,14 @@ describe('AI Employee Machine: Honcho deferred, flat-file core (ADR 0016 revised
     ).toBe(false)
   })
 
-  it('bootstrap.sh launches the gateway daemon, not the interactive chat REPL', () => {
+  it('bootstrap.sh launches the active-persona gateway daemon, not the default profile or the chat REPL', () => {
+    // Must run `hermes gateway run` (daemon) targeting a persona profile via
+    // `-p <slug>`. A bare `hermes gateway run` runs Hermes' built-in `default`
+    // profile — no model, SOUL.md, skills, or connector wiring — i.e. not the
+    // customer's agent. The `-p` flag is the regression guard for that bug.
     expect(
-      /exec\s+\S*hermes\s+gateway\s+run/.test(BOOTSTRAP_CODE),
-      'an unattended Machine must `exec hermes gateway run`'
+      /exec\s+\S*hermes\s+-p\s+\S+\s+gateway\s+run/.test(BOOTSTRAP_CODE),
+      'an unattended Machine must `exec hermes -p <profile> gateway run`'
     ).toBe(true)
     expect(
       /exec\s+\S*hermes\s+chat\b/.test(BOOTSTRAP_CODE),


### PR DESCRIPTION
## Summary
Pairs with overlay **v0.3.2**. Three boot fixes so customer-zero (`smd`) actually runs as **Crane** with its own mailbox.

- **bootstrap.sh** step 11 now derives the active persona slug from `customer.yaml` and `exec hermes -p <slug> gateway run`. A bare `hermes gateway run` ran Hermes' built-in `default` profile (no model, SOUL.md, skills, or connectors) — Crane's persona never actually ran on boot. Also mkdir the per-profile logs dir; updated the `AGENTMAIL_API_KEY` comment (now consumed by the translator, kept optional so a missing key degrades instead of crashlooping).
- **customer.yaml**: Email connector → `adapter: agentmail` / `backend: mcp:agentmail`. Crane gets its **own** AgentMail inbox (Captain decision 2026-05-31); AgentMail's native create_draft/send separation maps onto reviewer-as-sender (ADR 0005). Calendar + DocumentStorage stay the principal's Google services.
- **Dockerfile**: `OVERLAY_REF` v0.3.1 → **v0.3.2** (MCP connector materialization + agentmail send-tool ban + atomic profile-config write — the last also recovers customer-zero's root-owned `config.yaml` that was crashlooping the boot).

## Test plan
- [x] `npm run verify` — 0 TS errors, lint 0 errors, build + full suite green
- [x] Updated `ai-employee-dockerfile.test.ts`: asserts `exec hermes -p <profile> gateway run` (regression guard against the bare-default-profile bug)
- [x] Local proof: real `smd/customer.yaml` validates; overlay translator materializes exactly one `mcp_servers` entry (agentmail; key as `x-api-key`; the four send tools excluded; google-calendar/drive left unwired)
- [ ] Live boot: deploy, machine starts, crane gateway live, agentmail connected; email Crane → triage → draft; confirm send blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)