### PR TITLE
fix(evidence): stop overclaiming "signed" packet; gate the honest wording

### DIFF
--- a/.github/workflows/ai-employee-substrate.yml
+++ b/.github/workflows/ai-employee-substrate.yml
@@ -19,6 +19,7 @@ on:
   pull_request:
     paths:
       - 'ai-employee/adapter/**'
+      - 'ai-employee/bin/**'
       - 'ai-employee/safety-substrate/**'
       - 'ai-employee/verticals/**'
       - '.github/workflows/ai-employee-substrate.yml'
@@ -62,6 +63,6 @@ jobs:
           done
           exit $fail
 
-      - name: Run pytest suites (adapter + pytest-style invariants)
+      - name: Run pytest suites (adapter + evidence + pytest-style invariants)
         working-directory: ai-employee
-        run: python3 -m pytest adapter/tests safety-substrate/tests -q
+        run: python3 -m pytest adapter/tests adapter/evidence/tests safety-substrate/tests -q

--- a/ai-employee/adapter/evidence/__init__.py
+++ b/ai-employee/adapter/evidence/__init__.py
@@ -2,8 +2,12 @@
 
 Composes the per-customer audit_log, memory tables, voice tables,
 customer.yaml, skill_state, and invariant_boot_checks dumps into a
-single signed tar.gz packet per spec
-``docs/specs/ai-employee/compliance-evidence-packet.md``.
+single digest-verified tar.gz packet (per-artifact SHA-256 + a manifest
+SHA-256 recorded in the append-only audit log) per spec
+``docs/specs/ai-employee/compliance-evidence-packet.md``. The manifest
+is not yet cryptographically signed (``signature="unsigned-stub"``);
+detached Ed25519 signing is a tracked follow-on gated on provisioning
+the Captain signing key.
 
 The public entrypoint is :class:`EvidencePacketBuilder.build`. The
 CLI wrapper at ``ai-employee/bin/generate-evidence-packet.sh`` calls

