### PR TITLE
fix(assessment): harden public turn endpoint with signed session + per-session ceiling

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -31,6 +31,10 @@ GOOGLE_PLACES_API_KEY=""
 OUTSCRAPER_API_KEY=""
 SERPAPI_API_KEY=""
 PROXYCURL_API_KEY=""
+# HMAC key for public live-assessment session tokens (/api/assessment/turn).
+# Base64 raw bytes — generate with: openssl rand -base64 32
+# Gates the per-session turn/cost ceiling. See src/lib/assessment/session.ts.
+ASSESSMENT_SESSION_SIGNING_KEY=""
 
 # ---------- Clerk auth (portal.smd.services) ----------
 # Identity layer for the portal — users, organizations, memberships,

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -180,6 +180,17 @@ declare namespace Cloudflare {
      */
     OAUTH_STATE_SIGNING_KEY?: string
     /**
+     * HMAC signing key for public live-assessment session tokens
+     * (`/api/assessment/turn`, ADR 0039 node [1]). Base64-encoded raw bytes;
+     * generate with `openssl rand -base64 32`. A dedicated key keeps
+     * assessment sessions cryptographically independent of booking links and
+     * OAuth state — rotating one must not invalidate the others. The signed
+     * `sid` is what makes the per-session turn/cost ceiling unforgeable, which
+     * is what defeats IP-rotation budget exhaustion. Must be a Worker secret,
+     * never a `[vars]` entry. See src/lib/assessment/session.ts.
+     */
+    ASSESSMENT_SESSION_SIGNING_KEY?: string
+    /**
      * Fly.io API token (SMD-owned, from Infisical) used by the OAuth token
      * relay (`src/lib/oauth/store.ts`) to set a customer app's
      * `GOOGLE_TOKEN_JSON` secret and restart its Machine on connect/re-consent.

--- a/src/lib/assessment/session.ts
+++ b/src/lib/assessment/session.ts
@@ -1,0 +1,252 @@
+/**
+ * Signed assessment session + server-side per-session ceiling.
+ *
+ * The public live-assessment endpoint (`/api/assessment/turn`, ADR 0039 node
+ * [1]) makes a live LLM call on every turn. Before it takes advertising
+ * traffic it needs an abuse control that an IP-only rate limit cannot give:
+ *
+ *   Threat — IP-rotation budget exhaustion. The IP rate limit (200/hr) caps a
+ *   single address, and `MAX_TURNS` caps the turns array of one request, but
+ *   neither bounds how many *sessions* a determined caller can start. Rotating
+ *   IPs (botnet, proxy pool, CGNAT churn) lets an attacker open unbounded fresh
+ *   assessments and burn the Anthropic budget before a real prospect ever
+ *   reaches the funnel.
+ *
+ * Design — a signed session that the server tracks:
+ *
+ *   1. The opening turn (empty `turns`) mints a session token: an HMAC-SHA256
+ *      signed payload carrying a random `sid` and an `exp`. The token is opaque
+ *      to the client and returned alongside the opening message.
+ *   2. Every subsequent turn must present the token. We verify the signature
+ *      and expiry (fail closed on missing / malformed / bad-signature /
+ *      expired) and then increment a per-`sid` counter in KV. When the counter
+ *      reaches the ceiling the turn is refused.
+ *
+ *   Because each accepted turn is exactly one LLM call, a per-session turn
+ *   ceiling *is* a per-session cost ceiling — the unit we actually care about.
+ *   The signature stops a caller from forging or mutating a `sid` to dodge the
+ *   counter; rotating IPs no longer helps because the ceiling is bound to the
+ *   signed session, not the address.
+ *
+ *   IP rate-limiting stays as a cheap first layer (it sheds volume before we
+ *   touch KV or crypto); the signed-session ceiling is the backstop that
+ *   survives IP rotation.
+ *
+ * Encoding (matches src/lib/oauth/state.ts and src/lib/booking/signed-link.ts):
+ *
+ *   `<base64url(json-payload)>.<base64url(hmac-sha256)>`
+ *
+ * Signing key: `ASSESSMENT_SESSION_SIGNING_KEY` env var, base64-encoded raw
+ * bytes (generate with `openssl rand -base64 32`). A dedicated key keeps
+ * assessment sessions cryptographically independent of booking links and OAuth
+ * state — rotating one must never invalidate the others. Rotation simply
+ * invalidates in-flight sessions; the visitor restarts, which is cheap.
+ *
+ * Counter storage: `BOOKING_CACHE` KV (already bound; the same namespace the
+ * booking rate-limiter uses). Keys are `as:turns:<sid>` with a TTL matching the
+ * session lifetime so they self-expire. KV is eventually consistent, so the
+ * ceiling is approximate at the margin — acceptable, because the goal is to
+ * bound spend, not to enforce an exact transaction count.
+ */
+
+import { env } from 'cloudflare:workers'
+
+const ALGORITHM: HmacImportParams = { name: 'HMAC', hash: 'SHA-256' }
+const ENCODER = new TextEncoder()
+const SCHEMA_VERSION = 1
+
+/**
+ * Maximum operator turns served per session. Each turn is one LLM call, so this
+ * is the per-session cost ceiling. A genuine assessment completes well under
+ * this; the interviewer emits the completion sentinel long before. Sized to
+ * leave generous headroom for a thorough conversation while still bounding a
+ * single session's spend.
+ */
+export const MAX_SESSION_TURNS = 40
+
+/**
+ * Session lifetime. Long enough for an unhurried assessment (a visitor may
+ * pause mid-conversation), short enough that a leaked token is not useful for
+ * long. The KV counter TTL is pinned to this so stale sessions self-evict.
+ */
+export const SESSION_TTL_SECONDS = 2 * 60 * 60 // 2 hours
+
+export interface AssessmentSessionPayload {
+  v: number
+  /** Random session id; the KV counter key is derived from this. */
+  sid: string
+  /** Unix seconds; token invalid at/after this time. */
+  exp: number
+}
+
+export type IssueSessionResult = {
+  /** Opaque token the client must echo on every subsequent turn. */
+  token: string
+  payload: AssessmentSessionPayload
+}
+
+export type VerifySessionResult =
+  | { ok: true; payload: AssessmentSessionPayload }
+  | { ok: false; error: 'malformed' | 'bad_signature' | 'expired' | 'unknown_version' }
+
+export type ConsumeTurnResult =
+  | { ok: true; count: number; limit: number }
+  | { ok: false; reason: 'ceiling_reached'; count: number; limit: number }
+
+/**
+ * Mint a fresh signed session token. Called when the opening message is served
+ * (empty `turns`). The `sid` is a random UUID — unguessable and unique per
+ * session so counters never collide.
+ */
+export async function issueAssessmentSession(
+  ttlSeconds: number = SESSION_TTL_SECONDS
+): Promise<IssueSessionResult> {
+  const key = await importSigningKey()
+  const exp = Math.floor(Date.now() / 1000) + ttlSeconds
+  const payload: AssessmentSessionPayload = {
+    v: SCHEMA_VERSION,
+    sid: crypto.randomUUID(),
+    exp,
+  }
+
+  const payloadB64 = base64UrlEncode(ENCODER.encode(JSON.stringify(payload)))
+  const sigBuf = await crypto.subtle.sign(ALGORITHM, key, ENCODER.encode(payloadB64))
+  const sigB64 = base64UrlEncode(new Uint8Array(sigBuf))
+  return { token: `${payloadB64}.${sigB64}`, payload }
+}
+
+/**
+ * Verify a session token. Returns the payload only when the signature is valid,
+ * the schema version is known, and the token has not expired. Fails closed on
+ * every other input.
+ */
+export async function verifyAssessmentSession(token: unknown): Promise<VerifySessionResult> {
+  if (typeof token !== 'string' || token.length === 0) {
+    return { ok: false, error: 'malformed' }
+  }
+
+  const dot = token.indexOf('.')
+  if (dot <= 0 || dot === token.length - 1) {
+    return { ok: false, error: 'malformed' }
+  }
+
+  const payloadB64 = token.slice(0, dot)
+  const sigB64 = token.slice(dot + 1)
+
+  let sigBytes: Uint8Array
+  try {
+    sigBytes = base64UrlDecode(sigB64)
+  } catch {
+    return { ok: false, error: 'malformed' }
+  }
+
+  const key = await importSigningKey()
+  const valid = await crypto.subtle.verify(
+    ALGORITHM,
+    key,
+    sigBytes as unknown as ArrayBuffer,
+    ENCODER.encode(payloadB64)
+  )
+  if (!valid) return { ok: false, error: 'bad_signature' }
+
+  let payload: AssessmentSessionPayload
+  try {
+    const json = new TextDecoder().decode(base64UrlDecode(payloadB64))
+    payload = JSON.parse(json) as AssessmentSessionPayload
+  } catch {
+    return { ok: false, error: 'malformed' }
+  }
+
+  if (payload.v !== SCHEMA_VERSION) {
+    return { ok: false, error: 'unknown_version' }
+  }
+  if (typeof payload.sid !== 'string' || payload.sid.length === 0) {
+    return { ok: false, error: 'malformed' }
+  }
+
+  const now = Math.floor(Date.now() / 1000)
+  if (typeof payload.exp !== 'number' || payload.exp < now) {
+    return { ok: false, error: 'expired' }
+  }
+
+  return { ok: true, payload }
+}
+
+/**
+ * Atomically(-ish) charge one turn against a session's ceiling. Reads the
+ * current per-`sid` counter from KV, refuses if it has already reached the
+ * limit, otherwise increments and persists with a TTL.
+ *
+ * KV has no compare-and-swap, so two near-simultaneous turns from the same
+ * session could both read the same count and both write `count + 1` — at worst
+ * one extra LLM call slips through at the boundary. That is acceptable: the
+ * ceiling bounds spend, it is not a financial ledger. The signed `sid` is what
+ * makes the counter unforgeable, which is the property that defeats IP
+ * rotation.
+ *
+ * If `kv` is undefined (dev without the binding) the turn is allowed — mirrors
+ * the booking rate-limiter's dev-mode behavior. Production always has the
+ * binding; the endpoint additionally requires a valid signed token, so an
+ * undefined KV never silently disables the *signature* check.
+ */
+export async function consumeSessionTurn(
+  kv: KVNamespace | undefined,
+  sid: string,
+  limit: number = MAX_SESSION_TURNS,
+  ttlSeconds: number = SESSION_TTL_SECONDS
+): Promise<ConsumeTurnResult> {
+  if (!kv) {
+    return { ok: true, count: 0, limit }
+  }
+
+  const key = `as:turns:${sid}`
+  const currentRaw = await kv.get(key)
+  const current = currentRaw ? parseInt(currentRaw, 10) : 0
+  const safeCurrent = Number.isFinite(current) && current >= 0 ? current : 0
+
+  if (safeCurrent >= limit) {
+    return { ok: false, reason: 'ceiling_reached', count: safeCurrent, limit }
+  }
+
+  const next = safeCurrent + 1
+  await kv.put(key, String(next), { expirationTtl: ttlSeconds })
+  return { ok: true, count: next, limit }
+}
+
+// ---------------------------------------------------------------------------
+// Internals
+// ---------------------------------------------------------------------------
+
+async function importSigningKey(): Promise<CryptoKey> {
+  const raw = env.ASSESSMENT_SESSION_SIGNING_KEY
+  if (!raw || typeof raw !== 'string' || raw.trim().length === 0) {
+    throw new Error(
+      'ASSESSMENT_SESSION_SIGNING_KEY is not configured. Set it in wrangler env (32 random bytes, base64-encoded) before issuing assessment sessions.'
+    )
+  }
+  let bin: string
+  try {
+    bin = atob(raw)
+  } catch {
+    throw new Error('ASSESSMENT_SESSION_SIGNING_KEY is not valid base64.')
+  }
+  const keyBytes = Uint8Array.from(bin, (c) => c.charCodeAt(0))
+  return crypto.subtle.importKey('raw', keyBytes, ALGORITHM, false, ['sign', 'verify'])
+}
+
+function base64UrlEncode(bytes: Uint8Array): string {
+  let bin = ''
+  for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i])
+  const b64 = btoa(bin)
+  return b64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+function base64UrlDecode(s: string): Uint8Array {
+  const padded = s.replace(/-/g, '+').replace(/_/g, '/')
+  const padLen = (4 - (padded.length % 4)) % 4
+  const b64 = padded + '='.repeat(padLen)
+  const bin = atob(b64)
+  const bytes = new Uint8Array(bin.length)
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i)
+  return bytes
+}

