### PR TITLE
feat(operator): insurance pack — service-and-renewal desk (first fan-out)

### DIFF
--- a/docs/specs/verticals/insurance.md
+++ b/docs/specs/verticals/insurance.md
@@ -1,0 +1,129 @@
+---
+title: 'Vertical Spec: Insurance Agency (Operator pack)'
+date: 2026-06-02
+status: draft
+captain: Scott Durgan
+related-adr: 0022-vertical-pack-architecture.md, 0035-operator-thesis.md, 0005-reviewer-as-sender.md, 0025-autonomy-ceilings-configurable-exposure-vs-initiation.md, 0020-connector-strategy.md
+---
+
+# Vertical Spec: Insurance Agency
+
+The brief that drives the insurance pack's manifest, N=0 proof, marketing surface, and delivery SOP, skinned from the worked reference (`law-firm.md`). Per [ADR 0035](../../adr/0035-operator-thesis.md), the Operator competes with a **hire** (the service/renewal desk), not with software; the agency management system is a **connection target, not a competitor**.
+
+The substance is here: the domain read, the personas, the twelve specified skills, and the connector map. The manifest (`operator/verticals/insurance/vertical.yaml`) declares the identifiers; the runtime skill bodies and the AMS BUILD adapter are built from this spec in `hermes-smd-overlay`.
+
+> **Read this first, it differs from law.** Insurance is the inverse of the law pack on two axes. (1) **Integration is the hard path, not the easy one.** Law rode Clio's MCP and needed no BUILD adapter for its system of record; the insurance system of record is an agency management system (AMS) with no MCP, so the pilot **requires a `build:` adapter** before the first customer onboards. (2) **The market is contested, not open.** The native-AMS AI and a cluster of funded entrants are already in this space. That is evidence of demand, not a reason to avoid it, but it changes the wedge: we do not claim an open seat. See "Competitive read" below.
+
+## The agency service desk's world
+
+An independent property-and-casualty agency runs on systems that do not talk to each other. The inquiry arrives by web form, phone, or referral. The book of business lives in the AMS. Carrier data, renewal downloads, billing status, cancellation and non-renewal notices, dec pages, flows into that AMS through IVANS/AL3 download. Quotes run through a comparative rater. Certificates go out to third parties. Endorsements route to the carrier. Signatures run through e-sign. Documents land in storage.
+
+The connective work is servicing the book: moving a new inquiry to a producer, running the renewal cadence so policies do not lapse, assembling the certificate a client's customer demands, relaying the endorsement request to the carrier and confirming it back, answering the routine billing question, routing the first notice of loss to the carrier, and chasing the cancellation notice before a policy goes away. It is the same chain whether the agency writes personal lines, small commercial, or both; the lines change, the coordination does not.
+
+That coordination is a real seat, the customer service representative or account manager who services the book while the producer sells. An agency covers it with a person, or splits it across people who would rather be writing new business. The Operator takes the connective layer so the seat is covered, or the person is freed for higher-value account work. We make no assumption about which it is for a given agency.
+
+## Personas (the seat, described by role)
+
+- **Account manager / CSR** (`account-manager`) at an independent agency: services a book of policies, renewals, endorsements, certificates, billing questions, the routine client back-and-forth. The seat the pack fills.
+- **Service team lead** (`service-team-lead`) at a multi-CSR agency: runs the service team. The Operator can cover an open desk or overflow, or take the routine so the team goes to the account work that needs a person.
+- **Producer's assistant** (`producer-assistant`), unlicensed: supports a producer and handles service. The reason the coverage-advice and binding lines have to be architectural, not a matter of remembering to be careful.
+
+## Skill catalog
+
+Twelve insurance-specific skills plus two spine skills reused as-is. Format per skill: **what** | trigger | reads -> writes | connectors | trust posture | guardrail. Trust posture follows [ADR 0025](../../adr/0025-autonomy-ceilings-configurable-exposure-vs-initiation.md); external send sits at the reviewer-as-sender floor ([ADR 0005](../../adr/0005-reviewer-as-sender.md)) unless the engagement authors otherwise.
+
+### New business intake
+
+**`new-business-intake`** | a quote inquiry becomes a structured opportunity plus a drafted acknowledgment, routed to a producer. | _trigger:_ inbound lead (web form / email / referral) | _reads_ the inquiry, AMS contacts (dedupe), the agency's lines and carrier appetite -> _writes_ a draft contact and opportunity, a draft reply, an internal log | PracticeManagement, Email | record draft autonomous, send draft-for-review, quote and bind always a producer | never quotes a premium, never represents coverage or appetite; routes to a licensed producer.
+
+**`quote-info-gatherer`** | gathers the exposure information a quote needs and routes it to the producer or rater. | _trigger:_ after intake, or on producer request | _reads_ the line of business' required fields (drivers, vehicles, property, prior policy) -> _writes_ a structured exposure worksheet, a follow-up draft for missing items | PracticeManagement, Email | gather autonomous, send draft-for-review | collects facts only; no coverage recommendation, no rating, no eligibility judgment.
+
+### The renewal desk
+
+**`renewal-radar`** | surfaces upcoming renewals on the agency's cadence and assembles the worklist. | _trigger:_ scheduled scan (e.g. 60 / 45 / 30 days out, per agency) | _reads_ AMS policy expiration dates and renewal status -> _writes_ a renewal worklist for the team, per-policy flags (rate change, carrier non-renewal) | PracticeManagement | surfacing autonomous | flags what is approaching; the remarket and coverage decisions are the producer's.
+
+**`renewal-review-outreach`** | reaches the client ahead of renewal to confirm details and surface changes. | _trigger:_ a policy enters the renewal window | _reads_ the policy, last-known exposures -> _writes_ an outreach draft asking for changes (new vehicle, address, business change) | PracticeManagement, Email | send draft-for-review | asks for facts; offers no coverage advice or renewal recommendation.
+
+**`remarket-carrier-follow`** | chases the carrier or underwriter for the renewal or remarket answer. | _trigger:_ an open submission past the follow-up cadence | _reads_ submission status as it lands in the AMS or from the producer -> _writes_ a follow-up to the carrier contact, a status note on the file | PracticeManagement, Email | send draft-for-review | logistics only; never negotiates terms or accepts a quote.
+
+### The service desk
+
+**`coi-request-handler`** | intakes a certificate request, assembles it from the system of record, routes for review, delivers. | _trigger:_ a certificate request (email / portal) | _reads_ the policy's coverage as recorded in the AMS, the holder's requirements -> _writes_ a draft certificate assembled from the AMS, a cover note | PracticeManagement, DocumentStorage, Email | assemble autonomous, send draft-for-review (non-raisable) | reflects only coverage on record; never adds coverage, limits, or additional-insured status not already on the policy. A misstated certificate is errors-and-omissions exposure.
+
+**`endorsement-request-router`** | intakes a policy-change request, routes it to the carrier, confirms back to the client. | _trigger:_ a change request (add a vehicle, change an address, add an additional insured) | _reads_ the policy, the requested change -> _writes_ a structured change request to the carrier or producer, a client acknowledgment, a file note | PracticeManagement, Email | intake and route autonomous, client send draft-for-review, the change itself carrier or producer | relays the request; never binds, effects, or confirms a change until the carrier confirms it.
+
+**`policy-document-responder`** | fulfills ID-card, dec-page, and policy-copy requests from the system of record. | _trigger:_ a document request routed by inbox-triage | _reads_ the requested document in the AMS or carrier record -> _writes_ the document and a cover note | PracticeManagement, DocumentStorage, Email | retrieve autonomous, send draft-for-review | sends only documents already on file; no coverage interpretation.
+
+**`billing-status-responder`** | answers routine billing and payment-status questions from the record. | _trigger:_ a billing question routed by inbox-triage | _reads_ direct-bill status as it lands in the AMS via carrier download, or agency-bill status in Payments -> _writes_ a status reply draft | PracticeManagement, Payments, Email | send draft-for-review | reports status only; never advises on payment, reinstatement, or the coverage consequences of non-payment, which route to a producer.
+
+**`fnol-intake-router`** | captures a first notice of loss and hands it to the carrier's claims line; never adjudicates. | _trigger:_ a client reports a loss | _reads_ the loss details, the policy and carrier claims contact -> _writes_ a structured FNOL, the handoff to the carrier claims intake, a client acknowledgment with the claim path | PracticeManagement, Email | capture autonomous, send and carrier handoff draft-for-review | records and routes the notice; never opines on whether the loss is covered or what the client should do.
+
+### Retention and proactive
+
+**`cancellation-notice-chaser`** | on a carrier non-pay or pending-cancellation notice, reaches the client to cure before the policy lapses. | _trigger:_ a cancellation or non-pay notice lands in the AMS via carrier download | _reads_ the notice, the policy, the cure amount and date -> _writes_ an urgent client outreach with the cure path, a file note, a team flag | PracticeManagement, Email | send draft-for-review (time-sensitive; authorable to a tighter exposure per agency) | relays the carrier's notice and cure terms exactly; never states the policy is or is not reinstated.
+
+**`account-rounding-nudge`** | surfaces a monoline client for the producer to round out the account. | _trigger:_ scheduled scan | _reads_ the book for single-line clients (auto without home, and the like) -> _writes_ a flagged list for the producer with the gap noted | PracticeManagement | surfacing autonomous | surfaces the opportunity; the cross-sell conversation and any coverage recommendation are the producer's.
+
+### Spine (reused as-is)
+
+**`inbox-triage`** routes inbound to the right skill. **`status-report-assembler`** compiles the digests.
+
+## Connector map (the real independent-agency stack)
+
+| Capability         | Common tools                           | Backend                                                  | Used by                                            |
+| ------------------ | -------------------------------------- | -------------------------------------------------------- | -------------------------------------------------- |
+| PracticeManagement | EZLynx, HawkSoft, Applied Epic, AMS360 | `build:ezlynx` / `build:hawksoft` / `build:applied-epic` | every skill (system of record; carrier data sink)  |
+| Email              | M365, Google                           | `mcp:m365-mail` / `build:google-gmail`                   | intake, service, outreach                          |
+| Calendar           | M365, Google                           | `mcp:m365-calendar` / `build:google-calendar`            | renewal cadence                                    |
+| DocumentStorage    | SharePoint, Drive                      | `mcp:softeria/ms-365-mcp-server` / `build:google-drive`  | certificates, ID cards, document requests          |
+| ESign              | DocuSign, AMS e-sign                   | `build:docusign`                                         | applications, renewal signatures                   |
+| Payments           | ePayPolicy (agency-bill)               | `build:epaypolicy`                                       | agency-bill status (direct-bill reads via the AMS) |
+
+**The AMS is load-bearing, and it is a BUILD adapter.** Unlike law (Clio MCP, no BUILD adapter for the system of record), no insurance AMS ships an MCP server. The pilot needs a `build:` adapter for whichever AMS the pilot agency runs. **EZLynx** is the likely pilot AMS: dominant in independent personal lines, a documented API, and it co-locates rating and CRM. The adapter is per-AMS; HawkSoft and Applied Epic each have an API and are the next two. This adapter is the first and largest overlay hand-off, the equivalent of the work law did not have to do.
+
+**Carrier data arrives through the AMS, not through carrier portals.** Renewal downloads, billing status, cancellation and non-renewal notices, and dec pages flow into the AMS via IVANS/AL3 download. The Operator reads them through PracticeManagement; there is no per-carrier portal connector. That is why the AMS adapter is the system of record and the carrier-data sink at once.
+
+**Rating rides the AMS adapter where co-located.** EZLynx is both AMS and rater. The Operator gathers exposure information and routes to the producer; it does not operate the rater or quote autonomously, because quoting and binding are licensed acts. No separate rater capability is modeled in v1.
+
+## Compliance floor (authored, not assumed)
+
+Per [ADR 0035](../../adr/0035-operator-thesis.md) Tenet 3, no imposed defaults; floors are fail-closed until raised.
+
+- **Coverage-advice boundary** — connective service only. Never coverage advice, never a recommended limit or carrier, never an opinion on whether a loss is covered. The twelve skills are intake, renewal logistics, certificates, endorsement relay, document retrieval, billing status, FNOL routing, and retention nudges. This scope discipline is the insurance analog of the law pack's UPL boundary.
+- **No binding authority** — the Operator never binds, changes, cancels, or reinstates coverage. Those acts route to a licensed producer or the carrier.
+- **Reviewer-as-sender floor** — external mail ships under a human reviewer's identity ([ADR 0005](../../adr/0005-reviewer-as-sender.md)), one authored exposure option ([ADR 0025](../../adr/0025-autonomy-ceilings-configurable-exposure-vs-initiation.md)); the insurance pack pins it **non-raisable for certificates** and any representation of coverage to a third party, because a misstated certificate is direct E&O exposure.
+- **Nonpublic personal information** — agencies hold a great deal of NPI (Social Security numbers, dates of birth, license numbers, VINs, property details) under GLBA and, in the states that have adopted it, the NAIC Insurance Data Security Model Law. NPI stays inside the agency's surfaces; the Operator does not exfiltrate it.
+- **Licensed-producer routing** — quotes, binding, coverage questions, and claims-coverage questions route to a licensed producer; the Operator handles logistics only.
+
+## Labor-market context (the demand, without presumption)
+
+Insurance is the strongest labor hook of any vertical, and it pulls in both directions at once. The frontline service role is acutely **hard to fill**: the workforce is aging (about a quarter is already 55 or older, and a large share will retire within fifteen years), younger workers enter the field in small numbers, and service and account-management roles are the hardest-hit entry points. At the same time, the sector is under **cost pressure** and has been shedding frontline headcount. Either way, the service work, renewals, certificates, endorsements, billing, FNOL, does not go away.
+
+We do not presume which pressure applies to a given agency: some cannot keep the desk staffed and want it covered, some want to free an existing person for account work, some are cutting and still have to service the book. Keep dated figures in outreach and channel timing, not on the evergreen landing page, and do not imply pre-knowledge of any agency's situation.
+
+## Competitive read (system-features excluded, and the seat is contested)
+
+Per the corrected lens: **system-features are connection targets, not rivals; only true employee-replacers count.** Unlike law, the employee-replacer column here is populated.
+
+- **Connection targets (zero threat):** AMS-native AI, EZLynx Virtual Assistant (account summarization, coverage-gap surfacing), Applied's embedded vertical AI, AI-assisted rating. Features inside the AMS we connect across. They make a CSR faster inside one system; they do not run the cross-system connective desk.
+- **Employee-replacers (the real column, and it is occupied):** funded entrants are here. AI quoting agents target the new-business and quoting lane; point-automation vendors do end-to-end endorsement automation (reported handle time of roughly fourteen minutes down to about two, with human approval). The new-business/quoting lane and the single-task endorsement lane are the most contested.
+
+The honest read: insurance is a hot, contested market, and that is evidence of demand and willingness to pay, not a reason to avoid it. It changes the wedge. We do not claim an open seat. We win on four things, none of which is a single feature (ADR 0035 Tenet 4, the moat is harness + guide + memory):
+
+1. **The connective whole**, the full service, renewal, and retention desk, not a single point bot bolted onto one task.
+2. **Configurability** to the agency's own book, carriers, cadence, and voice, the substrate, not a fixed product.
+3. **The integration barrier itself**, the legacy AMS with no open API is exactly what leaves the long tail of agencies underserved by the native-AMS AI, and the harness that crosses it is the moat.
+4. **Competing with a hire**, priced against a service salary, not a per-seat software line.
+
+## The wedge
+
+> The service-and-renewal desk at independent P&C agencies: answer the new-client inquiry and route it to a producer, run the renewal cadence, assemble the certificate, relay the endorsement, answer the billing question, route the first notice of loss, and chase the cancellation notice before a policy lapses. Connects to the agency's management system and reads carrier data as it downloads there, runs the connective layer only, and stays clear of coverage advice and binding. It enters a contested market on the connective whole rather than a single automation, on configurability to the agency's own book, and on an integration barrier, the legacy AMS, that the moat is built to cross.
+
+## Base vs. add-on
+
+- **`insurance` (base):** independent P&C agency service desk, personal-lines lead. The cleanest renewal-and-service desk and the lowest-friction entry.
+- **`insurance/commercial` (add-on):** commercial-lines connective skin, high-volume certificate management with holder lists and renewal tracking, additional-insured handling, and premium-audit coordination. Additive on the base; rides the same AMS.
+
+## Channel
+
+Agency networks and aggregators (SIAA, Smart Choice, ISU, Keystone) are the cheapest path to many agencies at once. Independent-agent associations (the Big "I" / IIABA and state affiliates). AMS ecosystems and user communities (EZLynx, HawkSoft, Applied). Agency-management media (Insurance Journal, IA Magazine, Rough Notes) and agency-perpetuation consultants. Commercial add-on: warm intros through commercial-heavy agencies and wholesale brokers.

