### PR TITLE
fix(operator): make skill-catalog seed idempotent against stale volume aliases

### DIFF
--- a/operator/templates/bootstrap.sh
+++ b/operator/templates/bootstrap.sh
@@ -294,10 +294,41 @@ fi
 # seeded MUST NOT proceed to a guaranteed crash-loop with a misleading error.
 if [ -d /app/skills ]; then
   log "Seeding repo skill catalog onto the volume (/app/skills -> ${HERMES_HOME}/skills)..."
+  # If the catalog ROOT is itself a stale symlink (an older seeding approach
+  # aliased the whole dir back into /app/skills), drop the link before seeding —
+  # never write THROUGH it into the read-only image tree, and never let the
+  # per-skill clear below recurse through it and delete the source. `-L` tests
+  # the link; `rm -f` drops only the link, not its target.
+  if [ -L "${HERMES_HOME}/skills" ]; then
+    rm -f "${HERMES_HOME}/skills" \
+      || die "cannot clear stale ${HERMES_HOME}/skills symlink for the skill catalog seed"
+  fi
   mkdir -p "${HERMES_HOME}/skills" \
     || die "cannot create ${HERMES_HOME}/skills for the skill catalog seed"
-  cp -a /app/skills/. "${HERMES_HOME}/skills/" \
-    || die "skill catalog seed failed (/app/skills -> ${HERMES_HOME}/skills) — refusing to boot into a crash-loop"
+  # Per-skill replace, scoped to one repo skill name at a time. Each repo skill
+  # overwrites any stale volume entry of the SAME name — including a symlink
+  # alias left by an older seeding approach, which is what made a bare
+  # `cp -a /app/skills/. ${HERMES_HOME}/skills/` abort with "are the same file"
+  # and crash-loop the boot on a persisted volume. Agent-authored skills (present
+  # only on the volume, never under /app/skills) are never iterated, so the
+  # overlay stays ADDITIVE (ADR 0017). The `-L` guard removes an aliasing entry
+  # as a LINK (never recursing into /app/skills); a real stale dir is removed in
+  # place. FAIL-CLOSED: any unseedable bound skill stops the boot here rather
+  # than at a misleading "skill not found" crash in step 7.
+  for _src in /app/skills/*/; do
+    [ -e "${_src}" ] || continue
+    _name=$(basename "${_src}")
+    _dst="${HERMES_HOME}/skills/${_name}"
+    if [ -L "${_dst}" ]; then
+      rm -f "${_dst}" \
+        || die "skill catalog seed: cannot clear stale alias ${_dst}"
+    else
+      rm -rf "${_dst}" \
+        || die "skill catalog seed: cannot clear stale ${_dst}"
+    fi
+    cp -a "${_src}" "${_dst}" \
+      || die "skill catalog seed failed for ${_name} (/app/skills -> ${HERMES_HOME}/skills) — refusing to boot into a crash-loop"
+  done
   log "Skill catalog seeded ($(find "${HERMES_HOME}/skills" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ') skill dir(s) on volume)"
 else
   log "WARNING: /app/skills absent from image; skipping catalog seed (bound skills must already be on the volume)"

--- a/tests/operator-skill-deploy.test.ts
+++ b/tests/operator-skill-deploy.test.ts
@@ -15,7 +15,15 @@
  *     only there (ADR 0017).
  */
 import { execFileSync } from 'node:child_process'
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import {
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -120,37 +128,72 @@ describe('validate-customer-yaml: author-time skill-body guardrail (#1206)', () 
 })
 
 describe('bootstrap.sh: skill-catalog seed is additive (#1206)', () => {
-  it('overlays repo skills onto the volume without clobbering agent-authored skills', () => {
+  it('replaces stale aliases additively, preserving agent-authored skills, never touching the source', () => {
     const dir = makeTmpDir()
     const appSkills = join(dir, 'app', 'skills')
     const volSkills = join(dir, 'opt', 'data', 'skills')
+    // Repo (image) catalog: two skills.
     mkdirSync(join(appSkills, 'inbox-triage'), { recursive: true })
     writeFileSync(join(appSkills, 'inbox-triage', 'SKILL.md'), '# repo body v2\n')
-    // A skill that lives ONLY on the volume — the agent-authored case (ADR 0017).
+    mkdirSync(join(appSkills, 'proposal-drafter'), { recursive: true })
+    writeFileSync(join(appSkills, 'proposal-drafter', 'SKILL.md'), '# proposal repo body\n')
+    // Volume preexisting state:
+    mkdirSync(volSkills, { recursive: true })
+    //  (a) a stale SYMLINK alias to the image copy — the exact shape that made a
+    //      bare `cp -a /app/skills/. .../skills/` abort with "are the same file"
+    //      and crash-loop the boot on the customer-zero redeploy.
+    symlinkSync(join(appSkills, 'inbox-triage'), join(volSkills, 'inbox-triage'))
+    //  (b) a skill that lives ONLY on the volume — the agent-authored case (ADR 0017).
     mkdirSync(join(volSkills, 'agent-authored-skill'), { recursive: true })
     writeFileSync(join(volSkills, 'agent-authored-skill', 'SKILL.md'), '# authored at runtime\n')
 
-    // The exact idiom from bootstrap.sh step 6b.
-    execFileSync('cp', ['-a', `${appSkills}/.`, `${volSkills}/`])
+    // The exact per-skill replace idiom from bootstrap.sh step 6b.
+    const seed = `
+      set -eu
+      HERMES_HOME='${join(dir, 'opt', 'data')}'
+      for _src in '${appSkills}'/*/; do
+        [ -e "$_src" ] || continue
+        _name=$(basename "$_src")
+        _dst="$HERMES_HOME/skills/$_name"
+        if [ -L "$_dst" ]; then rm -f "$_dst"; else rm -rf "$_dst"; fi
+        cp -a "$_src" "$_dst"
+      done
+    `
+    execFileSync('bash', ['-c', seed])
 
-    // Repo skill landed on the volume...
-    expect(existsSync(join(volSkills, 'inbox-triage', 'SKILL.md'))).toBe(true)
+    // The stale alias is now a REAL dir carrying the repo body (no "same file" error).
+    expect(lstatSync(join(volSkills, 'inbox-triage')).isSymbolicLink()).toBe(false)
     expect(readFileSync(join(volSkills, 'inbox-triage', 'SKILL.md'), 'utf8')).toContain(
       'repo body v2'
     )
-    // ...and the agent-authored skill was preserved, not wiped.
-    expect(existsSync(join(volSkills, 'agent-authored-skill', 'SKILL.md'))).toBe(true)
+    // The other repo skill landed on the volume.
+    expect(readFileSync(join(volSkills, 'proposal-drafter', 'SKILL.md'), 'utf8')).toContain(
+      'proposal repo body'
+    )
+    // The agent-authored skill was preserved, not wiped.
     expect(readFileSync(join(volSkills, 'agent-authored-skill', 'SKILL.md'), 'utf8')).toContain(
       'authored at runtime'
     )
+    // Clearing the alias must NOT have mutated the image source it pointed at.
+    expect(readFileSync(join(appSkills, 'inbox-triage', 'SKILL.md'), 'utf8')).toContain(
+      'repo body v2'
+    )
   })
 
-  it('bootstrap.sh seeds the catalog additively and never destructively wipes it', () => {
+  it('bootstrap.sh seeds per-skill additively and never destructively wipes the catalog', () => {
     const script = readFileSync(BOOTSTRAP_SH, 'utf8')
-    // The additive seed must be present...
-    expect(script).toContain('cp -a /app/skills/.')
-    // ...and there must be NO destructive mirror of the skills catalog, which
-    // would delete agent-authored skills on the volume (the regression guard).
-    expect(script).not.toMatch(/rm\s+-rf[^\n]*\$\{HERMES_HOME\}\/skills/)
+    // The per-skill replace idiom must be present: scoped to one repo skill at a
+    // time so agent-authored skills (present only on the volume) survive.
+    expect(script).toContain('for _src in /app/skills/*/')
+    expect(script).toContain('cp -a "${_src}" "${_dst}"')
+    // Symlink-safety: an aliasing entry (the "are the same file" crash-loop) is
+    // removed as a LINK, never recursed through into the read-only /app/skills.
+    expect(script).toContain('[ -L "${_dst}" ]')
+    expect(script).toContain('[ -L "${HERMES_HOME}/skills" ]')
+    // Regression guard: the clear stays scoped to a single named skill — the
+    // catalog ROOT is never wiped (that would delete agent-authored skills), and
+    // its children are never globbed away.
+    expect(script).not.toMatch(/rm\s+-rf\s+["']?\$\{HERMES_HOME\}\/skills["'\s]/)
+    expect(script).not.toMatch(/rm\s+-rf\s+["']?\$\{HERMES_HOME\}\/skills\/\*/)
   })
 })


### PR DESCRIPTION
## Summary
The #1206/#1217 boot-time skill seed used a bare `cp -a /app/skills/. \${HERMES_HOME}/skills/`. On customer-zero's **persisted volume**, the per-skill entries were **symlink aliases** back into `/app/skills` (left by an older seeding approach), so `cp` aborted with `"are the same file"` on every repo skill and the fail-closed guard **crash-looped the boot**.

This surfaced when the merged-main image — the first build that carries the #1217 seed step — was deployed to `hermes-smd`: the machine hit its max restart count and stopped. (The #1218 Google work in that image booted fine; this is purely the seed step meeting stale volume state.)

## Fix
Replace the bulk copy with a **per-skill remove-then-copy loop** robust to every stale shape:
- a **root symlink** (`\${HERMES_HOME}/skills` itself aliased) is dropped as a LINK before seeding — never written through into the read-only image tree;
- a **per-entry symlink alias** is removed as a LINK (never recursed through into `/app/skills`, which would delete the source);
- a **real stale dir** is removed in place.

Agent-authored skills (present only on the volume, never under `/app/skills`) are never iterated → overlay stays **additive** (ADR 0017).

## Tests
- The additive-seed test now plants a **symlink alias** (reproducing the outage) and asserts it is replaced by a real dir **without mutating the source**, alongside the agent-authored-preservation case.
- The script-shape test pins the per-skill idiom + symlink guards and keeps the **no-whole-catalog-wipe** regression guard.
- `npm run verify` green locally.

## Deploy
On merge, rebuild + redeploy `hermes-smd` (`operator/bin/reprovision.sh smd`) to bring customer-zero back up on the merged image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)