### PR TITLE
fix(quotes): parse-and-validate line_items instead of casting; drop dead export

### DIFF
--- a/src/lib/db/quotes.ts
+++ b/src/lib/db/quotes.ts
@@ -170,6 +170,43 @@ export interface UpdateQuoteData {
 }
 
 /**
+ * Type guard for a single persisted line item. Validates the full LineItem
+ * shape so malformed or partially-shaped elements are rejected rather than
+ * cast through. Mirrors the per-element predicates in parseSchedule /
+ * parseDeliverables.
+ */
+function isLineItem(row: unknown): row is LineItem {
+  return (
+    row != null &&
+    typeof row === 'object' &&
+    typeof (row as Record<string, unknown>).problem === 'string' &&
+    typeof (row as Record<string, unknown>).description === 'string' &&
+    typeof (row as Record<string, unknown>).estimated_hours === 'number'
+  )
+}
+
+/**
+ * Parse a persisted JSON line-items string into validated rows. Returns an
+ * empty array when the input is null, missing, malformed, or not an array —
+ * never throws, never casts. Each element is validated against the LineItem
+ * shape (see isLineItem), so corrupt or shape-changed JSON yields a clean
+ * (possibly empty) result instead of an unhandled exception downstream.
+ *
+ * Use this anywhere a stored `line_items` column is read back. Mirrors
+ * parseSchedule / parseDeliverables.
+ */
+export function parseLineItems(raw: string | null): LineItem[] {
+  if (!raw) return []
+  try {
+    const parsed = JSON.parse(raw)
+    if (!Array.isArray(parsed)) return []
+    return parsed.filter(isLineItem)
+  } catch {
+    return []
+  }
+}
+
+/**
  * Parse the persisted JSON schedule into typed rows. Returns an empty array
  * when the column is null, missing, or malformed — callers should treat
  * "empty" the same as "not authored yet" and render nothing.
@@ -235,7 +272,7 @@ export function getMissingAuthoredContent(quote: Quote): string[] {
  * statuses (accepted, declined, expired, superseded) are terminal and do not
  * block a repeat quote (#472).
  */
