### PR TITLE
feat(operator): veterinary pack — front-desk coordinator desk (fan-out)

### DIFF
--- a/docs/specs/verticals/veterinary.md
+++ b/docs/specs/verticals/veterinary.md
@@ -1,0 +1,128 @@
+---
+title: 'Vertical Spec: Veterinary Clinic (Operator pack)'
+date: 2026-06-02
+status: draft
+captain: Scott Durgan
+related-adr: 0022-vertical-pack-architecture.md, 0035-operator-thesis.md, 0005-reviewer-as-sender.md, 0025-autonomy-ceilings-configurable-exposure-vs-initiation.md, 0020-connector-strategy.md
+---
+
+# Vertical Spec: Veterinary Clinic
+
+The brief that drives the veterinary pack's manifest, N=0 proof, marketing surface, and delivery SOP, skinned from the worked reference (`law-firm.md`). Per [ADR 0035](../../adr/0035-operator-thesis.md), the Operator competes with a **hire** (the front-desk client coordinator), not with software; the practice information management system is a **connection target, not a competitor**.
+
+The substance is here: the domain read, the personas, the twelve specified skills, and the connector map. The manifest (`operator/verticals/veterinary/vertical.yaml`) declares the identifiers; the runtime skill bodies and the PIMS BUILD adapter are built from this spec in `hermes-smd-overlay`.
+
+> **Where vet sits relative to law and insurance.** On the one axis that varies, integration cost, vet is **in between**: the cloud PIMS (ezyVet, Vetspire, Provet Cloud) expose open APIs, so the pilot needs a `build:` adapter, but on a modern API, lighter than insurance's legacy AMS and heavier than law's ready Clio MCP. On demand, the seat is wide open: front-desk turnover is the worst-staffed role in the dozen (see "Labor-market context"). There is a crowd of "AI vet receptionist" vendors, but they take slices, phone answering and symptom triage, and one of those slices, triage, is veterinary medical judgment we deliberately do not touch. See "Competitive read."
+
+## The clinic front desk's world
+
+A companion-animal clinic runs on systems that do not talk to each other. The client calls, texts, or fills out a form. The patient record lives in the PIMS. The schedule lives in the PIMS or a connected calendar. Reminders, refill requests, lab results, estimates, boarding bookings, and discharge notes all move through the front desk. Diagnostics flow back from the lab into the record.
+
+The connective work is running the front of house: booking the appointment, reminding and confirming it, rebooking the no-show, surfacing the patient overdue for wellness care, relaying the refill request to the doctor, getting the released result to the client, following up on the estimate, coordinating boarding, checking in after a visit, and reconnecting the client who has not been seen in a while. It is the same chain whether the clinic is a single-doctor practice or a four-doctor hospital; the case mix changes, the coordination does not.
+
+That coordination is a real seat, the client service representative or receptionist who runs the front desk while the doctors and technicians work in the back. It is also the hardest seat in the building to keep filled. A clinic covers it with a person, or splits it across a team pulled in every direction. The Operator takes the connective layer so the seat is covered, or the person is freed for the in-clinic work only a person can do. We make no assumption about which it is for a given clinic.
+
+## Personas (the seat, described by role)
+
+- **Client service representative** (`client-service-rep`) at a general practice: the front desk, phones, scheduling, reminders, refill requests, the routine client back-and-forth. The seat the pack fills, and the one with the highest turnover in the building.
+- **Practice manager** (`practice-manager`): runs clinic operations. The Operator can cover an open front desk or overflow, or take the routine so the team goes to the in-clinic work that needs a person.
+- **Veterinary assistant working front of house** (`assistant-front-of-house`), not a veterinarian or technician: the reason the no-medical-advice and emergency-escalation lines have to be architectural, not a matter of remembering to be careful.
+
+## Skill catalog
+
+Twelve veterinary-specific skills plus two spine skills reused as-is. Format per skill: **what** | trigger | reads -> writes | connectors | trust posture | guardrail. Trust posture follows [ADR 0025](../../adr/0025-autonomy-ceilings-configurable-exposure-vs-initiation.md); external send sits at the reviewer-as-sender floor ([ADR 0005](../../adr/0005-reviewer-as-sender.md)) unless the engagement authors otherwise.
+
+### New client and scheduling
+
+**`new-client-intake`** | a new-client inquiry becomes a structured client and patient record plus a drafted acknowledgment, with an offer to book. | _trigger:_ inbound inquiry (web form / email / referral) | _reads_ the inquiry, PIMS clients (dedupe), the clinic's services -> _writes_ a draft client and patient, a draft reply, an internal log | PracticeManagement, Email | record draft autonomous, send draft-for-review | no medical advice; if the inquiry describes a possible emergency, hands to the clinic immediately rather than handling it async (see `emergency-escalation-router`).
+
+**`appointment-scheduler`** | offers times, books, confirms, puts it on the schedule. | _trigger:_ a booking request, or after intake | _reads_ provider and room availability, appointment-type duration -> _writes_ the appointment and a confirmation | PracticeManagement, Calendar, Email | booking autonomous within the clinic's rules, confirmation per authored exposure | schedules by the appointment type the clinic defines; never assigns clinical urgency or decides whether a case is an emergency.
+
+**`appointment-reminder-confirmer`** | sends reminders and captures the confirm or reschedule. | _trigger:_ scheduled ahead of appointments | _reads_ upcoming appointments -> _writes_ reminder drafts, applies the confirm or reschedule | PracticeManagement, Email | send per authored exposure for reminders | reminder logistics only.
+
+**`no-show-rebooker`** | follows up on a missed appointment to get it rebooked. | _trigger:_ a no-show or late cancellation | _reads_ the missed appointment -> _writes_ a rebooking outreach draft | PracticeManagement, Email | send draft-for-review | rebooking logistics; makes no judgment about the clinical urgency of rebooking.
+
+### The recall engine (the retention spine)
+
+**`wellness-recall`** | surfaces patients overdue for wellness or vaccines per the clinic's protocol and drafts the reminder. | _trigger:_ scheduled scan | _reads_ PIMS recall and due dates (the clinic's authored protocols) -> _writes_ an overdue list, per-client recall drafts | PracticeManagement, Email | surfacing autonomous, send draft-for-review | surfaces what the clinic's own protocol marks due; never sets the protocol or decides what care a patient medically needs.
+
+### The service desk
+
+**`refill-request-router`** | intakes a prescription-refill request, routes it to the doctor for authorization, confirms back to the client. | _trigger:_ a refill request | _reads_ the patient, the prescription on record -> _writes_ a structured refill request to the doctor or technician, a client acknowledgment, a file note | PracticeManagement, Email | intake and route autonomous, client send draft-for-review, authorization always the doctor | relays the request; never authorizes a refill, never advises on dosing, flags controlled substances for the doctor.
+
+**`results-callback-coordinator`** | once a result is released by the doctor, coordinates getting it to the client. | _trigger:_ a doctor releases a result or marks it ready to share | _reads_ the released result and the doctor's authored note -> _writes_ a callback or notify draft conveying only what the doctor authored | PracticeManagement, Email | send draft-for-review | conveys only the doctor's authored result and instructions; never interprets a result or adds medical commentary.
+
+**`estimate-followup`** | follows up on a treatment estimate the clinic sent. | _trigger:_ an estimate sent and not yet approved | _reads_ the estimate status -> _writes_ a follow-up draft | PracticeManagement, Email | send draft-for-review | approval and payment logistics; no pressure and no medical framing of the consequences of declining.
+
+**`boarding-grooming-coordinator`** | books and confirms boarding or grooming and captures the requirements. | _trigger:_ a boarding or grooming request | _reads_ availability, the patient's vaccine status as recorded -> _writes_ the booking, a requirements checklist draft | PracticeManagement, Calendar, Email | booking autonomous within rules, send draft-for-review | states vaccine status as recorded; never makes a medical clearance decision.
+
+### Proactive and safety
+
+**`post-visit-followup`** | a day-after check-in on the clinic's cadence. | _trigger:_ scheduled after a visit | _reads_ the visit and the doctor's authored discharge note -> _writes_ a check-in draft carrying the discharge summary as authored | PracticeManagement, Email | send draft-for-review | conveys only the doctor's authored discharge content; if the client replies with a medical concern, hands to the clinic rather than advising.
+
+**`lapsed-client-winback`** | surfaces clients not seen in the clinic's window and drafts a reconnect. | _trigger:_ scheduled scan | _reads_ last-visit dates -> _writes_ a list and per-client winback drafts | PracticeManagement, Email | surfacing autonomous, send draft-for-review | reconnect logistics; makes no medical claim about what the patient is due for.
+
+**`emergency-escalation-router`** | the safety skill: detects a possible emergency in any inbound message and hands it to a human at the clinic immediately, never queues it. | _trigger:_ an inbound message that triage flags as possibly urgent | _reads_ the message -> _writes_ an immediate escalation to the clinic's on-call or front-desk channel, plus a holding acknowledgment telling the client to call or come in | PracticeManagement, InternalComms, Email | escalation autonomous and immediate; never an autonomous medical reply | never assesses urgency clinically itself, errs toward escalation, and follows the rule "when in doubt, hand it to a person now." This is fail-open to a human, the one place the pack is deliberately not async.
+
+### Spine (reused as-is)
+
+**`inbox-triage`** routes inbound to the right skill, and is the first gate the `emergency-escalation-router` hooks. **`status-report-assembler`** compiles the digests.
+
+## Connector map (the real clinic stack)
+
+| Capability         | Common tools                                | Backend                                                 | Used by                                          |
+| ------------------ | ------------------------------------------- | ------------------------------------------------------- | ------------------------------------------------ |
+| PracticeManagement | ezyVet, Vetspire, Provet Cloud, Cornerstone | `build:ezyvet` / `build:vetspire` / `build:provet`      | every skill (system of record)                   |
+| Email              | M365, Google                                | `mcp:m365-mail` / `build:google-gmail`                  | intake, reminders, recall, service               |
+| Calendar           | M365, Google                                | `mcp:m365-calendar` / `build:google-calendar`           | scheduling, boarding                             |
+| DocumentStorage    | SharePoint, Drive                           | `mcp:softeria/ms-365-mcp-server` / `build:google-drive` | discharge notes, records, requirement checklists |
+| InternalComms      | Slack, Teams                                | `mcp:slack` / `build:teams`                             | emergency escalation, team digests               |
+
+**The PIMS is a BUILD adapter, but a lighter one than insurance.** No PIMS ships an MCP today, so the pilot needs a `build:` adapter, the same shape as insurance. The difference is the API underneath: the cloud PIMS (ezyVet, Vetspire, Provet) expose modern, documented REST/GraphQL APIs, where the insurance AMS is a legacy platform. **ezyVet** is the likely pilot PIMS for reach (IDEXX flagship, large cloud install base); **Vetspire** is the cleanest API (open GraphQL) if the pilot clinic runs it. The adapter is per-PIMS; the legacy server systems (Cornerstone, AVImark) are the harder tail and come later.
+
+**Phone is out of scope on purpose.** The clinic front desk is phone-heavy, and the AI-vet-receptionist crowd is mostly phone-answering bots. The Operator is the async connective desk, not the phone line. No CallTracking connector in v1, this is a deliberate boundary, not a gap.
+
+## Compliance floor (authored, not assumed)
+
+Per [ADR 0035](../../adr/0035-operator-thesis.md) Tenet 3, no imposed defaults; floors are fail-closed until raised.
+
+- **No veterinary medical advice** — connective front-desk work only. Never a diagnosis, never a treatment recommendation, never an interpretation of a result, never a urgency or triage judgment. The twelve skills are intake, scheduling, reminders, recall, refill relay, result delivery of authored content, estimates, boarding, follow-up, and escalation. This scope discipline is the veterinary analog of the law pack's UPL boundary.
+- **Emergency escalation (fail-open to a human)** — a message that may describe an emergency is handed to a person at the clinic immediately, never handled async and never answered with medical content. `emergency-escalation-router` errs toward escalation by design.
+- **No prescription authorization** — refill requests route to the doctor for authorization; the Operator never authorizes a refill, sets a dose, or advises on medication, and flags controlled substances for the doctor.
+- **Reviewer-as-sender floor** — external mail ships under a human reviewer's identity ([ADR 0005](../../adr/0005-reviewer-as-sender.md)), one authored exposure option ([ADR 0025](../../adr/0025-autonomy-ceilings-configurable-exposure-vs-initiation.md)).
+- **Records stay in clinic surfaces** — client and patient records stay inside the clinic's systems; the Operator does not exfiltrate them.
+
+## Labor-market context (the demand, without presumption)
+
+Veterinary is one of the two strongest labor hooks in the dozen, and it is concentrated in exactly the seat this pack fills. The front desk is the worst-staffed role in the building: receptionist turnover runs around a third per year, more than half of receptionists leave inside two years, and the role is named as the most burnout-prone, first and last contact with emotional clients, constant phones, and little training. Turnover is expensive (industry analyses put the cost of a single lost staffer in the low tens of thousands for a typical clinic, and the cost of burnout industry-wide in the billions).
+
+We do not presume which pressure applies to a given clinic: some cannot keep the front desk staffed and want it covered, some want to free the team for in-clinic work, some are managing constant churn. Keep dated figures in outreach and channel timing, not on the evergreen landing page, and do not imply pre-knowledge of any clinic's situation.
+
+## Competitive read (a crowd of vendors is not a closed seat)
+
+Per the corrected lens: **system-features are connection targets, not rivals; only a true employee-replacer counts; and the seat is closed only when the clinic stops needing the front desk.** Veterinary has many AI vendors and an unfilled seat at the same time, and the seat is the worst-staffed in the dozen.
+
+- **Connection targets (zero threat):** PIMS-native and bolt-on client comms, IDEXX Vello, Vetspire 2-Way Messaging, PetDesk reminders. Reminders, texting, online booking. Slices inside or beside the PIMS we connect across. They do not run the cross-system connective desk.
+- **Slice-automators (vendors, not seat-replacers):** the AI-vet-receptionist space is crowded, and it is mostly two slices. **Phone answering**, 24/7 call coverage, FAQ, book-by-phone (a long list of answering-service vendors). **Symptom triage**, urgency rating and symptom checking (e.g. Petriage). Neither is the full connective coordinator running scheduling, recall, refill relay, results, estimates, boarding, and follow-up across the PIMS, configured to the clinic and in its voice. The connective seat is unfilled twice over: by humans (the clinic cannot keep it staffed) and by competitors (who take slices).
+
+The triage slice is one we **will not** take, on safety grounds: assessing urgency is veterinary medical judgment, and the hybrid services already concede that a human handles emergency symptom assessment. Our `emergency-escalation-router` does the opposite of triage, it routes a possible emergency to a person without judging it. That is both the compliance floor and a clean line between us and the triage vendors.
+
+The honest read: veterinary is a hot market with the most open seat in the dozen. We win on four things, none of which is a single feature (ADR 0035 Tenet 4, the moat is harness + guide + memory):
+
+1. **The connective whole**, the full front desk, not a phone bot or a symptom checker bolted onto one task.
+2. **Configurability** to the clinic's own protocols, schedule, services, and voice, the substrate, not a fixed product.
+3. **The safety line as a feature**, we route emergencies to a person and never play doctor, which the triage vendors cannot claim.
+4. **Competing with a hire**, priced against a front-desk salary the clinic cannot keep filled, not a per-seat software line.
+
+## The wedge
+
+> The front-desk client-coordinator seat at companion-animal clinics: book and confirm the appointment, rebook the no-show, surface the patient due for wellness care, relay the refill to the doctor, deliver the released result, follow the estimate, coordinate boarding, check in after the visit, and route a possible emergency straight to a person. Connects to the clinic's management system over its open API, runs the connective layer only, and stays clear of medical advice, triage, and prescription authorization. It wins on the worst-staffed seat in the dozen, on the connective whole the slice vendors do not cover, and on a safety line, never play doctor, that doubles as the differentiator.
+
+## Base vs. add-on
+
+- **`veterinary` (base):** companion-animal general-practice front desk. The cleanest, highest-turnover seat and the lowest-friction entry.
+- **`veterinary/specialty-er` (add-on):** specialty and emergency hospital connective skin, inbound referral intake from referring veterinarians (rDVMs), referral-status updates back to the rDVM, and discharge-summary routing to the rDVM. Additive on the base; the same no-medical-advice and emergency-escalation floors apply, and the referral coordination is connective only.
+
+## Channel
+
+PIMS ecosystems and app marketplaces (ezyVet, Vetspire, Provet partner programs). The Veterinary Hospital Managers Association (VHMA) and practice-manager communities, the buyers closest to the front-desk pain. Veterinary conferences (VMX, WVC, Fetch) and practice-management media (Today's Veterinary Business, dvm360). Buying groups and independent-practice networks. Specialty-ER add-on: referral-hospital networks and specialty associations.

--- a/docs/specs/verticals/veterinary.md
+++ b/docs/specs/verticals/veterinary.md
@@ -3,12 +3,12 @@ title: 'Vertical Spec: Veterinary Clinic (Operator pack)'
 date: 2026-06-02
 status: draft
 captain: Scott Durgan
-related-adr: 0022-vertical-pack-architecture.md, 0035-operator-thesis.md, 0005-reviewer-as-sender.md, 0025-autonomy-ceilings-configurable-exposure-vs-initiation.md, 0020-connector-strategy.md
+related-adr: 0022-vertical-pack-architecture.md, 0037-operator-thesis.md, 0005-reviewer-as-sender.md, 0025-autonomy-ceilings-configurable-exposure-vs-initiation.md, 0020-connector-strategy.md
 ---
 
 # Vertical Spec: Veterinary Clinic
 
-The brief that drives the veterinary pack's manifest, N=0 proof, marketing surface, and delivery SOP, skinned from the worked reference (`law-firm.md`). Per [ADR 0035](../../adr/0035-operator-thesis.md), the Operator competes with a **hire** (the front-desk client coordinator), not with software; the practice information management system is a **connection target, not a competitor**.
+The brief that drives the veterinary pack's manifest, N=0 proof, marketing surface, and delivery SOP, skinned from the worked reference (`law-firm.md`). Per [ADR 0037](../../adr/0037-operator-thesis.md), the Operator competes with a **hire** (the front-desk client coordinator), not with software; the practice information management system is a **connection target, not a competitor**.
 
 The substance is here: the domain read, the personas, the twelve specified skills, and the connector map. The manifest (`operator/verticals/veterinary/vertical.yaml`) declares the identifiers; the runtime skill bodies and the PIMS BUILD adapter are built from this spec in `hermes-smd-overlay`.
 
@@ -84,7 +84,7 @@ Twelve veterinary-specific skills plus two spine skills reused as-is. Format per
 
 ## Compliance floor (authored, not assumed)
 
-Per [ADR 0035](../../adr/0035-operator-thesis.md) Tenet 3, no imposed defaults; floors are fail-closed until raised.
+Per [ADR 0037](../../adr/0037-operator-thesis.md) Tenet 3, no imposed defaults; floors are fail-closed until raised.
 
 - **No veterinary medical advice** — connective front-desk work only. Never a diagnosis, never a treatment recommendation, never an interpretation of a result, never a urgency or triage judgment. The twelve skills are intake, scheduling, reminders, recall, refill relay, result delivery of authored content, estimates, boarding, follow-up, and escalation. This scope discipline is the veterinary analog of the law pack's UPL boundary.
 - **Emergency escalation (fail-open to a human)** — a message that may describe an emergency is handed to a person at the clinic immediately, never handled async and never answered with medical content. `emergency-escalation-router` errs toward escalation by design.
@@ -107,7 +107,7 @@ Per the corrected lens: **system-features are connection targets, not rivals; on
 
 The triage slice is one we **will not** take, on safety grounds: assessing urgency is veterinary medical judgment, and the hybrid services already concede that a human handles emergency symptom assessment. Our `emergency-escalation-router` does the opposite of triage, it routes a possible emergency to a person without judging it. That is both the compliance floor and a clean line between us and the triage vendors.
 
-The honest read: veterinary is a hot market with the most open seat in the dozen. We win on four things, none of which is a single feature (ADR 0035 Tenet 4, the moat is harness + guide + memory):
+The honest read: veterinary is a hot market with the most open seat in the dozen. We win on four things, none of which is a single feature (ADR 0037 Tenet 4, the moat is harness + guide + memory):
 
 1. **The connective whole**, the full front desk, not a phone bot or a symptom checker bolted onto one task.
 2. **Configurability** to the clinic's own protocols, schedule, services, and voice, the substrate, not a fixed product.

--- a/operator/verticals/veterinary/addons/specialty-er/addon.yaml
+++ b/operator/verticals/veterinary/addons/specialty-er/addon.yaml
@@ -1,0 +1,43 @@
+# Add-on pack manifest: veterinary/specialty-er
+#
+# Schema: docs/specs/operator/vertical-manifest-schema.md (identical to
+# vertical.yaml). `name` MUST appear in ACCEPTED_ADDONS['veterinary'] in
+# src/lib/operator/customer-yaml/types.ts (specialty-er is registered). Add-on
+# assets are ADDITIVE on top of the veterinary base; the base does not declare
+# them.
+#
+# Specialty / emergency hospital connective skin: inbound referral intake from
+# referring veterinarians (rDVMs), referral-status updates back to the rDVM, and
+# discharge-summary routing to the rDVM. The same no-medical-advice and
+# emergency-escalation floors as the base apply; referral coordination is
+# connective only.
+
+name: specialty-er
+version: 0.1.0
+
+# Additive floors on top of the base veterinary compliance set.
+compliance:
+  - referral-coordination-connective-only # relay referrals and status; never clinical content of our own
+  - rdvm-consent-on-shared-records # patient detail to an rDVM only as the hospital authorizes
+
+personas: []
+
+# Specialty/ER-specific connective skills (bodies in hermes-smd-overlay).
+skills:
+  - referral-intake-router # intakes an rDVM referral, routes to the right service
+  - referral-status-updater # sends authored status back to the referring vet
+  - discharge-summary-router # routes the doctor's authored discharge summary to the rDVM
+
+# Inherits the base veterinary connectors.
+connectors: []
+
+templates:
+  - referral-acknowledgment-rdvm.md
+  - referral-status-update-rdvm.md
+
+fixtures:
+  - synthetic-referral-ortho
+
+evals:
+  - cert-specialty-referral-connective-only
+  - cert-rdvm-consent-respected

--- a/operator/verticals/veterinary/fixtures/n0-deliverability-proof.md
+++ b/operator/verticals/veterinary/fixtures/n0-deliverability-proof.md
@@ -1,0 +1,94 @@
+# Veterinary pack — N=0 deliverability proof
+
+The deliverability gate (per the build plan): with **no customer-specific data**, can the pack produce connective artifacts a real clinic CSR would send with only light edits? Below are five core connective tasks hand-drafted against two synthetic scenarios. Every one is **substance-free** — recall, scheduling, follow-up, refill relay, and emergency routing. None gives medical advice, interprets a result, judges urgency, or authorizes a prescription (the no-medical-advice, emergency-escalation, and no-authorization boundaries in the brief).
+
+The fifth artifact is the important one: it shows the Operator handling a possible emergency by routing it to a person and sending a holding note, **without a word of medical advice**.
+
+Bracketed values are the only fields that need filling. These double as the pack's `templates[]` (see `vertical.yaml`).
+
+---
+
+## Synthetic scenario A — overdue wellness patient (`synthetic-wellness-recall-canine`)
+
+> Existing patient: [Biscuit], a [canine] seen last on [date]. The PIMS protocol marks [Biscuit] overdue for [an annual wellness exam and vaccines]. Owner: [Dana].
+
+### 1. Wellness recall reminder
+
+> Subject: [Biscuit] is due for a checkup
+>
+> Hi [Dana],
+>
+> Our records show [Biscuit] is due for [an annual wellness visit and vaccines]. It has been a little while, so we wanted to reach out and help you get back on the schedule.
+>
+> Would a weekday morning or afternoon work better? Reply here and I will send a couple of times, or you can book online at [link].
+>
+> [Clinic name]
+
+_Substance-free: surfaces what the clinic's own protocol marks due and offers to book. Makes no claim about what care [Biscuit] medically needs._
+
+### 2. Appointment confirmation
+
+> Subject: You're booked, [Biscuit] on [day]
+>
+> Hi [Dana],
+>
+> [Biscuit] is confirmed for [a wellness exam] with [Dr. name] on [day, date, time]. Please bring [any current medications and a stool sample if you have one]. If you need to change it, reply here or call us.
+>
+> See you both then,
+> [Clinic name]
+
+_Connective: confirms the booking, lists the clinic's standard bring-list. No clinical instruction beyond what the clinic authored._
+
+### 3. Post-visit follow-up
+
+> Subject: Checking in on [Biscuit]
+>
+> Hi [Dana],
+>
+> Just checking in after [Biscuit]'s visit yesterday. [Dr. name] sent you home with this summary: [paste the doctor's authored discharge note]. How is [Biscuit] doing today?
+>
+> If anything looks off or you have questions, the best thing is to call us at [number] and we will get you to the right person. Glad we saw you both.
+>
+> [Clinic name]
+
+_Connective: carries the doctor's authored discharge note verbatim and invites contact. Adds no medical commentary; routes any concern to a person rather than answering it._
+
+---
+
+## Synthetic scenario B — refill request and an emergency message (`synthetic-emergency-inbound-message`)
+
+> Two inbound messages from the same owner on different days. First: a routine refill request. Second: a message that may describe an emergency.
+
+### 4. Refill acknowledgment
+
+> Inbound: "Can I get a refill of [Biscuit]'s [heartworm prevention]?"
+>
+> Subject: We've sent your refill request to the doctor
+>
+> Hi [Dana],
+>
+> Thanks for the heads up. I have sent your request for [Biscuit]'s [heartworm prevention] refill to [Dr. name] to review and approve. Once it is approved I will let you know it is ready and where to pick it up or how it will ship.
+>
+> [Clinic name]
+
+_Connective: relays the refill request to the doctor and acknowledges it. Never authorizes the refill and never advises on the medication; approval is the doctor's._
+
+### 5. Emergency holding acknowledgment (the safety path)
+
+> Inbound: "[Biscuit] just got into a bag of chocolate maybe 20 minutes ago, he ate a lot. What should I do??"
+>
+> **Client-facing holding note (sent immediately, no medical advice):**
+>
+> > Hi [Dana], I want to get you to someone right now. Please call us at [clinic number] immediately so a member of our team can help you, and if we are closed or you cannot reach us, call [the clinic's authored emergency/after-hours number or the pet poison line the clinic lists]. Please do not wait for an email reply, calling is the fastest way to get [Biscuit] help.
+>
+> **Internal escalation (sent the same instant to the clinic's front-desk / on-call channel):**
+>
+> > URGENT, possible emergency. [Dana] reports [Biscuit] ([canine]) ingested a large amount of chocolate ~20 min ago. Message received [time]. Client told to call the clinic now and given [the after-hours/poison line]. Needs a person immediately.
+>
+> _The Operator does not assess how serious this is, does not tell the owner what to do for the dog, and does not handle it asynchronously. It routes the client to a human and flags the clinic the same instant. Assessing urgency and advising treatment is veterinary medical judgment the pack never performs, this is fail-open to a person by design._
+
+---
+
+## Gate result
+
+Five connective artifacts, two synthetic scenarios, zero medical advice, zero triage judgment, zero prescription authorization, zero customer-specific data. The four routine artifacts a clinic CSR would send with light edits (names, times, the link, the doctor's authored note). The fifth demonstrates the hard line: a possible emergency is routed to a person and acknowledged without a word of medical content. **Pass.** The value proposition holds, and the safety boundary holds with it.

--- a/operator/verticals/veterinary/vertical.yaml
+++ b/operator/verticals/veterinary/vertical.yaml
@@ -1,0 +1,109 @@
+# Vertical pack manifest: veterinary
+#
+# Schema: docs/specs/operator/vertical-manifest-schema.md (ADR 0022 Stream 1).
+# Brief:  docs/specs/verticals/veterinary.md (the skill catalog, connector map,
+#         personas, and domain read this manifest declares the identifiers for).
+#
+# `name` MUST match ACCEPTED_VERTICALS in src/lib/operator/customer-yaml/types.ts
+# (veterinary is registered by this PR). All list fields are required; [] is valid.
+#
+# The front-desk-coordinator pack: substance-free connective work across a
+# clinic's practice information management system (PIMS), email, calendar,
+# documents, and team comms. Per ADR 0035 the Operator competes with the
+# front-desk hire; the PIMS is a connection target, not a competitor.
+#
+# NB: the PIMS has no MCP, so the pilot needs a build: adapter (like insurance),
+# but on a modern cloud API (ezyVet / Vetspire / Provet), lighter than the
+# legacy insurance AMS. Phone is deliberately out of scope (the AI-receptionist
+# crowd is phone bots; this pack is the async connective desk).
+
+name: veterinary
+version: 0.1.0
+
+# Vertical-level safety floors (free-form slugs). Fail-closed, authored per
+# ADR 0035 Tenet 3 / ADR 0025. See the brief's "Compliance floor".
+compliance:
+  - no-medical-advice # connective front-desk work only; never diagnosis, triage, or result interpretation
+  - emergency-escalation-fail-open # possible emergencies go to a human immediately; never handled async
+  - no-prescription-authorization # refills route to the doctor; never authorize or advise on dosing
+  - reviewer-as-sender-floor # external mail under a human reviewer (ADR 0005)
+  - records-stay-in-clinic # client and patient records stay inside clinic surfaces
+
+# Reference persona archetypes (templates, not runtime personas). The seat the
+# pack fills, described by role. See the brief's "Personas".
+personas:
+  - slug: client-service-rep
+    title: Client Service Representative
+  - slug: practice-manager
+    title: Practice Manager
+  - slug: assistant-front-of-house
+    title: Veterinary Assistant (Front of House)
+
+# Vertical-default skills. Two spine skills are reused as-is; the twelve
+# veterinary-specific skills are specified in the brief's "Skill catalog"; their
+# runtime bodies live in hermes-smd-overlay (alongside the PIMS build adapter).
+skills:
+  # spine (reused)
+  - inbox-triage # routes inbound; first gate the emergency router hooks
+  - status-report-assembler # compiles the digests
+  # new client and scheduling
+  - new-client-intake # escalates a possible emergency rather than handling it async
+  - appointment-scheduler # never assigns clinical urgency
+  - appointment-reminder-confirmer
+  - no-show-rebooker
+  # the recall engine
+  - wellness-recall # surfaces what the clinic's protocol marks due; never sets the protocol
+  # the service desk
+  - refill-request-router # routes to the doctor; never authorizes or advises on dosing
+  - results-callback-coordinator # conveys only the doctor's authored result; never interprets
+  - estimate-followup
+  - boarding-grooming-coordinator # states vaccine status as recorded; no medical clearance
+  # proactive and safety
+  - post-visit-followup # conveys authored discharge content; escalates medical replies
+  - lapsed-client-winback
+  - emergency-escalation-router # the safety skill: routes possible emergencies to a human, never triages
+
+# Vertical-default connectors (capability + adapter + backend). MCP-first per
+# ADR 0020; no PIMS ships an MCP, so the system of record is a BUILD adapter on
+# a modern cloud API. Capabilities map onto the closed CapabilityName union (the
+# PIMS is the PracticeManagement system of record, as Clio is for law). Phone is
+# out of scope on purpose (see the brief).
+connectors:
+  - capability: PracticeManagement
+    adapter: ezyvet
+    backend: 'build:ezyvet' # pilot PIMS; Vetspire (open GraphQL) and Provet are the next adapters
+  - capability: Email
+    adapter: m365-mail
+    backend: 'mcp:m365-mail'
+  - capability: Calendar
+    adapter: m365-calendar
+    backend: 'mcp:m365-calendar'
+  - capability: DocumentStorage
+    adapter: ms-365
+    backend: 'mcp:softeria/ms-365-mcp-server'
+  - capability: InternalComms
+    adapter: slack
+    backend: 'mcp:slack' # emergency escalation to the clinic's on-call/front-desk channel
+
+# Connective-artifact templates the pack provides (the N=0 proof; see
+# fixtures/n0-deliverability-proof.md).
+templates:
+  - new-client-acknowledgment.md
+  - appointment-confirmation.md
+  - wellness-recall-reminder.md
+  - refill-acknowledgment.md
+  - estimate-followup.md
+  - emergency-holding-acknowledgment.md
+  - post-visit-followup.md
+
+# Synthetic test fixtures shipped with the pack.
+fixtures:
+  - synthetic-wellness-recall-canine
+  - synthetic-emergency-inbound-message
+
+# Certification evals the pack must pass before a customer is bound to it.
+evals:
+  - cert-connective-no-medical-advice
+  - cert-emergency-escalation-fail-open
+  - cert-refill-no-authorization
+  - cert-results-authored-content-only

--- a/operator/verticals/veterinary/vertical.yaml
+++ b/operator/verticals/veterinary/vertical.yaml
@@ -9,7 +9,7 @@
 #
 # The front-desk-coordinator pack: substance-free connective work across a
 # clinic's practice information management system (PIMS), email, calendar,
-# documents, and team comms. Per ADR 0035 the Operator competes with the
+# documents, and team comms. Per ADR 0037 the Operator competes with the
 # front-desk hire; the PIMS is a connection target, not a competitor.
 #
 # NB: the PIMS has no MCP, so the pilot needs a build: adapter (like insurance),
@@ -21,7 +21,7 @@ name: veterinary
 version: 0.1.0
 
 # Vertical-level safety floors (free-form slugs). Fail-closed, authored per
-# ADR 0035 Tenet 3 / ADR 0025. See the brief's "Compliance floor".
+# ADR 0037 Tenet 3 / ADR 0025. See the brief's "Compliance floor".
 compliance:
   - no-medical-advice # connective front-desk work only; never diagnosis, triage, or result interpretation
   - emergency-escalation-fail-open # possible emergencies go to a human immediately; never handled async

--- a/src/lib/operator/customer-yaml/types.ts
+++ b/src/lib/operator/customer-yaml/types.ts
@@ -28,6 +28,7 @@ export const ACCEPTED_VERTICALS = [
   'real-estate',
   'manufacturing',
   'insurance',
+  'veterinary',
   'mixed',
 ] as const
 export type Vertical = (typeof ACCEPTED_VERTICALS)[number]
@@ -52,6 +53,7 @@ export const ACCEPTED_ADDONS: Readonly<Record<Vertical, readonly string[]>> = {
   'real-estate': [],
   manufacturing: [],
   insurance: ['commercial'],
+  veterinary: ['specialty-er'],
   mixed: [],
 } as const
 
@@ -104,6 +106,7 @@ export const VERTICAL_AUDIT_LOG_DAYS_DEFAULTS: Readonly<Record<Vertical, number>
   'real-estate': 2555,
   manufacturing: 2555,
   insurance: 2555,
+  veterinary: 1825,
   mixed: 2555,
 } as const
 


### PR DESCRIPTION
Second fan-out from the law reference, built to the same depth. **Stacked on #1200** (base = `feat/operator-packs-law-pilot`) because the vet spec is skinned from the law reference and the pack factory. Rebase onto main once #1200 merges. Independent of the insurance PR (#1202).

## What's here (substance only)
- `docs/specs/verticals/veterinary.md` — domain read, 3 role-based personas, **12 specified skills + 2 spine**, connector map, 5 compliance floors, labor context, competitive read, wedge, base/addon, channel.
- `operator/verticals/veterinary/vertical.yaml` — manifest: 14 skills, 5 connectors (incl. InternalComms for emergency escalation), 3 personas, templates/fixtures/evals.
- `operator/verticals/veterinary/addons/specialty-er/addon.yaml` — specialty/ER add-on (rDVM referral intake, status updates, discharge-summary routing).
- `operator/verticals/veterinary/fixtures/n0-deliverability-proof.md` — 5 substance-free artifacts; centerpiece is a chocolate-ingestion message routed to a human with **zero medical advice**.
- `src/lib/operator/customer-yaml/types.ts` — registers `veterinary` as a new vertical across all three `Vertical`-keyed objects (ACCEPTED_VERTICALS, ACCEPTED_ADDONS → `specialty-er`, VERTICAL_AUDIT_LOG_DAYS_DEFAULTS → 1825d).

## Eye on the ball — the open-seat test, applied
- **The seat is the most open in the dozen.** Front-desk receptionist turnover ~33%/yr, >50% gone inside two years — the worst-staffed role in the clinic. Clinics cannot keep it filled.
- **The vendor crowd takes slices**, not the connective whole: phone-answering bots and symptom-triage checkers. Native PIMS comms (Vello, Vetspire 2-way, PetDesk) are connection targets, zero threat. A crowd of vendors is not a closed seat.
- **We refuse the triage slice on safety grounds.** Assessing urgency is veterinary medical judgment. `emergency-escalation-router` routes a possible emergency to a person *without judging it* — the safety floor that doubles as the differentiator.

## Where it sits vs law and insurance
Integration is **in between**: cloud PIMS (ezyVet, Vetspire, Provet) expose modern open APIs → a `build:` adapter on a clean API, lighter than insurance's legacy AMS, heavier than law's ready MCP. Phone is out of scope on purpose (async connective desk, not the phone line). The PIMS maps onto the existing `PracticeManagement` capability — no `CapabilityName` enum change.

## Verification
- `npm run typecheck` — 0 errors
- `npm test` — 2887 pass, 2 skipped

Marketing surface deferred to Captain's voice, same as law and insurance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
