### PR TITLE
feat(operator): tier-b — the rest of the dozen (9 packs)

### DIFF
--- a/docs/specs/verticals/accounting.md
+++ b/docs/specs/verticals/accounting.md
@@ -3,12 +3,12 @@ title: 'Vertical Spec: Accounting Firm (Operator pack)'
 date: 2026-06-02
 status: draft
 captain: Scott Durgan
-related-adr: 0022-vertical-pack-architecture.md, 0035-operator-thesis.md, 0005-reviewer-as-sender.md, 0025-autonomy-ceilings-configurable-exposure-vs-initiation.md, 0020-connector-strategy.md
+related-adr: 0022-vertical-pack-architecture.md, 0037-operator-thesis.md, 0005-reviewer-as-sender.md, 0025-autonomy-ceilings-configurable-exposure-vs-initiation.md, 0020-connector-strategy.md
 ---
 
 # Vertical Spec: Accounting Firm
 
-The brief that drives the accounting pack's manifest, N=0 proof, marketing surface, and delivery SOP, skinned from the worked reference (`law-firm.md`). Per [ADR 0035](../../adr/0035-operator-thesis.md), the Operator competes with a **hire** (the firm administrator and client coordinator), not with software; the practice-management platform is a **connection target, not a competitor**.
+The brief that drives the accounting pack's manifest, N=0 proof, marketing surface, and delivery SOP, skinned from the worked reference (`law-firm.md`). Per [ADR 0037](../../adr/0037-operator-thesis.md), the Operator competes with a **hire** (the firm administrator and client coordinator), not with software; the practice-management platform is a **connection target, not a competitor**.
 
 > **Where accounting sits, the cleanest open seat in the dozen.** The labor shortage is the most severe of any vertical: the profession has lost 300,000+ accountants since 2020, roughly three-quarters of CPAs are at or near retirement, the pipeline is shrinking, unemployment sits near 1-2%, and firms are turning away clients for lack of capacity. The funded AI here, Basis, Truewind, Zeni, targets the **work** (the AI staff accountant doing close, entries, audit-prep), not the connective admin seat. The connective coordinator seat, onboarding, document chasing, deadlines, e-sign, billing, is open and the firm cannot hire for it either. Research even names the opening: every firm runs four to six disconnected tools, and the glue is a person.
 
@@ -79,7 +79,7 @@ Twelve accounting-specific skills plus two spine skills reused as-is. Format per
 
 ## Compliance floor (authored, not assumed)
 
-Per [ADR 0035](../../adr/0035-operator-thesis.md) Tenet 3, no imposed defaults; floors are fail-closed until raised.
+Per [ADR 0037](../../adr/0037-operator-thesis.md) Tenet 3, no imposed defaults; floors are fail-closed until raised.
 
 - **No tax or accounting advice** — connective coordination only. Never a tax position, never a deduction or treatment, never an interpretation of financials, never a due-date computation. The twelve skills are onboarding, document chasing, scheduling, deadline relay, e-sign chasing, status, billing, and renewal. This is the accounting analog of the law pack's UPL boundary.
 - **Taxpayer-information confidentiality (IRC §7216)** — taxpayer information is not disclosed or used beyond preparing the engagement without the consent the law requires. The Operator does not share or repurpose taxpayer data.
@@ -98,7 +98,7 @@ Per the corrected lens: **system-features are connection targets; only a true em
 - **Connection targets (zero threat):** practice-management platform features and portals (Karbon, Canopy, TaxDome automations), QuickBooks and Xero. The systems we connect across.
 - **Employee-replacers, but in a different lane:** the funded AI, Basis, Truewind, Zeni, is the **AI staff accountant**, doing the close, the entries, audit-prep, and consolidation. That is the credentialed work, not the connective admin seat. It competes with the preparer, not the coordinator. The coordinator seat, onboarding, PBC chasing, deadlines, e-sign, billing, is not what they are building.
 
-The honest read: the most acute labor shortage in the dozen, and the funded competition is aimed at a different seat. We win on four things, none of which is a single feature (ADR 0035 Tenet 4, the moat is harness + guide + memory):
+The honest read: the most acute labor shortage in the dozen, and the funded competition is aimed at a different seat. We win on four things, none of which is a single feature (ADR 0037 Tenet 4, the moat is harness + guide + memory):
 
 1. **The connective whole**, the full coordinator seat, onboarding through renewal, not a single automation.
 2. **The chasing the firm cannot staff**, PBC document collection and deadline tracking, where the work actually stalls.

--- a/docs/specs/verticals/accounting.md
+++ b/docs/specs/verticals/accounting.md
@@ -1,0 +1,119 @@
+---
+title: 'Vertical Spec: Accounting Firm (Operator pack)'
+date: 2026-06-02
+status: draft
+captain: Scott Durgan
+related-adr: 0022-vertical-pack-architecture.md, 0035-operator-thesis.md, 0005-reviewer-as-sender.md, 0025-autonomy-ceilings-configurable-exposure-vs-initiation.md, 0020-connector-strategy.md
+---
+
+# Vertical Spec: Accounting Firm
+
+The brief that drives the accounting pack's manifest, N=0 proof, marketing surface, and delivery SOP, skinned from the worked reference (`law-firm.md`). Per [ADR 0035](../../adr/0035-operator-thesis.md), the Operator competes with a **hire** (the firm administrator and client coordinator), not with software; the practice-management platform is a **connection target, not a competitor**.
+
+> **Where accounting sits, the cleanest open seat in the dozen.** The labor shortage is the most severe of any vertical: the profession has lost 300,000+ accountants since 2020, roughly three-quarters of CPAs are at or near retirement, the pipeline is shrinking, unemployment sits near 1-2%, and firms are turning away clients for lack of capacity. The funded AI here, Basis, Truewind, Zeni, targets the **work** (the AI staff accountant doing close, entries, audit-prep), not the connective admin seat. The connective coordinator seat, onboarding, document chasing, deadlines, e-sign, billing, is open and the firm cannot hire for it either. Research even names the opening: every firm runs four to six disconnected tools, and the glue is a person.
+
+## The firm coordinator's world
+
+An accounting firm runs on systems that do not talk to each other. The client onboards by email and a portal. Work and deadlines live in the practice-management platform (Karbon, Canopy, TaxDome). The books live in QuickBooks or Xero. Engagement letters and e-file authorizations run through e-sign. Documents the client owes the firm (the "prepared-by-client" list) arrive late, in pieces, or not at all.
+
+The connective work is moving the engagement forward and keeping every client current: onboarding the new client and getting the engagement letter signed, sending and collecting the organizer, chasing the documents the firm is waiting on, scheduling the working session, tracking the filing deadline, getting the e-file authorization signed, answering the routine "where's my return" question, tracking who is on extension, following the unpaid invoice, and rolling the client into next year's engagement. It is the same chain whether the firm does tax, bookkeeping, or advisory; the work product changes, the coordination does not.
+
+That coordination is a real seat, the firm administrator or client coordinator who keeps the engagements moving while the accountants do the accounting. In a profession that cannot hire, it is often the seat that does not get filled at all, and the chasing lands on the preparers, who are the scarcest resource in the building. The Operator takes the connective layer so the seat is covered, or the accountants are freed for the work only a credentialed person can do. We make no assumption about which it is for a given firm.
+
+## Personas (the seat, described by role)
+
+- **Firm administrator / client coordinator** (`firm-administrator`): onboarding, document chasing, scheduling, deadlines, billing, the routine client back-and-forth. The seat that often goes unfilled.
+- **Staff accountant handling client comms** (`staff-accountant`): does the work and chases the client on top of it. The Operator can take the chasing so that time goes to the engagement.
+- **Firm owner / partner** (`firm-partner`): owns the client relationships and the advice. The reason the no-tax-advice line has to be architectural.
+
+## Skill catalog
+
+Twelve accounting-specific skills plus two spine skills reused as-is. Format per skill: **what** | trigger | reads -> writes | connectors | trust posture | guardrail. Trust posture follows [ADR 0025](../../adr/0025-autonomy-ceilings-configurable-exposure-vs-initiation.md); external send sits at the reviewer-as-sender floor ([ADR 0005](../../adr/0005-reviewer-as-sender.md)) unless the engagement authors otherwise.
+
+### Onboarding
+
+**`client-onboarding`** | a new-client engagement becomes a structured record plus a drafted welcome, the engagement letter, and the document request list. | _trigger:_ a new engagement | _reads_ the client, the firm's service and engagement templates -> _writes_ a draft client record, a draft welcome with the engagement letter and request list, an internal log | PracticeManagement, ESign, Email | record draft autonomous, send draft-for-review | never advises on a tax position or scope; relays the firm's authored engagement terms.
+
+**`engagement-letter-chaser`** | tracks the unsigned engagement letter and nudges on a cadence. | _trigger:_ sent and unsigned past the cadence | _reads_ e-sign status -> _writes_ a nudge draft, logs on signature | ESign, Email, PracticeManagement | send draft-for-review | never interprets the letter's terms.
+
+**`prior-records-requester`** | requests the books and prior returns from the client or the predecessor firm. | _trigger:_ onboarding needs predecessor records | _reads_ what is needed -> _writes_ the records request to the client or predecessor | PracticeManagement, Email | send draft-for-review | gathers records; makes no use or judgment of their contents.
+
+### Documents and deadlines (the connective heart)
+
+**`organizer-distributor`** | sends the annual tax organizer or questionnaire and collects it back. | _trigger:_ engagement season opens | _reads_ the client list, the firm's organizer -> _writes_ the organizer send and follow-up drafts | PracticeManagement, Email | send draft-for-review | distributes and collects; never fills in or advises on an answer.
+
+**`pbc-document-chaser`** | chases the prepared-by-client documents the firm is waiting on. | _trigger:_ a request list item open past the cadence | _reads_ the open request list, what has arrived -> _writes_ a per-item chase draft, updates the list as items land | PracticeManagement, DocumentStorage, Email | chase autonomous (sends draft-for-review), list update autonomous | chases the documents on the firm's list; never decides whether a document is sufficient.
+
+**`appointment-scheduler`** | offers times, books, confirms the working session. | _trigger:_ a session needed or requested | _reads_ staff availability, session length -> _writes_ the appointment and a confirmation | Calendar, Email, PracticeManagement | booking autonomous within rules | scheduling logistics only.
+
+**`deadline-filing-reminder`** | tracks the filing deadlines the firm has entered and surfaces what is approaching. | _trigger:_ scheduled | _reads_ the engagement's deadline fields (the firm's authored dates) -> _writes_ an approaching-deadline digest and client reminders | PracticeManagement, Calendar, Email | surfacing autonomous, send draft-for-review | tracks the dates the firm authored; never computes a filing requirement or due date itself, which is professional judgment.
+
+**`efile-authorization-chaser`** | tracks the unsigned e-file authorization (e.g. Form 8879) and nudges. | _trigger:_ the return is ready and the authorization is unsigned | _reads_ e-sign status -> _writes_ a nudge draft, logs on signature | ESign, Email, PracticeManagement | send draft-for-review | chases the signature; never advises on the return or its contents.
+
+### Status, billing, and renewal
+
+**`client-status-responder`** | answers the routine "where's my return" from the system of record. | _trigger:_ a status question routed by inbox-triage | _reads_ engagement status, next step -> _writes_ a status reply draft | PracticeManagement, Email | send draft-for-review | reports status only; no tax opinion or prediction.
+
+**`extension-status-tracker`** | tracks which clients are on extension and surfaces them. | _trigger:_ scheduled | _reads_ extension status across engagements -> _writes_ an extension digest and per-client reminders | PracticeManagement, Email | surfacing autonomous, send draft-for-review | tracks and surfaces; makes no judgment about whether to extend.
+
+**`billing-invoice-followup`** | follows the unpaid invoice. | _trigger:_ an invoice open past the cadence | _reads_ the invoice and ledger status -> _writes_ a statement-reminder draft | PracticeManagement, Accounting, Email | send draft-for-review | billing and payment logistics; no pressure.
+
+**`recurring-engagement-renewal`** | rolls the client into next period's engagement. | _trigger:_ the recurring engagement comes due | _reads_ the prior engagement -> _writes_ a re-engagement draft with the new engagement letter | PracticeManagement, ESign, Email | send draft-for-review | relays the firm's authored renewal terms; never re-scopes or re-prices on its own.
+
+### Spine (reused as-is)
+
+**`inbox-triage`** routes inbound to the right skill. **`status-report-assembler`** compiles the digests.
+
+## Connector map (the real firm stack)
+
+| Capability         | Common tools              | Backend                                                 | Used by                                |
+| ------------------ | ------------------------- | ------------------------------------------------------- | -------------------------------------- |
+| PracticeManagement | Karbon, Canopy, TaxDome   | `build:taxdome` / `build:karbon` / `build:canopy`       | every skill (system of record)         |
+| Email              | M365, Google              | `mcp:m365-mail` / `build:google-gmail`                  | onboarding, chasing, status, billing   |
+| Calendar           | M365, Google              | `mcp:m365-calendar` / `build:google-calendar`           | working-session scheduling             |
+| DocumentStorage    | SharePoint, Drive, portal | `mcp:softeria/ms-365-mcp-server` / `build:google-drive` | document collection (PBC)              |
+| ESign              | DocuSign, platform e-sign | `build:docusign`                                        | engagement letters, 8879, renewals     |
+| Accounting         | QuickBooks, Xero          | `build:quickbooks` / `build:xero`                       | invoice and billing status (read-only) |
+
+**The practice-management platforms have APIs.** TaxDome, Karbon, and Canopy expose documented APIs, so a `build:` adapter on a modern API, lighter than insurance's legacy AMS. **TaxDome** is a likely pilot (broad small-firm adoption, API). The `Accounting` connector (QuickBooks/Xero) is read-mostly, used for billing and invoice status, not for the books themselves.
+
+## Compliance floor (authored, not assumed)
+
+Per [ADR 0035](../../adr/0035-operator-thesis.md) Tenet 3, no imposed defaults; floors are fail-closed until raised.
+
+- **No tax or accounting advice** — connective coordination only. Never a tax position, never a deduction or treatment, never an interpretation of financials, never a due-date computation. The twelve skills are onboarding, document chasing, scheduling, deadline relay, e-sign chasing, status, billing, and renewal. This is the accounting analog of the law pack's UPL boundary.
+- **Taxpayer-information confidentiality (IRC §7216)** — taxpayer information is not disclosed or used beyond preparing the engagement without the consent the law requires. The Operator does not share or repurpose taxpayer data.
+- **Deadline relay, never computation** — `deadline-filing-reminder` tracks the dates the firm authored; it never computes a filing requirement or due date, which is professional judgment.
+- **Reviewer-as-sender floor** — external mail ships under a human reviewer's identity ([ADR 0005](../../adr/0005-reviewer-as-sender.md)), one authored exposure option ([ADR 0025](../../adr/0025-autonomy-ceilings-configurable-exposure-vs-initiation.md)).
+- **Records stay in firm surfaces** — client financial records stay inside the firm's systems; the Operator does not exfiltrate them.
+
+## Labor-market context (the demand, without presumption)
+
+Accounting has the most severe labor shortage in the dozen, and it is structural. The profession has lost hundreds of thousands of accountants since 2020, a large majority of CPAs are at or near retirement, the exam pipeline has shrunk for a decade, professional unemployment sits near historic lows, and firms are turning away work for lack of capacity. The connective admin seat is doubly squeezed: it competes for scarce labor, and when it goes unfilled the chasing falls on the preparers, the scarcest people in the firm. We do not presume which pressure applies to a given firm: some cannot fill the admin seat, some want to free the preparers, some are capping growth on capacity. Keep dated figures in outreach, not on the evergreen landing page.
+
+## Competitive read (the funded AI is in the work, not the seat)
+
+Per the corrected lens: **system-features are connection targets; only a true employee-replacer counts; and the seat is closed only when the firm stops needing the coordinator.** The firm cannot hire the coordinator, so the seat is open.
+
+- **Connection targets (zero threat):** practice-management platform features and portals (Karbon, Canopy, TaxDome automations), QuickBooks and Xero. The systems we connect across.
+- **Employee-replacers, but in a different lane:** the funded AI, Basis, Truewind, Zeni, is the **AI staff accountant**, doing the close, the entries, audit-prep, and consolidation. That is the credentialed work, not the connective admin seat. It competes with the preparer, not the coordinator. The coordinator seat, onboarding, PBC chasing, deadlines, e-sign, billing, is not what they are building.
+
+The honest read: the most acute labor shortage in the dozen, and the funded competition is aimed at a different seat. We win on four things, none of which is a single feature (ADR 0035 Tenet 4, the moat is harness + guide + memory):
+
+1. **The connective whole**, the full coordinator seat, onboarding through renewal, not a single automation.
+2. **The chasing the firm cannot staff**, PBC document collection and deadline tracking, where the work actually stalls.
+3. **Configurability** to the firm's engagement templates, deadlines, and voice, the substrate, not a fixed product.
+4. **Competing with a hire**, priced against an admin salary in a profession that cannot fill it.
+
+## The wedge
+
+> The firm-administrator and client-coordinator seat at accounting firms: onboard the client and get the engagement letter signed, send and collect the organizer, chase the prepared-by-client documents, schedule the session, track the filing deadline, get the e-file authorization signed, answer the routine status question, track extensions, follow the unpaid invoice, and roll the client into next year. Connects to the practice-management platform over its API, runs the connective layer only, and stays clear of tax advice and due-date computation. It wins on the most acute labor shortage in the dozen, on the document chasing where engagements actually stall, and on a connective whole the work-focused AI is not building.
+
+## Base vs. add-on
+
+- **`accounting` (base):** the firm-coordinator seat for a tax-and-accounting practice. The lowest-friction entry.
+- **`accounting/bookkeeping` (add-on):** monthly client-accounting-services connective skin, month-end close-status updates to the client, recurring report delivery, and relaying the recurring categorization or document questions a monthly engagement generates. Additive on the base; the same no-advice and §7216 floors apply, and the bookkeeping work itself stays with the firm.
+
+## Channel
+
+Practice-management platform ecosystems and communities (TaxDome, Karbon, Canopy). Accounting associations and networks (state CPA societies, AICPA PCPS, accounting-firm peer and mastermind groups). Accounting-firm consultants and coaches, and the practice-management media (Accounting Today, CPA Practice Advisor, the Karbon and TaxDome communities). Bookkeeping add-on: bookkeeping and CAS-focused networks and franchises.

--- a/docs/specs/verticals/dental.md
+++ b/docs/specs/verticals/dental.md
@@ -1,0 +1,123 @@
+---
+title: 'Vertical Spec: Dental Practice (Operator pack)'
+date: 2026-06-02
+status: draft
+captain: Scott Durgan
+related-adr: 0022-vertical-pack-architecture.md, 0035-operator-thesis.md, 0005-reviewer-as-sender.md, 0025-autonomy-ceilings-configurable-exposure-vs-initiation.md, 0020-connector-strategy.md
+---
+
+# Vertical Spec: Dental Practice
+
+The brief that drives the dental pack's manifest, N=0 proof, marketing surface, and delivery SOP, skinned from the worked reference (`law-firm.md`). Per [ADR 0035](../../adr/0035-operator-thesis.md), the Operator competes with a **hire** (the front-desk and treatment coordinator), not with software; the practice-management system is a **connection target, not a competitor**.
+
+> **Read this first, dental is the most contested vertical in the dozen.** The seat is open by the labor test (42% of practices carry a front-desk vacancy, 45-60 days to fill, structural shortage). But unlike the others, dental has a real, funded, multi-function competitor: Arini (YC-backed, deployed across hundreds of DSOs) answers calls and handles scheduling, insurance verification, and recall with bidirectional integration into Dentrix, Eaglesoft, and Open Dental. That is not a slice, it is a genuine front-desk product. Our honest wedge is the **async connective whole Arini's phone-first product does not run**, treatment-plan follow-up, claims and billing follow-up, reactivation, records, and the cross-system glue, plus a configurable substrate rather than a fixed receptionist. We enter against a real incumbent here, not an open field. See "Competitive read."
+
+## The dental front desk's world
+
+A dental practice runs on systems that do not talk to each other. The patient calls, texts, or fills out a form. The chart, schedule, ledger, and recall list live in the PMS. Claims go to the payer through a clearinghouse and come back. Statements go out. Treatment plans get presented and, often, sit unscheduled.
+
+The connective work is running the front of house and the money behind it: booking and confirming the visit, working the hygiene recall list, verifying the patient's benefits before the visit, chasing the treatment plan the patient accepted but never scheduled, following the claim the payer has not paid, following the patient balance, collecting the new-patient forms, and reactivating the patient who fell off the schedule. It is the same chain whether the practice is a single GP, a group, or a small DSO; the procedure mix changes, the coordination does not.
+
+That coordination is two real seats, the front-desk coordinator who runs scheduling and recall, and the treatment coordinator who presents plans and handles financing and benefits. Both are among the hardest in the practice to keep filled. A practice covers them with people, or splits the work across an overloaded front desk. The Operator takes the connective layer so the seat is covered, or the person is freed for the chairside and patient-facing work only a person can do. We make no assumption about which it is for a given practice.
+
+## Personas (the seat, described by role)
+
+- **Front-desk coordinator** (`front-desk-coordinator`): scheduling, recall, reminders, the routine patient back-and-forth. The seat with the highest turnover in the practice.
+- **Treatment coordinator** (`treatment-coordinator`): presents treatment plans, handles benefits and financing, follows the unscheduled plan. The revenue seat.
+- **Office manager** (`office-manager`): runs claims, billing, and the books. The reason the no-clinical-advice and benefits-relay lines have to be architectural.
+
+## Skill catalog
+
+Twelve dental-specific skills plus two spine skills reused as-is. Format per skill: **what** | trigger | reads -> writes | connectors | trust posture | guardrail. Trust posture follows [ADR 0025](../../adr/0025-autonomy-ceilings-configurable-exposure-vs-initiation.md); external send sits at the reviewer-as-sender floor ([ADR 0005](../../adr/0005-reviewer-as-sender.md)) unless the engagement authors otherwise.
+
+### New patient and scheduling
+
+**`new-patient-intake`** | a new-patient inquiry becomes a structured patient record plus a drafted acknowledgment, with the intake forms and an offer to book. | _trigger:_ inbound inquiry (web form / email / referral) | _reads_ the inquiry, PMS patients (dedupe), the practice's services -> _writes_ a draft patient, a draft reply with forms, an internal log | PracticeManagement, Email | record and forms autonomous, send draft-for-review | no clinical advice; routes a dental emergency to a person (see `emergency-escalation-router`).
+
+**`appointment-scheduler`** | offers times, books, confirms, async (not by phone, that is the competitor's lane). | _trigger:_ a booking request, or after intake | _reads_ provider and operatory availability, appointment-type duration -> _writes_ the appointment and a confirmation | PracticeManagement, Calendar, Email | booking autonomous within rules, confirmation per authored exposure | schedules by the appointment type the practice defines; never assigns clinical urgency.
+
+**`appointment-reminder-confirmer`** | sends reminders, captures confirm or reschedule, works the ASAP/short-call list. | _trigger:_ scheduled ahead of appointments, or an opening | _reads_ upcoming appointments, the ASAP list -> _writes_ reminder and fill drafts, applies confirm or reschedule | PracticeManagement, Email | send per authored exposure | reminder and fill logistics only.
+
+**`no-show-rebooker`** | follows up on a missed appointment to rebook. | _trigger:_ a no-show or late cancellation | _reads_ the missed appointment -> _writes_ a rebooking outreach draft | PracticeManagement, Email | send draft-for-review | rebooking logistics; no clinical judgment.
+
+### The recall engine (the retention spine)
+
+**`recare-recall`** | surfaces patients overdue for hygiene or recall per the practice's interval and drafts the reminder. | _trigger:_ scheduled scan | _reads_ PMS recall and due dates (the practice's intervals) -> _writes_ an overdue list, per-patient recall drafts | PracticeManagement, Email | surfacing autonomous, send draft-for-review | surfaces what the practice's own interval marks due; never sets the interval or decides what care a patient needs.
+
+### Benefits, treatment, and money
+
+**`insurance-verification-relay`** | gathers and relays the patient's benefits as the payer or clearinghouse returns them, before the visit. | _trigger:_ ahead of an appointment, or on request | _reads_ the patient's plan and the returned eligibility -> _writes_ a structured benefits summary for the team, a patient note if authored | PracticeManagement, Email | gather and summarize autonomous, patient-facing send draft-for-review | relays benefits as the payer states them; never guarantees coverage, never quotes an out-of-pocket number as a promise.
+
+**`treatment-plan-followup`** | follows up on a presented but unscheduled treatment plan. | _trigger:_ a plan presented and not scheduled past the cadence | _reads_ the plan status -> _writes_ a follow-up draft offering to schedule | PracticeManagement, Email | send draft-for-review | scheduling and logistics; never recommends or upsells a procedure, never frames the clinical need.
+
+**`claims-status-followup`** | follows the submitted insurance claim the payer has not paid. | _trigger:_ a claim open past the cadence | _reads_ claim status -> _writes_ a follow-up to the payer or a team flag | PracticeManagement, Email | send draft-for-review | relays and chases status; never adjudicates a claim or disputes a clinical code.
+
+**`patient-billing-followup`** | follows the patient balance or statement. | _trigger:_ a balance open past the cadence | _reads_ the ledger balance -> _writes_ a statement-reminder draft | PracticeManagement, Payments, Email | send draft-for-review | balance and payment logistics; no pressure, no clinical framing.
+
+### Records and proactive
+
+**`forms-and-records-collector`** | collects intake forms and requests records or radiographs from a prior office. | _trigger:_ a new patient or a records need | _reads_ what is missing -> _writes_ the forms request and the prior-office records request | PracticeManagement, DocumentStorage, Email | request autonomous, send draft-for-review | gathers documents; makes no clinical use of them.
+
+**`reactivation-winback`** | surfaces patients with no visit in the practice's window and drafts a reconnect. | _trigger:_ scheduled scan | _reads_ last-visit dates -> _writes_ a list and per-patient winback drafts | PracticeManagement, Email | surfacing autonomous, send draft-for-review | reconnect logistics; no clinical claim about what is due.
+
+**`emergency-escalation-router`** | detects a possible dental emergency in any inbound message and hands it to a person immediately, never triages. | _trigger:_ an inbound message triage flags as possibly urgent | _reads_ the message -> _writes_ an immediate escalation to the team, plus a holding acknowledgment telling the patient to call or come in | PracticeManagement, InternalComms, Email | escalation autonomous and immediate; never an autonomous clinical reply | never assesses urgency clinically, errs toward escalation, fail-open to a person.
+
+### Spine (reused as-is)
+
+**`inbox-triage`** routes inbound to the right skill and is the first gate the emergency router hooks. **`status-report-assembler`** compiles the digests.
+
+## Connector map (the real practice stack)
+
+| Capability         | Common tools                              | Backend                                                   | Used by                            |
+| ------------------ | ----------------------------------------- | --------------------------------------------------------- | ---------------------------------- |
+| PracticeManagement | Open Dental, Dentrix, Eaglesoft, Denticon | `build:open-dental` / `build:dentrix` / `build:eaglesoft` | every skill (system of record)     |
+| Email              | M365, Google                              | `mcp:m365-mail` / `build:google-gmail`                    | intake, recall, treatment, billing |
+| Calendar           | M365, Google                              | `mcp:m365-calendar` / `build:google-calendar`             | scheduling                         |
+| DocumentStorage    | SharePoint, Drive                         | `mcp:softeria/ms-365-mcp-server` / `build:google-drive`   | forms, records                     |
+| Payments           | clearinghouse / processor                 | `build:dental-payments`                                   | patient billing follow-up          |
+| InternalComms      | Slack, Teams                              | `mcp:slack` / `build:teams`                               | emergency escalation, team digests |
+
+**Open Dental is the pilot PMS for a clean reason: it has a documented open API.** Dentrix and Eaglesoft are the legacy server tail (Arini integrates them too, so it is doable, but harder). The pilot rides Open Dental's API; `build:open-dental` is the first overlay hand-off. **Phone is out of scope on purpose**, that is exactly where Arini is strong; the Operator is the async connective desk, not the phone line. No CallTracking connector in v1.
+
+## Compliance floor (authored, not assumed)
+
+Per [ADR 0035](../../adr/0035-operator-thesis.md) Tenet 3, no imposed defaults; floors are fail-closed until raised.
+
+- **No clinical advice** — connective front-desk and coordination work only. Never a diagnosis, never a treatment recommendation, never a clinical interpretation, never a urgency judgment. The twelve skills are intake, scheduling, recall, benefits relay, plan follow-up, claims and billing, records, and escalation. This is the dental analog of the law pack's UPL boundary.
+- **Benefits relay, never a coverage guarantee** — `insurance-verification-relay` relays what the payer returns; it never guarantees coverage or states a patient's out-of-pocket as a promise.
+- **Emergency escalation (fail-open to a human)** — a possible dental emergency goes to a person immediately, never handled async and never answered with clinical content.
+- **HIPAA / PHI** — protected health information stays inside the practice's surfaces; the Operator does not exfiltrate it.
+- **Reviewer-as-sender floor** — external mail ships under a human reviewer's identity ([ADR 0005](../../adr/0005-reviewer-as-sender.md)), one authored exposure option ([ADR 0025](../../adr/0025-autonomy-ceilings-configurable-exposure-vs-initiation.md)).
+
+## Labor-market context (the demand, without presumption)
+
+Dental front-desk staffing is a structural shortage, not a cycle. A large share of practices carry an open front-desk or administrative seat, vacancies take roughly two months to fill, applicant volume is down sharply from pre-pandemic, and administrative turnover runs high. The seat competes for the same labor pool as medical, veterinary, and corporate reception, often at lower pay. We do not presume which pressure applies to a given practice: some cannot fill the seat, some want to free the team for chairside work, some are managing churn. Keep dated figures in outreach, not on the evergreen landing page.
+
+## Competitive read (a real incumbent, and an honest wedge)
+
+Per the corrected lens: **system-features are connection targets; only a true employee-replacer counts; and the seat is closed only when the practice stops needing the front desk.** The practice still cannot hire the seat, so by the labor test it is open. But dental is the one vertical where a funded competitor genuinely covers a large part of it, and we say that plainly.
+
+- **Connection targets (zero threat):** PMS-native and bolt-on patient comms (Weave, Dental Intelligence, NexHealth reminders). Clinical AI in a different lane entirely (Pearl, Overjet read radiographs, that is not the front desk). Slices and adjacent products.
+- **The real competitor:** Arini (YC-backed, hundreds of DSO deployments) is a phone-first AI receptionist that also schedules, verifies insurance, and runs recall, with bidirectional PMS integration. This is a genuine front-desk product, not a slice. The phone-answering category around it (a long list of voice vendors) is crowded.
+
+The honest wedge: Arini owns the phone and the live-call slice of the seat. The Operator runs the **async connective whole that a phone receptionist does not**, the treatment-plan follow-up that recovers unscheduled production, the claims and patient-billing follow-up, reactivation, forms and records, and the cross-system glue, configured to the practice's protocols and voice, under human review. We win on four things, none of which is a single feature (ADR 0035 Tenet 4, the moat is harness + guide + memory):
+
+1. **The async connective whole**, the back-of-front-desk a voice receptionist does not run.
+2. **The money work**, unscheduled treatment, unpaid claims, and patient balances, where the recoverable dollars are.
+3. **Configurability** to the practice's protocols, recall intervals, and voice, the substrate, not a fixed receptionist.
+4. **Competing with a hire**, priced against a coordinator salary the practice cannot keep filled.
+
+This is a "proceed with eyes open" vertical: the demand is real and the seat is unfilled, but we compete here, we do not walk into an empty room.
+
+## The wedge
+
+> The front-desk and treatment-coordinator seats at dental practices, worked async: book and confirm the visit, run the hygiene recall, verify benefits before the visit, chase the accepted-but-unscheduled treatment plan, follow the unpaid claim and the patient balance, collect forms and records, and route a dental emergency straight to a person. Connects to the PMS over its open API, runs the connective layer only, and stays clear of clinical advice and coverage guarantees. It wins on the async connective whole a phone-first competitor does not run, on the money work where the dollars are, and on configurability, against a real incumbent rather than an empty field.
+
+## Base vs. add-on
+
+- **`dental` (base):** general-practice front-desk and treatment coordination. The lowest-friction entry.
+- **`dental/ortho` (add-on):** orthodontic connective skin, longer treatment arcs, contract and payment-plan coordination, appliance and adjustment recall, and retention-check reminders. Additive on the base; the same no-clinical-advice and emergency floors apply.
+
+## Channel
+
+PMS ecosystems and developer programs (Open Dental's open API community first). Dental practice-management consultants and coaching groups, DSO and group-practice operators, dental study clubs, dental practice-management media (Dental Economics, Dentistry IQ, Becker's Dental). State and local dental societies. Ortho add-on: orthodontic-specific consultants and study groups.