--- a/ai-employee/adapter/evidence/packet.py
+++ b/ai-employee/adapter/evidence/packet.py
@@ -584,7 +584,12 @@ def _compute_counts(
 
 @dataclass
 class EvidencePacketBuilder:
-    """Compose a signed evidence packet for one customer + period.
+    """Compose a digest-verified evidence packet for one customer + period.
+
+    The manifest is NOT yet cryptographically signed -- it self-discloses
+    ``signature="unsigned-stub"``; integrity rests on per-artifact SHA-256
+    digests plus the manifest hash recorded in the append-only audit log.
+    Detached signing is a tracked follow-on.
 
     Construction wires the read executor + audit writer + (optional)
     yaml parser. ``yaml_loader`` defaults to a minimal JSON-ish parser

--- a/ai-employee/adapter/evidence/tests/test_evidence_signing_honesty.py
+++ b/ai-employee/adapter/evidence/tests/test_evidence_signing_honesty.py
@@ -1,0 +1,55 @@
+"""Merge-gate: the evidence packet must not OVERCLAIM cryptographic signing.
+
+The packet is digest-verified (per-artifact SHA-256 + a manifest hash recorded
+in the append-only COMPLIANCE_PACKET_EXPORTED audit row) but is NOT yet
+cryptographically signed — the manifest self-discloses signature="unsigned-stub".
+Operator-facing surfaces previously claimed "signed tar.gz", contradicting the
+packet's own disclosure. For a law-firm compliance product, being caught
+overclaiming integrity taints every other claim in the packet. These tests pin
+the honest wording so it cannot silently regress, and stand as the merge gate
+until a real (Ed25519 detached) signer is wired.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).resolve()
+sys.path.insert(0, str(_HERE.parents[3]))  # ai-employee/ on sys.path
+
+from bin.lib import evidence  # noqa: E402
+
+
+def test_cli_description_does_not_claim_signed():
+    """The argparse help must not say the output is 'signed' — it is digest-
+    verified and unsigned. Catches the overclaim at the operator surface."""
+    import contextlib
+    import io
+
+    # parse_args builds the parser internally; capture its --help output.
+    buf = io.StringIO()
+    with contextlib.suppress(SystemExit), contextlib.redirect_stdout(buf):
+        evidence.parse_args(["--help"])
+    help_text = buf.getvalue().lower()
+    assert "signed tar.gz" not in help_text, (
+        "evidence CLI help claims 'signed tar.gz' but the packet is unsigned "
+        "(manifest signature='unsigned-stub'). Keep the wording honest."
+    )
+    # Positively assert the honest framing is present.
+    assert "digest-verified" in help_text or "unsigned" in help_text
+
+
+def test_evidence_package_docstrings_are_honest():
+    """The evidence package + builder docstrings must not call the packet
+    'signed'; they should describe the digest-verified / unsigned reality."""
+    from adapter import evidence as evidence_pkg
+    from adapter.evidence import packet as packet_mod
+
+    pkg_doc = (evidence_pkg.__doc__ or "").lower()
+    assert "single signed tar.gz" not in pkg_doc
+    assert "digest-verified" in pkg_doc
+
+    builder_doc = (packet_mod.EvidencePacketBuilder.__doc__ or "").lower()
+    assert "signed evidence packet" not in builder_doc
+    assert "digest-verified" in builder_doc or "unsigned-stub" in builder_doc

--- a/ai-employee/bin/generate-evidence-packet.sh
+++ b/ai-employee/bin/generate-evidence-packet.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 # generate-evidence-packet.sh: compose a compliance evidence packet
-# (issue #894) for one customer + period. Output is a signed tar.gz
-# containing a PDF, JSON manifest, and per-spec evidence files.
+# (issue #894) for one customer + period. Output is a digest-verified
+# tar.gz (per-artifact SHA-256 + a manifest SHA-256 recorded in the
+# append-only COMPLIANCE_PACKET_EXPORTED audit row) containing a PDF,
+# JSON manifest, and per-spec evidence files. The manifest is NOT yet
+# cryptographically signed -- it self-discloses signature="unsigned-stub";
+# detached Ed25519 signing is a tracked follow-on gated on /captain/signing-key.
 #
 # Usage:
 #   ai-employee/bin/generate-evidence-packet.sh \

--- a/ai-employee/bin/lib/evidence.py
+++ b/ai-employee/bin/lib/evidence.py
@@ -122,8 +122,11 @@ def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
         prog="generate-evidence-packet",
         description=(
             "Generate a compliance evidence packet for one customer + "
-            "period (issue 894). Output is a signed tar.gz containing a "
-            "PDF, JSON manifest, and per-spec evidence files."
+            "period (issue 894). Output is a digest-verified tar.gz "
+            "(per-artifact SHA-256; manifest hash recorded in the append-only "
+            "audit log) containing a PDF, JSON manifest, and per-spec evidence "
+            "files. The manifest is NOT yet cryptographically signed "
+            "(signature=unsigned-stub); detached signing is a tracked follow-on."
         ),
     )
     p.add_argument("--customer", required=True, help="Customer slug")


### PR DESCRIPTION
## What
Stops the compliance evidence packet from claiming it is "signed" when it isn't, and makes the honest wording a merge gate.

## Why
The packet is **digest-verified** (per-artifact SHA-256 + a manifest SHA-256 recorded in the append-only `COMPLIANCE_PACKET_EXPORTED` audit row) but **not cryptographically signed** — the manifest self-discloses `signature="unsigned-stub"`. Four operator-facing surfaces still claimed a "signed tar.gz", contradicting the packet's own UNSIGNED disclosure (PDF/README/manifest). For a law-firm compliance product, being caught overclaiming integrity taints every other claim in the packet.

PM review (A-hybrid): the digest + immutable-audit-row model is already audit-defensible; a real signature adds authenticity against insider forgery and is correctly a **separate, key-provisioning-gated effort (#1171)** — not a rider here, and not a fail-closed flip that would break the only working export path.

## Changes
- Corrected the 4 overclaim strings → "digest-verified … not yet cryptographically signed".
- Added merge-gate test `adapter/evidence/tests/test_evidence_signing_honesty.py`: CLI help must not say "signed tar.gz" and must state digest-verified/unsigned; package + builder docstrings stay honest.
- **Fixed a CI coverage gap:** `ai-employee-substrate.yml` ran `pytest adapter/tests safety-substrate/tests` — which did **not** collect `adapter/evidence/tests` (the manifest/packet/pdf tests AND this new gate). Added `adapter/evidence/tests` to the pytest command and `ai-employee/bin/**` to path triggers, so all 27 evidence tests + the honesty gate now actually gate.

## Follow-on
Real signer (Ed25519 detached, key in Infisical, rotation runbook): **#1171**.

## Verification
`pytest adapter/tests adapter/evidence/tests safety-substrate/tests` → **335 passed** (was 308; +27 evidence tests now gated, incl. 2 new honesty tests).

Refs: VERIFIED review (evidence-signing honesty); PM A-hybrid; #1171.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
