### PR TITLE
feat(operator): author the 6 deferred law skills (full 14-skill catalog)

### DIFF
--- a/operator/skills/client-matter-digest/SKILL.md
+++ b/operator/skills/client-matter-digest/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: client-matter-digest
+description: Drafts a proactive, client-facing per-matter status update — what's happened, what's coming, what's needed from the client — from Clio reads, in the firm's voice, for a human to send. Reports status; never advises or predicts.
+version: 0.1.0
+author: SMD Services
+license: MIT
+platforms: [linux, macos]
+prerequisites:
+  skills: []
+  commands: [python3]
+metadata:
+  hermes:
+    tags: [Law, Client, Status, Proactive, DraftForReview]
+  smd:
+    vertical: law-firm
+    skill_type: drafting (client-facing)
+    trust_ceiling: draft_for_review
+    action_class: read + external_send
+    connectors:
+      - clio # PracticeManagement — matters, tasks, calendar (read) for the status facts
+      - email # customer-bound — the drafted client update (send is reviewer-as-sender)
+---
+
+# Client Matter Digest
+
+Drafts a proactive update to the client about where their matter stands — recent activity, upcoming dates, and anything the firm needs from them — assembled from Clio and written in the firm's voice for a human to send. It is the outbound, scheduled counterpart to the reactive `matter-status-responder` (which answers one client who asked). Same status facts, opposite trigger: the firm reaching out before the client wonders.
+
+It **reports status; it never advises, predicts, or commits.** It tells the client what has happened and what is scheduled — it does not say what will happen, whether an outcome is likely, or what the client should do legally. Every fact traces to Clio; the message ships under a human reviewer's identity.
+
+## When to Use
+
+Use when the firm wants to keep clients informed on a cadence instead of waiting for "where are we?" emails — the proactive-communication habit that distinguishes a well-run practice. Most matters benefit; the firm authors which matters or practice areas get a digest and how often.
+
+Runs scheduled (e.g., a fortnightly per-matter cadence the firm sets).
+
+## Prerequisites
+
+Reads Clio (`get_matter`, `list_tasks`, `list_calendar_entries`) for the status facts, and the customer-bound **Email** connector to draft the client update. Requires `python3` for the fetch block. The draft is **never sent autonomously** — it ships under the reviewer's identity (reviewer-as-sender, ADR 0005).
+
+## How to Run
+
+```
+hermes run client-matter-digest                    # all matters due for a cadence update
+hermes run client-matter-digest --matter <id>      # one matter's client update
+```
+
+## Procedure
+
+Two phases (ADR 0021 Stream A). The mechanical per-matter Clio fetch runs in one `execute_code` block; the client-appropriate framing and drafting stay in the agent's reasoning loop.
+
+### Phase 1 — Fetch (single `execute_code` block)
+
+For each matter due for an update, pull `get_matter` (stage/status), `list_tasks` (open items, including anything `waiting on client`), and `list_calendar_entries` (upcoming dates the client should know). Accumulate in-process; `print()` one JSON document of (matter → status facts). A matter that can't be read is `parse_failed`; the run continues.
+
+### Phase 2 — Reason (agent, in-context)
+
+Per `references/algorithm.md` and `references/voice.md`:
+
+1. **Select client-appropriate facts.** What progressed since the last update, what is scheduled, and — most useful — **what the firm needs from the client** (a signature, a document, a decision). Internal-only detail (billing internals, strategy notes) stays out.
+2. **Frame as status, not advice.** "Your hearing is scheduled for [date]" — yes. "We expect a favorable ruling" / "you should accept the offer" — never. The line between informing and advising is the central discipline.
+3. **Draft in the firm's voice** (`voice.md`) — warm, plain, professional; no legalese, no false reassurance, no invented progress. If little has happened, say so honestly rather than manufacture activity.
+4. **Surface for review.** The drafted client update is surfaced; a human reviews and sends it under their own identity. Nothing goes to the client autonomously.
+
+## Trust Ceiling
+
+**Read + draft autonomous; client send is reviewer-as-sender (`draft_for_review`, non-raisable).**
+
+The agent MAY: read Clio status facts; select client-appropriate content; draft the update in the firm's voice; surface it for review.
+
+The agent MUST NOT: send to a client autonomously; give legal advice or predict an outcome; invent progress, a date, or a status; include privileged internal detail; promise firm behavior the engagement has not authored.
+
+## Safety invariants (any violation → `fails`, no recovery)
+
+1. **Reviewer-as-sender.** No autonomous send. Every client-bound digest ships under a human reviewer's identity.
+2. **Status, not advice.** Reports what happened and what is scheduled; never advises, predicts an outcome, or recommends a legal action.
+3. **No fabrication.** Every fact traces to a Clio read. A quiet matter is described as quiet, not dressed up.
+4. **No internal leakage.** Billing internals, strategy, and other firm-only detail never enter a client-facing draft.
+5. **No uncontracted promise.** The draft states status; it does not promise timelines or outcomes the engagement has not authored.
+
+## Pitfalls
+
+Drifting from "here's where things stand" into "here's what we expect / what you should do" (advice/prediction — the cardinal error); manufacturing progress to fill a quiet update; leaking internal notes or billing detail into a client message; an over-reassuring tone that implies an outcome; letting a draft send without human review.
+
+## Verification
+
+1. Every status fact in the draft traces to a Clio read; nothing invented.
+2. No sentence advises, predicts an outcome, or recommends a legal step.
+3. No privileged internal detail appears in the client-facing text.
+4. The draft is surfaced for review; no autonomous send occurs.
+5. Quiet matters are described honestly, not embellished.
+
+## References
+
+- `references/algorithm.md` — client-appropriate fact selection, the status-not-advice line, the cadence logic
+- `references/voice.md` — the firm's client-communication voice (warm, plain, no false reassurance) _(parity fast-follow)_
+- `references/output-format.md` — the client update structure _(parity fast-follow)_
+- `references/test-cases.md` — fixtures incl. active matter, quiet matter, waiting-on-client, and an advice-bait case _(parity fast-follow)_

