### PR TITLE
feat(assessment): voice widget on /assessment — talk to the operator (ADR 0039 node 1, voice)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@astrojs/cloudflare": "^13.1.10",
         "@astrojs/sitemap": "^3.7.2",
         "@clerk/astro": "^3.2.6",
+        "@elevenlabs/client": "^1.9.0",
         "@formepdf/core": "^0.8.2",
         "@formepdf/react": "^0.8.2",
         "@sentry/cloudflare": "^10.51.0",
@@ -263,6 +264,12 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.10.1.tgz",
+      "integrity": "sha512-wJ8ReQbHxsAfXhrf9ixl0aYbZorRuOWpBNzm8pL8ftmSxQx/wnJD5Eg861NwJU/czy2VXFIebCeZnZrI9rktIQ==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@capsizecss/unpack": {
       "version": "4.0.0",
@@ -526,6 +533,21 @@
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
+    },
+    "node_modules/@elevenlabs/client": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@elevenlabs/client/-/client-1.9.0.tgz",
+      "integrity": "sha512-czkbwUv7n18DoH5L9YdAKr0ATlcPSYNxhVQTfnFvAUdijvWfhwn8Ct0WHbPxX1oGwH6s1hMbPPAK+CUURHyowg==",
+      "license": "MIT",
+      "dependencies": {
+        "@elevenlabs/types": "0.14.0",
+        "livekit-client": "2.16.1"
+      }
+    },
+    "node_modules/@elevenlabs/types": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@elevenlabs/types/-/types-0.14.0.tgz",
+      "integrity": "sha512-CfpxFyNtTq9Iwm1/Hfxk+FK0QlFgsHpXcNM9jMPYrjP/kAYMFi9rgFoosdJcBGYbgkvzUL7hwT9I6WzHyNyxDg=="
     },
     "node_modules/@emmetio/abbreviation": {
       "version": "2.3.3",
@@ -1716,6 +1738,21 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@livekit/mutex": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@livekit/mutex/-/mutex-1.1.1.tgz",
+      "integrity": "sha512-EsshAucklmpuUAfkABPxJNhzj9v2sG7JuzFDL4ML1oJQSV14sqrpTYnsaOudMAw9yOaW53NU3QQTlUQoRs4czw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@livekit/protocol": {
+      "version": "1.42.2",
+      "resolved": "https://registry.npmjs.org/@livekit/protocol/-/protocol-1.42.2.tgz",
+      "integrity": "sha512-0jeCwoMJKcwsZICg5S6RZM4xhJoF78qMvQELjACJQn6/VB+jmiySQKOSELTXvPBVafHfEbMlqxUw2UR1jTXs2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bufbuild/protobuf": "^1.10.0"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
@@ -2641,6 +2678,13 @@
       "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/dom-mediacapture-record": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/@types/dom-mediacapture-record/-/dom-mediacapture-record-1.0.22.tgz",
+      "integrity": "sha512-mUMZLK3NvwRLcAAT9qmcK+9p7tpU2FHdDsntR3YI4+GY88XrgG4XiE7u1Q2LAN2/FZOz/tdMDC3GQCR4T8nFuw==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
@@ -4856,6 +4900,15 @@
       "version": "5.0.4",
       "license": "MIT"
     },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/execa": {
       "version": "8.0.1",
       "dev": true,
@@ -5595,6 +5648,15 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-cookie": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.7.tgz",
@@ -5966,6 +6028,27 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/livekit-client": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/livekit-client/-/livekit-client-2.16.1.tgz",
+      "integrity": "sha512-PmOHiGdkzw2P/t0vLbJRwHU59+T+JcFlGTYDV7PObWmzvypIij1Vlj0WhZKDZ/Ac7CvwWinbiGCVw/Pb/OiYYw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@livekit/mutex": "1.1.1",
+        "@livekit/protocol": "1.42.2",
+        "events": "^3.3.0",
+        "jose": "^6.1.0",
+        "loglevel": "^1.9.2",
+        "sdp-transform": "^2.15.0",
+        "ts-debounce": "^4.0.0",
+        "tslib": "2.8.1",
+        "typed-emitter": "^2.1.0",
+        "webrtc-adapter": "^9.0.1"
+      },
+      "peerDependencies": {
+        "@types/dom-mediacapture-record": "^1"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "dev": true,
@@ -6025,6 +6108,19 @@
       },
       "funding": {
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/loglevel": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
+      "integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/loglevel"
       }
     },
     "node_modules/longest-streak": {
@@ -7916,6 +8012,16 @@
       "version": "1.1.4",
       "license": "MIT"
     },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/s.color": {
       "version": "0.0.15",
       "dev": true,
