### PR TITLE
feat(ai-employee): harden Telegram allowlist — authored config + fail-closed guard (ADR 0033)

### DIFF
--- a/ai-employee/customers/smd/customer.yaml
+++ b/ai-employee/customers/smd/customer.yaml
@@ -111,17 +111,26 @@ webhook_triggers:
 
 # ---- TELEGRAM CHANNEL (ADR 0033) ----
 # Crane is reachable on Telegram via Hermes' native polling adapter (getUpdates) —
-# NO webhook/public surface (unlike AgentMail email above). It is enabled purely by
-# environment, NOT by this file: the Fly secrets TELEGRAM_BOT_TOKEN and
-# TELEGRAM_ALLOWED_USERS auto-enable the platform on boot. The image must be built
-# with the Dockerfile `--extra messaging` (python-telegram-bot); `--extra all` omits it.
-# Sourced from Infisical prod /ss/ai-employee/customer-zero/telegram/.
-# Allowlist = 7367659986 (Scott), DM-only — MANDATORY: the pinned ref fails OPEN on an
-# empty allowlist. Proven live 2026-06-01 (Scott DM'd, Crane replied autonomously).
-# NOT yet an authored config key here: a `telegram:` block + translate.py
-# _materialize_telegram_platform + a fail-closed launch guard are the documented
-# evolution (ADR 0033) to move the allowlist into reviewable config. Until then this
-# block is documentation only — the Fly secrets are the source of truth.
+# NO webhook/public surface (unlike AgentMail email above). The bot TOKEN is the Fly
+# secret TELEGRAM_BOT_TOKEN (credential, sourced from Infisical prod
+# /ss/ai-employee/customer-zero/telegram/), which auto-enables the polling platform.
+# The image must be built with the Dockerfile `--extra messaging` (python-telegram-bot);
+# `--extra all` omits it.
+#
+# The ALLOWLIST below is the AUTHORED SOURCE OF TRUTH (not a loose Fly secret): the
+# overlay translate.py _materialize_telegram_platform materializes it into the profile
+# config.yaml `telegram:` block, which Hermes maps to TELEGRAM_ALLOWED_USERS.
+# MANDATORY and fail-closed: the pinned Hermes ref allows ALL users when the allowlist
+# is empty (telegram.py: `if not allowed_csv: return True`); the materializer raises on
+# an empty allow_from, and the bootstrap guard (ensure-telegram-allowlist.py) refuses to
+# launch if the token is set without a resolvable allowlist. Proven live 2026-06-01.
+telegram:
+  enabled: true
+  # Permitted Telegram numeric user id(s). DM-only. 7367659986 = Scott Durgan.
+  allow_from:
+    - '7367659986'
+  # 1:1 DM assistant: reply to every DM from an allowed user (no @mention needed).
+  require_mention: false
 
 # ---- SCOPE ----
 scope:

--- a/ai-employee/templates/Dockerfile
+++ b/ai-employee/templates/Dockerfile
@@ -69,8 +69,11 @@ ARG HERMES_UPSTREAM_SHA=a91a57fa5a13d516c38b07a141a9ce8a3daabeb0
 # the stored rhythm signal (sentence-length distribution + punctuation), so the
 # pre_llm_call voice block can actually shape a draft instead of injecting a thin
 # greeting/signoff label. Superset of v0.4.3 (carries all webhook-gate work too).
+# v0.4.5 adds _materialize_telegram_platform (#32, ADR 0033): authors the Telegram
+# allowlist from customer.yaml.telegram into the profile config.yaml (fail-closed on
+# empty allow_from). Superset of v0.4.4.
 ARG OVERLAY_REPO="https://github.com/venturecrane/hermes-smd-overlay.git"
-ARG OVERLAY_REF="v0.4.4"
+ARG OVERLAY_REF="v0.4.5"
 
 ARG CUSTOMER_SLUG=customer-zero
 
