### PR TITLE
feat(operator): dual-mode Google auth — service-account domain-wide delegation

### DIFF
--- a/operator/connectors/google/_google_auth.py
+++ b/operator/connectors/google/_google_auth.py
@@ -1,21 +1,37 @@
 #!/usr/bin/env python3
-"""_google_auth.py — shared user-OAuth credential plumbing for the Operator's
+"""_google_auth.py — shared Google credential plumbing for the Operator's
 Google connector CLIs (crane_gmail.py, crane_calendar.py, crane_drive.py).
 
-One scope-limited Google authorized-user token serves all three connectors. The
-token (refresh_token + client_id + client_secret + granted scopes) lives on the
-per-customer Fly volume; this module loads it, auto-refreshes the access token,
-and persists the refreshed token back (0600 preserved). Google API client
-libraries are imported lazily inside the functions so importing this module (and
-the CLIs that import it) carries no hard dependency on google-* packages — the
-`capabilities` subcommands and the conformance suite run without them.
+Two AUTHORED credential shapes share one on-disk path and one entry point
+(`credentials()` → `service()`); the loader dispatches on the JSON's `type`:
+
+  * **authorized-user token** (user-OAuth; the default, no `type` or
+    `"type": "authorized_user"`). A scope-limited token a principal minted at
+    consent (refresh_token + client_id + client_secret + granted scopes) lives
+    on the per-customer Fly volume; we load it, auto-refresh the access token,
+    and persist the refreshed token back (0600 preserved).
+
+  * **service-account key** (`"type": "service_account"`; domain-wide
+    delegation). For a Workspace client whose own super-admin authorized our
+    service account's client ID, the Operator impersonates a user. The key
+    mints short-lived tokens on demand — there is NO refresh_token and nothing
+    is persisted. The impersonation subject and the requested scopes are
+    AUTHORED entitlement, sourced from the environment ($GOOGLE_IMPERSONATE_SUBJECT
+    / $GOOGLE_OAUTH_SCOPES, materialized from customer.yaml), never defaulted;
+    the loader is fail-closed if either is absent. The hard wall on top is what
+    the client's admin authorized for that client ID in their Admin console.
+
+Google API client libraries are imported lazily inside the functions so importing
+this module (and the CLIs that import it) carries no hard dependency on google-*
+packages — the `capabilities` subcommands and the conformance suite run without
+them.
 
 Governability note (ADR 0035 / ADR 0020): the security boundary is the TOKEN
-SCOPE granted at consent, not the verbs these CLIs expose. `execute_code` can
-read this same token and call Google at its full granted scope, so the adapters'
-verb minimalism is ergonomics; the hard wall is what Google itself permits for
-the granted scopes (e.g. `gmail.modify` cannot send). The scope set is an
-AUTHORED entitlement (what the principal consented to), never a harness default.
+SCOPE granted at consent (user-OAuth) or authorized for the client ID in the
+Admin console (DWD), not the verbs these CLIs expose. `execute_code` can read the
+same credential and call Google at its full granted scope, so the adapters' verb
+minimalism is ergonomics; the hard wall is what Google itself permits. The scope
+set is an AUTHORED entitlement, never a harness default.
 
 Token resolution order: explicit path arg, else $GOOGLE_TOKEN_PATH, else
 /opt/data/oauth/google.json (the per-customer Fly volume path, ADR 0010).
@@ -24,9 +40,16 @@ Token resolution order: explicit path arg, else $GOOGLE_TOKEN_PATH, else
 from __future__ import annotations
 
 import argparse
+import json
 import os
 
 DEFAULT_TOKEN = "/opt/data/oauth/google.json"
+
+# DWD (service-account) mode reads its authored entitlement from these env vars.
+# They are materialized onto the Machine from customer.yaml (boot wiring is a
+# follow-on); user-OAuth mode ignores them.
+SCOPES_ENV = "GOOGLE_OAUTH_SCOPES"
+SUBJECT_ENV = "GOOGLE_IMPERSONATE_SUBJECT"
 
 
 def resolve_token_path(explicit: str | None = None) -> str:
