### PR TITLE
feat(schema): add real FKs to config_change_audit governance ledger

### DIFF
--- a/migrations/0047_config_change_audit_fks.sql
+++ b/migrations/0047_config_change_audit_fks.sql
@@ -1,0 +1,98 @@
+-- ============================================================================
+-- Migration 0047: add real FOREIGN KEY constraints to config_change_audit
+-- ============================================================================
+--
+-- 0046 created config_change_audit (the control-plane governance ledger, ADR
+-- 0026 / ADR 0030) with entity_id and actor_user_id as bare TEXT NOT NULL —
+-- no REFERENCES. Every sibling table (cost_anomaly_alerts, matter_assignments,
+-- product_roles, ...) FK-constrains those. This migration brings the ledger
+-- in line so an auditor reading the DDL sees declared referential integrity:
+--   entity_id     -> entities(id)
+--   actor_user_id -> users(id)
+--
+-- SQLite has no ALTER TABLE ADD CONSTRAINT, so a constraint add is a table
+-- rebuild (create new -> copy -> drop old -> rename -> recreate indexes), the
+-- pattern proven in migration 0035. config_change_audit has NO child tables
+-- (nothing REFERENCES it), so this is the SIMPLE single-table case — no FK-chain
+-- dance, unlike 0035's users rebuild.
+--
+-- EMPTINESS + EVIDENCE ENVELOPE:
+--   A Captain-authorized read-only count at authoring time showed
+--   config_change_audit has 0 rows in prod (no governance action recorded yet),
+--   so the copy step moves zero rows and there is no historical chain-of-custody
+--   to preserve.
+--
+--   MANDATORY PRE-FLIGHT (run immediately before applying, mirrors 0035):
+--     npx wrangler d1 execute ss-console-db --remote \
+--       --command "SELECT COUNT(*) AS n FROM config_change_audit"
+--   The count MUST be 0. If rows exist (someone used the trust-ceiling /
+--   skill-toggle portal flow between authoring and deploy), DO NOT APPLY this
+--   migration — re-author it with the populated-ledger evidence envelope
+--   (pre/post per-row hash + retain config_change_audit_legacy + no backfill).
+--   A SQL-level RAISE guard is not used here: RAISE() is only legal inside a
+--   trigger, and adding a trigger to a ledger mid-rebuild is more surface than
+--   the human pre-flight check warrants for a one-time, verified-empty table.
+--
+-- Append-only semantics, FK enforcement note:
+--   D1/Workers does not set PRAGMA foreign_keys=ON per connection, so these FKs
+--   are NOT runtime-enforced today — they document referential integrity in the
+--   DDL for audit-readiness (the stated goal). App-side, recordConfigChangeAudit
+--   already supplies entity_id/actor_user_id from authenticated principal
+--   context. If runtime enforcement is later turned on, these constraints are
+--   already in place.
+--
+-- D1 wraps this file in a single atomic transaction; a partial-apply half-state
+-- is not a risk. Manual rollback: migrations/rollbacks/0047_config_change_audit_fks_down.sql
+-- ============================================================================
+
+PRAGMA defer_foreign_keys = ON;
+
+-- (Emptiness is enforced by the MANDATORY PRE-FLIGHT count documented in the
+-- header, not by an in-SQL RAISE — RAISE() is trigger-only in SQLite.)
+
+-- Step 1: new table, identical columns + CHECKs, with FKs added.
+CREATE TABLE config_change_audit_new (
+  id              INTEGER PRIMARY KEY AUTOINCREMENT,
+  customer_slug   TEXT NOT NULL,
+  entity_id       TEXT NOT NULL REFERENCES entities(id),
+  source          TEXT NOT NULL DEFAULT 'portal_intent'
+                    CHECK (source IN ('portal_intent', 'runtime_confirmed')),
+  actor_user_id   TEXT NOT NULL REFERENCES users(id),
+  actor_email     TEXT NOT NULL,
+  actor_role      TEXT NOT NULL,
+  change_type     TEXT NOT NULL
+                    CHECK (change_type IN ('trust_ceiling', 'action_ceiling', 'skill_toggle')),
+  persona_slug    TEXT,
+  skill_name      TEXT,
+  action_class    TEXT,
+  old_value       TEXT,
+  new_value       TEXT,
+  outcome         TEXT NOT NULL
+                    CHECK (outcome IN ('accepted', 'rejected_floor', 'rejected_invalid')),
+  outcome_reason  TEXT,
+  direction       TEXT NOT NULL DEFAULT 'n/a'
+                    CHECK (direction IN ('raise', 'lower', 'lateral', 'n/a')),
+  created_at      TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+
+-- Step 2: copy rows (zero today; the guard above proved emptiness). Explicit
+-- column list so a future column drift surfaces as an error, not a silent skip.
+INSERT INTO config_change_audit_new
+  (id, customer_slug, entity_id, source, actor_user_id, actor_email, actor_role,
+   change_type, persona_slug, skill_name, action_class, old_value, new_value,
+   outcome, outcome_reason, direction, created_at)
+SELECT
+   id, customer_slug, entity_id, source, actor_user_id, actor_email, actor_role,
+   change_type, persona_slug, skill_name, action_class, old_value, new_value,
+   outcome, outcome_reason, direction, created_at
+FROM config_change_audit;
+
+-- Step 3: drop old, rename new into place.
+DROP TABLE config_change_audit;
+ALTER TABLE config_change_audit_new RENAME TO config_change_audit;
+
+-- Step 4: recreate the indexes (the rebuild dropped them with the old table).
+CREATE INDEX IF NOT EXISTS idx_cca_slug_created
+  ON config_change_audit (customer_slug, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_cca_entity_created
+  ON config_change_audit (entity_id, created_at DESC);

--- a/migrations/rollbacks/0047_config_change_audit_fks_down.sql
+++ b/migrations/rollbacks/0047_config_change_audit_fks_down.sql
@@ -1,0 +1,58 @@
+-- Manual rollback for migration 0047. NOT auto-applied.
+-- See migrations/rollbacks/README.md.
+--
+-- Reverses the FK add by rebuilding config_change_audit WITHOUT the
+-- entity_id -> entities(id) / actor_user_id -> users(id) REFERENCES (back to
+-- the 0046 shape: bare TEXT NOT NULL). Single-table rebuild; no child tables.
+--
+-- Pre-flight (run before applying this rollback), same as the forward migration:
+--   npx wrangler d1 execute ss-console-db --remote \
+--     --command "SELECT COUNT(*) AS n FROM config_change_audit"
+-- Count MUST be 0. If rows exist, handle the populated case explicitly (this
+-- rollback copies rows through a table rebuild and is authored for the empty
+-- case 0047 applies to). RAISE() is trigger-only in SQLite, so the guard is the
+-- human pre-flight, not in-SQL.
+
+PRAGMA defer_foreign_keys = ON;
+
+CREATE TABLE config_change_audit_old (
+  id              INTEGER PRIMARY KEY AUTOINCREMENT,
+  customer_slug   TEXT NOT NULL,
+  entity_id       TEXT NOT NULL,
+  source          TEXT NOT NULL DEFAULT 'portal_intent'
+                    CHECK (source IN ('portal_intent', 'runtime_confirmed')),
+  actor_user_id   TEXT NOT NULL,
+  actor_email     TEXT NOT NULL,
+  actor_role      TEXT NOT NULL,
+  change_type     TEXT NOT NULL
+                    CHECK (change_type IN ('trust_ceiling', 'action_ceiling', 'skill_toggle')),
+  persona_slug    TEXT,
+  skill_name      TEXT,
+  action_class    TEXT,
+  old_value       TEXT,
+  new_value       TEXT,
+  outcome         TEXT NOT NULL
+                    CHECK (outcome IN ('accepted', 'rejected_floor', 'rejected_invalid')),
+  outcome_reason  TEXT,
+  direction       TEXT NOT NULL DEFAULT 'n/a'
+                    CHECK (direction IN ('raise', 'lower', 'lateral', 'n/a')),
+  created_at      TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+
+INSERT INTO config_change_audit_old
+  (id, customer_slug, entity_id, source, actor_user_id, actor_email, actor_role,
+   change_type, persona_slug, skill_name, action_class, old_value, new_value,
+   outcome, outcome_reason, direction, created_at)
+SELECT
+   id, customer_slug, entity_id, source, actor_user_id, actor_email, actor_role,
+   change_type, persona_slug, skill_name, action_class, old_value, new_value,
+   outcome, outcome_reason, direction, created_at
+FROM config_change_audit;
+
+DROP TABLE config_change_audit;
+ALTER TABLE config_change_audit_old RENAME TO config_change_audit;
+
+CREATE INDEX IF NOT EXISTS idx_cca_slug_created
+  ON config_change_audit (customer_slug, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_cca_entity_created
+  ON config_change_audit (entity_id, created_at DESC);

--- a/tests/config-governance.test.ts
+++ b/tests/config-governance.test.ts
@@ -35,7 +35,34 @@ const migrationsDir = resolve(process.cwd(), 'migrations')
 async function freshDb(): Promise<D1Database> {
   const db = createTestD1()
   await runMigrations(db, { files: discoverNumericMigrations(migrationsDir) })
+  await seedParents(db)
   return db
+}
+
+/**
+ * Seed the FK parents config_change_audit now requires (migration 0047 added
+ * entity_id -> entities(id) and actor_user_id -> users(id); the test harness
+ * runs with PRAGMA foreign_keys=ON). The recordConfigChangeAudit calls below
+ * reference ACTOR.user_id and entity-1..4, so insert one org, the actor user,
+ * and those entities. Minimal valid rows — only the columns each table
+ * requires NOT NULL without a default.
+ */
+async function seedParents(db: D1Database): Promise<void> {
+  await db
+    .prepare("INSERT INTO organizations (id, name, slug) VALUES ('org-1', 'Test Org', 'test-org')")
+    .run()
+  await db
+    .prepare(
+      "INSERT INTO users (id, org_id, email, name, role) VALUES (?, 'org-1', ?, 'Owner', 'client')"
+    )
+    .bind(ACTOR.user_id, ACTOR.email)
+    .run()
+  for (const id of ['entity-1', 'entity-2', 'entity-3', 'entity-4']) {
+    await db
+      .prepare("INSERT INTO entities (id, org_id, name, slug) VALUES (?, 'org-1', ?, ?)")
+      .bind(id, `Entity ${id}`, id)
+      .run()
+  }
 }
 
 const ACTOR = { user_id: 'user-1', email: 'owner@firm.test', role: 'principal' }


### PR DESCRIPTION
## What
Adds real `FOREIGN KEY` constraints to the `config_change_audit` governance ledger (the Captain-locked "rebuild with real FKs" decision).

## Why (verified S-1)
`0046` created `config_change_audit` (control-plane governance ledger, ADR 0026/0030) with `entity_id` and `actor_user_id` as bare `TEXT NOT NULL` — no `REFERENCES`, unlike every sibling table. `0047` rebuilds it with:
- `entity_id     → entities(id)`
- `actor_user_id → users(id)`

SQLite has no `ALTER TABLE ADD CONSTRAINT`, so this is the table-rebuild pattern from `0035` — but the **simple single-table case**: nothing `REFERENCES config_change_audit`, so no FK-chain dance.

## Empty-ledger + evidence envelope
A **Captain-authorized read-only prod count** showed `config_change_audit` has **0 rows** (no governance action recorded yet) → the copy step moves zero rows; no compliance chain-of-custody to preserve. The migration header documents a **mandatory pre-flight count (must be 0)** before apply; if rows exist at deploy, re-author with the populated-ledger envelope (pre/post row-hash + retain `_legacy` + no backfill). No in-SQL `RAISE` guard — `RAISE()` is trigger-only in SQLite (**caught in round-trip testing**).

## FK enforcement note
D1/Workers doesn't set `PRAGMA foreign_keys=ON` per connection, so these FKs document referential integrity in the **DDL for audit-readiness**; they're not runtime-enforced today (app-side `recordConfigChangeAudit` already supplies both ids from authenticated principal context). The test harness *does* enable the pragma — which surfaced an incomplete fixture (it inserted audit rows without parent `entities`/`users`); fixed by seeding parents in `freshDb()`.

## Verification (executed)
- Round-trip on scratch sqlite: all 50 migrations apply; after `0047`, `config_change_audit` has **2 FKs** (users, entities) + 17 cols + both indexes; after rollback, **0 FKs** (bare TEXT) + indexes preserved.
- `config-governance.test.ts`: **15/15** (with FK enforced + parents seeded).
- Pre-push `npm run verify`: full suite green.

Paired rollback: `rollbacks/0047_config_change_audit_fks_down.sql`.

Refs: VERIFIED review S-1; Captain "rebuild with real FKs"; prod count = 0 (authorized 2026-06-01).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