@@ -221,6 +224,7 @@ RUN chmod +x /app/bootstrap.sh
 # overlay materializes profile configs, ensuring the autonomous curator is off
 # before Hermes starts; the boot smoke test re-runs it with --check.
 COPY ai-employee/templates/ensure-curator-disabled.py /app/ensure-curator-disabled.py
+COPY ai-employee/templates/ensure-telegram-allowlist.py /app/ensure-telegram-allowlist.py
 
 # NOTE: customer.yaml is NOT copied into the image. It lives on the Fly
 # volume at /opt/data/customer.yaml; bootstrap.sh fetches it from R2 on

--- a/ai-employee/templates/bootstrap.sh
+++ b/ai-employee/templates/bootstrap.sh
@@ -232,6 +232,18 @@ log "Disabling Hermes curator in profile configs (ADR 0017)..."
   || die "Failed to disable curator in profile configs (ADR 0017)"
 log "Curator disabled in profile config(s)"
 
+# Step 7c: fail closed if Telegram would run without an allowlist (ADR 0033).
+# TELEGRAM_BOT_TOKEN alone auto-enables Hermes' Telegram platform, and the pinned
+# ref fails OPEN on an empty allowlist (telegram.py: `if not allowed_csv: return
+# True`) — so a token without an allowlist = a bot anyone can talk to. This guard
+# refuses to launch unless an allowlist is resolvable from TELEGRAM_ALLOWED_USERS
+# or a profile config's telegram.allow_from (authored via customer.yaml). No-op
+# when TELEGRAM_BOT_TOKEN is unset.
+log "Verifying Telegram allowlist (fail-closed, ADR 0033)..."
+/opt/hermes/.venv/bin/python3 /app/ensure-telegram-allowlist.py "${HERMES_HOME}" \
+  || die "Telegram allowlist guard failed (ADR 0033): refusing to launch an unrestricted bot"
+log "Telegram allowlist guard passed"
+
 # ============================================================================
 # Step 8: safety substrate invariant checks (Phase A.5 gate)
 # ============================================================================