--- a/operator/skills/client-matter-digest/references/algorithm.md
+++ b/operator/skills/client-matter-digest/references/algorithm.md
@@ -1,0 +1,51 @@
+# client-matter-digest algorithm
+
+Source of truth for keeping clients informed without crossing into advice.
+
+## Relationship to matter-status-responder
+
+Same Clio reads, same status-not-advice discipline, opposite trigger:
+
+- `matter-status-responder` — **reactive**, one client asked "where are we?", answer that client.
+- `client-matter-digest` — **proactive**, scheduled cadence, reach out before they ask.
+
+Where both could fire for the same matter (a client asks right as a digest is due), the reactive response wins for that client this cycle; the digest skips them to avoid a duplicate. They are a clean directional split, not an overlap.
+
+## Client-appropriate fact selection
+
+```
+include:  stage/status change since last update
+          activity that advanced the matter (sourced)
+          upcoming dates the client should know (hearings, filings, meetings)
+          *** what the firm needs from the client *** (signature, document, decision)
+exclude:  billing internals, write-off/realization detail
+          strategy notes, internal deliberations
+          anything the firm marks internal-only
+```
+
+The single most useful line in a client update is usually "here's what we need from you" — surface it prominently when present.
+
+## The status-not-advice line
+
+This is the discipline the skill lives or dies on:
+
+| Allowed (status)                                   | Forbidden (advice / prediction)        |
+| -------------------------------------------------- | -------------------------------------- |
+| "Your hearing is set for [date]."                  | "We expect the hearing to go well."    |
+| "We filed the response on [date]."                 | "This strengthens your position."      |
+| "We're waiting on the other side to respond."      | "They'll likely settle soon."          |
+| "We need your signature on the engagement letter." | "You should sign so we can move fast." |
+
+When unsure whether a sentence informs or advises, it advises — cut it.
+
+## Honest about quiet
+
+A matter with little recent activity gets an honest short update ("no major developments since our last note; next scheduled date is [X]") — never manufactured progress. A fabricated "things are moving along nicely" is both a fabrication invariant breach and a trust corrosion.
+
+## Cadence
+
+`cadence` is firm-authored per matter or practice area (from `customer.yaml` where set). The run selects matters whose last-update age exceeds their cadence. No date math produces client-facing content beyond reflecting authored Clio dates.
+
+## Reviewer-as-sender
+
+The output is always a draft. A human reviews and sends under their own identity. There is no autonomous-send path for client-bound mail in any phase (ADR 0005 floor, non-raisable).

--- a/operator/skills/conflict-intake-router/SKILL.md
+++ b/operator/skills/conflict-intake-router/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: conflict-intake-router
+description: The full conflict workflow — rich multi-party capture, routing a surfaced potential conflict to the specific person who must clear it, and a cross-matter re-scan as the matter set grows. Surfaces and routes; never clears.
+version: 0.1.0
+author: SMD Services
+license: MIT
+platforms: [linux, macos]
+prerequisites:
+  skills: []
+  commands: [python3]
+metadata:
+  hermes:
+    tags: [Law, Conflict, Intake, Compliance, Routing, DraftForReview]
+  smd:
+    vertical: law-firm
+    skill_type: decision/surfacing (compliance routing)
+    trust_ceiling: draft_for_review
+    action_class: read + route
+    connectors:
+      - clio # PracticeManagement — search_contacts / list_matters / get_matter (read) for the cross-check
+      - email # customer-bound — to route the conflict notice to the responsible person
+---
+
+# Conflict Intake Router
+
+The deep version of the firm's conflict workflow. `new-matter-intake` already carries the **detect-and-halt invariant** — on intake it runs a read-only name/entity cross-check and halts the chain on any hit. This skill is what that invariant defers to when the firm wants the full treatment: **rich multi-party capture** (every party, adverse party, and related entity a matter touches, not just the named client), **routing** a surfaced potential conflict to the **specific person** who owns the clearance decision, and a **cross-matter cadence re-scan** that re-checks open matters as new parties enter the system.
+
+It sits on a compliance floor. It is **never "just another skill."** Its entire job is to make sure a possible conflict reaches a human cleanly and is never advanced past — it **surfaces and routes; it does not clear.** Clearance is definitionally a human act.
+
+## When to Use
+
+Use when the firm wants conflict handling beyond the intake halt: capturing the full party graph of a matter, directing a flagged conflict to the right attorney rather than a generic queue, and periodically re-checking the existing book as new clients and adverse parties arrive (a party who was clean at intake can become conflicted when a later matter brings in the other side).
+
+Runs event-driven (a new matter or new party is captured) and scheduled (the cadence re-scan across open matters).
+
+## Prerequisites
+
+Reads Clio (`search_contacts`, `list_matters`, `get_matter`) for the name/entity cross-check, and the customer-bound **Email** connector to route a surfaced conflict notice to the responsible person. Requires `python3` for the fetch block. Read-only against Clio — it never writes a clearance, a matter, or a contact.
+
+## How to Run
+
+```
+hermes run conflict-intake-router --matter <id>     # full-party capture + check for one matter
+hermes run conflict-intake-router --cadence-scan     # re-scan all open matters for newly-emerged conflicts
+```
+
+## Procedure
+
+Two phases (ADR 0021 Stream A): the mechanical Clio cross-check runs inside one `execute_code` block so per-party reads never flood context; the adversity judgment and routing stay in the agent's reasoning loop.
+
+### Phase 1 — Fetch (single `execute_code` block)
+
+Enumerate the parties in scope (for a matter: the client plus every party named in the intake capture; for a cadence scan: the party set of each open matter). For each party run `search_contacts` and `list_matters`, accumulate the matches in-process, and `print()` one JSON document of (party → existing contacts/matters it touches). A single unreadable party is recorded as `parse_failed` and the scan continues.
+
+### Phase 2 — Reason (agent, in-context)
+
+Per `references/capture-rubric.md` and `references/algorithm.md`:
+
+1. **Capture the full party graph.** Per `capture-rubric.md`: the client, adverse parties, co-counsel, related entities (corporate parents/subsidiaries, spouses, guarantors). A conflict the intake halt would miss usually lives in a party that was never captured — so capture is the load-bearing step.
+2. **Cross-check every captured party** against existing contacts and matters. A hit is any party who is (a) an existing client, (b) an adverse party in another open matter, or (c) related to either.
+3. **On a hit, assemble a conflict packet** — which party, which existing matter, the nature of the adversity, and the responsible attorney on the conflicting matter (read from the matter where available; `clio-surface.md` notes attorney may require the field-set widening or a `list_users` lookup).
+4. **Route to the specific person.** Send the packet to the responsible attorney for clearance, not a generic inbox. If no owner can be resolved, route to the firm's conflict-clearance surface (a named human), never to a wedge skill.
+5. **Hold the matter.** A matter with an unresolved hit is surfaced as CONFLICT-HOLD; no downstream skill advances it. Advancing past a surfaced hit is a `fails` safety violation.
+6. **Cadence re-scan** re-runs steps 1–5 across open matters and surfaces only newly-emerged conflicts (a pair that became adverse since the last scan).
+
+## Trust Ceiling
+
+**Capture + cross-check + route autonomous; zero clearance, zero writes.**
+
+The agent MAY: read Clio for the cross-check; capture the party graph; assemble a conflict packet; route it to the responsible human; surface a matter as CONFLICT-HOLD.
+
+The agent MUST NOT: clear or waive a conflict; mark a matter conflict-free; write to Clio; advance a held matter; route a flagged conflict to anything but a human clearance surface; invent a party association not resolved from Clio.
+
+## Safety invariants (any violation → `fails`, no recovery)
+
+1. **Never clears.** Clearance is human-only. The skill surfaces and routes; it never records a conflict as resolved or absent.
+2. **Halt precedes everything.** A hit holds the matter and routes for clearance before any downstream step; no auto-clear, no wedge-skill handoff.
+3. **Route to a person, not a queue.** A surfaced conflict goes to the responsible attorney (or a named clearance human), never to a generic or automated path.
+4. **No fabricated party link.** A party is tied to an existing contact/matter only via a real Clio resolution; an unresolved party is reported as unresolved, not guessed clear.
+5. **Privilege.** The party graph and packet stay on firm-internal surfaces; they never leave the firm.
+
+## Pitfalls
+
+Capturing only the named client and missing the adverse/related parties where conflicts actually hide; treating "no hit found" as "cleared" (it is "no hit found" — clearance is still human); routing to a generic inbox instead of the owner; advancing a held matter; inventing a corporate-relationship link the Clio data does not support.
+
+## Verification
+
+1. Every captured party is cross-checked; the party graph includes adverse and related parties, not just the client.
+2. Every hit produces a packet routed to a specific human; no hit is auto-cleared.
+3. Held matters are visibly CONFLICT-HOLD and no downstream skill advances them.
+4. All party→matter links trace to a Clio read; unresolved parties are labeled unresolved.
+5. The cadence scan surfaces newly-emerged conflicts without re-flagging already-cleared ones.
+
+## References
+
+- `references/capture-rubric.md` — the full party graph to capture (client, adverse, co-counsel, related entities) and the adversity tests (the load-bearing logic)
+- `references/algorithm.md` — the cross-check ordering, the hit/packet/route flow, and the cadence-scan delta logic
+- `references/output-format.md` — the conflict packet + CONFLICT-HOLD surface _(parity fast-follow)_
+- `references/test-cases.md` — fixtures incl. clean intake, direct hit, related-entity hit, and the cadence newly-emerged case _(parity fast-follow)_

