### PR TITLE
feat(operator): law talk-track + page revisions to ADR 0040 positioning

### DIFF
--- a/docs/collateral/index.md
+++ b/docs/collateral/index.md
@@ -12,6 +12,7 @@ Sales and marketing collateral for the SMD Services go-to-market motion, includi
 - [google-business-profile.md](./google-business-profile.md) - Google Business Profile setup and optimization guide
 - [lead-automation-blueprint.md](./lead-automation-blueprint.md) - Lead automation system blueprint
 - [one-pager.md](./one-pager.md) - SMD Services one-pager sales document
+- [operator-law-talk-track.md](./operator-law-talk-track.md) - Operator (law) founder-led talk-track, objection responses, and the live-demo showcase (derives from ADR 0040)
 - [outreach-plan.md](./outreach-plan.md) - Outreach plan and sequences
 - [pricing-framework.md](./pricing-framework.md) - Internal scope-to-price methodology (not client-facing)
 - [proposal-sow-template.md](./proposal-sow-template.md) - Proposal and Statement of Work template

--- a/docs/collateral/operator-law-talk-track.md
+++ b/docs/collateral/operator-law-talk-track.md
@@ -1,0 +1,75 @@
+---
+title: 'Operator (Law) — Talk-Track & Objection Responses'
+date: 2026-06-07
+status: collateral
+captain: Scott Durgan
+derives-from: docs/adr/0040-operator-positioning-and-why-us.md
+---
+
+# Operator (Law) — Talk-Track & Objection Responses
+
+Internal sales enablement for founder-led conversations with small law firms. Derived from [ADR 0040](../adr/0040-operator-positioning-and-why-us.md); if the two ever disagree, the ADR wins. This is the conversation we have once we are in the room (warm, via an intermediary intro where possible). It is not the marketing site and not a script to read verbatim — it is the spine, the beats, and the answers, in plain language.
+
+## The one-liner (the why-us)
+
+> A staff member that does your firm's coordination and paralegal work the way your firm does it, that we build and run for you, that you control, that never touches the lawyering, and that **gets better at your firm every week** because it runs on your firm's expertise, not ours.
+
+If you only land one thing: **it runs on your firm's expertise and gets better at your firm every week.** That is the part no competitor can shortcut.
+
+## The frame (hold this the whole way through)
+
+- Compete with a **hire**, not software. Price it against the assistant they are replacing or freeing up, never against a subscription. The moment a partner files us next to a $400 tool, we have lost.
+- The client is the expert. We are not law experts and we do not pretend to be. We build the worker; they teach it.
+- Lead with the seat and the outcome. **Do not open with "AI employee"** (it lowers trust and raises replacement fear). Keep the "serves any business" / horizontal story out of the room.
+
+## The talk-track (eight beats)
+
+1. **Name their reality, claim nothing about their firm.** "You're getting pitched AI constantly, so let me tell you what we're not. Almost everything coming at you is software you run yourself, a service that answers your phones and stops there, or people you have to hire and manage. We're none of those. We're closer to staffing than software: we give you a worker, and we run it for you."
+
+2. **What it is, in employee terms.** "Think of it as a staff member who happens to be software. It has its own email, works inside the tools you already use, and you reach it like a colleague. It does the coordination and paralegal work of the practice. It does not practice law. The advice, the strategy, the judgment on a matter, that stays with your lawyers, the same as it would with any paralegal, because that takes a license."
+
+3. **The heart (the spine).** "Here's where we're different from the tools. We're not pretending to know how your firm runs. You do. So we build the worker around how you already work. You teach it, the way you'd train a new hire: your intake questions, your voice, the way you like a matter handled. And it gets better at your firm every week, because it learns from your corrections and remembers them. What it learns belongs to the firm. When someone moves on, what it knows about how you run doesn't walk out with them."
+
+4. **You set the line.** "You decide what it does on its own and what it brings to you first, the same way you'd set expectations for any employee. Early on, maybe it drafts everything and someone on your team sends it. Later, maybe you let it handle the routine things itself. Your call, and you can change it anytime. It can never give itself more authority than you've granted, and everything it does is written down in a record you can read."
+
+5. **Confidentiality.** "The worker runs in your own walled-off environment, on your own accounts. We don't see your client files or your messages. We watch that the system is healthy and we can see the record of what it did, but the contents stay yours and stay private. An outside provider that genuinely cannot read your privileged files is a better spot than a person you hire and simply trust."
+
+6. **Why it's good, not the cheap AI you've been burned by.** "You've seen the stories about AI making things up and lawyers getting sanctioned for it. That comes from cheap tools cutting corners on the thinking to hold their price down. We don't ration that. The worker runs the best models available, and we give it room to check its own work before anything reaches you. And because we're not tied to any one AI company, it keeps getting better underneath you without you doing a thing."
+
+7. **We run it.** "You're not buying something to figure out on your own. We sit with you to set it up, we work alongside your team while it finds its footing, we keep an eye on it, and we're there when you need us. The reason most firms buy AI and never really use it is that it's one more thing to adopt. This isn't. We run it."
+
+8. **Close: scope and the price frame.** "So, plainly: a staff member that does your coordination and paralegal work the way your firm does it, that we build and run and you control, and that never touches the lawyering. We think about the price the way you'd think about a hire, not another subscription, because that's what it frees up. What it costs depends on the seat we build together, and we'd walk through all of that before you commit to anything."
+
+## Objection responses
+
+| They say                                                          | We answer                                                                                                                                                                                                                                                                                                                          |
+| ----------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| "Another AI tool. I've seen people get burned."                   | We're not a tool you run, we're a seat we run. And we don't do legal work, so the hallucination and sanctions risk you're picturing doesn't live here.                                                                                                                                                                             |
+| "$60k? LegalClerk is $400 a month."                               | Category error, and we win it on contact: you're not buying software, you're covering the seat you pay $60k-plus for and lose every couple of years at roughly $50k a turnover. Compare us to payroll, never to a subscription.                                                                                                    |
+| "I'll just have my paralegal run Copilot for $30."                | Smart, cheap, and you probably should. But Copilot makes the person you already have faster at their desk; it doesn't cover the seat at 7pm, when they're out, or when they quit. We're not a faster paralegal, we're the worker. If you can't keep that seat filled, a $30 tool doesn't touch that.                               |
+| "I'll buy LegalClerk for the intake and Smith.ai for the phones." | Sensible stack, and if your only pain is the front door it might be enough. Those each cover a slice. Neither does the connective work behind it: chasing the engagement letter, answering status, keeping the matter current, the document follow-ups. We're the one worker across all of it, in your voice, to one set of rules. |
+| "Confidentiality. How do I know my client data is safe?"          | Lead with this, don't wait for it. It runs in your own isolated environment on your own accounts; we never see the content, only system health and the record of what it did; if we ever need to look at something specific it's only with your say-so and it's logged.                                                            |
+| "Will my team actually use it?"                                   | That's the question that kills most legal AI, and it's exactly what the managed service answers: we run it. You're not adopting software.                                                                                                                                                                                          |
+| "Who else has this?" (the hard one)                               | Be straight: we're early and selective. Offer a low-risk pilot, point to whoever referred us as the trust, and show the live thing rather than name-drop. Show beats tell with a burned buyer.                                                                                                                                     |
+
+**Where we honestly lose (internal note, not for the room):** a high-volume shop whose only pain is fast intake plus phones may be right to buy the cheap stack today, especially before we have references. We win where the job is broader than intake-and-phones and where one accountable, governed, in-your-voice worker that we run is worth more than assembling point tools. Don't force the firms we're not for.
+
+## The live demo carries the proof
+
+The spine claim (gets better at your firm every week) is the one a skeptic discounts to zero on words. Show it, don't say it. Three demonstrable moments:
+
+- **The onboarding teach-back** — it reflects their intake back to them and drafts in their voice from their own samples in the first sitting. They watch it learn their firm.
+- **The employee manual on screen** — their captured rules, theirs to read and edit. The configuration is their expertise, written down.
+- **The action journal** — a correction made once, then holding. The journal is the receipt for the compounding.
+
+## The room-opener (intermediary motion)
+
+We get in front of firms by borrowing the trust of the people who already serve them (legal bookkeepers/trust-accounting specialists and Clio consultants first). The ask to a prospect is not "can I sell you something," it's **"can I show you something for ten minutes."** The live demo is differentiated enough to earn that, where a pitch isn't. See [ADR 0040](../adr/0040-operator-positioning-and-why-us.md) "GTM" for the lever and the first-cohort target list.
+
+## Guardrails (do not drift)
+
+- Never open with "AI employee." Lead with the seat and the outcome.
+- Never say "we don't do legal work." It's paralegal and coordinator work, never licensed work (the same line a human paralegal works within).
+- Reviewer-as-sender is one option the firm can choose, not what the Operator "is." Don't present any fixed posture (never sends, never moves money) as the product's identity; those are dials the firm sets.
+- Salary is the frame, not the moat. The durable why-us is the spine plus the managed-and-compounding combination.
+- Keep the horizontal "serves any business" story out of the room; it dilutes the "built for your firm" intimacy.

