### PR TITLE
fix(operator): durable R2 creds + runtime overlay-plugin install + smoke-test fixes

### DIFF
--- a/docs/runbooks/operator/first-boot.md
+++ b/docs/runbooks/operator/first-boot.md
@@ -17,16 +17,40 @@ It does **not** exercise a real agent turn, a live LLM call, or a connector writ
 - `fly` CLI, authenticated to the target org (`fly auth login`). The script creates the app with `--org personal`; change that in `provision-customer.sh` if booting into a different org.
 - `aws` CLI (for the R2 `customer.yaml` upload), `openssl`, `pbpaste` (macOS).
 
-### Operator environment (exported before running — never pasted into chat)
+### R2 credentials — DO NOT hunt for or re-mint these
+
+The operator-local R2 creds are stored in **Infisical `/ss` (prod)** and are injected
+automatically by the wrapper. **Use the wrapper** and you never touch them:
 
 ```
-R2_ENDPOINT_URL        # https://<account>.r2.cloudflarestorage.com
-R2_ACCESS_KEY_ID       # operator-local, used by `aws s3 cp` for the customer.yaml upload
-R2_SECRET_ACCESS_KEY
-R2_BUCKET_CONFIG       # optional; defaults to "smd-customer-config"
+operator/bin/reprovision.sh <slug>
+```
+
+For months these were not stored anywhere and every agent re-derived them (a ~2h
+trap). They are now in `/ss` and are **derivable from `CLOUDFLARE_API_TOKEN`** (also
+in `/ss`) — Cloudflare R2's S3 API accepts a CF API token directly:
+
+- `R2_ACCESS_KEY_ID` = the CF token's id (`GET /user/tokens/verify` → `result.id`)
+- `R2_SECRET_ACCESS_KEY` = `sha256_hex(CLOUDFLARE_API_TOKEN value)`
+- `R2_ENDPOINT_URL` = `https://<account_id>.r2.cloudflarestorage.com`
+- `R2_BUCKET_CONFIG` = `smd-customer-config`
+
+The same derived pair has R/W on every bucket in the account, so it also covers the
+`R2_SKILL_BODIES_*` skill-bodies bucket — **no per-bucket token minting is needed.**
+To verify they're present: `crane_secret_check({ path: '/ss', env: 'prod', names: ['R2_ACCESS_KEY_ID','R2_SECRET_ACCESS_KEY','R2_ENDPOINT_URL','R2_BUCKET_CONFIG'] })`.
+
+```
 # Optional (warn-and-skip if unset): CF_API_TOKEN + CF_ACCOUNT_ID (per-customer skill-bodies
 # bucket auto-create), SENTRY_DSN, MACHINE_HEARTBEAT_KEY, HEALTHCHECKS_API_KEY (ADR 0023 Wave 1).
 ```
+
+### Overlay plugins are volume-shadowed (handled in bootstrap)
+
+The Dockerfile installs the `hermes-smd-overlay` pack under `${HERMES_HOME}` (= the
+Fly volume mount); on a **persisted** volume the build-time install is shadowed.
+`bootstrap.sh` therefore re-installs + enables it at runtime (fail-closed) before the
+gateway launches, so the trust/audit/voice safety harness always loads. The boot
+smoke test step `hermes-plugins-installed` is the live verification.
 
 ### Secrets you'll be prompted to paste (clipboard → `fly secrets`, never echoed)
 
@@ -44,17 +68,19 @@ The script prompts for each; copy to clipboard, press Enter (or `s` to skip). Va
 
 ## The command
 
-From the **repo root** (not a worktree subdir), with the operator env exported:
+From the **repo root**, use the wrapper (injects the R2 creds from Infisical `/ss`):
 
 ```bash
-operator/bin/provision-customer.sh smd
+operator/bin/reprovision.sh smd
+# fully non-interactive (skip the secret prompts — Machine secrets persist across deploy):
+yes s | operator/bin/reprovision.sh smd
 ```
 
