### PR TITLE
feat(ai-employee): author external_send=autonomous — turn Crane sending ON (#21)

### DIFF
--- a/ai-employee/customers/smd/customer.yaml
+++ b/ai-employee/customers/smd/customer.yaml
@@ -90,6 +90,20 @@ scope:
   email_folders_blind: []
   email_keyword_blocks: []
   domain_blocks: []
+  # ---- TRUST CEILINGS (per-action, ADR 0025) ----
+  # Customer-zero interview (2026-05-31): "default send level is autonomous."
+  # Crane sends from its OWN AgentMail identity without per-message approval.
+  # The overlay trust layer reads scope.action_ceilings.external_send
+  # (hermes-smd-trust enforce.py, v0.4.0).
+  #
+  # Floors that still apply ON TOP of this (cannot be raised away here):
+  #   - Content-sensitivity floor (ADR 0031): money / contract / scope / legal
+  #     content drops to draft-for-review even under autonomous send.
+  #   - Principal-identity sends (email_send / email_reply on Scott's Gmail) are
+  #     hard-banned in code — Crane never sends "as Scott", only drafts there.
+  #   - commitment / destructive keep their current-turn-approval floors.
+  action_ceilings:
+    external_send: autonomous
 
 # ---- ESCALATION ----
 # "just flag it to me at the same address."


### PR DESCRIPTION
## Summary

The config switch that makes Crane a **sending** employee. Authors `scope.action_ceilings.external_send = autonomous` in customer-zero's `customer.yaml`, which the overlay trust layer (v0.4.0) reads to permit Crane to send from its own AgentMail identity without per-message approval.

## Proven against the real `enforce.py` (with this config on the volume)
- clean send / reply -> SENDS
- money / contract / scope / legal body -> drafts (content floor, ADR 0031)
- `email_send` "as Scott" (principal Gmail) -> hard-banned, never sends
- reads -> allowed

## Sequencing
- Boot validator: clean (validated against `bootstrap.validate`).
- Deploy picks this up via the volume `customer.yaml` (+ R2 sync).
- Pre-existing repo-wide `formatNewsEvidence` mock warning is unrelated to this YAML change.

Generated with Claude Code