@@ -39,21 +62,58 @@ def add_token_arg(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--token",
         default=os.environ.get("GOOGLE_TOKEN_PATH", DEFAULT_TOKEN),
-        help="Path to the Google authorized-user token JSON (default: %(default)s).",
+        help="Path to the Google credential JSON (default: %(default)s).",
     )
 
 
-def credentials(token_path: str):
-    """Load the authorized-user token, refreshing + persisting if expired.
+def _parse_scopes(raw: str) -> list[str]:
+    """Split a scopes env value on commas and/or whitespace, dropping empties."""
+    return raw.replace(",", " ").split()
 
-    Raises RuntimeError if the token is invalid and not refreshable (the
-    operator must re-run consent). Google libraries are imported here, not at
-    module top, so this file imports cleanly without google-* installed.
+
+def _load_token_info(token_path: str) -> dict:
+    """Read and parse the on-disk credential JSON (used to dispatch on `type`)."""
+    with open(token_path, encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def _service_account_credentials(info: dict):
+    """Build domain-wide-delegation credentials from a service-account key.
+
+    Scopes and the impersonation subject are AUTHORED entitlement (ADR 0035),
+    sourced from the environment, never defaulted — fail-closed if absent. Env
+    is validated BEFORE the lazy google import so the fail-closed contract holds
+    even where google-* is not installed.
+    """
+    scopes = _parse_scopes(os.environ.get(SCOPES_ENV, ""))
+    subject = os.environ.get(SUBJECT_ENV, "").strip()
+    if not scopes:
+        raise RuntimeError(
+            f"service-account credential requires {SCOPES_ENV} (authored scopes); none set"
+        )
+    if not subject:
+        raise RuntimeError(
+            f"service-account credential requires {SUBJECT_ENV} "
+            "(user to impersonate); none set"
+        )
+
+    from google.oauth2 import service_account
+
+    return service_account.Credentials.from_service_account_info(
+        info, scopes=scopes, subject=subject
+    )
+
+
+def _authorized_user_credentials(token_path: str, info: dict):
+    """Load a user-OAuth token, refreshing + persisting the access token if expired.
+
+    Raises RuntimeError if the token is invalid and not refreshable (the operator
+    must re-run consent).
     """
     from google.auth.transport.requests import Request
     from google.oauth2.credentials import Credentials
 
-    creds = Credentials.from_authorized_user_file(token_path)
+    creds = Credentials.from_authorized_user_info(info)
     if not creds.valid:
         if creds.expired and creds.refresh_token:
             creds.refresh(Request())
@@ -64,6 +124,20 @@ def credentials(token_path: str):
         else:
             raise RuntimeError("token invalid and not refreshable (re-run consent)")
     return creds
+
+
+def credentials(token_path: str):
+    """Load Google credentials, dispatching on the on-disk credential kind.
+
+    `"type": "service_account"` → domain-wide delegation (impersonation, no
+    persist); anything else → user-OAuth authorized-user token (refresh +
+    persist). Google libraries are imported inside the branch helpers, not at
+    module top, so this file imports cleanly without google-* installed.
+    """
+    info = _load_token_info(token_path)
+    if info.get("type") == "service_account":
+        return _service_account_credentials(info)
+    return _authorized_user_credentials(token_path, info)
 
 
 def service(api: str, version: str, token_path: str):

--- a/operator/connectors/google/tests/test_google_auth_credentials.py
+++ b/operator/connectors/google/tests/test_google_auth_credentials.py
@@ -1,0 +1,74 @@
+"""Unit coverage for `_google_auth.credentials()` dual-mode dispatch.
+
+These tests run WITHOUT google-* installed (like the conformance suite): the
+dispatch decision and the service-account fail-closed contract are exercised
+before any lazy google import, and the branch builders are monkeypatched to
+sentinels so we never construct real credentials here.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import _google_auth  # type: ignore[import-not-found]
+
+
+def _write(tmp_path: Path, info: dict) -> str:
+    p = tmp_path / "cred.json"
+    p.write_text(json.dumps(info), encoding="utf-8")
+    return str(p)
+
+
+def test_parse_scopes_handles_commas_whitespace_and_empties():
+    assert _google_auth._parse_scopes("a b c") == ["a", "b", "c"]
+    assert _google_auth._parse_scopes("a,b,c") == ["a", "b", "c"]
+    assert _google_auth._parse_scopes(" a, b ,\n c ") == ["a", "b", "c"]
+    assert _google_auth._parse_scopes("") == []
+    assert _google_auth._parse_scopes("   ,  ") == []
+
+
+def test_credentials_routes_service_account(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        _google_auth, "_service_account_credentials", lambda info: ("SA", info)
+    )
+    monkeypatch.setattr(
+        _google_auth,
+        "_authorized_user_credentials",
+        lambda *a, **k: pytest.fail("authorized_user path must not run for a SA key"),
+    )
+    path = _write(tmp_path, {"type": "service_account", "client_email": "x@y.iam"})
+    kind, info = _google_auth.credentials(path)
+    assert kind == "SA"
+    assert info["type"] == "service_account"
+
+
+def test_credentials_routes_authorized_user_when_no_type(tmp_path, monkeypatch):
+    # The relayed user-OAuth token carries no `type` field — must NOT be treated
+    # as a service account.
+    monkeypatch.setattr(
+        _google_auth,
+        "_service_account_credentials",
+        lambda info: pytest.fail("SA path must not run for an authorized-user token"),
+    )
+    monkeypatch.setattr(
+        _google_auth, "_authorized_user_credentials", lambda token_path, info: "USER"
+    )
+    path = _write(tmp_path, {"refresh_token": "r", "client_id": "c", "client_secret": "s"})
+    assert _google_auth.credentials(path) == "USER"
+
+
+def test_service_account_fails_closed_without_scopes(tmp_path, monkeypatch):
+    monkeypatch.delenv(_google_auth.SCOPES_ENV, raising=False)
+    monkeypatch.setenv(_google_auth.SUBJECT_ENV, "user@example.com")
+    with pytest.raises(RuntimeError, match=_google_auth.SCOPES_ENV):
+        _google_auth._service_account_credentials({"type": "service_account"})
+
+
+def test_service_account_fails_closed_without_subject(tmp_path, monkeypatch):
+    monkeypatch.setenv(_google_auth.SCOPES_ENV, "https://www.googleapis.com/auth/calendar")
+    monkeypatch.delenv(_google_auth.SUBJECT_ENV, raising=False)
+    with pytest.raises(RuntimeError, match=_google_auth.SUBJECT_ENV):
+        _google_auth._service_account_credentials({"type": "service_account"})


