### PR TITLE
feat(ai-employee): Telegram channel for Crane (native polling, env-enabled)

### DIFF
--- a/ai-employee/customers/smd/customer.yaml
+++ b/ai-employee/customers/smd/customer.yaml
@@ -109,6 +109,20 @@ webhook_triggers:
     skill: inbox-triage
     persona: crane
 
+# ---- TELEGRAM CHANNEL (ADR 0033) ----
+# Crane is reachable on Telegram via Hermes' native polling adapter (getUpdates) —
+# NO webhook/public surface (unlike AgentMail email above). It is enabled purely by
+# environment, NOT by this file: the Fly secrets TELEGRAM_BOT_TOKEN and
+# TELEGRAM_ALLOWED_USERS auto-enable the platform on boot. The image must be built
+# with the Dockerfile `--extra messaging` (python-telegram-bot); `--extra all` omits it.
+# Sourced from Infisical prod /ss/ai-employee/customer-zero/telegram/.
+# Allowlist = 7367659986 (Scott), DM-only — MANDATORY: the pinned ref fails OPEN on an
+# empty allowlist. Proven live 2026-06-01 (Scott DM'd, Crane replied autonomously).
+# NOT yet an authored config key here: a `telegram:` block + translate.py
+# _materialize_telegram_platform + a fail-closed launch guard are the documented
+# evolution (ADR 0033) to move the allowlist into reviewable config. Until then this
+# block is documentation only — the Fly secrets are the source of truth.
+
 # ---- SCOPE ----
 scope:
   email_folders_visible:

--- a/ai-employee/templates/Dockerfile
+++ b/ai-employee/templates/Dockerfile
@@ -138,7 +138,13 @@ RUN npm install --prefer-offline --no-audit \
  && (cd ui-tui && npm install --prefer-offline --no-audit) \
  && npm cache clean --force
 
-RUN uv sync --frozen --no-install-project --extra all
+# `--extra all` deliberately EXCLUDES the `messaging` extra (python-telegram-bot,
+# discord.py, slack-bolt) — verified against the pinned ref's pyproject. Without
+# `--extra messaging` the native Telegram adapter imports fail and the platform is
+# inert (TELEGRAM_AVAILABLE=False), so a TELEGRAM_BOT_TOKEN env would silently do
+# nothing. We add it explicitly: lock-governed (frozen) and forward-aligned with the
+# Slack/Discord channels the productized AI Employee will offer. See ADR 0033.
+RUN uv sync --frozen --no-install-project --extra all --extra messaging
 RUN cd web && npm run build && cd ../ui-tui && npm run build
 RUN uv pip install --no-cache-dir --no-deps -e "."
 