--- a/docs/specs/verticals/insurance.md
+++ b/docs/specs/verticals/insurance.md
@@ -12,7 +12,7 @@ The brief that drives the insurance pack's manifest, N=0 proof, marketing surfac
 
 The substance is here: the domain read, the personas, the twelve specified skills, and the connector map. The manifest (`operator/verticals/insurance/vertical.yaml`) declares the identifiers; the runtime skill bodies and the AMS BUILD adapter are built from this spec in `hermes-smd-overlay`.
 
-> **Read this first, it differs from law.** Insurance is the inverse of the law pack on two axes. (1) **Integration is the hard path, not the easy one.** Law rode Clio's MCP and needed no BUILD adapter for its system of record; the insurance system of record is an agency management system (AMS) with no MCP, so the pilot **requires a `build:` adapter** before the first customer onboards. (2) **The market is contested, not open.** The native-AMS AI and a cluster of funded entrants are already in this space. That is evidence of demand, not a reason to avoid it, but it changes the wedge: we do not claim an open seat. See "Competitive read" below.
+> **Read this first.** Insurance differs from law on exactly one axis, and it is not demand. **Integration is the hard path, not the easy one.** Law rode Clio's MCP and needed no BUILD adapter for its system of record; the insurance system of record is an agency management system (AMS) with no MCP, so the pilot **requires a `build:` adapter** before the first customer onboards. That is a build-effort difference, not a demand difference. On demand, the seat is **more open than law's**, not less: insurance has the worst labor shortage in the dozen (see "Labor-market context"). There is a crowd of AI vendors in this market, but they automate slices (one does quoting, one does a single endorsement type), and a crowd of vendors is not a closed seat. See "Competitive read."
 
 ## The agency service desk's world
 
