### PR TITLE
refactor(portal): single-source the 4 byte-identical paginate functions

### DIFF
--- a/src/lib/portal/ai-employee/audit.ts
+++ b/src/lib/portal/ai-employee/audit.ts
@@ -42,6 +42,7 @@
  */
 
 import type { SubscriptionRow } from '../product-access'
+import { type Page, paginate } from './pagination'
 
 /**
  * Accepted `action_type` values for audit rows, mirrored from
@@ -439,41 +440,19 @@ export function applyAuditSort(rows: readonly AuditEntry[], sort: AuditSort): Au
   }
 }
 
-/**
- * Pagination return value. Same shape as the drafts resolver so the
- * page can share the table primitive's pagination contract. `pageCount`
- * is floored at 1 even when there are zero rows so "Page 1 of 1" reads
- * sensibly in the empty state.
- */
-export interface AuditListPage {
-  rows: AuditEntry[]
-  totalCount: number
-  page: number
-  pageSize: number
-  pageCount: number
-}
+/** Pagination return value. See {@link Page} (pagination.ts). */
+export type AuditListPage = Page<AuditEntry>
 
 /**
- * Apply offset-based pagination to a sorted+filtered list. Page is
- * 1-indexed, clamped to [1, pageCount]. Out-of-range pages return the
- * last page rather than an empty result.
+ * Apply offset-based pagination to a sorted+filtered list. Thin wrapper over
+ * the shared {@link paginate}; kept named for call-site + test stability.
  */
 export function paginateAuditEntries(
   rows: readonly AuditEntry[],
   page: number,
   pageSize: number
 ): AuditListPage {
-  const totalCount = rows.length
-  const pageCount = Math.max(1, Math.ceil(totalCount / pageSize))
-  const clampedPage = Math.min(Math.max(1, Math.floor(page)), pageCount)
-  const start = (clampedPage - 1) * pageSize
-  return {
-    rows: rows.slice(start, start + pageSize),
-    totalCount,
-    page: clampedPage,
-    pageSize,
-    pageCount,
-  }
+  return paginate(rows, page, pageSize)
 }
 
 /**

--- a/src/lib/portal/ai-employee/calendar.ts
+++ b/src/lib/portal/ai-employee/calendar.ts
@@ -40,6 +40,7 @@
  */
 
 import type { SubscriptionRow } from '../product-access'
+import { type Page, paginate } from './pagination'
 
 /**
  * The two kinds of items that land in the calendar surface. The
@@ -251,42 +252,19 @@ export function applyCalendarSort(
   return sorted
 }
 
-/**
- * Pagination return value. Same shape as Drafts. `totalCount` is the
- * count after filtering but before pagination; `pageCount` is floored
- * at 1 even when there are zero rows so "Page 1 of 1" reads sensibly
- * in the empty state.
- */
-export interface CalendarListPage {
-  rows: CalendarItem[]
-  totalCount: number
-  page: number
-  pageSize: number
-  pageCount: number
-}
+/** Pagination return value. See {@link Page} (pagination.ts). */
+export type CalendarListPage = Page<CalendarItem>
 
 /**
- * Apply offset-based pagination to a sorted+filtered list. Page is
- * 1-indexed, clamped to [1, pageCount]. Out-of-range pages return the
- * last page rather than an empty result — keeps deep links from
- * rendering as "no events" when the list shifted underneath.
+ * Apply offset-based pagination to a sorted+filtered list. Thin wrapper over
+ * the shared {@link paginate}; kept named for call-site + test stability.
  */
 export function paginateCalendarItems(
   rows: readonly CalendarItem[],
   page: number,
   pageSize: number
 ): CalendarListPage {
-  const totalCount = rows.length
-  const pageCount = Math.max(1, Math.ceil(totalCount / pageSize))
-  const clampedPage = Math.min(Math.max(1, Math.floor(page)), pageCount)
-  const start = (clampedPage - 1) * pageSize
-  return {
-    rows: rows.slice(start, start + pageSize),
-    totalCount,
-    page: clampedPage,
-    pageSize,
-    pageCount,
-  }
+  return paginate(rows, page, pageSize)
 }
 
 /**

--- a/src/lib/portal/ai-employee/drafts.ts
+++ b/src/lib/portal/ai-employee/drafts.ts
@@ -25,6 +25,7 @@
  */
 
 import type { SubscriptionRow } from '../product-access'
