### PR TITLE
feat(operator): law wedge spine + Clio connect-step findings + pilot-law sandbox

### DIFF
--- a/operator/customers/pilot-law/customer.yaml
+++ b/operator/customers/pilot-law/customer.yaml
@@ -1,0 +1,193 @@
+schema_version: 1
+
+# Pilot law customer Operator — vertical-1 stand-up (ADR 0038 steps 4–6).
+#
+# PURPOSE: the sandbox customer we stand the law wedge up on, connect to the
+# Clio developer sandbox, and harden against (the §3.6 contract-conformance
+# round-trip). This is NOT a real client — it is the disposable, real-fidelity
+# environment ADR 0038 §6 calls for: Clio's own developer tenant, seeded with
+# the two synthetic matters the pack ships (synthetic-intake-immigration,
+# synthetic-matter-estate-simple).
+#
+# Two things need external setup before provision (both in flight 2026-06-05):
+#   1. Clio dev app  → CLIO_CLIENT_ID / CLIO_CLIENT_SECRET (Captain creating it)
+#   2. a sandbox Google Workspace user for mail+calendar (the proven build path)
+#
+# Write posture is FAIL-CLOSED / draft-and-surface for the whole wedge, per
+# operator/verticals/law-firm/wedge.md "Write posture this phase" and ADR 0035.
+# Nothing sends or writes autonomously until the connect step proves the
+# capability callable AND the engagement authors it on.
+
+# ---- IDENTITY ----
+customer_id: pilot-law
+customer_name: 'Pilot Law (Clio Sandbox)'
+vertical: law-firm
+# Matches the two synthetic matters the pack ships (vertical.yaml fixtures:
+# synthetic-intake-immigration, synthetic-matter-estate-simple).
+practice_areas:
+  - immigration
+  - estate-planning
+fly_region: lax # Phoenix-adjacent, consistent with customer-zero
+
+# ---- RUNTIME ----
+# Opus for sensitive drafting (client-bound legal-adjacent mail), matching
+# customer-zero's sensitive-tier default.
+model: claude-opus-4-8
+hermes_ref: v2026.5.16@a91a57fa5a13d516c38b07a141a9ce8a3daabeb0
+
+machine:
+  size: shared-cpu-1x
+  memory_mb: 1024
+
+# ---- GOOGLE WORKSPACE AUTHORITY ----
+# Sandbox mail+calendar ride the proven customer-zero BUILD path (build:google-*)
+# on a customer-owned service account with domain-wide delegation. The law
+# MANIFEST's production binding is M365 (mcp:m365-*); for the sandbox we use the
+# Google adapter we already run live rather than stand up an M365 tenant. This is
+# a deliberate pilot scoping choice (capability-adapter pattern, ADR 0006 — the
+# Email/Calendar binding is swappable per customer.yaml without touching skills),
+# not drift from the manifest.
+#
+# Shared sandbox bench mailbox, reused across all vertical sandboxes (one seat,
+# not one per vertical). It is NOT the customer-zero `crane@` assessment-operator
+# identity and NOT a per-persona address — drafts are fail-closed/reviewer-sent,
+# so the From-address is the reviewer, not this box. The persona stays "Avery";
+# only the underlying mailbox is shared. DWD authorizes the service account across
+# the whole smd.services domain, so impersonating sandbox@ needs no extra grant.
+google_auth:
+  mode: dwd
+  subject: sandbox@smd.services # shared sandbox bench mailbox (Sandbox Operator)
+  scopes:
+    - https://www.googleapis.com/auth/gmail.modify
+    - https://www.googleapis.com/auth/gmail.send
+    - https://www.googleapis.com/auth/calendar.events
+
+# ---- HUMANS WITH PORTAL ACCESS ----
+# Scott is the reviewer-as-sender human for the sandbox (ADR 0005).
+users:
+  - email: scott@smd.services
+    role: principal
+    full_name: Scott Durgan
+
+# ---- PERSONAS ----
+# The intake-and-matter coordinator seat the law pack fills (vertical.yaml
+# personas: intake-coordinator). One persona runs the full 6-skill wedge plus
+# the two spine skills, all at the draft_for_review ceiling (fail-closed).
+personas:
+  - slug: avery
+    status: active
+    name: Avery
+    title: AI Associate
+    tone:
+      - plainspoken
+      - warm-but-professional
+      - concise
+    # The wedge (6) + spine (2). Every skill draft_for_review — the wedge is
+    # draft-and-surface this phase; no autonomous send/write until connect proves
+    # the capability and the engagement authors it on (wedge.md write posture).
+    skills:
+      # spine — law-context skills (the customer-zero `inbox-triage` and the
+      # marketing `status-report-assembler` are other verticals' skills; law's
+      # spine is purpose-built — matter-inbox-router routes inbound to the wedge
+      # skills, matter-status-digest assembles the internal Clio digest).
+      - name: matter-inbox-router
+        version: pending
+        trust_ceiling: draft_for_review
+        enabled: true
+      - name: matter-status-digest
+        version: pending
+        trust_ceiling: draft_for_review
+        enabled: true
+      # wedge — the named job: move a new inquiry to an active, current matter
+      - name: new-matter-intake
+        version: pending
+        trust_ceiling: draft_for_review
+        enabled: true
+      - name: consult-scheduler
+        version: pending
+        trust_ceiling: draft_for_review
+        enabled: true
+      - name: engagement-letter-chaser
+        version: pending
+        trust_ceiling: draft_for_review
+        enabled: true
+      - name: matter-status-responder
+        version: pending
+        trust_ceiling: draft_for_review
+        enabled: true
+      - name: trust-balance-nudge
+        version: pending
+        trust_ceiling: draft_for_review
+        enabled: true
+      - name: stalled-matter-nudge
+        version: pending
+        trust_ceiling: draft_for_review
+        enabled: true
+    # Native Google/Himalaya skills disabled — this customer uses the audited
+    # BUILD connector CLIs and the DWD credential, same as customer-zero.
+    skills_disabled:
+      - google-workspace
+      - himalaya
+
+# ---- CONNECTORS ----
+connectors:
+  # The connect target. Clio is the system of record for every law skill
+  # (clio-surface.md). Community MCP oktopeak/clio-mcp v2.0.0 (MIT, ADR 0020).
+  # v1 write scope is tasks/notes/documents only — create_matter and
+  # create_calendar_entry are GATED (confirmed against the repo 2026-06-05),
+  # which is exactly the fail-closed posture the wedge already authored.
+  # token_ref points at the Infisical path holding CLIO_CLIENT_ID/SECRET; the
+  # MCP brokers the OAuth flow against the sandbox tenant.
+  PracticeManagement:
+    adapter: clio
+    backend: mcp:clio-oktopeak
+    enabled: true
+    token_ref: 'infisical:/operator/pilot-law/practice-management/clio-oauth'
+
+  # Mail + calendar on the proven Google BUILD path (see google_auth note).
+  Email:
+    adapter: google-gmail
+    backend: build:google-gmail
+    enabled: true
+  Calendar:
+    adapter: google-calendar
+    backend: build:google-calendar
+    enabled: true
+
+  # DEFERRED this phase (fixture-supplied per the wedge): ESign (engagement
+  # signature status arrives via fixture), Payments/LawPay (trust balance is
+  # read-only, fixture-fed for harden), DocumentStorage. Added when the loop is
+  # real and we wire them live.
+
+# ---- SCOPE ----
+scope:
+  email_folders_visible:
+    - Inbox
+    - Sent
+  email_folders_blind: []
+  email_keyword_blocks: []
+  domain_blocks: []
+  # No trusted_sender_domains and no autonomous external_send: the wedge is
+  # draft-and-surface. Every client-/tribunal-bound message ships under the
+  # human reviewer's identity (reviewer-as-sender floor, non-raisable).
+  action_ceilings:
+    external_send: draft_for_review
+
+# ---- ESCALATION ----
+escalation:
+  red_flag_recipients:
+    - scott@smd.services
+  failure_recipients:
+    - scott@smd.services
+
+# ---- VOICE LIBRARY ----
+# No samples yet — sandbox drafts use the general voice. Voice fidelity is a
+# Voice-Layer-2 concern (#855), not a wedge-harden blocker.
+voice_library:
+  samples_path: 'r2://vaults/pilot-law/voice/samples/'
+
+# ---- MEMORY (per-customer isolation invariants; must match customer_id) ----
+memory:
+  d1_namespace: pilot-law
+  r2_vault_path: 'vaults/pilot-law/'
+  vectorize_index: 'hermes-pilot-law-vault'

