### PR TITLE
feat(operator): wire Clio into the deploy path (provisionable pilot-law)

### DIFF
--- a/operator/bin/provision-customer.sh
+++ b/operator/bin/provision-customer.sh
@@ -363,6 +363,27 @@ stage_secret_from_env() {
 stage_secret_from_env SENTRY_DSN            "${SENTRY_DSN:-}"            "Sentry DSN for the shared smd-operator project"
 stage_secret_from_env MACHINE_HEARTBEAT_KEY "${MACHINE_HEARTBEAT_KEY:-}" "shared bearer for POST /api/internal/heartbeat"
 
+# ---------- Step 6b-clio: connector secrets (law vertical + Google DWD) ----------
+# Staged from operator env (Infisical /ss, injected by reprovision.sh's
+# `infisical run --path=/ss`), same no-paste pattern as observability. Each is
+# warn+skip when unset, so a customer that doesn't use a given connector still
+# provisions cleanly.
+#
+# Clio (mcp:clio-oktopeak): client_id/secret authenticate the OAuth app; the
+# encryption key decrypts the seed token; CLIO_TOKENS_ENC_B64 is the base64 of
+# ~/.clio-mcp/tokens.enc captured at off-box consent (bootstrap.sh Step 2d seeds
+# it; the overlay materializer reads id/secret/key into the mcp_servers env).
+stage_secret_from_env CLIO_CLIENT_ID         "${CLIO_CLIENT_ID:-}"         "Clio OAuth app client id"
+stage_secret_from_env CLIO_CLIENT_SECRET     "${CLIO_CLIENT_SECRET:-}"     "Clio OAuth app client secret"
+stage_secret_from_env CLIO_ENCRYPTION_KEY    "${CLIO_ENCRYPTION_KEY:-}"    "AES key for the Clio token file (subprocess reads it as ENCRYPTION_KEY)"
+stage_secret_from_env CLIO_TOKENS_ENC_B64    "${CLIO_TOKENS_ENC_B64:-}"    "base64 of the seed ~/.clio-mcp/tokens.enc"
+
+# Google service-account key (DWD). REQUIRED for any customer.yaml with
+# google_auth.mode: dwd — bootstrap.sh Step 2b dies without it. Base64-encoded
+# service-account JSON. Shared across the smd.services domain (one SA, domain-wide
+# delegation impersonating each customer's authored subject).
+stage_secret_from_env GOOGLE_SERVICE_ACCOUNT_JSON "${GOOGLE_SERVICE_ACCOUNT_JSON:-}" "base64 service-account key (domain-wide delegation)"
+
 # ---------- Step 6c: healthchecks.io check (ADR 0023 Wave 1) ----------
 # Idempotent create-or-find. Healthchecks.io's POST /api/v3/checks/ creates
 # a new check; if a check with the same `unique` keys (tags+name) already

--- a/operator/templates/Dockerfile
+++ b/operator/templates/Dockerfile
@@ -72,8 +72,12 @@ ARG HERMES_UPSTREAM_SHA=a91a57fa5a13d516c38b07a141a9ce8a3daabeb0
 # v0.4.5 adds _materialize_telegram_platform (#32, ADR 0033): authors the Telegram
 # allowlist from customer.yaml.telegram into the profile config.yaml (fail-closed on
 # empty allow_from). Superset of v0.4.4.
+# v0.4.6 (#35) adds a LOCAL stdio MCP transport to the connector materializer and
+# wires Clio (mcp:clio-oktopeak) as a `clio-mcp` command server with a remapped
+# env block (ENCRYPTION_KEY <- CLIO_ENCRYPTION_KEY). Pairs with the clio-mcp
+# install + Clio token-seed block below. Superset of v0.4.5.
 ARG OVERLAY_REPO="https://github.com/venturecrane/hermes-smd-overlay.git"
-ARG OVERLAY_REF="v0.4.5"
+ARG OVERLAY_REF="v0.4.6"
 
 ARG CUSTOMER_SLUG=customer-zero
 
@@ -172,6 +176,15 @@ RUN uv pip install --no-cache-dir \
 # to read the principal's Gmail via a user-OAuth token (ADR 0010). These two
 # libraries are all it needs (read/modify; no oauthlib — consent happens off-box).
 RUN uv pip install --no-cache-dir google-api-python-client google-auth
+
+# ---------- Clio MCP server (law vertical practice-management connector) ----------
+# @oktopeak/clio-mcp (MIT) is a LOCAL stdio MCP server. The overlay (v0.4.6+)
+# materializes customer.yaml `mcp:clio-oktopeak` into the profile mcp_servers
+# block as a `clio-mcp` command server; install it globally so the binary is on
+# PATH for the gateway to launch. Pinned to 2.0.0 — the version the connector
+# reality-check and live loop test ran against. It reads its OAuth token from
+# ~/.clio-mcp/tokens.enc (seeded by bootstrap.sh) under ENCRYPTION_KEY.
+RUN npm install -g @oktopeak/clio-mcp@2.0.0
 
 # Register the plugin pack with Hermes' loader. `hermes plugins install` clones
 # the overlay repo's DEFAULT BRANCH HEAD into ~/.hermes/plugins/ — upstream

--- a/operator/templates/bootstrap.sh
+++ b/operator/templates/bootstrap.sh
@@ -258,6 +258,53 @@ else
 fi
 
 # ============================================================================
+# Step 2d: seed the Clio MCP OAuth token to the volume (if Clio connector enabled)
+# ============================================================================
+# The clio-mcp stdio server (wired into mcp_servers by the overlay materializer,
+# v0.4.6+) reads its OAuth token from ~/.clio-mcp/tokens.enc (hermes home =
+# /opt/data), AES-256-GCM encrypted under ENCRYPTION_KEY. The consent was
+# captured off-box (no browser in a headless Machine); we seed the encrypted
+# token here from the CLIO_TOKENS_ENC_B64 Fly secret. The connector REFRESHES
+# and rewrites the file in place thereafter, so we only seed when ABSENT — never
+# clobber a refreshed token on the persistent volume. The client_id/secret +
+# ENCRYPTION_KEY reach the subprocess via the materialized mcp_servers env block
+# (ENCRYPTION_KEY <- CLIO_ENCRYPTION_KEY remap), not from here.
+CLIO_ENABLED="$(/opt/hermes/.venv/bin/python3 - "${CUSTOMER_YAML}" <<'PY'
+import sys
+import yaml
+
+data = yaml.safe_load(open(sys.argv[1])) or {}
+conns = data.get("connectors") or {}
+for rec in conns.values():
+    if (
+        isinstance(rec, dict)
+        and rec.get("enabled")
+        and str(rec.get("backend", "")) == "mcp:clio-oktopeak"
+    ):
+        print("yes")
+        break
+PY
+)" || die "failed to read connectors from customer.yaml"
+
+if [ "${CLIO_ENABLED}" = "yes" ]; then
+  CLIO_TOKEN_DIR="/opt/data/.clio-mcp"
+  CLIO_TOKEN_FILE="${CLIO_TOKEN_DIR}/tokens.enc"
+  if [ -f "${CLIO_TOKEN_FILE}" ]; then
+    log "Clio token already on volume (${CLIO_TOKEN_FILE}); leaving in place (connector refreshes it)"
+  elif [ -n "${CLIO_TOKENS_ENC_B64:-}" ]; then
+    [ -n "${CLIO_ENCRYPTION_KEY:-}" ] \
+      || die "mcp:clio-oktopeak enabled with a seed token but CLIO_ENCRYPTION_KEY is unset (token could not be decrypted at runtime)"
+    mkdir -p "${CLIO_TOKEN_DIR}"
+    ( umask 077; printf '%s' "${CLIO_TOKENS_ENC_B64}" | base64 -d > "${CLIO_TOKEN_FILE}" ) \
+      || die "CLIO_TOKENS_ENC_B64 is not valid base64 (expected base64 of ~/.clio-mcp/tokens.enc)"
+    chmod 600 "${CLIO_TOKEN_FILE}"
+    log "Clio OAuth token seeded to ${CLIO_TOKEN_FILE} (0600)"
+  else
+    log "mcp:clio-oktopeak enabled but no CLIO_TOKENS_ENC_B64 seed; connector unauthenticated until a token is provided"
+  fi
+fi
+
+# ============================================================================
 # Steps 3-6: Honcho data plane — DEFERRED to Phase 2 (ADR 0016, revised)
 # ============================================================================
 # Previously: start Postgres, start Redis, run `python -m honcho.migrations`,