@@ -7934,6 +8040,21 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
+      }
+    },
+    "node_modules/sdp": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/sdp/-/sdp-3.2.2.tgz",
+      "integrity": "sha512-xZocWwfyp4hkbN4hLWxMjmv2Q8aNa9MhmOZ7L9aCZPT+dZsgRr6wZRrSYE3HTdyk/2pZKPSgqI7ns7Een1xMSA==",
+      "license": "MIT"
+    },
+    "node_modules/sdp-transform": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/sdp-transform/-/sdp-transform-2.15.0.tgz",
+      "integrity": "sha512-KrOH82c/W+GYQ0LHqtr3caRpM3ITglq3ljGUIb8LTki7ByacJZ9z+piSGiwZDsRyhQbYBOBJgr2k6X4BZXi3Kw==",
+      "license": "MIT",
+      "bin": {
+        "sdp-verify": "checker.js"
       }
     },
     "node_modules/semver": {
@@ -8393,6 +8514,12 @@
         "typescript": ">=4.8.4"
       }
     },
+    "node_modules/ts-debounce": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ts-debounce/-/ts-debounce-4.0.0.tgz",
+      "integrity": "sha512-+1iDGY6NmOGidq7i7xZGA4cm8DAa6fqdYcvO5Z6yBevH++Bdo9Qt/mN0TzHUgcCcKv1gmh9+W5dHqz8pMWbCbg==",
+      "license": "MIT"
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "license": "0BSD"
@@ -8406,6 +8533,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/typed-emitter/-/typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-g/KzbYKbH5C2vPkaXGu8DJlHrGKHLsM25Zg9WuC9pMGfuvT+X25tZQWo5fK1BjBm8+UrVE9LDCvaY0CQk+fXDA==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "rxjs": "*"
       }
     },
     "node_modules/typesafe-path": {
@@ -9321,6 +9457,19 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/webrtc-adapter": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-9.0.5.tgz",
+      "integrity": "sha512-U9vjByy/sK2OMXu5mmfuZFKTMIUQe34c0JXRO+oDrxJTsntdYT2iIFwYMOV7HhMTuktcZLGf2W1N/OcSf9ssWg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "sdp": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=6.0.0",
+        "npm": ">=3.10.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@astrojs/cloudflare": "^13.1.10",
     "@astrojs/sitemap": "^3.7.2",
     "@clerk/astro": "^3.2.6",
+    "@elevenlabs/client": "^1.9.0",
     "@formepdf/core": "^0.8.2",
     "@formepdf/react": "^0.8.2",
     "@sentry/cloudflare": "^10.51.0",

--- a/src/lib/claude/assessment-llm.ts
+++ b/src/lib/claude/assessment-llm.ts
@@ -20,6 +20,17 @@ const MAX_TOKENS = 1024
 const OPENAI_MODEL_LABEL = 'smd-assessment-interviewer'
 
 /**
+ * Appended to the interviewer system prompt for the voice channel: the reply is
+ * spoken aloud, so it must stay short and must never voice the typed-mode
+ * completion marker or any markdown/symbols. The voice session ends on the
+ * owner's action, not a sentinel.
+ */
+const VOICE_ADDENDUM = `
+
+--- VOICE MODE ---
+You are speaking aloud to the owner over a live voice call. Keep every reply short and natural for speech — a sentence or two, one question at a time. Never say, spell, or output any completion marker, a line of equals signs, or "===ASSESSMENT-COMPLETE===". When you have covered the ground, give a brief, warm spoken wrap-up and stop. Never read markdown, symbols, or formatting aloud.`
+
+/**
  * Split incoming OpenAI messages into the Anthropic shape: our interviewer
  * prompt is the authoritative system; any system text ElevenLabs injects is
  * appended after it; user/assistant turns become the message list. Anthropic
@@ -34,7 +45,8 @@ export function toAnthropicRequest(messages: ReadonlyArray<OpenAIChatMessage>): 
     .filter((m) => m.role === 'system' && typeof m.content === 'string')
     .map((m) => m.content)
     .join('\n\n')
-  const system = extraSystem ? `${INTERVIEWER_SYSTEM}\n\n${extraSystem}` : INTERVIEWER_SYSTEM
+  const base = extraSystem ? `${INTERVIEWER_SYSTEM}\n\n${extraSystem}` : INTERVIEWER_SYSTEM
+  const system = base + VOICE_ADDENDUM
 
   const turns = messages
     .filter((m) => m.role === 'user' || m.role === 'assistant')

--- a/src/pages/assessment.astro
+++ b/src/pages/assessment.astro
@@ -21,10 +21,18 @@ import Base from '../layouts/Base.astro'
         It's a real conversation, not a form. Talk the way you'd talk to a colleague who's trying to
         understand your business. When we're done, you'll see the findings.
       </p>
-      <button id="start-btn" class="btn" type="button">Start the assessment</button>
+      <div class="intro-actions">
+        <button id="start-voice" class="btn" type="button">Talk to it</button>
+        <button id="start-btn" class="btn btn-ghost" type="button">Or type instead</button>
+      </div>
     </div>
 
     <div id="chat" class="chat" hidden></div>
+
+    <div id="voice-controls" class="voice-controls" hidden aria-live="polite">
+      <span id="voice-status" class="voice-status">Connecting…</span>
+      <button id="voice-end" class="btn" type="button">End &amp; see findings</button>
+    </div>
 
     <div id="thinking" class="thinking" hidden aria-live="polite">
       <span></span><span></span><span></span>
@@ -51,6 +59,9 @@ import Base from '../layouts/Base.astro'
 
   <script>
     import '../scripts/assessment.ts'
+  </script>
+  <script>
+    import '../scripts/assessment-voice.ts'
   </script>
 </Base>
 
@@ -97,6 +108,38 @@ import Base from '../layouts/Base.astro'
     margin: 0 0 1.2rem;
     color: #444;
     line-height: 1.55;
+  }
+  .intro-actions {
+    display: flex;
+    gap: 0.75rem;
+    align-items: center;
+    flex-wrap: wrap;
+  }
+  .btn-ghost {
+    background: transparent;
+    color: #1a1a1a;
+    border: 1px solid #d8d8d8;
+    font-weight: 500;
+  }
+  .btn-ghost:hover {
+    background: #f0f0f0;
+  }
+  .voice-controls {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    margin: 1rem 0;
+    padding: 0.85rem 1rem;
+    border: 1px solid #e6e6e6;
+    border-radius: 10px;
+    background: #fafafa;
+    position: sticky;
+    bottom: 0;
+  }
+  .voice-status {
+    font-size: 0.95rem;
+    color: #555;
   }
   .btn {
     appearance: none;

--- a/src/scripts/assessment-voice.ts
+++ b/src/scripts/assessment-voice.ts
@@ -1,0 +1,195 @@
+/**
+ * Voice client for the assessment preview (ADR 0039 node [1], voice channel).
+ *
+ * Starts an ElevenLabs voice session (mic + speech + TTS) whose brain is our
+ * custom-LLM endpoint, accumulates the spoken transcript turn by turn, and on
+ * end feeds the same findings step the typed flow uses. The session ends on the
+ * owner's action — there is no spoken completion marker (see the voice addendum
+ * in assessment-llm.ts).
+ */
+
+import { Conversation } from '@elevenlabs/client'
+
+interface Turn {
+  speaker: 'owner' | 'operator'
+  text: string
+}
+
+type VoiceSession = Awaited<ReturnType<typeof Conversation.startSession>>
+
+const turns: Turn[] = []
+let session: VoiceSession | null = null
+let ending = false
+
+function el<T extends HTMLElement>(id: string): T {
+  const node = document.getElementById(id)
+  if (!node) throw new Error(`missing #${id}`)
+  return node as T
+}
+
+function strField(value: unknown, key: string): string | undefined {
+  if (typeof value === 'object' && value !== null && key in value) {
+    const v = (value as Record<string, unknown>)[key]
+    return typeof v === 'string' ? v : undefined
+  }
+  return undefined
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+}
+
+function inline(s: string): string {
+  return escapeHtml(s)
+    .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+    .replace(/(^|[^_])_([^_]+?)_(?=[^_]|$)/g, '$1<em>$2</em>')
+}
+
+function renderMarkdown(md: string): string {
+  const lines = md.split('\n')
+  const out: string[] = []
+  let inList = false
+  const closeList = (): void => {
+    if (inList) {
+      out.push('</ul>')
+      inList = false
+    }
+  }
+  for (const rawLine of lines) {
+    const line = rawLine.trimEnd()
+    if (line.trim() === '') {
+      closeList()
+      continue
+    }
+    if (line.startsWith('### ')) {
+      closeList()
+      out.push(`<h4>${inline(line.slice(4))}</h4>`)
+    } else if (line.startsWith('## ')) {
+      closeList()
+      out.push(`<h3>${inline(line.slice(3))}</h3>`)
+    } else if (line.startsWith('# ')) {
+      closeList()
+      out.push(`<h2>${inline(line.slice(2))}</h2>`)
+    } else if (line.startsWith('> ')) {
+      closeList()
+      out.push(`<blockquote>${inline(line.slice(2))}</blockquote>`)
+    } else if (line.startsWith('- ')) {
+      if (!inList) {
+        out.push('<ul>')
+        inList = true
+      }
+      out.push(`<li>${inline(line.slice(2))}</li>`)
+    } else {
+      closeList()
+      out.push(`<p>${inline(line)}</p>`)
+    }
+  }
+  closeList()
+  return out.join('\n')
+}
+
+function appendBubble(speaker: 'owner' | 'operator', text: string): void {
+  const chat = el<HTMLDivElement>('chat')
+  const wrap = document.createElement('div')
+  wrap.className = `bubble bubble-${speaker}`
+  const who = document.createElement('div')
+  who.className = 'bubble-who'
+  who.textContent = speaker === 'operator' ? 'Assessment' : 'You'
+  const body = document.createElement('div')
+  body.className = 'bubble-text'
+  body.textContent = text
+  wrap.appendChild(who)
+  wrap.appendChild(body)
+  chat.appendChild(wrap)
+  chat.scrollTop = chat.scrollHeight
+}
+
+function setStatus(text: string): void {
+  el<HTMLDivElement>('voice-status').textContent = text
+}
+
+async function drawFindings(): Promise<void> {
+  const report = el<HTMLElement>('report')
+  const reportBody = el<HTMLDivElement>('report-body')
+  report.hidden = false
+  reportBody.innerHTML = '<p class="muted">Drafting your findings…</p>'
+  report.scrollIntoView({ behavior: 'smooth' })
+  try {
+    const res = await fetch('/api/assessment/findings', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ turns }),
+    })
+    const data: unknown = await res.json()
+    const findings = strField(data, 'findings')
+    if (!res.ok || !findings) {
+      reportBody.innerHTML = `<p class="muted">${escapeHtml(strField(data, 'error') ?? 'Could not draft findings.')}</p>`
+      return
+    }
+    reportBody.innerHTML = renderMarkdown(findings)
+  } catch {
+    reportBody.innerHTML = '<p class="muted">Connection problem drafting findings.</p>'
+  }
+}
+
+async function endVoice(): Promise<void> {
+  if (ending) return
+  ending = true
+  el<HTMLButtonElement>('voice-end').disabled = true
+  setStatus('Wrapping up…')
+  el<HTMLDivElement>('voice-controls').hidden = true
+  try {
+    if (session) await session.endSession()
+  } catch {
+    /* ignore */
+  }
+  if (turns.length > 0) await drawFindings()
+  else setStatus('No conversation captured.')
+}
+
+async function startVoice(): Promise<void> {
+  el<HTMLButtonElement>('start-voice').hidden = true
+  el<HTMLButtonElement>('start-btn').hidden = true
+  el<HTMLDivElement>('intro').hidden = true
+  el<HTMLDivElement>('chat').hidden = false
+  el<HTMLDivElement>('voice-controls').hidden = false
+  setStatus('Connecting… allow microphone access when asked.')
+  try {
+    const res = await fetch('/api/assessment/voice-token')
+    const data: unknown = await res.json()
+    const signedUrl = strField(data, 'signedUrl')
+    if (!signedUrl) {
+      setStatus('Voice is unavailable right now.')
+      return
+    }
+    session = await Conversation.startSession({
+      signedUrl,
+      onConnect: () => setStatus('Connected. Start talking when you’re ready.'),
+      onModeChange: ({ mode }) =>
+        setStatus(mode === 'speaking' ? 'Assessment is speaking…' : 'Listening…'),
+      onMessage: ({ message, source }: { message: string; source: 'user' | 'ai' }) => {
+        if (!message) return
+        const speaker: 'owner' | 'operator' = source === 'ai' ? 'operator' : 'owner'
+        appendBubble(speaker, message)
+        turns.push({ speaker, text: message })
+      },
+      onError: (msg: string) => setStatus(`Error: ${msg}`),
+      onDisconnect: () => {
+        void endVoice()
+      },
+    })
+  } catch {
+    setStatus('Could not start the voice session. Please try again.')
+  }
+}
+
+function init(): void {
+  el<HTMLButtonElement>('start-voice').addEventListener('click', () => void startVoice())
+  el<HTMLButtonElement>('voice-end').addEventListener('click', () => void endVoice())
+}
+
+init()

