### PR TITLE
fix(voice): reject agent role-prompts + pasted markdown from the voice corpus

### DIFF
--- a/ai-employee/bin/lib/voice_corpus.py
+++ b/ai-employee/bin/lib/voice_corpus.py
@@ -190,6 +190,25 @@ _NOISE_MARKERS = (
     "stdout>",
 )
 
+# Second-person role/instruction openers. These are agent PROMPTS (often
+# skill-authored, pasted as user turns), not the author's own voice — they
+# read as formal instructions TO an agent and would teach the exact opposite
+# of the author's terse first-person register. Matched case-insensitively
+# against the start of the message.
+_AGENT_PROMPT_OPENERS = (
+    "you are ",
+    "you're the ",
+    "you're a ",
+    "your task",
+    "your job",
+    "your role",
+    "act as ",
+    "you will be ",
+    "output only",
+    "return only",
+    "respond only",
+)
+
 
 def _is_prose(text: str, *, min_words: int) -> bool:
     """Heuristic: is this the author's own prose, not tooling/code/noise?"""
@@ -199,6 +218,10 @@ def _is_prose(text: str, *, min_words: int) -> bool:
     if "```" in t:  # pasted code/fenced block
         return False
     if t.startswith("<") or t.startswith("{") or t.startswith("["):
+        return False
+    if t.startswith("# ") or t.startswith("## "):  # pasted markdown doc / skill definition
+        return False
+    if t.lower().startswith(_AGENT_PROMPT_OPENERS):  # agent role prompt, not the author
         return False
     if len(t.split()) < min_words:
         return False

--- a/ai-employee/bin/tests/test_voice_corpus.py
+++ b/ai-employee/bin/tests/test_voice_corpus.py
@@ -147,6 +147,31 @@ def test_extract_user_messages_filters_noise(tmp_path):
     assert any("configurable" in m for m in msgs)
 
 
+def test_extract_user_messages_rejects_agent_prompts_and_markdown(tmp_path):
+    """Agent role-prompts and pasted skill/markdown docs are not the author's
+    voice — they read as instructions TO an agent and would teach the opposite
+    of the author's terse first-person register."""
+    transcript = tmp_path / "t.jsonl"
+    _write_transcript(
+        transcript,
+        [
+            # drop: second-person agent role prompts (skill-authored, pasted)
+            {"message": {"role": "user", "content": "You are Claude Code, an interactive agent that helps with software engineering tasks."}},
+            {"message": {"role": "user", "content": "Your task is to review the diff and report every correctness bug you can find."}},
+            {"message": {"role": "user", "content": "Output only the final answer as a single JSON object with no other commentary."}},
+            # drop: pasted markdown doc / skill definition header
+            {"message": {"role": "user", "content": "# /ship - Ship to Production\n\nCommit, push, PR, CI, merge, and confirm deployment all in one shot."}},
+            # keep: the author's own terse first-person prose
+            {"message": {"role": "user", "content": "Stop guessing. Verify the secret values, then ship it cleanly through a PR."}},
+        ],
+    )
+    msgs = list(extract_user_messages(transcript, min_words=5))
+    assert len(msgs) == 1
+    assert "Verify the secret values" in msgs[0]
+    # case-insensitive: lowercased agent opener must also be rejected
+    assert not any(m.lower().startswith(("you are", "your task", "output only")) for m in msgs)
+
+
 def test_extract_corpus_dedupes_and_limits(tmp_path):
     t1 = tmp_path / "a.jsonl"
     t2 = tmp_path / "b.jsonl"


### PR DESCRIPTION
## What

The voice-corpus prose filter (`ai-employee/bin/lib/voice_corpus.py`) was accepting **agent role-prompts** ("You are…", "Your task is…", "Output only…", skill definitions) and **pasted markdown docs** as if they were the author's own writing. Those messages read as formal instructions *to* an agent — the exact opposite of the author's terse first-person register — and would teach the wrong voice.

Adds two heuristics to `_is_prose`:
- reject messages opening with a known agent-prompt opener (case-insensitive)
- reject pasted markdown headers (`# ` / `## `)

## Why

Crane learns its writing voice from the customer's own prose. Letting skill prompts and pasted docs into the corpus dilutes the signal with second-person imperative boilerplate. See `project_voice_subsystem_meaning`.

## Test

New `test_extract_user_messages_rejects_agent_prompts_and_markdown` covers both rejections + the case-insensitive guard. Full suite green:

```
10 passed in 0.05s
```

## Provenance

Recovered from session `be295e5f` (voice-corpus work, closed before `/eos`). This was the uncommitted change left in the `ethereal-dancing-knuth` worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)