### PR DESCRIPTION
## Summary
- `_google_auth.credentials()` now dispatches on the on-disk credential's `type`: `"type": "service_account"` → domain-wide delegation (impersonate `$GOOGLE_IMPERSONATE_SUBJECT` at authored `$GOOGLE_OAUTH_SCOPES`, no refresh/persist); anything else → the existing user-OAuth path, behavior unchanged.
- DWD env (scopes + subject) is **authored entitlement** (ADR 0035), validated **before** the lazy google import → **fail-closed** even without `google-*` installed.
- Connector-side enablement for the **zero-verification Workspace-client path**: a client whose own super-admin authorizes our service account's client ID is Internal-to-their-org (no CASA, no consent screen). Backward-compatible and **dormant** — customer-zero (user-OAuth) is identical; the SA path only activates when a service-account key + the two env vars are present on a Machine.
- `service()` and the three CLIs (`crane_gmail`/`crane_calendar`/`crane_drive`) are untouched.

## Out of scope (follow-on)
Boot wiring — land the SA key at `/opt/data/oauth/google.json` and materialize `GOOGLE_OAUTH_SCOPES` / `GOOGLE_IMPERSONATE_SUBJECT` from `customer.yaml`. Without it the SA path is inert (by design).

## Test plan
- [x] `npm run verify` passes (TS pipeline; exit 0)
- [x] `python3 -m pytest operator/connectors/google/tests/` — 11/11 (6 baseline + 5 new)
- [x] `_google_auth` imports clean without `google-*`
- [x] ruff clean on changed Python

🤖 Generated with [Claude Code](https://claude.com/claude-code)