--- a/tests/assessment-voice-llm.test.ts
+++ b/tests/assessment-voice-llm.test.ts
@@ -10,10 +10,12 @@ import { toAnthropicRequest } from '../src/lib/claude/assessment-llm'
 import { INTERVIEWER_SYSTEM } from '../src/lib/assessment/prompts'
 
 describe('toAnthropicRequest', () => {
-  it('uses the interviewer skill as the authoritative system prompt', () => {
+  it('uses the interviewer skill as the authoritative system prompt + a voice addendum', () => {
     const { system } = toAnthropicRequest([{ role: 'user', content: 'hi' }])
-    expect(system).toBe(INTERVIEWER_SYSTEM)
+    expect(system.startsWith(INTERVIEWER_SYSTEM)).toBe(true)
     expect(system).toContain('operations consultant')
+    expect(system).toContain('VOICE MODE')
+    expect(system).toContain('Never say, spell, or output any completion marker')
   })
 
   it('appends any system text ElevenLabs injects after ours', () => {


### PR DESCRIPTION
## Summary

Adds the browser **voice channel**. A "Talk to it" button on `/assessment` starts an ElevenLabs voice session (mic, speech, TTS) whose brain is our custom-LLM endpoint — the same eval-proven interviewer. Spoken turns are accumulated and fed into the **same findings step** as the typed flow.

- `@elevenlabs/client` (1.9.0) browser SDK.
- `src/scripts/assessment-voice.ts` — `startSession({signedUrl})`, accumulate turns from `onMessage`, render the report on end.
- `src/pages/assessment.astro` — "Talk to it" / "Or type instead", a voice status + "End & see findings" bar.
- `src/lib/claude/assessment-llm.ts` — voice addendum (never voice the completion marker/markdown; wrap up naturally; short replies for speech).

## Already live + verified (backend, PR #1228)
- Agent created and bound; `/api/assessment/llm` streams our interviewer; `/api/assessment/voice-token` returns a signed `wss` URL.

## Test plan
- [x] `npm run verify` green (build bundles the SDK; lint + types clean; voice-llm + forbidden-strings tests pass).
- [ ] Post-deploy: open `/assessment`, click "Talk to it", have a spoken assessment, confirm the report renders.

## Follow-up (flagged, not deferred silently)
`/api/assessment/llm` is not yet auth-locked (`ELEVENLABS_LLM_SECRET` unset). Closing that open proxy is the immediate next step once voice is confirmed working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)