### PR TITLE
test(middleware): add behavioral coverage; fix(review): WASM state doc, contact XSS hardening

### DIFF
--- a/src/lib/pdf/render.ts
+++ b/src/lib/pdf/render.ts
@@ -24,6 +24,16 @@ import formeWasm from '@formepdf/core/pkg/forme_bg.wasm'
 /**
  * Ensure the Forme WASM module is initialized before rendering.
  * Memoizes the init promise; resets on failure so the next call retries.
+ *
+ * Accepted module-scope-state exception (coding-standards.md §10, "Module-level
+ * `let`/`const` for immutable init-time values only"): this is NOT request-scoped
+ * state. `init(formeWasm)` binds the build-imported, immutable WebAssembly.Module
+ * into the @formepdf/core glue exactly once per isolate; the result is idempotent
+ * and carries no per-request data. Memoizing it here is the correct pattern —
+ * re-initializing per request would re-instantiate the WASM instance on every
+ * PDF render for no benefit. The promise is re-nulled ONLY on init failure so a
+ * subsequent render retries a cold init rather than awaiting a permanently
+ * rejected promise; it is never reassigned per request on the success path.
  */
 let wasmReady: Promise<void> | null = null
 function ensureWasm(): Promise<void> {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -70,6 +70,9 @@ async function resolveLegacyPortalSession(
   const sessionData = await validateSession(env.DB, env.SESSIONS, token)
   if (sessionData && sessionData.role === 'client') {
     context.locals.session = sessionData
+    // Fire-and-forget sliding-window renewal: a KV/D1 write failure here must
+    // not fail an otherwise-authenticated request. The session stays valid off
+    // its existing expiry; the next request retries the renewal.
     renewSession(env.DB, env.SESSIONS, token, sessionData).catch(() => {})
     return token
   }

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -85,7 +85,7 @@ import Footer from '../components/Footer.astro'
 
         button.disabled = true
         button.textContent = 'Sending...'
-        status.innerHTML = ''
+        status.replaceChildren()
 
         const data = {
           name: form.elements.namedItem('name').value,
@@ -94,8 +94,21 @@ import Footer from '../components/Footer.astro'
           website: form.elements.namedItem('website').value,
         }
 
-        function setBanner(variant, html) {
-          status.innerHTML = '<div class="ss-banner ss-banner-' + variant + '">' + html + '</div>'
+        // Build the banner with safe DOM construction. `content` is either a
+        // plain string (set via textContent — never parsed as HTML) or a Node
+        // assembled by the caller for the one case that needs a link. Response
+        // field values (validation messages, body.error) are server-controlled
+        // but flow into this sink as untrusted text, so they go through
+        // textContent, not innerHTML.
+        function setBanner(variant, content) {
+          const banner = document.createElement('div')
+          banner.className = 'ss-banner ss-banner-' + variant
+          if (typeof content === 'string') {
+            banner.textContent = content
+          } else {
+            banner.appendChild(content)
+          }
+          status.replaceChildren(banner)
         }
 
         try {
@@ -119,10 +132,17 @@ import Footer from '../components/Footer.astro'
             throw new Error(body.error || 'Request failed')
           }
         } catch {
-          setBanner(
-            'error',
-            'Something went wrong. Please email <a href="mailto:team@smd.services" class="ss-quiet-link">team@smd.services</a> directly.'
-          )
+          // The mailto link is authored markup, not dynamic data — build it as
+          // a real element so the surrounding copy stays plain text.
+          const frag = document.createDocumentFragment()
+          frag.appendChild(document.createTextNode('Something went wrong. Please email '))
+          const link = document.createElement('a')
+          link.href = 'mailto:team@smd.services'
+          link.className = 'ss-quiet-link'
+          link.textContent = 'team@smd.services'
+          frag.appendChild(link)
+          frag.appendChild(document.createTextNode(' directly.'))
+          setBanner('error', frag)
         } finally {
           button.disabled = false
           button.textContent = 'Send message'

--- a/tests/middleware-behavior.test.ts
+++ b/tests/middleware-behavior.test.ts
@@ -1,0 +1,378 @@
+/**
+ * Behavioral tests for src/middleware.ts.
+ *
+ * The sibling tests/middleware.test.ts enforces architectural invariants by
+ * matching the middleware SOURCE TEXT. This file exercises the same code at
+ * RUNTIME: it invokes the exported `onRequest` against a fake APIContext, a
+ * real migrated D1 (via @venturecrane/crane-test-harness), and an in-memory
+ * KV, and asserts on the Response the middleware actually produces.
+ *
+ * How the composed pipeline is driven under test
+ * -----------------------------------------------
+ * Production wires `onRequest = sequence(clerkMiddleware(), ssMiddleware)`.
+ * Clerk's middleware is the obstacle for a runtime test — it expects a live
+ * Clerk session + signing keys and would clobber the `locals.auth()` we want
+ * to control. We mock `@clerk/astro/server` so `clerkMiddleware()` is a
+ * pass-through `(ctx, next) => next()`. That leaves `ssMiddleware` — the
+ * SS-owned subdomain rewrites, legacy redirects, admin shim, and auth
+ * enforcement — running exactly as in production, while the test owns
+ * `context.locals.auth()` (the Clerk session state Clerk would otherwise set).
+ *
+ * `context.rewrite` / `context.redirect` are supplied by Astro in production;
+ * here the fake context provides equivalents that return a sentinel Response so
+ * the test can distinguish a rewrite (200, X-Rewrite-To header) from a redirect
+ * (3xx, Location header) from a fall-through to `next()` (200, X-Next header).
+ *
+ * Branch coverage map (src/middleware.ts):
+ *   - handleSubdomainRewrite: portal. + admin. host → path prepend; exempt paths
+ *   - redirectToAdminHost: strict `hostname === 'smd.services'` apex guard
+ *   - enforceAdminAuth: no Clerk userId → redirect / 401; Clerk userId but
+ *     no admin row (or role != admin) → /portal redirect / 403
+ *   - enforcePortalAuth: Clerk userId OR legacy magic-link client session →
+ *     allow; neither → redirect / 401
+ *   - resolveLegacyPortalSession: validates the session_token cookie against D1
+ *
+ * Deferred (documented, not faked):
+ *   - The apex admin-cookie clearing described in CLAUDE.md is performed by the
+ *     admin page/layout chrome on the next visit, NOT by src/middleware.ts —
+ *     there is no cookie-clearing branch in the middleware to exercise here.
+ *   - clerkMiddleware's own session parsing is owned by Clerk and mocked out;
+ *     this file tests the SS middleware's response to a given auth() state, not
+ *     Clerk's derivation of it.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import {
+  createTestD1,
+  runMigrations,
+  discoverNumericMigrations,
+  installWorkerdPolyfills,
+} from '@venturecrane/crane-test-harness'
+import { resolve } from 'path'
+import type { D1Database, KVNamespace } from '@cloudflare/workers-types'
+import { env as testEnv } from 'cloudflare:workers'
+import { ORG_ID } from '../src/lib/constants'
+import { SESSION_COOKIE_NAME } from '../src/lib/auth/session'
+
+// Replace Clerk's middleware with a transparent pass-through so ssMiddleware
+// runs against the auth() state the test plants on locals. The real
+// clerkMiddleware would require live Clerk config and overwrite locals.auth().
+vi.mock('@clerk/astro/server', () => ({
+  clerkMiddleware: () => (_ctx: unknown, next: () => unknown) => next(),
+}))
+
+// Import AFTER the mock is declared so the middleware module picks up the
+// stubbed clerkMiddleware.
+import { onRequest } from '../src/middleware'
+
+installWorkerdPolyfills()
+
+const migrationsDir = resolve(process.cwd(), 'migrations')
+
+// ---------------------------------------------------------------------------
+// In-memory KV backing SESSIONS (admin-session-shim cache + magic-link cache).
+// ---------------------------------------------------------------------------
+function createMemoryKv(): KVNamespace {
+  const store = new Map<string, string>()
+  return {
+    get: vi.fn(async (key: string) => store.get(key) ?? null),
+    put: vi.fn(async (key: string, value: string) => {
+      store.set(key, value)
+    }),
+    delete: vi.fn(async (key: string) => {
+      store.delete(key)
+    }),
+    list: vi.fn(),
+    getWithMetadata: vi.fn(),
+  } as unknown as KVNamespace
+}
+
+// ---------------------------------------------------------------------------
+// Fake APIContext. `next`, `rewrite`, and `redirect` each return a sentinel
+// Response so the test can classify which branch the middleware took.
+// ---------------------------------------------------------------------------
+const NEXT_MARKER = 'X-Next'
+const REWRITE_MARKER = 'X-Rewrite-To'
+
+type AuthState = { userId: string | null; orgId?: string | null }
+
+function buildContext(opts: { url: string; auth?: AuthState; cookie?: string }): {
+  context: unknown
+  next: ReturnType<typeof vi.fn>
+} {
+  const headers = new Headers()
+  if (opts.cookie) headers.set('cookie', opts.cookie)
+  const request = new Request(opts.url, { headers })
+  const url = new URL(opts.url)
+  const auth: AuthState = opts.auth ?? { userId: null, orgId: null }
+
+  const next = vi.fn(
+    async () => new Response('next', { status: 200, headers: { [NEXT_MARKER]: '1' } })
+  )
+
+  const context = {
+    request,
+    url,
+    locals: {
+      auth: () => auth,
+      // session is set to null by the middleware itself before resolution.
+      session: null as unknown,
+    },
+    // Astro's context.rewrite — returns a transparent 200 carrying the target
+    // so assertions can confirm the destination path without a real pipeline.
+    rewrite: (req: Request) =>
+      new Response('rewrite', {
+        status: 200,
+        headers: { [REWRITE_MARKER]: new URL(req.url).pathname },
+      }),
+    // Astro's context.redirect.
+    redirect: (location: string, status = 302) =>
+      new Response(null, { status, headers: { Location: location } }),
+  }
+
+  return { context, next }
+}
+
+async function invoke(opts: {
+  url: string
+  auth?: AuthState
+  cookie?: string
+}): Promise<{ res: Response; next: ReturnType<typeof vi.fn> }> {
+  const { context, next } = buildContext(opts)
+  // onRequest is Astro's MiddlewareHandler; the fake context/next satisfy the
+  // shape the SS middleware actually reads. A single structural cast keeps the
+  // call honest without per-arg gymnastics.
+  const handler = onRequest as (ctx: unknown, n: unknown) => Promise<Response>
+  const res = await handler(context, next)
+  return { res, next }
+}
+
+// ---------------------------------------------------------------------------
+// Seeding helpers.
+// ---------------------------------------------------------------------------
+const ADMIN_CLERK_ID = 'user_admin_clerk'
+const NONADMIN_CLERK_ID = 'user_client_clerk'
+const CLIENT_TOKEN = 'client-session-token-001'
+
+async function seedBaseOrg(db: D1Database): Promise<void> {
+  await db
+    .prepare('INSERT OR IGNORE INTO organizations (id, name, slug) VALUES (?, ?, ?)')
+    .bind(ORG_ID, 'SMD Services', 'smd-services')
+    .run()
+}
+
+async function seedAdminUser(db: D1Database): Promise<void> {
+  await db
+    .prepare(
+      `INSERT INTO users (id, org_id, email, name, role, clerk_user_id)
+       VALUES (?, ?, ?, ?, 'admin', ?)`
+    )
+    .bind('u-admin', ORG_ID, 'admin@smd.services', 'Admin', ADMIN_CLERK_ID)
+    .run()
+}
+
+async function seedNonAdminUser(db: D1Database): Promise<void> {
+  await db
+    .prepare(
+      `INSERT INTO users (id, org_id, email, name, role, clerk_user_id)
+       VALUES (?, ?, ?, ?, 'client', ?)`
+    )
+    .bind('u-client', ORG_ID, 'client@example.com', 'Client', NONADMIN_CLERK_ID)
+    .run()
+}
+
+async function seedClientSession(db: D1Database): Promise<void> {
+  // users row for the FK target, then a non-expired client session.
+  await db
+    .prepare(
+      `INSERT INTO users (id, org_id, email, name, role)
+       VALUES (?, ?, ?, ?, 'client')`
+    )
+    .bind('u-portal', ORG_ID, 'portal@example.com', 'Portal Client')
+    .run()
+  const expiresAt = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString()
+  await db
+    .prepare(
+      `INSERT INTO sessions (id, token, user_id, org_id, role, email, expires_at)
+       VALUES (?, ?, ?, ?, 'client', ?, ?)`
+    )
+    .bind('sess-1', CLIENT_TOKEN, 'u-portal', ORG_ID, 'portal@example.com', expiresAt)
+    .run()
+}
+
+// ---------------------------------------------------------------------------
+// Suite.
+// ---------------------------------------------------------------------------
+describe('middleware runtime: behavior', () => {
+  let db: D1Database
+
+  beforeEach(async () => {
+    db = createTestD1()
+    await runMigrations(db, { files: discoverNumericMigrations(migrationsDir) })
+    await seedBaseOrg(db)
+    Object.assign(testEnv, { DB: db, SESSIONS: createMemoryKv() })
+    // SENTRY_DSN unset → withSentryRequestHandler is a transparent pass-through.
+    delete (testEnv as unknown as Record<string, unknown>).SENTRY_DSN
+  })
+
+  afterEach(() => {
+    for (const key of Object.keys(testEnv)) {
+      delete (testEnv as unknown as Record<string, unknown>)[key]
+    }
+    vi.clearAllMocks()
+  })
+
+  // ---- Subdomain rewrite -------------------------------------------------
+  describe('subdomain rewrite', () => {
+    it('rewrites a bare path on portal.smd.services to /portal<path>', async () => {
+      const { res } = await invoke({ url: 'https://portal.smd.services/dashboard' })
+      expect(res.headers.get(REWRITE_MARKER)).toBe('/portal/dashboard')
+    })
+
+    it('rewrites "/" on portal.smd.services to /portal (no trailing slash)', async () => {
+      const { res } = await invoke({ url: 'https://portal.smd.services/' })
+      expect(res.headers.get(REWRITE_MARKER)).toBe('/portal')
+    })
+
+    it('rewrites a bare path on admin.smd.services to /admin<path>', async () => {
+      const { res } = await invoke({
+        url: 'https://admin.smd.services/entities',
+        auth: { userId: ADMIN_CLERK_ID },
+      })
+      expect(res.headers.get(REWRITE_MARKER)).toBe('/admin/entities')
+    })
+
+    it('does NOT rewrite a path already under /portal on the portal subdomain', async () => {
+      // Already-prefixed paths fall through to auth enforcement, not rewrite.
+      // With no auth, the portal page path redirects to sign-in (not a rewrite).
+      const { res } = await invoke({ url: 'https://portal.smd.services/portal/quotes' })
+      expect(res.headers.get(REWRITE_MARKER)).toBeNull()
+      expect(res.status).toBe(302)
+      expect(res.headers.get('Location')).toBe('/auth/sign-in')
+    })
+
+    it('does NOT rewrite /auth paths on the admin subdomain (exempt)', async () => {
+      const { res, next } = await invoke({ url: 'https://admin.smd.services/auth/sign-in' })
+      expect(res.headers.get(REWRITE_MARKER)).toBeNull()
+      // /auth is neither admin nor portal protected → falls through to next().
+      expect(next).toHaveBeenCalledOnce()
+    })
+  })
+
+  // ---- Apex admin-host redirect (strict hostname guard) ------------------
+  describe('apex → admin-host redirect', () => {
+    it('301s smd.services/admin/* to admin.smd.services', async () => {
+      const { res } = await invoke({ url: 'https://smd.services/admin/entities' })
+      expect(res.status).toBe(301)
+      expect(new URL(res.headers.get('Location')!).hostname).toBe('admin.smd.services')
+    })
+
+    it('does NOT redirect admin.smd.services/admin/* back to itself (no loop)', async () => {
+      // The strict `hostname === 'smd.services'` guard means the admin
+      // subdomain skips the apex redirect entirely; the request proceeds to
+      // auth enforcement instead of 301-looping.
+      const { res } = await invoke({
+        url: 'https://admin.smd.services/admin/entities',
+        auth: { userId: ADMIN_CLERK_ID },
+      })
+      expect(res.status).not.toBe(301)
+    })
+  })
+
+  // ---- Admin auth enforcement -------------------------------------------
+  describe('admin auth enforcement', () => {
+    it('redirects an unauthenticated admin PAGE request to /auth/sign-in', async () => {
+      const { res } = await invoke({ url: 'https://admin.smd.services/admin/entities' })
+      expect(res.status).toBe(302)
+      expect(res.headers.get('Location')).toBe('/auth/sign-in')
+    })
+
+    it('returns 401 JSON for an unauthenticated admin API request', async () => {
+      const { res } = await invoke({ url: 'https://admin.smd.services/api/admin/entities' })
+      expect(res.status).toBe(401)
+      expect(await res.json()).toEqual({ error: 'Unauthorized' })
+    })
+
+    it('redirects a Clerk-authenticated NON-admin to /portal on an admin page', async () => {
+      await seedNonAdminUser(db)
+      const { res } = await invoke({
+        url: 'https://admin.smd.services/admin/entities',
+        auth: { userId: NONADMIN_CLERK_ID },
+      })
+      expect(res.status).toBe(302)
+      expect(res.headers.get('Location')).toBe('/portal')
+    })
+
+    it('returns 403 JSON for a Clerk-authenticated non-admin on an admin API route', async () => {
+      await seedNonAdminUser(db)
+      const { res } = await invoke({
+        url: 'https://admin.smd.services/api/admin/entities',
+        auth: { userId: NONADMIN_CLERK_ID },
+      })
+      expect(res.status).toBe(403)
+      expect(await res.json()).toEqual({ error: 'Forbidden' })
+    })
+
+    it('allows a Clerk-authenticated admin (role=admin in D1) through to next()', async () => {
+      await seedAdminUser(db)
+      const { res, next } = await invoke({
+        url: 'https://admin.smd.services/admin/entities',
+        auth: { userId: ADMIN_CLERK_ID },
+      })
+      expect(next).toHaveBeenCalledOnce()
+      expect(res.headers.get(NEXT_MARKER)).toBe('1')
+    })
+  })
+
+  // ---- Portal auth enforcement ------------------------------------------
+  describe('portal auth enforcement', () => {
+    it('redirects an unauthenticated portal PAGE request to /auth/sign-in', async () => {
+      const { res } = await invoke({ url: 'https://portal.smd.services/portal/quotes' })
+      expect(res.status).toBe(302)
+      expect(res.headers.get('Location')).toBe('/auth/sign-in')
+    })
+
+    it('returns 401 JSON for an unauthenticated portal API request', async () => {
+      const { res } = await invoke({ url: 'https://portal.smd.services/api/portal/quotes' })
+      expect(res.status).toBe(401)
+      expect(await res.json()).toEqual({ error: 'Unauthorized' })
+    })
+
+    it('allows a Clerk-authenticated user through (primary portal path)', async () => {
+      const { res, next } = await invoke({
+        url: 'https://portal.smd.services/portal/quotes',
+        auth: { userId: 'user_any_clerk' },
+      })
+      expect(next).toHaveBeenCalledOnce()
+      expect(res.headers.get(NEXT_MARKER)).toBe('1')
+    })
+
+    it('allows a legacy magic-link client session (cookie) as a Clerk fallback', async () => {
+      await seedClientSession(db)
+      const { res, next } = await invoke({
+        url: 'https://portal.smd.services/portal/quotes',
+        cookie: `${SESSION_COOKIE_NAME}=${CLIENT_TOKEN}`,
+      })
+      expect(next).toHaveBeenCalledOnce()
+      expect(res.headers.get(NEXT_MARKER)).toBe('1')
+    })
+
+    it('rejects an unknown/invalid session_token cookie with no Clerk session', async () => {
+      const { res } = await invoke({
+        url: 'https://portal.smd.services/portal/quotes',
+        cookie: `${SESSION_COOKIE_NAME}=not-a-real-token`,
+      })
+      expect(res.status).toBe(302)
+      expect(res.headers.get('Location')).toBe('/auth/sign-in')
+    })
+  })
+
+  // ---- Marketing/public fall-through ------------------------------------
+  describe('public paths', () => {
+    it('lets a marketing path on the apex fall through to next()', async () => {
+      const { res, next } = await invoke({ url: 'https://smd.services/operator' })
+      expect(next).toHaveBeenCalledOnce()
+      expect(res.headers.get(NEXT_MARKER)).toBe('1')
+    })
+  })
+})


### PR DESCRIPTION
Addresses the test-gap (MEDIUM) and three LOW-priority findings from the 2026-06-08 code review.

## 1. [MEDIUM] Behavioral middleware tests — `tests/middleware-behavior.test.ts` (new)
`tests/middleware.test.ts` only matched middleware **source text**. This new file exercises `src/middleware.ts` at **runtime** and asserts on the `Response` the middleware actually returns.

**How it's driven:** `@clerk/astro/server` is mocked so `clerkMiddleware()` is a pass-through, leaving the SS-owned `ssMiddleware` (subdomain rewrites, legacy redirects, admin shim, auth enforcement) running exactly as in production while the test controls `locals.auth()`. Backed by a real migrated D1 (`@venturecrane/crane-test-harness`) + in-memory KV — same harness/KV pattern as `tests/booking/reserve.test.ts` and `tests/clerk-bridge.test.ts`. The fake `context.rewrite`/`redirect`/`next` each return a sentinel `Response` so each branch is classifiable.

**Branches covered (runtime):**
- Subdomain rewrite — `portal.`/`admin.` host → `/portal`/`/admin` path prepend; `/` → no trailing slash; exempt `/auth` paths; already-prefixed paths fall through to auth
- Strict apex `hostname === 'smd.services'` redirect guard — 301 apex `/admin/*` → admin subdomain; **no-loop** proof on the admin subdomain (`src/middleware.ts:117`)
- Admin auth (`enforceAdminAuth`, `src/middleware.ts:210`) — no Clerk userId → `/auth/sign-in` (page) / 401 (API); Clerk userId but non-admin/no D1 row → `/portal` (page) / 403 (API); `role=admin` → `next()`
- Portal auth (`enforcePortalAuth`, `src/middleware.ts:225`) — Clerk primary → `next()`; legacy magic-link `session_token` cookie validated against D1 → `next()`; invalid cookie + no Clerk → `/auth/sign-in`
- Marketing fall-through → `next()`

Source-text guards in `tests/middleware.test.ts` are **retained** as architectural invariants (no coverage reduction).

**Deferred (documented in the file header, not faked):**
- Apex admin-cookie clearing (CLAUDE.md) is performed by the admin page/layout chrome on next visit, **not** by `src/middleware.ts` — there is no cookie-clearing branch in the middleware to exercise.
- `clerkMiddleware`'s own session parsing is owned by Clerk and mocked out; this file tests the SS middleware's response to a given `auth()` state, not Clerk's derivation of it.

## 2. [LOW] WASM Worker-state — `src/lib/pdf/render.ts:28`
Assessed: the module-level `wasmReady` is **not** request-scoped state — it memoizes an idempotent, immutable build-imported `WebAssembly.Module` init that's correct to cache per-isolate; per-request re-init would re-instantiate WASM on every PDF render. Kept as-is and documented as an accepted `coding-standards.md` §10 exception (re-nulled only on init failure for retry). No render regression.

## 3. [LOW] contact.astro innerHTML — `src/pages/contact.astro:97`
`/api/contact` currently returns only hardcoded literal `error`/`fields.*` strings (verified — no live XSS), but the `status.innerHTML = '...' + html + '...'` sink is structurally XSS-receptive. Hardened with safe DOM construction: dynamic response text now flows through `textContent`; the authored `mailto:` link is built as a real `<a>` element; `replaceChildren` replaces innerHTML clears. Banner markup, variant classes, and visual result unchanged.

## 4. [LOW] middleware fire-and-forget comment — `src/middleware.ts:73`
Added a one-line intent comment to the `renewSession(...).catch(() => {})` (a KV/D1 write failure must not fail an authenticated request). No logic change.

## Gates
`npm run typecheck` (no new errors in touched files), `npm run lint` (clean on all four files), `npx vitest run` (18/18 new + 817 across auth/portal/admin/middleware/contact), `npm run build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)