### PR TITLE
feat(assessment): portal-native findings report (node 3/4 render preview)

### DIFF
--- a/src/components/portal/AssessmentReport.astro
+++ b/src/components/portal/AssessmentReport.astro
@@ -1,0 +1,130 @@
+---
+/**
+ * AssessmentReport: portal-native rendering of the assessment findings
+ * (ADR 0039 node [3/4]). Renders STRUCTURED findings into the portal design
+ * language; it only places authored values, so it cannot invent content
+ * (the anti-fabrication guarantee Gamma would have to be guarded for).
+ *
+ * The read is deliberately withheld; the report shows what IS and where it
+ * strains, and routes the prospect to book the call where the human delivers
+ * the verdict, the priorities, and the fix.
+ */
+
+export interface Finding {
+  statement: string
+  quote: string
+}
+export interface Domain {
+  label: string
+  reached: boolean
+  findings: Finding[]
+  note?: string
+}
+export interface Props {
+  businessName: string
+  dateLabel: string
+  intro: string
+  domains: Domain[]
+  whereThisPoints: string
+  bookHref: string
+}
+
+const { businessName, dateLabel, intro, domains, whereThisPoints, bookHref } = Astro.props
+const reached = domains.filter((d) => d.reached).length
+---
+
+<main id="main" role="main" class="max-w-[1120px] mx-auto px-6 py-8 sm:py-12 pb-24 md:pb-12">
+  <div class="grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_340px] gap-section lg:gap-12">
+    <!-- Main column -->
+    <section class="min-w-0 max-w-3xl">
+      <!-- Hero -->
+      <div class="mb-section">
+        <p class="text-label uppercase text-[color:var(--ss-color-meta)]">Assessment findings</p>
+        <h1 class="mt-3 text-display text-[color:var(--ss-color-text-primary)]">
+          A read on how {businessName} runs
+        </h1>
+        <p class="mt-stack text-body-lg text-[color:var(--ss-color-text-secondary)] max-w-xl">
+          {intro}
+        </p>
+        <p class="mt-stack text-caption text-[color:var(--ss-color-meta)]">
+          Drafted from your conversation on {dateLabel} · {reached} of {domains.length} areas covered
+        </p>
+      </div>
+
+      <!-- Domain sections -->
+      <div class="space-y-section">
+        {
+          domains.map((d) => (
+            <section class="border-t border-[color:var(--ss-color-border)] pt-section">
+              <h2 class="text-title text-[color:var(--ss-color-text-primary)] mb-card">
+                {d.label}
+              </h2>
+              {d.reached ? (
+                <ul class="space-y-card">
+                  {d.findings.map((f) => (
+                    <li>
+                      <p class="text-body text-[color:var(--ss-color-text-primary)] font-semibold">
+                        {f.statement}
+                      </p>
+                      <blockquote class="mt-stack border-l-2 border-[color:var(--ss-color-border)] pl-card text-body text-[color:var(--ss-color-text-secondary)] italic">
+                        “{f.quote}”
+                      </blockquote>
+                    </li>
+                  ))}
+                  {d.note && (
+                    <li class="text-caption text-[color:var(--ss-color-meta)]">{d.note}</li>
+                  )}
+                </ul>
+              ) : (
+                <p class="text-body text-[color:var(--ss-color-text-muted)]">
+                  We didn’t get to this in the conversation. It’s one of the threads worth picking
+                  up on the call.
+                </p>
+              )}
+            </section>
+          ))
+        }
+
+        <!-- Where this points (the withheld read) -->
+        <section
+          class="rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-[color:var(--ss-color-surface)] p-card"
+        >
+          <h2 class="text-title text-[color:var(--ss-color-text-primary)] mb-card">
+            Where this points
+          </h2>
+          <p class="text-body text-[color:var(--ss-color-text-secondary)]">{whereThisPoints}</p>
+          <a
+            href={bookHref}
+            class="mt-card inline-flex items-center justify-center min-h-[44px] px-6 py-3 rounded-[var(--ss-radius-card)] bg-[color:var(--ss-color-primary)] hover:bg-[color:var(--ss-color-primary-hover)] text-white text-body font-semibold transition-colors lg:hidden"
+          >
+            Book your read
+          </a>
+        </section>
+      </div>
+    </section>
+
+    <!-- Right rail: the conversion CTA -->
+    <aside class="hidden lg:block">
+      <div class="sticky top-8 space-y-card">
+        <div
+          class="bg-[color:var(--ss-color-surface)] rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card"
+        >
+          <p class="text-label uppercase text-[color:var(--ss-color-meta)]">The read</p>
+          <p class="mt-stack text-body text-[color:var(--ss-color-text-primary)] font-semibold">
+            Your findings are ready.
+          </p>
+          <p class="mt-stack text-caption text-[color:var(--ss-color-text-secondary)]">
+            What matters most, what to fix first, and what it would take: that’s the read, and it
+            happens with a person on a call. This report is the picture. The call is the plan.
+          </p>
+          <a
+            href={bookHref}
+            class="mt-card inline-flex w-full items-center justify-center min-h-[44px] px-6 py-3 rounded-[var(--ss-radius-card)] bg-[color:var(--ss-color-primary)] hover:bg-[color:var(--ss-color-primary-hover)] text-white text-body font-semibold transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2"
+          >
+            Book your read
+          </a>
+        </div>
+      </div>
+    </aside>
+  </div>
+</main>