--- a/operator/skills/matter-inbox-router/SKILL.md
+++ b/operator/skills/matter-inbox-router/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: matter-inbox-router
+description: Classifies inbound firm mail and routes each message to the wedge skill that handles it — dispatches, never answers, never decides legal substance.
+version: 0.1.0
+author: SMD Services
+license: MIT
+platforms: [linux, macos]
+prerequisites:
+  skills: []
+  commands: [python3]
+metadata:
+  hermes:
+    tags: [Law, Inbox, Routing, Dispatch, DraftForReview]
+  smd:
+    vertical: law-firm
+    skill_type: decision/surfacing (routing)
+    trust_ceiling: draft_for_review
+    action_class: read + route
+    connectors:
+      - email # customer-bound (mcp:m365-mail in prod; build:google-gmail in the sandbox)
+      - clio # PracticeManagement — contact/matter lookup to resolve sender → matter (read)
+    # Shared-core candidate. This is law's concrete realization of the inbox
+    # "spine" role. The customer-zero `inbox-triage` (a Gmail drafter) and the
+    # marketing `status-report-assembler` are NOT generic — each is its own
+    # vertical's skill. Per ADR 0038 §7, the shared inbox-router core is EARNED
+    # at vertical-2 (marketing), not designed up front. Extract the common
+    # router shell then; until then this is the law delta.
+---
+
+# Matter Inbox Router
+
+Reads the firm's inbound mail, classifies each message into a law inbound class, and routes it to the wedge skill that completes that job. It is a **dispatcher, not a drafter** — it never answers the client itself; it hands the message (with the matter/contact context it resolved) to `new-matter-intake`, `consult-scheduler`, `engagement-letter-chaser`, `matter-status-responder`, or `trust-balance-nudge`, or surfaces it for a human when no skill owns it. The reply, when one is warranted, is drafted by the routed-to skill under reviewer-as-sender.
+
+This is the connective tissue of the wedge's named job — _move a new inquiry to an active, current matter_ (`operator/verticals/law-firm/wedge.md`). Without a reliable router, every inbound message is a human triage decision; with it, the loop starts itself.
+
+## When to Use
+
+Inbound mail arrives at the firm continuously: new-client inquiries, clients asking "where are we," signed engagement letters, scheduling back-and-forth, payment questions. A coordinator reads each one and decides _who/what handles this_. This skill does that decision — fast, conflict-aware, and without ever crossing into legal substance — so the right wedge skill picks the message up.
+
+It runs scheduled (poll the inbox on the firm's cadence) and event-driven (an inbound webhook delivers one message).
+
+## The routing decision
+
+Each message is classified into exactly one **inbound class**, which names the **target skill**. The full rubric — the owner-statement tells that map to each class, the multi-intent tie-breaks, and the conflict/UPL guards — is `references/routing-rubric.md`. Summary:
+
+| Inbound class                         | Routes to                                      | One-line tell                                                         |
+| ------------------------------------- | ---------------------------------------------- | --------------------------------------------------------------------- |
+| New-client inquiry                    | `new-matter-intake`                            | a non-client asking the firm to take something on                     |
+| Scheduling / consult                  | `consult-scheduler`                            | a request to book, move, or confirm a meeting time                    |
+| Engagement letter / signature         | `engagement-letter-chaser`                     | anything about the engagement letter going out, signed, or its terms  |
+| Status request ("where are we")       | `matter-status-responder`                      | an existing client asking the state of their matter                   |
+| Payment / trust / retainer            | `trust-balance-nudge`                          | a question about a balance, invoice, or replenishing the retainer     |
+| Document received                     | surface + (deferred `document-receipt-logger`) | an inbound document to be filed; no wedge step depends on it          |
+| Conflict signal                       | **HALT + surface for human**                   | opposing party, adverse mention, or a hit on the conflict cross-check |
+| Ambiguous / multi-intent / non-client | surface for human                              | no single skill owns it, or it needs a person                         |
+
+**Routing is not answering.** A message that asks a legal question ("do I have a case?", "what does this clause mean?") is routed to the skill whose job is to _acknowledge-and-defer_ it (or surfaced for the attorney) — the router never answers the legal question itself.
+
+## Prerequisites
+
+Reads the customer-bound **Email** connector (resolved from `customer.yaml`: `mcp:m365-mail` in production, `build:google-gmail` in the sandbox) and Clio (`search_contacts`, `list_matters`, `get_matter`) to resolve a sender to a known contact/matter. Requires `python3` for the fetch block. Connector-agnostic by design — the router reads whatever Email adapter the customer binds; it does not hardcode a provider.
+
+## How to Run
+
+```
+hermes run matter-inbox-router               # poll the inbox on cadence
+hermes run matter-inbox-router --window "newer_than:1d"
+hermes run matter-inbox-router --max 25
+```
+
+## Procedure
+
+Two phases, mirroring the established fetch/reason split (ADR 0021 Stream A): the mechanical inbox fetch runs inside one `execute_code` block so per-message bodies never flood context; classification and routing stay in the agent's reasoning loop.
+
+### Phase 1 — Fetch (single `execute_code` block)
+
+Enumerate unread messages in the window via the customer-bound Email CLI, fetch each body, and emit one JSON payload. The Email command is resolved from `customer.yaml` (the sandbox binds `crane_gmail.py`; production binds the M365 MCP) — the skill reads the binding rather than hardcoding it. The shape matches `inbox-triage` Phase 1: accumulate in-process, `print()` one document. A single unparseable message is recorded as `parse_failed` and the batch continues; it never aborts.
+
+### Phase 2 — Reason (agent, in-context)
+
+Per `references/routing-rubric.md` and `references/algorithm.md`:
+
+1. **Resolve the sender** against Clio (`search_contacts` on the from-address/name; `list_matters` for that contact). Known client + matter, known contact no matter, or unknown — this gates class and conflict.
+2. **Run the conflict cross-check FIRST.** Before any routing, a read-only `search_contacts` + `list_matters` name/entity check (the same invariant `new-matter-intake` carries). On any hit — the sender or a named party is adverse to an existing matter — **HALT**: the message routes to the human conflict-clearance surface, not to a wedge skill, and no downstream draft is started. Advancing a flagged message is a `fails` safety violation.
+3. **Classify** into exactly one inbound class (rubric tells + tie-breaks).
+4. **Route**: emit the target skill plus the handoff context it needs (resolved contact_id / matter_id, the inbound message_id for in-thread reply, the extracted ask). The routed-to skill owns the draft.
+5. **Surface** the routing decisions as a list for the team — what came in, where each went, and the held/ambiguous ones called out separately.
+
+## Trust Ceiling
+
+**Routing + surfacing autonomous; zero sends, zero writes.**
+
+The agent MAY: read inbound mail; read Clio for sender/matter resolution and the conflict cross-check; classify; emit a routing decision + handoff context; surface the list.
+
+The agent MUST NOT: send or reply to any message; write to Clio or any system; answer a legal question; route a conflict-flagged message to anything but the human clearance surface; invent a matter/contact association it did not resolve from Clio.
+
+## Safety invariants (any violation → `fails`, no recovery)
+
+1. **Routes, never answers.** No legal substance, no advice, no "you have a case" — a substantive question is routed/deferred, never answered by the router.
+2. **Conflict halt precedes routing.** A conflict hit stops the chain and goes to human clearance; no auto-clear, no wedge-skill handoff.
+3. **No fabricated association.** A sender is linked to a matter only via a real Clio resolution; an unresolved sender is classed unknown, not guessed onto a matter.
+4. **Reviewer-as-sender preserved.** The router sends nothing; it dispatches to skills that draft under a human reviewer's identity.
+5. **Privilege.** Resolved matter detail stays in the handoff to firm-internal skills; it never leaves firm surfaces.
+
+## Pitfalls
+
+Answering a question instead of routing it; routing a conflict-flagged message to a wedge skill; guessing a matter for an unknown sender; collapsing a multi-intent message to one class without the rubric's tie-break (a "sign the letter and also when's my hearing" message has a primary route and a noted secondary).
+
+## Verification
+
+1. Every inbound message gets exactly one class and a route (or an explicit human-surface).
+2. Conflict cross-check runs before routing; any hit halts and surfaces, with no downstream handoff.
+3. No legal question is answered by the router.
+4. Sender→matter associations are all Clio-sourced; unknowns are classed unknown.
+5. The surfaced list lets a human see, in under a minute, what came in and where it went.
+
+## References
+
+- `references/routing-rubric.md` — the inbound-class tells, target-skill map, multi-intent tie-breaks, and conflict/UPL guards (the load-bearing logic)
+- `references/algorithm.md` — sender resolution, the conflict-first ordering, the fetch/reason split
+- `references/output-format.md` — the routing-decision list + held/ambiguous surface _(parity fast-follow)_
+- `references/test-cases.md` — fixtures incl. the cross-skill selector test + conflict-bait + multi-intent _(parity fast-follow)_

--- a/operator/skills/matter-inbox-router/references/algorithm.md
+++ b/operator/skills/matter-inbox-router/references/algorithm.md
@@ -1,0 +1,28 @@
+# Matter Inbox Router — Algorithm
+
+The ordering that keeps routing fast, conflict-safe, and substance-free.
+
+## Phase 1 — Fetch (mechanical, one `execute_code` block)
+
+Resolve the Email command from `customer.yaml` (sandbox: `crane_gmail.py`; production: the M365 MCP wrapper) — read the binding, do not hardcode a provider. Enumerate `is:unread {window}`, fetch each body, accumulate in-process, `print()` one JSON document (`window`, `fetched`, `messages[]`). A single unparseable message becomes a `parse_failed` row; the batch continues. Only the final document enters context (ADR 0021 Stream A) — the same shape as `inbox-triage` Phase 1.
+
+## Phase 2 — Reason (agent, in-context)
+
+Per message, in this fixed order:
+
+1. **Resolve sender.** `search_contacts(from_name_or_email)` → contact?; `list_matters(contact_id)` → matter(s)? Yields one of: known-client+matter, known-contact-no-matter, unknown. Record the resolution; never associate a matter the resolution did not return (invariant 3).
+
+2. **Conflict cross-check — before any classification commits to a route.** Read-only `search_contacts` + `list_matters` over the sender and any parties named in the body, cross-checked against existing matters' parties. On a hit → set class `conflict-signal`, route to the human clearance surface, stop processing this message (no wedge handoff, no draft). This ordering is the point: the router decides "is this a conflict?" before it decides "who handles this?"
+
+3. **Classify** into one inbound class (`references/routing-rubric.md` tells). Multi-intent → apply the tie-breaks: conflict wins; primary = the action that advances the matter furthest; record the secondary; a legal question routes to acknowledge-and-defer, never to "answer."
+
+4. **Build the handoff.** Emit `{ target_skill, contact_id?, matter_id?, message_id, inbound_class, extracted_ask, secondary? }`. The `message_id` lets the routed-to skill reply in-thread under reviewer-as-sender; the resolved IDs save it a lookup.
+
+5. **Surface.** One list for the team: each message, its class, its route; the conflict-held and ambiguous ones called out in their own sections so a human sees the exceptions first.
+
+## What this algorithm is NOT
+
+- Not an answerer — it routes substance to the skill that defers it, never resolves it.
+- Not a guesser — unknown senders are classed unknown, not forced onto a matter.
+- Not a sender or writer — zero outbound, zero Clio writes.
+- Not blind to conflict — the cross-check precedes routing, structurally.

--- a/operator/skills/matter-inbox-router/references/routing-rubric.md
+++ b/operator/skills/matter-inbox-router/references/routing-rubric.md
@@ -1,0 +1,51 @@
+# Matter Inbox Router — Routing Rubric
+
+Source of truth for _which wedge skill owns an inbound message_. The router classifies each message into exactly one inbound class; the class names the target skill. This rubric is the tells, the tie-breaks, and the guards.
+
+## Sender resolution (runs before classification)
+
+Resolve the from-address/name against Clio:
+
+- **Known client + open matter** — `search_contacts` hits a contact who is on a `list_matters` result. Most inbound is this.
+- **Known contact, no matter** — a contact exists but no matter (a prior consult, a referral source). Treat as non-client unless context says otherwise.
+- **Unknown** — no Clio hit. A candidate new inquiry, or noise.
+
+Resolution gates both the class and the conflict check. A message is never associated with a matter the router did not resolve from Clio (invariant 3).
+
+## The conflict cross-check (runs FIRST, before routing)
+
+Read-only `search_contacts(sender + any named parties)` + `list_matters` name/entity cross-check — the same invariant `new-matter-intake` carries. **On any hit** (the sender or a named party is adverse to an existing matter, or the same party appears on an opposing side), **HALT**: route only to the human conflict-clearance surface, start no wedge-skill handoff, draft nothing. Clearance is definitionally human. Advancing a flagged message is a `fails` violation. The router is never structurally blind to a conflict.
+
+## Inbound classes → target skill
+
+| Class                      | Target                                         | Tells (owner/client statements that map here)                                                                                                                                            |
+| -------------------------- | ---------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **new-client-inquiry**     | `new-matter-intake`                            | a non-client (unknown sender, or known contact with no matter) describing a problem and asking the firm to take it on: "I was referred to you," "do you handle…," "I need a lawyer for…" |
+| **scheduling**             | `consult-scheduler`                            | a request to book, move, or confirm a time: "can we set up the consult," "does Tuesday work," "I need to reschedule"                                                                     |
+| **engagement-letter**      | `engagement-letter-chaser`                     | anything about the engagement letter: "I signed it," "I have a question about section 4," "haven't gotten to it yet," a signature-platform notification                                  |
+| **status-request**         | `matter-status-responder`                      | an existing client asking the state of their matter: "any update," "where are we," "did we hear back," "what's next"                                                                     |
+| **payment-trust**          | `trust-balance-nudge`                          | a balance/invoice/retainer question: "did my payment go through," "do I owe anything," "you said the retainer was low"                                                                   |
+| **document-received**      | surface + (deferred `document-receipt-logger`) | an inbound document/attachment to be filed. No wedge step depends on it this phase — surface it; do not block the loop.                                                                  |
+| **conflict-signal**        | **HALT → human clearance**                     | opposing party, adverse party, or a conflict cross-check hit. Overrides every other class.                                                                                               |
+| **ambiguous / non-client** | surface for human                              | no single skill owns it; spam/solicitation; a vendor; a message needing a person's judgment. Do not force-fit a class.                                                                   |
+
+## Multi-intent tie-breaks
+
+A message often carries more than one ask ("I signed the letter — also, when's my hearing?"). Do not collapse it to one class blindly:
+
+1. **Conflict-signal wins over everything.** If any part trips the conflict check, the whole message halts.
+2. **Primary = the action that advances the matter furthest.** Signing the letter (engagement-letter) outranks a status question riding along; a new-inquiry outranks a scheduling aside inside it (intake precedes scheduling).
+3. **Note the secondary.** The route carries a `secondary` note so the routed-to skill (or the team) sees the rider. The router never silently drops the second ask.
+4. **A legal question is never a route to "answer."** "What does this clause mean," "do I qualify," "what are my chances" → routed to the skill whose job is acknowledge-and-defer (engagement-letter-chaser for letter terms; matter-status-responder for outcome questions), or surfaced for the attorney. The router does not answer it.
+
+## UPL guard (applies to every class)
+
+The router carries no legal substance. It does not characterize a matter's merits, name a cause of action, or decide what a matter "needs." It moves the message to the skill that handles it; substance stays with the routed-to skill's deferral logic and, ultimately, the attorney.
+
+## Worked examples
+
+- _Unknown sender: "I got hurt at work and HR is stonewalling — can you help?"_ → conflict cross-check (clear) → **new-client-inquiry** → `new-matter-intake`. The router does not assess the claim.
+- _Known client on an open estate matter: "just checking where things stand."_ → **status-request** → `matter-status-responder`.
+- _Known client: "signed! also what does the indemnification clause mean?"_ → **engagement-letter** (primary: signed) with a `secondary` legal-question note → `engagement-letter-chaser`, whose job is to log the signature and route the clause question to the attorney (never interpret it).
+- _Sender shares a surname/entity with the adverse party on an active matter_ → conflict cross-check **hit** → **HALT** → human clearance surface; no wedge handoff.
+- _"Re: Invoice 1042 — did you receive my payment?"_ → **payment-trust** → `trust-balance-nudge` (read-only on funds).

--- a/operator/skills/matter-status-digest/SKILL.md
+++ b/operator/skills/matter-status-digest/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: matter-status-digest
+description: Assembles a periodic internal digest of the firm's matters from Clio — open matters by stage, upcoming dates, quiet matters, low-trust and held flags. Reports state; never decides legal next steps.
+version: 0.1.0
+author: SMD Services
+license: MIT
+platforms: [linux, macos]
+prerequisites:
+  skills: []
+  commands: [python3]
+metadata:
+  hermes:
+    tags: [Law, Matter, Digest, Internal, DraftForReview]
+  smd:
+    vertical: law-firm
+    skill_type: read + assembly (internal digest)
+    trust_ceiling: draft_for_review
+    action_class: read + internal_write
+    connectors:
+      - clio # PracticeManagement — matters, tasks, calendar, billing (read)
+      - lawpay # Payments — trust balance (read-only) for the low-trust flag
+    # Shared-core candidate. This is law's concrete realization of the status
+    # "spine" role. It is NOT the marketing `status-report-assembler` (that skill
+    # is `vertical: marketing-agency` — Asana/GA4/paid-media, client-facing
+    # weekly reports). The shared digest core is EARNED at vertical-2, not
+    # designed up front (ADR 0038 §7). Until then this is the law delta.
+---
+
+# Matter Status Digest
+
+Assembles a periodic **internal** digest of the firm's matters from Clio: what's open and where it stands, what's coming due, what's gone quiet, what's low on trust, and what's held for conflict clearance. It is the principal's "state of the practice this week" view. It **reports state; it never decides or recommends a legal next step** — surfacing a quiet matter is connective work, deciding what that matter needs is the lawyer's.
+
+This is the proactive counterpart to the wedge's reactive `matter-status-responder` (which answers one client's "where are we"). Same Clio reads, opposite direction: one client asking outward vs. the principal scanning inward.
+
+## When to Use
+
+A principal running a book of matters loses the forest for the trees: which matters are advancing, which are waiting on the firm, which on the client, which have gone silent, which are running low on retainer. Reconstructing that by clicking through Clio every week is the bottleneck. This skill assembles it — sourced, current, and honest about what Clio can and cannot tell — so the principal reads one digest instead of auditing the system.
+
+Runs on the firm's cadence (e.g., a Monday-morning scan).
+
+## Prerequisites
+
+Reads Clio (`list_matters`, `get_matter`, `list_tasks`, `list_calendar_entries`, `get_billing_summary`) and, for the low-trust flag, the `build:lawpay` read-only balance (trust is NOT in Clio — `get_billing_summary` is AR, not trust; see `operator/verticals/law-firm/clio-surface.md`). Requires `python3` for the fetch block. Internal output only — this digest is for the principal, not a client.
+
+## How to Run
+
+```
+hermes run matter-status-digest                  # full scan on cadence
+hermes run matter-status-digest --status open
+hermes run matter-status-digest --window 7d      # "what changed / came due" window
+```
+
+## Procedure
+
+Two phases (ADR 0021 Stream A). The mechanical per-matter Clio fetch runs in one `execute_code` block so per-matter reads never flood context; the sectioning and flagging stay in the agent's reasoning loop.
+
+### Phase 1 — Fetch (single `execute_code` block)
+
+Enumerate matters (`list_matters`, filtered by `--status`), then per matter pull `get_matter` (stage, `updated_at`, responsible attorney — **pending the connector field-widening**, see below), `list_tasks` (open tasks + `due_at`), `list_calendar_entries` (upcoming events), and `get_billing_summary` (AR). Pull the LawPay trust balance per matter for the low-trust flag. Accumulate in-process; `print()` one JSON document. A single matter's read failure is a `parse_failed` row; the scan does not abort.
+
+> **Connector dependency.** `responsible_attorney` and `updated_at` on matters require the matter-field-set widening tracked at the connect step (`clio-surface.md` findings 2–3). Until it lands, the digest omits the attorney column and falls back to calendar-entry recency for the quiet-matter flag, and says so in the header — it does not fabricate either.
+
+### Phase 2 — Reason (agent, in-context)
+
+Per `references/algorithm.md`, assemble the digest:
+
+1. **Group by stage/status** — open matters bucketed by their Clio stage; counts up top.
+2. **Upcoming dates** — tasks with a near `due_at` and calendar entries in the window, per matter. Sourced dates only; no invented deadlines.
+3. **Quiet matters** — reuse `stalled-matter-nudge`'s recency model (`matter.updated_at` floored by latest calendar entry; the same `updated_at` caveat and fallback apply). Flag matters past the firm's window that are NOT legitimately waiting (open task with a future due date = waiting, not quiet).
+4. **Low trust** — matters whose LawPay trust balance is below the firm's floor (read-only; never a fund movement).
+5. **Held** — matters on conflict-hold surfaced in their own section (need human clearance, not a status line).
+6. **Write the digest** to the firm's internal notes surface per `references/output-format.md`. Internal only.
+
+## Trust Ceiling
+
+**Assemble + surface autonomous; internal-only; `draft_for_review` if ever delivered externally.**
+
+The agent MAY: read Clio + the LawPay trust balance; compute recency and flags; write the digest to the firm-internal notes surface.
+
+The agent MUST NOT: recommend or decide a matter's next legal step; move or touch trust funds; send anything to a client; invent a date, balance, or stage; present a degraded signal as a precise one.
+
+## Safety invariants (any violation → `fails`, no recovery)
+
+1. **Reports, does not decide.** The digest states where matters stand and flags the quiet/low/held ones; it never prescribes the next legal step.
+2. **No fabrication.** Every stage, date, and balance traces to a Clio/LawPay read. Missing data is shown as missing, not filled.
+3. **Trust read-only.** The low-trust flag reads the balance; zero fund-movement calls, enforced independently of adapter capability.
+4. **Held matters gated.** Conflict-held matters are surfaced separately, not folded into the normal status sections.
+5. **Internal + privilege.** The digest is for the principal; matter detail stays on firm surfaces.
+
+## Pitfalls
+
+Recommending what a quiet matter needs (flag only); presenting `updated_at` recency as precise when the connector fallback is in effect; conflating AR (`get_billing_summary`) with trust (LawPay); inventing a due date when `list_tasks` is sparse.
+
+## Verification
+
+1. Every open matter appears once, in the right stage bucket.
+2. Upcoming dates, quiet flags, low-trust flags, and held matters are each sourced; none invented.
+3. No legal-next-step recommendation appears anywhere.
+4. The recency signal's precision (full `updated_at` vs. calendar-only fallback) is stated in the header honestly.
+5. The principal reads the practice's state in a few minutes without opening Clio.
+
+## References
+
+- `references/algorithm.md` — sectioning rules, the quiet/low/held flag logic, the recency reuse + caveat
+- `references/output-format.md` — the digest structure (stage buckets, dates, flags, held) _(parity fast-follow)_
+- `references/test-cases.md` — synthetic matter sets (advancing / waiting / quiet / low-trust / held) _(parity fast-follow)_

