### PR TITLE
chore(ai-employee): bump OVERLAY_REF v0.4.0 → v0.4.1 (persona skill-install fix)

### DIFF
--- a/ai-employee/templates/Dockerfile
+++ b/ai-employee/templates/Dockerfile
@@ -66,7 +66,7 @@ ARG HERMES_UPSTREAM_SHA=a91a57fa5a13d516c38b07a141a9ce8a3daabeb0
 # vendor), bans the agentmail autonomous-send tools at the trust layer, and
 # makes the profile-config write atomic (recovers a root-owned config.yaml).
 ARG OVERLAY_REPO="https://github.com/venturecrane/hermes-smd-overlay.git"
-ARG OVERLAY_REF="v0.4.0"
+ARG OVERLAY_REF="v0.4.1"
 
 ARG CUSTOMER_SLUG=customer-zero
 


### PR DESCRIPTION
Pins the Dockerfile to hermes-smd-overlay **v0.4.1**, which installs enabled persona skills into the profile skills dir (venturecrane/hermes-smd-overlay#23). Deployed to `hermes-smd` via a `--build-arg` override and **verified live**: `inbox-triage` is now in the crane profile and the first real triage run against the principal's Gmail succeeded. This pins the ref so the next deploy doesn't regress to v0.4.0. Refs #1166.

🤖 Generated with [Claude Code](https://claude.com/claude-code)