--- a/src/pages/assessment/report-preview.astro
+++ b/src/pages/assessment/report-preview.astro
@@ -1,0 +1,120 @@
+---
+export const prerender = false
+
+import '../../styles/global.css'
+import AssessmentReport from '../../components/portal/AssessmentReport.astro'
+import type { Domain } from '../../components/portal/AssessmentReport.astro'
+
+// Real findings from the 2026-06-05 dogfood VOICE assessment, rendered through
+// the portal-native report. Structured data → template (no invention possible).
+const domains: Domain[] = [
+  {
+    label: 'Process & how work flows',
+    reached: true,
+    findings: [
+      {
+        statement: 'Every quote that reaches a client passes through one person first: you.',
+        quote: 'At this stage, that’s me.',
+      },
+      {
+        statement: 'When you’re unavailable, the whole quote-delivery process waits on you.',
+        quote: 'At this point, that process waits on me if I’m unavailable.',
+      },
+      {
+        statement:
+          'You have a plan to ease that bottleneck, tiered auto-approval by price or complexity, but it isn’t built yet.',
+        quote:
+          'Refining our AI agents and leveling up our trust with them, so they could auto-approve and pass those on… exceptions that must have a human approval, based on a price threshold or a complexity threshold.',
+      },
+    ],
+  },
+  {
+    label: 'Tools & systems',
+    reached: true,
+    findings: [
+      {
+        statement:
+          'The business runs on two portals, a client portal (quotes, approvals, invoicing, status) and an internal admin portal, with AI agents as a core operating layer, not a side tool.',
+        quote:
+          'Our company is largely driven by AI agents… the assessment call is recorded, there’s a transcript that gets passed off to an agent who produces the solution and develops the quote.',
+      },
+      {
+        statement: 'You consider the admin portal a work in progress.',
+        quote: 'It’s not perfect, but it’s always in evolution.',
+      },
+    ],
+  },
+  {
+    label: 'Visibility into the numbers',
+    reached: true,
+    findings: [
+      {
+        statement:
+          'You were describing where the admin portal falls short when the call ended, and that detail wasn’t captured.',
+        quote: 'Hey, I’m sorry, I have to hop off now. I’ve got another call.',
+      },
+    ],
+    note: 'An open thread worth picking up: where things fall through the cracks, and where you find yourself hunting for information.',
+  },
+  {
+    label: 'Customers & pipeline',
+    reached: true,
+    findings: [
+      {
+        statement:
+          'There’s a defined pipeline model in the admin portal: prospect to lead to client, with repeat and retainer engagements tracked.',
+        quote:
+          'They start off as a prospect and move through the pipeline… we can track their engagements, their repeat engagements, retainer situations where we can track the status.',
+      },
+    ],
+    note: 'How a new prospect first enters that pipeline (lead source, inbound vs. outbound) didn’t come up.',
+  },
+  {
+    label: 'Team & people',
+    reached: false,
+    findings: [],
+  },
+]
+
+const intro =
+  'A roughly one-year-old software and services company doing AI implementation for small businesses nationwide. Engagements start with a remote assessment; AI agents then turn the transcript into a solution and quote, which you review before it reaches the client through a portal that also handles approvals, invoicing, and status.'
+
+const whereThisPoints =
+  'There are real, addressable strains in what you described, plus at least one thread the call ended before reaching. The next conversation is where we work through what these findings mean for where the business is headed, which strains carry the most weight right now, and what a realistic path forward looks like.'
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;900&family=Archivo+Narrow:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0&display=swap"
+      rel="stylesheet"
+    />
+    <title>[preview] Assessment report (portal-native)</title>
+  </head>
+  <body class="min-h-screen bg-[color:var(--ss-color-background)]">
+    <div
+      class="border-b border-[color:var(--ss-color-border)] bg-[color:var(--ss-color-surface)] px-6 py-3"
+    >
+      <p class="max-w-[1120px] mx-auto text-label uppercase text-[color:var(--ss-color-meta)]">
+        Preview · portal-native report · not yet public
+      </p>
+    </div>
+    <AssessmentReport
+      businessName="your operation"
+      dateLabel="June 5, 2026"
+      intro={intro}
+      domains={domains}
+      whereThisPoints={whereThisPoints}
+      bookHref="/book"
+    />
+  </body>
+</html>


### PR DESCRIPTION
## Summary
A real, styled rendering of the assessment findings in the **portal's design language** — the artifact for deciding **portal-native vs. Gamma** on actual output, not opinion. Unlinked preview at **`/assessment/report-preview`**, rendering the real 2026-06-05 dogfood voice-assessment findings.

- Renders from **structured findings data** → template, so it can only place authored values (cannot fabricate — the guarantee a Gamma render would need guarding for).
- The **read is withheld**: shows what is and where it strains, marks un-reached domains honestly, routes to **"Book your read."**
- `AssessmentReport.astro` (portal `--ss-*` tokens, two-column layout, evidence quotes, conversion rail) + an unlinked prod preview page.

This is the **render-quality artifact** for the Gamma-vs-native call, not the full node 3/4 plumbing (persistence, identity, portal wiring) yet.

## Test plan
- [x] `npm run verify` green; no em dashes (forbidden-strings passes); build clean.
- [ ] Open `/assessment/report-preview` on prod and judge the design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)