--- a/operator/skills/conflict-intake-router/references/algorithm.md
+++ b/operator/skills/conflict-intake-router/references/algorithm.md
@@ -1,0 +1,42 @@
+# conflict-intake-router algorithm
+
+Source of truth for catching a conflict without ever clearing one.
+
+## Ordering (single matter)
+
+```
+parties        = capture_party_graph(matter)        # capture-rubric.md — wide
+for each party:
+    contacts   = search_contacts(party.name)        # Clio, read-only
+    matters    = list_matters(contact_id)           # Clio, read-only
+hits           = [p for p in parties if adverse(p, existing book)]   # adversity tests
+if hits:
+    for h in hits:
+        packet = { party, existing_matter, nature_of_adversity, responsible_attorney }
+        route(packet -> responsible_attorney_or_named_clearance_human)
+    surface(matter -> CONFLICT-HOLD)                 # no downstream advance
+else:
+    surface(matter -> "no conflict detected; clearance pending")   # NOT cleared
+```
+
+The cross-check is **read-only and runs before any routing or surfacing**. There is no branch in which the skill writes a clearance.
+
+## Resolving the responsible attorney
+
+The packet routes to the owner of the _conflicting existing matter_ so the right person decides. Per `operator/verticals/law-firm/clio-surface.md` findings 2–3, the responsible attorney is not in the default matter field set; recover it via the connector field-widening or a `list_users` association. If it cannot be resolved, route to the firm's named conflict-clearance human — **never** drop to a generic queue and never to a wedge skill.
+
+## Cadence re-scan (delta logic)
+
+```
+prev_pairs = last_scan.adverse_pairs            # persisted set of (party_a, party_b) already surfaced/cleared
+cur_pairs  = compute_adverse_pairs(open_matters)
+new_pairs  = cur_pairs - prev_pairs             # only newly-emerged adversity
+surface(new_pairs)                              # re-route only the new ones
+```
+
+Dedup against the **already-surfaced/cleared** set, not against confirmed-conflicts — otherwise a human-cleared pair re-surfaces every scan and the firm learns to ignore the signal. A pair becomes new when a later matter brings in the other side of an existing party.
+
+## Honest limits
+
+- The check is name/entity matching over Clio contacts and matters. It will miss a conflict whose party is recorded under a different name/spelling, or not recorded at all — capture width (capture-rubric.md) is the main defense, and even then this is a surfacing aid, not a guarantee.
+- It cannot judge waivability, materiality, or distance of a relationship. Those are clearance judgments; the skill stops at "possible conflict — route to human."

--- a/operator/skills/conflict-intake-router/references/capture-rubric.md
+++ b/operator/skills/conflict-intake-router/references/capture-rubric.md
@@ -1,0 +1,38 @@
+# Conflict capture rubric
+
+The load-bearing step. A conflict the intake halt misses almost always lives in a party that was never captured. Capture wide; check everything captured.
+
+## The party graph to capture
+
+For every matter, capture beyond the named client:
+
+- **Client(s)** — the engaging party, including all individuals on a joint engagement.
+- **Adverse parties** — the opposing side: the defendant/plaintiff, the other spouse, the counterparty to a transaction, the party a demand is directed at.
+- **Co-counsel and co-parties** — other firms or aligned parties on the same matter.
+- **Related entities** — the relationships where adversity hides:
+  - corporate parents, subsidiaries, and affiliates of a party
+  - owners, officers, and guarantors of a party entity
+  - spouses and immediate family in family/estate matters
+  - trustees, beneficiaries, executors, and the estate/decedent in probate matters
+  - insurers and indemnitors standing behind a party
+- **Witnesses and experts** only when the firm's policy treats them as conflict-relevant (firm-authored; do not assume).
+
+Capture each as (name, role-in-this-matter, entity-or-individual). Do not infer a relationship the intake material does not state — capture what is given; flag what is ambiguous.
+
+## The adversity tests (what counts as a hit)
+
+A captured party is a **hit** if any holds against the existing book:
+
+1. **Existing-client adversity** — the party is, or is related to, a current/former client AND appears on the _adverse_ side of this matter.
+2. **Cross-matter adversity** — the party is an adverse party in another open matter where the firm represents the other side.
+3. **Positional/issue** — only when firm policy defines it (firm-authored). Not assumed by default.
+
+"No hit found" is a finding, not a clearance. Surface it as "no conflict detected on the captured parties — clearance pending"; the human still clears.
+
+## What this rubric does NOT do
+
+- It does not weigh whether a conflict is _waivable_ — that is the attorney's call.
+- It does not draft a waiver or consent.
+- It does not decide that a thin or distant relationship is "fine."
+
+All three are clearance judgments. This rubric only decides **what to capture** and **what to surface as a possible conflict**.

