### PR TITLE
feat(assessment): voice backend — custom-LLM bridge + signed-URL endpoint (ADR 0039 node 1, voice)

### DIFF
--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -82,6 +82,12 @@ declare namespace Cloudflare {
      */
     RESEND_WEBHOOK_SECRET?: string
     ANTHROPIC_API_KEY?: string
+    /** ElevenLabs API key (voice agent for the assessment funnel). Org key from /vc. */
+    ELEVENLABS_API_KEY?: string
+    /** ID of the ElevenLabs assessment agent (custom-LLM = our interviewer). */
+    ELEVENLABS_ASSESSMENT_AGENT_ID?: string
+    /** Optional shared secret the agent's custom-LLM sends as `Authorization: Bearer`. */
+    ELEVENLABS_LLM_SECRET?: string
     SIGNWELL_API_KEY?: string
     SIGNWELL_WEBHOOK_SECRET?: string
     STRIPE_API_KEY?: string

--- a/src/lib/claude/assessment-llm.ts
+++ b/src/lib/claude/assessment-llm.ts
@@ -1,0 +1,147 @@
+/**
+ * OpenAI-compatible custom-LLM bridge for the ElevenLabs voice agent
+ * (ADR 0039 node [1], voice channel). ElevenLabs calls a `/chat/completions`
+ * endpoint on us; we inject OUR interviewer system prompt (the same skill body
+ * the typed loop and the eval harness use) and proxy to Anthropic, translating
+ * the Anthropic SSE stream into OpenAI `chat.completion.chunk` SSE so the voice
+ * agent's brain is our eval-proven operator, not a model in their dashboard.
+ */
+
+import { INTERVIEWER_SYSTEM } from '../assessment/prompts'
+import { ANTHROPIC_API_URL, ANTHROPIC_VERSION, QUALITY_MODEL } from '../llm/models'
+
+export interface OpenAIChatMessage {
+  /** OpenAI role; validated against system/user/assistant at the route + here. */
+  role: string
+  content: string
+}
+
+const MAX_TOKENS = 1024
+const OPENAI_MODEL_LABEL = 'smd-assessment-interviewer'
+
+/**
+ * Split incoming OpenAI messages into the Anthropic shape: our interviewer
+ * prompt is the authoritative system; any system text ElevenLabs injects is
+ * appended after it; user/assistant turns become the message list. Anthropic
+ * requires the first message to be `user`, so a leading assistant turn is
+ * given a minimal user kickoff.
+ */
+export function toAnthropicRequest(messages: ReadonlyArray<OpenAIChatMessage>): {
+  system: string
+  messages: Array<{ role: 'user' | 'assistant'; content: string }>
+} {
+  const extraSystem = messages
+    .filter((m) => m.role === 'system' && typeof m.content === 'string')
+    .map((m) => m.content)
+    .join('\n\n')
+  const system = extraSystem ? `${INTERVIEWER_SYSTEM}\n\n${extraSystem}` : INTERVIEWER_SYSTEM
+
+  const turns = messages
+    .filter((m) => m.role === 'user' || m.role === 'assistant')
+    .map((m) => ({ role: m.role as 'user' | 'assistant', content: String(m.content ?? '') }))
+
+  if (turns.length === 0 || turns[0]?.role !== 'user') {
+    turns.unshift({ role: 'user', content: '[The business owner has joined the call.]' })
+  }
+  return { system, messages: turns }
+}
+
+function sseChunk(delta: { role?: string; content?: string }, finish: string | null): string {
+  const payload = {
+    id: 'chatcmpl-assessment',
+    object: 'chat.completion.chunk',
+    model: OPENAI_MODEL_LABEL,
+    choices: [{ index: 0, delta, finish_reason: finish }],
+  }
+  return `data: ${JSON.stringify(payload)}\n\n`
+}
+
+/** Extract the text out of one Anthropic SSE `data:` line, or null if it carries no text. */
+function textFromAnthropicEvent(jsonLine: string): string | null {
+  try {
+    const evt: unknown = JSON.parse(jsonLine)
+    if (
+      typeof evt === 'object' &&
+      evt !== null &&
+      (evt as { type?: unknown }).type === 'content_block_delta'
+    ) {
+      const delta = (evt as { delta?: { type?: string; text?: string } }).delta
+      if (delta?.type === 'text_delta' && typeof delta.text === 'string') return delta.text
+    }
+  } catch {
+    // ignore non-JSON keepalive lines
+  }
+  return null
+}
+
+/**
+ * Call Anthropic with streaming and return an OpenAI-compatible SSE Response.
+ * Throws (caller maps to an error response) only on the initial connect; once
+ * the stream is open, transport errors end the stream cleanly.
+ */
+export async function streamInterviewerCompletion(
+  apiKey: string,
+  messages: ReadonlyArray<OpenAIChatMessage>
+): Promise<Response> {
+  const { system, messages: anthropicMessages } = toAnthropicRequest(messages)
+
+  const upstream = await fetch(ANTHROPIC_API_URL, {
+    method: 'POST',
+    headers: {
+      'x-api-key': apiKey,
+      'anthropic-version': ANTHROPIC_VERSION,
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      model: QUALITY_MODEL,
+      max_tokens: MAX_TOKENS,
+      system,
+      messages: anthropicMessages,
+      stream: true,
+    }),
+  })
+
+  if (!upstream.ok || !upstream.body) {
+    throw new Error(`Anthropic stream failed: ${upstream.status}`)
+  }
+
+  const reader = upstream.body.getReader()
+  const decoder = new TextDecoder()
+  const encoder = new TextEncoder()
+  let buffer = ''
+
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(encoder.encode(sseChunk({ role: 'assistant', content: '' }, null)))
+    },
+    async pull(controller) {
+      const { done, value } = await reader.read()
+      if (done) {
+        controller.enqueue(encoder.encode(sseChunk({}, 'stop')))
+        controller.enqueue(encoder.encode('data: [DONE]\n\n'))
+        controller.close()
+        return
+      }
+      buffer += decoder.decode(value, { stream: true })
+      const lines = buffer.split('\n')
+      buffer = lines.pop() ?? ''
+      for (const line of lines) {
+        const trimmed = line.trim()
+        if (!trimmed.startsWith('data:')) continue
+        const text = textFromAnthropicEvent(trimmed.slice(5).trim())
+        if (text) controller.enqueue(encoder.encode(sseChunk({ content: text }, null)))
+      }
+    },
+    cancel() {
+      void reader.cancel()
+    },
+  })
+
+  return new Response(stream, {
+    headers: {
+      'content-type': 'text/event-stream; charset=utf-8',
+      'cache-control': 'no-cache',
+      connection: 'keep-alive',
+    },
+  })
+}

