### PR TITLE
fix(assessment): harden custom-LLM bridge so the voice agent stops failing

### DIFF
--- a/src/lib/claude/assessment-llm.ts
+++ b/src/lib/claude/assessment-llm.ts
@@ -51,6 +51,7 @@ export function toAnthropicRequest(messages: ReadonlyArray<OpenAIChatMessage>): 
   const turns = messages
     .filter((m) => m.role === 'user' || m.role === 'assistant')
     .map((m) => ({ role: m.role as 'user' | 'assistant', content: String(m.content ?? '') }))
+    .filter((m) => m.content.trim().length > 0)
 
   if (turns.length === 0 || turns[0]?.role !== 'user') {
     turns.unshift({ role: 'user', content: '[The business owner has joined the call.]' })
@@ -58,15 +59,31 @@ export function toAnthropicRequest(messages: ReadonlyArray<OpenAIChatMessage>): 
   return { system, messages: turns }
 }
 
-function sseChunk(delta: { role?: string; content?: string }, finish: string | null): string {
+function sseChunk(
+  delta: { role?: string; content?: string },
+  finish: string | null,
+  created: number
+): string {
   const payload = {
     id: 'chatcmpl-assessment',
     object: 'chat.completion.chunk',
+    created,
     model: OPENAI_MODEL_LABEL,
     choices: [{ index: 0, delta, finish_reason: finish }],
   }
   return `data: ${JSON.stringify(payload)}\n\n`
 }
+
+/** SSE error event in the shape OpenAI-compatible consumers (ElevenLabs) expect. */
+function sseError(message: string): string {
+  return `data: ${JSON.stringify({ error: message })}\n\ndata: [DONE]\n\n`
+}
+
+const SSE_HEADERS = {
+  'content-type': 'text/event-stream; charset=utf-8',
+  'cache-control': 'no-cache',
+  connection: 'keep-alive',
+} as const
 
 /** Extract the text out of one Anthropic SSE `data:` line, or null if it carries no text. */
 function textFromAnthropicEvent(jsonLine: string): string | null {
@@ -88,14 +105,16 @@ function textFromAnthropicEvent(jsonLine: string): string | null {
 
 /**
  * Call Anthropic with streaming and return an OpenAI-compatible SSE Response.
- * Throws (caller maps to an error response) only on the initial connect; once
- * the stream is open, transport errors end the stream cleanly.
+ * Always returns text/event-stream (an error becomes an SSE `error` event), so
+ * the ElevenLabs custom-LLM parser never sees a non-stream response.
  */
 export async function streamInterviewerCompletion(
   apiKey: string,
-  messages: ReadonlyArray<OpenAIChatMessage>
+  messages: ReadonlyArray<OpenAIChatMessage>,
+  now: number
 ): Promise<Response> {
   const { system, messages: anthropicMessages } = toAnthropicRequest(messages)
+  const created = Math.floor(now / 1000)
 
   const upstream = await fetch(ANTHROPIC_API_URL, {
     method: 'POST',
@@ -114,7 +133,8 @@ export async function streamInterviewerCompletion(
   })
 
   if (!upstream.ok || !upstream.body) {
-    throw new Error(`Anthropic stream failed: ${upstream.status}`)
+    console.error(`[assessment-llm] anthropic ${upstream.status}`)
+    return new Response(sseError(`upstream ${upstream.status}`), { headers: SSE_HEADERS })
   }
 
   const reader = upstream.body.getReader()
@@ -124,12 +144,14 @@ export async function streamInterviewerCompletion(
 
   const stream = new ReadableStream<Uint8Array>({
     start(controller) {
-      controller.enqueue(encoder.encode(sseChunk({ role: 'assistant', content: '' }, null)))
+      controller.enqueue(
+        encoder.encode(sseChunk({ role: 'assistant', content: '' }, null, created))
+      )
     },
     async pull(controller) {
       const { done, value } = await reader.read()
       if (done) {
-        controller.enqueue(encoder.encode(sseChunk({}, 'stop')))
+        controller.enqueue(encoder.encode(sseChunk({}, 'stop', created)))
         controller.enqueue(encoder.encode('data: [DONE]\n\n'))
         controller.close()
         return
@@ -141,7 +163,7 @@ export async function streamInterviewerCompletion(
         const trimmed = line.trim()
         if (!trimmed.startsWith('data:')) continue
         const text = textFromAnthropicEvent(trimmed.slice(5).trim())
-        if (text) controller.enqueue(encoder.encode(sseChunk({ content: text }, null)))
+        if (text) controller.enqueue(encoder.encode(sseChunk({ content: text }, null, created)))
       }
     },
     cancel() {
@@ -149,11 +171,5 @@ export async function streamInterviewerCompletion(
     },
   })
 
-  return new Response(stream, {
-    headers: {
-      'content-type': 'text/event-stream; charset=utf-8',
-      'cache-control': 'no-cache',
-      connection: 'keep-alive',
-    },
-  })
+  return new Response(stream, { headers: SSE_HEADERS })
 }

--- a/src/pages/api/assessment/llm.ts
+++ b/src/pages/api/assessment/llm.ts
@@ -25,20 +25,42 @@ function json(status: number, body: unknown): Response {
   })
 }
 
+/** Normalize OpenAI content, which may arrive as a string OR an array of parts (ElevenLabs/OpenAI multimodal). */
+function contentToString(content: unknown): string {
+  if (typeof content === 'string') return content
+  if (Array.isArray(content)) {
+    return content
+      .map((part) =>
+        typeof part === 'object' &&
+        part !== null &&
+        typeof (part as { text?: unknown }).text === 'string'
+          ? (part as { text: string }).text
+          : ''
+      )
+      .join('')
+  }
+  return ''
+}
+
+/**
+ * Lenient parse: coerce each message rather than rejecting the whole batch on a
+ * single odd one (the agent may send array-content or empty placeholder turns).
+ * Returns null only if there is no usable conversation at all.
+ */
 function parseMessages(body: unknown): OpenAIChatMessage[] | null {
   if (typeof body !== 'object' || body === null) return null
   const raw = (body as { messages?: unknown }).messages
   if (!Array.isArray(raw) || raw.length === 0 || raw.length > 200) return null
   const messages: OpenAIChatMessage[] = []
   for (const item of raw) {
-    if (typeof item !== 'object' || item === null) return null
+    if (typeof item !== 'object' || item === null) continue
     const role = (item as { role?: unknown }).role
-    const content = (item as { content?: unknown }).content
-    if (typeof role !== 'string') return null
-    if (typeof content !== 'string') return null
+    if (typeof role !== 'string') continue
+    const content = contentToString((item as { content?: unknown }).content)
+    if (content.length === 0) continue
     messages.push({ role, content })
   }
-  return messages
+  return messages.length > 0 ? messages : null
 }
 
 export const POST: APIRoute = async ({ request }: APIContext) => {
@@ -60,9 +82,19 @@ export const POST: APIRoute = async ({ request }: APIContext) => {
   const messages = parseMessages(body)
   if (messages === null) return json(400, { error: 'invalid messages' })
 
+  // Diagnostic: metadata only (counts + roles), never content. Aids wrangler tail
+  // while the voice channel is being stabilized.
+  console.error(
+    `[assessment-llm] in ${messages.length} msgs [${messages.map((m) => m.role).join(',')}]`
+  )
+
   try {
-    return await streamInterviewerCompletion(env.ANTHROPIC_API_KEY, messages)
+    return await streamInterviewerCompletion(env.ANTHROPIC_API_KEY, messages, Date.now())
   } catch {
-    return json(502, { error: 'upstream error' })
+    // Always answer the custom-LLM caller in SSE shape, never JSON.
+    return new Response('data: {"error":"upstream error"}\n\ndata: [DONE]\n\n', {
+      status: 200,
+      headers: { 'content-type': 'text/event-stream; charset=utf-8' },
+    })
   }
 }

--- a/src/scripts/assessment-voice.ts
+++ b/src/scripts/assessment-voice.ts
@@ -147,8 +147,18 @@ async function endVoice(): Promise<void> {
   } catch {
     /* ignore */
   }
-  if (turns.length > 0) await drawFindings()
-  else setStatus('No conversation captured.')
+  const ownerTurns = turns.filter((t) => t.speaker === 'owner').length
+  if (ownerTurns >= 1 && turns.length >= 2) {
+    await drawFindings()
+    return
+  }
+  // The session ended before a real exchange — never draft findings from a
+  // greeting alone (that produced a confusing refusal). Offer a retry instead.
+  const report = el<HTMLElement>('report')
+  const reportBody = el<HTMLDivElement>('report-body')
+  report.hidden = false
+  reportBody.innerHTML =
+    '<p class="muted">The conversation ended before we captured enough to draft findings. Refresh and try again — and if it keeps dropping right after the greeting, the voice connection is the issue, not you.</p>'
 }
 
 async function startVoice(): Promise<void> {

--- a/tests/assessment-voice-llm.test.ts
+++ b/tests/assessment-voice-llm.test.ts
@@ -52,4 +52,13 @@ describe('toAnthropicRequest', () => {
     expect(messages).toHaveLength(1)
     expect(messages[0]?.role).toBe('user')
   })
+
+  it('drops empty / whitespace-only turns (never sends an empty message upstream)', () => {
+    const { messages } = toAnthropicRequest([
+      { role: 'user', content: 'real' },
+      { role: 'assistant', content: '   ' },
+      { role: 'user', content: '' },
+    ])
+    expect(messages).toEqual([{ role: 'user', content: 'real' }])
+  })
 })


### PR DESCRIPTION
## Summary
Live voice sessions failed `custom_llm generation failed` after the first owner answer (confirmed via the ElevenLabs conversation API: `termination_reason: custom_llm generation failed`, the owner's speech *was* captured). A direct curl to `/api/assessment/llm` streamed fine — the gap is what the real agent sends:

- **Missing `created`** on OpenAI chunks — added (strict parsers require it).
- **Strict parsing** rejected the whole batch on any non-string `content` (agent sends array/multimodal or empty placeholder turns) → now coerces array content, skips empties, fails only if nothing usable. Empty turns dropped before Anthropic.
- **Error paths return SSE**, not JSON, so the custom-LLM caller always gets a stream.
- **Metadata-only diagnostic log** (counts + roles, never content) for `wrangler tail`.
- **Client guard**: a greeting-only session no longer drafts a confusing refusal; shows a retry message.

## Test plan
- [x] `npm run verify` green; toAnthropicRequest empty-turn filtering covered.
- [ ] Post-deploy: retry a voice session; confirm the ElevenLabs conversation succeeds (not `failed`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)