@@ -101,23 +101,23 @@ Insurance is the strongest labor hook of any vertical, and it pulls in both dire
 
 We do not presume which pressure applies to a given agency: some cannot keep the desk staffed and want it covered, some want to free an existing person for account work, some are cutting and still have to service the book. Keep dated figures in outreach and channel timing, not on the evergreen landing page, and do not imply pre-knowledge of any agency's situation.
 
-## Competitive read (system-features excluded, and the seat is contested)
+## Competitive read (a crowd of vendors is not a closed seat)
 
-Per the corrected lens: **system-features are connection targets, not rivals; only true employee-replacers count.** Unlike law, the employee-replacer column here is populated.
+Per the corrected lens: **system-features are connection targets, not rivals; only a true employee-replacer counts; and the seat is closed only when the business stops needing the employee.** Insurance has many AI vendors and an unfilled seat at the same time. Those are different facts, and conflating them is the trap. The seat is closed when an agency no longer needs a CSR. Insurance is the opposite of that: it cannot hire the CSR it needs (see "Labor-market context").
 
 - **Connection targets (zero threat):** AMS-native AI, EZLynx Virtual Assistant (account summarization, coverage-gap surfacing), Applied's embedded vertical AI, AI-assisted rating. Features inside the AMS we connect across. They make a CSR faster inside one system; they do not run the cross-system connective desk.