--- a/operator/skills/deadline-and-sol-tracker/SKILL.md
+++ b/operator/skills/deadline-and-sol-tracker/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: deadline-and-sol-tracker
+description: Surfaces the firm's authored court dates, filing deadlines, and statute-of-limitations dates by proximity — overdue, imminent, upcoming. Reflects dates a human entered; never computes a limitation period.
+version: 0.1.0
+author: SMD Services
+license: MIT
+platforms: [linux, macos]
+prerequisites:
+  skills: []
+  commands: [python3]
+metadata:
+  hermes:
+    tags: [Law, Deadlines, Calendar, Internal, DraftForReview]
+  smd:
+    vertical: law-firm
+    skill_type: read + assembly (internal surfacing)
+    trust_ceiling: draft_for_review
+    action_class: read + internal_write
+    connectors:
+      - clio # PracticeManagement — list_calendar_entries / list_tasks (read) for authored dates
+---
+
+# Deadline and SOL Tracker
+
+Surfaces the firm's **authored** critical dates — court dates, filing deadlines, response windows, and statute-of-limitations dates that a human has entered into the system — bucketed by proximity so nothing critical arrives by surprise. It is the date-awareness layer for the practice.
+
+This skill is the **nearest of all the law skills to legal judgment**, so it is drawn with the hardest line: **it tracks dates a human authored; it never computes one.** A statute of limitations is a legal determination — the date the deadline falls is the lawyer's to set. This skill reads the date the lawyer set and tells them it is coming. It does not calculate "three years from the incident," does not infer a filing window from a rule, and does not advise. Authored in, surfaced out.
+
+## When to Use
+
+Use when the firm wants a standing view of what is coming due across matters — the dates that, if missed, cause real harm. A principal otherwise reconstructs this by clicking through every matter's calendar; this assembles it, sourced and honest about what it can and cannot know.
+
+Runs scheduled (e.g., a daily or Monday-morning scan).
+
+## Prerequisites
+
+Reads Clio (`list_calendar_entries` for authored court/filing dates, `list_tasks` for deadline-bearing tasks via `due_at`). Requires `python3` for the fetch block. Internal output only. No write to funds, matters, or dates.
+
+## How to Run
+
+```
+hermes run deadline-and-sol-tracker                 # full scan, all open matters
+hermes run deadline-and-sol-tracker --window 30d    # only dates within N days
+hermes run deadline-and-sol-tracker --matter <id>   # one matter's dates
+```
+
+## Procedure
+
+Two phases (ADR 0021 Stream A). The mechanical per-matter date fetch runs in one `execute_code` block; the bucketing and surfacing stay in the agent's reasoning loop.
+
+### Phase 1 — Fetch (single `execute_code` block)
+
+Enumerate open matters, then per matter pull `list_calendar_entries` (court dates, hearings, authored deadline events) and `list_tasks` (tasks carrying a `due_at`). Accumulate in-process; `print()` one JSON document of (matter → authored dates with their source type and date). A matter whose dates can't be read is a `parse_failed` row; the scan does not abort.
+
+### Phase 2 — Reason (agent, in-context)
+
+Per `references/algorithm.md`:
+
+1. **Bucket by proximity** — `overdue` (past, still open), `imminent` (within the firm's near window), `upcoming` (within the scan window). Buckets are date arithmetic on authored dates only.
+2. **Label the source** — each date is tagged court-date / filing-deadline / SOL / task-deadline as authored. The label is read from how the human entered it; the skill does not classify a date as an SOL on its own.
+3. **Flag missing-where-expected** — if firm policy says a matter type should carry an SOL date and none is authored, surface **"no authored deadline on file"** for a human to address. This is the one place the skill points at an absence — and it points, it does not fill.
+4. **Assemble the surface** — dates per matter, by bucket, each sourced and labeled, to the firm-internal surface per `references/output-format.md`.
+
+## Trust Ceiling
+
+**Read + assemble + surface autonomous; internal-only; zero date computation.**
+
+The agent MAY: read authored calendar entries and task due dates; bucket them by proximity; flag a matter that lacks an expected authored deadline; write the surface to the firm-internal notes surface.
+
+The agent MUST NOT: compute, infer, or estimate a limitation period or any deadline; advise on timeliness; move a date; send anything to a client; present a computed date as if authored.
+
+## Safety invariants (any violation → `fails`, no recovery)
+
+1. **Never computes a deadline.** Every date surfaced is one a human authored. The skill does no date math beyond comparing authored dates to today for bucketing.
+2. **No legal advice.** It surfaces "this date is coming"; it never says whether a filing is timely or what the limitation is.
+3. **Missing is flagged, not filled.** An absent expected deadline is surfaced as absent; the skill never supplies a plausible date.
+4. **No fabrication.** Every date traces to a Clio read with its authored source label.
+5. **Internal + privilege.** The surface is for the firm; it stays on firm surfaces.
+
+## Pitfalls
+
+Computing "X years from the incident" — the cardinal sin here; inferring a filing window from a court rule; labeling a generic calendar entry as an SOL the human didn't mark; presenting a missing deadline as though a date were known; sending date reminders to clients (this skill is internal — client-facing date communication is a separate, reviewer-sent concern).
+
+## Verification
+
+1. Every surfaced date traces to an authored Clio calendar entry or task `due_at` — none computed.
+2. Buckets (overdue/imminent/upcoming) are correct date arithmetic against today.
+3. Source labels match how the human authored each date; no date is self-classified as an SOL.
+4. Matters missing an expected authored deadline are flagged as missing, not filled.
+5. Nothing is sent to a client; the surface is firm-internal.
+
+## References
+
+- `references/algorithm.md` — the proximity buckets, the authored-only rule, and the missing-where-expected flag logic
+- `references/output-format.md` — the by-matter, by-bucket date surface _(parity fast-follow)_
+- `references/test-cases.md` — fixtures incl. overdue/imminent/upcoming, an authored SOL, and a missing-expected-deadline matter _(parity fast-follow)_

--- a/operator/skills/deadline-and-sol-tracker/references/algorithm.md
+++ b/operator/skills/deadline-and-sol-tracker/references/algorithm.md
@@ -1,0 +1,37 @@
+# deadline-and-sol-tracker algorithm
+
+Source of truth for surfacing critical dates without ever computing one.
+
+## The authored-only rule
+
+Every date this skill surfaces is read from Clio — an authored calendar entry or a task `due_at`. The skill performs exactly one kind of arithmetic: comparing an authored date to today, to assign a bucket. It performs **no** arithmetic that _produces_ a deadline (no "incident_date + limitation_period", no "service_date + response_window"). That computation is a legal determination and is out of scope by invariant, not by omission.
+
+## Buckets
+
+```
+today = run date (passed in; no wall-clock in scripts)
+for each authored_date d on an open matter:
+    if d < today and matter open:  bucket = overdue
+    elif d <= today + near_window: bucket = imminent     # firm-authored near window, e.g. 7d
+    elif d <= today + scan_window: bucket = upcoming      # firm-authored scan window, e.g. 30d
+    else:                          omit (outside scan)
+```
+
+`near_window` and `scan_window` are firm-authored (from `customer.yaml` where set; otherwise sensible defaults that the surface header states explicitly).
+
+## Source labels
+
+Each date carries the label the human gave it: `court-date`, `filing-deadline`, `sol`, `response-window`, `task-deadline`. The label is read, never inferred. A bare calendar entry with no deadline semantics is surfaced as a plain calendar date, not promoted to a deadline.
+
+## Missing-where-expected
+
+```
+if firm_policy.expects_sol(matter.practice_area) and no authored sol on matter:
+    surface "no authored deadline on file — needs human attention"
+```
+
+This is the only place the skill speaks about a date that does not exist, and it speaks by **pointing at the gap**, never by filling it. `firm_policy.expects_sol(...)` is firm-authored configuration; absent that configuration, the skill does not guess which matters "should" have an SOL.
+
+## Why the line is absolute
+
+A computed limitation date that is wrong is a malpractice-grade error, and a computed date that is _right_ still launders a legal judgment through an automated surface. Either way the firm would come to rely on a number the system is not competent to produce. So the skill produces no such number — it is a mirror for authored dates and a flag for missing ones, nothing more.

--- a/operator/skills/document-receipt-logger/SKILL.md
+++ b/operator/skills/document-receipt-logger/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: document-receipt-logger
+description: Logs an inbound document against the right matter — resolves sender to matter, proposes the filing location, drafts a receipt entry, and surfaces it. Records that a document arrived; never interprets its contents.
+version: 0.1.0
+author: SMD Services
+license: MIT
+platforms: [linux, macos]
+prerequisites:
+  skills: []
+  commands: [python3]
+metadata:
+  hermes:
+    tags: [Law, Documents, Filing, Intake, DraftForReview]
+  smd:
+    vertical: law-firm
+    skill_type: read + assembly (filing proposal)
+    trust_ceiling: draft_for_review
+    action_class: read + write
+    connectors:
+      - email # customer-bound — the inbound message + its attachment
+      - clio # PracticeManagement — resolve sender→matter, draft the receipt note (read; write gated)
+      - document-storage # DocumentStorage (mcp:ms-365) — proposed filing target (write gated)
+---
+
+# Document Receipt Logger
+
+When a document arrives in the firm's inbox — a signed agreement, a returned form, a record from a third party — this skill records that it came in and proposes where it belongs: it resolves the sender to a matter, identifies the filing location, drafts a receipt log entry, and surfaces the proposal. It is the firm's "we received this and here is where it goes" step, so a document never sits unfiled and untracked.
+
+It logs **receipt**, not meaning. It records that a document arrived, from whom, and against which matter — it does **not** read the document for legal content, summarize its terms, or act on what it says. Interpreting an inbound document is legal work; this skill is filing hygiene.
+
+## When to Use
+
+Use when inbound documents would otherwise pile up unlogged — the firm wants every received document tied to its matter with a receipt trail. No wedge step depends on a logged document, which is why it is a parallel workflow rather than part of the named-job loop, but unlogged documents are how things get lost.
+
+Runs event-driven (an inbound message with an attachment) and scheduled (sweep the inbox for unlogged attachments).
+
+## Prerequisites
+
+Reads the customer-bound **Email** connector (the inbound message + attachment metadata), Clio (`search_contacts`, `list_matters` to resolve sender→matter; the receipt note is a gated write), and the **DocumentStorage** connector (the proposed filing target; a gated write). Requires `python3` for the fetch block.
+
+## How to Run
+
+```
+hermes run document-receipt-logger                     # sweep inbox for unlogged attachments
+hermes run document-receipt-logger --message <id>      # log one inbound document
+```
+
+## Procedure
+
+Two phases (ADR 0021 Stream A). The mechanical inbox/attachment + Clio resolution runs in one `execute_code` block; the filing proposal stays in the agent's reasoning loop.
+
+### Phase 1 — Fetch (single `execute_code` block)
+
+Enumerate inbound messages carrying attachments in the window. For each, capture sender, subject, and attachment **metadata only** (filename, type, size) — not the document body. Resolve the sender via Clio (`search_contacts` → `list_matters`). Accumulate in-process; `print()` one JSON document of (message → sender, attachment metadata, resolved matter candidates). A single unreadable message is `parse_failed`; the sweep continues.
+
+### Phase 2 — Reason (agent, in-context)
+
+Per `references/algorithm.md`:
+
+1. **Resolve the matter.** Map the sender (and any matter reference in the subject) to a single matter via Clio. A confident single match proceeds; an ambiguous or unknown sender is surfaced for a human to assign, not guessed.
+2. **Propose the filing location** — the matter's document area in DocumentStorage, plus a category if the firm authors one (correspondence, signed-docs, records). The proposal names where; it does not classify the document's legal nature.
+3. **Draft the receipt entry** — a Clio note recording: document received, from whom, when, attachment filename/type, and the resolved matter. Receipt facts only.
+4. **Surface for review.** The proposal (matter + location + receipt draft) is surfaced; in this phase the actual file move and note write are **gated** — a human confirms before the document is filed and the receipt committed.
+
+## Trust Ceiling
+
+**Resolve + propose + draft autonomous; the file move and receipt write are gated (`draft_for_review`).**
+
+The agent MAY: read inbound message + attachment metadata; resolve sender→matter via Clio; propose a filing location; draft the receipt note.
+
+The agent MUST NOT: interpret, summarize, or act on the document's contents; file a document or write the receipt without review (this phase); attach a document to a matter it could not confidently resolve; alter or delete an existing document.
+
+## Safety invariants (any violation → `fails`, no recovery)
+
+1. **Receipt, not meaning.** The skill records that a document arrived; it never reads it for legal content or advises on it.
+2. **No fabricated filing.** A document is tied to a matter only via a confident Clio resolution; an unresolved sender is surfaced for human assignment.
+3. **Fail-closed write.** The file move and receipt note are gated behind human review this phase; nothing is filed autonomously.
+4. **No destructive document action.** Never overwrites, moves, or deletes an existing filed document — it only adds a received one.
+5. **Privilege.** Sender, matter, and attachment metadata stay on firm surfaces.
+
+## Pitfalls
+
+Reading the attachment to "be helpful" and summarizing its terms (out of scope — that is legal work); filing to a guessed matter when the sender is ambiguous; classifying the document's legal type instead of just its filing category; committing the receipt write before review in the fail-closed phase.
+
+## Verification
+
+1. Every logged document traces to a real inbound message and a confidently resolved matter; ambiguous senders are surfaced, not guessed.
+2. The receipt entry contains receipt facts only — no content summary or interpretation.
+3. The file move and note write are gated behind review this phase.
+4. No existing document is altered or deleted.
+5. Attachment contents never appear in the surface or logs — metadata only.
+
+## References
+
+- `references/algorithm.md` — the sender→matter resolution, the metadata-only rule, and the gated filing/receipt flow
+- `references/output-format.md` — the filing proposal + receipt-note draft _(parity fast-follow)_
+- `references/test-cases.md` — fixtures incl. clean match, ambiguous sender, unknown sender, and multi-attachment _(parity fast-follow)_

--- a/operator/skills/document-receipt-logger/references/algorithm.md
+++ b/operator/skills/document-receipt-logger/references/algorithm.md
@@ -1,0 +1,48 @@
+# document-receipt-logger algorithm
+
+Source of truth for filing inbound documents by receipt, without reading them.
+
+## The metadata-only rule
+
+The skill touches attachment **metadata** (filename, MIME type, size) and never the document body. It does not extract text, OCR, parse, or summarize the contents. This is both a privilege/scope guard and the line between filing hygiene (this skill) and legal review (a human). The receipt is about provenance — who sent what, when, for which matter — not about what the document says.
+
+## Sender → matter resolution
+
+```
+candidates = list_matters( contact_id from search_contacts(sender) )
++ any matter reference parsed from the subject line (display_number)
+resolve:
+  exactly one confident match  -> proceed
+  multiple / weak / none       -> surface for human assignment (do NOT guess)
+```
+
+A document filed to the wrong matter is worse than an unfiled one, so the bar is a confident single match. Everything else is a human assignment surface.
+
+## Filing proposal
+
+```
+location = matter.document_area
++ category if firm authors a taxonomy (correspondence | signed-docs | records | ...)
+```
+
+The category names _where it goes_, not _what it legally is_. "Signed-docs" is a folder, not a determination that the document is an executed, enforceable agreement.
+
+## Receipt entry (the draft)
+
+A Clio note containing receipt facts only:
+
+```
+Received: <filename> (<type>) on <date> from <sender name / address>
+Matter: <display_number>
+Filed to: <proposed location>
+```
+
+No summary, no terms, no "this appears to be …". If the human wants the document read, that is their work or another skill's, not this one's.
+
+## Fail-closed this phase
+
+Resolution, proposal, and the receipt draft are autonomous. The **file move** (DocumentStorage write) and the **receipt note commit** (Clio write) are gated behind human review in the current phase per `operator/verticals/law-firm/wedge.md` write posture. Nothing is filed or committed without a person confirming the matter and location.
+
+## Never destructive
+
+The skill only _adds_ a received document and a receipt note. It never overwrites, renames, moves, or deletes an existing filed document — a misrouted overwrite could destroy the only copy of a client record.

--- a/operator/skills/intake-to-system-sync/SKILL.md
+++ b/operator/skills/intake-to-system-sync/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: intake-to-system-sync
+description: Syncs a converted lead from a separate intake CRM (Clio Grow / Lawmatics) into Clio Manage — maps fields, dedupes, conflict-cross-checks before any matter create. Only load-bearing when a distinct intake CRM runs alongside Clio.
+version: 0.1.0
+author: SMD Services
+license: MIT
+platforms: [linux, macos]
+prerequisites:
+  skills: []
+  commands: [python3]
+metadata:
+  hermes:
+    tags: [Law, Intake, Sync, CRM, DraftForReview]
+  smd:
+    vertical: law-firm
+    skill_type: read + assembly (cross-system sync)
+    trust_ceiling: draft_for_review
+    action_class: read + write
+    connectors:
+      - intake-crm # IntakeCRM (build:clio-grow) — the converted lead source (read)
+      - clio # PracticeManagement — dedupe + draft the contact/matter (read; write gated)
+---
+
+# Intake to System Sync
+
+Carries a converted intake from a **separate intake CRM** — Clio Grow, Lawmatics, or similar — into Clio Manage as a contact and matter, keeping the two systems in step so a won lead doesn't get hand-re-keyed (or dropped) on the way to the practice-management system.
+
+It is **only load-bearing when a distinct intake CRM runs alongside Clio.** The pilot assumes Clio as the single system of record, so this skill is **authored but not enabled for the pilot** — it requires the `build:clio-grow` (IntakeCRM) connector, which the wedge deliberately avoids. It exists for firms whose intake lives in a separate front-end and needs a clean, deduped, conflict-checked handoff into Clio.
+
+## When to Use
+
+Use only when the firm runs a dedicated intake CRM separate from Clio Manage and wants converted leads to flow into Clio without manual re-entry. If Clio is the single system of record (as in the pilot), this skill stays disabled — there is nothing to sync from.
+
+Runs event-driven (a lead is marked converted in the CRM) and scheduled (sweep the CRM for converted-but-unsynced leads).
+
+## Prerequisites
+
+Reads the **IntakeCRM** connector (`build:clio-grow` — the converted lead, its captured fields, and intake party data) and Clio (`search_contacts`, `list_matters` for dedupe and the conflict cross-check; the contact/matter create is a gated write). Requires `python3` for the fetch block. **Not enabled in the pilot** (`customer.yaml` for the pilot does not bind IntakeCRM).
+
+## How to Run
+
+```
+hermes run intake-to-system-sync                 # sweep CRM for converted-unsynced leads
+hermes run intake-to-system-sync --lead <id>     # sync one converted lead
+```
+
+## Procedure
+
+Two phases (ADR 0021 Stream A). The mechanical CRM read + Clio dedupe/cross-check runs in one `execute_code` block; the field mapping and sync proposal stay in the agent's reasoning loop.
+
+### Phase 1 — Fetch (single `execute_code` block)
+
+Enumerate converted-but-unsynced leads in the CRM. For each, capture the intake fields (client identity, contact channels, matter description, practice area, captured parties) and run the Clio dedupe + cross-check reads (`search_contacts`, `list_matters`) on the lead's parties. Accumulate in-process; `print()` one JSON document of (lead → fields, existing-Clio matches, conflict cross-check hits). A single unreadable lead is `parse_failed`; the sweep continues.
+
+### Phase 2 — Reason (agent, in-context)
+
+Per `references/algorithm.md`:
+
+1. **Conflict cross-check FIRST.** Before proposing any matter create, run the same read-only name/entity cross-check the wedge carries (the `new-matter-intake` / `conflict-intake-router` invariant). On any hit, **HALT**: route to human conflict clearance, do not propose the matter. Advancing a flagged lead is a `fails` safety violation.
+2. **Dedupe.** If the lead's client already exists as a Clio contact/matter, propose linking rather than creating — never mint a duplicate client or a second matter for the same engagement.
+3. **Map fields** from the CRM schema to Clio's (client → contact, lead detail → matter description, captured practice area, parties). Fields the CRM didn't capture are left empty, not invented.
+4. **Draft the sync** — the proposed Clio contact and matter records, plus a back-link so the CRM lead is marked synced. In this phase the actual Clio create and the CRM mark-synced are **gated** behind human review.
+5. **Surface for review.** The proposed records, the dedupe decision, and any conflict hold are surfaced; a human confirms before anything is written to either system.
+
+## Trust Ceiling
+
+**Read + dedupe + map + draft autonomous; the Clio create and CRM mark-synced are gated (`draft_for_review`).**
+
+The agent MAY: read the converted lead; dedupe against Clio; run the conflict cross-check; map fields; draft the proposed contact/matter and the sync-back.
+
+The agent MUST NOT: create a Clio matter/contact or mark a lead synced without review (this phase); create a duplicate when a match exists; advance a conflict-flagged lead; invent a field the CRM didn't capture.
+
+## Safety invariants (any violation → `fails`, no recovery)
+
+1. **Conflict cross-check precedes matter create.** A hit halts the sync and routes to human clearance; no auto-clear, no matter proposal past a hit.
+2. **No duplicates.** A matching existing client/matter is linked, never re-created; the dedupe decision is explicit and surfaced.
+3. **Fail-closed write.** Both the Clio create and the CRM mark-synced are gated behind human review this phase; nothing is written to either system autonomously.
+4. **No fabricated fields.** Only CRM-captured data is mapped; missing fields stay empty, never guessed.
+5. **Privilege + isolation.** Lead and matter data stay on firm surfaces; the sync touches only the two authored systems.
+
+## Pitfalls
+
+Creating a duplicate matter because the dedupe match was weak and got ignored; proposing a matter before the conflict cross-check (ordering breach); inventing a practice area or client detail the CRM didn't capture; committing the write before review in the fail-closed phase; enabling this skill when Clio is the single system of record (there is nothing to sync from).
+
+## Verification
+
+1. Every synced lead is checked for an existing Clio match first; matches are linked, not duplicated.
+2. The conflict cross-check runs before any matter is proposed; hits halt and route to a human.
+3. Field mapping uses only CRM-captured data; missing fields are empty, not invented.
+4. The Clio create and CRM mark-synced are gated behind review this phase.
+5. The skill is disabled when no separate intake CRM is bound (e.g., the pilot).
+
+## References
+
+- `references/algorithm.md` — the dedupe rule, the conflict-first ordering, the CRM→Clio field map, and the gated write flow
+- `references/output-format.md` — the sync proposal (mapped records + dedupe decision + holds) _(parity fast-follow)_
+- `references/test-cases.md` — fixtures incl. clean new lead, existing-client dedupe, conflict-hit, and partial-fields _(parity fast-follow)_

--- a/operator/skills/intake-to-system-sync/references/algorithm.md
+++ b/operator/skills/intake-to-system-sync/references/algorithm.md
@@ -1,0 +1,53 @@
+# intake-to-system-sync algorithm
+
+Source of truth for moving a converted lead into Clio without duplicates, conflicts, or invented data.
+
+## When this skill is even live
+
+Only when `customer.yaml` binds an **IntakeCRM** connector (`build:clio-grow` or similar). If Clio is the single system of record (the pilot), there is no separate front-end to sync from and the skill stays disabled. This is a configuration fact, not a runtime guess — the skill does not invent a CRM to read.
+
+## Ordering (the invariant comes first)
+
+```
+lead = read converted-unsynced lead from IntakeCRM
+parties = lead.client + captured parties
+
+# 1. CONFLICT CROSS-CHECK FIRST — before any matter is proposed
+hits = conflict_cross_check(parties)          # same read-only check as new-matter-intake
+if hits:
+    route(hits -> human conflict clearance)
+    HALT                                        # no matter proposal past a hit
+
+# 2. DEDUPE
+match = find_existing(lead.client)            # search_contacts + list_matters
+if match:
+    propose link-to-existing                   # never create a duplicate
+else:
+    propose new contact + matter
+
+# 3. MAP fields (CRM schema -> Clio), missing stays empty
+# 4. DRAFT proposed records + CRM sync-back
+# 5. SURFACE for review; Clio create + CRM mark-synced are GATED
+```
+
+Conflict-check precedes dedupe and create because advancing a conflicted lead is the gravest failure; a duplicate is recoverable, a missed conflict is not.
+
+## Dedupe rule
+
+A "match" is a confident identity match on the lead's client against existing Clio contacts (name + a corroborating field — email/phone). On a match, propose **linking** the new matter to the existing client (or flagging a likely-existing matter) rather than minting a duplicate. A weak/ambiguous match is surfaced for a human to decide — not silently merged and not silently duplicated.
+
+## Field map (CRM → Clio)
+
+```
+lead.client_name      -> contact (Person/Company)
+lead.email / phone    -> contact channels
+lead.matter_summary   -> matter.description
+lead.practice_area    -> matter.practice_area (only if the CRM captured it)
+lead.parties          -> captured for the conflict check; recorded as authored
+```
+
+Fields the CRM did not capture are left empty. The skill never fills a plausible practice area or a guessed party — empty is honest; invented is a fabrication breach.
+
+## Fail-closed writes
+
+Both sides are gated this phase: the Clio contact/matter **create** and the CRM **mark-synced** wait for human review. A premature mark-synced would orphan a lead that never actually landed in Clio, so the sync-back only fires after the Clio create is confirmed.

--- a/operator/skills/referral-source-acknowledgment/SKILL.md
+++ b/operator/skills/referral-source-acknowledgment/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: referral-source-acknowledgment
+description: Drafts a courtesy thank-you to the source who referred a new matter — warm, prompt, and confidential. Acknowledges the referral without disclosing client identity or matter detail. Reviewer-as-sender.
+version: 0.1.0
+author: SMD Services
+license: MIT
+platforms: [linux, macos]
+prerequisites:
+  skills: []
+  commands: [python3]
+metadata:
+  hermes:
+    tags: [Law, Referral, Relationship, Confidentiality, DraftForReview]
+  smd:
+    vertical: law-firm
+    skill_type: drafting (relationship)
+    trust_ceiling: draft_for_review
+    action_class: read + external_send
+    connectors:
+      - clio # PracticeManagement — matter → referral source contact (read)
+      - email # customer-bound — the drafted thank-you (send is reviewer-as-sender)
+---
+
+# Referral Source Acknowledgment
+
+When a new matter arrives through a referral, this skill drafts a prompt, warm thank-you to the person who sent it — the courtesy that keeps a firm's referral network alive. It identifies the referral source from the matter, drafts an acknowledgment in the firm's voice, and surfaces it for a human to send.
+
+Its defining constraint is **confidentiality.** A referral source is, by definition, _not_ the firm's client, and the existence and details of the new engagement are confidential. So the thank-you acknowledges the gesture **without disclosing who the client is or what the matter concerns** unless the firm has explicit authorization to do so. The relationship value is in the promptness and warmth, not in confirming details the firm may not share.
+
+## When to Use
+
+Use when the firm wants to reliably acknowledge referrals — the small, often-skipped courtesy that compounds into a referral pipeline. It is off the matter-progression path (no matter step depends on it), which is exactly why it tends to get dropped without a skill that catches it.
+
+Runs event-driven (a new matter is opened with a referral source recorded) and scheduled (sweep recent matters for un-acknowledged referrals).
+
+## Prerequisites
+
+Reads Clio (`get_matter` / `get_contact`) to identify the referral source on a new matter, and the customer-bound **Email** connector to draft the thank-you. Requires `python3` for the fetch block. The draft is **never sent autonomously** (reviewer-as-sender, ADR 0005).
+
+## How to Run
+
+```
+hermes run referral-source-acknowledgment                  # sweep recent matters for un-acked referrals
+hermes run referral-source-acknowledgment --matter <id>    # acknowledge one matter's referral
+```
+
+## Procedure
+
+Two phases (ADR 0021 Stream A). The mechanical referral-source resolution runs in one `execute_code` block; the confidentiality-bound drafting stays in the agent's reasoning loop.
+
+### Phase 1 — Fetch (single `execute_code` block)
+
+Enumerate recent matters carrying a recorded referral source. For each, resolve the source contact (`get_contact`) and capture only what the thank-you needs — the referrer's name and contact, and whether the firm has authored a flag permitting client/matter detail to be shared with this source. Accumulate in-process; `print()` one JSON document. A matter whose source can't be resolved is `parse_failed`; the sweep continues.
+
+### Phase 2 — Reason (agent, in-context)
+
+Per `references/algorithm.md` and `references/voice.md`:
+
+1. **Confirm the referral source** — a real, resolved Clio contact marked as the matter's referral source. An unrecorded or unresolved source is surfaced for a human, never guessed.
+2. **Apply the confidentiality gate.** Default: acknowledge the referral generally ("thank you for thinking of us / sending someone our way") **without** naming the client or describing the matter. Only if the firm has authored explicit permission to share detail with this source does the draft reference specifics.
+3. **Draft in the firm's voice** (`voice.md`) — brief, warm, genuine; a real thank-you, not a templated form-letter.
+4. **Surface for review.** The draft is surfaced; a human reviews and sends under their own identity. No autonomous send.
+
+## Trust Ceiling
+
+**Read + draft autonomous; send is reviewer-as-sender (`draft_for_review`, non-raisable).**
+
+The agent MAY: read the matter's referral source from Clio; draft a confidentiality-respecting thank-you; surface it for review.
+
+The agent MUST NOT: send autonomously; disclose the client's identity or matter detail to the referral source without authored permission; invent a referral link that isn't recorded in Clio; thank the wrong person.
+
+## Safety invariants (any violation → `fails`, no recovery)
+
+1. **Confidentiality first.** No client identity or matter detail goes to a referral source absent the firm's authored permission. When in doubt, acknowledge generally.
+2. **Reviewer-as-sender.** No autonomous send; the thank-you ships under a human's identity.
+3. **No fabricated referral.** The source is acknowledged only when Clio records the referral link; an unresolved source is surfaced, not assumed.
+4. **Right recipient.** The thank-you goes to the resolved referral source, never to the client or another party.
+5. **Privilege.** The matter detail used to identify the source stays internal and out of the outbound text by default.
+
+## Pitfalls
+
+Naming the client or the matter to the referrer out of friendliness (the central confidentiality breach); thanking a guessed source when none is recorded; a generic form-letter tone that reads as automated and undercuts the relationship; letting the draft send without review.
+
+## Verification
+
+1. The referral source is a resolved Clio contact marked as the matter's referrer; unresolved sources are surfaced, not guessed.
+2. No client identity or matter detail appears in the draft unless the firm authored permission to share it.
+3. The recipient is the referral source, not the client or another party.
+4. The draft is surfaced for review; no autonomous send.
+5. The voice reads as a genuine, brief thank-you, not a template.
+
+## References
+
+- `references/algorithm.md` — referral-source resolution and the confidentiality gate (the load-bearing logic)
+- `references/voice.md` — the firm's brief, warm thank-you voice _(parity fast-follow)_
+- `references/output-format.md` — the acknowledgment draft _(parity fast-follow)_
+- `references/test-cases.md` — fixtures incl. general acknowledgment, authored-permission-to-share, unresolved source, and a confidentiality-bait case _(parity fast-follow)_

--- a/operator/skills/referral-source-acknowledgment/references/algorithm.md
+++ b/operator/skills/referral-source-acknowledgment/references/algorithm.md
@@ -1,0 +1,41 @@
+# referral-source-acknowledgment algorithm
+
+Source of truth for thanking the referrer without breaching client confidentiality.
+
+## Referral-source resolution
+
+```
+src = matter.referral_source (a Clio contact reference)
+if not src or not resolvable:
+    surface "referral source not recorded — human to confirm"   # never guess a referrer
+contact = get_contact(src.id)   # name + contact channel
+```
+
+A thank-you to the wrong person, or to a guessed referrer, is worse than none. Only a recorded, resolved referral source proceeds.
+
+## The confidentiality gate
+
+This is the skill's defining logic. A referral source is not the firm's client; the engagement's existence and details are confidential.
+
+```
+if firm.authored_permission_to_share(src):     # explicit, per-source firm flag
+    draft MAY reference the client/matter as the firm authored
+else:                                           # DEFAULT
+    draft acknowledges the referral GENERALLY:
+        - thank them for thinking of the firm / sending someone their way
+        - NO client name, NO matter type, NO matter detail
+```
+
+Default is general acknowledgment. Detail is the exception, allowed only on an explicit firm-authored permission for that source — never inferred from "they probably know already" or "they're a close referral partner."
+
+## Why general is the safe default
+
+Often the referrer _does_ know who they sent — but the firm confirming it in writing is still a disclosure the firm may not be authorized to make, and the value of the thank-you (promptness, warmth) does not require it. So the default costs nothing and risks nothing: "Thank you for thinking of us — we appreciate you sending business our way" carries the full relationship value without naming anyone.
+
+## Recipient check
+
+The drafted message is addressed to the resolved referral source's contact channel only. A guard confirms the recipient is the referrer, not the client and not another matter party — a misaddressed thank-you would itself disclose the referral relationship to the wrong person.
+
+## Reviewer-as-sender
+
+Output is always a draft surfaced for review; a human sends under their identity. No autonomous-send path for outbound mail (ADR 0005 floor).


### PR DESCRIPTION
## Summary
Completes the law catalog. The 8 wedge+spine skills already shipped (#1216, #1226); these are the 6 deferred (off the named-job critical path), each authored to the spine bar (`SKILL.md` + `algorithm.md`; conflict router also carries its capture rubric; `output-format`/`test-cases`/`voice` marked parity fast-follow).

- **conflict-intake-router** — full conflict workflow beyond `new-matter-intake`'s absorbed detect-and-halt: wide party-graph capture, route a hit to the specific clearance owner, cross-matter cadence re-scan. Surfaces/routes, never clears.
- **deadline-and-sol-tracker** — surfaces firm-AUTHORED court/filing/SOL dates by proximity; never computes a limitation period.
- **document-receipt-logger** — logs inbound docs to the resolved matter, metadata-only, no content interpretation; fail-closed write.
- **client-matter-digest** — proactive client-facing per-matter status; reviewer-as-sender; status not advice.
- **referral-source-acknowledgment** — confidential thank-you to a referrer; no client/matter disclosure absent authored permission.
- **intake-to-system-sync** — CRM→Clio sync with dedupe + conflict-first ordering; needs `build:clio-grow`, NOT enabled for the Clio-single-SoR pilot.

pilot-law persona unchanged — these stay enable-per-engagement; the pilot keeps its lean 8.

## Test plan
- [x] `npm run verify` passes (typecheck + format + tests)
- [ ] Author the `output-format`/`test-cases`/`voice` parity references when a skill is enabled on a live engagement

🤖 Generated with [Claude Code](https://claude.com/claude-code)