### PR TITLE
feat(ai-employee): wire Crane's AgentMail identity + fix report sign-off

### DIFF
--- a/ai-employee/customers/smd/customer.yaml
+++ b/ai-employee/customers/smd/customer.yaml
@@ -74,9 +74,14 @@ personas:
 # read/label/archive/trash but CANNOT send — drafts only. Crane's own outbound
 # identity (AgentMail) is NOT wired and is an open onboarding item, not a connector here.
 connectors:
+  # Crane's OWN mailbox identity = AgentMail (smdcrane@agentmail.to), wired as an
+  # MCP server (overlay mcp_registry → mcp.agentmail.to, key AGENTMAIL_API_KEY).
+  # This is what makes Crane reachable + able to send/reply on its own identity.
+  # The intake Gmail (smdurgan@smdurgan.com) is triaged by the inbox-triage skill
+  # via crane_gmail.py directly (gmail.modify, never-send) — NOT this connector.
   Email:
-    adapter: google-gmail
-    backend: mcp:google-gmail
+    adapter: agentmail
+    backend: mcp:agentmail
     enabled: true
   Calendar:
     adapter: google-calendar
@@ -94,6 +99,14 @@ scope:
   email_folders_blind: []
   email_keyword_blocks: []
   domain_blocks: []
+  # ---- TRUST CEILINGS (per-action, ADR 0025) ----
+  # Crane sends from its OWN AgentMail identity (smdcrane@agentmail.to) without
+  # per-message approval ("default send level autonomous", interview). Floors that
+  # still apply ON TOP: content-sensitivity floor (ADR 0031) drops money/contract/
+  # scope/legal to draft-for-review; principal-identity (Gmail) sends stay hard-
+  # banned (draft only); commitment/destructive keep current-turn-approval floors.
+  action_ceilings:
+    external_send: autonomous
 
 # ---- ESCALATION ----
 # "just flag it to me" → red flags + run failures go to the boss/escalation address.

--- a/ai-employee/skills/inbox-triage/SKILL.md
+++ b/ai-employee/skills/inbox-triage/SKILL.md
@@ -129,7 +129,9 @@ If the agent infers it would help to do one of these, it MUST instead include a 
 
 ### Voice Rules
 
-The agent's drafts must match Captain's voice. See `references/voice.md` for the long form. Hard rules:
+**Two distinct identities — never conflate them:**
+
+**1. Draft replies** (replies the agent prepares for Captain to send to third parties). These go out AS Captain, in Captain's voice. See `references/voice.md` for the long form. Hard rules:
 
 - No em dashes. Period.
 - No "I hope this email finds you well." No "Just wanted to follow up." No "Touching base."
@@ -139,6 +141,12 @@ The agent's drafts must match Captain's voice. See `references/voice.md` for the
 - No emojis in business correspondence unless the inbound thread is already using them.
 
 If the agent cannot write a draft that passes these rules, it marks the message `LOW` confidence and writes a one-line plan for the reply instead of attempting prose.
+
+**2. The triage report itself** (the note/email the agent sends to Captain or `team@`). This is **Crane's own communication to its principal**, sent from Crane's own identity (`smdcrane@agentmail.to`) — Chief-of-Staff voice: plainspoken, direct, executive-summary first. It is authored AS Crane.
+
+- **NEVER sign the report "Scott."** Crane is not the principal; signing as Scott is an identity error. Sign as "Crane" or use no sign-off.
+- The same em-dash / no-AI-tell discipline applies.
+- The "Sign-off: Scott" rule above governs the embedded draft _replies_ only, never the report envelope.
 
 ## Pitfalls
 


### PR DESCRIPTION
## Verified LIVE 2026-06-01 — real round-trip, witnessed by the principal

Crane sent a real inbox-triage report from its own identity (`smdcrane@agentmail.to`) to `team@smd.services` + `scott@smd.services`. Confirmed three ways: agent returned an SES message id; the AgentMail API shows the message labeled `sent`; **the principal received it in his Gmail inbox** (screenshot). No longer hearsay.

### customer.yaml
- `Email` connector → `agentmail` / `mcp:agentmail` — Crane's OWN mailbox identity (`smdcrane@agentmail.to`), the only MCP-materialized mailbox. Makes Crane reachable + able to send/reply. The intake Gmail is triaged by `inbox-triage` via `crane_gmail.py` directly (`gmail.modify`, never-send), independent of this connector. The prior `google-gmail` Email connector was **inert** (no MCP registry entry).
- `scope.action_ceilings.external_send: autonomous` (**Captain-authorized**). Content floor (ADR 0031) still forces money/contract/scope/legal → draft; Gmail as-principal sends stay hard-banned.

### inbox-triage SKILL.md — sign-off identity fix
The live report signed off "Scott" — an identity error the principal caught (Crane is not the principal). Separated the two identities: the "Sign-off: Scott" rule governs draft **replies** only (sent as Captain); the triage **report** is Crane's own communication and must be signed "Crane" or unsigned. Lands on next redeploy (skills are baked).

Refs #1165 (send transport — now proven), #1166 (wiring epic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)