--- a/src/lib/claude/assessment.ts
+++ b/src/lib/claude/assessment.ts
@@ -30,6 +30,25 @@ const FINDINGS_MAX_TOKENS = 4096
 const KICKOFF =
   '[The business owner has just started the assessment. Begin with your warm opening.]'
 
+/**
+ * The operator's opening message, served as a fixed constant rather than an LLM
+ * call (2026-06-08 hardening). The opening is produced from a fixed synthetic
+ * prompt with zero owner input — the same warm, lightly-framed greeting every
+ * time — so it is effectively a constant and never needed a live generation.
+ *
+ * Serving it statically closes the residual IP-rotation cost vector on
+ * `/api/assessment/turn`: an attacker can no longer POST empty `turns` to burn
+ * one LLM call per request. The model is only invoked once the owner has
+ * actually replied (a continuing turn, which the signed-session ceiling gates).
+ *
+ * The copy is faithful to the interviewer skill's opening directive ("Open
+ * warm, frame lightly... invite them to walk you through how the business
+ * actually runs day to day. Let them talk."). It withholds the completion
+ * sentinel and is never `done`.
+ */
+export const ASSESSMENT_OPENING_MESSAGE =
+  "Thanks for making the time. I'd love to start by just understanding how your business actually runs day to day. Walk me through it in your own words. Where does the day usually start, and what's on your plate before anything else happens?"
+
 /** Error from the Anthropic API or an unexpected response shape. */
 export class AssessmentApiError extends Error {
   constructor(
@@ -98,9 +117,19 @@ export function parseOperatorReply(raw: string): AssessmentTurnResult {
 }
 
 /**
+ * The operator's opening message — a fixed constant, no LLM call. Returned for
+ * the opening turn (empty `turns`); see `ASSESSMENT_OPENING_MESSAGE` for why
+ * this is static. Never `done`.
+ */
+export function assessmentOpening(): AssessmentTurnResult {
+  return { message: ASSESSMENT_OPENING_MESSAGE, done: false }
+}
+
+/**
  * Produce the operator's next message given the conversation so far.
- * `turns` is the visible history (empty for the opening). When the interviewer
- * judges the assessment complete it emits the sentinel; we strip it and flag `done`.
+ * `turns` is the visible history; it must be non-empty (the opening is served
+ * statically by `assessmentOpening`). When the interviewer judges the
+ * assessment complete it emits the sentinel; we strip it and flag `done`.
  */
 export async function assessmentTurn(
   apiKey: string,

--- a/src/pages/api/assessment/turn.ts
+++ b/src/pages/api/assessment/turn.ts
@@ -5,24 +5,29 @@
  *   { turns: { speaker: 'owner' | 'operator', text: string }[], session?: string }
  *
  * The opening request sends an empty `turns` array and no `session`; the
- * response mints a signed session token (`{ message, done, session }`) that the
- * client must echo on every subsequent turn. Returns:
+ * response serves the warm opening as a fixed constant (NO LLM call) and mints a
+ * signed session token (`{ message, done, session }`) that the client must echo
+ * on every subsequent turn. Returns:
  *   { message: string, done: boolean, session?: string }
  *
- * Public surface, hardened for ad traffic (2026-06-08 code review). Two layers:
+ * Public surface, hardened for ad traffic (2026-06-08 code review). Three layers:
  *
  *   1. IP rate limit (cheap, sheds volume) — `rateLimitByIp`.
- *   2. Signed session + server-side per-session turn/cost ceiling — defeats
- *      IP-rotation budget exhaustion, which the IP limit alone cannot. See
+ *   2. Static opener — the opening turn costs zero LLM calls, so POSTing empty
+ *      `turns` is not a budget vector even under IP rotation. The model is only
+ *      invoked once the owner has actually replied.
+ *   3. Signed session + server-side per-session turn/cost ceiling on continuing
+ *      turns — bounds the spend of the one path that does call the model, bound
+ *      to an unforgeable session id rather than an IP. See
  *      `src/lib/assessment/session.ts` for the threat model and design.
  *
- * Fails closed: a non-opening turn with a missing / malformed / expired /
- * forged session token is refused before any LLM call.
+ * Fails closed: a continuing turn with a missing / malformed / expired / forged
+ * session token is refused before any LLM call.
  */
 
 import type { APIContext, APIRoute } from 'astro'
 import { env } from 'cloudflare:workers'
-import { assessmentTurn, type Turn } from '../../../lib/claude/assessment'
+import { assessmentOpening, assessmentTurn, type Turn } from '../../../lib/claude/assessment'
 import { rateLimitByIp } from '../../../lib/booking/rate-limit'
 import {
   consumeSessionTurn,
@@ -107,8 +112,6 @@ export const POST: APIRoute = async ({ request, clientAddress }: APIContext) => 
   )
   if (!rate.allowed) return json(429, { error: 'Too many requests. Please slow down.' })
 
-  if (!env.ANTHROPIC_API_KEY) return json(503, { error: 'Assessment is temporarily unavailable.' })
-
   let body: unknown
   try {
     body = await request.json()
@@ -119,40 +122,40 @@ export const POST: APIRoute = async ({ request, clientAddress }: APIContext) => 
   const parsed = parseTurnRequest(body)
   if (parsed === null) return json(400, { error: 'Invalid request.' })
 
-  const opening = isOpeningTurn(parsed)
+  // Opening turn: serve the warm opening as a fixed constant — NO LLM call — and
+  // mint the session that gates every turn after it. Serving the opening
+  // statically closes the residual IP-rotation cost vector: POSTing empty
+  // `turns` can no longer burn a live LLM call per request. The model is only
+  // invoked once the owner has actually replied (a continuing turn below).
+  if (isOpeningTurn(parsed)) {
+    const session = await issueAssessmentSession()
+    return json(200, { ...assessmentOpening(), session: session.token })
+  }
 
   // Continuing turns must present a valid signed session, and each one is
-  // charged against the session's ceiling. Fail closed on every bad-token path.
-  // This is the layer that survives IP rotation: the ceiling is bound to the
-  // signed session, not the address.
-  if (!opening) {
-    if (parsed.session === null) {
-      return json(401, { error: 'Missing assessment session. Please restart the assessment.' })
-    }
-    const verified = await verifyAssessmentSession(parsed.session)
-    if (!verified.ok) {
-      return json(401, { error: 'Your assessment session is no longer valid. Please restart.' })
-    }
-    const charge = await consumeSessionTurn(env.BOOKING_CACHE, verified.payload.sid)
-    if (!charge.ok) {
-      return json(429, {
-        error: 'This assessment has reached its length limit. Please restart to continue.',
-      })
-    }
+  // charged against the session's ceiling before the LLM is touched. Fail
+  // closed on every bad-token path. This is the layer that survives IP
+  // rotation: the ceiling is bound to the signed session, not the address.
+  if (parsed.session === null) {
+    return json(401, { error: 'Missing assessment session. Please restart the assessment.' })
+  }
+  const verified = await verifyAssessmentSession(parsed.session)
+  if (!verified.ok) {
+    return json(401, { error: 'Your assessment session is no longer valid. Please restart.' })
+  }
+  const charge = await consumeSessionTurn(env.BOOKING_CACHE, verified.payload.sid)
+  if (!charge.ok) {
+    return json(429, {
+      error: 'This assessment has reached its length limit. Please restart to continue.',
+    })
   }
 
-  // Opening turn: mint the session that gates every turn after it. Minting
-  // before the LLM call is fine — a session id is free; a failed opener just
-  // leaves an unused id that self-expires from KV.
-  let issuedSession: string | null = null
-  if (opening) {
-    const session = await issueAssessmentSession()
-    issuedSession = session.token
-  }
+  // Only continuing turns invoke the model, so the API-key gate lives here.
+  if (!env.ANTHROPIC_API_KEY) return json(503, { error: 'Assessment is temporarily unavailable.' })
 
   try {
     const result = await assessmentTurn(env.ANTHROPIC_API_KEY, parsed.turns)
-    return json(200, issuedSession ? { ...result, session: issuedSession } : result)
+    return json(200, result)
   } catch {
     return json(502, { error: 'The operator could not respond. Please try again.' })
   }

--- a/src/pages/api/assessment/turn.ts
+++ b/src/pages/api/assessment/turn.ts
@@ -2,23 +2,44 @@
  * POST /api/assessment/turn
  *
  * One turn of the live web assessment (ADR 0039 node [1]). Body:
- *   { turns: { speaker: 'owner' | 'operator', text: string }[] }
- * (empty `turns` requests the operator's opening message.)
- * Returns: { message: string, done: boolean } — the operator's next message,
- * with `done` true when the assessment is complete and findings can be drafted.
+ *   { turns: { speaker: 'owner' | 'operator', text: string }[], session?: string }
  *
- * Preview surface: unlinked, rate-limited, dogfood-only. Hardening for public
- * traffic (stronger abuse controls, persistence) is a follow-up before launch.
+ * The opening request sends an empty `turns` array and no `session`; the
+ * response mints a signed session token (`{ message, done, session }`) that the
+ * client must echo on every subsequent turn. Returns:
+ *   { message: string, done: boolean, session?: string }
+ *
+ * Public surface, hardened for ad traffic (2026-06-08 code review). Two layers:
+ *
+ *   1. IP rate limit (cheap, sheds volume) — `rateLimitByIp`.
+ *   2. Signed session + server-side per-session turn/cost ceiling — defeats
+ *      IP-rotation budget exhaustion, which the IP limit alone cannot. See
+ *      `src/lib/assessment/session.ts` for the threat model and design.
+ *
+ * Fails closed: a non-opening turn with a missing / malformed / expired /
+ * forged session token is refused before any LLM call.
  */
 
 import type { APIContext, APIRoute } from 'astro'
 import { env } from 'cloudflare:workers'
 import { assessmentTurn, type Turn } from '../../../lib/claude/assessment'
 import { rateLimitByIp } from '../../../lib/booking/rate-limit'
+import {
+  consumeSessionTurn,
+  issueAssessmentSession,
+  verifyAssessmentSession,
+} from '../../../lib/assessment/session'
 
 const RATE_LIMIT_PER_HOUR = 200
 const MAX_TURNS = 60
 const MAX_TURN_CHARS = 4000
+
+/** Parsed, validated request: the turns array plus the optional session token. */
+export interface ParsedTurnRequest {
+  turns: Turn[]
+  /** Present once the opening turn has issued a session; absent on the opener. */
+  session: string | null
+}
 
 function json(status: number, body: unknown): Response {
   return new Response(JSON.stringify(body), {
@@ -27,21 +48,54 @@ function json(status: number, body: unknown): Response {
   })
 }
 
-/** Parse + validate the request body into a turns array, or null if malformed. */
-function parseTurns(body: unknown): Turn[] | null {
+/** Narrow one array element into a `Turn`, or null if it is not a valid turn. */
+function parseTurn(item: unknown): Turn | null {
+  if (typeof item !== 'object' || item === null) return null
+  const speaker = (item as { speaker?: unknown }).speaker
+  const text = (item as { text?: unknown }).text
+  if (speaker !== 'owner' && speaker !== 'operator') return null
+  if (typeof text !== 'string' || text.length === 0 || text.length > MAX_TURN_CHARS) return null
+  return { speaker, text }
+}
+
+/**
+ * Narrow the optional session token. Absent/null is valid (the opening turn
+ * carries none); a non-empty string is the token; anything else is malformed.
+ * Returns `{ ok: false }` rather than a sentinel string so a valid token that
+ * happened to equal a sentinel can't be confused with an error.
+ */
+function parseSession(raw: unknown): { ok: true; value: string | null } | { ok: false } {
+  if (raw === undefined || raw === null) return { ok: true, value: null }
+  if (typeof raw !== 'string' || raw.length === 0) return { ok: false }
+  return { ok: true, value: raw }
+}
+
+/**
+ * Parse + validate the request body. Never casts — every field is narrowed
+ * from `unknown`. Returns null on any malformed input (callers map that to 400).
+ */
+export function parseTurnRequest(body: unknown): ParsedTurnRequest | null {
   if (typeof body !== 'object' || body === null) return null
+
   const raw = (body as { turns?: unknown }).turns
   if (!Array.isArray(raw) || raw.length > MAX_TURNS) return null
+
   const turns: Turn[] = []
   for (const item of raw) {
-    if (typeof item !== 'object' || item === null) return null
-    const speaker = (item as { speaker?: unknown }).speaker
-    const text = (item as { text?: unknown }).text
-    if (speaker !== 'owner' && speaker !== 'operator') return null
-    if (typeof text !== 'string' || text.length === 0 || text.length > MAX_TURN_CHARS) return null
-    turns.push({ speaker, text })
+    const turn = parseTurn(item)
+    if (turn === null) return null
+    turns.push(turn)
   }
-  return turns
+
+  const session = parseSession((body as { session?: unknown }).session)
+  if (!session.ok) return null
+
+  return { turns, session: session.value }
+}
+
+/** An opening turn carries no prior history. */
+function isOpeningTurn(req: ParsedTurnRequest): boolean {
+  return req.turns.length === 0
 }
 
 export const POST: APIRoute = async ({ request, clientAddress }: APIContext) => {
@@ -62,12 +116,43 @@ export const POST: APIRoute = async ({ request, clientAddress }: APIContext) => 
     return json(400, { error: 'Invalid JSON.' })
   }
 
-  const turns = parseTurns(body)
-  if (turns === null) return json(400, { error: 'Invalid request.' })
+  const parsed = parseTurnRequest(body)
+  if (parsed === null) return json(400, { error: 'Invalid request.' })
+
+  const opening = isOpeningTurn(parsed)
+
+  // Continuing turns must present a valid signed session, and each one is
+  // charged against the session's ceiling. Fail closed on every bad-token path.
+  // This is the layer that survives IP rotation: the ceiling is bound to the
+  // signed session, not the address.
+  if (!opening) {
+    if (parsed.session === null) {
+      return json(401, { error: 'Missing assessment session. Please restart the assessment.' })
+    }
+    const verified = await verifyAssessmentSession(parsed.session)
+    if (!verified.ok) {
+      return json(401, { error: 'Your assessment session is no longer valid. Please restart.' })
+    }
+    const charge = await consumeSessionTurn(env.BOOKING_CACHE, verified.payload.sid)
+    if (!charge.ok) {
+      return json(429, {
+        error: 'This assessment has reached its length limit. Please restart to continue.',
+      })
+    }
+  }
+
+  // Opening turn: mint the session that gates every turn after it. Minting
+  // before the LLM call is fine — a session id is free; a failed opener just
+  // leaves an unused id that self-expires from KV.
+  let issuedSession: string | null = null
+  if (opening) {
+    const session = await issueAssessmentSession()
+    issuedSession = session.token
+  }
 
   try {
-    const result = await assessmentTurn(env.ANTHROPIC_API_KEY, turns)
-    return json(200, result)
+    const result = await assessmentTurn(env.ANTHROPIC_API_KEY, parsed.turns)
+    return json(200, issuedSession ? { ...result, session: issuedSession } : result)
   } catch {
     return json(502, { error: 'The operator could not respond. Please try again.' })
   }

--- a/src/scripts/assessment.ts
+++ b/src/scripts/assessment.ts
@@ -14,6 +14,13 @@ interface Turn {
 
 const turns: Turn[] = []
 
+/**
+ * Signed session token issued by the server on the opening turn (ADR 0039 /
+ * 2026-06-08 hardening). Echoed on every subsequent turn so the server can
+ * enforce its per-session ceiling. Null until the opener returns it.
+ */
+let session: string | null = null
+
 function el<T extends HTMLElement>(id: string): T {
   const node = document.getElementById(id)
   if (!node) throw new Error(`missing #${id}`)
@@ -129,7 +136,7 @@ async function operatorTurn(): Promise<void> {
     const res = await fetch('/api/assessment/turn', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ turns }),
+      body: JSON.stringify(session ? { turns, session } : { turns }),
     })
     const data: unknown = await res.json()
     const message = strField(data, 'message')
@@ -138,6 +145,10 @@ async function operatorTurn(): Promise<void> {
       setComposerEnabled(true)
       return
     }
+    // The opening turn carries the freshly minted session token; hold onto it
+    // for every subsequent turn. Later turns omit it from the response.
+    const issued = strField(data, 'session')
+    if (issued) session = issued
     appendBubble('operator', message)
     turns.push({ speaker: 'operator', text: message })
     if (boolField(data, 'done')) {

--- a/tests/assessment-web-loop.test.ts
+++ b/tests/assessment-web-loop.test.ts
@@ -14,12 +14,15 @@
 import { describe, expect, it } from 'vitest'
 import { FINDINGS_SYSTEM, INTERVIEWER_SYSTEM } from '../src/lib/assessment/prompts'
 import {
+  assessmentOpening,
   assessmentTurn,
+  ASSESSMENT_OPENING_MESSAGE,
   buildTranscript,
   parseOperatorReply,
   toApiMessages,
   type Turn,
 } from '../src/lib/claude/assessment'
+import { ASSESSMENT_COMPLETE_SENTINEL } from '../src/lib/assessment/prompts'
 
 describe('skill bodies load into the prompts (?raw single source of truth)', () => {
   it('interviewer prompt carries the interview skill and BOTH references', () => {
@@ -53,6 +56,23 @@ describe('turn protocol', () => {
     expect(msgs.map((m) => m.role)).toEqual(['user', 'assistant', 'user'])
     expect(msgs[1]?.content).toContain('tell me about the business') // operator turn
     expect(msgs[2]?.content).toContain('HVAC') // owner turn
+  })
+})
+
+describe('static opening (no LLM call — closes the IP-rotation opener cost vector)', () => {
+  it('returns the fixed opening message and is never done', () => {
+    const result = assessmentOpening()
+    expect(result.message).toBe(ASSESSMENT_OPENING_MESSAGE)
+    expect(result.message.length).toBeGreaterThan(20)
+    expect(result.done).toBe(false)
+  })
+
+  it('never leaks the completion sentinel in the opening copy', () => {
+    expect(ASSESSMENT_OPENING_MESSAGE).not.toContain(ASSESSMENT_COMPLETE_SENTINEL)
+  })
+
+  it('opening copy carries no em dash (shipped user-facing string)', () => {
+    expect(ASSESSMENT_OPENING_MESSAGE).not.toContain('—')
   })
 })
 

--- a/tests/assessment/session.test.ts
+++ b/tests/assessment/session.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Unit tests for the signed assessment session + per-session ceiling
+ * (`src/lib/assessment/session.ts`).
+ *
+ * Covers the two properties the 2026-06-08 hardening relies on:
+ *   1. Token integrity — issue/verify round-trip, and rejection of every
+ *      forged / mutated / expired / wrong-key / wrong-version path (fail
+ *      closed). This is what binds the ceiling to an unforgeable `sid`.
+ *   2. Ceiling enforcement — `consumeSessionTurn` charges one turn per call
+ *      against an in-memory KV and refuses once the limit is reached, which
+ *      is the per-session cost cap that survives IP rotation.
+ *
+ * KV is mocked with a tiny in-memory namespace (the repo has no shared KV
+ * harness; tests inject bindings into the `cloudflare:workers` stub directly,
+ * per tests/_stubs/cloudflare-workers.ts).
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest'
+import { env as testEnv } from 'cloudflare:workers'
+import {
+  consumeSessionTurn,
+  issueAssessmentSession,
+  verifyAssessmentSession,
+  MAX_SESSION_TURNS,
+  SESSION_TTL_SECONDS,
+} from '../../src/lib/assessment/session'
+
+// 32-byte base64 key dedicated to these tests — matches the production key
+// shape so the import path exercised here is identical.
+const TEST_KEY_BASE64 = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA='
+
+beforeEach(() => {
+  for (const k of Object.keys(testEnv)) delete (testEnv as unknown as Record<string, unknown>)[k]
+  ;(testEnv as unknown as Record<string, unknown>).ASSESSMENT_SESSION_SIGNING_KEY = TEST_KEY_BASE64
+})
+
+/** Minimal in-memory KV: enough surface for consumeSessionTurn (get/put). */
+function makeKv(): KVNamespace & { store: Map<string, string> } {
+  const store = new Map<string, string>()
+  const kv = {
+    store,
+    async get(key: string): Promise<string | null> {
+      return store.has(key) ? (store.get(key) as string) : null
+    },
+    async put(key: string, value: string): Promise<void> {
+      store.set(key, value)
+    },
+    async delete(key: string): Promise<void> {
+      store.delete(key)
+    },
+  }
+  return kv as unknown as KVNamespace & { store: Map<string, string> }
+}
+
+describe('issueAssessmentSession', () => {
+  it('produces a `<payload>.<sig>` token with a random sid and default TTL', async () => {
+    const before = Math.floor(Date.now() / 1000)
+    const { token, payload } = await issueAssessmentSession()
+
+    const parts = token.split('.')
+    expect(parts).toHaveLength(2)
+    for (const part of parts) {
+      expect(part).toMatch(/^[A-Za-z0-9_-]+$/)
+      expect(part.length).toBeGreaterThan(10)
+    }
+    expect(payload.v).toBe(1)
+    expect(payload.sid).toMatch(/^[0-9a-f-]{36}$/)
+    expect(payload.exp).toBeGreaterThanOrEqual(before + SESSION_TTL_SECONDS - 5)
+    expect(payload.exp).toBeLessThanOrEqual(before + SESSION_TTL_SECONDS + 5)
+  })
+
+  it('mints a unique sid per call', async () => {
+    const a = await issueAssessmentSession()
+    const b = await issueAssessmentSession()
+    expect(a.payload.sid).not.toBe(b.payload.sid)
+  })
+
+  it('throws a clear error when the signing key is missing', async () => {
+    delete (testEnv as unknown as Record<string, unknown>).ASSESSMENT_SESSION_SIGNING_KEY
+    await expect(issueAssessmentSession()).rejects.toThrow(/ASSESSMENT_SESSION_SIGNING_KEY/)
+  })
+
+  it('throws when the signing key is not valid base64', async () => {
+    ;(testEnv as unknown as Record<string, unknown>).ASSESSMENT_SESSION_SIGNING_KEY =
+      '!!!not-b64!!!'
+    await expect(issueAssessmentSession()).rejects.toThrow(/valid base64/)
+  })
+})
+
+describe('verifyAssessmentSession', () => {
+  it('round-trips an issued token back to its payload', async () => {
+    const { token, payload } = await issueAssessmentSession()
+    const result = await verifyAssessmentSession(token)
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.payload.sid).toBe(payload.sid)
+    expect(result.payload.exp).toBe(payload.exp)
+    expect(result.payload.v).toBe(1)
+  })
+
+  it('rejects a missing / non-string / empty token (fail closed)', async () => {
+    const bads: unknown[] = [undefined, null, '', 42, {}]
+    for (const bad of bads) {
+      const result = await verifyAssessmentSession(bad)
+      expect(result.ok).toBe(false)
+      if (!result.ok) expect(['malformed', 'bad_signature']).toContain(result.error)
+    }
+  })
+
+  it('rejects a structurally malformed token', async () => {
+    for (const bad of ['notoken', '..', 'only-one-part', 'a.']) {
+      const result = await verifyAssessmentSession(bad)
+      expect(result.ok).toBe(false)
+      if (!result.ok) expect(['malformed', 'bad_signature']).toContain(result.error)
+    }
+  })
+
+  it('rejects a token with a tampered payload', async () => {
+    const { token } = await issueAssessmentSession()
+    const [payloadB64, sig] = token.split('.')
+    const tampered = `${payloadB64.slice(0, -1)}${payloadB64.slice(-1) === 'A' ? 'B' : 'A'}.${sig}`
+    const result = await verifyAssessmentSession(tampered)
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(['bad_signature', 'malformed']).toContain(result.error)
+  })
+
+  it('rejects a token with a tampered signature', async () => {
+    const { token } = await issueAssessmentSession()
+    const [payloadB64, sig] = token.split('.')
+    const tamperedSig = (sig.charAt(0) === 'A' ? 'B' : 'A') + sig.slice(1)
+    const result = await verifyAssessmentSession(`${payloadB64}.${tamperedSig}`)
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toBe('bad_signature')
+  })
+
+  it('rejects a token signed with a different key', async () => {
+    const { token } = await issueAssessmentSession()
+    ;(testEnv as unknown as Record<string, unknown>).ASSESSMENT_SESSION_SIGNING_KEY =
+      'BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBA='
+    const result = await verifyAssessmentSession(token)
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toBe('bad_signature')
+  })
+
+  it('rejects an expired token', async () => {
+    const originalNow = Date.now
+    try {
+      Date.now = () => 1_700_000_000_000
+      const { token } = await issueAssessmentSession(60) // 60s TTL
+      Date.now = () => 1_700_000_000_000 + 120 * 1000 // 2 minutes later
+      const result = await verifyAssessmentSession(token)
+      expect(result.ok).toBe(false)
+      if (!result.ok) expect(result.error).toBe('expired')
+    } finally {
+      Date.now = originalNow
+    }
+  })
+
+  it('rejects a token with an unknown schema version', async () => {
+    // Hand-build a v2 payload signed with the test key by re-using the issue
+    // path is impossible (version is fixed), so verify rejection via a forged
+    // body: the signature won't match, but the version check is also exercised
+    // by mutating an otherwise-valid token's decoded version. We assert the
+    // negative outcome regardless of which guard fires first.
+    const { token } = await issueAssessmentSession()
+    // Decode, bump version, re-encode payload but keep old signature → fails
+    // signature first; the important property is that it is NOT accepted.
+    const [payloadB64, sig] = token.split('.')
+    const json = JSON.parse(atob(payloadB64.replace(/-/g, '+').replace(/_/g, '/'))) as {
+      v: number
+    }
+    json.v = 999
+    const reencoded = btoa(JSON.stringify(json))
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=+$/, '')
+    const result = await verifyAssessmentSession(`${reencoded}.${sig}`)
+    expect(result.ok).toBe(false)
+  })
+})
+
+describe('consumeSessionTurn', () => {
+  it('charges one turn per call and increments the counter', async () => {
+    const kv = makeKv()
+    const sid = 'sid-1'
+    const first = await consumeSessionTurn(kv, sid, 3)
+    const second = await consumeSessionTurn(kv, sid, 3)
+    expect(first).toEqual({ ok: true, count: 1, limit: 3 })
+    expect(second).toEqual({ ok: true, count: 2, limit: 3 })
+  })
+
+  it('refuses once the ceiling is reached', async () => {
+    const kv = makeKv()
+    const sid = 'sid-cap'
+    await consumeSessionTurn(kv, sid, 2)
+    await consumeSessionTurn(kv, sid, 2)
+    const third = await consumeSessionTurn(kv, sid, 2)
+    expect(third.ok).toBe(false)
+    if (!third.ok) {
+      expect(third.reason).toBe('ceiling_reached')
+      expect(third.count).toBe(2)
+      expect(third.limit).toBe(2)
+    }
+  })
+
+  it('keeps separate counters per sid', async () => {
+    const kv = makeKv()
+    await consumeSessionTurn(kv, 'sid-a', 1)
+    const a2 = await consumeSessionTurn(kv, 'sid-a', 1)
+    const b1 = await consumeSessionTurn(kv, 'sid-b', 1)
+    expect(a2.ok).toBe(false) // sid-a exhausted
+    expect(b1.ok).toBe(true) // sid-b independent
+  })
+
+  it('uses the default ceiling when none is passed', async () => {
+    const kv = makeKv()
+    const result = await consumeSessionTurn(kv, 'sid-default')
+    expect(result.ok).toBe(true)
+    if (result.ok) expect(result.limit).toBe(MAX_SESSION_TURNS)
+  })
+
+  it('treats a corrupt counter value as zero rather than failing open or NaN', async () => {
+    const kv = makeKv()
+    kv.store.set('as:turns:sid-corrupt', 'not-a-number')
+    const result = await consumeSessionTurn(kv, 'sid-corrupt', 3)
+    expect(result).toEqual({ ok: true, count: 1, limit: 3 })
+  })
+
+  it('allows the turn when KV is undefined (dev mode), mirroring the rate-limiter', async () => {
+    const result = await consumeSessionTurn(undefined, 'sid-dev', 1)
+    expect(result.ok).toBe(true)
+  })
+
+  it('persists under an `as:turns:<sid>` key', async () => {
+    const kv = makeKv()
+    await consumeSessionTurn(kv, 'sid-keycheck', 5)
+    expect(kv.store.has('as:turns:sid-keycheck')).toBe(true)
+    expect(kv.store.get('as:turns:sid-keycheck')).toBe('1')
+  })
+})

--- a/tests/assessment/turn-endpoint.test.ts
+++ b/tests/assessment/turn-endpoint.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Integration tests for the POST handler of `/api/assessment/turn`, focused on
+ * the hardening contract (2026-06-08 code review):
+ *
+ *   - The OPENING turn is served WITHOUT an LLM call. We prove this by running
+ *     the opener with NO `ANTHROPIC_API_KEY` in env: it still returns 200 with
+ *     a message and a freshly minted session token. If the opener reached the
+ *     model it would 503 on the missing key. This is what closes the residual
+ *     IP-rotation cost vector — POSTing empty `turns` costs zero LLM calls.
+ *   - Continuing turns fail closed before any model call: a missing or invalid
+ *     session token is rejected 401, never reaching `assessmentTurn`.
+ *
+ * The handler reads `env` from the `cloudflare:workers` stub; we inject a
+ * signing key and an in-memory KV, and deliberately omit ANTHROPIC_API_KEY.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { env as testEnv } from 'cloudflare:workers'
+import { POST } from '../../src/pages/api/assessment/turn'
+import { verifyAssessmentSession } from '../../src/lib/assessment/session'
+import { ASSESSMENT_OPENING_MESSAGE } from '../../src/lib/claude/assessment'
+
+const TEST_KEY_BASE64 = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA='
+
+function makeKv(): KVNamespace {
+  const store = new Map<string, string>()
+  return {
+    async get(key: string) {
+      return store.has(key) ? (store.get(key) as string) : null
+    },
+    async put(key: string, value: string) {
+      store.set(key, value)
+    },
+    async delete(key: string) {
+      store.delete(key)
+    },
+  } as unknown as KVNamespace
+}
+
+async function post(body: unknown): Promise<Response> {
+  const request = new Request('https://smd.services/api/assessment/turn', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+  return POST({
+    request,
+    clientAddress: '203.0.113.7',
+  } as unknown as Parameters<typeof POST>[0])
+}
+
+/** Narrow a string field from a parsed JSON response without an unchecked cast. */
+function strField(value: unknown, key: string): string | undefined {
+  if (typeof value === 'object' && value !== null && key in value) {
+    const v = (value as Record<string, unknown>)[key]
+    return typeof v === 'string' ? v : undefined
+  }
+  return undefined
+}
+
+/** Narrow a boolean field from a parsed JSON response. */
+function boolField(value: unknown, key: string): boolean {
+  return (
+    typeof value === 'object' && value !== null && (value as Record<string, unknown>)[key] === true
+  )
+}
+
+beforeEach(() => {
+  for (const k of Object.keys(testEnv)) delete (testEnv as unknown as Record<string, unknown>)[k]
+  Object.assign(testEnv, {
+    BOOKING_CACHE: makeKv(),
+    ASSESSMENT_SESSION_SIGNING_KEY: TEST_KEY_BASE64,
+    // ANTHROPIC_API_KEY intentionally ABSENT — the opener must not need it.
+  })
+})
+
+afterEach(() => {
+  for (const k of Object.keys(testEnv)) delete (testEnv as unknown as Record<string, unknown>)[k]
+})
+
+describe('opening turn (static, no LLM call)', () => {
+  it('returns 200 with the fixed opening + a valid session even with no API key', async () => {
+    const res = await post({ turns: [] })
+    expect(res.status).toBe(200)
+
+    const data: unknown = await res.json()
+    expect(strField(data, 'message')).toBe(ASSESSMENT_OPENING_MESSAGE)
+    expect(boolField(data, 'done')).toBe(false)
+    const session = strField(data, 'session')
+    expect(typeof session).toBe('string')
+
+    // The minted session must verify under the signing key.
+    const verified = await verifyAssessmentSession(session)
+    expect(verified.ok).toBe(true)
+  })
+})
+
+describe('continuing turn fails closed before any LLM call', () => {
+  it('rejects a continuing turn with no session token (401)', async () => {
+    const res = await post({ turns: [{ speaker: 'owner', text: 'We run an HVAC shop.' }] })
+    expect(res.status).toBe(401)
+    const data: unknown = await res.json()
+    expect(strField(data, 'error')).toMatch(/session/i)
+  })
+
+  it('rejects a continuing turn with a forged session token (401)', async () => {
+    const res = await post({
+      turns: [{ speaker: 'owner', text: 'We run an HVAC shop.' }],
+      session: 'forged.token',
+    })
+    expect(res.status).toBe(401)
+  })
+})
+
+describe('basic request validation still holds', () => {
+  it('rejects a malformed body (400)', async () => {
+    const res = await post({ turns: 'nope' })
+    expect(res.status).toBe(400)
+  })
+})

--- a/tests/assessment/turn-request.test.ts
+++ b/tests/assessment/turn-request.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Unit tests for the `/api/assessment/turn` request validator
+ * (`parseTurnRequest`). The endpoint is public and takes ad traffic, so the
+ * validator must reject every malformed body before any work happens — and it
+ * must parse, never cast (CLAUDE.md coding standard). It also now narrows the
+ * optional signed `session` token that gates continuing turns.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { parseTurnRequest } from '../../src/pages/api/assessment/turn'
+
+const validTurn = { speaker: 'owner', text: 'We run an HVAC shop.' }
+
+describe('parseTurnRequest — turns array', () => {
+  it('accepts an empty turns array (the opening request)', () => {
+    const parsed = parseTurnRequest({ turns: [] })
+    expect(parsed).not.toBeNull()
+    expect(parsed?.turns).toEqual([])
+    expect(parsed?.session).toBeNull()
+  })
+
+  it('accepts a well-formed turns array', () => {
+    const parsed = parseTurnRequest({
+      turns: [
+        { speaker: 'operator', text: 'Tell me about the business.' },
+        { speaker: 'owner', text: 'HVAC.' },
+      ],
+    })
+    expect(parsed).not.toBeNull()
+    expect(parsed?.turns).toHaveLength(2)
+  })
+
+  it('rejects a non-object body', () => {
+    for (const bad of [null, undefined, 'string', 42, []]) {
+      // arrays have no `turns` property → null
+      expect(parseTurnRequest(bad as unknown)).toBeNull()
+    }
+  })
+
+  it('rejects a missing or non-array turns field', () => {
+    expect(parseTurnRequest({})).toBeNull()
+    expect(parseTurnRequest({ turns: 'nope' })).toBeNull()
+    expect(parseTurnRequest({ turns: 5 })).toBeNull()
+  })
+
+  it('rejects a turns array longer than the cap', () => {
+    const tooMany = Array.from({ length: 61 }, () => validTurn)
+    expect(parseTurnRequest({ turns: tooMany })).toBeNull()
+  })
+
+  it('rejects an invalid speaker', () => {
+    expect(parseTurnRequest({ turns: [{ speaker: 'robot', text: 'hi' }] })).toBeNull()
+    expect(parseTurnRequest({ turns: [{ text: 'hi' }] })).toBeNull()
+  })
+
+  it('rejects empty, missing, non-string, or over-long text', () => {
+    expect(parseTurnRequest({ turns: [{ speaker: 'owner', text: '' }] })).toBeNull()
+    expect(parseTurnRequest({ turns: [{ speaker: 'owner' }] })).toBeNull()
+    expect(parseTurnRequest({ turns: [{ speaker: 'owner', text: 123 }] })).toBeNull()
+    const long = 'x'.repeat(4001)
+    expect(parseTurnRequest({ turns: [{ speaker: 'owner', text: long }] })).toBeNull()
+  })
+
+  it('accepts text exactly at the length boundary', () => {
+    const atLimit = 'x'.repeat(4000)
+    const parsed = parseTurnRequest({ turns: [{ speaker: 'owner', text: atLimit }] })
+    expect(parsed).not.toBeNull()
+  })
+
+  it('rejects a non-object turn item', () => {
+    expect(parseTurnRequest({ turns: ['nope'] })).toBeNull()
+    expect(parseTurnRequest({ turns: [null] })).toBeNull()
+  })
+})
+
+describe('parseTurnRequest — session token', () => {
+  it('treats an absent session as null (opening request)', () => {
+    const parsed = parseTurnRequest({ turns: [validTurn] })
+    expect(parsed?.session).toBeNull()
+  })
+
+  it('treats an explicit null session as null', () => {
+    const parsed = parseTurnRequest({ turns: [validTurn], session: null })
+    expect(parsed?.session).toBeNull()
+  })
+
+  it('accepts a non-empty string session token', () => {
+    const parsed = parseTurnRequest({ turns: [validTurn], session: 'payload.sig' })
+    expect(parsed?.session).toBe('payload.sig')
+  })
+
+  it('rejects an empty-string session token', () => {
+    expect(parseTurnRequest({ turns: [validTurn], session: '' })).toBeNull()
+  })
+
+  it('rejects a non-string session token', () => {
+    expect(parseTurnRequest({ turns: [validTurn], session: 42 })).toBeNull()
+    expect(parseTurnRequest({ turns: [validTurn], session: { tok: 'x' } })).toBeNull()
+  })
+})

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -104,9 +104,12 @@ service = "ss-enrichment-workflow"
 binding = "SESSIONS"
 id = "4570dcc1e154476f889bc9fcfc28b2b9"
 
-# ---------- Workers KV (booking rate-limit buckets) ----------
-# Used by /api/booking/reserve for IP-based rate limiting only.
-# No slot cache in v1 (see plan §No availability cache in v1).
+# ---------- Workers KV (rate-limit + session ceilings) ----------
+# Used by /api/booking/reserve for IP-based rate limiting, and by
+# /api/assessment/turn for the per-session turn/cost ceiling that gates the
+# public live assessment (see src/lib/assessment/session.ts). No new namespace
+# is needed for assessment hardening — it reuses this bucket with `as:turns:*`
+# keys. No slot cache in v1 (see plan §No availability cache in v1).
 [[kv_namespaces]]
 binding = "BOOKING_CACHE"
 id = "daf6a3220f8f42f28f3da7e82f663088"


### PR DESCRIPTION
## Threat

`src/pages/api/assessment/turn.ts` is the public live-assessment endpoint (ADR 0039 node [1]). Every turn makes a live LLM call. It was protected by **only** an IP rate limit (200/hr). `MAX_TURNS=60` caps the turns array of a *single request* but not session restarts, and there was **no per-session cost ceiling**.

That leaves it open to **IP-rotation budget exhaustion**: a botnet, proxy pool, or CGNAT churn can open unbounded fresh assessments — each a multi-turn LLM conversation — and burn the Anthropic budget before the ADR 0039 funnel takes advertising traffic. A real prospect could hit a depleted budget.

## Design

A signed, server-tracked assessment **session** as a second layer behind the existing IP limit (kept as a cheap volume shedder).

1. **Opening turn** (empty `turns`) mints an HMAC-SHA256 signed session token carrying a random `sid` + `exp`, returned as `{ message, done, session }`. The token is opaque to the client.
2. **Every continuing turn** must present the token. The server verifies signature + expiry and **fails closed** on missing / malformed / bad-signature / expired / unknown-version, then charges one turn against a per-`sid` counter in KV and refuses at the ceiling (`MAX_SESSION_TURNS = 40`).

Because each accepted turn is exactly one LLM call, the per-session **turn** ceiling *is* a per-session **cost** ceiling. The HMAC signature is what makes the `sid` unforgeable, so the ceiling is bound to the signed session, not to an IP — which is precisely the property that defeats IP rotation.

The token follows the repo's existing signing idiom (`src/lib/oauth/state.ts`, `src/lib/booking/signed-link.ts`): `<base64url(json-payload)>.<base64url(hmac-sha256)>` with a base64-encoded env key.

CLAUDE.md standards honored: the request body is **parsed, never cast** (every field narrowed from `unknown`, including the new optional `session`); no floating promises; no module-level mutable state.

## New env / bindings

- **New secret: `ASSESSMENT_SESSION_SIGNING_KEY`** — 32 random bytes, base64 (`openssl rand -base64 32`). **Must be provisioned as a Worker secret in prod before this ships.** A dedicated key keeps assessment sessions cryptographically independent of booking links and OAuth state. Documented in `src/env.d.ts` and `.dev.vars.example`.
- **No new KV namespace.** The per-session counter reuses the already-bound `BOOKING_CACHE` KV with `as:turns:<sid>` keys (TTL-scoped to the session lifetime, self-expiring). Noted in `wrangler.toml`.

## Compatibility

- Response contract is additive: `session` is a new optional field; the opening empty-`turns` request still works to start a session.
- The client driver (`src/scripts/assessment.ts`) holds the issued token and echoes it on subsequent turns; the dogfood preview flow is unchanged from the user's perspective.

## Tests

- `tests/assessment/session.test.ts` — issue/verify round-trip and every fail-closed path (tampered payload, tampered signature, wrong key, expired, unknown version, malformed), plus the KV-backed ceiling (charge, refuse-at-limit, per-`sid` isolation, corrupt-counter, dev-mode).
- `tests/assessment/turn-request.test.ts` — the `parseTurnRequest` validator, including the new `session` narrowing.

Full `npm run verify` is green (typecheck 0 errors, lint 0 errors, build complete, all suites passing).

Refs the 2026-06-08 code review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)