### PR TITLE
chore(ai-employee): bump OVERLAY_REF v0.4.3 -> v0.4.4 (voice render fix live)

### DIFF
--- a/ai-employee/templates/Dockerfile
+++ b/ai-employee/templates/Dockerfile
@@ -65,8 +65,12 @@ ARG HERMES_UPSTREAM_SHA=a91a57fa5a13d516c38b07a141a9ce8a3daabeb0
 # connectors into the profile's mcp_servers block (AgentMail is the first
 # vendor), bans the agentmail autonomous-send tools at the trust layer, and
 # makes the profile-config write atomic (recovers a root-owned config.yaml).
+# v0.4.4 adds the voice render-signal fix (#28): render_sample_block now surfaces
+# the stored rhythm signal (sentence-length distribution + punctuation), so the
+# pre_llm_call voice block can actually shape a draft instead of injecting a thin
+# greeting/signoff label. Superset of v0.4.3 (carries all webhook-gate work too).
 ARG OVERLAY_REPO="https://github.com/venturecrane/hermes-smd-overlay.git"
-ARG OVERLAY_REF="v0.4.3"
+ARG OVERLAY_REF="v0.4.4"
 
 ARG CUSTOMER_SLUG=customer-zero
 


### PR DESCRIPTION
## Summary
Bumps the per-customer Machine's overlay pin to **v0.4.4**, the current `hermes-smd-overlay` main HEAD. v0.4.4 is a strict superset of v0.4.3 (all webhook-gate work) plus the **voice render-signal fix (#28)** — `render_sample_block` now surfaces the sentence-length distribution + punctuation rhythm it already computed, so the `pre_llm_call` voice block carries real style signal instead of a thin greeting/signoff label.

Part of making sample-driven voice actually work (pairs with ingestion wiring PR #1179).

## Notes
- Pin-only change. The Machine rebuild that picks this up is **Captain/fleet-gated** and coordinates with the in-flight webhook-inbound deploy — v0.4.4 carries both workstreams, so it's safe to deploy as the single next tag.
- Pre-existing: overlay `pyproject` version (0.4.0) lags the release tags across v0.4.1–v0.4.4; that tag/version coherence is a repo-wide cleanup, filed separately rather than diverged here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)