-- **Employee-replacers (the real column, and it is occupied):** funded entrants are here. AI quoting agents target the new-business and quoting lane; point-automation vendors do end-to-end endorsement automation (reported handle time of roughly fourteen minutes down to about two, with human approval). The new-business/quoting lane and the single-task endorsement lane are the most contested.
+- **Slice-automators (vendors, not seat-replacers):** the funded crowd is here, and it automates slivers. AI quoting agents take the new-business quoting slice; point-automation vendors take a single endorsement type (reported handle time of roughly fourteen minutes down to about two, with human approval); training and call-assist tools augment a human CSR rather than replace the seat. None of them runs the whole connective service desk across the agency's systems. The connective seat is unfilled twice over: by humans (the agency cannot hire it) and by competitors (who only take slices).
 
-The honest read: insurance is a hot, contested market, and that is evidence of demand and willingness to pay, not a reason to avoid it. It changes the wedge. We do not claim an open seat. We win on four things, none of which is a single feature (ADR 0035 Tenet 4, the moat is harness + guide + memory):
+The honest read: insurance is a hot market with a wide-open seat. The vendor crowd is evidence of demand and willingness to pay, not evidence the seat is taken. We win on four things, none of which is a single feature (ADR 0035 Tenet 4, the moat is harness + guide + memory):
 
 1. **The connective whole**, the full service, renewal, and retention desk, not a single point bot bolted onto one task.
 2. **Configurability** to the agency's own book, carriers, cadence, and voice, the substrate, not a fixed product.
 3. **The integration barrier itself**, the legacy AMS with no open API is exactly what leaves the long tail of agencies underserved by the native-AMS AI, and the harness that crosses it is the moat.
