### PR TITLE
fix(customer-yaml): type + validate persona override blobs (was unknown)

### DIFF
--- a/src/lib/ai-employee/customer-yaml/sections-personas.ts
+++ b/src/lib/ai-employee/customer-yaml/sections-personas.ts
@@ -111,12 +111,42 @@ function checkOnePersona(
     pronouns: pronouns,
     send_as: sendAs,
     skills,
-    voice_overrides: p['voice_overrides'] ?? null,
-    escalation_overrides: p['escalation_overrides'] ?? null,
+    voice_overrides: checkOverrideBlob(
+      p['voice_overrides'],
+      `personas[${i}].voice_overrides`,
+      errors
+    ),
+    escalation_overrides: checkOverrideBlob(
+      p['escalation_overrides'],
+      `personas[${i}].escalation_overrides`,
+      errors
+    ),
     channel_bindings: channelBindings,
     bundles,
     cron,
   }
+}
+
+/**
+ * Validate a free-form per-persona override blob. Absent → null. A plain
+ * object is carried verbatim (internal shape is intentionally open). Any other
+ * authored value (string, number, array) is a malformed override → push an
+ * error and coerce to null rather than silently passing a scalar through, which
+ * the prior `unknown` typing allowed.
+ */
+function checkOverrideBlob(
+  value: unknown,
+  path: string,
+  errors: ValidationError[]
+): Record<string, unknown> | null {
+  if (value === undefined || value === null) return null
+  if (isPlainObject(value)) return value
+  errors.push({
+    code: 'TypeMismatch',
+    path,
+    message: `${path} must be a mapping (object) or absent`,
+  })
+  return null
 }
 
 function checkPersonaSlug(

--- a/src/lib/ai-employee/customer-yaml/types.ts
+++ b/src/lib/ai-employee/customer-yaml/types.ts
@@ -323,8 +323,13 @@ export interface Persona {
   pronouns: Pronouns | null
   send_as: PersonaSendAs | null
   skills: PersonaSkill[]
-  voice_overrides: unknown
-  escalation_overrides: unknown
+  // Free-form per-persona override blobs (object or absent). Typed as an object
+  // map rather than `unknown` so the validator can gate them to plain-object /
+  // null — a malformed scalar is rejected, not silently carried. Their internal
+  // shape is deliberately open; no consumer destructures them today, so
+  // structuring is a future change for when one does.
+  voice_overrides: Record<string, unknown> | null
+  escalation_overrides: Record<string, unknown> | null
   channel_bindings: PersonaChannelBinding[]
   /** Skill bundles declared by this persona — ADR 0021 Stream D. */
   bundles: PersonaBundle[]

--- a/tests/customer-yaml-validator.test.ts
+++ b/tests/customer-yaml-validator.test.ts
@@ -498,6 +498,37 @@ describe('validate — personas[]', () => {
     }
     expect(r.value.personas).toHaveLength(2)
   })
+
+  it('accepts a plain-object voice_overrides / escalation_overrides', () => {
+    const f = validFixture()
+    const persona = (f['personas'] as Array<Record<string, unknown>>)[0]
+    persona['voice_overrides'] = { greeting: 'Hi' }
+    persona['escalation_overrides'] = { after_hours: 'page' }
+    const r = validate(f)
+    if (!r.ok) throw new Error(`expected ok; got: ${JSON.stringify(r.errors)}`)
+    expect(r.value.personas[0].voice_overrides).toEqual({ greeting: 'Hi' })
+    expect(r.value.personas[0].escalation_overrides).toEqual({ after_hours: 'page' })
+  })
+
+  it('absent overrides resolve to null (no error)', () => {
+    const f = validFixture()
+    const r = validate(f)
+    if (!r.ok) throw new Error(`expected ok; got: ${JSON.stringify(r.errors)}`)
+    expect(r.value.personas[0].voice_overrides).toBeNull()
+    expect(r.value.personas[0].escalation_overrides).toBeNull()
+  })
+
+  it('rejects a non-object override (the gate the old `unknown` typing skipped)', () => {
+    const f = validFixture()
+    const persona = (f['personas'] as Array<Record<string, unknown>>)[0]
+    persona['voice_overrides'] = 'not-an-object'
+    const r = validate(f)
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(
+      r.errors.some((e) => e.path === 'personas[0].voice_overrides' && e.code === 'TypeMismatch')
+    ).toBe(true)
+  })
 })
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
## What
Types and validates the two persona override blobs that were `unknown`.

## Why (verified S-6)
`Persona.voice_overrides` and `escalation_overrides` were typed `unknown` and parsed with a bare `?? null` passthrough — the two override fields that change agent behavior bypassed all validation, so an authored scalar (string/number/array) was silently carried instead of rejected.

## How
- **types.ts:** re-type both as `Record<string, unknown> | null` (object-or-absent), matching the actual contract. Internal shape left deliberately open — no consumer destructures them today; inventing a schema would be premature (structuring is a future change for when one does).
- **sections-personas.ts:** new `checkOverrideBlob()` gate — absent → `null`, plain object → carried verbatim, anything else → `TypeMismatch` error + coerce `null`. Closes the validation hole.

## Verification
- 3 new tests (object accepted, absent → null, non-object rejected with `TypeMismatch` at `personas[i].voice_overrides`)
- `customer-yaml-validator`: **165/165**
- Full suite green (behavior-preserving for valid configs)

Refs: VERIFIED review S-6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