+import { type Page, paginate } from './pagination'
 
 /**
  * Trust-ceiling decisions emitted by the AI Employee per ADR 0005. The
@@ -257,37 +258,19 @@ export function applyDraftSort(rows: readonly Draft[], sort: DraftSort): Draft[]
  * at 1 even when there are zero rows so "Page 1 of 1" reads sensibly
  * in the empty state.
  */
-export interface DraftListPage {
-  rows: Draft[]
-  totalCount: number
-  page: number
-  pageSize: number
-  pageCount: number
-}
+export type DraftListPage = Page<Draft>
 
 /**
- * Apply offset-based pagination to a sorted+filtered list. Page is
- * 1-indexed, clamped to [1, pageCount]. Out-of-range pages return the
- * last page rather than an empty result — keeps deep links to a
- * just-cleared page from rendering as "no drafts" when the reviewer
- * meant the new top of the list.
+ * Apply offset-based pagination to a sorted+filtered list. Thin wrapper over
+ * the shared {@link paginate} (see pagination.ts for the clamping contract);
+ * kept as a named export for call-site + test stability.
  */
 export function paginateDrafts(
   rows: readonly Draft[],
   page: number,
   pageSize: number
 ): DraftListPage {
-  const totalCount = rows.length
-  const pageCount = Math.max(1, Math.ceil(totalCount / pageSize))
-  const clampedPage = Math.min(Math.max(1, Math.floor(page)), pageCount)
-  const start = (clampedPage - 1) * pageSize
-  return {
-    rows: rows.slice(start, start + pageSize),
-    totalCount,
-    page: clampedPage,
-    pageSize,
-    pageCount,
-  }
+  return paginate(rows, page, pageSize)
 }
 
 /**

--- a/src/lib/portal/ai-employee/notifications.ts
+++ b/src/lib/portal/ai-employee/notifications.ts
@@ -40,6 +40,7 @@
  */
 
 import type { SubscriptionRow } from '../product-access'
+import { type Page, paginate } from './pagination'
 
 /**
  * Closed vocabulary of notification kinds. Each maps to one of the
@@ -233,41 +234,19 @@ export function applyNotificationSort(
   }
 }
 
-/**
- * Pagination return value. Same shape as the drafts and audit
- * resolvers so the page can share the table primitive's pagination
- * contract. `pageCount` is floored at 1 even when there are zero rows
- * so "Page 1 of 1" reads sensibly in the empty state.
- */
-export interface NotificationListPage {
-  rows: Notification[]
-  totalCount: number
-  page: number
-  pageSize: number
-  pageCount: number
-}
+/** Pagination return value. See {@link Page} (pagination.ts). */
+export type NotificationListPage = Page<Notification>
 
 /**
- * Apply offset-based pagination to a sorted+filtered list. Page is
- * 1-indexed, clamped to [1, pageCount]. Out-of-range pages return the
- * last page rather than an empty result.
+ * Apply offset-based pagination to a sorted+filtered list. Thin wrapper over
+ * the shared {@link paginate}; kept named for call-site + test stability.
  */
 export function paginateNotifications(
   rows: readonly Notification[],
   page: number,
   pageSize: number
 ): NotificationListPage {
-  const totalCount = rows.length
-  const pageCount = Math.max(1, Math.ceil(totalCount / pageSize))
-  const clampedPage = Math.min(Math.max(1, Math.floor(page)), pageCount)
-  const start = (clampedPage - 1) * pageSize
-  return {
-    rows: rows.slice(start, start + pageSize),
-    totalCount,
-    page: clampedPage,
-    pageSize,
-    pageCount,
-  }
+  return paginate(rows, page, pageSize)
 }
 
 /**

--- a/src/lib/portal/ai-employee/pagination.ts
+++ b/src/lib/portal/ai-employee/pagination.ts
@@ -1,0 +1,35 @@
+/**
+ * Generic offset-based pagination for the AI Employee portal list surfaces.
+ *
+ * The drafts / notifications / audit / calendar resolvers each carried a
+ * byte-identical `paginate*` function and a structurally-identical `*ListPage`
+ * interface. This is the single source; each surface keeps its named wrapper +
+ * type alias for call-site stability, delegating here.
+ *
+ * Page is 1-indexed and clamped to `[1, pageCount]`. Out-of-range pages return
+ * the last page rather than an empty result — keeps a deep link to a
+ * just-cleared page from rendering as "nothing here" when the reviewer meant
+ * the new top of the list. `pageCount` is floored at 1 even with zero rows so
+ * "Page 1 of 1" reads sensibly in the empty state.
+ */
+export interface Page<T> {
+  rows: T[]
+  totalCount: number
+  page: number
+  pageSize: number
+  pageCount: number
+}
+
+export function paginate<T>(rows: readonly T[], page: number, pageSize: number): Page<T> {
+  const totalCount = rows.length
+  const pageCount = Math.max(1, Math.ceil(totalCount / pageSize))
+  const clampedPage = Math.min(Math.max(1, Math.floor(page)), pageCount)
+  const start = (clampedPage - 1) * pageSize
+  return {
+    rows: rows.slice(start, start + pageSize),
+    totalCount,
+    page: clampedPage,
+    pageSize,
+    pageCount,
+  }
+}