--- a/operator/skills/matter-status-digest/references/algorithm.md
+++ b/operator/skills/matter-status-digest/references/algorithm.md
@@ -1,0 +1,25 @@
+# Matter Status Digest — Algorithm
+
+The rules that make the digest accurate and honest about Clio's limits.
+
+## Sectioning
+
+1. **Open by stage.** Bucket `list_matters(status=open)` by Clio stage/status. Counts at the top so the principal sees the shape before the detail.
+2. **Upcoming.** Per matter: `list_tasks` with a near `due_at`, and `list_calendar_entries` in the window. Sourced dates only — a matter with no scheduled date shows none, never an invented one.
+3. **Quiet.** Reuse `stalled-matter-nudge`'s recency: `last_activity = matter.updated_at` floored by the latest calendar-entry end time. Past the firm's window AND not legitimately waiting (an open task with a future `due_at` = waiting on purpose, not quiet). Same `updated_at` caveat (last-record-modification, a strong-not-perfect proxy) and same fallback (calendar-only recency, reduced specificity, flagged) as the nudge skill — the two share the model.
+4. **Low trust.** Per matter, the `build:lawpay` read-only trust balance vs. the firm's authored floor. Trust is NOT Clio's `get_billing_summary` (that is AR — `total_outstanding`; do not conflate). Read-only: the flag never triggers a fund movement.
+5. **Held.** Conflict-hold matters in their own section — they need human clearance, not a status line.
+
+## The connector dependency (stated, not worked around)
+
+`responsible_attorney` and `updated_at` on matters require widening the Clio MCP matter field set (`clio-surface.md` findings 2–3; the connect-step connector patch). The digest is built to degrade honestly:
+
+- **With the widening:** attorney column populated; quiet flag uses `updated_at`.
+- **Without it:** attorney column omitted; quiet flag falls back to calendar-entry recency only (misses matters with no calendar history → lower specificity). The header states which mode is in effect. Never fabricate the attorney or a precise recency the connector cannot supply.
+
+## What this algorithm is NOT
+
+- Not a decider — flags state, never prescribes the legal next step.
+- Not a fabricator — every stage, date, and balance is sourced; gaps show as gaps.
+- Not a trust-mover — the low-trust flag reads only.
+- Not client-facing — internal digest for the principal.

