### PR TITLE
fix(ai-employee): propagate customer.yaml edits to running machines (R2 re-fetch)

### DIFF
--- a/ai-employee/bin/sync-customer-yaml.sh
+++ b/ai-employee/bin/sync-customer-yaml.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+#
+# sync-customer-yaml.sh <slug>
+#
+# Push an EDITED ai-employee/customers/<slug>/customer.yaml to R2 (the source of
+# truth) so it propagates to the running Machine on its next restart.
+#
+# Why this exists: provision-customer.sh uploads customer.yaml to R2 only at
+# provision time, and bootstrap.sh re-fetches from R2 on every boot (so a restart
+# picks up the new config). But nothing pushes a *merged edit* to R2 — the live
+# customer-sync sidecar is a Phase-2 stub. Without this step, editing and merging
+# customer.yaml leaves the running customer on its old on-disk copy. Run this after
+# merging a customer.yaml change, then `fly machine restart` (or redeploy) the
+# customer's app to apply it.
+#
+# Validates before uploading (never ships an invalid config to the source of truth).
+#
+# Required env (stage via your shell, e.g. `infisical run --env prod --path /ss -- ...`):
+#   R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY  — R2 creds with write on the config bucket
+#   R2_ENDPOINT_URL                         — Cloudflare R2 S3 endpoint
+# Optional:
+#   R2_BUCKET_CONFIG  — config bucket name (default: smd-customer-config)
+#
+# This script does NOT touch Fly, secrets, or git. It validates + uploads, nothing else.
+
+set -euo pipefail
+
+die() { echo "ERROR: $*" >&2; exit 1; }
+log() { echo "[sync-customer-yaml] $*"; }
+
+SLUG="${1:-}"
+[ -n "${SLUG}" ] || die "usage: sync-customer-yaml.sh <slug>"
+echo "${SLUG}" | grep -qE '^[a-z0-9][a-z0-9-]{0,31}$' || die "invalid slug: ${SLUG}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+CUSTOMER_YAML="${REPO_ROOT}/ai-employee/customers/${SLUG}/customer.yaml"
+[ -f "${CUSTOMER_YAML}" ] || die "not found: ${CUSTOMER_YAML}"
+
+: "${R2_ACCESS_KEY_ID:?R2_ACCESS_KEY_ID not set in env}"
+: "${R2_SECRET_ACCESS_KEY:?R2_SECRET_ACCESS_KEY not set in env}"
+: "${R2_ENDPOINT_URL:?R2_ENDPOINT_URL not set in env}"
+R2_BUCKET_CONFIG="${R2_BUCKET_CONFIG:-smd-customer-config}"
+R2_CONFIG_KEY="vaults/${SLUG}/customer.yaml"
+
+command -v aws >/dev/null 2>&1 || die "aws CLI not found (required for R2 upload)"
+
+# Validate against the canonical TS validator before touching the source of truth.
+log "Validating ${CUSTOMER_YAML}..."
+( cd "${REPO_ROOT}" && npx --quiet tsx scripts/validate-customer-yaml.ts "${CUSTOMER_YAML}" ) \
+  || die "customer.yaml validation failed; not uploading"
+log "customer.yaml OK"
+
+log "Uploading to R2: s3://${R2_BUCKET_CONFIG}/${R2_CONFIG_KEY}"
+AWS_ACCESS_KEY_ID="${R2_ACCESS_KEY_ID}" \
+AWS_SECRET_ACCESS_KEY="${R2_SECRET_ACCESS_KEY}" \
+  aws s3 cp "${CUSTOMER_YAML}" "s3://${R2_BUCKET_CONFIG}/${R2_CONFIG_KEY}" \
+    --endpoint-url "${R2_ENDPOINT_URL}" \
+    --only-show-errors \
+  || die "R2 upload failed"
+log "R2 upload OK"
+log "Next: restart the customer's Machine to apply (fly machine restart <id> -a hermes-${SLUG}), or redeploy."

--- a/ai-employee/templates/bootstrap.sh
+++ b/ai-employee/templates/bootstrap.sh
@@ -133,27 +133,37 @@ done
 # ============================================================================
 # Step 2: verify (or fetch) customer.yaml on the volume
 # ============================================================================