--- a/tests/portal-ai-employee-pagination.test.ts
+++ b/tests/portal-ai-employee-pagination.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Tests for the shared generic paginate<T> (src/lib/portal/ai-employee/
+ * pagination.ts). This is the single source the drafts/notifications/audit/
+ * calendar resolvers delegate to; their per-surface suites cover the wrappers,
+ * this pins the generic's clamping contract directly.
+ */
+import { describe, expect, it } from 'vitest'
+
+import { type Page, paginate } from '../src/lib/portal/ai-employee/pagination'
+
+const rows = Array.from({ length: 25 }, (_, i) => i + 1) // 1..25
+
+describe('paginate<T>', () => {
+  it('returns the first page and a floored-at-1 pageCount', () => {
+    const p = paginate(rows, 1, 10)
+    expect(p.rows).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+    expect(p.totalCount).toBe(25)
+    expect(p.page).toBe(1)
+    expect(p.pageSize).toBe(10)
+    expect(p.pageCount).toBe(3)
+  })
+
+  it('slices the requested middle page', () => {
+    expect(paginate(rows, 2, 10).rows).toEqual([11, 12, 13, 14, 15, 16, 17, 18, 19, 20])
+  })
+
+  it('returns the partial last page', () => {
+    expect(paginate(rows, 3, 10).rows).toEqual([21, 22, 23, 24, 25])
+  })
+
+  it('clamps an out-of-range high page to the last page (not empty)', () => {
+    const p = paginate(rows, 99, 10)
+    expect(p.page).toBe(3)
+    expect(p.rows).toEqual([21, 22, 23, 24, 25])
+  })
+
+  it('clamps page < 1 and non-integers up to page 1', () => {
+    expect(paginate(rows, 0, 10).page).toBe(1)
+    expect(paginate(rows, -5, 10).page).toBe(1)
+    expect(paginate(rows, 1.9, 10).page).toBe(1)
+  })
+
+  it('empty input yields page 1 of 1 with no rows', () => {
+    const p: Page<number> = paginate([], 1, 10)
+    expect(p.rows).toEqual([])
+    expect(p.totalCount).toBe(0)
+    expect(p.page).toBe(1)
+    expect(p.pageCount).toBe(1)
+  })
+
+  it('accepts a readonly array and returns a mutable rows array', () => {
+    const ro: readonly number[] = [1, 2, 3]
+    const p = paginate(ro, 1, 2)
+    p.rows.push(99) // compiles + runs: rows is T[], not readonly
+    expect(p.rows).toEqual([1, 2, 99])
+  })
+})


### PR DESCRIPTION
## What
Single-sources the four byte-identical `paginate*` functions in the AI Employee portal resolvers into one generic `paginate<T>`.

## Why (verified P1-1)
`drafts.ts`, `notifications.ts`, `audit.ts`, `calendar.ts` each carried a byte-for-byte identical pagination function (differing only in the row type and the `*ListPage` return-type name) plus a structurally-identical `*ListPage` interface — confirmed by `diff` of the function bodies.

## How
- New `src/lib/portal/ai-employee/pagination.ts` — `paginate<T>(rows, page, pageSize): Page<T>` with the clamping contract (1-indexed, clamped to `[1, pageCount]`, out-of-range → last page, `pageCount` floored at 1).
- Each surface keeps its named `paginate*` wrapper (call-site + test stability) delegating to the generic; each `*ListPage` becomes a `Page<T>` alias.

## Verification
- Typecheck: **0 errors**
- Per-surface suites: drafts 33, notifications 43, audit 48, calendar 41 — all pass
- New generic test: **7 cases** pinning clamp/empty/readonly contract
- Behavior-preserving; net duplication removed (the contract now lives in one place a future edit can't desync)

Refs: VERIFIED review P1-1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