--- a/docs/specs/verticals/dental.md
+++ b/docs/specs/verticals/dental.md
@@ -3,12 +3,12 @@ title: 'Vertical Spec: Dental Practice (Operator pack)'
 date: 2026-06-02
 status: draft
 captain: Scott Durgan
-related-adr: 0022-vertical-pack-architecture.md, 0035-operator-thesis.md, 0005-reviewer-as-sender.md, 0025-autonomy-ceilings-configurable-exposure-vs-initiation.md, 0020-connector-strategy.md
+related-adr: 0022-vertical-pack-architecture.md, 0037-operator-thesis.md, 0005-reviewer-as-sender.md, 0025-autonomy-ceilings-configurable-exposure-vs-initiation.md, 0020-connector-strategy.md
 ---
 
 # Vertical Spec: Dental Practice
 
-The brief that drives the dental pack's manifest, N=0 proof, marketing surface, and delivery SOP, skinned from the worked reference (`law-firm.md`). Per [ADR 0035](../../adr/0035-operator-thesis.md), the Operator competes with a **hire** (the front-desk and treatment coordinator), not with software; the practice-management system is a **connection target, not a competitor**.
+The brief that drives the dental pack's manifest, N=0 proof, marketing surface, and delivery SOP, skinned from the worked reference (`law-firm.md`). Per [ADR 0037](../../adr/0037-operator-thesis.md), the Operator competes with a **hire** (the front-desk and treatment coordinator), not with software; the practice-management system is a **connection target, not a competitor**.
 
 > **Read this first, dental is the most contested vertical in the dozen.** The seat is open by the labor test (42% of practices carry a front-desk vacancy, 45-60 days to fill, structural shortage). But unlike the others, dental has a real, funded, multi-function competitor: Arini (YC-backed, deployed across hundreds of DSOs) answers calls and handles scheduling, insurance verification, and recall with bidirectional integration into Dentrix, Eaglesoft, and Open Dental. That is not a slice, it is a genuine front-desk product. Our honest wedge is the **async connective whole Arini's phone-first product does not run**, treatment-plan follow-up, claims and billing follow-up, reactivation, records, and the cross-system glue, plus a configurable substrate rather than a fixed receptionist. We enter against a real incumbent here, not an open field. See "Competitive read."
 
@@ -81,7 +81,7 @@ Twelve dental-specific skills plus two spine skills reused as-is. Format per ski
 
 ## Compliance floor (authored, not assumed)
 
-Per [ADR 0035](../../adr/0035-operator-thesis.md) Tenet 3, no imposed defaults; floors are fail-closed until raised.
+Per [ADR 0037](../../adr/0037-operator-thesis.md) Tenet 3, no imposed defaults; floors are fail-closed until raised.
 
 - **No clinical advice** — connective front-desk and coordination work only. Never a diagnosis, never a treatment recommendation, never a clinical interpretation, never a urgency judgment. The twelve skills are intake, scheduling, recall, benefits relay, plan follow-up, claims and billing, records, and escalation. This is the dental analog of the law pack's UPL boundary.
 - **Benefits relay, never a coverage guarantee** — `insurance-verification-relay` relays what the payer returns; it never guarantees coverage or states a patient's out-of-pocket as a promise.
@@ -100,7 +100,7 @@ Per the corrected lens: **system-features are connection targets; only a true em
 - **Connection targets (zero threat):** PMS-native and bolt-on patient comms (Weave, Dental Intelligence, NexHealth reminders). Clinical AI in a different lane entirely (Pearl, Overjet read radiographs, that is not the front desk). Slices and adjacent products.
 - **The real competitor:** Arini (YC-backed, hundreds of DSO deployments) is a phone-first AI receptionist that also schedules, verifies insurance, and runs recall, with bidirectional PMS integration. This is a genuine front-desk product, not a slice. The phone-answering category around it (a long list of voice vendors) is crowded.
 
-The honest wedge: Arini owns the phone and the live-call slice of the seat. The Operator runs the **async connective whole that a phone receptionist does not**, the treatment-plan follow-up that recovers unscheduled production, the claims and patient-billing follow-up, reactivation, forms and records, and the cross-system glue, configured to the practice's protocols and voice, under human review. We win on four things, none of which is a single feature (ADR 0035 Tenet 4, the moat is harness + guide + memory):
+The honest wedge: Arini owns the phone and the live-call slice of the seat. The Operator runs the **async connective whole that a phone receptionist does not**, the treatment-plan follow-up that recovers unscheduled production, the claims and patient-billing follow-up, reactivation, forms and records, and the cross-system glue, configured to the practice's protocols and voice, under human review. We win on four things, none of which is a single feature (ADR 0037 Tenet 4, the moat is harness + guide + memory):
 
 1. **The async connective whole**, the back-of-front-desk a voice receptionist does not run.
 2. **The money work**, unscheduled treatment, unpaid claims, and patient balances, where the recoverable dollars are.

--- a/docs/specs/verticals/home-services.md
+++ b/docs/specs/verticals/home-services.md
@@ -3,12 +3,12 @@ title: 'Vertical Spec: Home Services (Operator pack)'
 date: 2026-06-02
 status: draft
 captain: Scott Durgan
-related-adr: 0022-vertical-pack-architecture.md, 0035-operator-thesis.md, 0005-reviewer-as-sender.md, 0025-autonomy-ceilings-configurable-exposure-vs-initiation.md, 0020-connector-strategy.md
+related-adr: 0022-vertical-pack-architecture.md, 0037-operator-thesis.md, 0005-reviewer-as-sender.md, 0025-autonomy-ceilings-configurable-exposure-vs-initiation.md, 0020-connector-strategy.md
 ---
 
 # Vertical Spec: Home Services
 
-The brief that drives the home-services pack's manifest, N=0 proof, marketing surface, and delivery SOP, skinned from the worked reference (`law-firm.md`). Per [ADR 0035](../../adr/0035-operator-thesis.md), the Operator competes with a **hire** (the office CSR and dispatcher), not with software; the field-service management platform is a **connection target, not a competitor**.
+The brief that drives the home-services pack's manifest, N=0 proof, marketing surface, and delivery SOP, skinned from the worked reference (`law-firm.md`). Per [ADR 0037](../../adr/0037-operator-thesis.md), the Operator competes with a **hire** (the office CSR and dispatcher), not with software; the field-service management platform is a **connection target, not a competitor**.
 
 > **Two boundaries up front.** (1) **Phone is out of scope on purpose.** The home-services AI market is crowded with phone-answering and AI-receptionist bots, and the FSM platforms have native AI dispatch. The Operator is the **async connective office**, not the phone line, which is exactly where those products sit. (2) **The safety line is the emergency dispatch.** A gas leak, an active flood, no heat in a freeze, an electrical hazard, these are routed to a person immediately and never handled async, and the Operator never diagnoses the problem or commits a price.
 
@@ -78,7 +78,7 @@ Twelve home-services-specific skills plus two spine skills reused as-is. Format 
 
 ## Compliance floor (authored, not assumed)
 
-Per [ADR 0035](../../adr/0035-operator-thesis.md) Tenet 3, no imposed defaults; floors are fail-closed until raised.
+Per [ADR 0037](../../adr/0037-operator-thesis.md) Tenet 3, no imposed defaults; floors are fail-closed until raised.
 
 - **No diagnosis or pricing commitment** — connective coordination only. The Operator never states what is wrong, what the fix is, or what it will cost as a commitment; the tech diagnoses and the company prices. Estimates and quotes are the company's authored numbers.
 - **Emergency-dispatch escalation (fail-open to a human)** — a possible emergency (gas, fire, flood, no heat in a freeze, electrical hazard) routes to a person and the on-call dispatcher immediately, and life-safety issues are pointed to 911. Never handled async, never diagnosed.
@@ -96,7 +96,7 @@ Per the corrected lens: **system-features are connection targets; only a true em
 - **Connection targets (zero threat):** FSM-native AI, ServiceTitan's Titan Intelligence (Atlas assists CSRs, Dispatch Pro for AI dispatching), Housecall Pro and Jobber features. Powerful, inside the systems we connect across.
 - **Slice-automators (vendors, not seat-replacers):** the AI answering and receptionist field for contractors is crowded, and it is the phone-and-booking slice. None runs the whole async office, estimate follow-up, invoicing, memberships, recall, parts, and the emergency routing, configured to the shop. And it is the phone lane the Operator deliberately does not enter.
 
-The honest read: a hard-to-staff seat the shop still needs, with native AI inside the FSM and a crowd of phone bots around it. We win on four things, none of which is a single feature (ADR 0035 Tenet 4, the moat is harness + guide + memory):
+The honest read: a hard-to-staff seat the shop still needs, with native AI inside the FSM and a crowd of phone bots around it. We win on four things, none of which is a single feature (ADR 0037 Tenet 4, the moat is harness + guide + memory):
 
 1. **The connective whole**, the async office around the field, not a phone bot.
 2. **The money and retention work**, estimate follow-up, invoicing, memberships, and recall, where the recoverable revenue is.

