### PR TITLE
feat(ai-employee): wire voice ingestion — corpus to content-free vault samples

### DIFF
--- a/.github/workflows/ai-employee-substrate.yml
+++ b/.github/workflows/ai-employee-substrate.yml
@@ -65,4 +65,7 @@ jobs:
 
       - name: Run pytest suites (adapter + evidence + pytest-style invariants)
         working-directory: ai-employee
-        run: python3 -m pytest adapter/tests adapter/evidence/tests safety-substrate/tests -q
+        # bin/tests/test_voice_corpus.py is named explicitly: the rest of bin/tests
+        # needs substrate deps (pyyaml etc.) not installed in this bare-pytest env,
+        # but the voice-corpus tracer lib imports only adapter.voice + stdlib.
+        run: python3 -m pytest adapter/tests adapter/evidence/tests safety-substrate/tests bin/tests/test_voice_corpus.py -q

--- a/ai-employee/bin/lib/voice_corpus.py
+++ b/ai-employee/bin/lib/voice_corpus.py
@@ -1,0 +1,277 @@
+"""Voice-corpus tracer: turn the author's own writing into vault samples.
+
+The sample-driven voice subsystem was built end-to-end but never wired: the
+ingestion runner (``adapter.voice.pipeline.VoiceIngestionRunner``) is an
+email-sent-folder watcher with no operational caller, so the per-customer R2
+voice vault is never populated and the plugin stays INACTIVE. This module is
+the tracer-bullet wiring: a one-shot path that turns a curated corpus of the
+author's own messages into the exact structural-diff JSON the runtime reader
+(``hermes-smd-voice`` ``R2VaultSampleReader``) consumes.
+
+It deliberately reuses the REAL fidelity-critical primitive —
+:func:`adapter.voice.extract_structural_diff` — and the REAL R2 key/format
+contract. It does NOT drag in the email-watcher orchestration (cursor,
+sent-folder, partner-authored filter); that machinery is irrelevant to a
+curated one-shot corpus and belongs to the durable ingestion follow-up.
+
+Privacy posture
+---------------
+``extract_structural_diff`` is content-free by construction: every field is a
+count, a categorical enum (``greeting_style`` etc. are assigned
+``_classify_*(body).value``), a numeric histogram, or the cohort tag. No raw
+prose survives. :func:`assert_style_only` is the enforced invariant on that
+guarantee — it fails the ingest if any string value in the emitted JSON falls
+outside the closed style vocabulary, so a future change that let literal text
+leak into a sample would break the build rather than ship the leak.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Iterator
+
+from adapter.voice import GreetingStyle, SignoffStyle, extract_structural_diff
+
+# ---------------------------------------------------------------------------
+# Leak invariant
+# ---------------------------------------------------------------------------
+
+
+class VoiceLeakError(Exception):
+    """Raised when an emitted sample carries anything but style vocabulary.
+
+    A content leak in a voice sample is a P0 — the whole point of the
+    structural-diff format is that raw prose never reaches R2.
+    """
+
+
+def _style_vocabulary(cohort: str) -> frozenset[str]:
+    """The closed set of string values a content-free diff may contain.
+
+    Built from the enums at runtime so the allowlist tracks the schema
+    automatically. ``recipient_cohort`` is the only free-form string the
+    format carries, and it is a tag the caller controls (never derived
+    from the body), so the specific cohort is allowed too.
+    """
+    return frozenset(
+        [g.value for g in GreetingStyle]
+        + [s.value for s in SignoffStyle]
+        + [cohort]
+    )
+
+
+# Secret-shaped tokens that must never appear even inside an allowed field.
+_SECRET_PATTERNS = [
+    re.compile(r"sk-[A-Za-z0-9]{16,}"),
+    re.compile(r"AKIA[0-9A-Z]{12,}"),
+    re.compile(r"ghp_[A-Za-z0-9]{20,}"),
+    re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----"),
+    re.compile(r"xox[baprs]-[A-Za-z0-9-]{10,}"),
+]
+
+
+def _iter_strings(value: object) -> Iterator[str]:
+    """Yield every string anywhere in a JSON-ish structure."""
+    if isinstance(value, str):
+        yield value
+    elif isinstance(value, dict):
+        for k, v in value.items():
+            if isinstance(k, str):
+                yield k
+            yield from _iter_strings(v)
+    elif isinstance(value, (list, tuple)):
+        for item in value:
+            yield from _iter_strings(item)
+
+
+def assert_style_only(diff_dict: dict, *, cohort: str) -> None:
+    """Fail the ingest unless every string in ``diff_dict`` is style vocab.
+
+    The tightest possible check given the content-free format: any string
+    value outside the closed greeting/signoff vocabulary (plus the cohort
+    tag and the JSON keys themselves) means raw content leaked into a
+    field. Numeric fields are ignored. Also scans for secret-shaped tokens
+    as defense in depth.
+
+    Raises:
+        VoiceLeakError: on any out-of-vocabulary string or secret pattern.
+    """
+    allowed = _style_vocabulary(cohort)
+    known_keys = {
+        "schema_version",
+        "word_count",
+        "sentence_count",
+        "paragraph_count",
+        "subject_word_count",
+        "avg_sentence_length",
+        "sentence_length_distribution",
+        "greeting_style",
+        "signoff_style",
+        "opener_template",
+        "closer_template",
+        "punctuation_rhythm",
+        "recipient_cohort",
+        "lt_5",
+        "lt_10",
+        "lt_20",
+        "lt_35",
+        "gte_35",
+        "period_per_100",
+        "comma_per_100",
+        "semicolon_per_100",
+        "dash_per_100",
+        "question_per_100",
+        "exclamation_per_100",
+    }
+    for s in _iter_strings(diff_dict):
+        for pat in _SECRET_PATTERNS:
+            if pat.search(s):
+                raise VoiceLeakError(f"secret-shaped token in sample: {pat.pattern!r}")
+        if s in allowed or s in known_keys:
+            continue
+        raise VoiceLeakError(
+            f"non-style string in sample: {s!r} (not in greeting/signoff vocab, "
+            f"cohort {cohort!r}, or known JSON keys) — possible raw-content leak"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Sample construction (reuses the real differ)
+# ---------------------------------------------------------------------------
+
+VAULT_ROOT = "vaults/"
+
+
+@dataclass
+class BuiltSample:
+    sample_id: str
+    r2_key: str  # full bucket key, including the vaults/ root
+    diff_bytes: bytes
+    diff_dict: dict
+
+
+def build_sample(text: str, *, slug: str, cohort: str = "unassigned") -> BuiltSample:
+    """Run one corpus message through the real differ and the leak guard.
+
+    The R2 key matches the runtime contract exactly:
+    ``vaults/{slug}/voice/cohort/{cohort}/{sample_id}.json`` — the same
+    shape ``pipeline._ingest_one`` writes and ``R2VaultSampleReader`` reads.
+    """
+    diff = extract_structural_diff(body_text=text, subject="", recipient_cohort=cohort)
+    diff_dict = diff.as_dict()
+    assert_style_only(diff_dict, cohort=cohort)  # fail-closed before any write
+    sample_id = uuid.uuid4().hex
+    r2_key = f"{VAULT_ROOT}{slug}/voice/cohort/{cohort}/{sample_id}.json"
+    return BuiltSample(
+        sample_id=sample_id,
+        r2_key=r2_key,
+        diff_bytes=diff.to_json_bytes(),
+        diff_dict=diff_dict,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Corpus extraction (the author's role=user prose from CC transcripts)
+# ---------------------------------------------------------------------------
+
+# Markers of harness/tooling noise that is not the author's own writing.
+_NOISE_MARKERS = (
+    "<system-reminder>",
+    "<local-command-stdout>",
+    "<command-name>",
+    "<command-message>",
+    "<command-args>",
+    "[Request interrupted",
+    "Caveat: The messages below",
+    "stdout>",
+)
+
+
+def _is_prose(text: str, *, min_words: int) -> bool:
+    """Heuristic: is this the author's own prose, not tooling/code/noise?"""
+    t = text.strip()
+    if not t or any(m in t for m in _NOISE_MARKERS):
+        return False
+    if "```" in t:  # pasted code/fenced block
+        return False
+    if t.startswith("<") or t.startswith("{") or t.startswith("["):
+        return False
+    if len(t.split()) < min_words:
+        return False
+    # Reject paste-heavy blobs: lots of lines that look like code/indentation.
+    lines = [ln for ln in t.splitlines() if ln.strip()]
+    if lines:
+        codeish = sum(1 for ln in lines if ln.startswith(("    ", "\t")) or ln.rstrip().endswith((";", "{", "}", ")")))
+        if codeish / len(lines) > 0.4:
+            return False
+    return True
+
+
+def _text_from_content(content: object) -> str:
+    """Pull the user-authored text from a transcript message's content."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for block in content:
+            if isinstance(block, dict) and block.get("type") == "text":
+                txt = block.get("text")
+                if isinstance(txt, str):
+                    parts.append(txt)
+        return "\n".join(parts)
+    return ""
+
+
+def extract_user_messages(
+    transcript_path: Path, *, min_words: int = 12
+) -> Iterator[str]:
+    """Yield the author's own prose messages from one CC transcript .jsonl.
+
+    Reads ``role == 'user'`` turns, takes only text blocks (never
+    tool_result), and filters harness noise and pasted code. Defensive
+    against malformed lines — a bad line is skipped, never fatal.
+    """
+    try:
+        raw = transcript_path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except (ValueError, TypeError):
+            continue
+        message = obj.get("message") if isinstance(obj, dict) else None
+        if not isinstance(message, dict) or message.get("role") != "user":
+            continue
+        text = _text_from_content(message.get("content"))
+        if _is_prose(text, min_words=min_words):
+            yield text.strip()
+
+
+def extract_corpus(
+    transcript_paths: Iterable[Path], *, min_words: int = 12, limit: int | None = None
+) -> list[dict]:
+    """Collect curated corpus samples across transcripts.
+
+    Returns a list of ``{"id", "source", "text"}`` dicts. De-duplicates
+    on exact text so repeated boilerplate doesn't dominate the profile.
+    """
+    seen: set[str] = set()
+    out: list[dict] = []
+    for path in transcript_paths:
+        for text in extract_user_messages(path, min_words=min_words):
+            key = text.strip()
+            if key in seen:
+                continue
+            seen.add(key)
+            out.append({"id": uuid.uuid4().hex, "source": path.name, "text": text})
+            if limit is not None and len(out) >= limit:
+                return out
+    return out

--- a/ai-employee/bin/tests/test_voice_corpus.py
+++ b/ai-employee/bin/tests/test_voice_corpus.py
@@ -1,0 +1,172 @@
+"""Tests for bin/lib/voice_corpus.py — the voice-tracer ingest wiring.
+
+Covers the three things that make this safe and useful:
+
+* The leak invariant (assert_style_only) passes on a real content-free
+  diff, and FAILS on a planted raw string and on a secret-shaped token —
+  the privacy guarantee is enforced, not asserted.
+* build_sample reuses the real differ, emits the exact runtime R2 key
+  shape, and the emitted JSON contains none of the source words.
+* Corpus extraction pulls the author's prose and filters harness noise,
+  tool_result blocks, pasted code, and trivially short turns.
+
+Run::
+
+    cd ai-employee && python -m pytest bin/tests/test_voice_corpus.py -v
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_HERE = Path(__file__).resolve()
+sys.path.insert(0, str(_HERE.parents[2]))  # ai-employee/ on sys.path
+
+from bin.lib.voice_corpus import (  # noqa: E402
+    VoiceLeakError,
+    assert_style_only,
+    build_sample,
+    extract_corpus,
+    extract_user_messages,
+)
+
+# A terse, declarative message in the author's register — no greeting/signoff.
+_SCOTT_STYLE = (
+    "Stop. Verify the secret values, not just the keys. "
+    "We ship through PRs. Never push to main. Figure it out."
+)
+
+
+# ---------------------------------------------------------------------------
+# Leak invariant
+# ---------------------------------------------------------------------------
+
+
+def test_assert_style_only_passes_on_real_diff():
+    sample = build_sample(_SCOTT_STYLE, slug="smd", cohort="unassigned")
+    # build_sample already runs the guard; assert it directly too.
+    assert_style_only(sample.diff_dict, cohort="unassigned")
+
+
+def test_assert_style_only_fails_on_planted_raw_string():
+    """The core safety proof: a literal body fragment in any field aborts."""
+    leaky = {
+        "greeting_style": "none",
+        "signoff_style": "none",
+        "opener_template": "Hey Sarah, here is the wire transfer for the Henderson matter",
+        "punctuation_rhythm": {"period_per_100": 10.0},
+        "recipient_cohort": "unassigned",
+    }
+    with pytest.raises(VoiceLeakError):
+        assert_style_only(leaky, cohort="unassigned")
+
+
+def test_assert_style_only_fails_on_secret_token():
+    leaky = {
+        "greeting_style": "none",
+        "closer_template": "sk-abcdef0123456789abcdef",
+        "recipient_cohort": "unassigned",
+    }
+    with pytest.raises(VoiceLeakError):
+        assert_style_only(leaky, cohort="unassigned")
+
+
+def test_cohort_tag_is_allowed_but_arbitrary_strings_are_not():
+    assert_style_only(
+        {"greeting_style": "none", "recipient_cohort": "law-firm-clients"},
+        cohort="law-firm-clients",
+    )
+    with pytest.raises(VoiceLeakError):
+        assert_style_only(
+            {"greeting_style": "none", "recipient_cohort": "law-firm-clients"},
+            cohort="unassigned",  # tag doesn't match the declared cohort
+        )
+
+
+# ---------------------------------------------------------------------------
+# build_sample
+# ---------------------------------------------------------------------------
+
+
+def test_build_sample_is_content_free():
+    """No source word survives into the emitted JSON."""
+    sample = build_sample(_SCOTT_STYLE, slug="smd", cohort="unassigned")
+    blob = sample.diff_bytes.decode("utf-8").lower()
+    for word in ["henderson", "wire", "secret", "transfer", "verify", "ship", "main"]:
+        assert word not in blob, f"source word {word!r} leaked into the sample JSON"
+
+
+def test_build_sample_r2_key_matches_runtime_contract():
+    sample = build_sample(_SCOTT_STYLE, slug="smd", cohort="unassigned")
+    assert sample.r2_key.startswith("vaults/smd/voice/cohort/unassigned/")
+    assert sample.r2_key.endswith(".json")
+    # round-trips as JSON with the expected style fields
+    parsed = json.loads(sample.diff_bytes)
+    assert parsed["greeting_style"] == "none"
+    assert "sentence_length_distribution" in parsed
+    assert "punctuation_rhythm" in parsed
+
+
+# ---------------------------------------------------------------------------
+# Corpus extraction
+# ---------------------------------------------------------------------------
+
+
+def _write_transcript(path: Path, events: list[dict]) -> None:
+    path.write_text("\n".join(json.dumps(e) for e in events), encoding="utf-8")
+
+
+def test_extract_user_messages_filters_noise(tmp_path):
+    transcript = tmp_path / "t.jsonl"
+    _write_transcript(
+        transcript,
+        [
+            # keep: real prose, role=user, string content
+            {"message": {"role": "user", "content": "Let's reverse course and fix this. Figure it out, please, and ship it cleanly."}},
+            # drop: system-reminder noise
+            {"message": {"role": "user", "content": "<system-reminder>do x</system-reminder> blah blah blah more words here"}},
+            # drop: assistant turn
+            {"message": {"role": "assistant", "content": "Sure, I will do that for you right away sir."}},
+            # drop: tool_result block (list content, non-text)
+            {"message": {"role": "user", "content": [{"type": "tool_result", "content": "exit 0"}]}},
+            # drop: pasted code fence
+            {"message": {"role": "user", "content": "```python\ndef f():\n    return 1\n```"}},
+            # drop: too short
+            {"message": {"role": "user", "content": "yes do it"}},
+            # keep: text block in a list
+            {"message": {"role": "user", "content": [{"type": "text", "text": "Many features of the harness must be configurable, including the send threshold."}]}},
+        ],
+    )
+    msgs = list(extract_user_messages(transcript, min_words=5))
+    assert len(msgs) == 2
+    assert any("reverse course" in m for m in msgs)
+    assert any("configurable" in m for m in msgs)
+
+
+def test_extract_corpus_dedupes_and_limits(tmp_path):
+    t1 = tmp_path / "a.jsonl"
+    t2 = tmp_path / "b.jsonl"
+    dup = {"message": {"role": "user", "content": "This exact sentence repeats across two different transcripts verbatim."}}
+    _write_transcript(t1, [dup])
+    _write_transcript(t2, [dup, {"message": {"role": "user", "content": "A second distinct message with enough words to pass the prose filter cleanly."}}])
+    corpus = extract_corpus([t1, t2], min_words=5)
+    texts = [c["text"] for c in corpus]
+    assert len(texts) == 2  # the duplicate is collapsed
+    corpus_limited = extract_corpus([t1, t2], min_words=5, limit=1)
+    assert len(corpus_limited) == 1
+
+
+def test_extract_corpus_malformed_lines_are_skipped(tmp_path):
+    transcript = tmp_path / "bad.jsonl"
+    transcript.write_text(
+        "not json\n"
+        + json.dumps({"message": {"role": "user", "content": "A perfectly good prose message with sufficient length to be kept."}})
+        + "\n{also not json",
+        encoding="utf-8",
+    )
+    corpus = extract_corpus([transcript], min_words=5)
+    assert len(corpus) == 1