-export const OPEN_QUOTE_STATUSES: QuoteStatus[] = ['draft', 'sent']
+const OPEN_QUOTE_STATUSES: QuoteStatus[] = ['draft', 'sent']
 
 /**
  * Return true if the entity has at least one draft or sent quote.
@@ -418,7 +455,7 @@ function appendTotalsFields(
   const lineItems = data.lineItems
   const rate = data.rate
   if (lineItems !== undefined || rate !== undefined) {
-    const effectiveItems = lineItems ?? (JSON.parse(existing.line_items) as LineItem[])
+    const effectiveItems = lineItems ?? parseLineItems(existing.line_items)
     const effectiveRate = rate ?? existing.rate
     const totalHours = effectiveItems.reduce((sum, item) => sum + item.estimated_hours, 0)
     const totalPrice = totalHours * effectiveRate

--- a/src/pages/api/admin/quotes/[id].ts
+++ b/src/pages/api/admin/quotes/[id].ts
@@ -4,6 +4,7 @@ import {
   updateQuote,
   updateQuoteStatus,
   parseDeliverables,
+  parseLineItems,
 } from '../../../../lib/db/quotes'
 import type { LineItem, DeliverableRow } from '../../../../lib/db/quotes'
 import { getEntity } from '../../../../lib/db/entities'
@@ -101,7 +102,7 @@ async function handleGeneratePdf(
     )
   }
 
-  const lineItems: LineItem[] = JSON.parse(existing.line_items) as LineItem[]
+  const lineItems: LineItem[] = parseLineItems(existing.line_items)
   const authoredDeliverables: DeliverableRow[] = parseDeliverables(existing)
   const sowItems = buildSowItems(lineItems, authoredDeliverables)
 
@@ -160,13 +161,13 @@ function parseJsonArray<T extends object>(
 function parseLineItemsField(formData: FormData): LineItem[] | undefined {
   const raw = formData.get('line_items')
   if (!raw || typeof raw !== 'string') return undefined
-  try {
-    const parsed = JSON.parse(raw) as unknown
-    if (Array.isArray(parsed) && parsed.length > 0) return parsed as LineItem[]
-  } catch {
-    // Invalid JSON — skip
-  }
-  return undefined
+  // parseLineItems parses + validates each element against the LineItem shape
+  // (never casts, never throws). An empty result means the field was absent,
+  // malformed, or had no valid rows — in all cases we skip the update so a
+  // bad payload can't blank out a quote's line items. Returns undefined to
+  // signal "leave unchanged" to buildUpdateData.
+  const parsed = parseLineItems(raw)
+  return parsed.length > 0 ? parsed : undefined
 }
 
 function parseDepositPct(formData: FormData): number | undefined {

--- a/src/pages/api/admin/quotes/index.ts
+++ b/src/pages/api/admin/quotes/index.ts
@@ -1,5 +1,5 @@
 import type { APIContext, APIRoute } from 'astro'
-import { createQuote } from '../../../../lib/db/quotes'
+import { createQuote, parseLineItems } from '../../../../lib/db/quotes'
 import type { LineItem } from '../../../../lib/db/quotes'
 import { env } from 'cloudflare:workers'
 
@@ -27,16 +27,6 @@ function getStringField(formData: FormData, key: string): string | null {
   return v && typeof v === 'string' ? v : null
 }
 
-function parseLineItems(json: string): LineItem[] | null {
-  try {
-    const parsed = JSON.parse(json) as unknown
-    if (!Array.isArray(parsed) || parsed.length === 0) return null
-    return parsed as LineItem[]
-  } catch {
-    return null
-  }
-}
-
 function parseDepositPct(formData: FormData): number {
   const raw = getStringField(formData, 'deposit_pct')
   const v = raw ? parseFloat(raw) : 0.5
@@ -53,8 +43,11 @@ function parseQuoteForm(redirect: Redirect, formData: FormData): ParsedQuoteForm
     return redirect(`/admin/entities/${entityId ?? ''}?error=missing`, 302)
   }
 
+  // parseLineItems parses + validates each element against the LineItem shape,
+  // returning [] for malformed JSON, a non-array, or no valid rows. An empty
+  // result means there's nothing valid to quote — reject it.
   const lineItems = parseLineItems(lineItemsJson)
-  if (!lineItems) {
+  if (lineItems.length === 0) {
     return redirect(`/admin/entities/${entityId}?error=invalid_line_items`, 302)
   }
 

--- a/tests/quotes-authored-content.test.ts
+++ b/tests/quotes-authored-content.test.ts
@@ -35,6 +35,7 @@ import {
   updateQuoteStatus,
   parseSchedule,
   parseDeliverables,
+  parseLineItems,
   getMissingAuthoredContent,
 } from '../src/lib/db/quotes'
 import type { Quote } from '../src/lib/db/quotes'
@@ -140,6 +141,54 @@ describe('parseDeliverables', () => {
     ])
     expect(parseDeliverables(makeQuote({ deliverables: json }))).toEqual([
       { title: 'Good', body: 'ok' },
+    ])
+  })
+})
+
+describe('parseLineItems', () => {
+  it('returns empty array when raw is null', () => {
+    expect(parseLineItems(null)).toEqual([])
+  })
+
+  it('returns empty array when raw is an empty string', () => {
+    expect(parseLineItems('')).toEqual([])
+  })
+
+  it('returns empty array when raw is not a JSON array', () => {
+    expect(parseLineItems('{"problem":"x","description":"y","estimated_hours":1}')).toEqual([])
+  })
+
+  it('returns empty array — does NOT throw — when JSON is malformed', () => {
+    // Regression: previously `JSON.parse(existing.line_items) as LineItem[]`
+    // threw an unhandled exception on corrupt stored JSON, surfacing as a 500
+    // in handleGeneratePdf and appendTotalsFields. parse-don't-cast (#833/#834/#835).
+    expect(() => parseLineItems('not json')).not.toThrow()
+    expect(parseLineItems('not json')).toEqual([])
+    expect(parseLineItems('{ truncated')).toEqual([])
+  })
+
+  it('returns parsed rows when JSON is a valid LineItem array', () => {
+    const json = JSON.stringify([
+      { problem: 'Lead leakage', description: 'Follow-up automation.', estimated_hours: 12 },
+      { problem: 'Manual quoting', description: 'Quote builder.', estimated_hours: 8 },
+    ])
+    expect(parseLineItems(json)).toEqual([
+      { problem: 'Lead leakage', description: 'Follow-up automation.', estimated_hours: 12 },
+      { problem: 'Manual quoting', description: 'Quote builder.', estimated_hours: 8 },
+    ])
+  })
+
+  it('drops rows of the wrong shape (missing fields or wrong types)', () => {
+    const json = JSON.stringify([
+      { problem: 'Good', description: 'ok', estimated_hours: 4 },
+      { problem: 'No hours', description: 'ok' }, // missing estimated_hours
+      { problem: 'String hours', description: 'ok', estimated_hours: '4' }, // wrong type
+      { description: 'No problem', estimated_hours: 1 }, // missing problem
+      null,
+      'a string',
+    ])
+    expect(parseLineItems(json)).toEqual([
+      { problem: 'Good', description: 'ok', estimated_hours: 4 },
     ])
   })
 })


### PR DESCRIPTION
## Summary

CLAUDE.md mandates **"parse external inputs, never cast."** The admin quotes path read stored and submitted `line_items` JSON with `as LineItem[]` casts, so corrupt or shape-changed JSON threw an unhandled exception (surfacing as a 500) instead of failing safely. This adds one canonical parse-and-validate helper and routes **every** `line_items` call site through it.

## Fixes (from the 2026-06-08 code review)

1. **[MEDIUM]** `src/pages/api/admin/quotes/[id].ts:104` (`handleGeneratePdf`) — replaced `JSON.parse(existing.line_items) as LineItem[]` with the validated `parseLineItems()`. A corrupt stored column no longer throws.
2. **[MEDIUM]** `src/pages/api/admin/quotes/[id].ts:160` (`parseLineItemsField`) — previously `Array.isArray(parsed)` then `return parsed as LineItem[]` with no per-element validation. Now delegates to `parseLineItems`, so malformed elements are rejected. Preserves the `undefined`-when-empty/absent semantics that `buildUpdateData` relies on to skip the update.
3. **[LOW]** `src/lib/db/quotes.ts:238` — `OPEN_QUOTE_STATUSES` had no importer outside its own file (verified by grep). Dropped the `export` keyword; the const stays (used internally by `hasOpenQuoteForEntity`).

### Same violation, swept in the same PR
- `src/lib/db/quotes.ts:421` (`appendTotalsFields`) carried the identical `JSON.parse(existing.line_items) as LineItem[]` cast on the stored column. Now uses `parseLineItems()`.
- `src/pages/api/admin/quotes/index.ts:30` (`createQuote` endpoint) had its **own** local `parseLineItems` that also did `return parsed as LineItem[]` with no per-element validation. Deleted the duplicate; it now imports and uses the canonical helper. Strictly stronger: a malformed-element array like `[{garbage}]` was previously passed straight to `createQuote`, and is now rejected as `invalid_line_items`.

## Approach

Added a canonical `parseLineItems(raw: string | null): LineItem[]` to `src/lib/db/quotes.ts`, sitting next to and mirroring the existing `parseSchedule` / `parseDeliverables` idiom exactly: `JSON.parse` in a try/catch, `Array.isArray` guard, and a per-element type guard (`isLineItem`) validating the full `LineItem` shape (`problem: string`, `description: string`, `estimated_hours: number`). Never throws, never casts. **All four read sites** now reuse it — no parsing idiom invented, zero duplication left in the quotes path.

## Tests

Extended `tests/quotes-authored-content.test.ts` with a `parseLineItems` block covering null/empty/non-array/malformed/valid/wrong-shape inputs, including a regression asserting malformed JSON returns `[]` rather than throwing.

- `npx vitest run tests/quotes*` — 190 passed
- `tests/forbidden-strings.test.ts` — 87 passed
- `npm run typecheck` — 0 errors
- `npm run lint` — 0 errors (new helper adds no warnings)
- `npm run build` — succeeds

## Out of scope (noted, not touched)

`createQuote` (84 lines) was flagged for length — left as-is per scope guidance.

Refs the 2026-06-08 code review and the open parse-don't-cast theme (#833 / #834 / #835).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