-4. **Competing with a hire**, priced against a service salary, not a per-seat software line.
+4. **Competing with a hire**, priced against a service salary the agency cannot fill, not a per-seat software line.
 
 ## The wedge
 
-> The service-and-renewal desk at independent P&C agencies: answer the new-client inquiry and route it to a producer, run the renewal cadence, assemble the certificate, relay the endorsement, answer the billing question, route the first notice of loss, and chase the cancellation notice before a policy lapses. Connects to the agency's management system and reads carrier data as it downloads there, runs the connective layer only, and stays clear of coverage advice and binding. It enters a contested market on the connective whole rather than a single automation, on configurability to the agency's own book, and on an integration barrier, the legacy AMS, that the moat is built to cross.
+> The service-and-renewal desk at independent P&C agencies: answer the new-client inquiry and route it to a producer, run the renewal cadence, assemble the certificate, relay the endorsement, answer the billing question, route the first notice of loss, and chase the cancellation notice before a policy lapses. Connects to the agency's management system and reads carrier data as it downloads there, runs the connective layer only, and stays clear of coverage advice and binding. It wins on a seat the agency cannot fill and the slice-automation vendors do not cover: the connective whole rather than a single automation, configured to the agency's own book, across the integration barrier, the legacy AMS, that the moat is built to cross.
 
 ## Base vs. add-on
 

--- a/docs/specs/verticals/insurance.md
+++ b/docs/specs/verticals/insurance.md
@@ -3,12 +3,12 @@ title: 'Vertical Spec: Insurance Agency (Operator pack)'
 date: 2026-06-02
 status: draft
 captain: Scott Durgan
-related-adr: 0022-vertical-pack-architecture.md, 0035-operator-thesis.md, 0005-reviewer-as-sender.md, 0025-autonomy-ceilings-configurable-exposure-vs-initiation.md, 0020-connector-strategy.md
+related-adr: 0022-vertical-pack-architecture.md, 0037-operator-thesis.md, 0005-reviewer-as-sender.md, 0025-autonomy-ceilings-configurable-exposure-vs-initiation.md, 0020-connector-strategy.md
 ---
 
 # Vertical Spec: Insurance Agency
 
-The brief that drives the insurance pack's manifest, N=0 proof, marketing surface, and delivery SOP, skinned from the worked reference (`law-firm.md`). Per [ADR 0035](../../adr/0035-operator-thesis.md), the Operator competes with a **hire** (the service/renewal desk), not with software; the agency management system is a **connection target, not a competitor**.
+The brief that drives the insurance pack's manifest, N=0 proof, marketing surface, and delivery SOP, skinned from the worked reference (`law-firm.md`). Per [ADR 0037](../../adr/0037-operator-thesis.md), the Operator competes with a **hire** (the service/renewal desk), not with software; the agency management system is a **connection target, not a competitor**.
 
 The substance is here: the domain read, the personas, the twelve specified skills, and the connector map. The manifest (`operator/verticals/insurance/vertical.yaml`) declares the identifiers; the runtime skill bodies and the AMS BUILD adapter are built from this spec in `hermes-smd-overlay`.
 
@@ -87,7 +87,7 @@ Twelve insurance-specific skills plus two spine skills reused as-is. Format per 
 
 ## Compliance floor (authored, not assumed)
 
-Per [ADR 0035](../../adr/0035-operator-thesis.md) Tenet 3, no imposed defaults; floors are fail-closed until raised.
+Per [ADR 0037](../../adr/0037-operator-thesis.md) Tenet 3, no imposed defaults; floors are fail-closed until raised.
 
 - **Coverage-advice boundary** — connective service only. Never coverage advice, never a recommended limit or carrier, never an opinion on whether a loss is covered. The twelve skills are intake, renewal logistics, certificates, endorsement relay, document retrieval, billing status, FNOL routing, and retention nudges. This scope discipline is the insurance analog of the law pack's UPL boundary.
 - **No binding authority** — the Operator never binds, changes, cancels, or reinstates coverage. Those acts route to a licensed producer or the carrier.
@@ -108,7 +108,7 @@ Per the corrected lens: **system-features are connection targets, not rivals; on
 - **Connection targets (zero threat):** AMS-native AI, EZLynx Virtual Assistant (account summarization, coverage-gap surfacing), Applied's embedded vertical AI, AI-assisted rating. Features inside the AMS we connect across. They make a CSR faster inside one system; they do not run the cross-system connective desk.
 - **Slice-automators (vendors, not seat-replacers):** the funded crowd is here, and it automates slivers. AI quoting agents take the new-business quoting slice; point-automation vendors take a single endorsement type (reported handle time of roughly fourteen minutes down to about two, with human approval); training and call-assist tools augment a human CSR rather than replace the seat. None of them runs the whole connective service desk across the agency's systems. The connective seat is unfilled twice over: by humans (the agency cannot hire it) and by competitors (who only take slices).
 
-The honest read: insurance is a hot market with a wide-open seat. The vendor crowd is evidence of demand and willingness to pay, not evidence the seat is taken. We win on four things, none of which is a single feature (ADR 0035 Tenet 4, the moat is harness + guide + memory):
+The honest read: insurance is a hot market with a wide-open seat. The vendor crowd is evidence of demand and willingness to pay, not evidence the seat is taken. We win on four things, none of which is a single feature (ADR 0037 Tenet 4, the moat is harness + guide + memory):
 
 1. **The connective whole**, the full service, renewal, and retention desk, not a single point bot bolted onto one task.
 2. **Configurability** to the agency's own book, carriers, cadence, and voice, the substrate, not a fixed product.

