### PR TITLE
docs(adr): ADR 0031 content-sensitivity send floor + OVERLAY_REF v0.4.0 (#21)

### DIFF
--- a/ai-employee/templates/Dockerfile
+++ b/ai-employee/templates/Dockerfile
@@ -66,7 +66,7 @@ ARG HERMES_UPSTREAM_SHA=a91a57fa5a13d516c38b07a141a9ce8a3daabeb0
 # vendor), bans the agentmail autonomous-send tools at the trust layer, and
 # makes the profile-config write atomic (recovers a root-owned config.yaml).
 ARG OVERLAY_REPO="https://github.com/venturecrane/hermes-smd-overlay.git"
-ARG OVERLAY_REF="v0.3.2"
+ARG OVERLAY_REF="v0.4.0"
 
 ARG CUSTOMER_SLUG=customer-zero
 

--- a/docs/adr/0031-content-sensitivity-send-floor.md
+++ b/docs/adr/0031-content-sensitivity-send-floor.md
@@ -1,0 +1,112 @@
+---
+title: Content-Sensitivity Send Floor — Money / Contract / Scope / Legal Always Drafts
+date: 2026-05-31
+status: accepted
+captain: Scott Durgan
+amends: 0025-autonomy-ceilings-configurable-exposure-vs-initiation.md
+related-adr: 0005-reviewer-as-sender.md, 0028-outbound-integrity-gates-provenance-and-voice.md
+related-interview: ai-employee/customers/smd/onboarding-interview-2026-05-31.md
+related-issue: AI Employee task #21 (overlay PR venturecrane/hermes-smd-overlay#22, tag v0.4.0)
+---
+
+# ADR 0031 — Content-Sensitivity Send Floor
+
+**Status:** Accepted (Captain decision, customer-zero onboarding interview, 2026-05-31).
+
+## Context
+
+ADR 0025 made autonomous external send a **configurable per-action ceiling**: a
+customer can author `action_ceilings[external_send] = autonomous` and the agent
+sends from its own identity without per-message human approval, floored only by a
+vertical-pack ceiling (ADR 0022). That decision is by **action class** — it does
+not look at _what a specific message says_.
+
+The customer-zero onboarding interview surfaced a requirement ADR 0025 does not
+cover. Scott set Crane's default send level to **autonomous**, then immediately
+qualified it:
+
+> "Crane send from AgentMail — Autonomous, _except_ the content floor below.
+> Even under autonomous send, anything touching **money, contracts, scope, or
+> legal commitments** drops to draft-for-review."
+
+This is a **content-derived** floor, orthogonal to the action-class ceiling. An
+employee trusted to send routine email autonomously is still not trusted to
+autonomously send a wire instruction, a sign-off on a contract, a scope
+commitment, or a legal statement. Those must land in a draft a human ships.
+
+### Why this is not already covered
+
+- **ADR 0025 ceiling** decides by action class (`external_send`), not content. An
+  autonomous `external_send` ceiling would send a money email.
+- **ADR 0028 outbound gate** (`shared.outbound_gate`) scans for _fabrication_ —
+  banned marker strings and fabricated legal citations ("did the agent invent
+  something it must not say"). The content floor asks a different question: "is
+  this the _kind_ of message a human must sign off on before it autonomously
+  leaves." A perfectly truthful invoice email passes ADR 0028 and must still be
+  caught by this floor.
+
+## Decision
+
+**A content-sensitivity floor sits on top of the ADR 0025 ceiling. When an
+`EXTERNAL_SEND` is resolved to autonomous _send_, the message body (subject +
+content) is scanned for money / contract / scope / legal content. On a hit, the
+send is downgraded to `draft_for_review` — a human reviews and ships it. The
+floor can only narrow (send → draft); it never widens.**
+
+1. **Four content classes.** `money`, `contract`, `scope`, `legal` — curated
+   keyword/pattern sets (see overlay `shared/content_floor.py`). Broad on purpose.
+2. **Fail toward draft.** Draft is recoverable; an autonomous send of a
+   commitment is not. An uninspectable body (e.g. `send_draft` by id, a bodyless
+   forward) is treated as **sensitive** → draft, never waved through.
+3. **Applies only on the allow path.** A ceiling decision of draft/refuse already
+   withholds the send; the floor only acts where the ceiling _would_ send.
+4. **Enforced in code, at the live seam.** The floor runs in the overlay
+   `hermes-smd-trust` `pre_tool_call` hook, after the ceiling resolves an
+   autonomous send. It is exception-safe and fails toward draft. (Residual
+   invariant from ADR 0025 §5 — enforced in code, not prompt.)
+5. **Overlay-only home.** The floor governs _live sends_. The ss-console
+   `adapter/trust_ceiling.py` (boot invariant + grading harness) does not send,
+   so the floor lives in the overlay runtime (`shared/content_floor.py`), not the
+   adapter. This is deliberate, not drift.
+
+## Consequences
+
+**Positive.**
+
+- A customer can run their employee at autonomous send velocity while the
+  highest-stakes messages still get a human's eyes — the configuration Scott
+  actually wants, and the one most customers will want.
+- The floor is a single, testable, data-driven module; adding a category or
+  pattern is a one-line edit plus a test row.
+
+**Negative / accepted.**
+
+- **False positives cost a human glance at a draft.** Acceptable by design — the
+  alternative (a missed money/legal send) is a venture-risk, not an annoyance.
+  The pattern set is tuned over time against real drafts.
+- **Not yet a boot invariant.** The floor is enforced in the live fail-closed
+  hook and covered by unit + integration tests, but it is not (yet) one of the
+  safety-substrate boot invariants that re-run on every Hermes SHA bump. Adding a
+  boot invariant for the floor is reasonable future hardening (defense-in-depth
+  against a SHA-bump regression); it is tracked, not done here.
+- **`send_draft` / bodyless forward are conservatively blocked** under an
+  autonomous ceiling because their content is not inspectable at send time. A
+  human sends those. If this proves too restrictive in practice, the mitigation
+  is to scan at draft-creation time, not to weaken the send-time floor.
+
+## Verification
+
+1. Overlay `shared/content_floor.py::classify` returns `sensitive=True` for each
+   of the four classes and `False` for routine prose; `None`/empty → sensitive.
+2. The overlay trust hook downgrades an autonomous `agentmail:send_*` with a
+   money/contract/scope/legal body to a draft directive, and allows a clean body.
+3. Tests: overlay `tests/test_content_floor.py` (unit) and
+   `tests/test_trust_enforce.py` (integration via `evaluate_tool_call`).
+
+## References
+
+- [ADR 0025 — Autonomy ceilings are configurable](./0025-autonomy-ceilings-configurable-exposure-vs-initiation.md) (the action-class ceiling this floors)
+- [ADR 0005 — Reviewer-as-sender](./0005-reviewer-as-sender.md) (the default the floor restores for sensitive content)
+- [ADR 0028 — Outbound integrity gates](./0028-outbound-integrity-gates-provenance-and-voice.md) (the orthogonal _fabrication_ gate)
+- `ai-employee/customers/smd/onboarding-interview-2026-05-31.md` (the decision source)
+- `hermes-smd-overlay`: `shared/content_floor.py`, `plugins/hermes-smd-trust/enforce.py` (the implementation), PR #22 / tag v0.4.0


### PR DESCRIPTION
## Summary

ss-console companion to the AI Employee send-ban reversal (#21). The enforcement work shipped in **hermes-smd-overlay PR #22 / tag v0.4.0**; this PR records the decision and points the Machine build at it.

- **ADR 0031 — Content-Sensitivity Send Floor** *(new)*. Records the customer-zero interview decision (2026-05-31): even under an autonomous `external_send` ceiling (ADR 0025), **money / contract / scope / legal** content drops to draft-for-review. Distinct from the ADR 0028 fabrication gate (that asks "did the agent invent something"; this asks "must a human sign off"). Amends ADR 0025.
- **`Dockerfile` OVERLAY_REF v0.3.2 → v0.4.0** so the next Machine build picks up: agentmail sends un-banned + classified `EXTERNAL_SEND`, the ADR 0025 per-action ceiling ported into the overlay runtime, and the content floor.

## Not in scope (sequenced)
- **No deploy triggered.** Crane still **drafts** by default — there are no authored `action_ceilings` yet, so `external_send` resolves to draft. The report/reply skill (#19) raises `external_send` to autonomous and gets the Captain-gated deploy.
- The customer.yaml `action_ceilings` schema (ADR 0025 migration step 2) lands with #19, when there is a sending skill to author it for.

## Test plan
- [x] `tests/ai-employee-dockerfile.test.ts` 10/10 pass (OVERLAY_REF format gate accepts v0.4.0).
- [x] Overlay PR #22: 466 tests pass, ruff clean, CI green, merged + tagged v0.4.0.
- [x] No ss-console test pins OVERLAY_REF to a specific version.
- Note: the repo-wide `formatNewsEvidence` mock warning in `src/lib/enrichment/news` is pre-existing and unrelated to this docs+ARG change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)