-# Storage model change (§6): customer.yaml lives on the volume, not baked
-# into the image. R2 at vaults/<slug>/customer.yaml is the source of truth;
-# provisioning writes it there. Bootstrap fetches to /opt/data on first boot
-# and uses the volume copy on subsequent boots.
+# Storage model (§6): customer.yaml lives on the volume, not baked into the
+# image. R2 at vaults/<slug>/customer.yaml is the SOURCE OF TRUTH; provisioning
+# (and ai-employee/bin/sync-customer-yaml.sh, for edits) writes it there.
+# Bootstrap re-fetches from R2 on EVERY boot so merged config edits propagate on
+# restart, falling back to the volume copy only if R2 is unreachable. (The live
+# no-restart reload path — the customer-sync sidecar — is a Phase-2 stub.)
 CUSTOMER_YAML="/opt/data/customer.yaml"
 R2_ENDPOINT_URL="${R2_ENDPOINT_URL:-https://${R2_ACCOUNT_ID:-}.r2.cloudflarestorage.com}"
 R2_CUSTOMER_YAML_URI="s3://${R2_BUCKET_CONFIG}/vaults/${CUSTOMER_SLUG}/customer.yaml"
 
-if [ -f "${CUSTOMER_YAML}" ]; then
-  log "customer.yaml present on volume: ${CUSTOMER_YAML}"
+# Re-fetch from R2 (source of truth) on EVERY boot so merged customer.yaml edits
+# propagate on restart. Previously bootstrap only fetched when the volume copy was
+# ABSENT, so edits to an already-provisioned machine never reached it (the
+# customer-sync sidecar is a Phase-2 stub). Fetch to a temp path and atomically
+# swap, so a transient R2 failure never corrupts or strands the existing copy;
+# fall back to the volume copy if R2 is unreachable; die only if neither yields a
+# config. awscli is installed in the Dockerfile; R2 speaks S3 with a custom endpoint.
+if AWS_ACCESS_KEY_ID="${R2_ACCESS_KEY_ID}" \
+   AWS_SECRET_ACCESS_KEY="${R2_SECRET_ACCESS_KEY}" \
+     aws s3 cp \
+       --endpoint-url "${R2_ENDPOINT_URL}" \
+       --only-show-errors \
+       "${R2_CUSTOMER_YAML_URI}" \
+       "${CUSTOMER_YAML}.r2.tmp"; then
+  mv -f "${CUSTOMER_YAML}.r2.tmp" "${CUSTOMER_YAML}"
+  log "customer.yaml refreshed from R2 (source of truth): ${R2_CUSTOMER_YAML_URI}"
+elif [ -f "${CUSTOMER_YAML}" ]; then
+  rm -f "${CUSTOMER_YAML}.r2.tmp" 2>/dev/null || true
+  log "WARN: R2 fetch failed; using existing volume copy: ${CUSTOMER_YAML}"
 else
-  log "customer.yaml missing on volume; fetching from R2: ${R2_CUSTOMER_YAML_URI}"
-  # awscli is installed in the Dockerfile. R2 speaks S3 with a custom endpoint.
-  AWS_ACCESS_KEY_ID="${R2_ACCESS_KEY_ID}" \
-  AWS_SECRET_ACCESS_KEY="${R2_SECRET_ACCESS_KEY}" \
-    aws s3 cp \
-      --endpoint-url "${R2_ENDPOINT_URL}" \
-      "${R2_CUSTOMER_YAML_URI}" \
-      "${CUSTOMER_YAML}" \
-    || die "Failed to fetch customer.yaml from R2 (${R2_CUSTOMER_YAML_URI})"
-  log "customer.yaml fetched from R2 -> ${CUSTOMER_YAML}"
+  die "customer.yaml not on volume and R2 fetch failed (${R2_CUSTOMER_YAML_URI})"
 fi
 
 # ============================================================================


### PR DESCRIPTION
## The gap
Merged `customer.yaml` edits **never reached an already-provisioned Machine.** `bootstrap.sh` only fetched from R2 when the volume copy was *absent*, and the live customer-sync sidecar is a Phase-2 stub (`raise NotImplementedError`). So after first boot a Machine ran its stale on-disk copy forever — any config change (connector, scope, escalation address, the Telegram allowlist, …) silently failed to apply. Found while verifying the Telegram allowlist hardening (#1185): the materializer had nothing to render because the volume copy predated the edit.

## The fix
- **`bootstrap.sh`** — re-fetch `customer.yaml` from R2 (the source of truth) on **every boot**: to a temp path with an atomic swap, falling back to the existing volume copy if R2 is unreachable (never strands the Machine), dying only if neither yields a config. **Restart is now the refresh trigger.**
- **`ai-employee/bin/sync-customer-yaml.sh`** (new) — operator tool to validate + push an edited `customer.yaml` to R2 (the missing "edit → source of truth" step; provisioning only uploads at provision time). Validates via the canonical TS validator before upload; touches only R2.

## Config-edit workflow now
edit `customer.yaml` → merge → `sync-customer-yaml.sh <slug>` → restart the Machine. The live no-restart reload (sidecar) remains the Phase-2 follow-on.

## Safety
Temp-path + atomic swap means a partial/failed R2 fetch can't corrupt the volume copy. R2-unreachable falls back to the volume copy (boot still succeeds). `bash -n` clean on both scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)