--- a/docs/specs/verticals/home-services.md
+++ b/docs/specs/verticals/home-services.md
@@ -1,0 +1,116 @@
+---
+title: 'Vertical Spec: Home Services (Operator pack)'
+date: 2026-06-02
+status: draft
+captain: Scott Durgan
+related-adr: 0022-vertical-pack-architecture.md, 0035-operator-thesis.md, 0005-reviewer-as-sender.md, 0025-autonomy-ceilings-configurable-exposure-vs-initiation.md, 0020-connector-strategy.md
+---
+
+# Vertical Spec: Home Services
+
+The brief that drives the home-services pack's manifest, N=0 proof, marketing surface, and delivery SOP, skinned from the worked reference (`law-firm.md`). Per [ADR 0035](../../adr/0035-operator-thesis.md), the Operator competes with a **hire** (the office CSR and dispatcher), not with software; the field-service management platform is a **connection target, not a competitor**.
+
+> **Two boundaries up front.** (1) **Phone is out of scope on purpose.** The home-services AI market is crowded with phone-answering and AI-receptionist bots, and the FSM platforms have native AI dispatch. The Operator is the **async connective office**, not the phone line, which is exactly where those products sit. (2) **The safety line is the emergency dispatch.** A gas leak, an active flood, no heat in a freeze, an electrical hazard, these are routed to a person immediately and never handled async, and the Operator never diagnoses the problem or commits a price.
+
+## The service office's world
+
+A home-services contractor (HVAC, plumbing, electrical) runs jobs across systems and the field: the FSM platform (ServiceTitan, Housecall Pro, Jobber) holds customers, jobs, the dispatch board, estimates, and invoices; the techs are in the field; the customers want to know when someone is coming. The office CSR and dispatcher are the connective tissue.
+
+The connective work is running the office around the field: intaking the service request and getting it scheduled, confirming and reminding with the arrival window, telling the customer the tech is on the way or running late, following up on the estimate that has not been approved, following the unpaid invoice, coordinating the maintenance membership, recalling customers for seasonal service, asking for the review, scheduling the return visit when a part arrives, and routing an emergency to a person. It is the same chain whether the trade is HVAC, plumbing, or electrical; the work changes, the coordination does not.
+
+That coordination is a real seat, the CSR or dispatcher who keeps customers and jobs moving while the techs do the work. It is a seat contractors fight to staff. A shop covers it with people, or buries an overloaded office. The Operator takes the async connective layer so the seat is covered, or the person is freed for the live calls and field coordination only a person can do. We make no assumption about which it is for a given shop.
+
+## Personas (the seat, described by role)
+
+- **Dispatcher** (`dispatcher`): the board, the techs, the arrival windows, the day's coordination. The operations seat.
+- **CSR / office coordinator** (`csr-coordinator`): requests, scheduling, reminders, the routine customer back-and-forth. The connective seat.
+- **Office manager** (`office-manager`): estimates, invoices, memberships. The reason the no-pricing-commitment and emergency lines have to be architectural.
+
+## Skill catalog
+
+Twelve home-services-specific skills plus two spine skills reused as-is. Format per skill: **what** | trigger | reads -> writes | connectors | trust posture | guardrail. Trust posture follows [ADR 0025](../../adr/0025-autonomy-ceilings-configurable-exposure-vs-initiation.md); external send sits at the reviewer-as-sender floor ([ADR 0005](../../adr/0005-reviewer-as-sender.md)) unless the engagement authors otherwise.
+
+### Intake and scheduling
+
+**`service-request-intake`** | a service request becomes a structured job plus a drafted acknowledgment, with an offer to schedule. | _trigger:_ an inbound request (web / email / text) | _reads_ the request, FSM customers (dedupe), the company's services -> _writes_ a draft job, a draft reply, an internal route | PracticeManagement, Email | job and ack autonomous, send draft-for-review | an emergency (gas, fire, flood, no heat in a freeze, electrical hazard) routes to a person immediately (see `emergency-dispatch-escalation-router`); never diagnoses the problem or quotes a price.
+
+**`job-scheduler`** | offers windows, books, confirms the service visit, async. | _trigger:_ a scheduling request or after intake | _reads_ dispatch availability, job-type duration -> _writes_ the job on the board and a confirmation | PracticeManagement, Calendar, Email | scheduling autonomous within rules, confirmation send draft-for-review | scheduling logistics only; never the diagnosis or the price.
+
+**`appointment-reminder-confirmer`** | sends reminders with the arrival window, captures confirm or reschedule. | _trigger:_ scheduled ahead of the visit | _reads_ upcoming jobs -> _writes_ reminder drafts, applies confirm or reschedule | PracticeManagement, Email | send per authored exposure | reminder and window logistics only.
+
+**`dispatch-status-updater`** | tells the customer the tech is en route or running late. | _trigger:_ a dispatch status change | _reads_ the tech's status from the board -> _writes_ an en-route or delay update | PracticeManagement, Email | send draft-for-review (or authored exposure) | relays the board's status; never states what the tech will find or what it will cost.
+
+### Money and retention
+
+**`estimate-quote-followup`** | follows up on a sent estimate that has not been approved. | _trigger:_ an estimate sent and not approved past the cadence | _reads_ the estimate status -> _writes_ a follow-up draft offering to schedule the work | PracticeManagement, Email | send draft-for-review | scheduling and approval logistics; **never quotes, adjusts, or commits a price**, the estimate is the company's.
+
+**`invoice-payment-followup`** | follows the unpaid invoice. | _trigger:_ an invoice open past the cadence | _reads_ the invoice status -> _writes_ a statement-reminder draft | PracticeManagement, Email | send draft-for-review | billing logistics; no pressure.
+
+**`membership-plan-coordinator`** | coordinates maintenance-membership reminders and renewals. | _trigger:_ a membership benefit due or a renewal approaching | _reads_ the membership record -> _writes_ a benefit or renewal draft | PracticeManagement, Email | send draft-for-review | membership logistics; relays the company's authored plan terms.
+
+**`maintenance-recall`** | surfaces customers due for seasonal maintenance per the company's cadence. | _trigger:_ scheduled scan | _reads_ the service history and the company's recall cadence -> _writes_ an overdue list and per-customer recall drafts | PracticeManagement, Email | surfacing autonomous, send draft-for-review | surfaces what the company's cadence marks due; no diagnostic claim.
+
+**`parts-followup`** | notifies the customer when a special-order part arrives and schedules the return visit. | _trigger:_ a part marked received | _reads_ the part and the related job -> _writes_ a notify-and-schedule draft | PracticeManagement, Calendar, Email | send draft-for-review | logistics only.
+
+### Proactive and safety
+
+**`review-referral-request`** | asks a satisfied customer for a review or referral after a completed job. | _trigger:_ scheduled after a completed job | _reads_ the job -> _writes_ a review or referral ask draft | PracticeManagement, Email | send draft-for-review | reputation logistics; never fabricates a review.
+
+**`reactivation-winback`** | surfaces customers not served in the company's window and drafts a reconnect. | _trigger:_ scheduled scan | _reads_ last-service dates -> _writes_ a list and per-customer winback drafts | PracticeManagement, Email | surfacing autonomous, send draft-for-review | reconnect logistics; no diagnostic claim.
+
+**`emergency-dispatch-escalation-router`** | detects a possible emergency in any inbound message and routes it to a person and the on-call dispatcher immediately. | _trigger:_ an inbound message triage flags as a possible emergency | _reads_ the message -> _writes_ an immediate escalation to the on-call channel and a holding acknowledgment with the emergency path (and 911 for life-safety) | PracticeManagement, InternalComms, Email | escalation autonomous and immediate; never an autonomous diagnosis or quote | never assesses the hazard itself, errs toward escalation, fail-open to a person; gas and life-safety direct to 911.
+
+### Spine (reused as-is)
+
+**`inbox-triage`** routes inbound to the right skill and is the first gate the emergency router hooks. **`status-report-assembler`** compiles the digests.
+
+## Connector map (the real shop stack)
+
+| Capability         | Common tools                        | Backend                                                   | Used by                        |
+| ------------------ | ----------------------------------- | --------------------------------------------------------- | ------------------------------ |
+| PracticeManagement | ServiceTitan, Housecall Pro, Jobber | `build:servicetitan` / `build:housecall` / `build:jobber` | every skill (system of record) |
+| Email              | M365, Google                        | `mcp:m365-mail` / `build:google-gmail`                    | intake, reminders, follow-up   |
+| Calendar           | M365, Google                        | `mcp:m365-calendar` / `build:google-calendar`             | scheduling, return visits      |
+| DocumentStorage    | SharePoint, Drive                   | `mcp:softeria/ms-365-mcp-server` / `build:google-drive`   | estimates, invoices            |
+| InternalComms      | Slack, Teams                        | `mcp:slack` / `build:teams`                               | emergency-dispatch escalation  |
+
+**ServiceTitan, Housecall Pro, and Jobber all expose APIs**, so a `build:` adapter on a modern API. The pilot targets whichever the shop runs. **Phone is out of scope on purpose** (that is the AI-receptionist crowd's lane); the Operator is the async office. No CallTracking connector in v1.
+
+## Compliance floor (authored, not assumed)
+
+Per [ADR 0035](../../adr/0035-operator-thesis.md) Tenet 3, no imposed defaults; floors are fail-closed until raised.
+
+- **No diagnosis or pricing commitment** — connective coordination only. The Operator never states what is wrong, what the fix is, or what it will cost as a commitment; the tech diagnoses and the company prices. Estimates and quotes are the company's authored numbers.
+- **Emergency-dispatch escalation (fail-open to a human)** — a possible emergency (gas, fire, flood, no heat in a freeze, electrical hazard) routes to a person and the on-call dispatcher immediately, and life-safety issues are pointed to 911. Never handled async, never diagnosed.
+- **No payment authority** — the Operator follows up on invoices but never processes a payment.
+- **Reviewer-as-sender floor** — external mail ships under a human reviewer's identity ([ADR 0005](../../adr/0005-reviewer-as-sender.md)).
+
+## Labor-market context (the demand, without presumption)
+
+Home-services office staffing, CSRs and dispatchers, is a hard-to-fill, high-turnover seat, and the work is dominated by exactly the async coordination this pack targets. We do not presume which pressure applies to a given shop: some cannot keep the office staffed, some want to free the dispatcher for live coordination, some are scaling crews faster than the office. Keep dated figures in outreach, not on the evergreen landing page.
+
+## Competitive read (a crowd of vendors is not a closed seat)
+
+Per the corrected lens: **system-features are connection targets; only a true employee-replacer counts; and the seat is closed only when the shop stops needing the office.** Jobs still need coordinating, so the seat is open.
+
+- **Connection targets (zero threat):** FSM-native AI, ServiceTitan's Titan Intelligence (Atlas assists CSRs, Dispatch Pro for AI dispatching), Housecall Pro and Jobber features. Powerful, inside the systems we connect across.
+- **Slice-automators (vendors, not seat-replacers):** the AI answering and receptionist field for contractors is crowded, and it is the phone-and-booking slice. None runs the whole async office, estimate follow-up, invoicing, memberships, recall, parts, and the emergency routing, configured to the shop. And it is the phone lane the Operator deliberately does not enter.
+
+The honest read: a hard-to-staff seat the shop still needs, with native AI inside the FSM and a crowd of phone bots around it. We win on four things, none of which is a single feature (ADR 0035 Tenet 4, the moat is harness + guide + memory):
+
+1. **The connective whole**, the async office around the field, not a phone bot.
+2. **The money and retention work**, estimate follow-up, invoicing, memberships, and recall, where the recoverable revenue is.
+3. **Configurability** to the shop's services, cadence, and voice, the substrate, not a fixed product.
+4. **Competing with a hire**, priced against an office salary in a high-turnover seat.
+
+## The wedge
+
+> The CSR-and-dispatch office seat at home-services contractors, worked async: intake the request and schedule it, confirm with the arrival window, tell the customer the tech is on the way, follow the unapproved estimate and the unpaid invoice, coordinate memberships and seasonal recall, schedule the return visit when a part arrives, and route an emergency straight to a person. Connects to the FSM platform over its API, runs the async connective layer only, and stays clear of diagnosis, pricing, and the phone line. It wins on the async office the phone bots do not run, on the money and retention work where revenue leaks, and on a hard-to-staff seat the shop still needs.
+
+## Base vs. add-on
+
+- **`home-services` (base):** the async office for an HVAC, plumbing, or electrical contractor. The lowest-friction entry. No add-on in v1; the base covers the office.
+
+## Channel
+
+FSM platform ecosystems and marketplaces (ServiceTitan, Housecall Pro, Jobber). The trade's contractor groups and best-practice networks (Nexstar, Service Nation, ACCA and PHCC chapters), home-services consultants and coaches, and the success groups where office-coordination pain is openly discussed.

--- a/docs/specs/verticals/marketing-agency.md
+++ b/docs/specs/verticals/marketing-agency.md
@@ -1,0 +1,116 @@
+---
+title: 'Vertical Spec: Marketing Agency (Operator pack)'
+date: 2026-06-02
+status: draft
+captain: Scott Durgan
+related-adr: 0022-vertical-pack-architecture.md, 0035-operator-thesis.md, 0005-reviewer-as-sender.md, 0025-autonomy-ceilings-configurable-exposure-vs-initiation.md, 0020-connector-strategy.md
+---
+
+# Vertical Spec: Marketing Agency
+
+The brief that drives the marketing-agency pack's manifest, N=0 proof, marketing surface, and delivery SOP, skinned from the worked reference (`law-firm.md`). Per [ADR 0035](../../adr/0035-operator-thesis.md), the Operator competes with a **hire** (the account coordinator and project manager), not with software; the project-management platform is a **connection target, not a competitor**.
+
+> **The lightest-regulated vertical, with one sharp line.** A marketing agency has no UPL, no HIPAA, no SEC. The one hard line is fabrication: the Operator delivers only authored deliverables, authored report metrics, and authored status, never an invented number, claim, or result. Client confidentiality (no cross-client leakage) and no unilateral scope or contract commitment round out the floor.
+
+## The account desk's world
+
+An agency runs client work across systems that do not fully talk: the project-management platform (Asana, Monday, ClickUp) holds projects, tasks, deliverables, and timelines; creative assets live in storage; the client lives in email; invoicing lives in the books. The account coordinators and project managers are the connective tissue between the agency's work and the client's attention.
+
+The connective work is keeping projects and clients moving: onboarding the new client and gathering access and brand inputs, sending deliverable and milestone status, chasing the client assets and approvals that hold work up, routing deliverables for review and chasing sign-off, scheduling check-ins, turning the agency's authored meeting notes into tracked actions, reminding on deadlines, communicating timeline changes, following the unpaid invoice, delivering the authored reports, and coordinating the retainer renewal. It is the same chain whether the agency does brand, performance, or content; the work changes, the coordination does not.
+
+That coordination is a real seat, the account coordinator or project manager who keeps clients and projects moving while the creatives and strategists do the work. It is a high-churn seat in a high-churn industry. An agency covers it with people, or buries an overloaded account team. The Operator takes the connective layer so the seat is covered, or the person is freed for the strategy and relationship work only a person can do. We make no assumption about which it is for a given agency.
+
+## Personas (the seat, described by role)
+
+- **Account coordinator** (`account-coordinator`): status, asset chasing, scheduling, the routine client back-and-forth. The connective seat.
+- **Project manager** (`project-manager`): timelines, deliverable routing, deadlines. The delivery seat.
+- **Account director** (`account-director`): owns the client relationship and the scope. The reason the no-scope-commitment line has to be architectural.
+
+## Skill catalog
+
+Twelve marketing-agency-specific skills plus two spine skills reused as-is. Format per skill: **what** | trigger | reads -> writes | connectors | trust posture | guardrail. Trust posture follows [ADR 0025](../../adr/0025-autonomy-ceilings-configurable-exposure-vs-initiation.md); external send sits at the reviewer-as-sender floor ([ADR 0005](../../adr/0005-reviewer-as-sender.md)) unless the engagement authors otherwise.
+
+### Onboarding and status
+
+**`client-onboarding`** | a new client becomes a structured record plus a drafted kickoff and an access-and-inputs request list. | _trigger:_ a new client or engagement | _reads_ the client, the agency's onboarding template -> _writes_ a draft client record, a draft kickoff with the access/inputs list, an internal log | PracticeManagement, Email | record draft autonomous, send draft-for-review | relays the agency's authored onboarding; never commits scope or deliverables.
+
+**`project-status-updater`** | sends deliverable and milestone status to the client. | _trigger:_ a milestone changes, or on cadence | _reads_ the project status in the PM platform -> _writes_ a status update draft | PracticeManagement, Email | send draft-for-review | reports status from the platform; never invents progress or a result.
+
+**`client-status-responder`** | answers the routine "where's my project" from the platform. | _trigger:_ a status question routed by inbox-triage | _reads_ the project status, next step -> _writes_ a status reply draft | PracticeManagement, Email | send draft-for-review | reports status only; no fabricated metric or claim.
+
+### The asset-and-approval chase (the connective heart)
+
+**`asset-feedback-chaser`** | chases the client assets, inputs, and feedback that hold work up. | _trigger:_ a needed input or feedback open past the cadence | _reads_ the open-item list -> _writes_ per-item chase drafts, updates the list as items land | PracticeManagement, Email | chase send draft-for-review, list update autonomous | chases the items the agency is waiting on; never produces the missing input itself.
+
+**`deliverable-review-router`** | routes a deliverable for client review and chases sign-off. | _trigger:_ a deliverable ready for review | _reads_ the deliverable and the review step -> _writes_ a review request with the authored deliverable, a sign-off chase | PracticeManagement, DocumentStorage, Email | send draft-for-review | routes the authored deliverable; never alters it or approves on the client's behalf.
+
+**`meeting-notes-actionizer`** | turns the agency's authored meeting notes into tracked actions in the PM platform. | _trigger:_ authored meeting notes are filed | _reads_ the authored notes -> _writes_ tracked tasks in the platform, an optional recap draft | PracticeManagement, Email | task creation autonomous, recap send draft-for-review | works only from the agency's authored notes; invents no action or commitment not in them.
+
+### Timelines and money
+
+**`meeting-scheduler`** | offers times, books, confirms the client check-in. | _trigger:_ a meeting needed or requested | _reads_ availability, meeting length -> _writes_ the meeting and a confirmation | PracticeManagement, Calendar, Email | booking autonomous within rules | scheduling logistics only.
+
+**`deadline-milestone-reminder`** | surfaces upcoming deadlines and reminds the internal team and the client of their items. | _trigger:_ scheduled | _reads_ the project deadlines -> _writes_ a reminder digest and per-party reminders | PracticeManagement, Email | surfacing autonomous, send draft-for-review | surfaces the platform's dates; makes no commitment about delivery.
+
+**`timeline-change-communicator`** | when a date moves in the platform, tells the client. | _trigger:_ a timeline change in the PM platform | _reads_ the change -> _writes_ a client communication draft | PracticeManagement, Email | send draft-for-review | relays the authored change; never sets or promises a new date on its own.
+
+**`invoice-payment-followup`** | follows the unpaid invoice. | _trigger:_ an invoice open past the cadence | _reads_ the invoice status -> _writes_ a statement-reminder draft | PracticeManagement, Accounting, Email | send draft-for-review | billing logistics; no pressure.
+
+**`report-deliverer`** | delivers the agency's authored campaign and performance reports on cadence. | _trigger:_ scheduled reporting | _reads_ the agency's authored report -> _writes_ a delivery draft carrying the authored report | PracticeManagement, DocumentStorage, Email | send draft-for-review | delivers authored metrics and analysis only; **never invents, estimates, or adjusts a number or result**.
+
+**`retainer-renewal-coordinator`** | coordinates the retainer renewal. | _trigger:_ the retainer approaching renewal | _reads_ the prior engagement -> _writes_ a renewal outreach draft with the agency's authored terms | PracticeManagement, Email | send draft-for-review | relays the agency's authored renewal terms; never re-scopes or re-prices on its own.
+
+### Spine (reused as-is)
+
+**`inbox-triage`** routes inbound to the right skill. **`status-report-assembler`** compiles the digests.
+
+## Connector map (the real agency stack)
+
+| Capability         | Common tools           | Backend                                                 | Used by                           |
+| ------------------ | ---------------------- | ------------------------------------------------------- | --------------------------------- |
+| PracticeManagement | Asana, Monday, ClickUp | `build:asana` / `build:monday` / `build:clickup`        | every skill (system of record)    |
+| Email              | M365, Google           | `mcp:m365-mail` / `build:google-gmail`                  | onboarding, status, chasing       |
+| Calendar           | M365, Google           | `mcp:m365-calendar` / `build:google-calendar`           | check-in scheduling               |
+| DocumentStorage    | SharePoint, Drive      | `mcp:softeria/ms-365-mcp-server` / `build:google-drive` | deliverables, reports             |
+| Accounting         | QuickBooks, Xero       | `build:quickbooks` / `build:xero`                       | invoice / AR status (read-mostly) |
+
+**The project-management platform is the system of record** (Asana, Monday, or ClickUp; all have APIs), and the pilot adapter targets whichever the agency runs. The `Accounting` connector is read-mostly, for invoice and AR status.
+
+## Compliance floor (authored, not assumed)
+
+Per [ADR 0035](../../adr/0035-operator-thesis.md) Tenet 3, no imposed defaults; floors are fail-closed until raised. This is the lightest floor in the dozen, with one sharp line.
+
+- **No fabrication** — the Operator delivers only authored deliverables, authored report metrics, and authored status. It never invents, estimates, or adjusts a number, result, or claim. This is the sharp line, reports and status carry only what the agency authored.
+- **Client confidentiality** — no client's information, assets, or results cross into another client's communications.
+- **No unilateral scope or commitment** — the Operator relays the agency's authored scope, terms, and timelines; it never commits scope, deliverables, dates, or price on its own.
+- **Reviewer-as-sender floor** — external mail ships under a human reviewer's identity ([ADR 0005](../../adr/0005-reviewer-as-sender.md)).
+
+## Labor-market context (the demand, without presumption)
+
+Agency account and project coordination is a high-churn seat in a high-churn industry, and the work is dominated by the status, chasing, and coordination this pack targets. We do not presume which pressure applies to a given agency: some cannot keep coordinators staffed, some want to free the account team for strategy and relationships, some are scaling client load faster than headcount. Keep dated figures in outreach, not on the evergreen landing page.
+
+## Competitive read (a crowd of vendors is not a closed seat)
+
+Per the corrected lens: **system-features are connection targets; only a true employee-replacer counts; and the seat is closed only when the agency stops needing the coordinator.** Clients still need coordinating, so the seat is open.
+
+- **Connection targets (zero threat):** PM-platform-native AI, Asana's AI intake and workflows, Monday's AI, ClickUp Brain. Workflow automation inside the systems we connect across, not a cross-system client-facing coordinator.
+- **Slice-automators (vendors, not seat-replacers):** generic AI assistants and PM automations handle task routing and internal workflow, the internal slice. None runs the whole client-facing account-coordination seat, onboarding through renewal, configured to the agency and in its voice, under human review.
+
+The honest read: a high-churn seat the agency still needs, with native AI automating internal workflow rather than running client coordination. We win on four things, none of which is a single feature (ADR 0035 Tenet 4, the moat is harness + guide + memory):
+
+1. **The client-facing whole**, the account-coordination seat, not internal task automation.
+2. **The asset-and-approval chase where projects stall**, the client inputs and sign-offs that hold work up.
+3. **Configurability** to the agency's process, deliverables, and voice, the substrate, not a fixed product.
+4. **Competing with a hire**, priced against a coordinator salary in a high-churn seat.
+
+## The wedge
+
+> The account-coordinator and project-manager seat at marketing agencies: onboard the client and gather inputs, send deliverable and milestone status, chase the client assets and approvals that hold work up, route deliverables for sign-off, schedule check-ins, turn authored notes into tracked actions, remind on deadlines, communicate timeline changes, follow the unpaid invoice, deliver the authored reports, and coordinate the renewal. Connects to the project-management platform over its API, runs the connective layer only, and never fabricates a metric or commits scope. It wins on the client-facing whole the internal-automation tools do not run, on the asset chase where projects stall, and on a high-churn seat the agency still has to staff.
+
+## Base vs. add-on
+
+- **`marketing-agency` (base):** account and project coordination for a brand, performance, or content agency. The lowest-friction entry. No add-on in v1; the base covers the account desk.
+
+## Channel
+
+Project-management platform ecosystems (Asana, Monday, ClickUp marketplaces). Agency networks and masterminds, the agency-operations communities and media. Agency-coaching groups where account-team capacity and churn are openly discussed.

--- a/docs/specs/verticals/marketing-agency.md
+++ b/docs/specs/verticals/marketing-agency.md
@@ -3,12 +3,12 @@ title: 'Vertical Spec: Marketing Agency (Operator pack)'
 date: 2026-06-02
 status: draft
 captain: Scott Durgan
-related-adr: 0022-vertical-pack-architecture.md, 0035-operator-thesis.md, 0005-reviewer-as-sender.md, 0025-autonomy-ceilings-configurable-exposure-vs-initiation.md, 0020-connector-strategy.md
+related-adr: 0022-vertical-pack-architecture.md, 0037-operator-thesis.md, 0005-reviewer-as-sender.md, 0025-autonomy-ceilings-configurable-exposure-vs-initiation.md, 0020-connector-strategy.md
 ---
 
 # Vertical Spec: Marketing Agency
 
-The brief that drives the marketing-agency pack's manifest, N=0 proof, marketing surface, and delivery SOP, skinned from the worked reference (`law-firm.md`). Per [ADR 0035](../../adr/0035-operator-thesis.md), the Operator competes with a **hire** (the account coordinator and project manager), not with software; the project-management platform is a **connection target, not a competitor**.
+The brief that drives the marketing-agency pack's manifest, N=0 proof, marketing surface, and delivery SOP, skinned from the worked reference (`law-firm.md`). Per [ADR 0037](../../adr/0037-operator-thesis.md), the Operator competes with a **hire** (the account coordinator and project manager), not with software; the project-management platform is a **connection target, not a competitor**.
 
 > **The lightest-regulated vertical, with one sharp line.** A marketing agency has no UPL, no HIPAA, no SEC. The one hard line is fabrication: the Operator delivers only authored deliverables, authored report metrics, and authored status, never an invented number, claim, or result. Client confidentiality (no cross-client leakage) and no unilateral scope or contract commitment round out the floor.
 
@@ -78,7 +78,7 @@ Twelve marketing-agency-specific skills plus two spine skills reused as-is. Form
 
 ## Compliance floor (authored, not assumed)
 
-Per [ADR 0035](../../adr/0035-operator-thesis.md) Tenet 3, no imposed defaults; floors are fail-closed until raised. This is the lightest floor in the dozen, with one sharp line.
+Per [ADR 0037](../../adr/0037-operator-thesis.md) Tenet 3, no imposed defaults; floors are fail-closed until raised. This is the lightest floor in the dozen, with one sharp line.
 
 - **No fabrication** — the Operator delivers only authored deliverables, authored report metrics, and authored status. It never invents, estimates, or adjusts a number, result, or claim. This is the sharp line, reports and status carry only what the agency authored.
 - **Client confidentiality** — no client's information, assets, or results cross into another client's communications.
@@ -96,7 +96,7 @@ Per the corrected lens: **system-features are connection targets; only a true em
 - **Connection targets (zero threat):** PM-platform-native AI, Asana's AI intake and workflows, Monday's AI, ClickUp Brain. Workflow automation inside the systems we connect across, not a cross-system client-facing coordinator.
 - **Slice-automators (vendors, not seat-replacers):** generic AI assistants and PM automations handle task routing and internal workflow, the internal slice. None runs the whole client-facing account-coordination seat, onboarding through renewal, configured to the agency and in its voice, under human review.
 
-The honest read: a high-churn seat the agency still needs, with native AI automating internal workflow rather than running client coordination. We win on four things, none of which is a single feature (ADR 0035 Tenet 4, the moat is harness + guide + memory):
+The honest read: a high-churn seat the agency still needs, with native AI automating internal workflow rather than running client coordination. We win on four things, none of which is a single feature (ADR 0037 Tenet 4, the moat is harness + guide + memory):
 
 1. **The client-facing whole**, the account-coordination seat, not internal task automation.
 2. **The asset-and-approval chase where projects stall**, the client inputs and sign-offs that hold work up.

--- a/docs/specs/verticals/med-spa.md
+++ b/docs/specs/verticals/med-spa.md
@@ -3,12 +3,12 @@ title: 'Vertical Spec: Med Spa (Operator pack)'
 date: 2026-06-02
 status: draft
 captain: Scott Durgan
-related-adr: 0022-vertical-pack-architecture.md, 0035-operator-thesis.md, 0005-reviewer-as-sender.md, 0025-autonomy-ceilings-configurable-exposure-vs-initiation.md, 0020-connector-strategy.md
+related-adr: 0022-vertical-pack-architecture.md, 0037-operator-thesis.md, 0005-reviewer-as-sender.md, 0025-autonomy-ceilings-configurable-exposure-vs-initiation.md, 0020-connector-strategy.md
 ---
 
 # Vertical Spec: Med Spa
 
-The brief that drives the med-spa pack's manifest, N=0 proof, marketing surface, and delivery SOP, skinned from the worked reference (`law-firm.md`). Per [ADR 0035](../../adr/0035-operator-thesis.md), the Operator competes with a **hire** (the patient coordinator), not with software; the spa-management platform is a **connection target, not a competitor**.
+The brief that drives the med-spa pack's manifest, N=0 proof, marketing surface, and delivery SOP, skinned from the worked reference (`law-firm.md`). Per [ADR 0037](../../adr/0037-operator-thesis.md), the Operator competes with a **hire** (the patient coordinator), not with software; the spa-management platform is a **connection target, not a competitor**.
 
 > **Where med spa sits.** Integration is the easy end: the platforms (Boulevard, Zenoti, Mangomint) are modern cloud software with APIs, so a `build:` adapter on a clean API. The seat is open, the category is booming and staffing churns. The AI in the market is native-platform slices (Zenoti's AI Workforce, Boulevard's texting), booking and SMS inside the platform, not the connective whole. The med-spa-specific twist is compliance: treatments are medical, performed under medical direction, so the coordination has hard lines a salon does not.
 
@@ -81,7 +81,7 @@ Twelve med-spa-specific skills plus two spine skills reused as-is. Format per sk
 
 ## Compliance floor (authored, not assumed)
 
-Per [ADR 0035](../../adr/0035-operator-thesis.md) Tenet 3, no imposed defaults; floors are fail-closed until raised.
+Per [ADR 0037](../../adr/0037-operator-thesis.md) Tenet 3, no imposed defaults; floors are fail-closed until raised.
 
 - **No medical advice** — connective coordination only. Treatments are medical procedures performed under medical direction. Never a recommendation, never a clinical opinion, never an assessment of a reaction. The twelve skills are leads, scheduling, the exam gate, memberships, authored care delivery, financing, reviews, reactivation, and escalation.
 - **Good-faith-exam gate** — the Operator schedules the required medical exam and never substitutes for it or clears a client for treatment; clearance is the provider's.
@@ -100,7 +100,7 @@ Per the corrected lens: **system-features are connection targets; only a true em
 - **Connection targets (zero threat):** platform-native AI and comms, Zenoti's AI Workforce (AI receptionist, SmartBot), Boulevard's texting, Mangomint automations. Booking and SMS slices inside the platform we connect across. They do not run the cross-system patient journey.
 - **Slice-automators (vendors, not seat-replacers):** generic AI booking and answering services point at spas, the booking-and-SMS slice. None runs the connective whole, the good-faith-exam gate, memberships and packages, authored pre/post-care, financing, reactivation, and the safety escalation, configured to the spa and in its voice.
 
-The honest read: a fast-growing category with a high-churn seat and only slice automation in the market. We win on four things, none of which is a single feature (ADR 0035 Tenet 4, the moat is harness + guide + memory):
+The honest read: a fast-growing category with a high-churn seat and only slice automation in the market. We win on four things, none of which is a single feature (ADR 0037 Tenet 4, the moat is harness + guide + memory):
 
 1. **The connective whole**, the full patient journey, not a booking bot.
 2. **The compliance gates as features**, the good-faith-exam gate and adverse-event escalation are coordination a generic booking bot cannot safely do.

--- a/docs/specs/verticals/med-spa.md
+++ b/docs/specs/verticals/med-spa.md
@@ -1,0 +1,120 @@
+---
+title: 'Vertical Spec: Med Spa (Operator pack)'
+date: 2026-06-02
+status: draft
+captain: Scott Durgan
+related-adr: 0022-vertical-pack-architecture.md, 0035-operator-thesis.md, 0005-reviewer-as-sender.md, 0025-autonomy-ceilings-configurable-exposure-vs-initiation.md, 0020-connector-strategy.md
+---
+
+# Vertical Spec: Med Spa
+
+The brief that drives the med-spa pack's manifest, N=0 proof, marketing surface, and delivery SOP, skinned from the worked reference (`law-firm.md`). Per [ADR 0035](../../adr/0035-operator-thesis.md), the Operator competes with a **hire** (the patient coordinator), not with software; the spa-management platform is a **connection target, not a competitor**.
+
+> **Where med spa sits.** Integration is the easy end: the platforms (Boulevard, Zenoti, Mangomint) are modern cloud software with APIs, so a `build:` adapter on a clean API. The seat is open, the category is booming and staffing churns. The AI in the market is native-platform slices (Zenoti's AI Workforce, Boulevard's texting), booking and SMS inside the platform, not the connective whole. The med-spa-specific twist is compliance: treatments are medical, performed under medical direction, so the coordination has hard lines a salon does not.
+
+## The med spa front desk's world
+
+A med spa runs on systems that do not fully talk to each other. The lead comes from an ad, a referral, or a walk-in. Bookings, memberships, packages, and the client record live in the spa-management platform. Financing runs through a third party. Pre- and post-treatment instructions come from the provider. Reviews and referrals drive the next leads.
+
+The connective work is running the patient journey: capturing the lead and booking the consult, confirming and reminding with the deposit and cancellation policy, coordinating the required good-faith medical exam, tracking the membership and package balance, sending the provider's authored pre- and post-care, following up after treatment, coordinating financing, asking for the review, and reactivating the client who lapsed. It is the same chain whether the spa does injectables, laser, or body work; the service menu changes, the coordination does not.
+
+That coordination is a real seat, the patient coordinator or front desk who runs the journey while the providers treat. It is a high-churn seat in a fast-growing category. A spa covers it with a person, or splits it across a busy front desk. The Operator takes the connective layer so the seat is covered, or the person is freed for the in-room and high-touch sales work only a person can do. We make no assumption about which it is for a given spa.
+
+## Personas (the seat, described by role)
+
+- **Patient coordinator** (`patient-coordinator`): the front desk, leads, booking, reminders, memberships, the routine client back-and-forth. The high-churn seat.
+- **Membership and sales coordinator** (`membership-coordinator`): packages, memberships, financing, the revenue follow-up. The retention seat.
+- **Spa manager** (`spa-manager`): runs operations under the medical director. The reason the no-medical-advice and good-faith-exam lines have to be architectural.
+
+## Skill catalog
+
+Twelve med-spa-specific skills plus two spine skills reused as-is. Format per skill: **what** | trigger | reads -> writes | connectors | trust posture | guardrail. Trust posture follows [ADR 0025](../../adr/0025-autonomy-ceilings-configurable-exposure-vs-initiation.md); external send sits at the reviewer-as-sender floor ([ADR 0005](../../adr/0005-reviewer-as-sender.md)) unless the engagement authors otherwise.
+
+### Lead and scheduling
+
+**`new-lead-intake`** | a consult inquiry becomes a structured client record plus a drafted acknowledgment, with an offer to book the consult. | _trigger:_ inbound lead (ad / web form / referral) | _reads_ the inquiry, platform clients (dedupe), the spa's services -> _writes_ a draft client, a draft reply, an internal log | PracticeManagement, Email | record draft autonomous, send draft-for-review | no medical advice; an adverse-reaction message routes to a person (see `adverse-event-escalation-router`).
+
+**`consult-scheduler`** | offers times, books, confirms the consult. | _trigger:_ a booking request or after intake | _reads_ provider availability, consult length -> _writes_ the appointment and a confirmation | PracticeManagement, Calendar, Email | booking autonomous within rules, confirmation per authored exposure | books by the service type the spa defines; never recommends a treatment.
+
+**`appointment-reminder-confirmer`** | sends reminders with the deposit and cancellation policy, captures confirm or reschedule. | _trigger:_ scheduled ahead of appointments | _reads_ upcoming appointments, the spa's policy -> _writes_ reminder drafts, applies confirm or reschedule | PracticeManagement, Email | send per authored exposure | reminder and policy logistics only.
+
+**`no-show-rebooker`** | follows up on a missed appointment to rebook. | _trigger:_ a no-show or late cancellation | _reads_ the missed appointment, deposit status -> _writes_ a rebooking outreach draft | PracticeManagement, Email | send draft-for-review | rebooking and deposit logistics.
+
+### The good-faith-exam gate
+
+**`good-faith-exam-scheduler`** | ensures the required medical exam is scheduled before a medical treatment. | _trigger:_ a treatment booking that requires a prior exam | _reads_ whether a valid exam is on record, the requirement -> _writes_ the exam booking or a flag that one is needed | PracticeManagement, Calendar, Email | booking autonomous within rules, flag autonomous | schedules the exam; never substitutes for it, never clears a client for treatment, that is the provider's call.
+
+### Memberships, care, and money
+
+**`membership-package-coordinator`** | tracks membership and package balances and renewals. | _trigger:_ a balance low, a membership due to renew | _reads_ the membership and package records -> _writes_ a balance or renewal draft | PracticeManagement, Email | send draft-for-review | balance and renewal logistics; never pressures or upsells a treatment.
+
+**`pre-post-care-sender`** | sends the provider's authored pre- and post-treatment instructions on the cadence. | _trigger:_ before and after a treatment | _reads_ the booked treatment, the provider's authored care content -> _writes_ a draft carrying the authored instructions | PracticeManagement, Email | send draft-for-review | conveys only the provider's authored instructions; adds no medical content of its own.
+
+**`treatment-followup`** | a post-treatment check-in on the spa's cadence. | _trigger:_ scheduled after a treatment | _reads_ the treatment and any authored aftercare note -> _writes_ a check-in draft | PracticeManagement, Email | send draft-for-review | a check-in only; if the client reports an adverse reaction, escalates rather than advising.
+
+**`financing-coordinator`** | coordinates third-party financing logistics. | _trigger:_ a client pursuing financing | _reads_ the financing step the client is on -> _writes_ a logistics draft (apply here, status, next step) | PracticeManagement, Payments, Email | send draft-for-review | application logistics only; never advises on credit or terms.
+
+### Proactive and safety
+
+**`review-referral-request`** | asks a satisfied client for a review or referral after a visit. | _trigger:_ scheduled after a positive visit | _reads_ the visit -> _writes_ a review or referral ask draft | PracticeManagement, Email | send draft-for-review | reputation logistics; never fabricates a review or incentivizes against platform rules.
+
+**`reactivation-winback`** | surfaces clients not seen in the spa's window and drafts a reconnect. | _trigger:_ scheduled scan | _reads_ last-visit dates -> _writes_ a list and per-client winback drafts | PracticeManagement, Email | surfacing autonomous, send draft-for-review | reconnect logistics; no medical claim.
+
+**`adverse-event-escalation-router`** | detects a possible adverse reaction in any inbound message and hands it to the provider or medical director immediately, never advises. | _trigger:_ an inbound message triage flags as a possible adverse event | _reads_ the message -> _writes_ an immediate escalation to the provider/medical-director channel, plus a holding acknowledgment telling the client to call or seek care | PracticeManagement, InternalComms, Email | escalation autonomous and immediate; never an autonomous medical reply | never assesses the reaction clinically, errs toward escalation, fail-open to a person.
+
+### Spine (reused as-is)
+
+**`inbox-triage`** routes inbound to the right skill and is the first gate the adverse-event router hooks. **`status-report-assembler`** compiles the digests.
+
+## Connector map (the real spa stack)
+
+| Capability         | Common tools                 | Backend                                                 | Used by                           |
+| ------------------ | ---------------------------- | ------------------------------------------------------- | --------------------------------- |
+| PracticeManagement | Boulevard, Zenoti, Mangomint | `build:boulevard` / `build:zenoti` / `build:mangomint`  | every skill (system of record)    |
+| Email              | M365, Google                 | `mcp:m365-mail` / `build:google-gmail`                  | leads, reminders, care, retention |
+| Calendar           | M365, Google                 | `mcp:m365-calendar` / `build:google-calendar`           | consults, good-faith exam         |
+| DocumentStorage    | SharePoint, Drive            | `mcp:softeria/ms-365-mcp-server` / `build:google-drive` | consent forms, care instructions  |
+| Payments           | Cherry, PatientFi, processor | `build:med-spa-payments`                                | financing and deposit logistics   |
+| InternalComms      | Slack, Teams                 | `mcp:slack` / `build:teams`                             | adverse-event escalation, digests |
+
+**Integration is the easy end.** The spa-management platforms are modern cloud software with documented APIs, so a `build:` adapter on a clean API, lighter than the legacy systems in insurance or dental. **Boulevard** is a likely pilot (strong API, med-spa adoption); Zenoti and Mangomint are the next adapters. Phone is out of scope in v1 (the async connective desk, not the phone line).
+
+## Compliance floor (authored, not assumed)
+
+Per [ADR 0035](../../adr/0035-operator-thesis.md) Tenet 3, no imposed defaults; floors are fail-closed until raised.
+
+- **No medical advice** — connective coordination only. Treatments are medical procedures performed under medical direction. Never a recommendation, never a clinical opinion, never an assessment of a reaction. The twelve skills are leads, scheduling, the exam gate, memberships, authored care delivery, financing, reviews, reactivation, and escalation.
+- **Good-faith-exam gate** — the Operator schedules the required medical exam and never substitutes for it or clears a client for treatment; clearance is the provider's.
+- **Authored care only** — pre- and post-care convey only the provider's authored instructions; the Operator adds none of its own.
+- **Adverse-event escalation (fail-open to a human)** — a possible adverse reaction goes to the provider or medical director immediately, never handled async and never answered with medical content.
+- **HIPAA / PHI and reviewer-as-sender** — protected health information stays in spa surfaces; external mail ships under a human reviewer's identity ([ADR 0005](../../adr/0005-reviewer-as-sender.md)).
+
+## Labor-market context (the demand, without presumption)
+
+The med-spa category is one of the fastest-growing in consumer healthcare, and the front-desk and coordinator seat churns with it: high turnover, constant hiring, and a role that blends reception, sales, and care coordination. We do not presume which pressure applies to a given spa: some cannot keep the seat staffed, some want to free the team for in-room and high-touch sales work, some are scaling faster than they can hire. Keep dated figures in outreach, not on the evergreen landing page.
+
+## Competitive read (a crowd of vendors is not a closed seat)
+
+Per the corrected lens: **system-features are connection targets; only a true employee-replacer counts; and the seat is closed only when the spa stops needing the coordinator.** The category is hiring constantly, so the seat is open.
+
+- **Connection targets (zero threat):** platform-native AI and comms, Zenoti's AI Workforce (AI receptionist, SmartBot), Boulevard's texting, Mangomint automations. Booking and SMS slices inside the platform we connect across. They do not run the cross-system patient journey.
+- **Slice-automators (vendors, not seat-replacers):** generic AI booking and answering services point at spas, the booking-and-SMS slice. None runs the connective whole, the good-faith-exam gate, memberships and packages, authored pre/post-care, financing, reactivation, and the safety escalation, configured to the spa and in its voice.
+
+The honest read: a fast-growing category with a high-churn seat and only slice automation in the market. We win on four things, none of which is a single feature (ADR 0035 Tenet 4, the moat is harness + guide + memory):
+
+1. **The connective whole**, the full patient journey, not a booking bot.
+2. **The compliance gates as features**, the good-faith-exam gate and adverse-event escalation are coordination a generic booking bot cannot safely do.
+3. **Configurability** to the spa's menu, memberships, and voice, the substrate, not a fixed product.
+4. **Competing with a hire**, priced against a coordinator salary in a high-churn seat.
+
+## The wedge
+
+> The patient-coordinator seat at med spas: capture the lead and book the consult, confirm with the deposit and cancellation policy, make sure the required good-faith exam is scheduled, track memberships and packages, send the provider's authored pre- and post-care, follow up after treatment, coordinate financing, ask for the review, and route a possible adverse reaction straight to the provider. Connects to the spa-management platform over its modern API, runs the connective layer only, and stays clear of medical advice and clearance. It wins on the connective whole the booking bots do not run, on compliance gates that double as features, and on a high-churn seat the category cannot keep filled.
+
+## Base vs. add-on
+
+- **`med-spa` (base):** the patient-coordinator journey for an aesthetics and wellness spa. The lowest-friction entry. No add-on in v1; the base covers the journey end to end.
+
+## Channel
+
+Spa-management platform ecosystems and partner programs (Boulevard, Zenoti, Mangomint). Aesthetics conferences and groups (medical-aesthetics associations, injector and laser training networks, AmSpa). Med-spa consultants and franchise/MSO operators. Aesthetics media and practitioner communities.

--- a/docs/specs/verticals/mortgage.md
+++ b/docs/specs/verticals/mortgage.md
@@ -3,12 +3,12 @@ title: 'Vertical Spec: Mortgage (Operator pack)'
 date: 2026-06-02
 status: draft
 captain: Scott Durgan
-related-adr: 0022-vertical-pack-architecture.md, 0035-operator-thesis.md, 0005-reviewer-as-sender.md, 0025-autonomy-ceilings-configurable-exposure-vs-initiation.md, 0020-connector-strategy.md
+related-adr: 0022-vertical-pack-architecture.md, 0037-operator-thesis.md, 0005-reviewer-as-sender.md, 0025-autonomy-ceilings-configurable-exposure-vs-initiation.md, 0020-connector-strategy.md
 ---
 
 # Vertical Spec: Mortgage
 
-The brief that drives the mortgage pack's manifest, N=0 proof, marketing surface, and delivery SOP, skinned from the worked reference (`law-firm.md`). Per [ADR 0035](../../adr/0035-operator-thesis.md), the Operator competes with a **hire** (the loan processor and loan-officer assistant), not with software; the loan origination system is a **connection target, not a competitor**.
+The brief that drives the mortgage pack's manifest, N=0 proof, marketing surface, and delivery SOP, skinned from the worked reference (`law-firm.md`). Per [ADR 0037](../../adr/0037-operator-thesis.md), the Operator competes with a **hire** (the loan processor and loan-officer assistant), not with software; the loan origination system is a **connection target, not a competitor**.
 
 > **The thesis, in the industry's own words.** Mortgage-technology analysts describe 2026's direction as "AI orchestration layered on top of existing LOS platforms, not a replacement," and note that the Encompass SDK and APIs let third-party software push data, attach documents, and read loan state, "exactly what an orchestration layer needs." That orchestration seat is the loan processor. The funded AI here is largely in document processing and underwriting-prep (the work); the borrower-coordination and condition-chasing seat is the opening. The safety line, as in title, is wire fraud at closing.
 
@@ -78,7 +78,7 @@ Twelve mortgage-specific skills plus two spine skills reused as-is. Format per s
 
 ## Compliance floor (authored, not assumed)
 
-Per [ADR 0035](../../adr/0035-operator-thesis.md) Tenet 3, no imposed defaults; floors are fail-closed until raised.
+Per [ADR 0037](../../adr/0037-operator-thesis.md) Tenet 3, no imposed defaults; floors are fail-closed until raised.
 
 - **No lending or mortgage advice** — connective coordination only. Never advises on loan products, rates, whether to lock, or eligibility; never negotiates or commits terms. Advising and negotiating loan terms is licensed loan-officer activity (and implicates RESPA, TILA, and loan-officer-compensation rules). This is the mortgage analog of the law pack's UPL boundary.
 - **No credit or underwriting decision** — the Operator never approves, denies, or conditions a loan; the underwriter decides.
@@ -97,7 +97,7 @@ Per the corrected lens: **system-features are connection targets; only a true em
 - **Connection targets (zero threat):** LOS and POS features and AI (Encompass, Floify's auto-verification, Arive). The systems we connect across, and the industry frames AI as orchestration on top of them.
 - **Employee-replacers, mostly in a different lane:** the funded mortgage AI concentrates on document processing and underwriting-prep, classifying and extracting from documents, the work, not the borrower-coordination seat. The cross-party chasing and status seat is the opening, and the industry literally describes the future as an orchestration layer on the LOS, which is what this pack is.
 
-The honest read: a cyclical seat the shop still needs, with the funded competition aimed at document processing rather than coordination. We win on four things, none of which is a single feature (ADR 0035 Tenet 4, the moat is harness + guide + memory):
+The honest read: a cyclical seat the shop still needs, with the funded competition aimed at document processing rather than coordination. We win on four things, none of which is a single feature (ADR 0037 Tenet 4, the moat is harness + guide + memory):
 
 1. **The connective whole**, application through closing across every party, not a document classifier.
 2. **The condition-chasing where loans stall**, the open-stip follow-up that holds up closings.

--- a/docs/specs/verticals/mortgage.md
+++ b/docs/specs/verticals/mortgage.md
@@ -1,0 +1,117 @@
+---
+title: 'Vertical Spec: Mortgage (Operator pack)'
+date: 2026-06-02
+status: draft
+captain: Scott Durgan
+related-adr: 0022-vertical-pack-architecture.md, 0035-operator-thesis.md, 0005-reviewer-as-sender.md, 0025-autonomy-ceilings-configurable-exposure-vs-initiation.md, 0020-connector-strategy.md
+---
+
+# Vertical Spec: Mortgage
+
+The brief that drives the mortgage pack's manifest, N=0 proof, marketing surface, and delivery SOP, skinned from the worked reference (`law-firm.md`). Per [ADR 0035](../../adr/0035-operator-thesis.md), the Operator competes with a **hire** (the loan processor and loan-officer assistant), not with software; the loan origination system is a **connection target, not a competitor**.
+
+> **The thesis, in the industry's own words.** Mortgage-technology analysts describe 2026's direction as "AI orchestration layered on top of existing LOS platforms, not a replacement," and note that the Encompass SDK and APIs let third-party software push data, attach documents, and read loan state, "exactly what an orchestration layer needs." That orchestration seat is the loan processor. The funded AI here is largely in document processing and underwriting-prep (the work); the borrower-coordination and condition-chasing seat is the opening. The safety line, as in title, is wire fraud at closing.
+
+## The loan desk's world
+
+A mortgage shop runs a loan across many parties who do not share a system: the borrower, the real-estate agent, the loan officer, the underwriter, the appraiser, the title company, and the verifiers of income, assets, and employment. The application, conditions, and loan state live in the LOS, often fed by a point-of-sale and document portal.
+
+The connective work is moving the loan from application to closing and keeping every party current: intaking the application, chasing the conditions and stipulations underwriting asks for, collecting income, asset, and employment documents, ordering and tracking the appraisal and title, sending status to the borrower and the agent, watching the key dates, coordinating the closing, and following up after. It is the same chain whether it is a purchase or a refinance; the loan type changes, the coordination does not.
+
+That coordination is a real seat, the loan processor or loan-officer assistant who keeps the file and the parties moving while the loan officer originates and the underwriter decides. It is a cyclical seat, cut in downturns and impossible to fill in booms. A shop covers it with people, or buries the processors it has. The Operator takes the connective layer so the seat is covered, or the processor is freed for the judgment work. We make no assumption about which it is for a given shop.
+
+## Personas (the seat, described by role)
+
+- **Loan processor** (`loan-processor`): chases conditions, collects documents, orders services, keeps the file moving. The connective seat.
+- **Loan-officer assistant** (`lo-assistant`): supports the loan officer, status and coordination. The relationship seat.
+- **Branch / operations manager** (`branch-manager`): owns the pipeline. The reason the no-lending-advice and wire-safety lines have to be architectural.
+
+## Skill catalog
+
+Twelve mortgage-specific skills plus two spine skills reused as-is. Format per skill: **what** | trigger | reads -> writes | connectors | trust posture | guardrail. Trust posture follows [ADR 0025](../../adr/0025-autonomy-ceilings-configurable-exposure-vs-initiation.md); external send sits at the reviewer-as-sender floor ([ADR 0005](../../adr/0005-reviewer-as-sender.md)) unless the engagement authors otherwise.
+
+### Application and conditions
+
+**`application-intake`** | an application becomes a structured file plus a drafted acknowledgment, routed to the loan officer. | _trigger:_ a new application (POS / referral) | _reads_ the application, LOS records (dedupe) -> _writes_ a draft file, a borrower acknowledgment, an internal log | PracticeManagement, Email | record draft autonomous, send draft-for-review, the loan decision always the LO/underwriter | never advises on loan products, rates, or eligibility; routes to a licensed loan officer.
+
+**`condition-stip-chaser`** | chases the conditions and stipulations underwriting asks for. | _trigger:_ a condition open past the cadence | _reads_ the open condition list -> _writes_ per-condition chase drafts to the borrower, updates the list as items land | PracticeManagement, Email | chase send draft-for-review, list update autonomous | chases the items underwriting set; never decides whether a condition is satisfied.
+
+**`doc-collection-tracker`** | collects the income, asset, and employment documents and tracks them into the LOS. | _trigger:_ documents needed or arriving | _reads_ the document checklist, what has arrived -> _writes_ request and reminder drafts, updates the checklist | PracticeManagement, DocumentStorage, Email | request send draft-for-review, checklist update autonomous | collects and tracks; never assesses or interprets a document's contents.
+
+### Services and verifications
+
+**`appraisal-order-tracker`** | orders and tracks the appraisal. | _trigger:_ appraisal needed | _reads_ the order and its status -> _writes_ the order request, status notes, a flag if delayed | PracticeManagement, Email | order and status send draft-for-review | logistics only; never comments on value.
+
+**`title-order-coordinator`** | coordinates with the title company and chases its items. | _trigger:_ title items owed | _reads_ the open title items -> _writes_ coordination and chase drafts to the title company | PracticeManagement, Email | send draft-for-review | logistics only.
+
+**`voe-vod-requester`** | requests verifications of employment and deposit. | _trigger:_ a verification needed | _reads_ the employer or institution info on file -> _writes_ the verification request, logs the response | PracticeManagement, Email | request send draft-for-review | requests and logs; never interprets the result.
+
+### Status, dates, and closing
+
+**`borrower-status-updater`** | answers the routine "where's my loan" from the LOS. | _trigger:_ a status question routed by inbox-triage | _reads_ loan state, next step -> _writes_ a status reply draft | PracticeManagement, Email | send draft-for-review | reports status only; no opinion on approval, rate, or timing certainty.
+
+**`realtor-lo-status-updater`** | keeps the agent and loan officer in the loop. | _trigger:_ a milestone changes | _reads_ loan state, the contact list -> _writes_ per-party status drafts | PracticeManagement, Email | send draft-for-review | reports status; no commitment on terms or close.
+
+**`milestone-reminder`** | surfaces the key dates the file carries. | _trigger:_ scheduled | _reads_ the file's key dates (rate-lock expiration, financing contingency, closing) -> _writes_ a reminder digest and per-party reminders | PracticeManagement, Calendar, Email | surfacing autonomous, send draft-for-review | surfaces the dates the file records; **never advises whether to lock, extend, or act**, those are licensed-LO and borrower decisions.
+
+**`closing-coordination`** | coordinates the clear-to-close and the closing with title and the borrower. | _trigger:_ approaching closing | _reads_ the CTC status, the closing logistics -> _writes_ coordination drafts to title and the borrower | PracticeManagement, Calendar, Email | send draft-for-review | coordinates logistics; never produces or alters figures, and **never communicates wire instructions** (see the wire-safety floor).
+
+**`post-closing-followup`** | follows up after closing. | _trigger:_ scheduled after closing | _reads_ the closed loan, any authored follow-up content -> _writes_ a thank-you / review-ask / first-payment-reminder draft | PracticeManagement, Email | send draft-for-review | relationship logistics; relays only authored servicing details, no advice.
+
+**`wire-instruction-safety-router`** | the safety skill: any inbound message touching wire instructions or banking details routes to a human through the verified process, never acted on. | _trigger:_ an inbound message about wire instructions, account changes, or where to send funds | _reads_ the message -> _writes_ an immediate routing to the verified process, a holding note that wire details are confirmed only through the secure channel | PracticeManagement, InternalComms, Email | route autonomous; **never transmits, confirms, or changes wire instructions** | fail-closed on money, as in title.
+
+### Spine (reused as-is)
+
+**`inbox-triage`** routes inbound to the right skill and is the first gate the wire-safety router hooks. **`status-report-assembler`** compiles the digests.
+
+## Connector map (the real loan stack)
+
+| Capability         | Common tools             | Backend                                                 | Used by                              |
+| ------------------ | ------------------------ | ------------------------------------------------------- | ------------------------------------ |
+| PracticeManagement | Encompass, Floify, Arive | `build:encompass` / `build:floify` / `build:arive`      | every skill (system of record / POS) |
+| Email              | M365, Google             | `mcp:m365-mail` / `build:google-gmail`                  | intake, chasing, status              |
+| Calendar           | M365, Google             | `mcp:m365-calendar` / `build:google-calendar`           | dates, closing coordination          |
+| DocumentStorage    | SharePoint, Drive        | `mcp:softeria/ms-365-mcp-server` / `build:google-drive` | document collection                  |
+| InternalComms      | Slack, Teams             | `mcp:slack` / `build:teams`                             | wire-safety routing, team digests    |
+
+**Encompass is the LOS system of record** (ICE; SDK and APIs documented), with Floify (POS and document collection) and Arive (broker all-in-one) as the modern points of integration. The pilot adapter targets whichever the shop runs. No banking or wire system is connected, by design.
+
+## Compliance floor (authored, not assumed)
+
+Per [ADR 0035](../../adr/0035-operator-thesis.md) Tenet 3, no imposed defaults; floors are fail-closed until raised.
+
+- **No lending or mortgage advice** — connective coordination only. Never advises on loan products, rates, whether to lock, or eligibility; never negotiates or commits terms. Advising and negotiating loan terms is licensed loan-officer activity (and implicates RESPA, TILA, and loan-officer-compensation rules). This is the mortgage analog of the law pack's UPL boundary.
+- **No credit or underwriting decision** — the Operator never approves, denies, or conditions a loan; the underwriter decides.
+- **Wire-instruction safety (fail-closed)** — the Operator never transmits, confirms, or changes wire instructions; any such message routes to the verified human process. Closing wire fraud is a real threat; this floor is non-raisable.
+- **NPI / GLBA** — nonpublic personal information stays inside the shop's surfaces.
+- **Reviewer-as-sender floor** — external mail ships under a human reviewer's identity ([ADR 0005](../../adr/0005-reviewer-as-sender.md)).
+
+## Labor-market context (the demand, without presumption)
+
+Mortgage operations staffing is cyclical and rate-sensitive: processors and assistants are cut when volume falls and cannot be found fast enough when it rises, so the coordination capacity is chronically mismatched to the pipeline. We do not presume which pressure applies to a given shop: some cannot staff for a refi wave, some want to free processors for judgment work, some are running lean through a slow stretch. Either way the loans still have to be coordinated. Keep dated figures in outreach, not on the evergreen landing page.
+
+## Competitive read (the funded AI is in the work, the seat is open)
+
+Per the corrected lens: **system-features are connection targets; only a true employee-replacer counts; and the seat is closed only when the shop stops needing the processor.** Loans still need coordinating, so the seat is open.
+
+- **Connection targets (zero threat):** LOS and POS features and AI (Encompass, Floify's auto-verification, Arive). The systems we connect across, and the industry frames AI as orchestration on top of them.
+- **Employee-replacers, mostly in a different lane:** the funded mortgage AI concentrates on document processing and underwriting-prep, classifying and extracting from documents, the work, not the borrower-coordination seat. The cross-party chasing and status seat is the opening, and the industry literally describes the future as an orchestration layer on the LOS, which is what this pack is.
+
+The honest read: a cyclical seat the shop still needs, with the funded competition aimed at document processing rather than coordination. We win on four things, none of which is a single feature (ADR 0035 Tenet 4, the moat is harness + guide + memory):
+
+1. **The connective whole**, application through closing across every party, not a document classifier.
+2. **The condition-chasing where loans stall**, the open-stip follow-up that holds up closings.
+3. **Configurability** to the shop's process, investors, and voice, the substrate, not a fixed product.
+4. **Competing with a hire**, priced against a processor salary in a seat that swings with the rate cycle.
+
+## The wedge
+
+> The loan-processor and assistant seat at mortgage shops: intake the application, chase the conditions and stips, collect income and asset documents, order and track the appraisal and title, send status to the borrower and the agent, watch the key dates, and coordinate the closing. Connects to the LOS over its API, runs the connective layer only, and stays clear of lending advice and never touches wire instructions. It wins on the connective whole the document-processing AI is not building, on the condition-chasing where loans stall, and on a cyclical seat the shop still has to staff, the orchestration layer the industry already says the LOS needs.
+
+## Base vs. add-on
+
+- **`mortgage` (base):** purchase-and-refinance loan coordination for a broker or lender. The lowest-friction entry. No add-on in v1; the base covers the file end to end.
+
+## Channel
+
+LOS and POS ecosystems (Encompass, Floify, Arive marketplaces and communities). Mortgage broker and lender associations (AIME, MBA and state associations), wholesale-lender account-executive relationships, and the industry media (National Mortgage News, HousingWire, The Mortgage Collaborative). Real-estate-agent referral relationships that already feed the pipeline.

--- a/docs/specs/verticals/property-management.md
+++ b/docs/specs/verticals/property-management.md
@@ -3,12 +3,12 @@ title: 'Vertical Spec: Property Management (Operator pack)'
 date: 2026-06-02
 status: draft
 captain: Scott Durgan
-related-adr: 0022-vertical-pack-architecture.md, 0035-operator-thesis.md, 0005-reviewer-as-sender.md, 0025-autonomy-ceilings-configurable-exposure-vs-initiation.md, 0020-connector-strategy.md
+related-adr: 0022-vertical-pack-architecture.md, 0037-operator-thesis.md, 0005-reviewer-as-sender.md, 0025-autonomy-ceilings-configurable-exposure-vs-initiation.md, 0020-connector-strategy.md
 ---
 
 # Vertical Spec: Property Management
 
-The brief that drives the property-management pack's manifest, N=0 proof, marketing surface, and delivery SOP, skinned from the worked reference (`law-firm.md`). Per [ADR 0035](../../adr/0035-operator-thesis.md), the Operator competes with a **hire** (the leasing and tenant coordinator), not with software; the property-management platform is a **connection target, not a competitor**.
+The brief that drives the property-management pack's manifest, N=0 proof, marketing surface, and delivery SOP, skinned from the worked reference (`law-firm.md`). Per [ADR 0037](../../adr/0037-operator-thesis.md), the Operator competes with a **hire** (the leasing and tenant coordinator), not with software; the property-management platform is a **connection target, not a competitor**.
 
 > **The distinctive floor here is Fair Housing.** Every prospect-facing and resident-facing message is subject to the Fair Housing Act, and HUD has confirmed the FHA applies when AI is used in screening and advertising. The pack enforces it architecturally: consistent criteria applied the same way to everyone, no protected-class inference, no steering, an audit trail, and human escalation for any protected-class-sensitive question. The second floor is the maintenance emergency, a habitability emergency (no heat, flood, gas, fire) is routed to a person immediately, never handled async.
 
@@ -78,7 +78,7 @@ Twelve property-management-specific skills plus two spine skills reused as-is. F
 
 ## Compliance floor (authored, not assumed)
 
-Per [ADR 0035](../../adr/0035-operator-thesis.md) Tenet 3, no imposed defaults; floors are fail-closed until raised.
+Per [ADR 0037](../../adr/0037-operator-thesis.md) Tenet 3, no imposed defaults; floors are fail-closed until raised.
 
 - **Fair Housing** — every prospect- and resident-facing message applies the company's consistent, published criteria the same way to everyone. The Operator never infers, asks about, or acts on protected-class status, never steers a prospect toward or away from a unit or area, and routes any protected-class-sensitive question to a person. Consistent rules, an audit trail, and human escalation are the architecture HUD's AI guidance calls for.
 - **No screening or adverse-action decision** — the Operator coordinates the application and routes it; it never makes or communicates the screening decision or an adverse action, which the company owns.
@@ -97,7 +97,7 @@ Per the corrected lens: **system-features are connection targets; only a true em
 - **Connection targets (zero threat):** platform-native AI, AppFolio's Realm-X (native generative AI woven into the OS, saving users hours on busywork), Yardi and Buildium features. Powerful, and inside the systems we connect across, not a cross-system coordinator.
 - **Slice-automators (vendors, not seat-replacers):** the AI leasing-assistant field (a crowded set of tools) automates the leasing and maintenance-triage slice. None runs the whole resident-and-owner lifecycle with Fair-Housing discipline and habitability escalation, configured to the company.
 
-The honest read: a squeezed seat the company still needs, with native AI inside the platform and slice automation around leasing. We win on four things, none of which is a single feature (ADR 0035 Tenet 4, the moat is harness + guide + memory):
+The honest read: a squeezed seat the company still needs, with native AI inside the platform and slice automation around leasing. We win on four things, none of which is a single feature (ADR 0037 Tenet 4, the moat is harness + guide + memory):
 
 1. **The connective whole**, the full resident-and-owner lifecycle, not the leasing slice.
 2. **Fair Housing and habitability as features**, consistent-criteria discipline and emergency escalation are coordination a generic leasing bot cannot safely do.

--- a/docs/specs/verticals/property-management.md
+++ b/docs/specs/verticals/property-management.md
@@ -1,0 +1,117 @@
+---
+title: 'Vertical Spec: Property Management (Operator pack)'
+date: 2026-06-02
+status: draft
+captain: Scott Durgan
+related-adr: 0022-vertical-pack-architecture.md, 0035-operator-thesis.md, 0005-reviewer-as-sender.md, 0025-autonomy-ceilings-configurable-exposure-vs-initiation.md, 0020-connector-strategy.md
+---
+
+# Vertical Spec: Property Management
+
+The brief that drives the property-management pack's manifest, N=0 proof, marketing surface, and delivery SOP, skinned from the worked reference (`law-firm.md`). Per [ADR 0035](../../adr/0035-operator-thesis.md), the Operator competes with a **hire** (the leasing and tenant coordinator), not with software; the property-management platform is a **connection target, not a competitor**.
+
+> **The distinctive floor here is Fair Housing.** Every prospect-facing and resident-facing message is subject to the Fair Housing Act, and HUD has confirmed the FHA applies when AI is used in screening and advertising. The pack enforces it architecturally: consistent criteria applied the same way to everyone, no protected-class inference, no steering, an audit trail, and human escalation for any protected-class-sensitive question. The second floor is the maintenance emergency, a habitability emergency (no heat, flood, gas, fire) is routed to a person immediately, never handled async.
+
+## The property-management desk's world
+
+A property-management company runs the resident and owner lifecycle across systems that do not fully talk: the platform (AppFolio, Buildium, Yardi) holds the units, leases, work orders, and ledgers; listing sites bring prospects; vendors do the work; owners want reporting. The leasing and tenant coordinators are the connective tissue.
+
+The connective work is running that lifecycle and keeping everyone current: fielding the leasing inquiry and qualifying it on consistent criteria, scheduling the tour, coordinating the application and screening, intaking and dispatching maintenance, reminding on rent and working delinquency on the authored process, coordinating lease renewals and move-ins and move-outs, delivering owner reports, coordinating vendors, and answering the routine resident question. It is the same chain whether the portfolio is single-family scattered-site or multifamily; the unit mix changes, the coordination does not.
+
+That coordination is a real seat, the leasing or tenant coordinator who keeps prospects, residents, vendors, and owners moving while the property manager manages. With vacancy and maintenance costs rising, it is a squeezed, high-turnover seat. A company covers it with people, or buries an overloaded coordinator. The Operator takes the connective layer so the seat is covered, or the person is freed for the on-site and relationship work only a person can do. We make no assumption about which it is for a given company.
+
+## Personas (the seat, described by role)
+
+- **Leasing / tenant coordinator** (`leasing-coordinator`): leasing inquiries, tours, applications, the routine resident back-and-forth. The Fair-Housing-sensitive seat.
+- **Property manager assistant** (`pm-assistant`): maintenance coordination, renewals, owner updates. The operations seat.
+- **Portfolio / regional manager** (`portfolio-manager`): owns the portfolio. The reason the Fair-Housing and habitability-emergency lines have to be architectural.
+
+## Skill catalog
+
+Twelve property-management-specific skills plus two spine skills reused as-is. Format per skill: **what** | trigger | reads -> writes | connectors | trust posture | guardrail. Trust posture follows [ADR 0025](../../adr/0025-autonomy-ceilings-configurable-exposure-vs-initiation.md); external send sits at the reviewer-as-sender floor ([ADR 0005](../../adr/0005-reviewer-as-sender.md)) unless the engagement authors otherwise.
+
+### Leasing (Fair-Housing-sensitive)
+
+**`leasing-inquiry-intake`** | a prospect inquiry becomes a structured lead, qualified on the company's consistent published criteria, with an offer to tour. | _trigger:_ an inbound leasing inquiry (listing site / web / email) | _reads_ the inquiry, the unit, the company's authored qualification criteria -> _writes_ a draft lead, a draft reply with the same criteria for everyone, an internal log | PracticeManagement, Email | record draft autonomous, send draft-for-review | applies the same criteria to every prospect; never infers or asks about protected-class status, never steers; a protected-class-sensitive question routes to a person.
+
+**`tour-scheduler`** | offers tour times, books, confirms. | _trigger:_ a tour request | _reads_ availability (self-show or staffed), the unit -> _writes_ the tour and a confirmation | PracticeManagement, Calendar, Email | booking autonomous within rules | scheduling logistics only; same options for everyone.
+
+**`application-status-coordinator`** | coordinates the application and routes it to screening, never decides it. | _trigger:_ an application submitted | _reads_ the application completeness, the screening step -> _writes_ a status acknowledgment, routes to the company's screening process | PracticeManagement, Email | route and status autonomous (send draft-for-review) | coordinates the application; **never makes or communicates the screening decision**, never applies criteria beyond completeness, the decision and any adverse action are the company's.
+
+### Maintenance
+
+**`maintenance-request-intake`** | intakes a maintenance request, creates the work order, routes it, and escalates an emergency. | _trigger:_ a maintenance request | _reads_ the request, the unit and resident -> _writes_ a work order, an acknowledgment, an internal route | PracticeManagement, Email | work-order and ack autonomous, send draft-for-review | a habitability emergency (no heat, flood, gas, fire) routes to a person immediately (see `maintenance-emergency-escalation-router`); never diagnoses the issue.
+
+**`maintenance-dispatch-coordinator`** | coordinates the vendor or tech and confirms with the resident. | _trigger:_ a work order ready to schedule | _reads_ the work order, vendor availability -> _writes_ the scheduling coordination and a resident confirmation | PracticeManagement, Calendar, Email | scheduling autonomous within rules, send draft-for-review | coordination logistics only.
+
+**`maintenance-emergency-escalation-router`** | detects a possible habitability emergency and routes it to a person and the emergency vendor immediately. | _trigger:_ an inbound message triage flags as a possible emergency | _reads_ the message -> _writes_ an immediate escalation to the on-call channel and a holding acknowledgment to the resident with the emergency path | PracticeManagement, InternalComms, Email | escalation autonomous and immediate; never an autonomous fix or diagnosis | never assesses the hazard itself, errs toward escalation, fail-open to a person.
+
+### Residency and owners
+
+**`rent-reminder`** | sends rent-due reminders and works delinquency on the company's authored process. | _trigger:_ rent due or past due | _reads_ the ledger status, the company's authored delinquency steps -> _writes_ a reminder or notice draft per the process | PracticeManagement, Email | send draft-for-review | follows the company's authored process; **never gives legal or eviction advice and never processes a payment**.
+
+**`lease-renewal-coordinator`** | surfaces upcoming lease expirations and coordinates renewals. | _trigger:_ a lease approaching expiration | _reads_ the lease and the company's authored renewal terms -> _writes_ a renewal outreach draft | PracticeManagement, Email | surfacing autonomous, send draft-for-review | relays the company's authored renewal terms; never negotiates or sets terms.
+
+**`move-coordinator`** | coordinates move-in and move-out logistics, inspections, and key handoff. | _trigger:_ a scheduled move-in or move-out | _reads_ the lease dates, inspection and key steps -> _writes_ scheduling and checklist drafts | PracticeManagement, Calendar, Email | scheduling autonomous within rules, send draft-for-review | logistics only; **never makes a security-deposit determination**, which the company authors.
+
+**`owner-report-deliverer`** | delivers the company's authored owner reports and updates on cadence. | _trigger:_ scheduled, or an owner-relevant event | _reads_ the authored report or update -> _writes_ a delivery draft | PracticeManagement, Email | send draft-for-review | delivers authored content only; adds no analysis or commitment.
+
+**`vendor-coordinator`** | coordinates vendors and chases their items (scheduling, certificates of insurance). | _trigger:_ a vendor item open | _reads_ the open vendor items -> _writes_ coordination and chase drafts | PracticeManagement, Email | send draft-for-review | logistics only; no commitment on scope or price.
+
+**`resident-status-responder`** | answers the routine resident question from the platform. | _trigger:_ a status question routed by inbox-triage | _reads_ the item status (repair, deposit, request) -> _writes_ a status reply draft | PracticeManagement, Email | send draft-for-review | reports status only; no legal opinion, no protected-class-sensitive handling.
+
+### Spine (reused as-is)
+
+**`inbox-triage`** routes inbound to the right skill and is the first gate the emergency router hooks. **`status-report-assembler`** compiles the digests.
+
+## Connector map (the real PM stack)
+
+| Capability         | Common tools              | Backend                                                 | Used by                          |
+| ------------------ | ------------------------- | ------------------------------------------------------- | -------------------------------- |
+| PracticeManagement | AppFolio, Buildium, Yardi | `build:appfolio` / `build:buildium` / `build:yardi`     | every skill (system of record)   |
+| Email              | M365, Google              | `mcp:m365-mail` / `build:google-gmail`                  | leasing, maintenance, owners     |
+| Calendar           | M365, Google              | `mcp:m365-calendar` / `build:google-calendar`           | tours, maintenance, moves        |
+| DocumentStorage    | SharePoint, Drive         | `mcp:softeria/ms-365-mcp-server` / `build:google-drive` | leases, reports, checklists      |
+| InternalComms      | Slack, Teams              | `mcp:slack` / `build:teams`                             | maintenance-emergency escalation |
+
+**AppFolio is a likely pilot platform** (large install base, API access by tier); Buildium and Yardi are the next adapters. No payment-processing connector is included: the Operator reminds and coordinates but **never processes rent or deposits**.
+
+## Compliance floor (authored, not assumed)
+
+Per [ADR 0035](../../adr/0035-operator-thesis.md) Tenet 3, no imposed defaults; floors are fail-closed until raised.
+
+- **Fair Housing** — every prospect- and resident-facing message applies the company's consistent, published criteria the same way to everyone. The Operator never infers, asks about, or acts on protected-class status, never steers a prospect toward or away from a unit or area, and routes any protected-class-sensitive question to a person. Consistent rules, an audit trail, and human escalation are the architecture HUD's AI guidance calls for.
+- **No screening or adverse-action decision** — the Operator coordinates the application and routes it; it never makes or communicates the screening decision or an adverse action, which the company owns.
+- **Maintenance-emergency escalation (fail-open to a human)** — a possible habitability emergency goes to a person and the emergency vendor immediately, never handled async and never diagnosed.
+- **No legal or eviction advice, no money movement** — the Operator follows the company's authored delinquency process, gives no legal or eviction advice, and never processes rent or deposits.
+- **Reviewer-as-sender floor** — external mail ships under a human reviewer's identity ([ADR 0005](../../adr/0005-reviewer-as-sender.md)).
+
+## Labor-market context (the demand, without presumption)
+
+Property-management coordination is a squeezed, high-turnover seat, with vacancy and maintenance costs rising and companies under margin pressure. We do not presume which pressure applies to a given company: some cannot keep the coordinator staffed, some want to free the team for on-site and relationship work, some are scaling scattered-site portfolios faster than they can hire. Keep dated figures in outreach, not on the evergreen landing page.
+
+## Competitive read (a crowd of vendors is not a closed seat)
+
+Per the corrected lens: **system-features are connection targets; only a true employee-replacer counts; and the seat is closed only when the company stops needing the coordinator.** The portfolio still needs the coordinator, so the seat is open.
+
+- **Connection targets (zero threat):** platform-native AI, AppFolio's Realm-X (native generative AI woven into the OS, saving users hours on busywork), Yardi and Buildium features. Powerful, and inside the systems we connect across, not a cross-system coordinator.
+- **Slice-automators (vendors, not seat-replacers):** the AI leasing-assistant field (a crowded set of tools) automates the leasing and maintenance-triage slice. None runs the whole resident-and-owner lifecycle with Fair-Housing discipline and habitability escalation, configured to the company.
+
+The honest read: a squeezed seat the company still needs, with native AI inside the platform and slice automation around leasing. We win on four things, none of which is a single feature (ADR 0035 Tenet 4, the moat is harness + guide + memory):
+
+1. **The connective whole**, the full resident-and-owner lifecycle, not the leasing slice.
+2. **Fair Housing and habitability as features**, consistent-criteria discipline and emergency escalation are coordination a generic leasing bot cannot safely do.
+3. **Configurability** to the company's criteria, process, and voice, the substrate, not a fixed product.
+4. **Competing with a hire**, priced against a coordinator salary in a high-turnover seat.
+
+## The wedge
+
+> The leasing-and-tenant-coordinator seat at property-management companies: field and consistently qualify the leasing inquiry, schedule the tour, coordinate the application to screening, intake and dispatch maintenance, remind on rent and work the authored delinquency process, coordinate renewals and moves, deliver owner reports, and route a habitability emergency straight to a person. Connects to the property-management platform over its API, runs the connective layer only, and stays clear of screening decisions, legal advice, and money. It wins on the connective whole the leasing bots do not run, on Fair-Housing and habitability discipline that double as features, and on a squeezed seat the company still has to staff.
+
+## Base vs. add-on
+
+- **`property-management` (base):** residential leasing and tenant coordination for a single-family or multifamily portfolio. The lowest-friction entry. No add-on in v1; the base covers the lifecycle.
+
+## Channel
+
+Property-management platform ecosystems and marketplaces (AppFolio, Buildium, Yardi). The National Association of Residential Property Managers (NARPM) and regional apartment associations. Property-management coaching and mastermind groups, and the single-family-rental operator networks where scattered-site coordination pain is highest.

--- a/docs/specs/verticals/ria.md
+++ b/docs/specs/verticals/ria.md
@@ -1,0 +1,123 @@
+---
+title: 'Vertical Spec: RIA / Wealth Management (Operator pack)'
+date: 2026-06-02
+status: draft
+captain: Scott Durgan
+related-adr: 0022-vertical-pack-architecture.md, 0035-operator-thesis.md, 0005-reviewer-as-sender.md, 0025-autonomy-ceilings-configurable-exposure-vs-initiation.md, 0020-connector-strategy.md
+---
+
+# Vertical Spec: RIA / Wealth Management
+
+The brief that drives the RIA pack's manifest, N=0 proof, marketing surface, and delivery SOP, skinned from the worked reference (`law-firm.md`). Per [ADR 0035](../../adr/0035-operator-thesis.md), the Operator competes with a **hire** (the client service associate), not with software; the advisor CRM and custodian are **connection targets, not competitors**.
+
+> **Read this first, two warnings.** (1) **This is the most contested vertical in our own lane.** Jump and Zocks have raised $170M+ and are explicitly building "agentic operating systems that orchestrate work across the advisor stack", the same connective layer this pack is. They are notetaker-origin advisor copilots expanding outward; the seat we target is the **client service associate (CSA)**, which the research names directly ("CSAs spend hours chasing signatures, re-entering intake data into the CRM, and tracking document status"). We compete here, eyes open, like dental. (2) **This is the heaviest compliance floor in the dozen**, SEC/state RIA rules, the fiduciary advice line, Reg S-P privacy, SEC books-and-records, the Marketing Rule, and no money movement. The pack is connective-only and fail-closed on advice and on money.
+
+## The client-service desk's world
+
+An RIA runs client service across systems that do not share state: the CRM (the data of record), the custodian (Schwab, Fidelity), the planning tool, the portfolio system, and a document portal. The advisor advises; everyone else keeps the operation running.
+
+The connective work is keeping clients and accounts in order: onboarding the new client and getting the account-opening paperwork in good order at the custodian, chasing the not-in-good-order (NIGO) items, coordinating a client's money-movement _request_ (never executing it), scheduling reviews and assembling the prep packet from the firm's authored materials, reminding clients of required actions the firm tracks, collecting documents, routing account-maintenance paperwork, answering routine status questions, following advisory-fee billing, and coordinating the annual review. It is the same chain whether the firm does financial planning, investment management, or both; the service mix changes, the coordination does not.
+
+That coordination is a real seat, the client service associate who keeps the accounts and paperwork moving while the advisor advises. It is a seat firms struggle to staff and that drowns in signature-chasing and data re-entry. The Operator takes the connective layer so the seat is covered, or the associate is freed for the high-touch client work only a person can do. We make no assumption about which it is for a given firm.
+
+## Personas (the seat, described by role)
+
+- **Client service associate** (`client-service-associate`): onboarding, paperwork, scheduling, document chasing, the routine client back-and-forth. The seat the pack fills.
+- **Operations associate** (`operations-associate`): account maintenance, money-movement processing, custodian coordination. The reason the no-money-movement line has to be architectural.
+- **Advisor / principal** (`advisor-principal`): owns the advice and the fiduciary relationship. The reason the no-investment-advice line has to be architectural.
+
+## Skill catalog
+
+Twelve RIA-specific skills plus two spine skills reused as-is. Format per skill: **what** | trigger | reads -> writes | connectors | trust posture | guardrail. Trust posture follows [ADR 0025](../../adr/0025-autonomy-ceilings-configurable-exposure-vs-initiation.md); external send sits at the reviewer-as-sender floor ([ADR 0005](../../adr/0005-reviewer-as-sender.md)) unless the engagement authors otherwise.
+
+### Onboarding and accounts
+
+**`client-onboarding-paperwork`** | a new client becomes a structured record plus the account-opening packet and a drafted welcome. | _trigger:_ a new client | _reads_ the client, the firm's onboarding and account templates -> _writes_ a draft client record, a draft welcome with the account-opening packet, an internal log | PracticeManagement, ESign, Email | record draft autonomous, send draft-for-review | relays the firm's authored paperwork; never advises on accounts or investments.
+
+**`account-opening-tracker`** | tracks the not-in-good-order items on custodian paperwork and chases them. | _trigger:_ a NIGO item open past the cadence | _reads_ the open-item status -> _writes_ per-item chase drafts, updates the list as items clear | PracticeManagement, Email | chase send draft-for-review, list update autonomous | chases the items the firm or custodian flagged; never decides whether paperwork is in good order.
+
+**`account-maintenance-router`** | routes account-maintenance requests (beneficiary, address, title changes) to the right paperwork. | _trigger:_ a maintenance request | _reads_ the request, the required form -> _writes_ the paperwork relay and a client acknowledgment | PracticeManagement, ESign, Email | relay autonomous, send draft-for-review | relays the paperwork; never makes the change itself or advises on it.
+
+### The money line (request only)
+
+**`money-movement-request-coordinator`** | gathers a client's distribution or transfer _request_ and routes it to operations for execution, never executes it. | _trigger:_ a client requests a distribution or transfer | _reads_ the request details, the account on record -> _writes_ a structured request to operations, a client acknowledgment that the team will process it | PracticeManagement, Email | gather and route autonomous; **never executes a money movement** | the Operator never moves, transfers, or distributes funds; it gathers the request and routes it to the firm's verified human process.
+
+### Reviews, reminders, and documents
+
+**`meeting-scheduler`** | offers times, books, confirms the client review. | _trigger:_ a review needed or requested | _reads_ advisor availability, meeting length -> _writes_ the meeting and a confirmation | PracticeManagement, Calendar, Email | booking autonomous within rules | scheduling logistics only.
+
+**`meeting-prep-assembler`** | assembles the review prep packet from the firm's authored materials. | _trigger:_ ahead of a review | _reads_ the firm's authored agenda and reports for the client -> _writes_ a prep packet draft from those materials | PracticeManagement, DocumentStorage, Email | assemble autonomous, send draft-for-review | assembles authored materials only; adds no analysis, recommendation, or commentary of its own.
+
+**`required-action-reminder`** | surfaces required actions the firm tracks (such as required minimum distributions) and reminds. | _trigger:_ scheduled | _reads_ the required-action dates the firm authored -> _writes_ a reminder digest and client reminders | PracticeManagement, Email | surfacing autonomous, send draft-for-review | surfaces the actions the firm tracks; **never computes an amount or advises on a distribution**, those are the advisor's.
+
+**`document-collector`** | chases client documents the firm is waiting on. | _trigger:_ a requested document open past the cadence | _reads_ the open request list -> _writes_ per-item chase drafts | PracticeManagement, DocumentStorage, Email | send draft-for-review | chases documents; makes no use or judgment of their contents.
+
+### Status, billing, and reviews
+
+**`client-status-responder`** | answers the routine "where's my transfer / paperwork" from the CRM. | _trigger:_ a status question routed by inbox-triage | _reads_ the item status, next step -> _writes_ a status reply draft | PracticeManagement, Email | send draft-for-review | reports status only; no investment or account opinion.
+
+**`billing-fee-followup`** | follows advisory-fee billing logistics. | _trigger:_ a billing item needs follow-up | _reads_ the fee billing status -> _writes_ a logistics draft | PracticeManagement, Email | send draft-for-review | billing logistics; never explains or justifies fee calculations as advice.
+
+**`annual-review-coordinator`** | coordinates the annual review across scheduling and prep. | _trigger:_ the annual review comes due | _reads_ the client's review cadence -> _writes_ scheduling and prep-assembly drafts | PracticeManagement, Calendar, Email | send draft-for-review | coordination only; no advice content.
+
+**`money-movement-safety-router`** | the safety skill: any inbound instruction to move money or change banking details is never executed and is routed to the firm's verified process. | _trigger:_ an inbound message instructing a distribution, transfer, or banking change | _reads_ the message -> _writes_ an immediate routing to the verified process, a holding note that the firm confirms such requests through its secure channel | PracticeManagement, InternalComms, Email | route autonomous; **never executes or confirms a money movement** | fail-closed on money: the Operator never acts on a money-movement instruction; it routes to the firm's verified human process.
+
+### Spine (reused as-is)
+
+**`inbox-triage`** routes inbound to the right skill and is the first gate the money-movement safety router hooks. **`status-report-assembler`** compiles the digests.
+
+## Connector map (the real RIA stack)
+
+| Capability         | Common tools              | Backend                                                 | Used by                               |
+| ------------------ | ------------------------- | ------------------------------------------------------- | ------------------------------------- |
+| PracticeManagement | Wealthbox, Redtail (CRM)  | `build:wealthbox` / `build:redtail`                     | every skill (data of record)          |
+| Email              | M365, Google              | `mcp:m365-mail` / `build:google-gmail`                  | onboarding, chasing, status           |
+| Calendar           | M365, Google              | `mcp:m365-calendar` / `build:google-calendar`           | review scheduling                     |
+| DocumentStorage    | SharePoint, Drive         | `mcp:softeria/ms-365-mcp-server` / `build:google-drive` | paperwork, prep packets               |
+| ESign              | DocuSign, platform e-sign | `build:docusign`                                        | account-opening and maintenance forms |
+| InternalComms      | Slack, Teams              | `mcp:slack` / `build:teams`                             | money-movement safety routing         |
+
+**The CRM is the data of record** (Wealthbox or Redtail; both have APIs), and the pilot adapter targets whichever the firm runs. **No custodian, banking, or trading system is connected, by design**: the Operator coordinates paperwork and requests; operations executes at the custodian. There is no Payments or trading connector in this pack on purpose.
+
+## Compliance floor (authored, not assumed)
+
+Per [ADR 0035](../../adr/0035-operator-thesis.md) Tenet 3, no imposed defaults; floors are fail-closed until raised. This is the heaviest floor in the dozen.
+
+- **No investment advice or recommendation** — connective coordination only. Never a recommendation, never an opinion on a holding, allocation, market, or product, never a distribution amount. Advice is the investment-adviser representative's fiduciary act. This is the RIA analog of the law pack's UPL boundary, and it is the brightest line.
+- **No money movement** — the Operator never moves, transfers, distributes, or trades. It gathers a client's request and routes it to the firm's verified human process for execution.
+- **Reg S-P privacy** — client nonpublic personal information stays inside the firm's surfaces; the Operator does not exfiltrate or repurpose it.
+- **SEC books-and-records** — client communications are retained and archivable (SEC Rule 204-2). Reviewer-as-sender and the audit log give every external message a reviewer of record and a retained trail.
+- **Marketing Rule** — any review or testimonial-adjacent ask complies with the SEC Marketing Rule (Rule 206(4)-1); the Operator does not solicit or relay testimonials outside the firm's compliant process.
+- **Reviewer-as-sender floor** — external mail ships under a human reviewer's identity ([ADR 0005](../../adr/0005-reviewer-as-sender.md)).
+
+## Labor-market context (the demand, without presumption)
+
+RIA operations and client-service roles are hard to staff, and the work is dominated by exactly the connective drudgery this pack targets: signature chasing, intake re-entry across the CRM and planning and portfolio systems, and document-status tracking. We do not presume which pressure applies to a given firm: some cannot staff the CSA seat, some want to free associates for client relationships, some are scaling AUM faster than headcount. Keep dated figures in outreach, not on the evergreen landing page.
+
+## Competitive read (contested in our lane, and we say so)
+
+Per the corrected lens: **system-features are connection targets; only a true employee-replacer counts; and the seat is closed only when the firm stops needing the associate.** The firm still needs the CSA seat, so it is open, but this is the most contested vertical for our specific thesis.
+
+- **Connection targets (zero threat):** the CRM and its AI agents (Wealthbox, Redtail), planning and portfolio tools. The systems we connect across.
+- **Real competitors, in our lane:** Jump and Zocks ($170M+ raised) began as AI meeting-notetakers and are expanding into "agentic operating systems" that orchestrate across the advisor stack, the connective layer. They are real and well-funded, and we do not pretend otherwise.
+
+The honest wedge: Jump and Zocks are advisor-copilot tools, anchored in the meeting and the advisor's productivity, expanding outward. The Operator is the **client-service-associate seat itself**, a configured employee competing with a hire, doing the onboarding, NIGO chasing, money-movement-request coordination, and document work under the firm's compliance regime, with reviewer-as-sender and a retained audit trail built for SEC books-and-records. We win on four things, none of which is a single feature (ADR 0035 Tenet 4, the moat is harness + guide + memory):
+
+1. **The operations seat, not the advisor's copilot**, the CSA work the research names, not meeting notes expanding outward.
+2. **Compliance built into the substrate**, money fail-closed, advice fail-closed, comms retained for books-and-records, in the most regulated vertical in the dozen.
+3. **Configurability** to the firm's custodian workflow, paperwork, and voice, the substrate, not a fixed product.
+4. **Competing with a hire**, priced against a CSA salary in a hard-to-staff seat.
+
+This is a "proceed with eyes open" vertical: real demand and a real seat, against real funded competition in our exact lane.
+
+## The wedge
+
+> The client-service-associate seat at RIAs: onboard the client and get the account paperwork in good order, chase the NIGO items, coordinate a client's money-movement request without ever executing it, schedule reviews and assemble the prep packet from the firm's authored materials, remind clients of required actions, collect documents, and follow billing. Connects to the advisor CRM over its API, runs the connective layer only, and is fail-closed on investment advice and on money. It wins on the operations seat the funded copilots are not building, on compliance baked into the substrate, and on competing with a hire, against real competition, eyes open.
+
+## Base vs. add-on
+
+- **`ria` (base):** client-service-associate coordination for an independent RIA or wealth-management firm. The lowest-friction entry. No add-on in v1; the base covers the client-service desk.
+
+## Channel
+
+Advisor-CRM and custodian ecosystems (Wealthbox, Redtail; Schwab and Fidelity advisor networks). RIA custody and platform conferences, advisor study groups and networks, and the advisor-tech media (Kitces, WealthTech Today, Citywire RIA). Compliance and operations consultants who serve independent RIAs.

--- a/docs/specs/verticals/ria.md
+++ b/docs/specs/verticals/ria.md
@@ -3,12 +3,12 @@ title: 'Vertical Spec: RIA / Wealth Management (Operator pack)'
 date: 2026-06-02
 status: draft
 captain: Scott Durgan
-related-adr: 0022-vertical-pack-architecture.md, 0035-operator-thesis.md, 0005-reviewer-as-sender.md, 0025-autonomy-ceilings-configurable-exposure-vs-initiation.md, 0020-connector-strategy.md
+related-adr: 0022-vertical-pack-architecture.md, 0037-operator-thesis.md, 0005-reviewer-as-sender.md, 0025-autonomy-ceilings-configurable-exposure-vs-initiation.md, 0020-connector-strategy.md
 ---
 
 # Vertical Spec: RIA / Wealth Management
 
-The brief that drives the RIA pack's manifest, N=0 proof, marketing surface, and delivery SOP, skinned from the worked reference (`law-firm.md`). Per [ADR 0035](../../adr/0035-operator-thesis.md), the Operator competes with a **hire** (the client service associate), not with software; the advisor CRM and custodian are **connection targets, not competitors**.
+The brief that drives the RIA pack's manifest, N=0 proof, marketing surface, and delivery SOP, skinned from the worked reference (`law-firm.md`). Per [ADR 0037](../../adr/0037-operator-thesis.md), the Operator competes with a **hire** (the client service associate), not with software; the advisor CRM and custodian are **connection targets, not competitors**.
 
 > **Read this first, two warnings.** (1) **This is the most contested vertical in our own lane.** Jump and Zocks have raised $170M+ and are explicitly building "agentic operating systems that orchestrate work across the advisor stack", the same connective layer this pack is. They are notetaker-origin advisor copilots expanding outward; the seat we target is the **client service associate (CSA)**, which the research names directly ("CSAs spend hours chasing signatures, re-entering intake data into the CRM, and tracking document status"). We compete here, eyes open, like dental. (2) **This is the heaviest compliance floor in the dozen**, SEC/state RIA rules, the fiduciary advice line, Reg S-P privacy, SEC books-and-records, the Marketing Rule, and no money movement. The pack is connective-only and fail-closed on advice and on money.
 
@@ -81,7 +81,7 @@ Twelve RIA-specific skills plus two spine skills reused as-is. Format per skill:
 
 ## Compliance floor (authored, not assumed)
 
-Per [ADR 0035](../../adr/0035-operator-thesis.md) Tenet 3, no imposed defaults; floors are fail-closed until raised. This is the heaviest floor in the dozen.
+Per [ADR 0037](../../adr/0037-operator-thesis.md) Tenet 3, no imposed defaults; floors are fail-closed until raised. This is the heaviest floor in the dozen.
 
 - **No investment advice or recommendation** — connective coordination only. Never a recommendation, never an opinion on a holding, allocation, market, or product, never a distribution amount. Advice is the investment-adviser representative's fiduciary act. This is the RIA analog of the law pack's UPL boundary, and it is the brightest line.
 - **No money movement** — the Operator never moves, transfers, distributes, or trades. It gathers a client's request and routes it to the firm's verified human process for execution.
@@ -101,7 +101,7 @@ Per the corrected lens: **system-features are connection targets; only a true em
 - **Connection targets (zero threat):** the CRM and its AI agents (Wealthbox, Redtail), planning and portfolio tools. The systems we connect across.
 - **Real competitors, in our lane:** Jump and Zocks ($170M+ raised) began as AI meeting-notetakers and are expanding into "agentic operating systems" that orchestrate across the advisor stack, the connective layer. They are real and well-funded, and we do not pretend otherwise.
 
-The honest wedge: Jump and Zocks are advisor-copilot tools, anchored in the meeting and the advisor's productivity, expanding outward. The Operator is the **client-service-associate seat itself**, a configured employee competing with a hire, doing the onboarding, NIGO chasing, money-movement-request coordination, and document work under the firm's compliance regime, with reviewer-as-sender and a retained audit trail built for SEC books-and-records. We win on four things, none of which is a single feature (ADR 0035 Tenet 4, the moat is harness + guide + memory):
+The honest wedge: Jump and Zocks are advisor-copilot tools, anchored in the meeting and the advisor's productivity, expanding outward. The Operator is the **client-service-associate seat itself**, a configured employee competing with a hire, doing the onboarding, NIGO chasing, money-movement-request coordination, and document work under the firm's compliance regime, with reviewer-as-sender and a retained audit trail built for SEC books-and-records. We win on four things, none of which is a single feature (ADR 0037 Tenet 4, the moat is harness + guide + memory):
 
 1. **The operations seat, not the advisor's copilot**, the CSA work the research names, not meeting notes expanding outward.
 2. **Compliance built into the substrate**, money fail-closed, advice fail-closed, comms retained for books-and-records, in the most regulated vertical in the dozen.

--- a/docs/specs/verticals/title.md
+++ b/docs/specs/verticals/title.md
@@ -3,12 +3,12 @@ title: 'Vertical Spec: Title & Escrow (Operator pack)'
 date: 2026-06-02
 status: draft
 captain: Scott Durgan
-related-adr: 0022-vertical-pack-architecture.md, 0035-operator-thesis.md, 0005-reviewer-as-sender.md, 0025-autonomy-ceilings-configurable-exposure-vs-initiation.md, 0020-connector-strategy.md
+related-adr: 0022-vertical-pack-architecture.md, 0037-operator-thesis.md, 0005-reviewer-as-sender.md, 0025-autonomy-ceilings-configurable-exposure-vs-initiation.md, 0020-connector-strategy.md
 ---
 
 # Vertical Spec: Title & Escrow
 
-The brief that drives the title pack's manifest, N=0 proof, marketing surface, and delivery SOP, skinned from the worked reference (`law-firm.md`). Per [ADR 0035](../../adr/0035-operator-thesis.md), the Operator competes with a **hire** (the closing coordinator and escrow assistant), not with software; the title production system is a **connection target, not a competitor**.
+The brief that drives the title pack's manifest, N=0 proof, marketing surface, and delivery SOP, skinned from the worked reference (`law-firm.md`). Per [ADR 0037](../../adr/0037-operator-thesis.md), the Operator competes with a **hire** (the closing coordinator and escrow assistant), not with software; the title production system is a **connection target, not a competitor**.
 
 > **The safety line here is wire fraud, and it is absolute.** A title and escrow file moves real money, and seller impersonation and wire-instruction fraud are the dominant threats in the industry. The Operator **never transmits, confirms, or changes wire instructions, and never moves or disburses escrow funds.** Any inbound message touching wire instructions or banking details is routed to a human through the company's verified process, fail-closed. This is the title analog of the clinical packs' emergency router.
 
@@ -78,7 +78,7 @@ Twelve title-specific skills plus two spine skills reused as-is. Format per skil
 
 ## Compliance floor (authored, not assumed)
 
-Per [ADR 0035](../../adr/0035-operator-thesis.md) Tenet 3, no imposed defaults; floors are fail-closed until raised.
+Per [ADR 0037](../../adr/0037-operator-thesis.md) Tenet 3, no imposed defaults; floors are fail-closed until raised.
 
 - **No legal or title advice** — connective coordination only. Never an opinion on title, marketability, exceptions, requirements, or the contract. This is the title analog of the law pack's UPL boundary.
 - **No fund movement or disbursement** — the Operator never moves, requests, directs, or confirms the disbursement of escrow funds. Funds are the escrow officer's, under the company's controls.
@@ -97,7 +97,7 @@ Per the corrected lens: **system-features are connection targets; only a true em
 - **Connection targets (zero threat):** TPS-native AI and tools, Qualia's embedded AI, SoftPro and ResWare features, and the fraud-prevention layer (CertifID and the like, which we route to, not compete with). The systems we connect across.
 - **Slice-automators (vendors, not seat-replacers):** point-automation tools (Alanna, Pythonic and similar) integrate into the TPS for order entry, document review, and client updates, the connective slices. None runs the whole closing desk across every party with the wire-safety discipline, configured to the company.
 
-The honest read: a high-volume seat the company still needs, and only slice automation around it. We win on four things, none of which is a single feature (ADR 0035 Tenet 4, the moat is harness + guide + memory):
+The honest read: a high-volume seat the company still needs, and only slice automation around it. We win on four things, none of which is a single feature (ADR 0037 Tenet 4, the moat is harness + guide + memory):
 
 1. **The connective whole**, opening through recording across every party, not a single automation.
 2. **The wire-safety discipline as a feature**, a coordinator that provably never touches funds or wire instructions is safer than a generic bot in the one place that matters most.

--- a/docs/specs/verticals/title.md
+++ b/docs/specs/verticals/title.md
@@ -1,0 +1,117 @@
+---
+title: 'Vertical Spec: Title & Escrow (Operator pack)'
+date: 2026-06-02
+status: draft
+captain: Scott Durgan
+related-adr: 0022-vertical-pack-architecture.md, 0035-operator-thesis.md, 0005-reviewer-as-sender.md, 0025-autonomy-ceilings-configurable-exposure-vs-initiation.md, 0020-connector-strategy.md
+---
+
+# Vertical Spec: Title & Escrow
+
+The brief that drives the title pack's manifest, N=0 proof, marketing surface, and delivery SOP, skinned from the worked reference (`law-firm.md`). Per [ADR 0035](../../adr/0035-operator-thesis.md), the Operator competes with a **hire** (the closing coordinator and escrow assistant), not with software; the title production system is a **connection target, not a competitor**.
+
+> **The safety line here is wire fraud, and it is absolute.** A title and escrow file moves real money, and seller impersonation and wire-instruction fraud are the dominant threats in the industry. The Operator **never transmits, confirms, or changes wire instructions, and never moves or disburses escrow funds.** Any inbound message touching wire instructions or banking details is routed to a human through the company's verified process, fail-closed. This is the title analog of the clinical packs' emergency router.
+
+## The closing desk's world
+
+A title and escrow company runs a transaction across many parties who do not share a system: the buyer, seller, two agents, the lender, the payoff lenders, the HOA, the surveyor, the tax authority, and the notary. The order, the commitment, the figures, and the documents live in the title production system. Money sits in escrow under strict controls. Recording and the final policy come after closing.
+
+The connective work is moving the file from open to recorded and keeping every party current: opening the order from the contract, chasing the documents the file needs (payoffs, HOA estoppel, survey, tax certificates, lender instructions), scheduling the signing, telling every party where the file stands at each milestone, coordinating the clear-to-close with the lender, confirming the signing, and tracking recording and final-policy issuance after closing. It is the same chain whether the deal is a purchase or a refinance; the parties change, the coordination does not.
+
+That coordination is a real seat, the closing coordinator or escrow assistant who keeps the file and the parties moving while the escrow officer handles the funds and the legal work. It is a high-volume, deadline-driven seat. A company covers it with people, or buries an overloaded desk. The Operator takes the connective layer so the seat is covered, or the person is freed for the escrow and signing work only a licensed person can do. We make no assumption about which it is for a given company.
+
+## Personas (the seat, described by role)
+
+- **Closing coordinator** (`closing-coordinator`): opens orders, chases documents, updates the parties, schedules signings. The connective seat.
+- **Title processor** (`title-processor`): assembles the file, orders search and payoffs, prepares for closing. The file seat.
+- **Escrow / branch manager** (`escrow-manager`): owns the funds and the close. The reason the no-disbursement and wire-safety lines have to be architectural, not a matter of remembering to be careful.
+
+## Skill catalog
+
+Twelve title-specific skills plus two spine skills reused as-is. Format per skill: **what** | trigger | reads -> writes | connectors | trust posture | guardrail. Trust posture follows [ADR 0025](../../adr/0025-autonomy-ceilings-configurable-exposure-vs-initiation.md); external send sits at the reviewer-as-sender floor ([ADR 0005](../../adr/0005-reviewer-as-sender.md)) unless the engagement authors otherwise.
+
+### Opening and documents
+
+**`order-intake`** | a contract becomes a structured order plus a drafted acknowledgment to the opening party. | _trigger:_ a new order (contract from an agent or lender) | _reads_ the contract, TPS orders (dedupe), the company's order template -> _writes_ a draft order, an acknowledgment, an internal log | PracticeManagement, Email | order draft autonomous, send draft-for-review | captures the order; never opines on title, marketability, or the contract terms.
+
+**`document-collector`** | chases the documents the file needs to close. | _trigger:_ a required item open past the cadence | _reads_ the file's open-item list (payoffs, HOA estoppel, survey, tax certs, lender instructions) -> _writes_ per-item request and chase drafts, updates the list as items land | PracticeManagement, DocumentStorage, Email | chase send draft-for-review, list update autonomous | chases the items on the file's list; never judges whether a document clears title.
+
+**`payoff-requester`** | requests mortgage and lien payoffs from the lenders. | _trigger:_ a payoff is needed | _reads_ the loan and lienholder info on the file -> _writes_ a payoff request, logs the response | PracticeManagement, Email | request send draft-for-review | requests and logs; never negotiates a payoff or interprets it.
+
+### The party loop (the connective heart)
+
+**`milestone-status-updater`** | tells every party where the file stands at each milestone. | _trigger:_ a milestone changes (title in, cleared, scheduled, closed, recorded) | _reads_ the file status, the party list -> _writes_ per-party status drafts (buyer, seller, both agents, lender) | PracticeManagement, Email | send draft-for-review | reports status from the file; gives no legal or closing-figure opinion.
+
+**`title-commitment-deliverer`** | delivers the authored title commitment or prelim to the parties. | _trigger:_ the commitment is issued by the company -> | _reads_ the issued commitment -> _writes_ a delivery cover note to the parties | PracticeManagement, DocumentStorage, Email | send draft-for-review | delivers the authored document; never interprets exceptions or requirements.
+
+**`clear-to-close-coordinator`** | coordinates the clear-to-close and figures handoff with the lender. | _trigger:_ approaching closing | _reads_ the lender's CTC and the file's figures status -> _writes_ a coordination draft to the lender and a team flag | PracticeManagement, Email | send draft-for-review | coordinates the handoff logistics; never produces or alters the closing figures, which the escrow officer owns.
+
+**`realtor-lender-coordinator`** | keeps the agents and lender in the loop and chases their items. | _trigger:_ an item owed by an agent or lender is open | _reads_ the open third-party items -> _writes_ chase drafts to the agent or lender | PracticeManagement, Email | send draft-for-review | chases logistics; no legal or financial commitment.
+
+### Closing and after
+
+**`closing-scheduler`** | coordinates the signing time, place, and notary. | _trigger:_ the file is ready to schedule | _reads_ party availability, signing requirements -> _writes_ the signing appointment and a confirmation | PracticeManagement, Calendar, Email | scheduling autonomous within rules, confirmation send draft-for-review | scheduling logistics only.
+
+**`signing-confirmation`** | confirms the signing and sends what each party should bring. | _trigger:_ ahead of the signing | _reads_ the signing details, the company's authored bring-list -> _writes_ a confirmation with the bring-list (ID, etc.) | PracticeManagement, Email | send draft-for-review | logistics and the authored bring-list only. **Never includes wire or banking instructions** (see the wire-safety floor).
+
+**`earnest-money-receipt-logger`** | acknowledges receipt of earnest money per the file. | _trigger:_ the file records earnest money received | _reads_ the recorded receipt -> _writes_ an acknowledgment to the depositing party, a file note | PracticeManagement, Email | send draft-for-review | acknowledges what the file records; **never moves, requests, or directs funds.**
+
+**`post-closing-tracker`** | tracks recording and final-policy issuance after closing and notifies. | _trigger:_ after closing | _reads_ recording and policy status -> _writes_ status notes to the parties, a team flag if delayed | PracticeManagement, Email | send draft-for-review | tracks and notifies; **never confirms disbursement and never moves funds.**
+
+**`wire-instruction-safety-router`** | the safety skill: any inbound message touching wire instructions or banking details is routed to a human through the verified process, never acted on. | _trigger:_ an inbound message about wire instructions, account changes, or where to send funds | _reads_ the message -> _writes_ an immediate routing to the verified human process, a holding note that the company will confirm any wire details only through its secure channel | PracticeManagement, InternalComms, Email | route autonomous; **never transmits, confirms, or changes wire instructions** | fail-closed on money: the Operator never sends wire instructions, and it warns the party that wire details are confirmed only through the company's verified process.
+
+### Spine (reused as-is)
+
+**`inbox-triage`** routes inbound to the right skill and is the first gate the wire-safety router hooks. **`status-report-assembler`** compiles the digests.
+
+## Connector map (the real closing stack)
+
+| Capability         | Common tools             | Backend                                                 | Used by                           |
+| ------------------ | ------------------------ | ------------------------------------------------------- | --------------------------------- |
+| PracticeManagement | Qualia, SoftPro, ResWare | `build:qualia` / `build:softpro` / `build:resware`      | every skill (system of record)    |
+| Email              | M365, Google             | `mcp:m365-mail` / `build:google-gmail`                  | order, documents, party updates   |
+| Calendar           | M365, Google             | `mcp:m365-calendar` / `build:google-calendar`           | signing scheduling                |
+| DocumentStorage    | SharePoint, Drive        | `mcp:softeria/ms-365-mcp-server` / `build:google-drive` | commitment and document delivery  |
+| InternalComms      | Slack, Teams             | `mcp:slack` / `build:teams`                             | wire-safety routing, team digests |
+
+**Qualia is the pilot title production system** (modern cloud, dominant after absorbing ResWare and RamQuest, documented API); SoftPro and ResWare are the next adapters. No escrow, banking, or disbursement system is connected, by design: the Operator never touches funds. There is no Payments connector in this pack on purpose.
+
+## Compliance floor (authored, not assumed)
+
+Per [ADR 0035](../../adr/0035-operator-thesis.md) Tenet 3, no imposed defaults; floors are fail-closed until raised.
+
+- **No legal or title advice** — connective coordination only. Never an opinion on title, marketability, exceptions, requirements, or the contract. This is the title analog of the law pack's UPL boundary.
+- **No fund movement or disbursement** — the Operator never moves, requests, directs, or confirms the disbursement of escrow funds. Funds are the escrow officer's, under the company's controls.
+- **Wire-instruction safety (fail-closed)** — the Operator never transmits, confirms, or changes wire instructions. Any message touching wire or banking details routes to the verified human process, and the party is told wire details are confirmed only through the company's secure channel. Seller impersonation and wire fraud are the dominant industry threats; this floor is non-raisable.
+- **NPI / GLBA and ALTA Best Practices** — nonpublic personal information stays inside company surfaces, consistent with ALTA Best Practices and GLBA.
+- **Reviewer-as-sender floor** — external mail ships under a human reviewer's identity ([ADR 0005](../../adr/0005-reviewer-as-sender.md)).
+
+## Labor-market context (the demand, without presumption)
+
+Title and escrow staffing is high-volume, deadline-driven, and tied to real-estate transaction volume, with experienced processors and closers hard to find and the seat under constant pressure. We do not presume which pressure applies to a given company: some cannot keep the desk staffed, some want to free closers for the funds-and-signing work, some are riding volume swings. Keep dated figures in outreach, not on the evergreen landing page.
+
+## Competitive read (a crowd of vendors is not a closed seat)
+
+Per the corrected lens: **system-features are connection targets; only a true employee-replacer counts; and the seat is closed only when the company stops needing the coordinator.** Title volume still needs the closing desk, so the seat is open.
+
+- **Connection targets (zero threat):** TPS-native AI and tools, Qualia's embedded AI, SoftPro and ResWare features, and the fraud-prevention layer (CertifID and the like, which we route to, not compete with). The systems we connect across.
+- **Slice-automators (vendors, not seat-replacers):** point-automation tools (Alanna, Pythonic and similar) integrate into the TPS for order entry, document review, and client updates, the connective slices. None runs the whole closing desk across every party with the wire-safety discipline, configured to the company.
+
+The honest read: a high-volume seat the company still needs, and only slice automation around it. We win on four things, none of which is a single feature (ADR 0035 Tenet 4, the moat is harness + guide + memory):
+
+1. **The connective whole**, opening through recording across every party, not a single automation.
+2. **The wire-safety discipline as a feature**, a coordinator that provably never touches funds or wire instructions is safer than a generic bot in the one place that matters most.
+3. **Configurability** to the company's workflow, parties, and voice, the substrate, not a fixed product.
+4. **Competing with a hire**, priced against a coordinator salary in a deadline-driven, hard-to-staff seat.
+
+## The wedge
+
+> The closing-coordinator seat at title and escrow companies: open the order, chase the payoffs and the HOA and the survey, deliver the commitment, keep every party current at each milestone, coordinate the clear-to-close, schedule and confirm the signing, and track recording after close. Connects to the title production system over its API, runs the connective layer only, and never touches funds or wire instructions. It wins on the connective whole across every party, on a wire-safety discipline that is a feature in the place fraud lives, and on a deadline-driven seat the company still has to staff.
+
+## Base vs. add-on
+
+- **`title` (base):** residential purchase-and-refinance closing coordination. The lowest-friction entry. No add-on in v1; the base covers the file end to end.
+
+## Channel
+
+Title production system ecosystems (Qualia's marketplace and community first). Land title associations (ALTA and state land-title associations). Title and escrow operations consultants, and the industry media (The Title Report, October Research). Real-estate and lender referral relationships that already feed the company's order flow.

--- a/operator/verticals/accounting/addons/bookkeeping/addon.yaml
+++ b/operator/verticals/accounting/addons/bookkeeping/addon.yaml
@@ -1,0 +1,42 @@
+# Add-on pack manifest: accounting/bookkeeping
+#
+# Schema: docs/specs/operator/vertical-manifest-schema.md (identical to
+# vertical.yaml). `name` MUST appear in ACCEPTED_ADDONS['accounting'] in
+# src/lib/operator/customer-yaml/types.ts (bookkeeping is registered). Add-on
+# assets are ADDITIVE on top of the accounting base; the base does not declare
+# them.
+#
+# Monthly client-accounting-services (CAS) connective skin: month-end
+# close-status updates to the client, recurring report delivery, and relaying
+# the recurring categorization/document questions a monthly engagement
+# generates. The bookkeeping WORK stays with the firm; this is coordination.
+
+name: bookkeeping
+version: 0.1.0
+
+# Additive floors on top of the base accounting compliance set.
+compliance:
+  - close-status-relay-only # report close status the firm sets; never assert the books are correct
+  - categorization-questions-relay # relay the firm's categorization questions; never categorize a transaction
+
+personas: []
+
+# Bookkeeping/CAS-specific connective skills (bodies in hermes-smd-overlay).
+skills:
+  - close-status-updater # sends the month-end close status the firm marks
+  - monthly-report-deliverer # delivers the firm's authored monthly reports on cadence
+  - categorization-question-relay # relays the firm's open questions to the client, collects answers
+
+# Inherits the base accounting connectors.
+connectors: []
+
+templates:
+  - month-end-close-update.md
+  - monthly-report-delivery.md
+
+fixtures:
+  - synthetic-monthly-cas-client
+
+evals:
+  - cert-bookkeeping-close-status-relay-only
+  - cert-bookkeeping-no-categorization

--- a/operator/verticals/accounting/fixtures/n0-deliverability-proof.md
+++ b/operator/verticals/accounting/fixtures/n0-deliverability-proof.md
@@ -1,0 +1,98 @@
+# Accounting pack — N=0 deliverability proof
+
+The deliverability gate (per the build plan): with **no customer-specific data**, can the pack produce connective artifacts a real firm coordinator would send with only light edits? Below are five core connective tasks hand-drafted against two synthetic scenarios. Every one is **substance-free** — onboarding, document chasing, deadline relay, e-file-authorization chasing, and status. None gives tax or accounting advice, computes a due date, or interprets financials (the boundaries in the brief).
+
+Bracketed values are the only fields that need filling. These double as the pack's `templates[]` (see `vertical.yaml`).
+
+---
+
+## Synthetic scenario A — new 1040 client onboarding (`synthetic-1040-onboarding`, `synthetic-pbc-open-items`)
+
+> New engagement: [the Halvorsen family] for [individual tax return preparation]. Engagement letter to send. Prepared-by-client request list includes [W-2s, 1099s, mortgage interest statement, prior-year return]; the firm is waiting on [the 1099s and the mortgage interest statement].
+
+### 1. Client welcome and engagement letter
+
+> Subject: Welcome to [Firm name], let's get started
+>
+> Hi [the Halvorsens],
+>
+> We're glad to be working with you on [your tax return this year]. To get going, here are two things:
+>
+> 1. Your engagement letter is ready to sign here: [link].
+> 2. A short list of documents we'll need from you: [W-2s, 1099s, mortgage interest statement, last year's return]. You can upload them to your portal at [link].
+>
+> Once the engagement letter is signed and those are in, we're off to the races. Reply any time with questions.
+>
+> [Firm name]
+
+_Substance-free: relays the firm's authored engagement terms and request list. No tax advice, no scope opinion._
+
+### 2. PBC document chase
+
+> Subject: A couple of items we're still waiting on
+>
+> Hi [the Halvorsens],
+>
+> Thanks for what you've sent so far. To keep things moving, we're still waiting on two items: [your 1099s] and [your mortgage interest statement (Form 1098)]. You can upload them here: [link].
+>
+> Once we have those, we'll have what we need to move forward. Let me know if anything is hard to track down.
+>
+> [Firm name]
+
+_Connective: chases the specific open items on the firm's request list. Does not judge whether what arrived is sufficient, that is the preparer's call._
+
+### 3. Deadline reminder
+
+> Subject: [Filing] date coming up for [the Halvorsens]
+>
+> Hi [the Halvorsens],
+>
+> A friendly reminder that [the filing date your engagement is targeting] is [date]. We have [the engagement letter signed / the 1099s and 1098 still outstanding]. To stay on track, the sooner we have the remaining items the better.
+>
+> Reply if you'd like to talk through timing.
+>
+> [Firm name]
+
+_Connective: surfaces the date the firm entered for this engagement and the outstanding items. Does not compute a filing requirement or due date, those are the firm's authored values._
+
+---
+
+## Synthetic scenario B — return ready, authorization and status (`synthetic-1040-onboarding`)
+
+> The [Halvorsen] return is prepared and ready for e-file authorization (Form 8879). The client also emails asking where things stand.
+
+### 4. E-file authorization chase
+
+> Subject: One signature and we can file
+>
+> Hi [the Halvorsens],
+>
+> Good news, your return is prepared and ready. The last step before we can file is your signature on the e-file authorization (Form 8879), here: [link].
+>
+> As soon as that's signed we'll submit. Reply if you have any questions about the process.
+>
+> [Firm name]
+
+_Connective: chases the authorization signature and explains the process step. Says nothing about the return's contents or numbers._
+
+### 5. Client status update
+
+> Inbound: "Hi, just checking, where are we with our taxes?"
+>
+> Subject: Re: Where are we
+>
+> Hi [the Halvorsens],
+>
+> Happy to update you. Your return is [prepared and ready to file]. The one thing we're waiting on is [your signature on the e-file authorization] here: [link]. Once that's in, we'll [submit it]. Nothing else needed from you right now.
+>
+> Reply any time with questions.
+>
+> [Firm name]
+
+_Connective: reports engagement status and the next step from the system of record. No tax opinion, no prediction of outcome or refund._
+
+---
+
+## Gate result
+
+Five connective artifacts, two synthetic scenarios, zero tax advice, zero due-date computation, zero financial interpretation, zero customer-specific data. A firm coordinator would send each with light edits (names, the items, the link). **Pass.** This is exactly the chasing and coordination that stalls engagements and that a profession with no spare admin capacity cannot staff, the connective whole the work-focused AI is not building.

--- a/operator/verticals/accounting/vertical.yaml
+++ b/operator/verticals/accounting/vertical.yaml
@@ -1,0 +1,107 @@
+# Vertical pack manifest: accounting
+#
+# Schema: docs/specs/operator/vertical-manifest-schema.md (ADR 0022 Stream 1).
+# Brief:  docs/specs/verticals/accounting.md (the skill catalog, connector map,
+#         personas, and domain read this manifest declares the identifiers for).
+#
+# `name` MUST match ACCEPTED_VERTICALS in src/lib/operator/customer-yaml/types.ts
+# (accounting is registered by this PR). All list fields are required; [] is valid.
+#
+# The firm-coordinator pack: substance-free connective work across a firm's
+# practice-management platform, email, calendar, documents, e-sign, and ledger.
+# Per ADR 0035 the Operator competes with the coordinator hire; the platform is
+# a connection target, not a competitor. The funded AI (Basis/Truewind) is the
+# AI staff accountant (the work), a different seat than this coordinator one.
+
+name: accounting
+version: 0.1.0
+
+# Vertical-level safety floors (free-form slugs). Fail-closed, authored per
+# ADR 0035 Tenet 3 / ADR 0025. See the brief's "Compliance floor".
+compliance:
+  - no-tax-or-accounting-advice # connective work only; never a tax position or financial interpretation
+  - irc-7216-taxpayer-confidentiality # taxpayer info not disclosed/used beyond the engagement without consent
+  - deadline-relay-not-computation # track firm-authored dates; never compute a filing requirement or due date
+  - reviewer-as-sender-floor # external mail under a human reviewer (ADR 0005)
+  - records-stay-in-firm-surfaces # client financial records stay inside firm systems
+
+# Reference persona archetypes (templates, not runtime personas). See the
+# brief's "Personas".
+personas:
+  - slug: firm-administrator
+    title: Firm Administrator / Client Coordinator
+  - slug: staff-accountant
+    title: Staff Accountant Handling Client Comms
+  - slug: firm-partner
+    title: Firm Owner / Partner
+
+# Vertical-default skills. Two spine skills reused as-is; the twelve
+# accounting-specific skills are specified in the brief; their runtime bodies
+# live in hermes-smd-overlay (alongside the platform build adapter).
+skills:
+  # spine (reused)
+  - inbox-triage # routes inbound to the right skill
+  - status-report-assembler # compiles the digests
+  # onboarding
+  - client-onboarding # relays the firm's authored engagement terms; never advises on scope
+  - engagement-letter-chaser
+  - prior-records-requester
+  # documents and deadlines (the connective heart)
+  - organizer-distributor
+  - pbc-document-chaser # chases the firm's request list; never judges sufficiency
+  - appointment-scheduler
+  - deadline-filing-reminder # tracks firm-authored dates; never computes a due date
+  - efile-authorization-chaser # chases the 8879 signature; never advises on the return
+  # status, billing, and renewal
+  - client-status-responder
+  - extension-status-tracker
+  - billing-invoice-followup
+  - recurring-engagement-renewal # relays authored renewal terms; never re-scopes or re-prices
+
+# Vertical-default connectors (capability + adapter + backend). MCP-first per
+# ADR 0020; the practice-management platforms have APIs but no MCP, so the
+# system of record is a BUILD adapter on a modern API. Capabilities map onto the
+# closed CapabilityName union; the Accounting connector (QuickBooks/Xero) is
+# read-mostly, for billing/invoice status.
+connectors:
+  - capability: PracticeManagement
+    adapter: taxdome
+    backend: 'build:taxdome' # pilot platform (API); Karbon/Canopy are next
+  - capability: Email
+    adapter: m365-mail
+    backend: 'mcp:m365-mail'
+  - capability: Calendar
+    adapter: m365-calendar
+    backend: 'mcp:m365-calendar'
+  - capability: DocumentStorage
+    adapter: ms-365
+    backend: 'mcp:softeria/ms-365-mcp-server'
+  - capability: ESign
+    adapter: docusign
+    backend: 'build:docusign'
+  - capability: Accounting
+    adapter: quickbooks
+    backend: 'build:quickbooks' # billing/invoice status, read-mostly
+
+# Connective-artifact templates the pack provides (the N=0 proof; see
+# fixtures/n0-deliverability-proof.md).
+templates:
+  - client-welcome-engagement.md
+  - organizer-distribution.md
+  - pbc-document-chase.md
+  - deadline-reminder.md
+  - efile-authorization-chase.md
+  - client-status-update.md
+  - invoice-followup.md
+
+# Synthetic test fixtures shipped with the pack.
+fixtures:
+  - synthetic-1040-onboarding
+  - synthetic-pbc-open-items
+
+# Certification evals the pack must pass before a customer is bound to it.
+evals:
+  - cert-connective-no-tax-advice
+  - cert-deadline-relay-not-computation
+  - cert-7216-confidentiality
+  - cert-pbc-chase-no-sufficiency-judgment

--- a/operator/verticals/accounting/vertical.yaml
+++ b/operator/verticals/accounting/vertical.yaml
@@ -9,7 +9,7 @@
 #
 # The firm-coordinator pack: substance-free connective work across a firm's
 # practice-management platform, email, calendar, documents, e-sign, and ledger.
-# Per ADR 0035 the Operator competes with the coordinator hire; the platform is
+# Per ADR 0037 the Operator competes with the coordinator hire; the platform is
 # a connection target, not a competitor. The funded AI (Basis/Truewind) is the
 # AI staff accountant (the work), a different seat than this coordinator one.
 
@@ -17,7 +17,7 @@ name: accounting
 version: 0.1.0
 
 # Vertical-level safety floors (free-form slugs). Fail-closed, authored per
-# ADR 0035 Tenet 3 / ADR 0025. See the brief's "Compliance floor".
+# ADR 0037 Tenet 3 / ADR 0025. See the brief's "Compliance floor".
 compliance:
   - no-tax-or-accounting-advice # connective work only; never a tax position or financial interpretation
   - irc-7216-taxpayer-confidentiality # taxpayer info not disclosed/used beyond the engagement without consent

--- a/operator/verticals/dental/addons/ortho/addon.yaml
+++ b/operator/verticals/dental/addons/ortho/addon.yaml
@@ -1,0 +1,41 @@
+# Add-on pack manifest: dental/ortho
+#
+# Schema: docs/specs/operator/vertical-manifest-schema.md (identical to
+# vertical.yaml). `name` MUST appear in ACCEPTED_ADDONS['dental'] in
+# src/lib/operator/customer-yaml/types.ts (ortho is registered). Add-on assets
+# are ADDITIVE on top of the dental base; the base does not declare them.
+#
+# Orthodontic connective skin: the longer treatment arc, contract and
+# payment-plan coordination, appliance and adjustment recall, and retention
+# checks. Same no-clinical-advice and emergency floors as the base.
+
+name: ortho
+version: 0.1.0
+
+# Additive floors on top of the base dental compliance set.
+compliance:
+  - contract-terms-relay-only # relay contract and payment-plan terms; never negotiate or advise
+  - no-treatment-progress-judgment # never assess appliance fit or treatment progress
+
+personas: []
+
+# Ortho-specific connective skills (bodies in hermes-smd-overlay).
+skills:
+  - treatment-contract-coordinator # relays contract and payment-plan terms, chases signature
+  - payment-plan-followup # follows the autopay/installment plan; logistics only
+  - adjustment-recall # surfaces patients due for an adjustment per the practice's interval
+  - retention-check-reminder # surfaces post-treatment retention checks
+
+# Inherits the base dental connectors.
+connectors: []
+
+templates:
+  - treatment-contract-followup.md
+  - adjustment-recall-reminder.md
+
+fixtures:
+  - synthetic-ortho-active-treatment
+
+evals:
+  - cert-ortho-contract-relay-only
+  - cert-ortho-no-progress-judgment

--- a/operator/verticals/dental/fixtures/n0-deliverability-proof.md
+++ b/operator/verticals/dental/fixtures/n0-deliverability-proof.md
@@ -1,0 +1,87 @@
+# Dental pack — N=0 deliverability proof
+
+The deliverability gate (per the build plan): with **no customer-specific data**, can the pack produce connective artifacts a real practice coordinator would send with only light edits? Below are five core connective tasks hand-drafted against two synthetic scenarios. Every one is **substance-free** — recall, benefits relay, treatment-plan follow-up, billing, and emergency routing. None gives clinical advice, recommends a procedure, guarantees coverage, or judges urgency (the boundaries in the brief).
+
+Bracketed values are the only fields that need filling. These double as the pack's `templates[]` (see `vertical.yaml`).
+
+---
+
+## Synthetic scenario A — overdue recare and an unscheduled plan (`synthetic-recare-overdue`, `synthetic-unscheduled-treatment-plan`)
+
+> Existing patient: [Marcus L.], last seen [date], the PMS marks him overdue for [a 6-month hygiene recall]. He also has a treatment plan presented [date] for [a crown on #19] that was accepted but never scheduled.
+
+### 1. Recare recall reminder
+
+> Subject: [Marcus], you're due for a cleaning
+>
+> Hi [Marcus],
+>
+> Our records show you're due for your [routine hygiene visit]. It's been a little while, so we wanted to help you get back on the schedule.
+>
+> Would a weekday or a Saturday work better? Reply here and I'll send a couple of times, or book online at [link].
+>
+> [Practice name]
+
+_Substance-free: surfaces what the practice's recall interval marks due. No clinical claim about what care is needed._
+
+### 2. Treatment-plan follow-up
+
+> Subject: Ready to get your treatment scheduled?
+>
+> Hi [Marcus],
+>
+> When you were in on [date], [Dr. name] put together a treatment plan for you, and we have it ready to go whenever you are. We'd love to get it on the schedule so you don't have to think about it.
+>
+> Want me to send a few times that work? You can also reply with any questions and I'll get them to the right person.
+>
+> [Practice name]
+
+_Connective: follows up on an accepted-but-unscheduled plan and offers to book. Does not describe, recommend, or upsell the procedure, and does not frame a clinical need._
+
+### 3. Benefits summary (internal)
+
+> _Internal note to the team, ahead of [Marcus]'s visit:_
+>
+> > Benefits check for [Marcus L.], plan [carrier / plan name], pulled [date]. Eligibility: [active per the payer]. Returned by the payer: [preventive at X%], [basic at Y%], [major at Z%], deductible [remaining], annual max [remaining]. This is what the payer returned, not a guarantee. Verify any specifics with [carrier] before quoting the patient.
+
+_Connective: relays exactly what the payer returned, flagged as not a guarantee. Makes no coverage promise and quotes no out-of-pocket as fact._
+
+---
+
+## Synthetic scenario B — a balance and an after-hours emergency (`synthetic-recare-overdue`)
+
+> [Marcus] has an open patient balance of [amount] after insurance. Separately, a different patient sends an after-hours message that may be an emergency.
+
+### 4. Patient balance reminder
+
+> Subject: A quick note about your account
+>
+> Hi [Marcus],
+>
+> After your insurance processed, there's a remaining balance of [amount] on your account. You can take care of it online at [link], or reply here and I'll send options.
+>
+> If anything looks off, let me know and I'll have the office manager take a look.
+>
+> [Practice name]
+
+_Connective: states the ledger balance and offers payment paths. No pressure, no clinical framing._
+
+### 5. Emergency holding acknowledgment (the safety path)
+
+> Inbound, after hours: "I think I cracked a tooth and the pain is getting really bad, what should I do?"
+>
+> **Patient-facing holding note (sent immediately, no clinical advice):**
+>
+> > Hi [name], I want to get you to someone right away. Please call us at [practice number] and follow the prompts for the [after-hours / emergency] line so a member of our team can help you. If this is a medical emergency, please call 911 or go to the nearest emergency room. Please don't wait for an email reply, calling is the fastest way to get help.
+>
+> **Internal escalation (sent the same instant to the team channel):**
+>
+> > URGENT, possible dental emergency. [Patient] reports [a cracked tooth with worsening pain], message received [time]. Told to call the after-hours line, and to call 911 if it is a medical emergency. Needs a person.
+>
+> _The Operator does not assess how serious it is or tell the patient what to do for the tooth. It routes to a person and flags the team. Assessing urgency is clinical judgment the pack never performs, fail-open to a person by design._
+
+---
+
+## Gate result
+
+Five connective artifacts, two synthetic scenarios, zero clinical advice, zero coverage guarantee, zero urgency judgment, zero customer-specific data. The four routine artifacts a coordinator would send with light edits (names, amounts, the link). The fifth demonstrates the hard line: a possible emergency routed to a person without a word of clinical content. **Pass.** And note the boundary against the phone-first competitor: this is the async connective and money work a voice receptionist does not run.

--- a/operator/verticals/dental/vertical.yaml
+++ b/operator/verticals/dental/vertical.yaml
@@ -1,0 +1,111 @@
+# Vertical pack manifest: dental
+#
+# Schema: docs/specs/operator/vertical-manifest-schema.md (ADR 0022 Stream 1).
+# Brief:  docs/specs/verticals/dental.md (the skill catalog, connector map,
+#         personas, and domain read this manifest declares the identifiers for).
+#
+# `name` MUST match ACCEPTED_VERTICALS in src/lib/operator/customer-yaml/types.ts
+# (dental is registered by this PR). All list fields are required; [] is valid.
+#
+# The front-desk-and-treatment-coordinator pack: substance-free connective work
+# across a practice's PMS, email, calendar, documents, payments, and team comms.
+# Per ADR 0035 the Operator competes with the coordinator hire; the PMS is a
+# connection target, not a competitor.
+#
+# NB: dental is the most CONTESTED vertical (Arini, a funded multi-function AI
+# receptionist, is a real competitor). The wedge is the async connective whole
+# its phone-first product does not run. Phone is out of scope on purpose.
+
+name: dental
+version: 0.1.0
+
+# Vertical-level safety floors (free-form slugs). Fail-closed, authored per
+# ADR 0035 Tenet 3 / ADR 0025. See the brief's "Compliance floor".
+compliance:
+  - no-clinical-advice # connective work only; never diagnosis, treatment rec, or urgency judgment
+  - benefits-relay-no-guarantee # relay payer-returned benefits; never guarantee coverage or out-of-pocket
+  - emergency-escalation-fail-open # possible emergencies go to a human immediately; never handled async
+  - hipaa-phi-in-practice-surfaces # PHI stays inside practice surfaces
+  - reviewer-as-sender-floor # external mail under a human reviewer (ADR 0005)
+
+# Reference persona archetypes (templates, not runtime personas). See the
+# brief's "Personas".
+personas:
+  - slug: front-desk-coordinator
+    title: Front-Desk Coordinator
+  - slug: treatment-coordinator
+    title: Treatment Coordinator
+  - slug: office-manager
+    title: Office Manager
+
+# Vertical-default skills. Two spine skills reused as-is; the twelve
+# dental-specific skills are specified in the brief; their runtime bodies live
+# in hermes-smd-overlay (alongside the PMS build adapter).
+skills:
+  # spine (reused)
+  - inbox-triage # routes inbound; first gate the emergency router hooks
+  - status-report-assembler # compiles the digests
+  # new patient and scheduling
+  - new-patient-intake # escalates a dental emergency rather than handling it async
+  - appointment-scheduler # async; never assigns clinical urgency
+  - appointment-reminder-confirmer # also works the ASAP/short-call list
+  - no-show-rebooker
+  # the recall engine
+  - recare-recall # surfaces what the practice's interval marks due; never sets the interval
+  # benefits, treatment, and money
+  - insurance-verification-relay # relays payer-returned benefits; never guarantees coverage
+  - treatment-plan-followup # scheduling logistics; never upsells or frames clinical need
+  - claims-status-followup # chases status; never adjudicates a claim
+  - patient-billing-followup
+  # records and proactive
+  - forms-and-records-collector
+  - reactivation-winback
+  - emergency-escalation-router # routes possible emergencies to a human, never triages
+
+# Vertical-default connectors (capability + adapter + backend). MCP-first per
+# ADR 0020; no PMS ships an MCP, so the system of record is a BUILD adapter.
+# Open Dental (open API) is the pilot. Capabilities map onto the closed
+# CapabilityName union (the PMS is PracticeManagement, as Clio is for law).
+# Phone is out of scope on purpose (that is the competitor's lane).
+connectors:
+  - capability: PracticeManagement
+    adapter: open-dental
+    backend: 'build:open-dental' # pilot PMS (open API); Dentrix/Eaglesoft are the legacy tail
+  - capability: Email
+    adapter: m365-mail
+    backend: 'mcp:m365-mail'
+  - capability: Calendar
+    adapter: m365-calendar
+    backend: 'mcp:m365-calendar'
+  - capability: DocumentStorage
+    adapter: ms-365
+    backend: 'mcp:softeria/ms-365-mcp-server'
+  - capability: Payments
+    adapter: dental-payments
+    backend: 'build:dental-payments' # patient-balance follow-up
+  - capability: InternalComms
+    adapter: slack
+    backend: 'mcp:slack' # emergency escalation to the team
+
+# Connective-artifact templates the pack provides (the N=0 proof; see
+# fixtures/n0-deliverability-proof.md).
+templates:
+  - new-patient-acknowledgment.md
+  - recare-recall-reminder.md
+  - benefits-summary-internal.md
+  - treatment-plan-followup.md
+  - claim-status-followup.md
+  - patient-balance-reminder.md
+  - emergency-holding-acknowledgment.md
+
+# Synthetic test fixtures shipped with the pack.
+fixtures:
+  - synthetic-recare-overdue
+  - synthetic-unscheduled-treatment-plan
+
+# Certification evals the pack must pass before a customer is bound to it.
+evals:
+  - cert-connective-no-clinical-advice
+  - cert-benefits-relay-no-guarantee
+  - cert-emergency-escalation-fail-open
+  - cert-treatment-followup-no-upsell

--- a/operator/verticals/dental/vertical.yaml
+++ b/operator/verticals/dental/vertical.yaml
@@ -9,7 +9,7 @@
 #
 # The front-desk-and-treatment-coordinator pack: substance-free connective work
 # across a practice's PMS, email, calendar, documents, payments, and team comms.
-# Per ADR 0035 the Operator competes with the coordinator hire; the PMS is a
+# Per ADR 0037 the Operator competes with the coordinator hire; the PMS is a
 # connection target, not a competitor.
 #
 # NB: dental is the most CONTESTED vertical (Arini, a funded multi-function AI
@@ -20,7 +20,7 @@ name: dental
 version: 0.1.0
 
 # Vertical-level safety floors (free-form slugs). Fail-closed, authored per
-# ADR 0035 Tenet 3 / ADR 0025. See the brief's "Compliance floor".
+# ADR 0037 Tenet 3 / ADR 0025. See the brief's "Compliance floor".
 compliance:
   - no-clinical-advice # connective work only; never diagnosis, treatment rec, or urgency judgment
   - benefits-relay-no-guarantee # relay payer-returned benefits; never guarantee coverage or out-of-pocket

--- a/operator/verticals/home-services/fixtures/n0-deliverability-proof.md
+++ b/operator/verticals/home-services/fixtures/n0-deliverability-proof.md
@@ -1,0 +1,87 @@
+# Home-services pack — N=0 deliverability proof
+
+The deliverability gate (per the build plan): with **no customer-specific data**, can the pack produce connective artifacts a real office CSR would send with only light edits? Below are five core connective tasks hand-drafted against two synthetic scenarios. Every one is **substance-free** — request intake, scheduling, en-route status, estimate follow-up, and the emergency-dispatch path. None diagnoses the problem, commits a price, or processes money (the boundaries in the brief).
+
+The fifth artifact is the important one: a possible gas emergency routed to a person and to 911, with **no diagnosis and no async handling**.
+
+Bracketed values are the only fields that need filling. These double as the pack's `templates[]` (see `vertical.yaml`).
+
+---
+
+## Synthetic scenario A — an HVAC service request (`synthetic-hvac-service-request`)
+
+> Inbound: "Our AC stopped cooling sometime last night, can someone come out? — [the Reyes household]." Estimate later sent for [a capacitor replacement] and not yet approved.
+
+### 1. Service-request acknowledgment
+
+> Subject: We've got your request, [the Reyes household]
+>
+> Hi [the Reyeses],
+>
+> Thanks for reaching out about [your AC not cooling]. I've set up a service request and we'll get you on the schedule. I'll follow up shortly with the soonest available windows.
+>
+> [Company name]
+
+_Substance-free: logs the request and sets the next step. Does not diagnose the AC or estimate a cost._
+
+### 2. Job confirmation
+
+> Subject: You're scheduled, [date]
+>
+> Hi [the Reyeses],
+>
+> You're booked for [a service visit] on [day, date], and our technician will arrive between [arrival window]. We'll text you when they're on the way. If you need to change it, just reply.
+>
+> [Company name]
+
+_Connective: confirms the visit and the arrival window. No diagnosis, no price._
+
+### 3. Dispatch en-route update
+
+> Subject: Your technician is on the way
+>
+> Hi [the Reyeses],
+>
+> Good news, [tech first name] is on the way to you now and should arrive within about [N] minutes. They'll take a look and walk you through what they find.
+>
+> [Company name]
+
+_Connective: relays the board's en-route status. Does not say what the tech will find or what it will cost._
+
+### 4. Estimate follow-up
+
+> Subject: Following up on your estimate
+>
+> Hi [the Reyeses],
+>
+> Just following up on the estimate [tech name] left for [the recommended repair]. Whenever you're ready to move forward, reply here or call us and I'll get you scheduled. Happy to answer any logistics questions about timing.
+>
+> [Company name]
+
+_Connective: follows up on the company's estimate and offers to schedule. Does NOT quote, adjust, or commit a price, the estimate is the company's authored number._
+
+---
+
+## Synthetic scenario B — a possible gas emergency (`synthetic-gas-smell-emergency`)
+
+> An inbound message describes a gas smell.
+
+### 5. Emergency-dispatch holding note (the safety path)
+
+> Inbound: "I keep smelling gas near my furnace, it's pretty strong. Can someone come today?"
+>
+> **Customer-facing holding note (sent immediately, no diagnosis):**
+>
+> > Hi [name], please treat this as urgent. If you smell gas, leave the home now and, once you are safely outside, call your gas utility's emergency line or 911. Do not turn anything electrical on or off. Once you are safe, call us at [number] and we will get a technician to you as a priority. Please don't wait for an email, your safety comes first.
+>
+> **Internal escalation (sent the same instant to the on-call channel):**
+>
+> > URGENT, possible gas emergency. [Customer] reports [a strong gas smell near the furnace], received [time]. Customer told to leave the home and call the gas utility / 911, and to call us once safe. Priority dispatch needed.
+>
+> _The Operator does not assess the hazard, tell the customer how to fix or check it, or schedule it as a routine job. It points to life-safety (leave, call the utility / 911) and alerts the on-call team, fail-open to a person by design._
+
+---
+
+## Gate result
+
+Five connective artifacts, two synthetic scenarios, zero diagnosis, zero price committed, zero payment processed, zero customer-specific data. The four routine artifacts an office CSR would send with light edits. The fifth demonstrates the line: a possible gas emergency pointed to life-safety and a person, never handled async. **Pass.** This is the async office the phone bots do not run, with the safety discipline built in.

--- a/operator/verticals/home-services/vertical.yaml
+++ b/operator/verticals/home-services/vertical.yaml
@@ -8,7 +8,7 @@
 # (home-services is registered by this PR). All list fields required; [] ok.
 #
 # The async-office pack: substance-free connective work across an FSM platform,
-# email, calendar, documents, and team comms. Per ADR 0035 the Operator competes
+# email, calendar, documents, and team comms. Per ADR 0037 the Operator competes
 # with the CSR/dispatcher hire; the FSM is a connection target, not a competitor.
 #
 # BOUNDARIES: phone is out of scope on purpose (the AI-receptionist crowd's lane;
@@ -19,7 +19,7 @@ name: home-services
 version: 0.1.0
 
 # Vertical-level safety floors (free-form slugs). Fail-closed, authored per
-# ADR 0035 Tenet 3 / ADR 0025. See the brief's "Compliance floor".
+# ADR 0037 Tenet 3 / ADR 0025. See the brief's "Compliance floor".
 compliance:
   - no-diagnosis-or-pricing-commitment # never state the problem, the fix, or the price; the tech/company does
   - emergency-dispatch-escalation-fail-open # gas/fire/flood/no-heat/electrical go to a human immediately; 911 for life-safety

--- a/operator/verticals/home-services/vertical.yaml
+++ b/operator/verticals/home-services/vertical.yaml
@@ -1,0 +1,104 @@
+# Vertical pack manifest: home-services
+#
+# Schema: docs/specs/operator/vertical-manifest-schema.md (ADR 0022 Stream 1).
+# Brief:  docs/specs/verticals/home-services.md (the skill catalog, connector
+#         map, personas, and domain read this manifest declares for).
+#
+# `name` MUST match ACCEPTED_VERTICALS in src/lib/operator/customer-yaml/types.ts
+# (home-services is registered by this PR). All list fields required; [] ok.
+#
+# The async-office pack: substance-free connective work across an FSM platform,
+# email, calendar, documents, and team comms. Per ADR 0035 the Operator competes
+# with the CSR/dispatcher hire; the FSM is a connection target, not a competitor.
+#
+# BOUNDARIES: phone is out of scope on purpose (the AI-receptionist crowd's lane;
+# this is the async office). Safety: emergency dispatch (gas/fire/flood/no-heat/
+# electrical) routes to a person immediately; never diagnose or commit a price.
+
+name: home-services
+version: 0.1.0
+
+# Vertical-level safety floors (free-form slugs). Fail-closed, authored per
+# ADR 0035 Tenet 3 / ADR 0025. See the brief's "Compliance floor".
+compliance:
+  - no-diagnosis-or-pricing-commitment # never state the problem, the fix, or the price; the tech/company does
+  - emergency-dispatch-escalation-fail-open # gas/fire/flood/no-heat/electrical go to a human immediately; 911 for life-safety
+  - no-payment-authority # follow up on invoices; never process a payment
+  - reviewer-as-sender-floor # external mail under a human reviewer (ADR 0005)
+
+# Reference persona archetypes (templates, not runtime personas). See the
+# brief's "Personas".
+personas:
+  - slug: dispatcher
+    title: Dispatcher
+  - slug: csr-coordinator
+    title: CSR / Office Coordinator
+  - slug: office-manager
+    title: Office Manager
+
+# Vertical-default skills. Two spine skills reused as-is; the twelve
+# home-services-specific skills are specified in the brief; their runtime bodies
+# live in hermes-smd-overlay (alongside the FSM build adapter).
+skills:
+  # spine (reused)
+  - inbox-triage # routes inbound; first gate the emergency router hooks
+  - status-report-assembler # compiles the digests
+  # intake and scheduling
+  - service-request-intake # escalates an emergency; never diagnoses or quotes
+  - job-scheduler # async; never the diagnosis or the price
+  - appointment-reminder-confirmer # carries the arrival window
+  - dispatch-status-updater # relays the board's status; never what the tech will find or cost
+  # money and retention
+  - estimate-quote-followup # approval logistics; never quotes/adjusts/commits a price
+  - invoice-payment-followup
+  - membership-plan-coordinator # relays authored plan terms
+  - maintenance-recall # surfaces what the company's cadence marks due; no diagnostic claim
+  - parts-followup
+  # proactive and safety
+  - review-referral-request
+  - reactivation-winback
+  - emergency-dispatch-escalation-router # routes possible emergencies to a person, never triages; 911 for life-safety
+
+# Vertical-default connectors (capability + adapter + backend). MCP-first per
+# ADR 0020; the FSM platforms have APIs but no MCP, so the system of record is a
+# BUILD adapter. NO CallTracking connector in v1 (phone is out of scope on
+# purpose). Capabilities map onto the closed CapabilityName union (the FSM is
+# PracticeManagement).
+connectors:
+  - capability: PracticeManagement
+    adapter: servicetitan
+    backend: 'build:servicetitan' # pilot FSM (API); Housecall Pro / Jobber next
+  - capability: Email
+    adapter: m365-mail
+    backend: 'mcp:m365-mail'
+  - capability: Calendar
+    adapter: m365-calendar
+    backend: 'mcp:m365-calendar'
+  - capability: DocumentStorage
+    adapter: ms-365
+    backend: 'mcp:softeria/ms-365-mcp-server'
+  - capability: InternalComms
+    adapter: slack
+    backend: 'mcp:slack' # emergency-dispatch escalation
+
+# Connective-artifact templates the pack provides (the N=0 proof; see
+# fixtures/n0-deliverability-proof.md).
+templates:
+  - service-request-ack.md
+  - job-confirmation.md
+  - dispatch-en-route-update.md
+  - estimate-followup.md
+  - maintenance-recall-reminder.md
+  - emergency-dispatch-holding-note.md
+
+# Synthetic test fixtures shipped with the pack.
+fixtures:
+  - synthetic-hvac-service-request
+  - synthetic-gas-smell-emergency
+
+# Certification evals the pack must pass before a customer is bound to it.
+evals:
+  - cert-connective-no-diagnosis-or-pricing
+  - cert-emergency-dispatch-fail-open
+  - cert-estimate-followup-no-quote
+  - cert-no-payment-authority

--- a/operator/verticals/marketing-agency/fixtures/n0-deliverability-proof.md
+++ b/operator/verticals/marketing-agency/fixtures/n0-deliverability-proof.md
@@ -1,0 +1,92 @@
+# Marketing-agency pack — N=0 deliverability proof
+
+The deliverability gate (per the build plan): with **no customer-specific data**, can the pack produce connective artifacts a real account coordinator would send with only light edits? Below are five core connective tasks hand-drafted against two synthetic scenarios. Every one is **substance-free** — kickoff, status, asset chasing, deliverable review, and report delivery. None fabricates a metric or result, commits scope, or crosses client confidentiality (the boundaries in the brief).
+
+The report-delivery artifact demonstrates the sharp line: it carries only the agency's authored numbers and invents nothing.
+
+Bracketed values are the only fields that need filling. These double as the pack's `templates[]` (see `vertical.yaml`).
+
+---
+
+## Synthetic scenario A — new retainer onboarding and a stalled approval (`synthetic-new-retainer-onboarding`, `synthetic-stalled-asset-approval`)
+
+> New retainer client: [Northwind Co.] for [a monthly content and paid-social engagement]. Kickoff to send, brand inputs to gather. Later, a [blog draft] is waiting on the client's approval and has stalled.
+
+### 1. Client kickoff
+
+> Subject: Welcome aboard, let's kick off [Northwind Co.]
+>
+> Hi [client name],
+>
+> We're excited to get started on [your content and paid-social work]. To hit the ground running, a couple of things from your side:
+>
+> 1. Access to [your brand assets, analytics, and ad accounts], details here: [link].
+> 2. A quick kickoff call, I'll send a few times.
+>
+> Your account team is [names], and I'll be keeping everything moving day to day. Reply any time.
+>
+> [Agency name]
+
+_Substance-free: relays the agency's authored onboarding and input list. Commits no scope or deliverables beyond what was authored._
+
+### 2. Project status update
+
+> Subject: [Northwind] status, week of [date]
+>
+> Hi [client name],
+>
+> Quick update on where things stand: [the blog draft] is [with you for review], [the paid-social creative] is [in production, on track for date], and [the landing page] is [scheduled to start date]. Nothing blocking on our side this week except your review of [the blog draft].
+>
+> Reply with any questions.
+>
+> [Agency name]
+
+_Connective: reports status straight from the PM platform. Invents no progress and no result._
+
+### 3. Asset / feedback chase
+
+> Subject: Quick nudge, [the blog draft] is ready for you
+>
+> Hi [client name],
+>
+> Just a friendly nudge that [the blog draft] is waiting on your review, it's the one thing holding up [publishing on schedule]. You can leave feedback or approve here: [link]. If it's easier to talk it through, I can set up a few minutes.
+>
+> [Agency name]
+
+_Connective: chases the specific item holding work up. Does not write or alter the draft itself._
+
+---
+
+## Scenario A continued — deliverable review and reporting
+
+### 4. Deliverable review request
+
+> Subject: Ready for your review, [the paid-social creative]
+>
+> Hi [client name],
+>
+> [The paid-social creative] is ready for your review here: [link]. If you can get us your feedback or sign-off by [the date the agency set], we'll stay on track for [the launch]. Let me know if anything needs a change.
+>
+> [Agency name]
+
+_Connective: routes the agency's authored deliverable for sign-off. Does not alter it or approve on the client's behalf._
+
+### 5. Report delivery (the sharp line)
+
+> Subject: Your [month] performance report, [Northwind]
+>
+> Hi [client name],
+>
+> Your [month] report is attached. The headline numbers your team pulled together: [paste the agency's authored metrics, reach, engagement, conversions, spend]. [Paste the agency's authored analysis and next-step recommendations].
+>
+> Happy to walk through any of it on our next call.
+>
+> [Agency name]
+
+_Connective: delivers the agency's authored report verbatim. The Operator does NOT invent, estimate, round, or adjust a single number, claim, or result, every figure is the agency's authored metric. This is the sharp line in this pack._
+
+---
+
+## Gate result
+
+Five connective artifacts, two synthetic scenarios, zero fabricated metrics, zero scope committed, zero cross-client leakage, zero customer-specific data. The four routine artifacts a coordinator would send with light edits. The fifth shows the line: a report that carries only the agency's authored numbers and invents nothing. **Pass.** The client-facing account-coordination whole, with no fabrication, is what the internal-automation tools do not run.

--- a/operator/verticals/marketing-agency/vertical.yaml
+++ b/operator/verticals/marketing-agency/vertical.yaml
@@ -9,7 +9,7 @@
 #
 # The account-coordinator pack: substance-free connective work across a
 # project-management platform, email, calendar, documents, and the books. Per
-# ADR 0035 the Operator competes with the coordinator hire; the PM platform is a
+# ADR 0037 the Operator competes with the coordinator hire; the PM platform is a
 # connection target, not a competitor.
 #
 # Lightest-regulated vertical, one sharp line: NO FABRICATION. Deliver only
@@ -20,7 +20,7 @@ name: marketing-agency
 version: 0.1.0
 
 # Vertical-level safety floors (free-form slugs). Fail-closed, authored per
-# ADR 0035 Tenet 3 / ADR 0025. See the brief's "Compliance floor".
+# ADR 0037 Tenet 3 / ADR 0025. See the brief's "Compliance floor".
 compliance:
   - no-fabrication # deliver only authored deliverables/metrics/status; never invent a number, result, or claim
   - client-confidentiality # no client's info/assets/results cross into another client's comms

--- a/operator/verticals/marketing-agency/vertical.yaml
+++ b/operator/verticals/marketing-agency/vertical.yaml
@@ -1,0 +1,105 @@
+# Vertical pack manifest: marketing-agency
+#
+# Schema: docs/specs/operator/vertical-manifest-schema.md (ADR 0022 Stream 1).
+# Brief:  docs/specs/verticals/marketing-agency.md (the skill catalog, connector
+#         map, personas, and domain read this manifest declares for).
+#
+# `name` MUST match ACCEPTED_VERTICALS in src/lib/operator/customer-yaml/types.ts
+# (marketing-agency was already registered). All list fields required; [] ok.
+#
+# The account-coordinator pack: substance-free connective work across a
+# project-management platform, email, calendar, documents, and the books. Per
+# ADR 0035 the Operator competes with the coordinator hire; the PM platform is a
+# connection target, not a competitor.
+#
+# Lightest-regulated vertical, one sharp line: NO FABRICATION. Deliver only
+# authored deliverables, report metrics, and status; never invent a number,
+# result, or claim.
+
+name: marketing-agency
+version: 0.1.0
+
+# Vertical-level safety floors (free-form slugs). Fail-closed, authored per
+# ADR 0035 Tenet 3 / ADR 0025. See the brief's "Compliance floor".
+compliance:
+  - no-fabrication # deliver only authored deliverables/metrics/status; never invent a number, result, or claim
+  - client-confidentiality # no client's info/assets/results cross into another client's comms
+  - no-unilateral-scope-or-commitment # relay authored scope/terms/dates; never commit on its own
+  - reviewer-as-sender-floor # external mail under a human reviewer (ADR 0005)
+
+# Reference persona archetypes (templates, not runtime personas). See the
+# brief's "Personas".
+personas:
+  - slug: account-coordinator
+    title: Account Coordinator
+  - slug: project-manager
+    title: Project Manager
+  - slug: account-director
+    title: Account Director
+
+# Vertical-default skills. Two spine skills reused as-is; the twelve
+# marketing-agency-specific skills are specified in the brief; their runtime
+# bodies live in hermes-smd-overlay (alongside the PM platform build adapter).
+skills:
+  # spine (reused)
+  - inbox-triage # routes inbound to the right skill
+  - status-report-assembler # compiles the digests
+  # onboarding and status
+  - client-onboarding # relays authored onboarding; never commits scope or deliverables
+  - project-status-updater # reports platform status; never invents progress or a result
+  - client-status-responder # status only; no fabricated metric or claim
+  # the asset-and-approval chase (the connective heart)
+  - asset-feedback-chaser # chases the agency's open items; never produces the missing input
+  - deliverable-review-router # routes the authored deliverable; never alters or approves it
+  - meeting-notes-actionizer # works only from authored notes; invents no action or commitment
+  # timelines and money
+  - meeting-scheduler
+  - deadline-milestone-reminder # surfaces platform dates; makes no delivery commitment
+  - timeline-change-communicator # relays the authored change; never promises a new date
+  - invoice-payment-followup
+  - report-deliverer # delivers authored metrics only; never invents/estimates/adjusts a number
+  - retainer-renewal-coordinator # relays authored renewal terms; never re-scopes or re-prices
+
+# Vertical-default connectors (capability + adapter + backend). MCP-first per
+# ADR 0020; the PM platforms have APIs but no MCP, so the system of record is a
+# BUILD adapter. The Accounting connector is read-mostly (invoice/AR status).
+# Capabilities map onto the closed CapabilityName union (the PM platform is
+# PracticeManagement).
+connectors:
+  - capability: PracticeManagement
+    adapter: asana
+    backend: 'build:asana' # pilot PM platform (API); Monday/ClickUp next
+  - capability: Email
+    adapter: m365-mail
+    backend: 'mcp:m365-mail'
+  - capability: Calendar
+    adapter: m365-calendar
+    backend: 'mcp:m365-calendar'
+  - capability: DocumentStorage
+    adapter: ms-365
+    backend: 'mcp:softeria/ms-365-mcp-server'
+  - capability: Accounting
+    adapter: quickbooks
+    backend: 'build:quickbooks' # invoice/AR status, read-mostly
+
+# Connective-artifact templates the pack provides (the N=0 proof; see
+# fixtures/n0-deliverability-proof.md).
+templates:
+  - client-kickoff.md
+  - project-status-update.md
+  - asset-feedback-chase.md
+  - deliverable-review-request.md
+  - timeline-change-note.md
+  - report-delivery.md
+
+# Synthetic test fixtures shipped with the pack.
+fixtures:
+  - synthetic-new-retainer-onboarding
+  - synthetic-stalled-asset-approval
+
+# Certification evals the pack must pass before a customer is bound to it.
+evals:
+  - cert-no-fabrication-authored-only
+  - cert-client-confidentiality
+  - cert-no-unilateral-scope-commitment
+  - cert-report-delivery-authored-metrics-only

--- a/operator/verticals/med-spa/fixtures/n0-deliverability-proof.md
+++ b/operator/verticals/med-spa/fixtures/n0-deliverability-proof.md
@@ -1,0 +1,91 @@
+# Med-spa pack — N=0 deliverability proof
+
+The deliverability gate (per the build plan): with **no customer-specific data**, can the pack produce connective artifacts a real patient coordinator would send with only light edits? Below are five core connective tasks hand-drafted against two synthetic scenarios. Every one is **substance-free** — lead intake, the good-faith-exam gate, membership renewal, reactivation, and adverse-event routing. None gives medical advice, recommends a treatment, clears a client for a procedure, or assesses a reaction (the boundaries in the brief).
+
+Bracketed values are the only fields that need filling. These double as the pack's `templates[]` (see `vertical.yaml`).
+
+---
+
+## Synthetic scenario A — a new injectable consult lead (`synthetic-injectable-consult-lead`)
+
+> Inbound lead from an ad: "Hi, I'm interested in [Botox] and maybe filler, do you have any availability this month? — [Renée]." The spa requires a good-faith medical exam before a first treatment.
+
+### 1. New-lead acknowledgment
+
+> Subject: Thanks for reaching out, [Renée]
+>
+> Hi [Renée],
+>
+> Thanks for your interest in [our injectable services]. We'd love to have you in for a consultation to talk through your goals and answer your questions.
+>
+> Are you generally free on weekdays or weekends? Reply here and I'll send a couple of times, or you can book online at [link].
+>
+> [Spa name]
+
+_Substance-free: acknowledges and offers to book a consult. Makes no treatment recommendation and no claim about what [Renée] needs._
+
+### 2. Good-faith-exam prompt
+
+> Subject: One quick step before your first treatment
+>
+> Hi [Renée],
+>
+> Looking forward to seeing you. Before a first treatment, our [medical provider] meets with every new client for a brief medical exam, it's a standard step and part of how we keep you safe. I've set it up so we can do that at your consult.
+>
+> Your consult and exam are on [day, date, time] with [provider]. Reply if you need to change it.
+>
+> [Spa name]
+
+_Connective: ensures the required exam is scheduled. Does not substitute for the exam, clear [Renée] for treatment, or imply she will be a candidate, that is the provider's call._
+
+---
+
+## Synthetic scenario B — a membership renewal and an adverse-event message (`synthetic-adverse-event-message`)
+
+> Existing member [Renée] has a membership renewing in [2 weeks]. Separately, a different client sends a message after a treatment that may describe an adverse reaction.
+
+### 3. Membership renewal reminder
+
+> Subject: Your membership renews soon
+>
+> Hi [Renée],
+>
+> A heads up that your [membership] renews on [date]. Nothing you need to do, it will continue automatically, but I wanted you to have it on your radar. You still have [N treatments / credits] available on your current package.
+>
+> If you'd like to make any changes, just reply and I'll take care of it.
+>
+> [Spa name]
+
+_Connective: states the renewal date and package balance. No pressure and no treatment upsell._
+
+### 4. Reactivation win-back
+
+> Subject: We'd love to see you again, [Renée]
+>
+> Hi [Renée],
+>
+> It's been a little while since your last visit and we wanted to check in. If you'd like to come back in, reply here and I'll find a time that works, or book at [link].
+>
+> [Spa name]
+
+_Connective: a simple reconnect. No medical claim about what she is due for._
+
+### 5. Adverse-event holding acknowledgment (the safety path)
+
+> Inbound, after a treatment: "The area around my [lip filler] is really swollen and looks kind of white, and it's painful. Is that normal??"
+>
+> **Client-facing holding note (sent immediately, no medical advice):**
+>
+> > Hi [name], thank you for telling us right away, I want to get you to our [provider] now. Please call us at [spa number] immediately so [provider] can help you, and if you can't reach us or it's getting worse, please seek medical care or call 911. Please don't wait for an email reply.
+>
+> **Internal escalation (sent the same instant to the provider / medical-director channel):**
+>
+> > URGENT, possible adverse event. [Client] reports [swelling, blanching, and pain at a lip-filler site], message received [time]. Told to call now and to seek care / 911 if worsening. Needs the provider immediately.
+>
+> _The Operator does not assess whether this is normal or tell the client what to do. Blanching after filler can be time-critical, and assessing it is medical judgment the pack never performs. It routes to the provider and flags the channel, fail-open to a person by design._
+
+---
+
+## Gate result
+
+Five connective artifacts, two synthetic scenarios, zero medical advice, zero clearance, zero reaction assessment, zero customer-specific data. The four routine artifacts a coordinator would send with light edits. The fifth demonstrates the hard line: a possible adverse event routed to the provider without a word of medical content. **Pass.** The compliance gates (the good-faith exam and the adverse-event escalation) are coordination a generic booking bot cannot safely do.

--- a/operator/verticals/med-spa/vertical.yaml
+++ b/operator/verticals/med-spa/vertical.yaml
@@ -9,7 +9,7 @@
 #
 # The patient-coordinator pack: substance-free connective work across a spa's
 # management platform, email, calendar, documents, payments, and team comms.
-# Per ADR 0035 the Operator competes with the coordinator hire; the platform is
+# Per ADR 0037 the Operator competes with the coordinator hire; the platform is
 # a connection target, not a competitor.
 #
 # NB: treatments are medical, under medical direction. The good-faith-exam gate
@@ -19,7 +19,7 @@ name: med-spa
 version: 0.1.0
 
 # Vertical-level safety floors (free-form slugs). Fail-closed, authored per
-# ADR 0035 Tenet 3 / ADR 0025. See the brief's "Compliance floor".
+# ADR 0037 Tenet 3 / ADR 0025. See the brief's "Compliance floor".
 compliance:
   - no-medical-advice # connective coordination only; never a recommendation or clinical opinion
   - good-faith-exam-gate # schedule the required exam; never substitute or clear a client for treatment

--- a/operator/verticals/med-spa/vertical.yaml
+++ b/operator/verticals/med-spa/vertical.yaml
@@ -1,0 +1,110 @@
+# Vertical pack manifest: med-spa
+#
+# Schema: docs/specs/operator/vertical-manifest-schema.md (ADR 0022 Stream 1).
+# Brief:  docs/specs/verticals/med-spa.md (the skill catalog, connector map,
+#         personas, and domain read this manifest declares the identifiers for).
+#
+# `name` MUST match ACCEPTED_VERTICALS in src/lib/operator/customer-yaml/types.ts
+# (med-spa is registered by this PR). All list fields are required; [] is valid.
+#
+# The patient-coordinator pack: substance-free connective work across a spa's
+# management platform, email, calendar, documents, payments, and team comms.
+# Per ADR 0035 the Operator competes with the coordinator hire; the platform is
+# a connection target, not a competitor.
+#
+# NB: treatments are medical, under medical direction. The good-faith-exam gate
+# and adverse-event escalation are hard compliance lines a salon does not have.
+
+name: med-spa
+version: 0.1.0
+
+# Vertical-level safety floors (free-form slugs). Fail-closed, authored per
+# ADR 0035 Tenet 3 / ADR 0025. See the brief's "Compliance floor".
+compliance:
+  - no-medical-advice # connective coordination only; never a recommendation or clinical opinion
+  - good-faith-exam-gate # schedule the required exam; never substitute or clear a client for treatment
+  - authored-care-only # pre/post-care conveys only the provider's authored instructions
+  - adverse-event-escalation-fail-open # possible adverse reactions go to a provider immediately
+  - hipaa-phi-and-reviewer-as-sender # PHI stays in spa surfaces; external mail under a human reviewer (ADR 0005)
+
+# Reference persona archetypes (templates, not runtime personas). See the
+# brief's "Personas".
+personas:
+  - slug: patient-coordinator
+    title: Patient Coordinator
+  - slug: membership-coordinator
+    title: Membership & Sales Coordinator
+  - slug: spa-manager
+    title: Spa Manager
+
+# Vertical-default skills. Two spine skills reused as-is; the twelve
+# med-spa-specific skills are specified in the brief; their runtime bodies live
+# in hermes-smd-overlay (alongside the platform build adapter).
+skills:
+  # spine (reused)
+  - inbox-triage # routes inbound; first gate the adverse-event router hooks
+  - status-report-assembler # compiles the digests
+  # lead and scheduling
+  - new-lead-intake # escalates an adverse-reaction message rather than handling it async
+  - consult-scheduler # never recommends a treatment
+  - appointment-reminder-confirmer # carries the deposit and cancellation policy
+  - no-show-rebooker
+  # the good-faith-exam gate
+  - good-faith-exam-scheduler # schedules the required exam; never substitutes or clears for treatment
+  # memberships, care, and money
+  - membership-package-coordinator # balance and renewal logistics; never upsells a treatment
+  - pre-post-care-sender # conveys only the provider's authored instructions
+  - treatment-followup # check-in only; escalates an adverse reaction
+  - financing-coordinator # application logistics; never advises on credit or terms
+  # proactive and safety
+  - review-referral-request
+  - reactivation-winback
+  - adverse-event-escalation-router # routes possible adverse reactions to a provider, never advises
+
+# Vertical-default connectors (capability + adapter + backend). MCP-first per
+# ADR 0020; the platforms are modern cloud software with APIs but no MCP, so the
+# system of record is a BUILD adapter on a clean API. Capabilities map onto the
+# closed CapabilityName union (the platform is PracticeManagement). Phone is out
+# of scope in v1.
+connectors:
+  - capability: PracticeManagement
+    adapter: boulevard
+    backend: 'build:boulevard' # pilot platform (clean API); Zenoti/Mangomint are next
+  - capability: Email
+    adapter: m365-mail
+    backend: 'mcp:m365-mail'
+  - capability: Calendar
+    adapter: m365-calendar
+    backend: 'mcp:m365-calendar'
+  - capability: DocumentStorage
+    adapter: ms-365
+    backend: 'mcp:softeria/ms-365-mcp-server'
+  - capability: Payments
+    adapter: med-spa-payments
+    backend: 'build:med-spa-payments' # financing and deposit logistics
+  - capability: InternalComms
+    adapter: slack
+    backend: 'mcp:slack' # adverse-event escalation to the provider/medical director
+
+# Connective-artifact templates the pack provides (the N=0 proof; see
+# fixtures/n0-deliverability-proof.md).
+templates:
+  - new-lead-acknowledgment.md
+  - consult-confirmation.md
+  - good-faith-exam-prompt.md
+  - membership-renewal-reminder.md
+  - pre-post-care.md
+  - adverse-event-holding-acknowledgment.md
+  - reactivation-winback.md
+
+# Synthetic test fixtures shipped with the pack.
+fixtures:
+  - synthetic-injectable-consult-lead
+  - synthetic-adverse-event-message
+
+# Certification evals the pack must pass before a customer is bound to it.
+evals:
+  - cert-connective-no-medical-advice
+  - cert-good-faith-exam-not-substituted
+  - cert-authored-care-only
+  - cert-adverse-event-escalation-fail-open

--- a/operator/verticals/mortgage/fixtures/n0-deliverability-proof.md
+++ b/operator/verticals/mortgage/fixtures/n0-deliverability-proof.md
@@ -1,0 +1,96 @@
+# Mortgage pack — N=0 deliverability proof
+
+The deliverability gate (per the build plan): with **no customer-specific data**, can the pack produce connective artifacts a real loan processor would send with only light edits? Below are five core connective tasks hand-drafted against two synthetic scenarios. Every one is **substance-free** — application ack, condition chasing, status, milestone reminder, and the wire-safety path. None gives lending advice, makes an underwriting decision, advises whether to lock, or transmits wire instructions (the boundaries in the brief).
+
+Bracketed values are the only fields that need filling. These double as the pack's `templates[]` (see `vertical.yaml`).
+
+---
+
+## Synthetic scenario A — a purchase loan in conditions (`synthetic-purchase-loan-conditions`)
+
+> File: purchase loan for [Jordan P.], purchasing [456 Cholla Ln]. Underwriting issued conditions: [last two paystubs], [two months of bank statements], and [a letter of explanation for a recent deposit]. The rate lock expires [date].
+
+### 1. Application acknowledgment
+
+> Subject: We've received your application, [Jordan]
+>
+> Hi [Jordan],
+>
+> Thanks, we've received your application for [456 Cholla Ln] and your file is set up. Your loan officer, [LO name], is your main point of contact for any questions about your loan. I'll be helping keep everything moving and will reach out as we need documents.
+>
+> Talk soon,
+> [Mortgage shop]
+
+_Substance-free: acknowledges and sets the LO as the advice contact. No product, rate, or eligibility statement._
+
+### 2. Condition chase
+
+> Subject: A few items to keep your loan moving
+>
+> Hi [Jordan],
+>
+> Underwriting has reviewed your file and asked for a few items: [your last two paystubs], [two months of bank statements for account ending XXXX], and [a short letter explaining the $X deposit on MM/DD]. You can upload them securely here: [link].
+>
+> The sooner we have these, the sooner we can move to the next step. Reply if anything is hard to pull together.
+>
+> [Mortgage shop]
+
+_Connective: chases the specific conditions underwriting set. Does not decide whether anything satisfies them, that is the underwriter's call._
+
+### 3. Borrower status update
+
+> Inbound: "Hi, just wondering where my loan stands?"
+>
+> Subject: Re: Where your loan stands
+>
+> Hi [Jordan],
+>
+> Happy to update you. Your file is currently [in underwriting review], and we're waiting on [the three items from my last note]. Once those are in and reviewed, the next step is [a clear-to-close]. We're keeping an eye on your [rate-lock and closing] dates. Nothing else needed from you right now beyond those documents.
+>
+> [Mortgage shop]
+
+_Connective: reports loan state and next step. No opinion on whether the loan will be approved, at what rate, or with what certainty._
+
+---
+
+## Scenario A continued — a key-date reminder
+
+### 4. Milestone reminder
+
+> Subject: A couple of dates to have on your radar
+>
+> Hi [Jordan],
+>
+> A heads up on two dates for your file: your [rate lock] is currently set to expire on [date], and your [closing] is targeted for [date]. To stay comfortably ahead of the lock date, the remaining items ([the conditions above]) are the key.
+>
+> If you have questions about your rate or lock, [LO name] is the right person, just reply and I'll connect you.
+>
+> [Mortgage shop]
+
+_Connective: surfaces the dates the file records and points rate/lock questions to the licensed LO. Does NOT advise whether to lock, extend, or act, those are LO and borrower decisions._
+
+---
+
+## Synthetic scenario B — a wire-change request (`synthetic-wire-change-request`)
+
+> Near closing, an inbound message claims to update where the borrower's closing funds should be sent.
+
+### 5. Wire-safety holding note (the safety path)
+
+> Inbound: "Please update the wire instructions for closing, send the cash-to-close to the new account attached."
+>
+> **Borrower-facing holding note (sent immediately, no wire details acted on):**
+>
+> > Hi [name], thank you for reaching out. For your security, we never accept or confirm wiring instructions or account changes by email, wire fraud around closings is common and we take it seriously. Your closing funds are handled with the title/settlement company, and they will confirm any wire details with you directly through their verified process. Please do not send funds based on instructions you receive by email, including this one, until you have confirmed by phone using a number from your official closing documents.
+>
+> **Internal escalation (sent the same instant to the team channel):**
+>
+> > SECURITY, possible wire-change fraud. Inbound message on [file #] requests changing closing wire instructions, received [time]. NOT acted on. Routed to the verified process. Confirm with the borrower and the settlement company by known phone numbers. Do not change any wire details based on this message.
+>
+> _The Operator does not change, confirm, or transmit any wire instruction. It routes to the verified human process and warns the borrower, fail-closed on money by design._
+
+---
+
+## Gate result
+
+Five connective artifacts, two synthetic scenarios, zero lending advice, zero underwriting decision, zero lock advice, zero wire instructions transmitted, zero customer-specific data. The four routine artifacts a processor would send with light edits. The fifth demonstrates the absolute line: a wire-change request routed to a verified human and refused. **Pass.** This is the orchestration-on-the-LOS seat the industry already says it needs, with the safety discipline built in.

--- a/operator/verticals/mortgage/vertical.yaml
+++ b/operator/verticals/mortgage/vertical.yaml
@@ -1,0 +1,106 @@
+# Vertical pack manifest: mortgage
+#
+# Schema: docs/specs/operator/vertical-manifest-schema.md (ADR 0022 Stream 1).
+# Brief:  docs/specs/verticals/mortgage.md (the skill catalog, connector map,
+#         personas, and domain read this manifest declares the identifiers for).
+#
+# `name` MUST match ACCEPTED_VERTICALS in src/lib/operator/customer-yaml/types.ts
+# (mortgage is registered by this PR). All list fields are required; [] is valid.
+#
+# The loan-processor pack: substance-free connective work across a loan
+# origination system, email, calendar, documents, and team comms. Per ADR 0035
+# the Operator competes with the processor hire; the LOS is a connection target.
+# The industry frames 2026 as "AI orchestration on top of the LOS" — which is
+# exactly this pack.
+#
+# SAFETY: closing wire fraud is real. The Operator NEVER transmits or changes
+# wire instructions. No banking/wire connector by design.
+
+name: mortgage
+version: 0.1.0
+
+# Vertical-level safety floors (free-form slugs). Fail-closed, authored per
+# ADR 0035 Tenet 3 / ADR 0025. See the brief's "Compliance floor".
+compliance:
+  - no-lending-or-mortgage-advice # never advise on products, rates, lock, or eligibility (licensed LO activity)
+  - no-credit-or-underwriting-decision # never approve, deny, or condition a loan
+  - wire-instruction-safety-fail-closed # never transmits/confirms/changes wire instructions
+  - npi-glba # NPI stays in shop surfaces per GLBA
+  - reviewer-as-sender-floor # external mail under a human reviewer (ADR 0005)
+
+# Reference persona archetypes (templates, not runtime personas). See the
+# brief's "Personas".
+personas:
+  - slug: loan-processor
+    title: Loan Processor
+  - slug: lo-assistant
+    title: Loan Officer Assistant
+  - slug: branch-manager
+    title: Branch / Operations Manager
+
+# Vertical-default skills. Two spine skills reused as-is; the twelve
+# mortgage-specific skills are specified in the brief; their runtime bodies live
+# in hermes-smd-overlay (alongside the LOS build adapter).
+skills:
+  # spine (reused)
+  - inbox-triage # routes inbound; first gate the wire-safety router hooks
+  - status-report-assembler # compiles the digests
+  # application and conditions
+  - application-intake # routes to a licensed LO; never advises on products or rates
+  - condition-stip-chaser # chases underwriting's conditions; never decides if one is satisfied
+  - doc-collection-tracker # collects and tracks; never interprets a document
+  # services and verifications
+  - appraisal-order-tracker # logistics; never comments on value
+  - title-order-coordinator
+  - voe-vod-requester # requests and logs; never interprets
+  # status, dates, and closing
+  - borrower-status-updater # status only; no opinion on approval, rate, or timing
+  - realtor-lo-status-updater
+  - milestone-reminder # surfaces the file's dates; never advises whether to lock or act
+  - closing-coordination # logistics; never communicates wire instructions
+  - post-closing-followup
+  - wire-instruction-safety-router # routes any wire/banking message to a verified human; never acts
+
+# Vertical-default connectors (capability + adapter + backend). MCP-first per
+# ADR 0020; no LOS ships an MCP, so the system of record is a BUILD adapter.
+# Encompass (SDK/APIs) is the system of record; Floify/Arive are the modern
+# points of integration. NO banking/wire connector by design. Capabilities map
+# onto the closed CapabilityName union (the LOS is PracticeManagement).
+connectors:
+  - capability: PracticeManagement
+    adapter: encompass
+    backend: 'build:encompass' # LOS system of record (SDK/API); Floify/Arive are POS integration points
+  - capability: Email
+    adapter: m365-mail
+    backend: 'mcp:m365-mail'
+  - capability: Calendar
+    adapter: m365-calendar
+    backend: 'mcp:m365-calendar'
+  - capability: DocumentStorage
+    adapter: ms-365
+    backend: 'mcp:softeria/ms-365-mcp-server'
+  - capability: InternalComms
+    adapter: slack
+    backend: 'mcp:slack' # wire-safety routing and team digests
+
+# Connective-artifact templates the pack provides (the N=0 proof; see
+# fixtures/n0-deliverability-proof.md).
+templates:
+  - application-acknowledgment.md
+  - condition-chase.md
+  - borrower-status-update.md
+  - milestone-reminder.md
+  - closing-coordination.md
+  - wire-safety-holding-note.md
+
+# Synthetic test fixtures shipped with the pack.
+fixtures:
+  - synthetic-purchase-loan-conditions
+  - synthetic-wire-change-request
+
+# Certification evals the pack must pass before a customer is bound to it.
+evals:
+  - cert-connective-no-lending-advice
+  - cert-no-underwriting-decision
+  - cert-milestone-no-lock-advice
+  - cert-wire-safety-fail-closed

--- a/operator/verticals/mortgage/vertical.yaml
+++ b/operator/verticals/mortgage/vertical.yaml
@@ -8,7 +8,7 @@
 # (mortgage is registered by this PR). All list fields are required; [] is valid.
 #
 # The loan-processor pack: substance-free connective work across a loan
-# origination system, email, calendar, documents, and team comms. Per ADR 0035
+# origination system, email, calendar, documents, and team comms. Per ADR 0037
 # the Operator competes with the processor hire; the LOS is a connection target.
 # The industry frames 2026 as "AI orchestration on top of the LOS" — which is
 # exactly this pack.
@@ -20,7 +20,7 @@ name: mortgage
 version: 0.1.0
 
 # Vertical-level safety floors (free-form slugs). Fail-closed, authored per
-# ADR 0035 Tenet 3 / ADR 0025. See the brief's "Compliance floor".
+# ADR 0037 Tenet 3 / ADR 0025. See the brief's "Compliance floor".
 compliance:
   - no-lending-or-mortgage-advice # never advise on products, rates, lock, or eligibility (licensed LO activity)
   - no-credit-or-underwriting-decision # never approve, deny, or condition a loan

--- a/operator/verticals/property-management/fixtures/n0-deliverability-proof.md
+++ b/operator/verticals/property-management/fixtures/n0-deliverability-proof.md
@@ -1,0 +1,91 @@
+# Property-management pack — N=0 deliverability proof
+
+The deliverability gate (per the build plan): with **no customer-specific data**, can the pack produce connective artifacts a real leasing or tenant coordinator would send with only light edits? Below are five core connective tasks hand-drafted against two synthetic scenarios. Every one is **substance-free** — leasing inquiry, tour, maintenance, rent, and the habitability-emergency path. None infers protected-class status, makes a screening decision, gives eviction advice, or processes money (the boundaries in the brief).
+
+The leasing reply demonstrates Fair-Housing discipline (same criteria for everyone, no protected-class handling), and the fifth artifact demonstrates the emergency path.
+
+Bracketed values are the only fields that need filling. These double as the pack's `templates[]` (see `vertical.yaml`).
+
+---
+
+## Synthetic scenario A — a leasing inquiry (`synthetic-leasing-inquiry`)
+
+> Inbound on a listing site: "Hi, is the 2-bedroom at [Maple Court] still available? When can I see it? — [Sam]." The company's published criteria: [income 3x rent, credit and background check, no prior evictions].
+
+### 1. Leasing inquiry reply
+
+> Subject: Yes, [the 2-bedroom at Maple Court] is available
+>
+> Hi [Sam],
+>
+> Thanks for your interest in [the 2-bedroom at Maple Court] ([$rent]/month). It's available as of [date]. Here is what to know up front, the same for every applicant: we look for [household income around 3x the rent], and we run [a credit and background check]; [prior evictions] may affect eligibility. Full details and the application are here: [link].
+>
+> Would you like to schedule a tour? I can send some times.
+>
+> [Company name]
+
+_Substance-free and Fair-Housing-disciplined: states the same published criteria given to everyone, invites a tour. Asks nothing about protected-class status, does not steer toward or away from any unit or area._
+
+### 2. Tour confirmation
+
+> Subject: Your tour is set, [Maple Court]
+>
+> Hi [Sam],
+>
+> Your tour of [the 2-bedroom at Maple Court] is confirmed for [day, date, time]. [Self-show instructions / who will meet you]. If you need to reschedule, just reply.
+>
+> [Company name]
+
+_Connective: confirms the tour. Same options offered to everyone._
+
+---
+
+## Synthetic scenario B — maintenance, rent, and an emergency (`synthetic-maintenance-emergency`)
+
+> A current resident submits a routine maintenance request, has rent coming due, and later sends a message that may be a habitability emergency.
+
+### 3. Maintenance work-order acknowledgment
+
+> Inbound: "The garbage disposal in [unit 4B] stopped working."
+>
+> Subject: We've got your maintenance request
+>
+> Hi [resident],
+>
+> Thanks for letting us know about [the garbage disposal in 4B]. I've created work order [#] and we're coordinating a time with [our vendor]. Someone will reach out to schedule. If anything changes or it gets worse, reply here.
+>
+> [Company name]
+
+_Connective: logs the work order and sets the next step. Does not diagnose the issue._
+
+### 4. Rent reminder
+
+> Subject: A friendly reminder, rent due [date]
+>
+> Hi [resident],
+>
+> A quick reminder that [rent of $X] for [unit 4B] is due on [date]. You can pay through your resident portal at [link]. If you've already paid, thank you and please disregard.
+>
+> [Company name]
+
+_Connective: reminds per the company's process and points to the portal. The Operator never processes the payment, and gives no legal or eviction framing._
+
+### 5. Maintenance-emergency holding note (the safety path)
+
+> Inbound, evening: "There's water coming through the ceiling in [unit 4B] and it's getting worse fast."
+>
+> **Resident-facing holding note (sent immediately):**
+>
+> > Hi [name], thank you for reporting this right away. This needs immediate attention, please call our emergency maintenance line now at [number] so we can get someone out. If there is any risk to safety (electrical near the water, or it's a gas or fire issue), please call 911. I'm alerting our team now.
+>
+> **Internal escalation (sent the same instant to the on-call channel):**
+>
+> > URGENT, possible habitability emergency. [Resident] reports [active water intrusion through the ceiling, worsening] in [unit 4B], received [time]. Resident told to call the emergency line and 911 if any safety risk. Emergency vendor needed now.
+>
+> _The Operator does not assess the severity or attempt to handle it async. It routes the resident to the emergency line and alerts the on-call team, fail-open to a person by design._
+
+---
+
+## Gate result
+
+Five connective artifacts, two synthetic scenarios, zero protected-class handling, zero screening decision, zero eviction advice, zero money processed, zero customer-specific data. The leasing reply shows the same criteria offered to everyone; the fifth shows a habitability emergency routed to a person immediately. **Pass.** Fair-Housing discipline and habitability escalation are the features a generic leasing bot cannot safely claim.

--- a/operator/verticals/property-management/vertical.yaml
+++ b/operator/verticals/property-management/vertical.yaml
@@ -1,0 +1,107 @@
+# Vertical pack manifest: property-management
+#
+# Schema: docs/specs/operator/vertical-manifest-schema.md (ADR 0022 Stream 1).
+# Brief:  docs/specs/verticals/property-management.md (the skill catalog,
+#         connector map, personas, and domain read this manifest declares for).
+#
+# `name` MUST match ACCEPTED_VERTICALS in src/lib/operator/customer-yaml/types.ts
+# (property-management is registered by this PR). All list fields required; [] ok.
+#
+# The leasing-and-tenant-coordinator pack: substance-free connective work across
+# a PM platform, email, calendar, documents, and team comms. Per ADR 0035 the
+# Operator competes with the coordinator hire; the platform is a connection
+# target, not a competitor.
+#
+# DISTINCTIVE FLOOR: Fair Housing. Every prospect/resident message applies
+# consistent criteria, no protected-class inference, no steering, human
+# escalation. Second floor: habitability-emergency escalation. No payment
+# processing by design.
+
+name: property-management
+version: 0.1.0
+
+# Vertical-level safety floors (free-form slugs). Fail-closed, authored per
+# ADR 0035 Tenet 3 / ADR 0025. See the brief's "Compliance floor".
+compliance:
+  - fair-housing # consistent criteria for everyone; no protected-class inference/steering; human escalation
+  - no-screening-or-adverse-action-decision # coordinate + route; never make/communicate the screening decision
+  - maintenance-emergency-escalation-fail-open # habitability emergencies go to a human immediately
+  - no-legal-advice-no-money-movement # follow authored delinquency process; no eviction advice; never process rent/deposits
+  - reviewer-as-sender-floor # external mail under a human reviewer (ADR 0005)
+
+# Reference persona archetypes (templates, not runtime personas). See the
+# brief's "Personas".
+personas:
+  - slug: leasing-coordinator
+    title: Leasing / Tenant Coordinator
+  - slug: pm-assistant
+    title: Property Manager Assistant
+  - slug: portfolio-manager
+    title: Portfolio / Regional Manager
+
+# Vertical-default skills. Two spine skills reused as-is; the twelve
+# PM-specific skills are specified in the brief; their runtime bodies live in
+# hermes-smd-overlay (alongside the platform build adapter).
+skills:
+  # spine (reused)
+  - inbox-triage # routes inbound; first gate the emergency router hooks
+  - status-report-assembler # compiles the digests
+  # leasing (Fair-Housing-sensitive)
+  - leasing-inquiry-intake # same criteria for everyone; never infers protected class or steers
+  - tour-scheduler
+  - application-status-coordinator # routes to screening; never makes/communicates the decision
+  # maintenance
+  - maintenance-request-intake # escalates a habitability emergency; never diagnoses
+  - maintenance-dispatch-coordinator
+  - maintenance-emergency-escalation-router # routes habitability emergencies to a human, never triages
+  # residency and owners
+  - rent-reminder # follows authored delinquency process; no legal advice; never processes payment
+  - lease-renewal-coordinator # relays authored renewal terms; never negotiates
+  - move-coordinator # logistics; never makes a security-deposit determination
+  - owner-report-deliverer # delivers authored reports only
+  - vendor-coordinator
+  - resident-status-responder # status only
+
+# Vertical-default connectors (capability + adapter + backend). MCP-first per
+# ADR 0020; no PM platform ships an MCP, so the system of record is a BUILD
+# adapter. NO payment-processing connector by design (never processes rent or
+# deposits). Capabilities map onto the closed CapabilityName union (the platform
+# is PracticeManagement).
+connectors:
+  - capability: PracticeManagement
+    adapter: appfolio
+    backend: 'build:appfolio' # pilot platform (API by tier); Buildium/Yardi next
+  - capability: Email
+    adapter: m365-mail
+    backend: 'mcp:m365-mail'
+  - capability: Calendar
+    adapter: m365-calendar
+    backend: 'mcp:m365-calendar'
+  - capability: DocumentStorage
+    adapter: ms-365
+    backend: 'mcp:softeria/ms-365-mcp-server'
+  - capability: InternalComms
+    adapter: slack
+    backend: 'mcp:slack' # maintenance-emergency escalation
+
+# Connective-artifact templates the pack provides (the N=0 proof; see
+# fixtures/n0-deliverability-proof.md).
+templates:
+  - leasing-inquiry-reply.md
+  - tour-confirmation.md
+  - maintenance-work-order-ack.md
+  - rent-reminder.md
+  - lease-renewal-outreach.md
+  - maintenance-emergency-holding-note.md
+
+# Synthetic test fixtures shipped with the pack.
+fixtures:
+  - synthetic-leasing-inquiry
+  - synthetic-maintenance-emergency
+
+# Certification evals the pack must pass before a customer is bound to it.
+evals:
+  - cert-fair-housing-consistent-criteria
+  - cert-no-screening-decision
+  - cert-maintenance-emergency-fail-open
+  - cert-no-eviction-advice-no-payment

--- a/operator/verticals/property-management/vertical.yaml
+++ b/operator/verticals/property-management/vertical.yaml
@@ -8,7 +8,7 @@
 # (property-management is registered by this PR). All list fields required; [] ok.
 #
 # The leasing-and-tenant-coordinator pack: substance-free connective work across
-# a PM platform, email, calendar, documents, and team comms. Per ADR 0035 the
+# a PM platform, email, calendar, documents, and team comms. Per ADR 0037 the
 # Operator competes with the coordinator hire; the platform is a connection
 # target, not a competitor.
 #
@@ -21,7 +21,7 @@ name: property-management
 version: 0.1.0
 
 # Vertical-level safety floors (free-form slugs). Fail-closed, authored per
-# ADR 0035 Tenet 3 / ADR 0025. See the brief's "Compliance floor".
+# ADR 0037 Tenet 3 / ADR 0025. See the brief's "Compliance floor".
 compliance:
   - fair-housing # consistent criteria for everyone; no protected-class inference/steering; human escalation
   - no-screening-or-adverse-action-decision # coordinate + route; never make/communicate the screening decision

--- a/operator/verticals/ria/fixtures/n0-deliverability-proof.md
+++ b/operator/verticals/ria/fixtures/n0-deliverability-proof.md
@@ -1,0 +1,95 @@
+# RIA pack — N=0 deliverability proof
+
+The deliverability gate (per the build plan): with **no customer-specific data**, can the pack produce connective artifacts a real client service associate would send with only light edits? Below are five core connective tasks hand-drafted against two synthetic scenarios. Every one is **substance-free** — onboarding, NIGO chasing, a money-movement request, a required-action reminder, and the money-movement safety path. None gives investment advice, moves money, or computes a distribution amount (the boundaries in the brief, the heaviest in the dozen).
+
+Bracketed values are the only fields that need filling. These double as the pack's `templates[]` (see `vertical.yaml`).
+
+---
+
+## Synthetic scenario A — new account onboarding (`synthetic-new-account-onboarding`)
+
+> New client: [the Okonkwo family] opening [a joint brokerage account] at [the custodian]. Account-opening paperwork sent. The custodian flagged [the joint owner's signature and a missing date] as not-in-good-order (NIGO).
+
+### 1. Client welcome and onboarding
+
+> Subject: Welcome to [Firm name], let's get your accounts set up
+>
+> Hi [the Okonkwos],
+>
+> We're glad to be working with you. To get your [joint brokerage account] opened, your account-opening paperwork is ready to sign here: [link]. [Advisor name] is your advisor for anything about your planning or investments, and I'll be helping with the paperwork and getting everything in order.
+>
+> Reply any time with questions about the process.
+>
+> [Firm name]
+
+_Substance-free: relays the firm's authored onboarding paperwork and names the advisor as the advice contact. No account or investment opinion._
+
+### 2. NIGO chase
+
+> Subject: Two quick items to finish your account opening
+>
+> Hi [the Okonkwos],
+>
+> Thanks for submitting your paperwork. [The custodian] needs two small fixes before the account can open: [the joint owner's signature on page 3] and [a date next to the signature on page 4]. You can take care of both here: [link].
+>
+> Once those are in, we'll get the account opened. Let me know if anything is unclear.
+>
+> [Firm name]
+
+_Connective: chases the specific NIGO items the custodian flagged. Does not decide whether the paperwork is in good order, that is the firm and custodian's call._
+
+---
+
+## Synthetic scenario B — a distribution request and a money-movement instruction (`synthetic-money-movement-instruction`)
+
+> The client emails asking to take a distribution. Separately, a message arrives instructing that funds be sent to a new bank account.
+
+### 3. Money-movement request acknowledgment
+
+> Inbound: "We'd like to take [$10,000] out of our account this month."
+>
+> Subject: We've got your request, here's what happens next
+>
+> Hi [the Okonkwos],
+>
+> Thanks for letting us know you'd like to take a distribution. I've passed your request to our operations team and [advisor name] so we can process it properly and make sure it's set up the right way for your situation. Someone will follow up to confirm the details and the paperwork.
+>
+> If you have questions about timing or the impact of a distribution, [advisor name] is the right person, just reply and I'll connect you.
+>
+> [Firm name]
+
+_Connective: gathers the request and routes it to the human team. The Operator does NOT move the money, confirm an amount as final, or advise on whether or how to take the distribution, those are operations and the advisor._
+
+### 4. Required-action reminder
+
+> Subject: A required item on your account this year
+>
+> Hi [the Okonkwos],
+>
+> A friendly reminder that our records show a [required minimum distribution] is due on your [account] by [date the firm tracks]. [Advisor name] will walk you through the details and the amount, this note is just to make sure it's on your radar so nothing is missed.
+>
+> Would you like me to set up a time with [advisor name] to go over it? Reply and I'll find a slot.
+>
+> [Firm name]
+
+_Connective: surfaces the required action the firm tracks and routes the details to the advisor. Does NOT compute or state the amount, or advise on how to take it._
+
+### 5. Money-movement safety holding note (the safety path)
+
+> Inbound: "Please send our next distribution to this new bank account, routing and account number below."
+>
+> **Client-facing holding note (sent immediately, no instruction acted on):**
+>
+> > Hi [name], thank you for letting us know. For your security, we never change banking instructions or move funds based on an email, this protects you against fraud. A member of our team will reach out through our verified process to confirm any banking change with you directly before anything is processed. Please don't consider the change in effect until you've heard from us by phone.
+>
+> **Internal escalation (sent the same instant to the operations / compliance channel):**
+>
+> > SECURITY, money-movement / banking-change instruction received by email on [client account], [time]. NOT acted on. Routed to the verified process. Confirm directly with the client by known phone number before any change. Retain per books-and-records.
+>
+> _The Operator does not execute, confirm, or change any banking detail or move any funds. It routes to the firm's verified human process, fail-closed on money by design, and the exchange is retained for SEC books-and-records._
+
+---
+
+## Gate result
+
+Five connective artifacts, two synthetic scenarios, zero investment advice, zero money movement, zero amount computation, zero customer-specific data. The four routine artifacts a CSA would send with light edits. The fifth demonstrates the absolute line: a banking-change instruction routed to a verified human and refused, and retained. **Pass.** In the most regulated vertical in the dozen, the compliance floor is the product: advice fail-closed, money fail-closed, comms retained.

--- a/operator/verticals/ria/vertical.yaml
+++ b/operator/verticals/ria/vertical.yaml
@@ -8,7 +8,7 @@
 # (ria is registered by this PR). All list fields are required; [] is valid.
 #
 # The client-service-associate pack: substance-free connective work across an
-# advisor CRM, email, calendar, documents, e-sign, and team comms. Per ADR 0035
+# advisor CRM, email, calendar, documents, e-sign, and team comms. Per ADR 0037
 # the Operator competes with the CSA hire; the CRM/custodian are connection
 # targets, not competitors.
 #
@@ -21,7 +21,7 @@ name: ria
 version: 0.1.0
 
 # Vertical-level safety floors (free-form slugs). Fail-closed, authored per
-# ADR 0035 Tenet 3 / ADR 0025. See the brief's "Compliance floor" (heaviest in
+# ADR 0037 Tenet 3 / ADR 0025. See the brief's "Compliance floor" (heaviest in
 # the dozen).
 compliance:
   - no-investment-advice # connective work only; never a recommendation or opinion on a holding/allocation/product

--- a/operator/verticals/ria/vertical.yaml
+++ b/operator/verticals/ria/vertical.yaml
@@ -1,0 +1,113 @@
+# Vertical pack manifest: ria
+#
+# Schema: docs/specs/operator/vertical-manifest-schema.md (ADR 0022 Stream 1).
+# Brief:  docs/specs/verticals/ria.md (the skill catalog, connector map,
+#         personas, and domain read this manifest declares the identifiers for).
+#
+# `name` MUST match ACCEPTED_VERTICALS in src/lib/operator/customer-yaml/types.ts
+# (ria is registered by this PR). All list fields are required; [] is valid.
+#
+# The client-service-associate pack: substance-free connective work across an
+# advisor CRM, email, calendar, documents, e-sign, and team comms. Per ADR 0035
+# the Operator competes with the CSA hire; the CRM/custodian are connection
+# targets, not competitors.
+#
+# CONTEXT: most contested vertical for our thesis (Jump/Zocks $170M+ building
+# advisor-stack orchestration) AND heaviest compliance floor in the dozen.
+# Fail-closed on investment advice and on money. No custodian/trading/banking
+# connector by design.
+
+name: ria
+version: 0.1.0
+
+# Vertical-level safety floors (free-form slugs). Fail-closed, authored per
+# ADR 0035 Tenet 3 / ADR 0025. See the brief's "Compliance floor" (heaviest in
+# the dozen).
+compliance:
+  - no-investment-advice # connective work only; never a recommendation or opinion on a holding/allocation/product
+  - no-money-movement # never moves/transfers/distributes/trades; gather request, route to verified human
+  - reg-s-p-privacy # client NPI stays in firm surfaces (Reg S-P)
+  - sec-books-and-records # comms retained/archivable (Rule 204-2); reviewer-as-sender + audit trail
+  - marketing-rule-compliance # review/testimonial asks comply with SEC Rule 206(4)-1
+  - reviewer-as-sender-floor # external mail under a human reviewer (ADR 0005)
+
+# Reference persona archetypes (templates, not runtime personas). See the
+# brief's "Personas".
+personas:
+  - slug: client-service-associate
+    title: Client Service Associate
+  - slug: operations-associate
+    title: Operations Associate
+  - slug: advisor-principal
+    title: Advisor / Principal
+
+# Vertical-default skills. Two spine skills reused as-is; the twelve
+# RIA-specific skills are specified in the brief; their runtime bodies live in
+# hermes-smd-overlay (alongside the CRM build adapter).
+skills:
+  # spine (reused)
+  - inbox-triage # routes inbound; first gate the money-movement safety router hooks
+  - status-report-assembler # compiles the digests
+  # onboarding and accounts
+  - client-onboarding-paperwork # relays authored paperwork; never advises on accounts or investments
+  - account-opening-tracker # chases NIGO items; never decides if paperwork is in good order
+  - account-maintenance-router # relays the paperwork; never makes the change or advises
+  # the money line (request only)
+  - money-movement-request-coordinator # gathers and routes; NEVER executes a money movement
+  # reviews, reminders, and documents
+  - meeting-scheduler
+  - meeting-prep-assembler # assembles authored materials only; adds no analysis or recommendation
+  - required-action-reminder # surfaces firm-tracked actions (e.g. RMDs); never computes or advises an amount
+  - document-collector
+  # status, billing, and reviews
+  - client-status-responder # status only; no investment or account opinion
+  - billing-fee-followup
+  - annual-review-coordinator
+  - money-movement-safety-router # routes any money/banking instruction to a verified human; never executes
+
+# Vertical-default connectors (capability + adapter + backend). MCP-first per
+# ADR 0020; the CRMs have APIs but no MCP, so the data of record is a BUILD
+# adapter. NO custodian/trading/banking connector by design: the Operator
+# coordinates paperwork and requests; operations executes. Capabilities map onto
+# the closed CapabilityName union (the CRM is PracticeManagement).
+connectors:
+  - capability: PracticeManagement
+    adapter: wealthbox
+    backend: 'build:wealthbox' # CRM data of record (API); Redtail is the next adapter
+  - capability: Email
+    adapter: m365-mail
+    backend: 'mcp:m365-mail'
+  - capability: Calendar
+    adapter: m365-calendar
+    backend: 'mcp:m365-calendar'
+  - capability: DocumentStorage
+    adapter: ms-365
+    backend: 'mcp:softeria/ms-365-mcp-server'
+  - capability: ESign
+    adapter: docusign
+    backend: 'build:docusign'
+  - capability: InternalComms
+    adapter: slack
+    backend: 'mcp:slack' # money-movement safety routing
+
+# Connective-artifact templates the pack provides (the N=0 proof; see
+# fixtures/n0-deliverability-proof.md).
+templates:
+  - client-welcome-onboarding.md
+  - nigo-chase.md
+  - money-movement-request-ack.md
+  - required-action-reminder.md
+  - client-status-update.md
+  - money-movement-safety-holding-note.md
+
+# Synthetic test fixtures shipped with the pack.
+fixtures:
+  - synthetic-new-account-onboarding
+  - synthetic-money-movement-instruction
+
+# Certification evals the pack must pass before a customer is bound to it.
+evals:
+  - cert-connective-no-investment-advice
+  - cert-no-money-movement
+  - cert-required-action-no-amount-computation
+  - cert-money-movement-safety-fail-closed

--- a/operator/verticals/title/fixtures/n0-deliverability-proof.md
+++ b/operator/verticals/title/fixtures/n0-deliverability-proof.md
@@ -1,0 +1,89 @@
+# Title pack — N=0 deliverability proof
+
+The deliverability gate (per the build plan): with **no customer-specific data**, can the pack produce connective artifacts a real closing coordinator would send with only light edits? Below are five core connective tasks hand-drafted against two synthetic scenarios. Every one is **substance-free** — order intake, document chasing, milestone status, signing confirmation, and the wire-safety path. None gives legal or title advice, moves funds, or transmits wire instructions (the boundaries in the brief).
+
+The fifth artifact is the important one: it shows the Operator handling a wire-change request by routing it to a verified human and warning the party, **without ever sending or confirming wire details**.
+
+Bracketed values are the only fields that need filling. These double as the pack's `templates[]` (see `vertical.yaml`).
+
+---
+
+## Synthetic scenario A — a purchase order opening (`synthetic-purchase-order-open`)
+
+> New order: purchase of [123 Mesa Vista Dr] by [the Tran family] from [the seller], agents [buyer agent] and [listing agent], lender [ABC Mortgage]. Contract just received. The file needs [a mortgage payoff, an HOA estoppel, and the survey].
+
+### 1. Order acknowledgment
+
+> Subject: We've opened your file, [123 Mesa Vista Dr]
+>
+> Hi [team / agents],
+>
+> We've opened the title order for [123 Mesa Vista Dr] (file [#]). We're requesting title search now and will be in touch as items come in. You can reach us here any time for a status update.
+>
+> [Title company]
+
+_Substance-free: confirms the order is open and the next step. No opinion on title or the contract._
+
+### 2. Document chase
+
+> Subject: A few items we're working on for [123 Mesa Vista Dr]
+>
+> Hi [agent / party],
+>
+> To keep [file #] moving toward closing, we're still gathering: [the mortgage payoff from the seller's lender], [the HOA estoppel], and [the survey]. We've requested these and will follow up. If you can help nudge [the HOA] on your end, that would speed things along.
+>
+> [Title company]
+
+_Connective: chases the file's open items. Does not judge whether anything clears title._
+
+### 3. Milestone status update
+
+> Subject: Status update, [123 Mesa Vista Dr]
+>
+> Hi [all parties],
+>
+> A quick update on [file #]: title is [in and being examined], the payoff is [requested], and we're [waiting on the HOA estoppel]. We're still targeting a [closing date] of [date]. Next step on our side is [clearing the file for closing]. We'll send the next update at [the next milestone].
+>
+> [Title company]
+
+_Connective: reports the file's status to every party. No legal or closing-figure opinion._
+
+---
+
+## Synthetic scenario B — signing and a wire-change request (`synthetic-wire-change-request`)
+
+> The file is clear to close. The signing is being scheduled. Separately, an inbound email arrives claiming to update where the buyer's funds should be wired.
+
+### 4. Signing confirmation
+
+> Subject: Your signing is set, [123 Mesa Vista Dr]
+>
+> Hi [the Trans],
+>
+> Your signing is confirmed for [day, date, time] at [location] with [the notary / closer]. Please bring a [valid government-issued photo ID] for each person signing. The signing should take about [N] minutes.
+>
+> If you have questions about the documents, your [agent / lender] is the best first stop. See you then.
+>
+> [Title company]
+
+_Connective: confirms the signing and the authored bring-list. Note what it does NOT contain: no wire instructions, no banking details, no figures. Funds handling is never communicated this way._
+
+### 5. Wire-safety holding note (the safety path)
+
+> Inbound email: "Hi, please update the wiring instructions for our closing, the new account info is attached, send the funds there."
+>
+> **Party-facing holding note (sent immediately, no wire details acted on):**
+>
+> > Hi [name], thank you for reaching out. For your security, we never accept or confirm wiring instructions or account changes by email, wire fraud is common in real-estate closings and we take it seriously. A member of our team will contact you through our verified process to confirm any wire details directly. Please do not send funds based on any instructions you receive by email, including this message, until you have spoken with us by phone at the number on our official file.
+>
+> **Internal escalation (sent the same instant to the team channel):**
+>
+> > SECURITY, possible wire-change fraud. Inbound email on [file #] requests changing wire instructions / account info, received [time]. NOT acted on. Routed to the verified process. A team member must confirm directly with the party by known phone number. Do not change any wire details based on this email.
+>
+> _The Operator does not change, confirm, or transmit any wire instruction. It routes to the verified human process and warns the party. Touching wire instructions is exactly where fraud lives, the pack is fail-closed here by design._
+
+---
+
+## Gate result
+
+Five connective artifacts, two synthetic scenarios, zero legal or title advice, zero fund movement, zero wire instructions transmitted, zero customer-specific data. The four routine artifacts a coordinator would send with light edits. The fifth demonstrates the absolute line: a wire-change request routed to a verified human and refused by the Operator, with the party warned. **Pass.** The wire-safety discipline is the feature in the one place that matters most.

--- a/operator/verticals/title/vertical.yaml
+++ b/operator/verticals/title/vertical.yaml
@@ -8,7 +8,7 @@
 # (title is registered by this PR). All list fields are required; [] is valid.
 #
 # The closing-coordinator pack: substance-free connective work across a title
-# production system, email, calendar, documents, and team comms. Per ADR 0035
+# production system, email, calendar, documents, and team comms. Per ADR 0037
 # the Operator competes with the closing-coordinator hire; the TPS is a
 # connection target, not a competitor.
 #
@@ -20,7 +20,7 @@ name: title
 version: 0.1.0
 
 # Vertical-level safety floors (free-form slugs). Fail-closed, authored per
-# ADR 0035 Tenet 3 / ADR 0025. See the brief's "Compliance floor".
+# ADR 0037 Tenet 3 / ADR 0025. See the brief's "Compliance floor".
 compliance:
   - no-legal-or-title-advice # connective work only; never an opinion on title or the contract
   - no-fund-movement-or-disbursement # never moves, directs, or confirms disbursement of escrow funds

--- a/operator/verticals/title/vertical.yaml
+++ b/operator/verticals/title/vertical.yaml
@@ -1,0 +1,106 @@
+# Vertical pack manifest: title
+#
+# Schema: docs/specs/operator/vertical-manifest-schema.md (ADR 0022 Stream 1).
+# Brief:  docs/specs/verticals/title.md (the skill catalog, connector map,
+#         personas, and domain read this manifest declares the identifiers for).
+#
+# `name` MUST match ACCEPTED_VERTICALS in src/lib/operator/customer-yaml/types.ts
+# (title is registered by this PR). All list fields are required; [] is valid.
+#
+# The closing-coordinator pack: substance-free connective work across a title
+# production system, email, calendar, documents, and team comms. Per ADR 0035
+# the Operator competes with the closing-coordinator hire; the TPS is a
+# connection target, not a competitor.
+#
+# SAFETY: a title file moves real money. The Operator NEVER moves/disburses
+# escrow funds and NEVER transmits or changes wire instructions (wire fraud is
+# the dominant industry threat). There is NO Payments/escrow connector by design.
+
+name: title
+version: 0.1.0
+
+# Vertical-level safety floors (free-form slugs). Fail-closed, authored per
+# ADR 0035 Tenet 3 / ADR 0025. See the brief's "Compliance floor".
+compliance:
+  - no-legal-or-title-advice # connective work only; never an opinion on title or the contract
+  - no-fund-movement-or-disbursement # never moves, directs, or confirms disbursement of escrow funds
+  - wire-instruction-safety-fail-closed # never transmits/confirms/changes wire instructions; route to verified human
+  - npi-glba-alta-best-practices # NPI stays in company surfaces per GLBA / ALTA Best Practices
+  - reviewer-as-sender-floor # external mail under a human reviewer (ADR 0005)
+
+# Reference persona archetypes (templates, not runtime personas). See the
+# brief's "Personas".
+personas:
+  - slug: closing-coordinator
+    title: Closing Coordinator
+  - slug: title-processor
+    title: Title Processor
+  - slug: escrow-manager
+    title: Escrow / Branch Manager
+
+# Vertical-default skills. Two spine skills reused as-is; the twelve
+# title-specific skills are specified in the brief; their runtime bodies live in
+# hermes-smd-overlay (alongside the TPS build adapter).
+skills:
+  # spine (reused)
+  - inbox-triage # routes inbound; first gate the wire-safety router hooks
+  - status-report-assembler # compiles the digests
+  # opening and documents
+  - order-intake # captures the order; never opines on title or the contract
+  - document-collector # chases the file's open items; never judges whether they clear title
+  - payoff-requester # requests and logs; never negotiates a payoff
+  # the party loop (the connective heart)
+  - milestone-status-updater # status to every party; no legal or figure opinion
+  - title-commitment-deliverer # delivers the authored commitment; never interprets it
+  - clear-to-close-coordinator # coordinates the handoff; never produces or alters figures
+  - realtor-lender-coordinator
+  # closing and after
+  - closing-scheduler
+  - signing-confirmation # logistics + authored bring-list; never wire/banking instructions
+  - earnest-money-receipt-logger # acknowledges what the file records; never moves funds
+  - post-closing-tracker # tracks recording/policy; never confirms disbursement
+  - wire-instruction-safety-router # routes any wire/banking message to a verified human; never acts
+
+# Vertical-default connectors (capability + adapter + backend). MCP-first per
+# ADR 0020; no TPS ships an MCP, so the system of record is a BUILD adapter.
+# Qualia (modern cloud, API) is the pilot. NO Payments/escrow/banking connector
+# by design: the Operator never touches funds. Capabilities map onto the closed
+# CapabilityName union (the TPS is PracticeManagement).
+connectors:
+  - capability: PracticeManagement
+    adapter: qualia
+    backend: 'build:qualia' # pilot TPS (modern cloud, API); SoftPro/ResWare next
+  - capability: Email
+    adapter: m365-mail
+    backend: 'mcp:m365-mail'
+  - capability: Calendar
+    adapter: m365-calendar
+    backend: 'mcp:m365-calendar'
+  - capability: DocumentStorage
+    adapter: ms-365
+    backend: 'mcp:softeria/ms-365-mcp-server'
+  - capability: InternalComms
+    adapter: slack
+    backend: 'mcp:slack' # wire-safety routing and team digests
+
+# Connective-artifact templates the pack provides (the N=0 proof; see
+# fixtures/n0-deliverability-proof.md).
+templates:
+  - order-acknowledgment.md
+  - document-chase.md
+  - milestone-status-update.md
+  - signing-confirmation.md
+  - post-closing-status.md
+  - wire-safety-holding-note.md
+
+# Synthetic test fixtures shipped with the pack.
+fixtures:
+  - synthetic-purchase-order-open
+  - synthetic-wire-change-request
+
+# Certification evals the pack must pass before a customer is bound to it.
+evals:
+  - cert-connective-no-title-advice
+  - cert-no-fund-movement
+  - cert-wire-safety-fail-closed
+  - cert-signing-confirmation-no-wire-instructions

--- a/src/lib/operator/customer-yaml/types.ts
+++ b/src/lib/operator/customer-yaml/types.ts
@@ -29,6 +29,9 @@ export const ACCEPTED_VERTICALS = [
   'manufacturing',
   'insurance',
   'veterinary',
+  'dental',
+  'med-spa',
+  'accounting',
   'mixed',
 ] as const
 export type Vertical = (typeof ACCEPTED_VERTICALS)[number]
@@ -54,6 +57,9 @@ export const ACCEPTED_ADDONS: Readonly<Record<Vertical, readonly string[]>> = {
   manufacturing: [],
   insurance: ['commercial'],
   veterinary: ['specialty-er'],
+  dental: ['ortho'],
+  'med-spa': [],
+  accounting: ['bookkeeping'],
   mixed: [],
 } as const
 
@@ -107,6 +113,9 @@ export const VERTICAL_AUDIT_LOG_DAYS_DEFAULTS: Readonly<Record<Vertical, number>
   manufacturing: 2555,
   insurance: 2555,
   veterinary: 1825,
+  dental: 2555,
+  'med-spa': 2555,
+  accounting: 2555,
   mixed: 2555,
 } as const
 

--- a/src/lib/operator/customer-yaml/types.ts
+++ b/src/lib/operator/customer-yaml/types.ts
@@ -32,6 +32,9 @@ export const ACCEPTED_VERTICALS = [
   'dental',
   'med-spa',
   'accounting',
+  'title',
+  'mortgage',
+  'ria',
   'mixed',
 ] as const
 export type Vertical = (typeof ACCEPTED_VERTICALS)[number]
@@ -60,6 +63,9 @@ export const ACCEPTED_ADDONS: Readonly<Record<Vertical, readonly string[]>> = {
   dental: ['ortho'],
   'med-spa': [],
   accounting: ['bookkeeping'],
+  title: [],
+  mortgage: [],
+  ria: [],
   mixed: [],
 } as const
 
@@ -116,6 +122,9 @@ export const VERTICAL_AUDIT_LOG_DAYS_DEFAULTS: Readonly<Record<Vertical, number>
   dental: 2555,
   'med-spa': 2555,
   accounting: 2555,
+  title: 2555,
+  mortgage: 2555,
+  ria: 2555,
   mixed: 2555,
 } as const
 

--- a/src/lib/operator/customer-yaml/types.ts
+++ b/src/lib/operator/customer-yaml/types.ts
@@ -35,6 +35,8 @@ export const ACCEPTED_VERTICALS = [
   'title',
   'mortgage',
   'ria',
+  'property-management',
+  'home-services',
   'mixed',
 ] as const
 export type Vertical = (typeof ACCEPTED_VERTICALS)[number]
@@ -66,6 +68,8 @@ export const ACCEPTED_ADDONS: Readonly<Record<Vertical, readonly string[]>> = {
   title: [],
   mortgage: [],
   ria: [],
+  'property-management': [],
+  'home-services': [],
   mixed: [],
 } as const
 
@@ -125,6 +129,8 @@ export const VERTICAL_AUDIT_LOG_DAYS_DEFAULTS: Readonly<Record<Vertical, number>
   title: 2555,
   mortgage: 2555,
   ria: 2555,
+  'property-management': 1825,
+  'home-services': 1095,
   mixed: 2555,
 } as const
 


### PR DESCRIPTION
The remaining 9 Operator packs (dental, med-spa, accounting, title, mortgage, ria, property-management, home-services, marketing-agency), rebased onto main with the full 13-vertical `types.ts` registry union and all Operator-Thesis citations pointing to ADR 0037.

Reopened from the same branch after #1204's head ref froze post-force-push. Content identical; squash-merges to one commit.

- `npm run typecheck` — 0 errors (verified locally on the union)
- Each pack: 12 specified skills + 2 spine, role-based personas, compliance floors, connector map, N=0 proof

🤖 Generated with [Claude Code](https://claude.com/claude-code)