### PR DESCRIPTION
## Summary
Companion to overlay [#35](https://github.com/venturecrane/hermes-smd-overlay/pull/35) (v0.4.6), which added a local stdio MCP transport + the `clio-oktopeak` registry entry. This makes a `customer.yaml` with `mcp:clio-oktopeak` actually run on a Machine — the deploy plumbing for pilot-law.

- **Dockerfile** — bump `OVERLAY_REF` v0.4.5 → v0.4.6; `npm install -g @oktopeak/clio-mcp@2.0.0` so the `clio-mcp` stdio binary is on PATH.
- **bootstrap.sh (Step 2d)** — when `mcp:clio-oktopeak` is enabled, seed `~/.clio-mcp/tokens.enc` from the `CLIO_TOKENS_ENC_B64` Fly secret (the off-box consent capture), `0600`, **only when absent** (the connector refreshes the token in place; never clobber a refreshed token on the volume). Fail-closed: enabled + seed but no `CLIO_ENCRYPTION_KEY` → die.
- **provision-customer.sh** — stage `CLIO_CLIENT_ID` / `CLIO_CLIENT_SECRET` / `CLIO_ENCRYPTION_KEY` / `CLIO_TOKENS_ENC_B64` (all in Infisical `/ss`) and `GOOGLE_SERVICE_ACCOUNT_JSON` as Fly secrets via the no-paste env path.

client_id/secret + encryption key reach the subprocess via the overlay-materialized `mcp_servers` env block (`ENCRYPTION_KEY` ← `CLIO_ENCRYPTION_KEY` remap); the token via the seeded file.

## Test plan
- [x] `bash -n` + `shellcheck -S error` clean on both scripts
- [x] `npm run verify` passes
- [ ] **Remaining input before provision:** `GOOGLE_SERVICE_ACCOUNT_JSON` is not yet in Infisical `/ss` (the DWD service-account key); `bootstrap.sh` hard-fails a `mode: dwd` customer without it. Add it to `/ss`, then run `operator/bin/reprovision.sh pilot-law`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)