### PR TITLE
fix(operator): skill→volume deploy seed + author-time skill-body guard (#1206)

### DIFF
--- a/operator/templates/bootstrap.sh
+++ b/operator/templates/bootstrap.sh
@@ -247,6 +247,36 @@ fi
 # Redis remain installed in the image (for Phase 2) but are not started here.
 
 # ============================================================================
+# Step 6b: seed/refresh the repo skill catalog onto the volume (#1206)
+# ============================================================================
+# Repo skills are baked into the image at /app/skills (Dockerfile
+# `COPY operator/skills/ /app/skills/`), but the catalog the overlay's
+# pin-resolver reads at step 7 is ${HERMES_HOME}/skills (= /opt/data/skills, the
+# Fly VOLUME). On a persisted volume the baked catalog is SHADOWED — the SAME
+# failure mode handled for the overlay plugin pack further below — so a skill
+# added to the repo and bound in customer.yaml is present in the image but
+# ABSENT on the volume the resolver checks, and `hermes-smd bootstrap` (step 7)
+# crash-loops with "skill '<name>' not found at /opt/data/skills/<name>"
+# (#1197, #1206).
+#
+# Fix: additively overlay /app/skills onto ${HERMES_HOME}/skills on every boot.
+# ADDITIVE, never a destructive mirror — agent-authored skills that live only on
+# the volume (ADR 0017) are preserved; repo skills are refreshed to the image
+# version (the image is the deploy unit). The copy runs as the hermes user into
+# the hermes-owned volume. FAIL-CLOSED: a Machine whose bound catalog cannot be
+# seeded MUST NOT proceed to a guaranteed crash-loop with a misleading error.
+if [ -d /app/skills ]; then
+  log "Seeding repo skill catalog onto the volume (/app/skills -> ${HERMES_HOME}/skills)..."
+  mkdir -p "${HERMES_HOME}/skills" \
+    || die "cannot create ${HERMES_HOME}/skills for the skill catalog seed"
+  cp -a /app/skills/. "${HERMES_HOME}/skills/" \
+    || die "skill catalog seed failed (/app/skills -> ${HERMES_HOME}/skills) — refusing to boot into a crash-loop"
+  log "Skill catalog seeded ($(find "${HERMES_HOME}/skills" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ') skill dir(s) on volume)"
+else
+  log "WARNING: /app/skills absent from image; skipping catalog seed (bound skills must already be on the volume)"
+fi
+
+# ============================================================================
 # Step 7: hermes-smd bootstrap (customer.yaml -> per-profile config)
 # ============================================================================
 # Installed at image build time via `pip install hermes-smd-overlay`. Reads

--- a/scripts/validate-customer-yaml.ts
+++ b/scripts/validate-customer-yaml.ts
@@ -13,21 +13,58 @@
  *
  * Exit codes:
  *   0 — valid
- *   1 — schema validation errors (printed to stderr)
+ *   1 — schema validation errors OR a bound skill with no deployable body
  *   2 — file not readable / not parseable YAML
  *
  * Called by `operator/bin/provision-customer.sh` before any Fly action.
  */
 
-import { readFileSync } from 'node:fs'
-import { resolve } from 'node:path'
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { parse as parseYaml } from 'yaml'
 
 import { validate } from '../src/lib/operator/customer-yaml'
 
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+
 function fail(code: number, message: string): never {
   process.stderr.write(`${message}\n`)
   process.exit(code)
+}
+
+/**
+ * Every enabled `personas[].skills[]` name, deduped. The runtime pin-resolver
+ * (overlay `translate._resolve_skill_pins`) hard-fails boot when a bound skill
+ * has no body on the volume, so a missing body is a boot crash-loop (#1206).
+ */
+function boundSkillNames(value: unknown): string[] {
+  const names = new Set<string>()
+  const personas = (value as { personas?: unknown }).personas
+  if (!Array.isArray(personas)) return []
+  for (const persona of personas) {
+    const skills = (persona as { skills?: unknown }).skills
+    if (!Array.isArray(skills)) continue
+    for (const entry of skills) {
+      const skill = entry as { name?: unknown; enabled?: unknown }
+      if (skill.enabled === true && typeof skill.name === 'string' && skill.name.length > 0) {
+        names.add(skill.name)
+      }
+    }
+  }
+  return [...names]
+}
+
+/**
+ * A bound skill is deployable if its body exists either in the shared repo
+ * catalog (`operator/skills/<name>/`, baked into the image) or in the
+ * customer-local catalog (`<customer.yaml dir>/skills/<name>/`). Mirrors the
+ * two lookup locations in `operator/adapter/resolve_skill_pins.py`.
+ */
+function skillBodyExists(name: string, customerYamlPath: string): boolean {
+  const repoSkill = join(REPO_ROOT, 'operator', 'skills', name, 'SKILL.md')
+  const customerSkill = join(dirname(customerYamlPath), 'skills', name, 'SKILL.md')
+  return existsSync(repoSkill) || existsSync(customerSkill)
 }
 
 const argPath = process.argv[2]
@@ -56,6 +93,27 @@ if (!result.ok) {
   process.stderr.write(`customer.yaml has ${result.errors.length} validation error(s):\n`)
   for (const e of result.errors) {
     process.stderr.write(`  [${e.code}] ${e.path}: ${e.message}\n`)
+  }
+  process.exit(1)
+}
+
+// Author-time guardrail (#1206): catch a bound-but-undeployed skill HERE, at the
+// pre-provision gate, instead of as a Machine boot crash-loop. Schema-valid is
+// not deploy-safe — `personas[].skills[]` only names a skill; the body must also
+// exist in a catalog that reaches the volume.
+const missingSkillBodies = boundSkillNames(parsed).filter(
+  (name) => !skillBodyExists(name, filePath)
+)
+if (missingSkillBodies.length > 0) {
+  process.stderr.write(
+    `customer.yaml binds ${missingSkillBodies.length} skill(s) with no deployable body — ` +
+      `each would crash-loop the Machine at boot (#1206):\n`
+  )
+  for (const name of missingSkillBodies) {
+    process.stderr.write(
+      `  [skill-body-missing] ${name}: no operator/skills/${name}/SKILL.md ` +
+        `(and no customer-local skills/${name}/SKILL.md)\n`
+    )
   }
   process.exit(1)
 }

--- a/tests/operator-skill-deploy.test.ts
+++ b/tests/operator-skill-deploy.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Skill-delivery pipeline coverage (#1206).
+ *
+ * Two halves of the same gap — a repo skill bound in customer.yaml must reach
+ * the Machine, and a missing body must be caught BEFORE boot, not as a runtime
+ * crash-loop:
+ *
+ *  1. The author-time guardrail in `scripts/validate-customer-yaml.ts` — a
+ *     schema-valid customer.yaml that binds a skill with no deployable body
+ *     fails the pre-provision gate (exit 1), while the real customer-zero config
+ *     still passes.
+ *  2. The boot-time seed in `operator/templates/bootstrap.sh` — the
+ *     `/app/skills -> ${HERMES_HOME}/skills` overlay is ADDITIVE: it lands repo
+ *     skills on the volume without clobbering agent-authored skills that live
+ *     only there (ADR 0017).
+ */
+import { execFileSync } from 'node:child_process'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { parse as parseYaml, stringify as stringifyYaml } from 'yaml'
+import { afterEach, describe, expect, it } from 'vitest'
+
+const REPO_ROOT = fileURLToPath(new URL('..', import.meta.url))
+const SMD_CUSTOMER_YAML = join(REPO_ROOT, 'operator', 'customers', 'smd', 'customer.yaml')
+const BOOTSTRAP_SH = join(REPO_ROOT, 'operator', 'templates', 'bootstrap.sh')
+
+interface ValidatorResult {
+  code: number
+  stdout: string
+  stderr: string
+}
+
+/** Run the real validator CLI exactly as `provision-customer.sh` does. */
+function runValidator(customerYamlPath: string): ValidatorResult {
+  try {
+    const stdout = execFileSync(
+      'npx',
+      ['--quiet', 'tsx', 'scripts/validate-customer-yaml.ts', customerYamlPath],
+      { cwd: REPO_ROOT, encoding: 'utf8' }
+    )
+    return { code: 0, stdout, stderr: '' }
+  } catch (err) {
+    const e = err as { status?: number; stdout?: Buffer | string; stderr?: Buffer | string }
+    return { code: e.status ?? 1, stdout: String(e.stdout ?? ''), stderr: String(e.stderr ?? '') }
+  }
+}
+
+const tmpDirs: string[] = []
+function makeTmpDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'skill-deploy-'))
+  tmpDirs.push(dir)
+  return dir
+}
+
+afterEach(() => {
+  while (tmpDirs.length > 0) {
+    const dir = tmpDirs.pop()
+    if (dir) rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+describe('validate-customer-yaml: author-time skill-body guardrail (#1206)', () => {
+  it('passes the real customer-zero config (no false positive)', () => {
+    const result = runValidator(SMD_CUSTOMER_YAML)
+    expect(result.code).toBe(0)
+    expect(result.stdout).toContain('OK')
+  })
+
+  it('fails a schema-valid config that binds a skill with no deployable body', () => {
+    // Keep the real (cron/webhook-referenced) skill so the config stays
+    // schema-valid; add one extra enabled skill whose body does not exist.
+    const cfg = parseYaml(readFileSync(SMD_CUSTOMER_YAML, 'utf8')) as {
+      personas: {
+        skills: { name: string; version: string; trust_ceiling: string; enabled: boolean }[]
+      }[]
+    }
+    cfg.personas[0].skills.push({
+      name: 'nonexistent-skill-xyz',
+      version: 'pending',
+      trust_ceiling: 'draft_for_review',
+      enabled: true,
+    })
+    const dir = makeTmpDir()
+    const bad = join(dir, 'customer.yaml')
+    writeFileSync(bad, stringifyYaml(cfg))
+
+    const result = runValidator(bad)
+    expect(result.code).toBe(1)
+    expect(result.stderr).toContain('skill-body-missing')
+    expect(result.stderr).toContain('nonexistent-skill-xyz')
+  })
+
+  it('accepts a customer-local skill body (skills/<name>/SKILL.md beside customer.yaml)', () => {
+    // Bind a skill that exists only in the customer-local catalog, not the
+    // shared repo catalog — the second lookup location must satisfy the gate.
+    const cfg = parseYaml(readFileSync(SMD_CUSTOMER_YAML, 'utf8')) as {
+      personas: {
+        skills: { name: string; version: string; trust_ceiling: string; enabled: boolean }[]
+      }[]
+    }
+    cfg.personas[0].skills.push({
+      name: 'customer-local-skill',
+      version: 'pending',
+      trust_ceiling: 'draft_for_review',
+      enabled: true,
+    })
+    const dir = makeTmpDir()
+    mkdirSync(join(dir, 'skills', 'customer-local-skill'), { recursive: true })
+    writeFileSync(join(dir, 'skills', 'customer-local-skill', 'SKILL.md'), '# local\n')
+    const yamlPath = join(dir, 'customer.yaml')
+    writeFileSync(yamlPath, stringifyYaml(cfg))
+
+    const result = runValidator(yamlPath)
+    expect(result.code).toBe(0)
+    expect(result.stdout).toContain('OK')
+  })
+})
+
+describe('bootstrap.sh: skill-catalog seed is additive (#1206)', () => {
+  it('overlays repo skills onto the volume without clobbering agent-authored skills', () => {
+    const dir = makeTmpDir()
+    const appSkills = join(dir, 'app', 'skills')
+    const volSkills = join(dir, 'opt', 'data', 'skills')
+    mkdirSync(join(appSkills, 'inbox-triage'), { recursive: true })
+    writeFileSync(join(appSkills, 'inbox-triage', 'SKILL.md'), '# repo body v2\n')
+    // A skill that lives ONLY on the volume — the agent-authored case (ADR 0017).
+    mkdirSync(join(volSkills, 'agent-authored-skill'), { recursive: true })
+    writeFileSync(join(volSkills, 'agent-authored-skill', 'SKILL.md'), '# authored at runtime\n')
+
+    // The exact idiom from bootstrap.sh step 6b.
+    execFileSync('cp', ['-a', `${appSkills}/.`, `${volSkills}/`])
+
+    // Repo skill landed on the volume...
+    expect(existsSync(join(volSkills, 'inbox-triage', 'SKILL.md'))).toBe(true)
+    expect(readFileSync(join(volSkills, 'inbox-triage', 'SKILL.md'), 'utf8')).toContain(
+      'repo body v2'
+    )
+    // ...and the agent-authored skill was preserved, not wiped.
+    expect(existsSync(join(volSkills, 'agent-authored-skill', 'SKILL.md'))).toBe(true)
+    expect(readFileSync(join(volSkills, 'agent-authored-skill', 'SKILL.md'), 'utf8')).toContain(
+      'authored at runtime'
+    )
+  })
+
+  it('bootstrap.sh seeds the catalog additively and never destructively wipes it', () => {
+    const script = readFileSync(BOOTSTRAP_SH, 'utf8')
+    // The additive seed must be present...
+    expect(script).toContain('cp -a /app/skills/.')
+    // ...and there must be NO destructive mirror of the skills catalog, which
+    // would delete agent-authored skills on the volume (the regression guard).
+    expect(script).not.toMatch(/rm\s+-rf[^\n]*\$\{HERMES_HOME\}\/skills/)
+  })
+})


### PR DESCRIPTION
## Summary
ADR 0038 **step 4 (pull infra)** — the load-bearing first piece. Repo skills bound in `customer.yaml` never reached the Machine, crash-looping boot. This unblocks every downstream step-4 piece (a Clio-sandbox connect needs skills to actually land on a Machine).

**Root cause:** `Dockerfile:211` bakes `operator/skills/` into `/app/skills` (image), but the overlay's pin-resolver (`translate._resolve_skill_pins`) reads `${HERMES_HOME}/skills` (= `/opt/data/skills`, the Fly **volume**). On a persisted volume the baked catalog is **shadowed** — the same failure mode already handled for the overlay plugin pack at `bootstrap.sh:410-440` — so a newly added repo skill is in the image but absent on the volume the resolver checks, and `hermes-smd bootstrap` aborts (`skill '<name>' not found`, #1197/#1206).

## Changes
- **`bootstrap.sh` (Step 6b):** additively overlay `/app/skills → ${HERMES_HOME}/skills` before the translate step. Additive (`cp -a src/.`), never a destructive mirror — agent-authored skills that live only on the volume are preserved (ADR 0017). Fail-closed if the seed cannot complete.
- **`validate-customer-yaml.ts`:** author-time guardrail — a schema-valid `customer.yaml` binding a skill with no deployable body now fails the pre-provision gate (exit 1) instead of reaching a boot crash-loop. Checks the shared repo catalog and the customer-local catalog, mirroring `resolve_skill_pins.py`'s two lookup locations.
- **`tests/operator-skill-deploy.test.ts`:** validator gate (real CLI: positive, negative, customer-local) + the seed's additive/preserve invariant (behavioral + a source guard against a destructive skills-catalog wipe).

## Scope
This fixes the deploy mechanism. Re-adding the `workspace` binding to `smd/customer.yaml` (the "Then" in #1206) is left as a separate follow-on.

## Test plan
- [x] `npm run verify` passes (exit 0)
- [x] New suite: 5/5 — validator passes real customer-zero, fails a no-body binding, accepts a customer-local body; seed preserves agent-authored skills
- [ ] Reviewer confirms the additive-seed reasoning vs. agent-authored persistence (ADR 0017)

🤖 Generated with [Claude Code](https://claude.com/claude-code)