-That single command: validates `customer.yaml` → uploads it to R2 → renders `fly.toml` → creates the Fly app + a 10 GB volume → prompts for secrets → `fly deploy` (builds the Dockerfile: clones+asserts upstream Hermes, installs the overlay **v0.2.0**, bundles Postgres/Redis/Honcho) → runs the boot smoke test. It is idempotent — safe to re-run.
+That single command: validates `customer.yaml` → uploads it to R2 → renders `fly.toml` → creates the Fly app + a 10 GB volume → prompts for secrets → `fly deploy` (builds the Dockerfile: clones+asserts upstream Hermes, installs the overlay **v0.4.5**, bundles Postgres/Redis/Honcho) → runs the boot smoke test. It is idempotent — safe to re-run.
 
-## Overlay pin (why v0.2.0 matters)
+## Overlay pin (why v0.4.5 matters)
 
-The Dockerfile pins the overlay at **v0.2.0** (`OVERLAY_REF`). The runtime trust plugin imports `shared.outbound_gate`, which first shipped after v0.1.1. The build now hard-asserts the policy core is importable (`import shared.outbound_gate, shared.inbound, shared.action_classes`) — a stale pin fails the build instead of booting a harness-less Machine. If you bump the overlay, re-tag and bump `OVERLAY_REF` in lockstep. (Known follow-up: `hermes plugins install` clones the overlay's default branch and cannot pin a ref, so the _plugin surface_ tracks main HEAD at build time; for a tagged build, main == the tag.)
+The Dockerfile pins the overlay at **v0.4.5** (`OVERLAY_REF`). The runtime trust plugin imports `shared.outbound_gate`, which first shipped after v0.1.1. The build now hard-asserts the policy core is importable (`import shared.outbound_gate, shared.inbound, shared.action_classes`) — a stale pin fails the build instead of booting a harness-less Machine. If you bump the overlay, re-tag and bump `OVERLAY_REF` in lockstep. (Known follow-up: `hermes plugins install` clones the overlay's default branch and cannot pin a ref, so the _plugin surface_ tracks main HEAD at build time; for a tagged build, main == the tag.)
 
 ## What to watch on the FIRST ever boot
 

--- a/operator/bin/boot-smoke-test.sh
+++ b/operator/bin/boot-smoke-test.sh
@@ -37,7 +37,11 @@ ssh_exec() {
   local step="$1"
   shift
   local cmd="$*"
-  if fly ssh console -a "${APP_NAME}" --command "${cmd}" >/dev/null 2>&1; then
+  # `fly ssh console --command` execs the string directly (no shell), so compound
+  # commands (&&, |, $(...), [ ]) fail unless wrapped in an explicit shell. Wrap
+  # every check in `sh -c` so shell constructs evaluate ON THE MACHINE. (Check
+  # commands contain no single quotes, so the single-quoted wrapper is safe.)
+  if fly ssh console -a "${APP_NAME}" --command "sh -c '${cmd}'" >/dev/null 2>&1; then
     pass "${step}"
   else
     fail "${step} — command failed: ${cmd}"
@@ -82,7 +86,7 @@ ssh_exec "hermes-profiles-dir" "test -d /opt/data/profiles && [ -n \"\$(ls -A /o
 # ---------- Step 7: overlay plugins installed ----------
 # `hermes plugins list` should include the four hermes-smd-* plugins
 # installed at image-build time via `hermes plugins install venturecrane/hermes-smd-overlay`.
-ssh_exec "hermes-plugins-installed" "hermes plugins list | grep -q hermes-smd-"
+ssh_exec "hermes-plugins-installed" "/opt/hermes/.venv/bin/hermes plugins list | grep -q hermes-smd-"
 
 # ---------- Step 8: Hermes curator disabled (ADR 0017) ----------
 # The autonomous curator is turned off per-customer (it rewrites agent-authored

--- a/operator/bin/provision-customer.sh
+++ b/operator/bin/provision-customer.sh
@@ -14,7 +14,16 @@
 # then runs the boot smoke test (boot-smoke-test.sh) to verify the Hermes
 # profile + plugin chain came up cleanly.
 #
-# Operator prerequisites (set in your shell / .envrc / direnv before running):
+# CANONICAL INVOCATION (do not hunt for R2 creds — they are in Infisical /ss prod):
+#   operator/bin/reprovision.sh <slug>
+#   # which is exactly:
+#   infisical run --env=prod --path=/ss --silent -- operator/bin/provision-customer.sh <slug>
+# The R2_* below are injected by that `infisical run`. They were historically NOT
+# stored anywhere (every agent re-derived them and lost ~2h); they are now in
+# Infisical /ss and are derivable from CLOUDFLARE_API_TOKEN (id + sha256(value)).
+# See docs/runbooks/operator/first-boot.md "R2 credentials".
+#
+# Operator prerequisites (injected by reprovision.sh; or set manually before running):
 #   R2_ENDPOINT_URL        — Cloudflare R2 endpoint (https://<account>.r2.cloudflarestorage.com)
 #   R2_ACCESS_KEY_ID       — R2 access key (operator-local, used for `aws s3 cp` upload)
 #   R2_SECRET_ACCESS_KEY   — R2 secret (operator-local)
@@ -91,9 +100,12 @@ die() { log "FATAL: $*"; exit 1; }
 # Machine can fetch from R2 at boot — but those are set via pbpaste below,
 # not echoed here.
 R2_BUCKET_CONFIG="${R2_BUCKET_CONFIG:-smd-customer-config}"
-[ -n "${R2_ENDPOINT_URL:-}" ] || die "R2_ENDPOINT_URL not set in operator env (see header for prerequisites)"
-[ -n "${R2_ACCESS_KEY_ID:-}" ] || die "R2_ACCESS_KEY_ID not set in operator env"
-[ -n "${R2_SECRET_ACCESS_KEY:-}" ] || die "R2_SECRET_ACCESS_KEY not set in operator env"
+# If these are unset you almost certainly ran this script directly instead of
+# through the wrapper. The creds are in Infisical /ss prod — do NOT re-derive them.
+R2_HINT="R2 creds missing. Run via: operator/bin/reprovision.sh ${SLUG}  (= infisical run --env=prod --path=/ss -- operator/bin/provision-customer.sh ${SLUG}). They live in Infisical /ss prod; see docs/runbooks/operator/first-boot.md."
+[ -n "${R2_ENDPOINT_URL:-}" ] || die "R2_ENDPOINT_URL not set. ${R2_HINT}"
+[ -n "${R2_ACCESS_KEY_ID:-}" ] || die "R2_ACCESS_KEY_ID not set. ${R2_HINT}"
+[ -n "${R2_SECRET_ACCESS_KEY:-}" ] || die "R2_SECRET_ACCESS_KEY not set. ${R2_HINT}"
 command -v aws >/dev/null 2>&1 || die "aws CLI not found (required for R2 customer.yaml upload)"
 command -v pbpaste >/dev/null 2>&1 || die "pbpaste not found (macOS-only; required for secret entry flow)"
 

--- a/operator/bin/reprovision.sh
+++ b/operator/bin/reprovision.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# reprovision.sh — one command, no credential hunt, to (re)provision a customer's
+# Operator Machine.
+#
+# WHY THIS EXISTS: the operator-local R2 credentials that provision-customer.sh
+# needs (R2_ENDPOINT_URL / R2_ACCESS_KEY_ID / R2_SECRET_ACCESS_KEY /
+# R2_BUCKET_CONFIG) were, for months, not stored anywhere discoverable — every
+# agent re-derived them and burned ~2h. They now live in Infisical `/ss` (prod)
+# and this wrapper injects them, so the recurring trap is closed for good.
+#
+# (The R2 S3 creds are derivable from CLOUDFLARE_API_TOKEN — id + sha256(value) —
+# which is why they need not be minted; see docs/runbooks/operator/first-boot.md
+# "R2 credentials".)
+#
+# Usage:
+#   operator/bin/reprovision.sh <slug>            # interactive (you answer secret prompts)
+#   yes s | operator/bin/reprovision.sh <slug>    # non-interactive: skip all secret
+#                                                 # prompts (Machine secrets persist
+#                                                 # across deploy; nothing to re-enter)
+#
+# Run from the repo root. Equivalent to:
+#   infisical run --env=prod --path=/ss --silent -- operator/bin/provision-customer.sh <slug>
+set -euo pipefail
+SLUG="${1:-}"
+[ -n "${SLUG}" ] || { echo "Usage: $0 <customer-slug>" >&2; exit 1; }
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec infisical run --env=prod --path=/ss --silent -- "${HERE}/provision-customer.sh" "${SLUG}"

--- a/operator/customers/smd/customer.yaml
+++ b/operator/customers/smd/customer.yaml
@@ -9,9 +9,13 @@ schema_version: 1
 #
 # Every value below traces to a stated interview answer. Capabilities the substrate
 # cannot yet honor are NOT encoded here — they live as open-items in onboarding-plan.md.
-# The biggest one: Crane has no outbound send transport yet (Gmail is modify-scope /
-# never-send; AgentMail is unwired, deferred Phase 2). This config is therefore the
-# buildable subset: inbox triage + draft-for-review, no autonomous sending.
+# Crane's outbound identity is its OWN AgentMail mailbox (smdcrane@agentmail.to):
+# autonomous send/reply from that identity (action_ceilings.external_send: autonomous),
+# gated ON TOP by the content-sensitivity floor (ADR 0031 — money/contract/scope/legal
+# drop to draft), the trusted-sender allowlist, and recipient-lock. The principal's
+# intake Gmail (smdurgan@smdurgan.com) stays modify-scope (read/label/archive/draft,
+# never-send). Telegram is wired (DM, allowlisted). Inbound AgentMail → inbox-triage
+# via the webhook trigger below.
 #
 # Not provisioned, not committed by the skill. Captain reviews before either.
 

--- a/operator/templates/bootstrap.sh
+++ b/operator/templates/bootstrap.sh
@@ -348,6 +348,39 @@ log "Active persona profile: ${ACTIVE_PROFILE}"
 # dir are hermes-owned, so these mkdirs create hermes-owned, writable dirs.
 mkdir -p "${HERMES_HOME}/logs" "${HERMES_HOME}/profiles/${ACTIVE_PROFILE}/logs"
 
+# ---------- Ensure overlay plugins are PRESENT on the volume (before gateway) ----------
+# The Dockerfile's `hermes plugins install` lands the overlay pack under
+# ${HERMES_HOME} (= /opt/data) — the Fly VOLUME mountpoint. On a persisted volume
+# the build-time install is SHADOWED, so the overlay pack (trust / inbound / audit
+# / voice hooks — the safety harness) is ABSENT at runtime and the gateway would
+# boot WITHOUT it. Re-install here, idempotently, as the hermes user, after the
+# volume mount and before the gateway launches.
+#
+# Use a deterministic DIRECTORY check, NOT `hermes plugins list` — the list does
+# not report an installed-but-not-yet-loaded pack before the gateway starts (that
+# false-negative previously dragged a healthy install into a fail-closed abort).
+# FAIL-CLOSED on a genuine install failure: a Machine whose overlay pack cannot be
+# installed MUST NOT serve (matches the Dockerfile build-time hard gate).
+# The dir check is a no-op skip on the common path: a fresh volume receives the
+# build-time-installed pack via Fly's empty-volume copy, and a persisted volume
+# keeps it across deploys — so the slow `git clone` only runs in the rare reseed
+# case and does not normally delay the public :8643 listener below.
+OVERLAY_PLUGIN_DIR="${HERMES_HOME}/plugins/hermes-smd-overlay"
+if [ -d "${OVERLAY_PLUGIN_DIR}" ]; then
+  log "Overlay plugin present on the volume (${OVERLAY_PLUGIN_DIR})"
+else
+  log "Overlay plugin absent (volume shadows build-time install); installing at runtime..."
+  # Clear a stale/empty plugins dir (e.g. a root-owned dir left by a diagnostic).
+  # rm needs only parent write (${HERMES_HOME} is hermes-owned), not target
+  # ownership, so this succeeds even on a root-owned empty dir.
+  rm -rf "${HERMES_HOME}/plugins" 2>/dev/null || true
+  /opt/hermes/.venv/bin/hermes plugins install venturecrane/hermes-smd-overlay --enable \
+    || die "runtime overlay plugin install failed — refusing to launch a harness-less gateway"
+  [ -d "${OVERLAY_PLUGIN_DIR}" ] \
+    || die "overlay plugin dir missing after install — refusing to launch a harness-less gateway"
+  log "Overlay plugin installed + enabled at runtime"
+fi
+
 # Inbound webhook front-door gate (overlay `hermes-smd-webhook-gate`). It binds
 # the public port (8643), verifies the vendor signature (AgentMail), and forwards
 # to the gateway's machine-local :8644 with the Generic header. FAIL-CLOSED: only


### PR DESCRIPTION
Hardens customer-zero (`hermes-smd`) provisioning. Three latent defects surfaced while reprovisioning Crane onto the renamed `operator/` substrate; all three are now fixed at the source and verified on the live Machine (all 5 boot smoke checks pass, overlay harness loads, healthy).

## 1. The recurring R2-credential trap (~2h every session)
The operator-local R2 S3 creds were **never stored anywhere** — every agent searched Infisical for `R2_ACCESS_KEY_ID`, found nothing, and re-derived them by hand. They are **derivable from `CLOUDFLARE_API_TOKEN`** (already in Infisical `/ss`): access-key-id = the CF token id, secret = `sha256(token value)`, endpoint from the account id. The same pair has R/W on every bucket, so it covers the skill-bodies bucket too — **no token minting, ever**.
- The four `R2_*` are now stored explicitly in Infisical `/ss` (prod).
- New wrapper **`operator/bin/reprovision.sh <slug>`** = `infisical run --env=prod --path=/ss -- operator/bin/provision-customer.sh <slug>`.
- `provision-customer.sh` header + Step 0 `die()` now point at the wrapper instead of dead-ending.
- Runbook documents the derivation + canonical invocation.

## 2. Overlay plugins were volume-shadowed → safety harness silently OFF
The Dockerfile installs the `hermes-smd-overlay` pack under `${HERMES_HOME}` (= the Fly **volume** mount); on a persisted volume the build-time install is shadowed, so the trust/audit/voice hooks never loaded at runtime (true on the prior image too). `bootstrap.sh` now re-installs + enables the overlay at runtime (**fail-closed**) before the gateway launches, gated on a deterministic **directory** check (`hermes plugins list` does not report an installed-but-not-yet-loaded pack pre-gateway — that false-negative must not gate boot).

## 3. `boot-smoke-test.sh` false negatives (masked #2)
`fly ssh console --command` execs without a shell, so compound checks (`&&`, `|`, `$()`, `[ ]`) failed spuriously while single-binary checks passed → wrap each in `sh -c`. The plugins check also called bare `hermes` (not on root's PATH) → use the full venv path.

## Also
- Corrects the now-false "no outbound send" comment block in `operator/customers/smd/customer.yaml` (AgentMail send **is** wired; Gmail stays `modify`-scope never-send).
- Fixes a stale `OVERLAY_REF` reference in the runbook (v0.2.0 → v0.4.5).

## Verification
`operator/bin/reprovision.sh smd` → exit 0, all 5 smoke checks pass (`machine-state`, `customer-yaml`, `profiles-dir`, `plugins-installed`, `curator-disabled`); `hermes plugins list` shows `hermes-smd-overlay │ enabled`; `/health` 200.

## Follow-ups (not in scope)
- Add `--rotate`/auto-skip-already-set to `provision-customer.sh` so a fully non-interactive run doesn't rely on piping `s` answers.
- `hermes plugins install` clones the overlay default branch (unpinned) — pin the runtime plugin surface to `OVERLAY_REF`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)