--- a/ai-employee/templates/ensure-telegram-allowlist.py
+++ b/ai-employee/templates/ensure-telegram-allowlist.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Fail closed if Telegram would run without an allowlist (ADR 0033).
+
+The pinned Hermes ref **fails OPEN** on an empty Telegram allowlist — its
+authorizer is ``if not allowed_csv: return True`` (``gateway/platforms/telegram.py``),
+so a bot with ``TELEGRAM_BOT_TOKEN`` set but no ``TELEGRAM_ALLOWED_USERS`` answers
+*anyone* who finds it. Setting ``TELEGRAM_BOT_TOKEN`` alone also AUTO-ENABLES the
+platform (``gateway/config.py:_apply_env_overrides``). This guard makes that
+fail-open branch structurally unreachable in our deployment: if the token is
+present, an allowlist MUST be resolvable, or the Machine refuses to boot.
+
+This is the Machine-entrypoint belt. The authored source of truth is
+``customer.yaml`` ``telegram.allow_from`` -> the overlay translate.py
+``_materialize_telegram_platform`` -> each ``profiles/<slug>/config.yaml``
+``telegram.allow_from`` (which Hermes maps to ``TELEGRAM_ALLOWED_USERS``). This
+guard verifies the *resolved* state independent of whether the overlay shipped
+the materializer, and also catches the case where someone sets the
+``TELEGRAM_BOT_TOKEN`` Fly secret without authoring any allowlist at all.
+
+An allowlist is "resolvable" when EITHER:
+  * the ``TELEGRAM_ALLOWED_USERS`` env var is set and non-empty, OR
+  * any per-profile ``config.yaml`` carries a non-empty ``telegram.allow_from``.
+
+Modes:
+  enforce (default):  exit non-zero if the token is set but no allowlist resolves.
+  --check:            same predicate; for the boot smoke test.
+
+Usage:
+  ensure-telegram-allowlist.py [--check] [HERMES_HOME]
+  (HERMES_HOME defaults to the $HERMES_HOME env var, then /opt/data.)
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+import yaml
+
+
+def profile_configs(hermes_home: Path) -> list[Path]:
+    """Every per-profile config.yaml under <hermes_home>/profiles/<slug>/."""
+    profiles_dir = hermes_home / "profiles"
+    if not profiles_dir.is_dir():
+        return []
+    return sorted(profiles_dir.glob("*/config.yaml"))
+
+
+def _config_allow_from(path: Path) -> list[str]:
+    """Non-empty, stringified telegram.allow_from entries from one config.yaml."""
+    try:
+        with path.open() as f:
+            cfg = yaml.safe_load(f) or {}
+    except Exception:
+        return []
+    if not isinstance(cfg, dict):
+        return []
+    tg = cfg.get("telegram")
+    if not isinstance(tg, dict):
+        return []
+    raw = tg.get("allow_from") or []
+    if not isinstance(raw, (list, tuple)):
+        return []
+    return [str(x).strip() for x in raw if str(x).strip()]
+
+
+def _env_allowlist() -> list[str]:
+    csv = os.environ.get("TELEGRAM_ALLOWED_USERS", "").strip()
+    return [p.strip() for p in csv.split(",") if p.strip()] if csv else []
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description="Refuse to launch an unrestricted (fail-open) Telegram bot."
+    )
+    parser.add_argument("--check", action="store_true", help="verify-only (boot smoke test)")
+    parser.add_argument(
+        "hermes_home",
+        nargs="?",
+        default=os.environ.get("HERMES_HOME", "/opt/data"),
+        help="Hermes home dir (default: $HERMES_HOME or /opt/data)",
+    )
+    args = parser.parse_args(argv[1:])
+    tag = "ensure-telegram-allowlist"
+
+    # No token -> Telegram never auto-enables -> nothing to guard.
+    if not os.environ.get("TELEGRAM_BOT_TOKEN", "").strip():
+        print(f"[{tag}] TELEGRAM_BOT_TOKEN unset; Telegram platform inert — nothing to guard")
+        return 0
+
+    env_allow = _env_allowlist()
+    home = Path(args.hermes_home)
+    config_allow: list[str] = []
+    for path in profile_configs(home):
+        config_allow.extend(_config_allow_from(path))
+
+    if env_allow or config_allow:
+        src = []
+        if env_allow:
+            src.append(f"TELEGRAM_ALLOWED_USERS env ({len(env_allow)})")
+        if config_allow:
+            src.append(f"config.yaml telegram.allow_from ({len(config_allow)})")
+        print(f"[{tag}] OK: Telegram allowlist resolved from {', '.join(src)}")
+        return 0
+
+    # Token set, but NO allowlist anywhere -> the bot would answer anyone. Refuse.
+    print(
+        f"[{tag}] FATAL: TELEGRAM_BOT_TOKEN is set but no allowlist is resolvable "
+        f"(TELEGRAM_ALLOWED_USERS env empty AND no telegram.allow_from in any profile "
+        f"config under {home}/profiles/). The pinned Hermes ref fails OPEN on an empty "
+        f"allowlist — refusing to launch an unrestricted Telegram bot. Author "
+        f"customer.yaml telegram.allow_from (ADR 0033) or set TELEGRAM_ALLOWED_USERS.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/src/lib/ai-employee/customer-yaml/sections-telegram.ts
+++ b/src/lib/ai-employee/customer-yaml/sections-telegram.ts
@@ -1,0 +1,77 @@
+/**
+ * Optional `telegram:` block validator (ADR 0033).
+ *
+ * Telegram is wired as a Hermes native polling channel: the bot token is a Fly
+ * secret (TELEGRAM_BOT_TOKEN) that auto-enables the platform; this block authors
+ * the ALLOWLIST (who may DM the bot) as reviewable config. The overlay
+ * translate.py `_materialize_telegram_platform` renders it into the profile
+ * config.yaml `telegram.allow_from`, which Hermes maps to TELEGRAM_ALLOWED_USERS.
+ *
+ * Fail-closed: when the block is enabled, `allow_from` MUST be a non-empty list of
+ * numeric Telegram user-id strings — the pinned Hermes ref allows ALL users when
+ * the allowlist is empty (`telegram.py: if not allowed_csv: return True`), so an
+ * empty allowlist is the fail-open trap this pre-merge check exists to catch.
+ *
+ * Validate-only (pushes errors); the value is materialized by the overlay, not
+ * consumed from the parsed CustomerYaml object.
+ */
+
+import type { ValidationError } from './types'
+import { isPlainObject } from './helpers'
+
+export function checkTelegram(root: Record<string, unknown>, errors: ValidationError[]): void {
+  const raw = root['telegram']
+  if (raw === undefined || raw === null) return // optional block
+  if (!isPlainObject(raw)) {
+    errors.push({ code: 'TypeMismatch', path: 'telegram', message: 'telegram must be an object' })
+    return
+  }
+
+  const enabled = raw['enabled']
+  if (enabled !== undefined && typeof enabled !== 'boolean') {
+    errors.push({
+      code: 'TypeMismatch',
+      path: 'telegram.enabled',
+      message: 'telegram.enabled must be a boolean',
+    })
+  }
+  for (const key of ['require_mention', 'reactions'] as const) {
+    if (raw[key] !== undefined && typeof raw[key] !== 'boolean') {
+      errors.push({
+        code: 'TypeMismatch',
+        path: `telegram.${key}`,
+        message: `telegram.${key} must be a boolean`,
+      })
+    }
+  }
+
+  const allow = raw['allow_from']
+  if (enabled === true) {
+    if (!Array.isArray(allow) || allow.length === 0) {
+      errors.push({
+        code: 'MissingField',
+        path: 'telegram.allow_from',
+        message:
+          'telegram.allow_from is required and must be a non-empty list when telegram.enabled is true. ' +
+          'An empty allowlist fails OPEN (the pinned Hermes ref answers any user). See ADR 0033.',
+      })
+    } else {
+      allow.forEach((id, i) => {
+        if (typeof id !== 'string' || !/^\d+$/.test(id.trim())) {
+          errors.push({
+            code: 'TypeMismatch',
+            path: `telegram.allow_from[${i}]`,
+            message:
+              'each allow_from entry must be a numeric Telegram user id as a string (e.g. "7367659986")',
+          })
+        }
+      })
+    }
+  } else if (allow !== undefined && !Array.isArray(allow)) {
+    errors.push({
+      code: 'TypeMismatch',
+      path: 'telegram.allow_from',
+      message: 'telegram.allow_from must be a list',
+    })
+  }
+}

--- a/src/lib/ai-employee/customer-yaml/validator.ts
+++ b/src/lib/ai-employee/customer-yaml/validator.ts
@@ -51,6 +51,7 @@ import {
   checkScope,
   checkVoiceLibrary,
 } from './sections-other'
+import { checkTelegram } from './sections-telegram'
 import { checkObservability } from './sections-observability'
 import { checkVoiceCohorts } from './sections-voice'
 import { checkWebhookTriggers } from './sections-webhook-triggers'
@@ -207,6 +208,7 @@ function validateSections(
   const personas = checkPersonas(root, errors)
   const connectors = checkConnectors(root, customerId, errors)
   const scope = checkScope(root, errors)
+  checkTelegram(root, errors) // optional telegram block; validate-only (ADR 0033)
   const escalation = checkEscalation(root, errors)
   const memory = checkMemory(root, customerId, verticalResult.vertical, errors)
   const webhookTriggers = checkWebhookTriggers(root, personas, connectors, errors)

--- a/tests/customer-yaml-validator.test.ts
+++ b/tests/customer-yaml-validator.test.ts
@@ -1904,3 +1904,59 @@ describe('validate — memory.r2_skill_bodies_* known-optional (ADR 0022)', () =
     ).toBe(true)
   })
 })