--- a/docs/adr/0033-telegram-channel-native-polling.md
+++ b/docs/adr/0033-telegram-channel-native-polling.md
@@ -1,0 +1,50 @@
+---
+title: Telegram Channel via Hermes Native Polling Adapter (env-enabled)
+date: 2026-06-01
+status: accepted
+captain: Scott Durgan
+related-adr: 0020-connector-strategy.md, 0021-leverage-hermes-native-primitives.md, 0025-autonomy-ceilings-configurable-exposure-vs-initiation.md, 0032-inbound-webhook-architecture.md
+related-issue: '#1166'
+---
+
+# ADR 0033 — Telegram Channel via Hermes Native Polling Adapter
+
+**Status:** Accepted (Captain decision, 2026-06-01). **Proven live on customer-zero:** Scott DM'd the bot ("Who's there?") and Crane replied autonomously ("Crane — your Chief of Staff. What do you need?"), recipient-locked to Scott, no operator, witnessed via screenshot.
+
+## Context
+
+The AI Employee needs to be reachable on the channels customers actually use. Email inbound was solved in [ADR 0032](0032-inbound-webhook-architecture.md) via a public webhook + front-door gate (AgentMail pushes). Telegram is the next channel and has a fundamentally simpler shape, verified against the pinned Hermes ref (`v2026.5.16@a91a57fa…`):
+
+- **Hermes ships a robust native Telegram adapter** (`gateway/platforms/telegram.py`) that uses **long-polling (`getUpdates`)** — the gateway makes outbound calls to Telegram. **No public URL, no webhook, no signature gate needed** (unlike email). The per-customer Machine already runs always-on, so it simply polls.
+- Setting **`TELEGRAM_BOT_TOKEN`** in the environment **auto-enables** the platform (`gateway/config.py:_apply_env_overrides`). `hermes … gateway run` launches it alongside the existing webhook platform — no bootstrap launch change.
+- **Two gotchas, both verified in source (not docs):**
+  1. **The image did not ship the Telegram SDK.** The Dockerfile installed `uv sync --extra all`, and `all` deliberately **excludes** the `messaging` extra that carries `python-telegram-bot`. Without it the adapter imports fail (`TELEGRAM_AVAILABLE=False`) and a `TELEGRAM_BOT_TOKEN` env would silently do nothing.
+  2. **The pinned ref fails OPEN on an empty allowlist.** `telegram.py`'s env-fallback authorizer is `if not allowed_csv: return True` — i.e. with `TELEGRAM_ALLOWED_USERS` unset, the bot answers **anyone** who finds it. (The published docs claim "denies all by default"; the pinned source does the opposite. Verify against source.) Setting the allowlist closes the risk under every code path.
+
+## Decision
+
+Wire Telegram as an **env-enabled native polling platform**, no new public surface:
+
+1. **Image:** add `--extra messaging` to the Dockerfile `uv sync` so `python-telegram-bot==22.6` (lock-governed) is present. Lean alternative (targeted single-package install) was considered; the lock-governed extra was chosen as it is also forward-aligned with the Slack/Discord channels the product will offer, and the build image already carries the toolchain (`build-essential`/`gcc`/`libffi-dev`) the extra's native deps need.
+2. **Credentials → Fly secrets:** `TELEGRAM_BOT_TOKEN` and `TELEGRAM_ALLOWED_USERS` are set as Fly secrets on the customer Machine (piped from Infisical `/ss/ai-employee/customer-zero/telegram/`, never displayed). The token auto-enables the platform; the allowlist (`7367659986`, Scott; DM-only) is **mandatory** to defeat the fail-open default.
+3. **No webhook, no gate, no overlay change** for Telegram. The overlay stays at its current ref; the channel is purely env + SDK.
+
+## Consequences
+
+- Crane is reachable on Telegram and replies autonomously, under the same trust-gate + content floor (ADR 0025/0031) as every other channel. Email inbound (ADR 0032) is unaffected — both run in one gateway.
+- The `--extra messaging` Dockerfile change is **load-bearing**: without it on `main`, any future rebuild silently drops the SDK and breaks Telegram. That is the reason this is committed rather than left as a one-off deploy.
+- Continuing always-on Fly cost (shared with the email-inbound requirement).
+- **Auxiliary-model note (non-blocking):** the live test surfaced `temperature is deprecated for this model` (HTTP 400) from the auxiliary title-generator, and openrouter/nous "payment/credit" errors. These are _auxiliary_ side-calls (chat-title generation); the primary agent (Anthropic Opus) is unaffected. Fix = top up / disable the aux providers or drop the deprecated `temperature` param.
+
+## Evolution (deferred, documented — not built now)
+
+The token+allowlist live as Fly secrets, which works but keeps the allowlist out of the reviewable config-as-source-of-truth. The product-grade shape, when a second customer needs it:
+
+- **`translate.py` `_materialize_telegram_platform`** (overlay repo) — emit a `telegram:` block (`allow_from`, `require_mention: false`, `reactions`) into the profile config from an authored `customer.yaml` `telegram:` section, mirroring `_materialize_webhook_platform`. The native-polling-platform seam; Slack/Discord reuse it.
+- **Fail-closed launch guard** in `bootstrap.sh` — if `TELEGRAM_BOT_TOKEN` is set but no allowlist is resolvable, refuse to launch, making the fail-open branch structurally unreachable in our deployment.
+- **Validator rule** — `telegram.allow_from` required + non-empty when the block is present (catches the fail-open trap pre-merge).
+- **`/sethome`** — set the Telegram home channel so cron/scheduled triage (#1166) can deliver into the chat.
+
+## Operational record (so the next session doesn't re-hunt)
+
+The Telegram credentials are in Infisical **prod** at **`/ss/ai-employee/customer-zero/telegram/`** (`TELEGRAM_BOT_TOKEN` + `TELEGRAM_ALLOWED_USERS`), captured by a VC-session agent on 2026-05-26 (handoff `[vc/venturecrane/crane-console] 2026-05-26T20:31Z`). Standing it up cost an hour of path-hunting because the handoff store was queried with a bare repo name (returns empty) instead of `venture` + full `owner/repo`, and the record was **cross-venture** (captured in VC, needed by SS). Lesson: at session start, read recent handoffs across both of a venture's repos before probing infrastructure.


### PR DESCRIPTION
## What

Wires the SMD AI Employee (customer-zero, `hermes-smd`) to **Telegram** via Hermes' native **long-polling** adapter — no public webhook/surface (contrast email inbound, ADR 0032).

**Proven live 2026-06-01:** Scott DM'd the bot ("Who's there?") and Crane replied autonomously ("Crane — your Chief of Staff. What do you need?"), recipient-locked, no operator, witnessed via screenshot.

## Changes

- **`Dockerfile`** — add `--extra messaging` so `python-telegram-bot==22.6` ships in the image. `--extra all` excludes it, so the native adapter was inert (`TELEGRAM_AVAILABLE=False`) and a `TELEGRAM_BOT_TOKEN` env did nothing. **Load-bearing:** without this on `main`, a future rebuild silently drops the SDK and breaks Telegram (the reason this is a PR, not a one-off deploy).
- **`docs/adr/0033`** — native-polling design; env auto-enable; the **fail-OPEN empty-allowlist** gotcha (pinned ref returns `True` when `TELEGRAM_ALLOWED_USERS` is unset — docs claim otherwise); deferred config-as-source-of-truth evolution (translate.py materializer + fail-closed guard + validator rule); creds-location operational record.
- **`customer.yaml`** — documentation comment for the Telegram wiring. Comment-only: `translate.py` does not yet read a `telegram:` key, so an inert parsed key would mislead.

## Credentials

Not in this repo. `TELEGRAM_BOT_TOKEN` + `TELEGRAM_ALLOWED_USERS` are **Fly secrets** on `hermes-smd`, sourced from Infisical prod `/ss/ai-employee/customer-zero/telegram/` (allowlist `7367659986`, Scott, DM-only). Token-freshness caveat (prefix `8303`, flagged for reissue 2026-05-27) resolved empirically — polling connected, no `401`.

## Verify

- `npx tsx scripts/validate-customer-yaml.ts ai-employee/customers/smd/customer.yaml` → OK
- Live: deployed v16 with `OVERLAY_REF=v0.4.3` (no overlay change; voice stays gated); Telegram round-trip confirmed; email inbound unaffected.

## Follow-ups (not in this PR)

- Auxiliary-model warnings seen in the live test (`temperature` deprecated; openrouter/nous credit) — auxiliary title-gen only, primary Opus unaffected.
- Productize the allowlist into authored config (overlay `translate.py` materializer + fail-closed guard + validator) per ADR 0033 Evolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)