--- a/operator/skills/stalled-matter-nudge/SKILL.md
+++ b/operator/skills/stalled-matter-nudge/SKILL.md
@@ -31,7 +31,8 @@ Matters go quiet and slip — not because anyone decided to drop them, but becau
 
 ## Inputs
 
-- The firm's matters and their activity timestamps: `list_matters`, then per matter the most recent of `list_tasks`, `list_calendar_entries`, and notes (the Clio MCP has no first-class matter `updated_at`; recency is the max of these — `clio-surface.md`).
+- The firm's matters and their last-modified time: `list_matters` / `get_matter`, reading the matter's **`updated_at`**. Clio's matter resource carries `updated_at` natively (the connector already requests it on contacts), but the upstream `oktopeak/clio-mcp` omits it from its matter field set — so this skill depends on **widening that field set to include `updated_at`** (the same connector fix `consult-scheduler` / `matter-status-responder` need for `responsible_attorney`). See `clio-surface.md` "CONNECT-STEP DIFF" findings 2–3. Until it lands, recency degrades to the calendar/task signals below and specificity drops — say so, don't fake it.
+- Refinement signals available today: `list_calendar_entries` (the most recent past entry per matter) and `list_tasks` (open tasks + their `due_at`). These power the waiting-vs-stalled filter; they are not the primary clock. **Not available:** per-task created/updated timestamps (`list_tasks` exposes only `due_at`, a future date) and note timestamps (the MCP has no note-read tool) — the earlier "max of task/calendar/note timestamps" model is unbuildable against this connector.
 - The firm's staleness window from `customer.yaml` (days of no activity = stalled), per practice area if authored.
 - Each matter's conflict state.
 