+
+// -----------------------------------------------------------------------------
+// Telegram block (ADR 0033) — optional; fail-closed allowlist
+// -----------------------------------------------------------------------------
+
+describe('validate — telegram block (ADR 0033)', () => {
+  it('accepts an enabled block with a non-empty numeric allow_from', () => {
+    const f = validFixture()
+    f['telegram'] = { enabled: true, allow_from: ['7367659986'], require_mention: false }
+    const r = validate(f)
+    expect(r.ok).toBe(true)
+  })
+
+  it('accepts absence of the block (optional)', () => {
+    const r = validate(validFixture())
+    expect(r.ok).toBe(true)
+  })
+
+  it('rejects enabled with an empty allow_from (fail-open trap)', () => {
+    const f = validFixture()
+    f['telegram'] = { enabled: true, allow_from: [] }
+    const r = validate(f)
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(
+      r.errors.some((e) => e.path === 'telegram.allow_from' && e.code === 'MissingField')
+    ).toBe(true)
+  })
+
+  it('rejects enabled with allow_from omitted', () => {
+    const f = validFixture()
+    f['telegram'] = { enabled: true }
+    const r = validate(f)
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(r.errors.some((e) => e.path === 'telegram.allow_from')).toBe(true)
+  })
+
+  it('rejects a non-numeric allow_from entry', () => {
+    const f = validFixture()
+    f['telegram'] = { enabled: true, allow_from: ['@scott'] }
+    const r = validate(f)
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(r.errors.some((e) => e.path === 'telegram.allow_from[0]')).toBe(true)
+  })
+
+  it('rejects a non-boolean require_mention', () => {
+    const f = validFixture()
+    f['telegram'] = { enabled: true, allow_from: ['7367659986'], require_mention: 'no' }
+    const r = validate(f)
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(r.errors.some((e) => e.path === 'telegram.require_mention')).toBe(true)
+  })
+})