--- a/src/pages/api/assessment/llm.ts
+++ b/src/pages/api/assessment/llm.ts
@@ -1,0 +1,68 @@
+/**
+ * POST /api/assessment/llm  — OpenAI-compatible `/chat/completions` for the
+ * ElevenLabs voice agent's custom LLM (ADR 0039 node [1], voice channel).
+ *
+ * ElevenLabs calls this with the conversation in OpenAI format; we inject our
+ * interviewer system prompt and stream back Anthropic's reply translated to
+ * OpenAI `chat.completion.chunk` SSE. The brain is our eval-proven operator.
+ *
+ * Auth: if ELEVENLABS_LLM_SECRET is configured, a matching `Authorization:
+ * Bearer <secret>` is required (set the same secret on the agent's custom-LLM
+ * config). If unset, the endpoint is open (dogfood default).
+ */
+
+import type { APIContext, APIRoute } from 'astro'
+import { env } from 'cloudflare:workers'
+import {
+  streamInterviewerCompletion,
+  type OpenAIChatMessage,
+} from '../../../lib/claude/assessment-llm'
+
+function json(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+function parseMessages(body: unknown): OpenAIChatMessage[] | null {
+  if (typeof body !== 'object' || body === null) return null
+  const raw = (body as { messages?: unknown }).messages
+  if (!Array.isArray(raw) || raw.length === 0 || raw.length > 200) return null
+  const messages: OpenAIChatMessage[] = []
+  for (const item of raw) {
+    if (typeof item !== 'object' || item === null) return null
+    const role = (item as { role?: unknown }).role
+    const content = (item as { content?: unknown }).content
+    if (typeof role !== 'string') return null
+    if (typeof content !== 'string') return null
+    messages.push({ role, content })
+  }
+  return messages
+}
+
+export const POST: APIRoute = async ({ request }: APIContext) => {
+  const expected = env.ELEVENLABS_LLM_SECRET
+  if (expected) {
+    const auth = request.headers.get('authorization') ?? ''
+    if (auth !== `Bearer ${expected}`) return json(401, { error: 'unauthorized' })
+  }
+
+  if (!env.ANTHROPIC_API_KEY) return json(503, { error: 'unavailable' })
+
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return json(400, { error: 'invalid json' })
+  }
+
+  const messages = parseMessages(body)
+  if (messages === null) return json(400, { error: 'invalid messages' })
+
+  try {
+    return await streamInterviewerCompletion(env.ANTHROPIC_API_KEY, messages)
+  } catch {
+    return json(502, { error: 'upstream error' })
+  }
+}