--- a/ai-employee/bin/voice-corpus-extract.py
+++ b/ai-employee/bin/voice-corpus-extract.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Extract the author's own prose from Claude Code transcripts into a corpus.
+
+Tracer Stage 1. Reads ``role=user`` text turns from ``~/.claude/projects``
+transcripts, filters harness noise and pasted code, de-dupes, and writes a
+reviewable corpus JSONL (``{"id","source","text"}`` per line). The output is
+RAW prose and stays local — never uploaded. The ingest step turns it into
+content-free structural-diff samples.
+
+Usage::
+
+    cd ai-employee
+    python bin/voice-corpus-extract.py --out /tmp/scott-corpus.jsonl --limit 30
+    # review /tmp/scott-corpus.jsonl by eye, delete any sample you don't want
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).resolve()
+sys.path.insert(0, str(_HERE.parents[1]))  # ai-employee/ on sys.path
+
+from bin.lib.voice_corpus import extract_corpus  # noqa: E402
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description="Extract author prose from CC transcripts.")
+    p.add_argument("--projects-dir", default=str(Path.home() / ".claude" / "projects"))
+    p.add_argument("--glob", default="**/*.jsonl", help="Glob under --projects-dir.")
+    p.add_argument("--out", required=True, help="Corpus JSONL output path (local only).")
+    p.add_argument("--min-words", type=int, default=12)
+    p.add_argument("--limit", type=int, default=30)
+    args = p.parse_args(argv)
+
+    paths = sorted(Path(args.projects_dir).glob(args.glob))
+    corpus = extract_corpus(paths, min_words=args.min_words, limit=args.limit)
+    out = Path(args.out)
+    out.write_text(
+        "\n".join(json.dumps(s, ensure_ascii=False) for s in corpus),
+        encoding="utf-8",
+    )
+    print(f"extracted {len(corpus)} samples from {len(paths)} transcripts -> {out}")
+    print("REVIEW the corpus by eye before ingesting; it contains raw prose.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ai-employee/bin/voice-ingest-corpus.py
+++ b/ai-employee/bin/voice-ingest-corpus.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Ingest a curated voice corpus into the per-customer R2 vault (tracer).
+
+Tracer Stage 3. Reads the reviewed corpus JSONL, runs each message through
+the REAL differ (:func:`adapter.voice.extract_structural_diff`) and the
+fail-closed leak invariant (:func:`bin.lib.voice_corpus.assert_style_only`),
+and writes content-free structural-diff samples to the vault at the exact
+key the runtime reader consumes:
+``vaults/{slug}/voice/cohort/{cohort}/{id}.json``.
+
+Two modes:
+  --out-dir DIR  dry-run; write samples to a local mirror of the vault keys
+  --r2           upload to R2 using the R2_* env the Machine bootstrap sets
+
+The leak invariant runs in BOTH modes (it guards the emitted JSON, not the
+transport). A leak aborts the whole run non-zero before anything is written.
+
+Usage::
+
+    cd ai-employee
+    python bin/voice-ingest-corpus.py --corpus /tmp/scott-corpus.jsonl --out-dir /tmp/vault   # dry-run
+    python bin/voice-ingest-corpus.py --corpus /tmp/scott-corpus.jsonl --r2                    # upload
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).resolve()
+sys.path.insert(0, str(_HERE.parents[1]))  # ai-employee/ on sys.path
+
+from bin.lib.voice_corpus import VoiceLeakError, build_sample  # noqa: E402
+
+
+def _load_corpus(path: str) -> list[str]:
+    texts: list[str] = []
+    for line in Path(path).read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        obj = json.loads(line)
+        text = obj.get("text") if isinstance(obj, dict) else None
+        if isinstance(text, str) and text.strip():
+            texts.append(text)
+    return texts
+
+
+def _upload_r2(key: str, body: bytes) -> None:
+    import boto3  # lazy: only needed in --r2 mode
+
+    client = boto3.client(
+        "s3",
+        endpoint_url=os.environ["R2_ENDPOINT_URL"],
+        aws_access_key_id=os.environ["R2_ACCESS_KEY_ID"],
+        aws_secret_access_key=os.environ["R2_SECRET_ACCESS_KEY"],
+    )
+    client.put_object(
+        Bucket=os.environ["R2_BUCKET_CONFIG"],
+        Key=key,
+        Body=body,
+        ContentType="application/json",
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description="Ingest a curated voice corpus into the R2 vault.")
+    p.add_argument("--corpus", required=True, help="Reviewed corpus JSONL.")
+    p.add_argument("--slug", default="smd")
+    p.add_argument("--cohort", default="unassigned")
+    p.add_argument("--out-dir", help="Dry-run: write samples under this dir using vault keys.")
+    p.add_argument("--r2", action="store_true", help="Upload to R2 via R2_* env.")
+    p.add_argument("--limit", type=int)
+    args = p.parse_args(argv)
+
+    if not args.out_dir and not args.r2:
+        p.error("choose --out-dir (dry-run) or --r2 (upload)")
+
+    texts = _load_corpus(args.corpus)
+    if args.limit:
+        texts = texts[: args.limit]
+
+    written = 0
+    for text in texts:
+        try:
+            sample = build_sample(text, slug=args.slug, cohort=args.cohort)
+        except VoiceLeakError as e:
+            print(f"LEAK BLOCKED — aborting, nothing further written: {e}", file=sys.stderr)
+            return 3
+        if args.out_dir:
+            dest = Path(args.out_dir) / sample.r2_key
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            dest.write_bytes(sample.diff_bytes)
+        else:
+            _upload_r2(sample.r2_key, sample.diff_bytes)
+        written += 1
+
+    target = f"R2 bucket {os.environ.get('R2_BUCKET_CONFIG', '?')}" if args.r2 else args.out_dir
+    print(f"ingested {written} content-free samples -> {target} (slug={args.slug} cohort={args.cohort})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
The sample-driven voice subsystem was built end-to-end but **never wired**: `VoiceIngestionRunner` is an email sent-folder watcher with no operational caller, so the R2 voice vault is never populated and the plugin stays INACTIVE. This is the tracer wiring that fills the vault from the author's own writing.

- **`bin/lib/voice_corpus.py`** — reuses the REAL differ (`adapter.voice.extract_structural_diff`) and the REAL R2 key/format the runtime reader consumes (`vaults/{slug}/voice/cohort/{cohort}/{id}.json`). Plus a **fail-closed leak invariant** (`assert_style_only`) that aborts the ingest if any string in an emitted sample falls outside the closed greeting/signoff vocabulary or matches a secret pattern — the privacy guarantee is enforced, not asserted.
- **`bin/voice-corpus-extract.py`** — pulls the author's `role=user` prose from Claude Code transcripts; filters harness noise / `tool_result` / pasted code; dedupes.
- **`bin/voice-ingest-corpus.py`** — corpus → real differ → leak guard → vault; local `--out-dir` dry-run and `--r2` upload modes.

Proven end-to-end **locally on a real 25-message corpus**: emitted samples are content-free (no source word survives), and they render into a signal-bearing author-voice profile (pairs with overlay PR #28's render fix).

> Note: the email-tuned sentence splitter under-segments punctuation-light chat prose, inflating `avg_sentence_length`; the distribution histogram is the accurate signal. Filed as a follow-up refinement, not a blocker.

## Test plan
- [x] `pytest bin/tests/test_voice_corpus.py` — 9 passed (leak invariant passes on a real diff; **FAILS on a planted raw string and a secret token**; content-free guarantee; R2 key contract; extraction filtering)
- [x] wired `bin/tests/test_voice_corpus.py` into the substrate CI pytest command
- [x] manual end-to-end dry-run against real transcripts → content-free samples → signal-bearing render block

🤖 Generated with [Claude Code](https://claude.com/claude-code)