### PR DESCRIPTION
Follow-up to the Telegram channel (#1183): moves the allowlist from a loose Fly secret into **reviewable config-as-source-of-truth** and makes the **fail-OPEN branch structurally unreachable**. Pairs with overlay **v0.4.5** (`_materialize_telegram_platform`, hermes-smd-overlay#32, merged).

## Why
The pinned Hermes ref allows **ALL** Telegram users when the allowlist is empty (`telegram.py: if not allowed_csv: return True`), and `TELEGRAM_BOT_TOKEN` alone auto-enables the platform. So a token without an allowlist = a bot anyone can DM. This hardens it at three layers.

## Changes
- **`customer.yaml`** — authored `telegram:` block (`enabled`, `allow_from: ["7367659986"]`, `require_mention: false`). Overlay v0.4.5 materializes it into the profile `config.yaml` → `TELEGRAM_ALLOWED_USERS`.
- **Validator** — new `sections-telegram.ts` `checkTelegram`, wired into `validator.ts`: enabled ⇒ `allow_from` required, non-empty, numeric-string ids. +6 tests (171 pass). Own file to keep `sections-other.ts` under the 500-line ceiling.
- **`ensure-telegram-allowlist.py`** (new) + **`bootstrap.sh`** step 7c — deterministic boot guard: token set but no allowlist resolvable (env empty AND no `telegram.allow_from` in any profile config) ⇒ refuse to launch. No-op without a token. Verified across 4 scenarios.
- **`Dockerfile`** — COPY the guard; bump `OVERLAY_REF` v0.4.4 → v0.4.5.

## Defense in depth
config-gen (materializer raises) · boot (guard refuses) · pre-merge (validator). Token stays a Fly secret; this authors *who* may talk to the bot.

## Note
v0.4.5 ⊇ v0.4.4, which carries the inert voice-render fix (#28). It does **not** activate voice — there are no samples/ingestion rows — so the voice-activation gate is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)