--- a/src/pages/api/assessment/voice-token.ts
+++ b/src/pages/api/assessment/voice-token.ts
@@ -1,0 +1,53 @@
+/**
+ * GET /api/assessment/voice-token
+ *
+ * Mints a short-lived signed URL the browser widget uses to connect to the
+ * private ElevenLabs assessment agent (ADR 0039 node [1], voice channel). The
+ * API key stays server-side; the browser never sees it. Rate-limited.
+ */
+
+import type { APIContext, APIRoute } from 'astro'
+import { env } from 'cloudflare:workers'
+import { rateLimitByIp } from '../../../lib/booking/rate-limit'
+
+const RATE_LIMIT_PER_HOUR = 60
+const SIGNED_URL_ENDPOINT = 'https://api.elevenlabs.io/v1/convai/conversation/get-signed-url'
+
+function json(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+export const GET: APIRoute = async ({ clientAddress }: APIContext) => {
+  const rate = await rateLimitByIp(
+    env.BOOKING_CACHE,
+    'assessment_voice_token',
+    clientAddress,
+    RATE_LIMIT_PER_HOUR
+  )
+  if (!rate.allowed) return json(429, { error: 'Too many requests. Please slow down.' })
+
+  const apiKey = env.ELEVENLABS_API_KEY
+  const agentId = env.ELEVENLABS_ASSESSMENT_AGENT_ID
+  if (!apiKey || !agentId) return json(503, { error: 'Voice is temporarily unavailable.' })
+
+  try {
+    const res = await fetch(`${SIGNED_URL_ENDPOINT}?agent_id=${encodeURIComponent(agentId)}`, {
+      headers: { 'xi-api-key': apiKey },
+    })
+    if (!res.ok) return json(502, { error: 'Could not start the voice session.' })
+    const data: unknown = await res.json()
+    const signedUrl =
+      typeof data === 'object' &&
+      data !== null &&
+      typeof (data as { signed_url?: unknown }).signed_url === 'string'
+        ? (data as { signed_url: string }).signed_url
+        : null
+    if (!signedUrl) return json(502, { error: 'Could not start the voice session.' })
+    return json(200, { signedUrl })
+  } catch {
+    return json(502, { error: 'Could not start the voice session.' })
+  }
+}

--- a/tests/assessment-voice-llm.test.ts
+++ b/tests/assessment-voice-llm.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Tests for the ElevenLabs custom-LLM bridge (ADR 0039 node [1], voice).
+ * Network-free: covers the OpenAI -> Anthropic translation — our interviewer
+ * prompt is the authoritative system, turns are filtered to user/assistant,
+ * and Anthropic's user-first requirement is enforced.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { toAnthropicRequest } from '../src/lib/claude/assessment-llm'
+import { INTERVIEWER_SYSTEM } from '../src/lib/assessment/prompts'
+
+describe('toAnthropicRequest', () => {
+  it('uses the interviewer skill as the authoritative system prompt', () => {
+    const { system } = toAnthropicRequest([{ role: 'user', content: 'hi' }])
+    expect(system).toBe(INTERVIEWER_SYSTEM)
+    expect(system).toContain('operations consultant')
+  })
+
+  it('appends any system text ElevenLabs injects after ours', () => {
+    const { system } = toAnthropicRequest([
+      { role: 'system', content: 'DYNAMIC_VAR=abc' },
+      { role: 'user', content: 'hi' },
+    ])
+    expect(system.startsWith(INTERVIEWER_SYSTEM)).toBe(true)
+    expect(system).toContain('DYNAMIC_VAR=abc')
+  })
+
+  it('keeps only user/assistant turns, in order', () => {
+    const { messages } = toAnthropicRequest([
+      { role: 'system', content: 's' },
+      { role: 'user', content: 'u1' },
+      { role: 'assistant', content: 'a1' },
+      { role: 'user', content: 'u2' },
+    ])
+    expect(messages).toEqual([
+      { role: 'user', content: 'u1' },
+      { role: 'assistant', content: 'a1' },
+      { role: 'user', content: 'u2' },
+    ])
+  })
+
+  it('forces a user-first message when the turns start with assistant', () => {
+    const { messages } = toAnthropicRequest([{ role: 'assistant', content: 'greeting' }])
+    expect(messages[0]?.role).toBe('user')
+    expect(messages[1]).toEqual({ role: 'assistant', content: 'greeting' })
+  })
+
+  it('produces a user kickoff when no turns are present', () => {
+    const { messages } = toAnthropicRequest([{ role: 'system', content: 's' }])
+    expect(messages).toHaveLength(1)
+    expect(messages[0]?.role).toBe('user')
+  })
+})


### PR DESCRIPTION
## Summary

Backend for the ElevenLabs voice channel (ADR 0039 §3). The voice agent's **brain stays our eval-proven interviewer**: ElevenLabs calls our OpenAI-compatible `/chat/completions`, we inject the interviewer system prompt and proxy to Anthropic, streaming the reply back translated to OpenAI chunks. No model lives in their dashboard.

- `src/lib/claude/assessment-llm.ts` — OpenAI→Anthropic translation + Anthropic SSE → OpenAI `chat.completion.chunk` SSE.
- `src/pages/api/assessment/llm.ts` — the endpoint ElevenLabs' custom LLM points at (optional `ELEVENLABS_LLM_SECRET` bearer auth).
- `src/pages/api/assessment/voice-token.ts` — mints a short-lived signed URL so the browser connects to the private agent without exposing the key.
- `env.d.ts` — the three ElevenLabs env vars.

## Why first

Endpoints must be live before the ElevenLabs agent can point at them. So this ships first; the agent creation + the `/assessment` voice widget follow in a second PR.

## Test plan

- [x] `npm run verify` green; OpenAI→Anthropic translation covered network-free (`tests/assessment-voice-llm.test.ts`).
- [ ] Post-deploy: bind `ELEVENLABS_API_KEY` to the Worker, create the agent against the live LLM URL, confirm `/api/assessment/voice-token` returns a signed URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)