@@ -45,7 +46,7 @@ Triggered on a schedule (e.g., weekly scan).
 
 ## Procedure
 
-1. **Compute recency** per matter: `last_activity = max(task, calendar, note timestamps)`. The matter is a candidate if `today − last_activity > window`.
+1. **Compute recency** per matter: `last_activity = matter.updated_at` (Clio's last-modified timestamp), floored by the most recent `list_calendar_entries` end time when present. The matter is a candidate if `today − last_activity > window`. `updated_at` is last-record-modification — a strong but imperfect proxy (a billing run or a note write bumps it); that is acceptable and far better than a signal the connector cannot supply. If the connector field-widening is not yet live, fall back to calendar-entry recency alone and flag the reduced specificity in the surfaced list.
 2. **Filter out the legitimately-waiting.** A matter with no recent notes but an **open task with a future due date** (awaiting an external response, a court date, a filing window) is **not stalled** — it is waiting on purpose. Do not flag it. (Specificity matters: a false "stalled" flag erodes trust in the list.)
 3. **Gate held matters.** A matter on CONFLICT-HOLD that appears stalled is surfaced **separately** (it needs human clearance, not a client follow-up); draft no client-facing follow-up for it.
 4. **Surface the list** (autonomous): the genuinely-stalled matters, each with its last-activity date and days-quiet.

--- a/operator/skills/stalled-matter-nudge/references/algorithm.md
+++ b/operator/skills/stalled-matter-nudge/references/algorithm.md
@@ -4,17 +4,20 @@ Source of truth for catching genuine drift without crying wolf.
 
 ## Recency
 
-The Clio MCP has no first-class matter `updated_at`. For each matter, compute:
+Clio's matter resource **has** a first-class `updated_at` (last-record-modification). The upstream `oktopeak/clio-mcp` simply does not request it in its matter field set — but it already requests `updated_at` on contacts, proving Clio honors the field, so the connect-step fix is to widen the matter field set (`clio-surface.md` findings 2–3; the same widening `responsible_attorney` needs). With that in place:
 
 ```
-last_activity = max(
-  latest list_tasks timestamp (created/updated/completed),
-  latest list_calendar_entries timestamp,
-  latest note timestamp
-)
+last_activity = matter.updated_at,  floored by
+                latest list_calendar_entries end time (when present)
 ```
 
 A matter is a **candidate** if `today − last_activity > window` (the firm's authored staleness window, per practice area if set).
+
+**Honest caveat.** `updated_at` is last-record-modification, not last-substantive-activity — a billing run or a note write bumps it. It is a strong proxy and the right primary signal; it is not perfect, and the surfaced list should not imply more precision than the field carries.
+
+**What is NOT available from this connector** (do not author against it): per-task created/updated/completed timestamps — `list_tasks` exposes only `due_at` (a future date) — and note timestamps (no note-read tool exists). The prior `max(task, calendar, note)` model assumed reads the connector does not provide.
+
+**Fallback if the field-widening is not yet live:** recency = latest `list_calendar_entries` end time alone. This misses matters with no calendar history, so specificity drops — surface that limitation in the list rather than presenting a weak signal as a strong one.
 
 ## The waiting-vs-stalled filter (specificity)
 

--- a/operator/verticals/law-firm/clio-surface.md
+++ b/operator/verticals/law-firm/clio-surface.md
@@ -59,3 +59,22 @@ There is **no trust-account / IOLTA tool** in the Clio MCP. `get_billing_summary
 - Exact field names/types of `get_matter` / `get_contact` / `list_tasks` payloads (e.g., the "responsible attorney", "practice area", "open date", last-activity timestamp keys) are **assumed** from the input-parameter names; verify against the sandbox before relying on a specific key in `output-format.md`.
 - "Last activity" for `stalled-matter-nudge` has no dedicated read; recency is **inferred** from the most recent of `list_tasks` / `list_calendar_entries` / notes timestamps — confirm there is no first-class `updated_at` on the matter at connect.
 - Pagination caps (`export_audit_log` max 1000/page) noted; other tools' default `limit` values unstated — assume small, paginate.
+
+## CONNECT-STEP DIFF — source-level (oktopeak/clio-mcp v2.0.0, read 2026-06-05)
+
+Read the connector's actual tool source (`src/tools/*.ts`) ahead of the live round-trip. This resolves most of the ASSUMED list from the published-doc shapes; the **live-tenant** round-trip (ADR 0038 §3.6) still has to confirm Clio's API returns these fields populated. Three findings carry forward; the rest confirm.
+
+**Finding 1 — `create_matter` AND `create_calendar_entry` ARE registered, callable tools in the v2.0.0 source**, contradicting the README's "write restricted to tasks/notes/documents." The README is **not authoritative**; the code registers both writes. Our fail-closed draft-and-surface posture stays correct as the _default_, but the connect step must **empirically test** whether each write actually succeeds against the sandbox (Clio plan / OAuth-scope dependent) before deciding whether either skill may graduate to autonomous-write. Do not treat "gated" as settled.
+
+**Finding 2 — matter reads carry NO responsible/originating attorney.** `MATTER_DETAIL_FIELDS` = `id,display_number,description,status,client{id,name},practice_area{id,name},open_date,close_date,billable`. `responsible_attorney`/`originating_attorney` are **create-only inputs**, never returned by `get_matter`/`list_matters`. Any skill that needs "who owns this matter" (addressing a status reply, routing a nudge) cannot read it from the matter. Mitigation is a fork/config to widen the field const, or a separate `list_users` association — **not free.** Audit `matter-status-responder`, `stalled-matter-nudge`, `consult-scheduler` output-formats for an attorney dependency before "deliverable."
+
+**Finding 3 (sharpest) — there is no matter-level last-activity signal.** `get_matter` has no `updated_at`; `list_tasks` exposes `due_at` (a _future_ due date, no `created_at`/`updated_at` in `TASK_FIELDS`); calendar entries give `start_at`/`end_at`. So "when did this matter last see activity" is **not cleanly answerable** from the current tool surface. `stalled-matter-nudge`'s trigger is thinner than the fixtures assume — its "gone quiet" detection needs a re-think (e.g. lean on note timestamps via a different read, or accept a weaker heuristic and say so). Flag per ADR 0038 tripwire: a wedge skill whose signal the connector can't supply is a mis-cut to address, not paper over.
+
+**Confirmed (no divergence):**
+
+- `search_contacts` returns the assumed envelope — `{ contacts[], total_count (meta.records), has_more, next_page_token }`; `next_page_token` parsed from `meta.paging.next`.
+- `get_contact` carries `created_at`/`updated_at` (matters do not).
+- Matter identifier is `display_number`; matter status enum is `open|pending|closed`.
+- `list_tasks` status input is Capitalized (`Pending|Complete|In Progress|In Review|Draft`) → mapped to lowercase for the API; `due_date` is `due_at[:10]`.
+- `get_billing_summary` → `{ matter_id, bill_count, total_billed, total_outstanding, last_invoice_date }` — note the key is **`total_outstanding`**, not the assumed `outstanding_balance`; filters out `draft`/`void` bills. This is AR, **not trust** (confirms trust rides `build:lawpay`).
+- Default `limit` is 25 (max 200) across list tools; 429 rate-limit retry/backoff is built in.

--- a/operator/verticals/law-firm/vertical.yaml
+++ b/operator/verticals/law-firm/vertical.yaml
@@ -35,13 +35,16 @@ personas:
   - slug: office-manager-intake
     title: Office Manager Handling Intake
 
-# Vertical-default skills. Two spine skills are reused as-is; the twelve
+# Vertical-default skills. The spine is law-specific (the 2026-06-05 spine
+# pass corrected the original "reused as-is" assumption: customer-zero's
+# `inbox-triage` and the marketing `status-report-assembler` are other
+# verticals' skills, not a generic spine — see wedge.md "Spine"). The twelve
 # law-specific skills are specified in the brief's "Skill catalog"; their
-# runtime bodies live in hermes-smd-overlay (the first hand-off).
+# runtime bodies live in operator/skills/.
 skills:
-  # spine (reused)
-  - inbox-triage # routes inbound to the right skill
-  - status-report-assembler # compiles the digests
+  # spine (law-specific)
+  - matter-inbox-router # routes inbound mail to the right wedge skill
+  - matter-status-digest # assembles the internal Clio matter digest
   # intake
   - new-matter-intake
   - conflict-intake-router # gather + route; never clears

--- a/operator/verticals/law-firm/wedge.md
+++ b/operator/verticals/law-firm/wedge.md
@@ -23,14 +23,18 @@ Method: [ADR 0038](../../../docs/adr/0038-operator-vertical-delivery-method.md).
 
 **Absorbed safety function (not a 7th skill).** `new-matter-intake` carries a **conflict detect-and-halt invariant**: on intake it runs a read-only name/entity check (`search_contacts` + `list_matters` cross-check) and, on any hit, **halts the consult/engagement chain** and surfaces _"possible conflict — human clearance required."_ Clearance stays definitionally human; intake is never structurally _blind_ to a conflict. Advancing a matter past a surfaced conflict hit is a `fails` safety violation.
 
-## Spine — reused in concept, not literally "as-is" (2) — **spot-check finding**
+## Spine — law-specific skills (2) — **resolved 2026-06-05**
 
-`inbox-triage` (routes inbound to the right wedge skill) and `status-report-assembler` (compiles digests) are reused in **concept**. The 2026-06-04 spot-check corrected the original "reused as-is" assumption:
+The wedge needs two spine skills: one to route inbound mail to the right wedge skill, one to assemble the firm's matter digest. The original plan said "reuse `inbox-triage` + `status-report-assembler` as-is"; the 2026-06-04 spot-check flagged that their bodies are vertical-specific, and the 2026-06-05 spine pass confirmed it and authored law's own:
 
-- **Selector:** the blind cross-skill simulation confirmed neither spine skill **misroutes** against the six wedge skills (the `matter-status-responder` ↔ `status-report-assembler` adjacency resolved correctly). Good.
-- **But their current bodies are vertical-specific, not law-generic.** `inbox-triage`'s description and body are customer-zero/Gmail-framed ("Daily Gmail triage… for owner"); `status-report-assembler`'s are agency-framed ("Weekly client status report from PM tools + analytics" — Asana/GA/paid-media). Reusing them for law needs a **law-context variant or config** (law-routing categories that target the wedge skills; a digest sourced from Clio, not Asana/GA), **not** a literal copy.
+- **`inbox-triage` is customer-zero's** (`customer: smd` — Gmail, `smdcrane@agentmail.to`, Scott's voice). **`status-report-assembler` is marketing's** (`vertical: marketing-agency` — Asana/GA4/paid-media, client-facing weekly reports). Neither is a generic spine; the skills dir is keyed by `name:`, so law cannot overload either.
+- **Law's spine, authored as purpose-built skills** (`operator/skills/`):
+  - **`matter-inbox-router`** (`vertical: law-firm`) — classifies inbound firm mail and routes each message to the wedge skill that owns it (intake / scheduler / engagement-chaser / status-responder / trust-nudge), conflict-cross-check-first, UPL-safe. It **dispatches, it does not draft** — the routed-to skill drafts under reviewer-as-sender.
+  - **`matter-status-digest`** (`vertical: law-firm`) — assembles the internal "state of the practice" digest from **Clio reads** (open-by-stage, upcoming dates, quiet matters via the `stalled-matter-nudge` recency model, low-trust via LawPay read, held matters), internal-only, reports state and never prescribes a legal next step.
+- **Selector check still holds:** the routing rubric targets the six wedge skills explicitly; the `matter-status-responder` (reactive, one client) vs. `matter-status-digest` (proactive, the principal) adjacency is a clean directional split, not an overlap.
+- **Shared-core note (ADR 0038 §7):** both carry a frontmatter shared-core-candidate marker. The common router/digest core is **earned at vertical-2 (marketing), not designed up front** — extract it from the law/marketing duplication then (rule-of-three). Until then these are the law delta.
 
-→ **Flag (connect/infra step):** generalize the spine bodies or author law-context configs before the wedge runs on a real Machine. Do not assume the marketing-framed spine bodies serve law unchanged.
+The wedge now binds `matter-inbox-router` + `matter-status-digest` (see `vertical.yaml` and `operator/customers/pilot-law/customer.yaml`). The old marketing-framed-spine flag is **closed.**
 
 ## Deferred — 6 (each off the named job's critical path)
 


### PR DESCRIPTION
## Summary
- **Law spine authored** — `matter-inbox-router` (inbound classifier/dispatcher, conflict-cross-check-first, UPL-safe) and `matter-status-digest` (internal Clio digest). Replaces the original "reuse `inbox-triage` + `status-report-assembler` as-is" plan; those are customer-zero (Gmail) and marketing (Asana/GA4) skills, not a generic spine. Wired into `vertical.yaml` + the pilot-law persona.
- **Clio connect-step findings** — source-level read of `oktopeak/clio-mcp` v2.0.0: `create_matter`/`create_calendar_entry` are registered writes (README wrong, must test live); matter reads carry no responsible attorney; no matter-level last-activity field.
- **`stalled-matter-nudge` recency re-cut** onto `matter.updated_at` (depends on connector matter-field-set widening) with a calendar-only fallback; the prior `max(task/calendar/note)` model is unbuildable against this connector.
- **`pilot-law/customer.yaml`** — disposable sandbox customer (ADR 0038 steps 4-6 prep): Clio dev tenant + shared `sandbox@smd.services` Google bench (one seat reused across verticals), 8 skills all `draft_for_review`/fail-closed. Not a real client.

## Test plan
- [x] `npm run verify` passes (typecheck + format + tests)
- [ ] Provision pilot-law Machine and run the §3.6 contract-conformance round-trip against the live Clio tenant
- [ ] Resolve the connector field-widening fork (Clio MCP fork vs. `list_users` lookup) before the skills run at full fidelity

🤖 Generated with [Claude Code](https://claude.com/claude-code)