--- a/operator/verticals/insurance/addons/commercial/addon.yaml
+++ b/operator/verticals/insurance/addons/commercial/addon.yaml
@@ -1,0 +1,44 @@
+# Add-on pack manifest: insurance/commercial
+#
+# Schema: docs/specs/operator/vertical-manifest-schema.md (identical to
+# vertical.yaml). `name` MUST appear in ACCEPTED_ADDONS['insurance'] in
+# src/lib/operator/customer-yaml/types.ts (commercial is registered). Add-on
+# assets are ADDITIVE on top of the insurance base; the base does not declare
+# them.
+#
+# Commercial-lines connective skin: high-volume certificate (COI) management
+# with holder lists and renewal tracking, additional-insured handling, and
+# premium-audit coordination. Same coverage-advice and no-binding floors as the
+# base, plus a certificate-accuracy floor. Rides the same AMS as the base.
+
+name: commercial
+version: 0.1.0
+
+# Additive floors on top of the base insurance compliance set.
+compliance:
+  - certificate-on-record-only # certificates reflect coverage on record; never add coverage or AI status
+  - premium-audit-no-advocacy # coordinate the audit logistics; never dispute or interpret findings
+
+personas: []
+
+# Commercial-specific connective skills (bodies in hermes-smd-overlay).
+skills:
+  - certificate-management # master holder lists, batch renewal of certificates on record
+  - additional-insured-handler # relays AI requests to the carrier; never confers status itself
+  - premium-audit-coordinator # gathers and routes audit documents; no advocacy or interpretation
+  - coi-renewal-tracker # tracks certificate-renewal cadence against policy renewals
+
+# Inherits the base insurance connectors.
+connectors: []
+
+templates:
+  - certificate-renewal-notice.md
+  - additional-insured-acknowledgment.md
+  - premium-audit-document-request.md
+
+fixtures:
+  - synthetic-commercial-gl-account
+
+evals:
+  - cert-commercial-certificate-on-record-only
+  - cert-commercial-no-binding-or-ai-status