--- a/src/pages/operator.astro
+++ b/src/pages/operator.astro
@@ -217,6 +217,12 @@ const industries = [
             it takes is recorded where you can see it: what it did, when, and why.
           </p>
           <p>
+            Your data stays yours. The Operator runs on its own isolated infrastructure, on your own
+            accounts. We watch that it is healthy and we can see the record of what it did, but we
+            do not see what is inside your files and messages. The configuration, the logs, and the
+            off switch stay with you.
+          </p>
+          <p>
             And keeping it running is our job, not yours. We wire it into your tools, we watch that
             it stays working, and we stay accountable for it. You are giving feedback to an
             Operator, not taking on a second job managing one.

--- a/src/pages/packs/law-firm.astro
+++ b/src/pages/packs/law-firm.astro
@@ -152,11 +152,18 @@ const roleLenses = [
             unlicensed paralegal could not give that advice either.
           </p>
           <p>
-            You govern where that line sits. Out of the box, anything that touches legal substance
-            waits for a lawyer, and every outbound message goes through a reviewer on your team who
-            sends it under their own name. You widen what the Operator runs on its own as you learn
-            what it is good at. It never grants itself more authority, and every action it takes is
-            logged where you can see it.
+            You govern where that line sits. You decide what the Operator handles on its own and
+            what waits for a person on your team to approve, and you can move that line as you learn
+            what it is good at. A common place to start is conservative: it drafts, and someone on
+            your team approves and sends, until you are ready to let it carry a kind of message
+            itself. It never grants itself more authority, and every action it takes is logged where
+            you can see it.
+          </p>
+          <p>
+            Your client files stay private, including from us. The Operator works in your firm's own
+            walled-off environment, on your own accounts. We watch that it is running and we can see
+            the record of what it did, but the contents of your matters and messages stay yours, and
+            so do the controls: the configuration, the logs, and the off switch.
           </p>
         </div>
         <div class="text-center">
@@ -187,9 +194,15 @@ const roleLenses = [
             works with the same one, and it gets sharper from everyone's corrections.
           </p>
           <p>
-            What it learns, your practice areas, your intake questions, the way you run a matter,
-            your voice, is a record you can read and correct. It belongs to the firm, not to a
-            person's login. When someone moves on, what the Operator knows about how you run does
+            We are not the experts in how your firm runs. You are. So the Operator runs on your
+            firm's expertise, not ours: your practice areas, your intake questions, the way you run
+            a matter, your voice. You teach it the way you would train a new hire, and it gets
+            better at your firm every week, because it learns from your corrections and remembers
+            them.
+          </p>
+          <p>
+            What it learns is a record you can read and correct, and it belongs to the firm, not to
+            a person's login. When someone moves on, what the Operator knows about how you run does
             not leave with them.
           </p>
         </div>


### PR DESCRIPTION
## What

The two collateral outcomes derived from **ADR 0040** (#1235): the sales talk-track and the marketing-page revisions. Both pull from the doctrine; neither is authored independently.

## Sales enablement (new)

`docs/collateral/operator-law-talk-track.md` — internal, founder-led:
- The why-us one-liner and the eight-beat talk-track
- Objection-response table (incl. "paralegal + Copilot $30" and "LegalClerk + Smith.ai")
- The live-demo showcase (teach-back, the manual on screen, the journal) and the intermediary room-opener
- Drift guardrails (no "AI employee" opener, never "we don't do legal work," reviewer-as-sender is configurable not identity, salary is the frame not the moat)

## Marketing pages (draft for voice pass)

Surgical, not rewrites — both pages were already on-thesis:
- **`packs/law-firm.astro`** — § 05 now lands the spine (*runs on your firm's expertise, gets better at your firm every week*, client-is-the-expert); § 04 adds the **privacy/control** pillar (vendor-blind, the firm holds the keys) and softens reviewer-as-sender from a fixed posture to a configurable starting point.
- **`operator.astro`** — § 05 adds the privacy/control pillar.

## Guards

Copy follows the public rules (no em dashes, no operator.astro fenced terms, no fabricated promises). `forbidden-strings` + `landing-page` pass — **112 tests green**. ESLint clean.

## Note

Per the voice standard, the marketing copy here is a **draft for Captain's voice pass** — this PR supplies the structure and the positioning; final public wording is yours. The talk-track is internal and ready to use.

Depends on / derives from #1235 (ADR 0040).

🤖 Generated with [Claude Code](https://claude.com/claude-code)