--- a/operator/verticals/insurance/fixtures/n0-deliverability-proof.md
+++ b/operator/verticals/insurance/fixtures/n0-deliverability-proof.md
@@ -1,0 +1,93 @@
+# Insurance pack — N=0 deliverability proof
+
+The deliverability gate (per the build plan): with **no customer-specific data**, can the pack produce connective artifacts a real agency CSR would send with only light edits? Below are five core connective tasks hand-drafted against two synthetic scenarios. Every one is **substance-free** — renewal logistics, billing status, FNOL routing, certificate cover, endorsement relay. None gives coverage advice, quotes a premium, binds a change, or opines on whether a loss is covered (the coverage-advice and no-binding boundaries in the brief).
+
+Bracketed values are the only fields that need filling. These double as the pack's `templates[]` (see `vertical.yaml`).
+
+---
+
+## Synthetic scenario A — personal auto renewal (`synthetic-personal-auto-renewal`)
+
+> Existing policy: personal auto for [the Okafor household], renewing in [45] days. The AMS flags a [premium increase] at renewal. Client has [auto only], no home policy on file.
+
+### 1. Renewal review outreach
+
+> Subject: Your auto policy renews soon, anything changed?
+>
+> Hi [Ms. Okafor],
+>
+> Your auto policy is coming up for renewal on [date], and I want to make sure it still fits before it does. A few quick questions: any new or replaced vehicles, a new driver in the household, a move, or a change in how far you drive to work?
+>
+> Reply whenever it is convenient and I will update the file. If nothing has changed, just let me know and we are set.
+>
+> [Agency name]
+
+_Substance-free: asks for facts that affect the renewal. Makes no coverage recommendation and does not characterize the premium change._
+
+### 2. Billing-status reply
+
+> Subject: Re: Did my payment go through?
+>
+> Hi [Ms. Okafor],
+>
+> Checking the record now: your payment of [amount] posted on [date], and the next installment is scheduled for [date]. The policy shows current.
+>
+> If you would like me to send the payment confirmation or the schedule, just say the word.
+>
+> [Agency name]
+
+_Connective: reports billing status from the record. No advice on payment, reinstatement, or coverage consequences._
+
+### 3. FNOL acknowledgment
+
+> Subject: We have your accident report, here is what happens next
+>
+> Hi [Ms. Okafor],
+>
+> Thanks for letting us know about the [parking-lot incident] on [date]. I have reported it to [carrier] and opened the first notice of loss. Your claim reference is [number], and a [carrier] adjuster will reach out to you directly, usually within [the carrier's stated window].
+>
+> If you have photos or the other party's information, you can reply here and I will add them to the file. I am glad you are alright.
+>
+> [Agency name]
+
+_Connective: captures and routes the notice, names the claim path. Never says whether the loss is covered or what the client should do about it._
+
+---
+
+## Synthetic scenario B — commercial certificate request (`synthetic-commercial-coi-request`)
+
+> Existing commercial account: [Riverbend Contracting], general liability in force. A general contractor ([the holder]) has requested a certificate of insurance naming themselves before [Riverbend] can start on a job. The client forwards the holder's requirements and asks us to "add them as additional insured and send the cert."
+
+### 4. Certificate cover note
+
+> Subject: Certificate of insurance for [the holder]
+>
+> Hi [Mr. Vance],
+>
+> Attached is the certificate of insurance for [Riverbend Contracting], reflecting the coverage currently on your general liability policy, sent to [the holder] as requested.
+>
+> One thing to flag for you: the holder's paperwork asks for [the holder] to be added as an additional insured. That is a change to the policy itself, not something the certificate can do on its own, so I have started that request with [carrier] separately (see the next note). The certificate attached reflects the policy as it stands today.
+>
+> [Agency name]
+
+_Connective: assembles the certificate from coverage on record and sends a cover note. Does not add coverage or additional-insured status the policy does not already carry, and flags the difference instead of papering over it._
+
+### 5. Endorsement acknowledgment
+
+> Subject: Request to add [the holder] as additional insured
+>
+> Hi [Mr. Vance],
+>
+> Following up on the additional-insured request for [the holder]. I have sent the change request to [carrier] to add them to your general liability policy. This is in their hands now; I will confirm the moment they process it and send you the updated certificate showing the change.
+>
+> Until [carrier] confirms, the additional-insured status is not yet in effect, so please hold off on relying on it for the job start. I will chase them and keep you posted.
+>
+> [Agency name]
+
+_Connective: relays the change request and acknowledges it. Never binds or confirms the change before the carrier does, and says so plainly._
+
+---
+
+## Gate result
+
+Five connective artifacts, two synthetic scenarios, zero coverage advice, zero binding, zero customer-specific data. A practicing agency CSR would send each with light edits (names, dates, the claim number, the attachment). **Pass.** The value proposition holds: the reviewer edits lightly and sends, rather than rewriting from scratch, and the artifacts demonstrate the hard line, certificate on record only, endorsement relayed not confirmed, FNOL routed not adjudicated.

--- a/operator/verticals/insurance/vertical.yaml
+++ b/operator/verticals/insurance/vertical.yaml
@@ -9,7 +9,7 @@
 #
 # The service-and-renewal-desk pack: substance-free connective work across an
 # independent P&C agency's management system, email, calendar, documents,
-# e-sign, and agency-bill payments. Per ADR 0035 the Operator competes with the
+# e-sign, and agency-bill payments. Per ADR 0037 the Operator competes with the
 # service-desk hire; the AMS is a connection target, not a competitor.
 #
 # NB (differs from law): the system of record (the AMS) has no MCP, so the pilot
@@ -20,7 +20,7 @@ name: insurance
 version: 0.1.0
 
 # Vertical-level safety floors (free-form slugs). Fail-closed, authored per
-# ADR 0035 Tenet 3 / ADR 0025. See the brief's "Compliance floor".
+# ADR 0037 Tenet 3 / ADR 0025. See the brief's "Compliance floor".
 compliance:
   - coverage-advice-boundary # connective service only; never coverage advice or substance
   - no-binding-authority # never binds, changes, cancels, or reinstates coverage

--- a/operator/verticals/insurance/vertical.yaml
+++ b/operator/verticals/insurance/vertical.yaml
@@ -1,0 +1,112 @@
+# Vertical pack manifest: insurance
+#
+# Schema: docs/specs/operator/vertical-manifest-schema.md (ADR 0022 Stream 1).
+# Brief:  docs/specs/verticals/insurance.md (the skill catalog, connector map,
+#         personas, and domain read this manifest declares the identifiers for).
+#
+# `name` MUST match ACCEPTED_VERTICALS in src/lib/operator/customer-yaml/types.ts
+# (insurance is already registered). All list fields are required; [] is valid.
+#
+# The service-and-renewal-desk pack: substance-free connective work across an
+# independent P&C agency's management system, email, calendar, documents,
+# e-sign, and agency-bill payments. Per ADR 0035 the Operator competes with the
+# service-desk hire; the AMS is a connection target, not a competitor.
+#
+# NB (differs from law): the system of record (the AMS) has no MCP, so the pilot
+# REQUIRES a build: adapter (see the brief's connector map). Carrier data is read
+# THROUGH the AMS (IVANS/AL3 download), not via per-carrier connectors.
+
+name: insurance
+version: 0.1.0
+
+# Vertical-level safety floors (free-form slugs). Fail-closed, authored per
+# ADR 0035 Tenet 3 / ADR 0025. See the brief's "Compliance floor".
+compliance:
+  - coverage-advice-boundary # connective service only; never coverage advice or substance
+  - no-binding-authority # never binds, changes, cancels, or reinstates coverage
+  - reviewer-as-sender-floor # external mail under a human reviewer (ADR 0005); non-raisable for certificates
+  - npi-handling # GLBA / NAIC Insurance Data Security Model Law; NPI stays in agency surfaces
+  - licensed-producer-routing # quotes, binding, coverage and claims-coverage questions route to a producer
+
+# Reference persona archetypes (templates, not runtime personas). The seat the
+# pack fills, described by role. See the brief's "Personas".
+personas:
+  - slug: account-manager
+    title: Account Manager / CSR
+  - slug: service-team-lead
+    title: Service Team Lead
+  - slug: producer-assistant
+    title: Producer's Assistant
+
+# Vertical-default skills. Two spine skills are reused as-is; the twelve
+# insurance-specific skills are specified in the brief's "Skill catalog"; their
+# runtime bodies live in hermes-smd-overlay (alongside the AMS build adapter).
+skills:
+  # spine (reused)
+  - inbox-triage # routes inbound to the right skill
+  - status-report-assembler # compiles the digests
+  # new business intake
+  - new-business-intake # routes to a producer; never quotes or binds
+  - quote-info-gatherer # gathers exposure facts; no rating or eligibility judgment
+  # the renewal desk
+  - renewal-radar
+  - renewal-review-outreach
+  - remarket-carrier-follow
+  # the service desk
+  - coi-request-handler # reflects only coverage on record; certificate send is non-raisable
+  - endorsement-request-router # relays; never binds or confirms before the carrier does
+  - policy-document-responder
+  - billing-status-responder # status only; non-pay consequences route to a producer
+  - fnol-intake-router # captures and routes; never adjudicates coverage
+  # retention and proactive
+  - cancellation-notice-chaser # relays carrier cure terms; never states reinstatement
+  - account-rounding-nudge # surfaces the gap; the cross-sell is the producer's
+
+# Vertical-default connectors (capability + adapter + backend). MCP-first per
+# ADR 0020; unlike law, the system of record (the AMS) has no MCP, so it is a
+# BUILD adapter (the first/largest overlay hand-off). Carrier data is read
+# through PracticeManagement; no per-carrier connector. Capabilities map onto
+# the closed CapabilityName union (no AgencyManagement slot without an ADR): the
+# AMS is the PracticeManagement system of record, as Clio is for law.
+connectors:
+  - capability: PracticeManagement
+    adapter: ezlynx
+    backend: 'build:ezlynx' # pilot AMS; HawkSoft / Applied Epic are the next adapters
+  - capability: Email
+    adapter: m365-mail
+    backend: 'mcp:m365-mail'
+  - capability: Calendar
+    adapter: m365-calendar
+    backend: 'mcp:m365-calendar'
+  - capability: DocumentStorage
+    adapter: ms-365
+    backend: 'mcp:softeria/ms-365-mcp-server'
+  - capability: ESign
+    adapter: docusign
+    backend: 'build:docusign'
+  - capability: Payments
+    adapter: epaypolicy
+    backend: 'build:epaypolicy' # agency-bill status; direct-bill reads via the AMS
+
+# Connective-artifact templates the pack provides (the N=0 proof; see
+# fixtures/n0-deliverability-proof.md).
+templates:
+  - new-business-acknowledgment.md
+  - renewal-review-outreach.md
+  - certificate-cover-note.md
+  - endorsement-acknowledgment.md
+  - billing-status-reply.md
+  - fnol-acknowledgment.md
+  - cancellation-cure-outreach.md
+
+# Synthetic test fixtures shipped with the pack.
+fixtures:
+  - synthetic-personal-auto-renewal
+  - synthetic-commercial-coi-request
+
+# Certification evals the pack must pass before a customer is bound to it.
+evals:
+  - cert-connective-no-coverage-advice
+  - cert-certificate-on-record-only
+  - cert-no-binding-authority
+  - cert-fnol-no-adjudication

--- a/src/lib/operator/customer-yaml/types.ts
+++ b/src/lib/operator/customer-yaml/types.ts
@@ -51,7 +51,7 @@ export const ACCEPTED_ADDONS: Readonly<Record<Vertical, readonly string[]>> = {
   'marketing-agency': [],
   'real-estate': [],
   manufacturing: [],
-  insurance: [],
+  insurance: ['commercial'],
   mixed: [],
 } as const
 


### PR DESCRIPTION
First fan-out from the law reference, built to the same depth. **Stacked on #1200** (base = `feat/operator-packs-law-pilot`) because the insurance spec is skinned from the law reference and the pack factory, both of which land in that PR. Rebase onto main once #1200 merges.

## What's here (substance only)
- `docs/specs/verticals/insurance.md` — domain read, 3 role-based personas, **12 specified skills + 2 spine** (each with trigger / reads to writes / connectors / trust posture / guardrail), connector map, compliance floor, labor-market context, competitive read, wedge, base/addon, channel.
- `operator/verticals/insurance/vertical.yaml` — manifest: 14 skills, 6 connectors, 3 personas, 5 compliance floors, templates/fixtures/evals.
- `operator/verticals/insurance/addons/commercial/addon.yaml` — commercial-lines add-on (COI management, additional-insured handling, premium-audit coordination).
- `operator/verticals/insurance/fixtures/n0-deliverability-proof.md` — 5 substance-free connective artifacts across 2 synthetic scenarios; stresses the coverage-advice / no-binding boundary.
- `src/lib/operator/customer-yaml/types.ts` — registers `insurance/commercial` in `ACCEPTED_ADDONS`.

## How it relates to law — one real difference, and it is not demand
1. **Integration is the hard path.** The AMS has **no MCP**, so the pilot needs a `build:ezlynx` adapter (the first/largest overlay hand-off). Law rode Clio's MCP and needed none. Carrier data is read *through* the AMS (IVANS/AL3 download), not via per-carrier connectors. The AMS maps onto the existing `PracticeManagement` capability, no `CapabilityName` enum change. This is a **build-effort** difference.
2. **On demand, the seat is more open than law's, not less.** Insurance has the worst labor shortage in the dozen, it cannot fill the CSR seat. There is a crowd of AI vendors, but they automate *slices* (quoting, one endorsement type, call-assist), not the connective whole. A crowd of vendors is not a closed seat: the seat is unfilled by humans (can't hire) and by competitors (only slices). The native-AMS AI (EVA, Applied vertical AI) are connection targets, zero threat.

## Verification
- `npm run typecheck` — 0 errors
- `npm test` — 2887 pass, 2 skipped

Marketing surface (`src/pages/packs/insurance.astro` + intake allow-lists) deliberately deferred to Captain's voice, same as law.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
