### PR TITLE
feat(operator): foundation seam for portal management (ADR 0041/0042/0043)

### DIFF
--- a/migrations/0049_operator_authority_posture.sql
+++ b/migrations/0049_operator_authority_posture.sql
@@ -1,0 +1,22 @@
+-- Operator authority posture projection — ADR 0041
+-- ============================================================================
+--
+-- Adds the projected `authority` block (per-domain client-self-serve switches
+-- over SMD's always-present full control) to the customer_configs read replica.
+-- Source of truth is `customer.yaml.authority` in git (ADR 0012); CI projects
+-- it here on merge alongside the other *_json columns.
+--
+-- NULL is the launch-safe state: an absent authority_json resolves to the
+-- default posture (`{ default: "managed", overrides: {} }`) — SMD operates
+-- every domain, every client switch off — via parseAuthorityPosture() in
+-- src/lib/operator/authority.ts. No backfill needed; the resolver treats a
+-- null row identically to an explicit launch-default block.
+--
+-- The resolved-side contract (domains, holders, resolver) lives in
+-- src/lib/operator/authority.ts; the authoring-side validator lives in
+-- src/lib/operator/customer-yaml/sections-authority.ts.
+--
+-- Forward-only, additive. No drops.
+-- ============================================================================
+
+ALTER TABLE customer_configs ADD COLUMN authority_json TEXT;

--- a/migrations/0050_operator_credential_custody.sql
+++ b/migrations/0050_operator_credential_custody.sql
@@ -1,0 +1,22 @@
+-- Operator credential-custody default projection — ADR 0042
+-- ============================================================================
+--
+-- Adds the client-level `credential_custody_default` to the customer_configs
+-- read replica. Per-connector custody rides inside connectors_json (each
+-- connector binding carries an optional `credential_custody`); this column is
+-- only the client-wide default applied when a connector does not pin its own.
+--
+-- Source of truth is `customer.yaml.credential_custody_default` in git
+-- (ADR 0012); CI projects it here on merge. NULL resolves to `delegated`
+-- (the hands-off default) via parseCredentialCustody() in
+-- src/lib/operator/credential-custody.ts — no backfill needed.
+--
+-- Custody governs whether SMD staff can reach a connector's secret value to
+-- re-establish a broken connection (delegated) or only the client can
+-- (self_held). Both modes store the secret in the per-customer isolated vault
+-- (ADR 0010); secrets never enter this table.
+--
+-- Forward-only, additive. No drops.
+-- ============================================================================
+
+ALTER TABLE customer_configs ADD COLUMN credential_custody_default TEXT;

--- a/migrations/0051_connector_secret_audit.sql
+++ b/migrations/0051_connector_secret_audit.sql
@@ -1,0 +1,40 @@
+-- Connector secret-set audit — ADR 0042 §Verification 5
+-- ============================================================================
+--
+-- Append-only record that a client entered a static secret for a connector via
+-- the write-only entry path. Records WHO set WHAT connector's key, WHEN, the
+-- masked tail, and the non-secret storage ref. There is deliberately NO column
+-- for the value: the raw secret is structurally incapable of landing here.
+--
+-- This is the console-side control-plane record (analogous to
+-- config_change_audit but a different event class — config_change_audit's
+-- change_type CHECK is scoped to autonomy-config governance, not connector
+-- credential entry, and is intentionally not widened). The per-customer runtime
+-- audit log on the Machine is separate (ADR 0009).
+--
+-- Append-only by convention: no UPDATE/DELETE code path.
+-- Forward-only, additive. No drops.
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS connector_secret_audit (
+  id              INTEGER PRIMARY KEY AUTOINCREMENT,
+  customer_slug   TEXT NOT NULL,
+  entity_id       TEXT NOT NULL,
+  -- Capability the secret authenticates (e.g. 'CourtAccess', 'CallTracking').
+  connector       TEXT NOT NULL,
+  -- Who entered it.
+  actor_user_id   TEXT NOT NULL,
+  actor_email     TEXT NOT NULL,
+  actor_role      TEXT NOT NULL,
+  -- The ONLY value-derived data: the masked tail (e.g. "••••••1a2b"). Never
+  -- the raw value. No column exists that could hold it.
+  masked_tail     TEXT NOT NULL,
+  -- Non-secret storage pointer returned by the vault transport.
+  storage_ref     TEXT NOT NULL,
+  created_at      TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_connector_secret_audit_slug_created
+  ON connector_secret_audit (customer_slug, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_connector_secret_audit_entity_created
+  ON connector_secret_audit (entity_id, created_at DESC);

--- a/migrations/0052_operator_runtime_summary.sql
+++ b/migrations/0052_operator_runtime_summary.sql
@@ -1,0 +1,55 @@
+-- Operator runtime-summary store — ADR 0043 path B
+-- ============================================================================
+--
+-- The console-side per-customer summary the admin fleet view reads. Each
+-- per-customer Machine pushes a small set of read-relevant summary rows here
+-- (generalizing the fleet_status heartbeat pattern, ADR 0023): a health
+-- rollup, last-activity timestamp, open-alert count, and draft-queue depth.
+--
+-- Why a summary mirror and not a live read for the fleet (ADR 0043):
+--   - The fleet roster must stay answerable even when a Machine is briefly
+--     down — a mirror survives that; a live read would break the whole view.
+--   - The highest-traffic view pays no per-request round-trip.
+--   - Carries a bounded staleness window (the push cadence) — acceptable for
+--     summary/rollup data, surfaced via `pushed_at` so the UI can label
+--     "health as of N seconds ago".
+--
+-- ISOLATION (ADR 0009): every row is keyed to ONE customer. Fleet rollups read
+-- many of these per-customer summary rows but NEVER join two Machines' runtime
+-- D1. Deep, fresh detail uses the live per-customer read path (ADR 0043 path A,
+-- src/lib/operator/runtime-read.ts) — not this mirror.
+--
+-- Append-via-upsert (one row per customer). Forward-only, additive. No drops.
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS operator_runtime_summary (
+  entity_id          TEXT PRIMARY KEY REFERENCES entities(id) ON DELETE CASCADE,
+  customer_slug      TEXT NOT NULL UNIQUE,
+
+  -- Health rollup pushed by the Machine. Distinct from fleet_status liveness:
+  -- this folds in sticky-stop state, escalation pressure, connector health —
+  -- "is the operator OK", not just "is the process alive".
+  summary_status     TEXT NOT NULL DEFAULT 'unknown'
+                       CHECK (summary_status IN ('green', 'yellow', 'red', 'unknown')),
+
+  -- Count of unresolved alert signals (red-flags / failures / invariant
+  -- triggers) on the Machine. Drives the fleet alert feed badge.
+  open_alerts        INTEGER NOT NULL DEFAULT 0,
+
+  -- Pending review items when a skill is authored to draft. NULL when the
+  -- operator has no draft-authored skills (an honest "no queue" vs "0 pending").
+  draft_queue_depth  INTEGER,
+
+  -- Most recent agent activity timestamp (ISO 8601 UTC), for the roster's
+  -- "last active" column. NULL before first activity.
+  last_activity_ts   TEXT,
+
+  -- When the Machine last pushed this summary (ISO 8601 UTC). The staleness
+  -- window: the reader marks the row stale if this is too old.
+  pushed_at          TEXT NOT NULL,
+
+  updated_at         TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_operator_runtime_summary_slug
+  ON operator_runtime_summary (customer_slug);

--- a/migrations/0053_operator_runtime_read_audit.sql
+++ b/migrations/0053_operator_runtime_read_audit.sql
@@ -1,0 +1,30 @@
+-- Console-side runtime-read audit — ADR 0043 §Invariants (reads are audited)
+-- ============================================================================
+--
+-- Records every console→Machine live runtime read (path A): who looked at what
+-- customer's runtime detail, which kind, and the outcome (including failures).
+-- This is the CONSOLE's audit of cross-boundary reads — distinct from the
+-- operator's own runtime audit log on the Machine (ADR 0009). It answers "which
+-- SMD/staff user drilled into which operator's runtime state, and when".
+--
+-- Every row names exactly one customer (single-customer-per-read invariant).
+-- Append-only by convention. Forward-only, additive. No drops.
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS operator_runtime_read_audit (
+  id              INTEGER PRIMARY KEY AUTOINCREMENT,
+  customer_slug   TEXT NOT NULL,
+  actor_user_id   TEXT NOT NULL,
+  actor_email     TEXT NOT NULL,
+  actor_role      TEXT NOT NULL,
+  -- The runtime detail class read (audit_log | draft | matter | activity).
+  kind            TEXT NOT NULL,
+  -- Outcome, including failures (ok | unreachable | unauthorized | not_configured).
+  outcome         TEXT NOT NULL,
+  created_at      TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_runtime_read_audit_slug_created
+  ON operator_runtime_read_audit (customer_slug, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_runtime_read_audit_actor_created
+  ON operator_runtime_read_audit (actor_user_id, created_at DESC);

--- a/migrations/0054_operator_change_requests.sql
+++ b/migrations/0054_operator_change_requests.sql
@@ -1,0 +1,44 @@
+-- Operator client change-request inbox — ADR 0041 §4.3
+-- ============================================================================
+--
+-- When a domain is SMD-operated (its authority switch is `managed`), the client
+-- portal renders that domain Read + Request: read-only data plus a "Request a
+-- change" path. This table is where those requests land; the admin change-
+-- request inbox reads them.
+--
+-- This is a console-side control-plane table (like config_change_audit), NOT
+-- per-customer runtime D1 — so the admin inbox legitimately reads across
+-- customers (it is a fleet-wide SMD surface). It carries no runtime state and
+-- no secrets; just the client's request text and its handling status.
+--
+-- `domain` is one of the switchable authority domains (a request only makes
+-- sense for a domain the client cannot currently operate). Forward-only,
+-- additive. No drops.
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS operator_change_requests (
+  id                 INTEGER PRIMARY KEY AUTOINCREMENT,
+  entity_id          TEXT NOT NULL REFERENCES entities(id) ON DELETE CASCADE,
+  customer_slug      TEXT NOT NULL,
+  -- The switchable authority domain the request concerns (e.g. 'people_access',
+  -- 'connectors'). Validated in code against SWITCHABLE_AUTHORITY_DOMAINS.
+  domain             TEXT NOT NULL,
+  -- Who filed it (client-internal user).
+  requested_by_user_id TEXT NOT NULL,
+  requested_by_email   TEXT NOT NULL,
+  -- The request text the client wrote.
+  summary            TEXT NOT NULL,
+  -- Handling status. 'open' on file; SMD moves it through the rest.
+  status             TEXT NOT NULL DEFAULT 'open'
+                       CHECK (status IN ('open', 'acknowledged', 'resolved', 'declined')),
+  -- Resolution metadata (set by SMD when handled).
+  resolved_by_email  TEXT,
+  resolved_at        TEXT,
+  resolution_note    TEXT,
+  created_at         TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_operator_change_requests_slug_created
+  ON operator_change_requests (customer_slug, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_operator_change_requests_status_created
+  ON operator_change_requests (status, created_at DESC);

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -223,6 +223,25 @@ declare namespace Cloudflare {
      */
     MACHINE_HEARTBEAT_KEY?: string
     /**
+     * Per-customer secret-relay endpoint base for the write-only static-secret
+     * entry path (ADR 0042 / ADR 0036). When set, the client credential-entry
+     * endpoint relays a client-entered API key into the customer's per-customer
+     * vault (Fly secret + Machine restart) and is enabled; when unset,
+     * `isSecretTransportConfigured` returns false and the endpoint returns an
+     * honest `not_enabled`. Provisioned at the integration step that wires the
+     * relay — see src/lib/operator/credential-secret-transport.ts.
+     */
+    OPERATOR_SECRET_RELAY_URL?: string
+    /**
+     * Base URL/credential locator for the live console→Machine runtime read
+     * path (ADR 0043 path A). When set, per-operator drill-ins fetch deep
+     * detail (audit log, drafts, matters) live from one customer's Machine;
+     * when unset, `isRuntimeReadConfigured` returns false and drill-in
+     * surfaces render honest empty states. Wired at the integration step —
+     * see src/lib/operator/runtime-read-transport.ts.
+     */
+    OPERATOR_RUNTIME_READ_URL?: string
+    /**
      * Sentry Internal Integration Client Secret used to verify
      * `Sentry-Hook-Signature` headers on inbound alert-rule webhook
      * deliveries to `/api/webhooks/sentry`. Pulled from the SMD-owned

--- a/src/lib/admin/runtime-summary.ts
+++ b/src/lib/admin/runtime-summary.ts
@@ -1,0 +1,98 @@
+/**
+ * Operator runtime-summary reader (ADR 0043 path B) for the admin fleet view.
+ *
+ * Reads the console-side per-customer summary mirror (`operator_runtime_summary`)
+ * that each Machine pushes to. The fleet roster, alert feed, and activity
+ * columns render entirely from this store, so the view stays answerable even
+ * when an individual Machine is down. Deep, fresh per-operator detail uses the
+ * live read path (src/lib/operator/runtime-read.ts) instead — never this mirror.
+ *
+ * Staleness is computed at render time (`summaryFreshness`) so a column never
+ * lies in the reassuring direction: a `pushed_at` hours old reads as stale
+ * regardless of when the row was last touched — same discipline as
+ * fleet-status heartbeatDisplay.
+ */
+
+import type { D1Database } from '@cloudflare/workers-types'
+
+export type SummaryStatus = 'green' | 'yellow' | 'red' | 'unknown'
+
+export interface RuntimeSummaryRow {
+  entity_id: string
+  customer_slug: string
+  summary_status: SummaryStatus
+  open_alerts: number
+  draft_queue_depth: number | null
+  last_activity_ts: string | null
+  pushed_at: string
+  updated_at: string
+}
+
+/**
+ * List every customer's runtime summary, ordered by slug. This is a fleet-wide
+ * read of per-customer summary rows — never a join across two Machines' runtime
+ * D1 (ADR 0009). Each row originated from exactly one Machine's push.
+ */
+export async function listRuntimeSummary(db: D1Database): Promise<RuntimeSummaryRow[]> {
+  const result = await db
+    .prepare(
+      `SELECT entity_id, customer_slug, summary_status, open_alerts,
+              draft_queue_depth, last_activity_ts, pushed_at, updated_at
+         FROM operator_runtime_summary
+        ORDER BY customer_slug ASC`
+    )
+    .all<RuntimeSummaryRow>()
+  return result.results ?? []
+}
+
+/** Read one customer's runtime summary, or null when none has been pushed. */
+export async function getRuntimeSummary(
+  db: D1Database,
+  customerSlug: string
+): Promise<RuntimeSummaryRow | null> {
+  const row = await db
+    .prepare(
+      `SELECT entity_id, customer_slug, summary_status, open_alerts,
+              draft_queue_depth, last_activity_ts, pushed_at, updated_at
+         FROM operator_runtime_summary
+        WHERE customer_slug = ?`
+    )
+    .bind(customerSlug)
+    .first<RuntimeSummaryRow>()
+  return row ?? null
+}
+
+export interface SummaryFreshness {
+  stale: boolean
+  label: string
+}
+
+/** Default staleness threshold (seconds). A summary pushed less often than
+ * roughly twice the heartbeat grace is treated as stale. */
+export const DEFAULT_SUMMARY_STALE_SECONDS = 600
+
+/**
+ * Compute whether a summary is stale and a relative-age label, from `pushed_at`.
+ * Mirrors the no-lie discipline of heartbeatDisplay: the label always shows the
+ * real age so the fleet view can render "as of 3m ago" / "stale 47m".
+ */
+export function summaryFreshness(
+  pushedAt: string | null,
+  staleSeconds: number = DEFAULT_SUMMARY_STALE_SECONDS,
+  now: Date = new Date()
+): SummaryFreshness {
+  if (!pushedAt) return { stale: true, label: 'no summary yet' }
+  const ts = Date.parse(pushedAt)
+  if (Number.isNaN(ts)) return { stale: true, label: 'invalid timestamp' }
+  const ageSec = Math.max(0, Math.floor((now.getTime() - ts) / 1000))
+  const stale = ageSec >= staleSeconds
+  const age = formatSummaryAge(ageSec)
+  return { stale, label: stale ? `stale ${age}` : `as of ${age} ago` }
+}
+
+function formatSummaryAge(sec: number): string {
+  if (sec < 60) return `${sec}s`
+  if (sec < 3600) return `${Math.floor(sec / 60)}m`
+  if (sec < 86400) return `${Math.floor(sec / 3600)}h`
+  return `${Math.floor(sec / 86400)}d`
+}

--- a/src/lib/operator/authority.ts
+++ b/src/lib/operator/authority.ts
@@ -1,0 +1,190 @@
+/**
+ * Operator authority posture — the frozen Layer-1 contract (ADR 0041).
+ *
+ * "Authority" answers a single question per client, per domain: between SMD
+ * and the client org, who may *operate* the controls for this domain? It is
+ * orthogonal to entitlements (ADR 0035 — what the operator itself may do) and
+ * to client-internal RBAC (which of the client's own people may act). See
+ * docs/design/operator/00-foundations.md §2 for the three-layer model.
+ *
+ * This module is the single source of truth both portals and the validator
+ * import. It is deliberately pure — no D1, no validator dependency, no I/O —
+ * so it can be imported from anywhere (portal pages, the customer.yaml
+ * validator, the projection reader) without pulling a heavier graph.
+ *
+ * Two invariants this module encodes and never bends:
+ *   1. SMD control is a constant, not a posture. Authority governs only the
+ *      *client* org's operability. SMD always retains full control regardless
+ *      of any value here — that lives in admin RBAC (Layer 0), not in this
+ *      data. Nothing in this module ever returns "SMD may not".
+ *   2. Launch-safe by construction. The absent / unconfigured posture resolves
+ *      to `managed` for every switchable domain (every client self-serve
+ *      switch off). Turning a domain client-operable is an explicit authored
+ *      change, never a default.
+ */
+
+/**
+ * The per-client preset applied to every switchable domain that has no
+ * explicit override.
+ *
+ * - `managed` — SMD operates every domain (all client switches off). Launch
+ *   default and the value an absent `authority` block resolves to.
+ * - `self_managed` — every switchable domain is client-operable unless an
+ *   override pins it back to `managed`. Not a launch state; reachable only by
+ *   authoring it once an operator has settled.
+ */
+export const ACCEPTED_AUTHORITY_DEFAULTS = ['managed', 'self_managed'] as const
+export type AuthorityDefault = (typeof ACCEPTED_AUTHORITY_DEFAULTS)[number]
+
+/**
+ * Who holds operability for a single switchable domain once resolved (also the
+ * value space for an override).
+ *
+ * - `managed` — SMD-operated; the client sees the domain read-only with a
+ *   "request a change" path (Read + Request mode in the client portal).
+ * - `client` — the client org *also* gets operable controls (subject to
+ *   client-internal RBAC). Never instead of SMD — strictly additive.
+ */
+export const ACCEPTED_AUTHORITY_HOLDERS = ['managed', 'client'] as const
+export type AuthorityHolder = (typeof ACCEPTED_AUTHORITY_HOLDERS)[number]
+
+/**
+ * The closed set of domains a client switch can cover. Maps to the capability
+ * domains in foundations §4.2. Two domains are deliberately absent because
+ * they are SMD-only always (see {@link SMD_ONLY_AUTHORITY_DOMAINS}):
+ * provisioning/lifecycle and cost/economics.
+ *
+ * Adding or splitting a domain here is a schema + portal commitment (ADR 0041
+ * §Consequences) — the list is intentionally conservative.
+ */
+export const SWITCHABLE_AUTHORITY_DOMAINS = [
+  'configuration', // persona/skill/scope/business-hours authoring
+  'trust', // entitlement ceilings within authored floors
+  'connectors', // connect / reconnect / credential custody (§5)
+  'runtime', // whatever controls the authored entitlements expose
+  'memory', // review/dismiss observations + agent-authored skills
+  'people_access', // users, roles, PTO, voice profiles
+  'compliance', // evidence packets, retention posture, holds
+  'observability', // health/connector/sticky-stop action subset
+] as const
+export type SwitchableAuthorityDomain = (typeof SWITCHABLE_AUTHORITY_DOMAINS)[number]
+
+/**
+ * Domains that are never a client switch — SMD operates them in every state.
+ * Listed (not merely omitted) so the validator can reject them as override
+ * keys with a precise error and so read-access logic can reason over the full
+ * domain space.
+ *
+ * - `provisioning` — stand up / pin / resize / pause / decommission.
+ * - `cost` — COGS, COGS/MRR, anomalies. The one domain the client never even
+ *   *reads* — our cost basis is ours by nature, not by posture.
+ */
+export const SMD_ONLY_AUTHORITY_DOMAINS = ['provisioning', 'cost'] as const
+export type SmdOnlyAuthorityDomain = (typeof SMD_ONLY_AUTHORITY_DOMAINS)[number]
+
+export const ALL_AUTHORITY_DOMAINS = [
+  ...SWITCHABLE_AUTHORITY_DOMAINS,
+  ...SMD_ONLY_AUTHORITY_DOMAINS,
+] as const
+export type AuthorityDomain = (typeof ALL_AUTHORITY_DOMAINS)[number]
+
+const SWITCHABLE_SET: ReadonlySet<string> = new Set(SWITCHABLE_AUTHORITY_DOMAINS)
+
+/**
+ * The resolved customer authority posture. On a validated `customer.yaml` this
+ * is always present (the validator fills the absent block with the launch
+ * default). `overrides` is sparse — only domains that deviate from `default`.
+ */
+export interface AuthorityPosture {
+  default: AuthorityDefault
+  overrides: Partial<Record<SwitchableAuthorityDomain, AuthorityHolder>>
+}
+
+/** The launch posture: SMD operates everything, every client switch off. */
+export const DEFAULT_AUTHORITY_POSTURE: AuthorityPosture = {
+  default: 'managed',
+  overrides: {},
+}
+
+export function isSwitchableDomain(domain: string): domain is SwitchableAuthorityDomain {
+  return SWITCHABLE_SET.has(domain)
+}
+
+/**
+ * Resolve who operates a single switchable domain for a client. The base comes
+ * from the preset (`self_managed` → `client`, else `managed`); an override, if
+ * present, wins. A `null` posture (no row / unconfigured) resolves to the
+ * launch default — `managed` for every domain.
+ */
+export function resolveDomainAuthority(
+  posture: AuthorityPosture | null,
+  domain: SwitchableAuthorityDomain
+): AuthorityHolder {
+  if (posture === null) return 'managed'
+  const base: AuthorityHolder = posture.default === 'self_managed' ? 'client' : 'managed'
+  return posture.overrides[domain] ?? base
+}
+
+/** Resolve every switchable domain at once — the shape both portals iterate. */
+export function resolveAllDomains(
+  posture: AuthorityPosture | null
+): Record<SwitchableAuthorityDomain, AuthorityHolder> {
+  const out = {} as Record<SwitchableAuthorityDomain, AuthorityHolder>
+  for (const domain of SWITCHABLE_AUTHORITY_DOMAINS) {
+    out[domain] = resolveDomainAuthority(posture, domain)
+  }
+  return out
+}
+
+/**
+ * Is this domain client-operable for this client? `true` → the client portal
+ * renders Operable controls (still subject to client-internal RBAC); `false` →
+ * Read + Request. SMD-only domains are never client-operable.
+ */
+export function isClientOperable(
+  posture: AuthorityPosture | null,
+  domain: AuthorityDomain
+): boolean {
+  if (!isSwitchableDomain(domain)) return false
+  return resolveDomainAuthority(posture, domain) === 'client'
+}
+
+/**
+ * May the client *read* this domain? Read access is on for every domain from
+ * day one (foundations §4.1 principle 3) — the sole exception is `cost`, which
+ * is SMD-only by nature. Independent of the operability switch: a `managed`
+ * domain is still readable (that is exactly the Read + Request state).
+ */
+export function canClientRead(domain: AuthorityDomain): boolean {
+  return domain !== 'cost'
+}
+
+/**
+ * Fail-safe parse of a projected `authority_json` value (or any untrusted
+ * source) into an {@link AuthorityPosture}. Unlike the customer.yaml validator
+ * (which collects authoring errors), this is defensive and total: malformed
+ * input, unknown override keys, and unknown values are dropped, never thrown.
+ * The strict gate at authoring time is `checkAuthority` in the validator; by
+ * the time data reaches the projection it has already passed that gate, so the
+ * projection's job is only to never crash a portal render on a corrupt row.
+ *
+ * A `null`/absent/invalid root resolves to {@link DEFAULT_AUTHORITY_POSTURE}.
+ */
+export function parseAuthorityPosture(raw: unknown): AuthorityPosture {
+  if (!isRecord(raw)) return { ...DEFAULT_AUTHORITY_POSTURE }
+  const def: AuthorityDefault = raw['default'] === 'self_managed' ? 'self_managed' : 'managed'
+  const overrides: Partial<Record<SwitchableAuthorityDomain, AuthorityHolder>> = {}
+  const rawOverrides = raw['overrides']
+  if (isRecord(rawOverrides)) {
+    for (const [key, value] of Object.entries(rawOverrides)) {
+      if (isSwitchableDomain(key) && (value === 'managed' || value === 'client')) {
+        overrides[key] = value
+      }
+    }
+  }
+  return { default: def, overrides }
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v)
+}

--- a/src/lib/operator/credential-custody.ts
+++ b/src/lib/operator/credential-custody.ts
@@ -1,0 +1,71 @@
+/**
+ * Operator credential custody — the frozen contract (ADR 0042).
+ *
+ * Custody answers, per connector, one question: can SMD staff reach the
+ * credential value to re-establish a broken connection, or only the client?
+ * It is the security dimension of the connectors authority domain (ADR 0041),
+ * not a separate axis of who-operates. Both modes store the secret in the
+ * per-customer isolated vault (ADR 0010 / 0007); the only thing custody moves
+ * is whether SMD can read/rotate it.
+ *
+ * Pure module — no D1, no validator dependency, no I/O. Imported by the
+ * customer.yaml validator, the projection reader, and both portals.
+ *
+ * The two modes (ADR 0042 §Decision):
+ *   - delegated  (default): SMD monitors and drives re-establishment. For
+ *     OAuth, SMD never holds the secret but fires the one-click re-consent
+ *     link; for static secrets, the key is stored SMD-readable so SMD can
+ *     rotate it without the customer.
+ *   - self_held (privacy-max): SMD cannot reach the value. OAuth re-consent is
+ *     client-initiated; a static secret is stored so only the operator runtime
+ *     can use it — SMD drives the customer through re-entry but cannot paste it
+ *     back. The cost of the "our consultant literally cannot touch our keys"
+ *     guarantee.
+ */
+
+export const ACCEPTED_CREDENTIAL_CUSTODY = ['delegated', 'self_held'] as const
+export type CredentialCustody = (typeof ACCEPTED_CREDENTIAL_CUSTODY)[number]
+
+/**
+ * Delegated is the default because not-fussing-with-connectors is core to the
+ * Operator value (ADR 0042 §Delegated). Self-held is always opt-in.
+ */
+export const DEFAULT_CREDENTIAL_CUSTODY: CredentialCustody = 'delegated'
+
+/**
+ * Resolve a connector's effective custody: per-connector value → client-level
+ * default → `delegated` (ADR 0042 §Verification rule 1). A `null` at either
+ * level means "inherit"; only an explicit value pins it.
+ */
+export function resolveCredentialCustody(
+  perConnector: CredentialCustody | null,
+  clientDefault: CredentialCustody | null
+): CredentialCustody {
+  return perConnector ?? clientDefault ?? DEFAULT_CREDENTIAL_CUSTODY
+}
+
+/**
+ * Does this resolved custody allow SMD staff to read/rotate the secret value
+ * without the customer? True only for delegated. Self-held is, by definition,
+ * unreachable by SMD — the property the privacy guarantee rests on.
+ *
+ * NOTE: this describes the *intended* policy for static secrets. For OAuth,
+ * SMD never holds the secret in either mode (ADR 0010) — delegated only means
+ * SMD *drives* re-consent, not that SMD reads the token. The write-only
+ * static-secret entry path is what physically enforces self-held for static
+ * keys; this predicate is the policy these surfaces read to decide whether to
+ * offer an SMD-side "rotate for the client" affordance.
+ */
+export function smdCanReachSecret(custody: CredentialCustody): boolean {
+  return custody === 'delegated'
+}
+
+/**
+ * Fail-safe parse of an untrusted custody value (projected JSON, form input).
+ * Returns the value when it is one of the accepted modes, else `null`
+ * ("inherit"). Never throws — the strict authoring gate is in the validator.
+ */
+export function parseCredentialCustody(raw: unknown): CredentialCustody | null {
+  if (raw === 'delegated' || raw === 'self_held') return raw
+  return null
+}

--- a/src/lib/operator/credential-secret-transport.ts
+++ b/src/lib/operator/credential-secret-transport.ts
@@ -1,0 +1,112 @@
+/**
+ * Production wiring for the write-only static-secret core
+ * (credential-secret-write.ts). Two seams the edge needs:
+ *
+ *   1. The vault transport ({@link CustomerSecretWriter}) that physically
+ *      relays the client-entered value into the per-customer isolated store.
+ *      The real relay is the ADR 0036 pattern (set a per-customer Fly secret,
+ *      restart the Machine so its boot-decode writes the value to the volume).
+ *      That requires live per-customer Fly app context and the Fly API; it is
+ *      the integration step. Until it is wired, {@link isSecretTransportConfigured}
+ *      returns false and the endpoint returns an honest `not_enabled` — it
+ *      NEVER calls a half-built transport. The contract above this seam (the
+ *      no-leak core) is frozen and tested; wiring the relay does not touch it.
+ *
+ *   2. The console-side audit sink ({@link CredentialSecretAudit}) — a D1
+ *      insert into `connector_secret_audit`. That table has no value column, so
+ *      the record is structurally incapable of carrying the secret.
+ *
+ * Keeping both seams here (not in the endpoint) means the endpoint reads as a
+ * thin auth + parse + orchestrate wrapper, and the one function the integration
+ * team implements (the Fly relay) is isolated.
+ */
+
+import type { CapabilityName } from './capabilities/types'
+import type { CredentialSecretAudit, CustomerSecretWriter } from './credential-secret-write'
+
+/**
+ * Minimal structural view of the env the transport needs. Declared structurally
+ * (optional field) rather than via a Cloudflare.Env augmentation so this module
+ * compiles before the binding is provisioned — passing the real `env` is valid
+ * because the field is optional. When the relay lands, declare the binding in
+ * env.d.ts + wrangler and this check starts returning true.
+ */
+export interface SecretTransportEnv {
+  /** Per-customer secret-relay endpoint base. Absent until the relay is wired. */
+  OPERATOR_SECRET_RELAY_URL?: string
+}
+
+/**
+ * Is the production vault transport wired? The endpoint checks this BEFORE
+ * touching the core, and returns `not_enabled` when false — so a client never
+ * hits a half-built relay and no value is ever handed to an unimplemented sink.
+ */
+export function isSecretTransportConfigured(env: SecretTransportEnv): boolean {
+  return (
+    typeof env.OPERATOR_SECRET_RELAY_URL === 'string' && env.OPERATOR_SECRET_RELAY_URL.length > 0
+  )
+}
+
+/**
+ * Tagged error the not-yet-wired transport throws if ever invoked. The core
+ * (`handleSecretWrite`) discards thrown detail and maps it to `write_failed`,
+ * so even this sentinel cannot leak — but the endpoint guards with
+ * `isSecretTransportConfigured` so it is never reached in practice.
+ */
+export class SecretTransportNotConfiguredError extends Error {
+  constructor() {
+    super('operator secret transport is not configured (OPERATOR_SECRET_RELAY_URL unset)')
+    this.name = 'SecretTransportNotConfiguredError'
+  }
+}
+
+/**
+ * Construct the production vault transport. Until the ADR 0036 Fly-secret relay
+ * is wired (guarded by isSecretTransportConfigured), `write` throws the tagged
+ * sentinel — it is never called in production because the endpoint gates on
+ * the same configured check first.
+ *
+ * INTEGRATION STEP: replace the throwing body with the relay call —
+ *   POST {OPERATOR_SECRET_RELAY_URL}/{customerSlug}/{connector}
+ *   → sets the per-customer Fly secret + restarts the Machine (ADR 0036)
+ *   → returns the non-secret storage ref.
+ * The signature and the no-leak contract above it do not change.
+ */
+export function createSecretWriter(_env: SecretTransportEnv): CustomerSecretWriter {
+  return {
+    write: () => Promise.reject(new SecretTransportNotConfiguredError()),
+  }
+}
+
+/**
+ * Construct the console-side audit sink. Binds the per-request identity that
+ * the core's audit interface does not carry (entity_id, actor_user_id) and
+ * writes one append-only `connector_secret_audit` row. No value column exists.
+ */
+export function createSecretAudit(
+  db: D1Database,
+  ctx: { entityId: string; actorUserId: string }
+): CredentialSecretAudit {
+  return {
+    record: async (row) => {
+      await db
+        .prepare(
+          'INSERT INTO connector_secret_audit ' +
+            '(customer_slug, entity_id, connector, actor_user_id, actor_email, ' +
+            'actor_role, masked_tail, storage_ref) ' +
+            'VALUES (?, ?, ?, ?, ?, ?, ?, ?)'
+        )
+        .bind(
+          row.customerSlug,
+          ctx.entityId,
+          row.connector satisfies CapabilityName,
+          ctx.actorUserId,
+          row.actor,
+          row.actorRole,
+          row.masked,
+          row.ref
+        )
+        .run()
+    },
+  }
+}

--- a/src/lib/operator/credential-secret-write.ts
+++ b/src/lib/operator/credential-secret-write.ts
@@ -1,0 +1,157 @@
+/**
+ * Write-only static-secret entry core (ADR 0042 §Rules 3, §Verification 3).
+ *
+ * A client entering a raw static secret (an API key for CourtListener,
+ * CallRail, etc.) needs it to land in their per-customer isolated vault
+ * WITHOUT the value ever touching the console DB, an application log, or any
+ * transcript. This module is that guarantee, expressed as a pure, fully
+ * testable core: parse → validate → write (via an injected vault transport) →
+ * return ONLY a masked confirmation, and record an audit row that proves a
+ * secret was set without ever carrying the value.
+ *
+ * The value appears in exactly one place: the `secret` argument flowing into
+ * `CustomerSecretWriter.write`. It is never returned, never audited, never
+ * logged. `maskSecret` is the only value-derived output and reveals at most
+ * the last four characters.
+ *
+ * The transport is injected (the {@link CustomerSecretWriter} interface) so:
+ *   - the no-leak invariants are tested against a spy with zero infra, and
+ *   - the production transport (Fly per-customer secret + Machine relay, the
+ *     ADR 0036 pattern, or an Infisical per-customer path for delegated static
+ *     keys) is wired at the edge without touching this contract.
+ *
+ * Self-held vs delegated custody (ADR 0042) is a property of the *transport*,
+ * not this core: a self-held writer stores the value where only the operator
+ * runtime can read it (SMD-unreadable); a delegated writer stores it
+ * SMD-readable. Both honor the same no-leak-into-console contract here — the
+ * console process must never persist or log the value in either mode.
+ */
+
+import { ACCEPTED_CAPABILITY_NAMES } from './customer-yaml/types'
+import type { CapabilityName } from './capabilities/types'
+
+/** Max accepted secret length. Generous for API keys / PATs; rejects pasted
+ * blobs that are almost certainly a mistake (a whole file, a cert chain). */
+export const MAX_SECRET_LENGTH = 8192
+
+export interface SecretWriteInput {
+  /** Per-customer slug — scopes the write to exactly one customer's vault. */
+  customerSlug: string
+  /** Capability the secret authenticates; validated against the closed union. */
+  connector: string
+  /** The raw secret value. NEVER logged, returned, or audited. */
+  secret: string
+}
+
+export interface SecretWriteActor {
+  /** Identity of the human entering the secret — for the audit row. */
+  actor: string
+  /** Their client-internal role — for the audit row. */
+  actorRole: string
+}
+
+/**
+ * Injected vault transport. The ONLY component that sees the raw value.
+ * Implementations MUST write straight to the per-customer isolated store and
+ * MUST NOT log or persist the value anywhere the console can read it (in
+ * self-held mode, anywhere SMD can read it at all).
+ */
+export interface CustomerSecretWriter {
+  /**
+   * Write `secret` into the customer's vault for `connector`. Return a
+   * NON-secret storage pointer (e.g. "infisical:/operator/<slug>/<cap>/api-key"
+   * or a Fly secret name) — never the value. Throw on failure; the core maps a
+   * throw to `write_failed` and never surfaces the thrown detail to the client.
+   */
+  write(input: { customerSlug: string; connector: CapabilityName; secret: string }): Promise<{
+    ref: string
+  }>
+}
+
+/**
+ * Injected audit sink. Records THAT a secret was set — actor, connector,
+ * masked tail, storage ref, timestamp. Never the value. Append-only at the
+ * edge (a row in the operator audit log).
+ */
+export interface CredentialSecretAudit {
+  record(row: {
+    customerSlug: string
+    connector: CapabilityName
+    actor: string
+    actorRole: string
+    masked: string
+    ref: string
+  }): Promise<void>
+}
+
+export type SecretWriteError = 'invalid_connector' | 'empty_secret' | 'too_long' | 'write_failed'
+
+export type SecretWriteResult =
+  | { ok: true; masked: string; ref: string }
+  | { ok: false; error: SecretWriteError }
+
+/**
+ * Mask a secret for confirmation display. Reveals at most the last four
+ * characters, and nothing at all for short secrets (≤8 chars) where four
+ * characters would expose too much. Never returns the full value.
+ */
+export function maskSecret(secret: string): string {
+  if (secret.length <= 8) return '••••••••'
+  return `••••••${secret.slice(-4)}`
+}
+
+function isAcceptedConnector(connector: string): connector is CapabilityName {
+  return ACCEPTED_CAPABILITY_NAMES.has(connector as CapabilityName)
+}
+
+/**
+ * Validate input WITHOUT echoing the value. Returns an error tag or null.
+ * Length/emptiness are the only value-derived checks and they never include
+ * the value in their result.
+ */
+export function validateSecretInput(input: SecretWriteInput): SecretWriteError | null {
+  if (!isAcceptedConnector(input.connector)) return 'invalid_connector'
+  if (input.secret.length === 0) return 'empty_secret'
+  if (input.secret.length > MAX_SECRET_LENGTH) return 'too_long'
+  return null
+}
+
+/**
+ * Orchestrate a write-only secret entry. The value flows only into
+ * `writer.write`; everything returned or audited is masked or a non-secret
+ * ref. A transport failure is collapsed to `write_failed` so no thrown detail
+ * (which could embed the value) reaches the caller.
+ */
+export async function handleSecretWrite(
+  deps: { writer: CustomerSecretWriter; audit: CredentialSecretAudit },
+  input: SecretWriteInput,
+  actor: SecretWriteActor
+): Promise<SecretWriteResult> {
+  const invalid = validateSecretInput(input)
+  if (invalid !== null) return { ok: false, error: invalid }
+
+  const connector = input.connector as CapabilityName
+  let ref: string
+  try {
+    const written = await deps.writer.write({
+      customerSlug: input.customerSlug,
+      connector,
+      secret: input.secret,
+    })
+    ref = written.ref
+  } catch {
+    // Deliberately discard the thrown value — it may embed the secret.
+    return { ok: false, error: 'write_failed' }
+  }
+
+  const masked = maskSecret(input.secret)
+  await deps.audit.record({
+    customerSlug: input.customerSlug,
+    connector,
+    actor: actor.actor,
+    actorRole: actor.actorRole,
+    masked,
+    ref,
+  })
+  return { ok: true, masked, ref }
+}

--- a/src/lib/operator/customer-yaml/sections-authority.ts
+++ b/src/lib/operator/customer-yaml/sections-authority.ts
@@ -1,0 +1,126 @@
+/**
+ * Authority-posture section validator (ADR 0041). The optional top-level
+ * `authority` block declares, per switchable domain, whether the client org
+ * may operate it (`client`) or only SMD does (`managed`). See
+ * src/lib/operator/authority.ts for the resolved-side contract and semantics.
+ *
+ * Absent block → the launch posture (`default: managed`, no overrides): SMD
+ * operates everything, every client self-serve switch off. This is the safe,
+ * explicit default — a client never becomes operable by omission.
+ *
+ * Strict where the resolved-side parser (`parseAuthorityPosture`) is lenient:
+ * here an unknown override key, an SMD-only domain used as a switch, or a bad
+ * value is a hard authoring error. The lenient parser exists only to keep a
+ * corrupt projected row from crashing a render; authoring must be clean.
+ */
+
+import {
+  ACCEPTED_AUTHORITY_DEFAULTS,
+  ACCEPTED_AUTHORITY_HOLDERS,
+  DEFAULT_AUTHORITY_POSTURE,
+  SMD_ONLY_AUTHORITY_DOMAINS,
+  SWITCHABLE_AUTHORITY_DOMAINS,
+  isSwitchableDomain,
+  type AuthorityDefault,
+  type AuthorityHolder,
+  type AuthorityPosture,
+  type SwitchableAuthorityDomain,
+} from '../authority'
+import type { ValidationError } from './types'
+import { isPlainObject } from './helpers'
+
+const SMD_ONLY_SET: ReadonlySet<string> = new Set(SMD_ONLY_AUTHORITY_DOMAINS)
+
+export function checkAuthority(
+  root: Record<string, unknown>,
+  errors: ValidationError[]
+): AuthorityPosture {
+  const raw = root['authority']
+  if (raw === undefined || raw === null) {
+    return { ...DEFAULT_AUTHORITY_POSTURE }
+  }
+  if (!isPlainObject(raw)) {
+    errors.push({
+      code: 'TypeMismatch',
+      path: 'authority',
+      message: 'authority must be an object when present',
+    })
+    return { ...DEFAULT_AUTHORITY_POSTURE }
+  }
+  const def = checkDefault(raw['default'], errors)
+  const overrides = checkOverrides(raw['overrides'], errors)
+  return { default: def, overrides }
+}
+
+function checkDefault(raw: unknown, errors: ValidationError[]): AuthorityDefault {
+  if (raw === undefined || raw === null) return 'managed'
+  if (
+    typeof raw !== 'string' ||
+    !(ACCEPTED_AUTHORITY_DEFAULTS as readonly string[]).includes(raw)
+  ) {
+    errors.push({
+      code: 'EnumViolation',
+      path: 'authority.default',
+      message: `authority.default must be one of: ${ACCEPTED_AUTHORITY_DEFAULTS.join(', ')}`,
+    })
+    return 'managed'
+  }
+  return raw as AuthorityDefault
+}
+
+function checkOverrides(
+  raw: unknown,
+  errors: ValidationError[]
+): Partial<Record<SwitchableAuthorityDomain, AuthorityHolder>> {
+  const out: Partial<Record<SwitchableAuthorityDomain, AuthorityHolder>> = {}
+  if (raw === undefined || raw === null) return out
+  if (!isPlainObject(raw)) {
+    errors.push({
+      code: 'TypeMismatch',
+      path: 'authority.overrides',
+      message: 'authority.overrides must be an object when present',
+    })
+    return out
+  }
+  for (const [key, value] of Object.entries(raw)) {
+    const domain = checkOverrideKey(key, errors)
+    const holder = checkOverrideValue(key, value, errors)
+    if (domain !== null && holder !== null) out[domain] = holder
+  }
+  return out
+}
+
+function checkOverrideKey(
+  key: string,
+  errors: ValidationError[]
+): SwitchableAuthorityDomain | null {
+  if (isSwitchableDomain(key)) return key
+  const reason = SMD_ONLY_SET.has(key)
+    ? `"${key}" is SMD-only and can never be a client switch`
+    : `unknown authority domain "${key}"`
+  errors.push({
+    code: 'UnknownAuthorityDomain',
+    path: `authority.overrides.${key}`,
+    message: `${reason}; switchable domains: ${SWITCHABLE_AUTHORITY_DOMAINS.join(', ')}`,
+  })
+  return null
+}
+
+function checkOverrideValue(
+  key: string,
+  value: unknown,
+  errors: ValidationError[]
+): AuthorityHolder | null {
+  if (
+    typeof value !== 'string' ||
+    !(ACCEPTED_AUTHORITY_HOLDERS as readonly string[]).includes(value)
+  ) {
+    errors.push({
+      code: 'EnumViolation',
+      path: `authority.overrides.${key}`,
+      message: `authority override value must be one of: ${ACCEPTED_AUTHORITY_HOLDERS.join(', ')}`,
+    })
+    return null
+  }
+  return value as AuthorityHolder
+}

--- a/src/lib/operator/customer-yaml/sections-connectors.ts
+++ b/src/lib/operator/customer-yaml/sections-connectors.ts
@@ -6,13 +6,40 @@
 
 import type { CapabilityName } from '../capabilities/types'
 import {
+  ACCEPTED_CREDENTIAL_CUSTODY,
+  DEFAULT_CREDENTIAL_CUSTODY,
+  type CredentialCustody,
+} from '../credential-custody'
+import {
   ACCEPTED_BACKEND_PREFIXES,
   ACCEPTED_CAPABILITY_NAMES,
   WEBHOOK_URL_PATTERN,
   type Connector,
   type ValidationError,
 } from './types'
-import { isPlainObject } from './helpers'
+import { isPlainObject, optionalEnum } from './helpers'
+
+/**
+ * `credential_custody_default` (ADR 0042) — optional top-level client-level
+ * default applied to every connector whose own `credential_custody` is null.
+ * Defaults to `delegated` (the hands-off value) when absent. Per-connector
+ * values override it; the resolver is `resolveCredentialCustody`. Lives with
+ * the connectors section because custody is the security dimension of the
+ * connectors authority domain.
+ */
+export function checkCredentialCustodyDefault(
+  root: Record<string, unknown>,
+  errors: ValidationError[]
+): CredentialCustody {
+  const v = optionalEnum(
+    root,
+    'credential_custody_default',
+    ACCEPTED_CREDENTIAL_CUSTODY,
+    'credential_custody_default',
+    errors
+  )
+  return v ?? DEFAULT_CREDENTIAL_CUSTODY
+}
 
 export function checkConnectors(
   root: Record<string, unknown>,
@@ -70,6 +97,15 @@ function checkOneConnector(
   if (webhookUrl === undefined) return null
   const enabled = typeof value['enabled'] === 'boolean' ? value['enabled'] : true
   const tokenRef = typeof value['token_ref'] === 'string' ? value['token_ref'] : null
+  // ADR 0042: optional per-connector custody; null ⇒ inherit the client-level
+  // credential_custody_default. Enum-gated; absence is the common case.
+  const custody = optionalEnum(
+    value,
+    'credential_custody',
+    ACCEPTED_CREDENTIAL_CUSTODY,
+    `connectors.${key}.credential_custody`,
+    errors
+  )
   return {
     adapter,
     backend,
@@ -77,6 +113,7 @@ function checkOneConnector(
     scopes,
     token_ref: tokenRef,
     webhook_url: webhookUrl,
+    credential_custody: custody,
   }
 }
 

--- a/src/lib/operator/customer-yaml/types.ts
+++ b/src/lib/operator/customer-yaml/types.ts
@@ -7,6 +7,8 @@
  */
 
 import type { CapabilityName } from '../capabilities/types'
+import type { AuthorityPosture } from '../authority'
+import type { CredentialCustody } from '../credential-custody'
 
 export const ACCEPTED_CAPABILITY_NAMES: ReadonlySet<CapabilityName> = new Set<CapabilityName>([
   'PracticeManagement',
@@ -422,6 +424,15 @@ export interface Connector {
    * Null when the connector is pull-only (no vendor push events configured).
    */
   webhook_url: string | null
+  /**
+   * Per-connector credential custody (ADR 0042). `null` ⇒ inherit the
+   * client-level `credential_custody_default`. An explicit value pins this
+   * connector: `delegated` (SMD can read/rotate or drive re-consent) or
+   * `self_held` (only the client can re-establish; SMD cannot reach the
+   * secret). The resolver + semantics live in
+   * src/lib/operator/credential-custody.ts.
+   */
+  credential_custody: CredentialCustody | null
 }
 
 /**
@@ -671,6 +682,21 @@ export interface CustomerYaml {
    * side effect of seat provisioning.
    */
   compliance_enabled: boolean
+  /**
+   * Authority posture (ADR 0041) — per-domain client-self-serve switches over
+   * SMD's always-present full control. Always non-null on a validated
+   * CustomerYaml: an absent block resolves to the launch default
+   * (`{ default: 'managed', overrides: {} }`) via `checkAuthority`. The
+   * resolved-side contract and resolver live in src/lib/operator/authority.ts.
+   */
+  authority: AuthorityPosture
+  /**
+   * Client-level default credential custody (ADR 0042). Applies to every
+   * connector whose own `credential_custody` is null. Defaults to `delegated`
+   * when the field is absent. Per-connector values override it. The resolver
+   * is `resolveCredentialCustody` in src/lib/operator/credential-custody.ts.
+   */
+  credential_custody_default: CredentialCustody
 }
 
 export type ValidationErrorCode =
@@ -710,6 +736,7 @@ export type ValidationErrorCode =
   | 'UnknownAddon'
   | 'InvalidActionClass'
   | 'InvalidActionCeiling'
+  | 'UnknownAuthorityDomain'
 
 export interface ValidationError {
   code: ValidationErrorCode

--- a/src/lib/operator/customer-yaml/validator.ts
+++ b/src/lib/operator/customer-yaml/validator.ts
@@ -52,6 +52,7 @@ import {
   checkScope,
   checkVoiceLibrary,
 } from './sections-other'
+import { checkCredentialCustodyDefault } from './sections-connectors'
 import { checkTelegram } from './sections-telegram'
 import { checkObservability } from './sections-observability'
 import { checkVoiceCohorts } from './sections-voice'
@@ -59,6 +60,9 @@ import { checkWebhookTriggers } from './sections-webhook-triggers'
 import { checkExtendsReserved, checkVerticalPinned } from './sections-vertical'
 import { checkAddons } from './sections-addons'
 import { checkGoogleAuth } from './sections-google-auth'
+import { checkAuthority } from './sections-authority'
+import type { AuthorityPosture } from '../authority'
+import type { CredentialCustody } from '../credential-custody'
 
 export type {
   CustomerYaml,
@@ -123,6 +127,34 @@ export {
   type SyncSource,
 } from './types'
 export { resolveCohortVocabulary } from './sections-voice'
+export {
+  ACCEPTED_AUTHORITY_DEFAULTS,
+  ACCEPTED_AUTHORITY_HOLDERS,
+  ALL_AUTHORITY_DOMAINS,
+  DEFAULT_AUTHORITY_POSTURE,
+  SMD_ONLY_AUTHORITY_DOMAINS,
+  SWITCHABLE_AUTHORITY_DOMAINS,
+  canClientRead,
+  isClientOperable,
+  isSwitchableDomain,
+  parseAuthorityPosture,
+  resolveAllDomains,
+  resolveDomainAuthority,
+  type AuthorityDefault,
+  type AuthorityDomain,
+  type AuthorityHolder,
+  type AuthorityPosture,
+  type SmdOnlyAuthorityDomain,
+  type SwitchableAuthorityDomain,
+} from '../authority'
+export {
+  ACCEPTED_CREDENTIAL_CUSTODY,
+  DEFAULT_CREDENTIAL_CUSTODY,
+  parseCredentialCustody,
+  resolveCredentialCustody,
+  smdCanReachSecret,
+  type CredentialCustody,
+} from '../credential-custody'
 
 export interface ValidateOptions {
   /** Raw YAML text. When provided, scanRawYaml runs as the first pass so a
@@ -191,6 +223,8 @@ interface ParsedSections {
   observability: Observability
   webhookTriggers: ReturnType<typeof checkWebhookTriggers>
   complianceEnabled: boolean
+  authority: AuthorityPosture
+  credentialCustodyDefault: CredentialCustody
 }
 
 function validateSections(
@@ -241,6 +275,8 @@ function validateSections(
     observability: checkObservability(root, errors),
     webhookTriggers,
     complianceEnabled: checkComplianceEnabled(root, errors),
+    authority: checkAuthority(root, errors),
+    credentialCustodyDefault: checkCredentialCustodyDefault(root, errors),
   }
 }
 
@@ -274,5 +310,7 @@ function assembleCustomerYaml(root: Record<string, unknown>, p: ParsedSections):
     observability: p.observability,
     webhook_triggers: p.webhookTriggers,
     compliance_enabled: p.complianceEnabled,
+    authority: p.authority,
+    credential_custody_default: p.credentialCustodyDefault,
   }
 }

--- a/src/lib/operator/runtime-read-transport.ts
+++ b/src/lib/operator/runtime-read-transport.ts
@@ -1,0 +1,86 @@
+/**
+ * Production wiring for the live runtime read path (runtime-read.ts, ADR 0043
+ * path A). Two seams the edge needs:
+ *
+ *   1. The console→Machine transport ({@link MachineRuntimeTransport}) — the
+ *      authenticated, read-only HTTP call to one customer's Machine read
+ *      endpoint. Until that endpoint + the per-customer console→Machine
+ *      credential are wired, {@link isRuntimeReadConfigured} returns false and
+ *      drill-in surfaces render honest empty states (the design's documented
+ *      "until built, runtime surfaces render empty states"). The not-configured
+ *      transport throws, and `readMachineRuntime` is fail-closed, so a caller
+ *      always gets a clean empty result — never a crash.
+ *
+ *   2. The console-side read-audit sink ({@link RuntimeReadAudit}) — a D1
+ *      insert into `operator_runtime_read_audit`.
+ *
+ * Keeping both here means the drill-in surfaces stay thin and the one piece the
+ * integration team implements (the Machine read transport) is isolated.
+ */
+
+import type { MachineRuntimeTransport, RuntimeReadAudit } from './runtime-read'
+
+/**
+ * Structural view of the env the transport needs. Optional field so this module
+ * compiles before the binding is provisioned; declared in env.d.ts. When the
+ * Machine read endpoint + per-customer credential land, this check returns true.
+ */
+export interface RuntimeReadEnv {
+  /** Base URL/credential locator for the console→Machine read calls. Absent
+   * until the live read path is wired. */
+  OPERATOR_RUNTIME_READ_URL?: string
+}
+
+export function isRuntimeReadConfigured(env: RuntimeReadEnv): boolean {
+  return (
+    typeof env.OPERATOR_RUNTIME_READ_URL === 'string' && env.OPERATOR_RUNTIME_READ_URL.length > 0
+  )
+}
+
+export class RuntimeReadNotConfiguredError extends Error {
+  constructor() {
+    super('operator runtime read path is not configured (OPERATOR_RUNTIME_READ_URL unset)')
+    this.name = 'RuntimeReadNotConfiguredError'
+  }
+}
+
+/**
+ * Construct the production console→Machine transport. Until the Machine read
+ * endpoint is wired (guarded by isRuntimeReadConfigured), `read` throws — which
+ * `readMachineRuntime` collapses to a fail-closed empty result. Read-only by
+ * construction: the only method is `read`, scoped to one customer per call.
+ *
+ * INTEGRATION STEP: replace the throwing body with the authenticated read —
+ *   GET {OPERATOR_RUNTIME_READ_URL}/{customerSlug}/{query.kind}?... with the
+ *   per-customer console→Machine credential (ADR 0043 §A). Throw
+ *   RuntimeReadUnauthorizedError on 401/403; throw on any other failure so the
+ *   client fails closed. The contract above this seam does not change.
+ */
+export function createMachineRuntimeTransport(_env: RuntimeReadEnv): MachineRuntimeTransport {
+  return {
+    read: () => Promise.reject(new RuntimeReadNotConfiguredError()),
+  }
+}
+
+/**
+ * Construct the console-side read-audit sink. Binds the per-request actor id
+ * (which the core's audit interface does not carry) and writes one append-only
+ * `operator_runtime_read_audit` row per read attempt.
+ */
+export function createRuntimeReadAudit(
+  db: D1Database,
+  ctx: { actorUserId: string }
+): RuntimeReadAudit {
+  return {
+    record: async (row) => {
+      await db
+        .prepare(
+          'INSERT INTO operator_runtime_read_audit ' +
+            '(customer_slug, actor_user_id, actor_email, actor_role, kind, outcome) ' +
+            'VALUES (?, ?, ?, ?, ?, ?)'
+        )
+        .bind(row.customerSlug, ctx.actorUserId, row.actor, row.actorRole, row.kind, row.outcome)
+        .run()
+    },
+  }
+}

--- a/src/lib/operator/runtime-read.ts
+++ b/src/lib/operator/runtime-read.ts
@@ -1,0 +1,142 @@
+/**
+ * Live per-customer runtime read client (ADR 0043 path A) — the frozen
+ * console→Machine read contract both portals' deep drill-ins import.
+ *
+ * Each operator keeps its runtime state (audit log, drafts, matters, activity)
+ * on its own isolated Machine D1 (ADR 0007). The console cannot query that D1
+ * across the isolation boundary (ADR 0009). This client is the controlled,
+ * audited read path: it fetches deep detail for EXACTLY ONE customer, on
+ * demand, read-only, and fails closed (empty) when the Machine is unreachable
+ * so one operator being down never breaks another's surface.
+ *
+ * Four invariants this module encodes and never bends (ADR 0043 §Invariants):
+ *   1. Single customer per call. The function takes one `customerSlug`; there
+ *      is no list form and no surface here ever joins across customers.
+ *   2. Read-only. The transport exposes `read` and nothing else — no mutation
+ *      path exists.
+ *   3. Audited at the console. Every read attempt records who looked at what,
+ *      distinct from the operator's own runtime audit log.
+ *   4. Fail-closed. A transport error resolves to an empty result with a
+ *      reason, never a throw that bubbles into a portal render.
+ *
+ * The transport and the audit sink are injected; the production wiring (the
+ * authenticated console→Machine HTTP call and the read-audit D1 insert) lives
+ * in runtime-read-transport.ts. The Machine-side read endpoint lives in the
+ * overlay repo; this contract is the console side of that seam.
+ */
+
+/** The classes of runtime detail a drill-in can request. Each maps to a
+ * read-only endpoint on the Machine. Extend as drill-in surfaces are added. */
+export const RUNTIME_READ_KINDS = ['audit_log', 'draft', 'matter', 'activity'] as const
+export type RuntimeReadKind = (typeof RUNTIME_READ_KINDS)[number]
+
+export interface RuntimeReadQuery {
+  kind: RuntimeReadKind
+  /** Opaque pagination cursor for list kinds (audit_log, activity). */
+  cursor?: string | null
+  /** Specific item id for detail kinds (draft, matter). */
+  id?: string | null
+  /** Page size hint for list kinds; the Machine clamps it. */
+  limit?: number | null
+}
+
+export interface RuntimeReadActor {
+  actor: string
+  actorRole: string
+}
+
+export type RuntimeReadFailure = 'unreachable' | 'unauthorized' | 'not_configured'
+
+export type RuntimeReadResult =
+  | { ok: true; kind: RuntimeReadKind; data: unknown }
+  | { ok: false; kind: RuntimeReadKind; reason: RuntimeReadFailure }
+
+/**
+ * Injected console→Machine transport. Read-only by construction — the only
+ * method is `read`. Scoped to one customer per call. Throws on transport
+ * failure (unreachable, timeout); the client collapses that to a fail-closed
+ * empty result. A thrown {@link RuntimeReadUnauthorizedError} is mapped to the
+ * `unauthorized` reason instead of `unreachable`.
+ */
+export interface MachineRuntimeTransport {
+  read(customerSlug: string, query: RuntimeReadQuery): Promise<{ data: unknown }>
+}
+
+/** Injected console-side read-audit sink. Records the read ATTEMPT (who, what
+ * customer, what kind, outcome) — distinct from the operator's runtime audit. */
+export interface RuntimeReadAudit {
+  record(row: {
+    customerSlug: string
+    actor: string
+    actorRole: string
+    kind: RuntimeReadKind
+    outcome: 'ok' | RuntimeReadFailure
+  }): Promise<void>
+}
+
+/** Transports throw this to signal an auth failure (vs a reachability failure),
+ * so the client can distinguish `unauthorized` from `unreachable`. */
+export class RuntimeReadUnauthorizedError extends Error {
+  constructor() {
+    super('console→Machine runtime read was unauthorized')
+    this.name = 'RuntimeReadUnauthorizedError'
+  }
+}
+
+/**
+ * Read deep runtime detail for one customer. Audits the attempt (always),
+ * returns the data on success, and fails closed to an empty result with a
+ * reason on any transport failure — never throws into the caller.
+ *
+ * The single `customerSlug` parameter is the isolation guarantee: there is no
+ * way to express a cross-customer read through this signature.
+ */
+export async function readMachineRuntime(
+  deps: { transport: MachineRuntimeTransport; audit: RuntimeReadAudit },
+  customerSlug: string,
+  query: RuntimeReadQuery,
+  actor: RuntimeReadActor
+): Promise<RuntimeReadResult> {
+  try {
+    const { data } = await deps.transport.read(customerSlug, query)
+    await safeAudit(deps.audit, {
+      customerSlug,
+      actor: actor.actor,
+      actorRole: actor.actorRole,
+      kind: query.kind,
+      outcome: 'ok',
+    })
+    return { ok: true, kind: query.kind, data }
+  } catch (err) {
+    const reason: RuntimeReadFailure =
+      err instanceof RuntimeReadUnauthorizedError ? 'unauthorized' : 'unreachable'
+    await safeAudit(deps.audit, {
+      customerSlug,
+      actor: actor.actor,
+      actorRole: actor.actorRole,
+      kind: query.kind,
+      outcome: reason,
+    })
+    return { ok: false, kind: query.kind, reason }
+  }
+}
+
+/** Audit failures must never turn a read into a throw — the read path is
+ * fail-closed end to end. A failed audit write is swallowed (the read outcome
+ * is what the caller needs); production audit should log its own failures. */
+async function safeAudit(
+  audit: RuntimeReadAudit,
+  row: {
+    customerSlug: string
+    actor: string
+    actorRole: string
+    kind: RuntimeReadKind
+    outcome: 'ok' | RuntimeReadFailure
+  }
+): Promise<void> {
+  try {
+    await audit.record(row)
+  } catch {
+    // swallow — see doc comment
+  }
+}

--- a/src/lib/portal/customer-config.ts
+++ b/src/lib/portal/customer-config.ts
@@ -19,6 +19,13 @@
  * an optional selector parameter; v1 callers continue to work).
  */
 
+import { parseAuthorityPosture, type AuthorityPosture } from '../operator/authority'
+import {
+  DEFAULT_CREDENTIAL_CUSTODY,
+  parseCredentialCustody,
+  type CredentialCustody,
+} from '../operator/credential-custody'
+
 export type PersonaStatus = 'active' | 'archived'
 
 export interface PersonaSendAs {
@@ -75,6 +82,23 @@ export interface CustomerConfigRow {
    * can backfill before CI sync writes the column.
    */
   vertical: string | null
+  /**
+   * Resolved authority posture (ADR 0041) — per-domain client-self-serve
+   * switches over SMD's always-present full control. Always present: a null
+   * `authority_json` column resolves to the launch default
+   * (`{ default: 'managed', overrides: {} }`) via parseAuthorityPosture, so
+   * portals never special-case absence. The resolver + domain contract live
+   * in src/lib/operator/authority.ts.
+   */
+  authority: AuthorityPosture
+  /**
+   * Resolved client-level default credential custody (ADR 0042). Always
+   * present: a null `credential_custody_default` column resolves to
+   * `delegated`. Per-connector overrides live inside `connectors`. The
+   * resolver `resolveCredentialCustody` lives in
+   * src/lib/operator/credential-custody.ts.
+   */
+  credential_custody_default: CredentialCustody
   git_sha: string
   synced_at: string
 }
@@ -92,6 +116,8 @@ interface CustomerConfigDbRow {
   scope_json: string | null
   compliance_enabled: number
   vertical: string | null
+  authority_json: string | null
+  credential_custody_default: string | null
   git_sha: string
   synced_at: string
 }
@@ -102,8 +128,11 @@ interface CustomerConfigDbRow {
  * for ensuring the projection is well-formed; a malformed JSON column is a
  * corruption signal, not a routine condition to recover from.
  */
-function parseJsonNullable<T>(value: string | null): T | null {
-  if (value === null) return null
+function parseJsonNullable<T>(value: string | null | undefined): T | null {
+  // null = column is SQL NULL; undefined = column absent from the row (e.g. a
+  // freshly-added projection column a row predates, or a partial test row).
+  // Both mean "no value" — only a present, malformed JSON string is corruption.
+  if (value === null || value === undefined) return null
   return JSON.parse(value) as T
 }
 
@@ -138,6 +167,12 @@ function projectRow(row: CustomerConfigDbRow): CustomerConfigRow {
     scope: parseJsonNullable(row.scope_json),
     compliance_enabled: row.compliance_enabled === 1,
     vertical: row.vertical,
+    // JSON-syntax corruption throws like any other projected column; semantic
+    // shape (unknown override keys/values) is tolerated by parseAuthorityPosture,
+    // and a null column resolves to the launch-default posture.
+    authority: parseAuthorityPosture(parseJsonNullable(row.authority_json)),
+    credential_custody_default:
+      parseCredentialCustody(row.credential_custody_default) ?? DEFAULT_CREDENTIAL_CUSTODY,
     git_sha: row.git_sha,
     synced_at: row.synced_at,
   }

--- a/src/lib/portal/operator/change-request.ts
+++ b/src/lib/portal/operator/change-request.ts
@@ -1,0 +1,155 @@
+/**
+ * Operator change-request model (ADR 0041 §4.3). The Read + Request half of the
+ * dual-mode surface: when a domain is SMD-operated, the client files a change
+ * request here instead of editing directly, and the admin change-request inbox
+ * reads them.
+ *
+ * Console-side control-plane store (`operator_change_requests`) — not runtime
+ * D1 — so the admin inbox legitimately reads across customers. The `domain` is
+ * validated against the switchable authority domains: a request only makes
+ * sense for a domain the client cannot currently operate.
+ *
+ * Parse-and-validate on the way in (never cast a client-supplied domain or
+ * status); read helpers return typed rows.
+ */
+
+import type { D1Database } from '@cloudflare/workers-types'
+import { isSwitchableDomain, type SwitchableAuthorityDomain } from '../../operator/authority'
+
+export const CHANGE_REQUEST_STATUSES = ['open', 'acknowledged', 'resolved', 'declined'] as const
+export type ChangeRequestStatus = (typeof CHANGE_REQUEST_STATUSES)[number]
+
+export interface ChangeRequestRow {
+  id: number
+  entity_id: string
+  customer_slug: string
+  domain: SwitchableAuthorityDomain
+  requested_by_user_id: string
+  requested_by_email: string
+  summary: string
+  status: ChangeRequestStatus
+  resolved_by_email: string | null
+  resolved_at: string | null
+  resolution_note: string | null
+  created_at: string
+}
+
+export interface CreateChangeRequestInput {
+  entity_id: string
+  customer_slug: string
+  domain: string
+  requested_by_user_id: string
+  requested_by_email: string
+  summary: string
+}
+
+export type CreateChangeRequestResult =
+  | { ok: true; id: number }
+  | { ok: false; error: 'invalid_domain' | 'empty_summary' }
+
+/** Max accepted request text — generous for a paragraph, rejects pasted blobs. */
+export const MAX_SUMMARY_LENGTH = 4000
+
+/**
+ * File a client change request. Validates the domain (must be a switchable
+ * authority domain) and the summary (non-empty, bounded) without casting.
+ */
+export async function createChangeRequest(
+  db: D1Database,
+  input: CreateChangeRequestInput
+): Promise<CreateChangeRequestResult> {
+  if (!isSwitchableDomain(input.domain)) return { ok: false, error: 'invalid_domain' }
+  const summary = input.summary.trim()
+  if (summary.length === 0 || summary.length > MAX_SUMMARY_LENGTH) {
+    return { ok: false, error: 'empty_summary' }
+  }
+  const result = await db
+    .prepare(
+      `INSERT INTO operator_change_requests
+         (entity_id, customer_slug, domain, requested_by_user_id, requested_by_email, summary)
+       VALUES (?, ?, ?, ?, ?, ?)
+       RETURNING id`
+    )
+    .bind(
+      input.entity_id,
+      input.customer_slug,
+      input.domain,
+      input.requested_by_user_id,
+      input.requested_by_email,
+      summary
+    )
+    .first<{ id: number }>()
+  return { ok: true, id: result?.id ?? 0 }
+}
+
+/** A client's own change requests (most recent first). */
+export async function listChangeRequestsForCustomer(
+  db: D1Database,
+  customerSlug: string,
+  limit = 50
+): Promise<ChangeRequestRow[]> {
+  const { results } = await db
+    .prepare(
+      `SELECT * FROM operator_change_requests
+        WHERE customer_slug = ? ORDER BY created_at DESC LIMIT ?`
+    )
+    .bind(customerSlug, limit)
+    .all<ChangeRequestRow>()
+  return results ?? []
+}
+
+/**
+ * The admin inbox: open (unhandled) change requests across all customers, most
+ * recent first. Fleet-wide read of a console-side table — not runtime D1.
+ */
+export async function listOpenChangeRequests(
+  db: D1Database,
+  limit = 100
+): Promise<ChangeRequestRow[]> {
+  const { results } = await db
+    .prepare(
+      `SELECT * FROM operator_change_requests
+        WHERE status IN ('open', 'acknowledged') ORDER BY created_at DESC LIMIT ?`
+    )
+    .bind(limit)
+    .all<ChangeRequestRow>()
+  return results ?? []
+}
+
+export interface ResolveChangeRequestInput {
+  id: number
+  status: ChangeRequestStatus
+  resolved_by_email: string
+  resolution_note: string | null
+}
+
+/**
+ * SMD moves a request through its lifecycle. Stamps resolver + timestamp for
+ * the terminal states (resolved/declined); 'acknowledged' records receipt
+ * without closing. Returns false when the id does not exist.
+ */
+export async function updateChangeRequestStatus(
+  db: D1Database,
+  input: ResolveChangeRequestInput
+): Promise<boolean> {
+  const terminal = input.status === 'resolved' || input.status === 'declined'
+  const resolvedAt = terminal ? new Date().toISOString() : null
+  const result = await db
+    .prepare(
+      `UPDATE operator_change_requests
+          SET status = ?,
+              resolved_by_email = ?,
+              resolved_at = ?,
+              resolution_note = ?
+        WHERE id = ?`
+    )
+    .bind(
+      input.status,
+      terminal ? input.resolved_by_email : null,
+      resolvedAt,
+      input.resolution_note,
+      input.id
+    )
+    .run()
+  return (result.meta.changes ?? 0) > 0
+}

--- a/src/lib/portal/operator/customer-yaml-editor.ts
+++ b/src/lib/portal/operator/customer-yaml-editor.ts
@@ -450,6 +450,8 @@ function lockedFromCurrent(
   | 'users'
   | 'compliance_enabled'
   | 'google_auth'
+  | 'authority'
+  | 'credential_custody_default'
 > {
   return {
     schema_version: current.schema_version,
@@ -473,6 +475,15 @@ function lockedFromCurrent(
     // mode is a provisioning/setup decision, not a self-serve toggle).
     // Preserve verbatim across portal edits. (#1213)
     google_auth: current.google_auth,
+    // authority (ADR 0041) is SMD-set and NEVER client-editable — a client
+    // editing their own authority block would be self-granting authority
+    // (privilege escalation). The switches are flipped by SMD per domain;
+    // the client portal preserves the block verbatim across any self-serve
+    // config edit, even when the `configuration` domain is client-operable.
+    authority: current.authority,
+    // credential_custody_default (ADR 0042) is set at provisioning / via the
+    // connectors authority domain, not the general config editor. Preserve.
+    credential_custody_default: current.credential_custody_default,
   }
 }
 
@@ -500,6 +511,10 @@ function mergeConnectors(
       // changing it via the editor would risk cross-customer routing.
       // Configured at provisioning time, never via portal.
       webhook_url: existing.webhook_url,
+      // credential_custody locked — ADR 0042. Custody is a security decision
+      // in the connectors authority domain, set via the dedicated custody flow,
+      // never through the general config editor.
+      credential_custody: existing.credential_custody,
     }
   }
   return merged

--- a/src/lib/portal/operator/domain-surface.ts
+++ b/src/lib/portal/operator/domain-surface.ts
@@ -1,0 +1,75 @@
+/**
+ * Dual-mode surface resolver (ADR 0041 §4.3) — the frozen logic every
+ * client-portal domain surface wraps.
+ *
+ * Each switchable domain renders in one of two modes:
+ *   - operable      → live controls; the client edits directly.
+ *   - read_request  → identical data, read-only, with a "Request a change"
+ *                     path that files into the admin inbox.
+ *
+ * The mode is the composition of the two independent layers (foundations §2):
+ *   Layer 1 (authority): is the domain client-operable for this client?
+ *   Layer 2 (client RBAC): does the acting user's client-internal role permit
+ *                          this domain?
+ * Operable iff BOTH. Otherwise read_request. This module never assumes a gate
+ * the entitlements (Layer 3) did not author — it governs only who-may-operate,
+ * not what-the-operator-does.
+ *
+ * Visibility is a separate axis: every domain is readable from day one except
+ * cost (SMD-only by nature). `resolveDomainSurface` folds visibility + mode
+ * into one state the surface consumes.
+ *
+ * Pure — imports only the frozen authority contract. The Astro `<DomainSurface>`
+ * wrapper renders the operable slot or the read-only slot + request affordance
+ * from the `mode` this returns; the server-side write endpoints re-check the
+ * same composition (never trust a client-only mode).
+ */
+
+import {
+  canClientRead,
+  isClientOperable,
+  isSwitchableDomain,
+  type AuthorityDomain,
+  type AuthorityPosture,
+  type SwitchableAuthorityDomain,
+} from '../../operator/authority'
+
+export type DomainSurfaceMode = 'operable' | 'read_request'
+
+export interface DomainSurfaceState {
+  /** Whether the client may see this domain at all (false only for cost). */
+  visible: boolean
+  /** Operable vs read+request. Meaningful only when `visible` is true. */
+  mode: DomainSurfaceMode
+}
+
+/**
+ * Resolve operable vs read_request for a switchable domain. `clientRolePermits`
+ * is the Layer-2 decision (does this user's client-internal role allow this
+ * domain) — the caller computes it from the RBAC matrix. Operable requires
+ * both the authority switch (`client`) AND the role permission.
+ */
+export function resolveDomainSurfaceMode(
+  authority: AuthorityPosture | null,
+  domain: SwitchableAuthorityDomain,
+  clientRolePermits: boolean
+): DomainSurfaceMode {
+  return isClientOperable(authority, domain) && clientRolePermits ? 'operable' : 'read_request'
+}
+
+/**
+ * Full surface state for any domain: visibility (read access) plus mode.
+ * SMD-only / non-switchable domains are never operable to the client — they
+ * resolve to read_request when visible (e.g. provisioning: the client watches
+ * but cannot operate), and invisible for cost.
+ */
+export function resolveDomainSurface(
+  authority: AuthorityPosture | null,
+  domain: AuthorityDomain,
+  clientRolePermits: boolean
+): DomainSurfaceState {
+  const visible = canClientRead(domain)
+  if (!visible) return { visible: false, mode: 'read_request' }
+  if (!isSwitchableDomain(domain)) return { visible: true, mode: 'read_request' }
+  return { visible: true, mode: resolveDomainSurfaceMode(authority, domain, clientRolePermits) }
+}

--- a/src/pages/api/internal/runtime-summary.ts
+++ b/src/pages/api/internal/runtime-summary.ts
@@ -1,0 +1,94 @@
+/**
+ * POST /api/internal/runtime-summary
+ *
+ * Per-customer Operator Machine → control-plane runtime-summary push
+ * (ADR 0043 path B). The Machine pushes a small read-relevant summary on a
+ * cadence; this handler upserts the per-customer row in
+ * `operator_runtime_summary` that the admin fleet view reads. Generalizes the
+ * heartbeat ingestion pattern (src/pages/api/internal/heartbeat.ts) — same
+ * shared-key + X-Tenant-Slug auth.
+ *
+ * Body (JSON), all fields validated, none cast:
+ *   {
+ *     "summary_status":     "green"|"yellow"|"red"|"unknown",  // optional, default unknown
+ *     "open_alerts":         <integer ≥ 0>,                    // optional, default 0
+ *     "draft_queue_depth":   <integer ≥ 0 | null>,             // optional
+ *     "last_activity_ts":    <ISO 8601 UTC | null>,            // optional
+ *     "pushed_at":           <ISO 8601 UTC>                    // required
+ *   }
+ *
+ * Isolation (ADR 0009): the row is keyed to the authenticated tenant only;
+ * one Machine, one row. No cross-customer surface here.
+ */
+
+import type { APIRoute } from 'astro'
+import { env } from 'cloudflare:workers'
+import { verifyMachineRequest } from '../../../lib/auth/machine-key'
+import type { SummaryStatus } from '../../../lib/admin/runtime-summary'
+
+const STATUSES: ReadonlySet<string> = new Set(['green', 'yellow', 'red', 'unknown'])
+
+interface SummaryBody {
+  summary_status?: unknown
+  open_alerts?: unknown
+  draft_queue_depth?: unknown
+  last_activity_ts?: unknown
+  pushed_at?: unknown
+}
+
+function json(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+function nonNegInt(v: unknown): number | null {
+  return typeof v === 'number' && Number.isInteger(v) && v >= 0 ? v : null
+}
+
+export const POST: APIRoute = async ({ request }) => {
+  const auth = await verifyMachineRequest(request, env.MACHINE_HEARTBEAT_KEY, env.DB)
+  if (!auth.ok) return json({ error: 'unauthorized' }, 401)
+
+  let body: SummaryBody
+  try {
+    body = await request.json<SummaryBody>()
+  } catch {
+    return json({ error: 'invalid_json' }, 400)
+  }
+
+  if (typeof body.pushed_at !== 'string' || body.pushed_at.length === 0) {
+    return json({ error: 'missing_pushed_at' }, 400)
+  }
+
+  const status: SummaryStatus =
+    typeof body.summary_status === 'string' && STATUSES.has(body.summary_status)
+      ? (body.summary_status as SummaryStatus)
+      : 'unknown'
+  const openAlerts = nonNegInt(body.open_alerts) ?? 0
+  const draftDepth = nonNegInt(body.draft_queue_depth)
+  const lastActivity =
+    typeof body.last_activity_ts === 'string' && body.last_activity_ts.length > 0
+      ? body.last_activity_ts
+      : null
+
+  await env.DB.prepare(
+    `INSERT INTO operator_runtime_summary (
+       entity_id, customer_slug, summary_status, open_alerts,
+       draft_queue_depth, last_activity_ts, pushed_at, updated_at
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+     ON CONFLICT(entity_id) DO UPDATE SET
+       customer_slug      = excluded.customer_slug,
+       summary_status     = excluded.summary_status,
+       open_alerts        = excluded.open_alerts,
+       draft_queue_depth  = excluded.draft_queue_depth,
+       last_activity_ts   = COALESCE(excluded.last_activity_ts, operator_runtime_summary.last_activity_ts),
+       pushed_at          = excluded.pushed_at,
+       updated_at         = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')`
+  )
+    .bind(auth.entityId, auth.slug, status, openAlerts, draftDepth, lastActivity, body.pushed_at)
+    .run()
+
+  return json({ ok: true }, 200)
+}

--- a/src/pages/api/portal/products/operator/connectors/[connector]/secret.ts
+++ b/src/pages/api/portal/products/operator/connectors/[connector]/secret.ts
@@ -1,0 +1,84 @@
+import type { APIRoute } from 'astro'
+import { env } from 'cloudflare:workers'
+import { resolveOperatorAccess } from '../../../../../../../lib/portal/operator-access'
+import { getCustomerConfig } from '../../../../../../../lib/portal/customer-config'
+import { isClientOperable } from '../../../../../../../lib/operator/authority'
+import { handleSecretWrite } from '../../../../../../../lib/operator/credential-secret-write'
+import {
+  createSecretAudit,
+  createSecretWriter,
+  isSecretTransportConfigured,
+} from '../../../../../../../lib/operator/credential-secret-transport'
+
+/**
+ * POST /api/portal/products/operator/connectors/{connector}/secret
+ *
+ * Write-only static-secret entry (ADR 0042). A client (principal) enters a raw
+ * API key for a connector; the value relays straight into the per-customer
+ * isolated vault and NEVER touches the console DB, a log, or this transcript.
+ * Only a masked confirmation is returned. The no-leak orchestration lives in
+ * `handleSecretWrite`; the vault transport + audit are wired in
+ * credential-secret-transport.ts.
+ *
+ * Gates (all server-side, never client-only hiding):
+ *   - principal role (ADR 0011) — the agent can never reach this surface.
+ *   - the connectors authority switch must be `client` (ADR 0041 Verification 5):
+ *     a write to a switched-off domain is rejected here, not merely hidden.
+ *     At launch every switch is off, so this returns `not_permitted` for all
+ *     clients until SMD flips the connectors switch for that client.
+ *   - the vault transport must be configured (ADR 0036 relay): until wired,
+ *     returns an honest `not_enabled` rather than half-storing the value.
+ *
+ * Body: form field `secret` (the raw value). Never logged.
+ * Returns JSON: { ok: true, masked, ref } | { ok: false, error }.
+ */
+
+function json(status: number, body: Record<string, unknown>): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+export const POST: APIRoute = async ({ locals, params, request }) => {
+  const access = await resolveOperatorAccess(env.DB, locals, { allowedRoles: ['principal'] })
+  if (access.kind === 'redirect') {
+    return json(403, { ok: false, error: 'forbidden' })
+  }
+
+  const connector = params.connector
+  if (typeof connector !== 'string' || connector.length === 0) {
+    return json(400, { ok: false, error: 'invalid_connector' })
+  }
+
+  const config = await getCustomerConfig(env.DB, access.client.id)
+  if (!isClientOperable(config?.authority ?? null, 'connectors')) {
+    // ADR 0041 Verification 5 — reject server-side, not merely hide.
+    return json(403, { ok: false, error: 'not_permitted' })
+  }
+
+  if (!isSecretTransportConfigured(env)) {
+    return json(503, { ok: false, error: 'not_enabled' })
+  }
+
+  const form = await request.formData()
+  const secret = form.get('secret')
+  if (typeof secret !== 'string') {
+    return json(400, { ok: false, error: 'empty_secret' })
+  }
+
+  const result = await handleSecretWrite(
+    {
+      writer: createSecretWriter(env),
+      audit: createSecretAudit(env.DB, { entityId: access.client.id, actorUserId: access.user.id }),
+    },
+    { customerSlug: config?.customer_slug ?? access.client.id, connector, secret },
+    { actor: access.user.email, actorRole: 'principal' }
+  )
+
+  if (!result.ok) {
+    const status = result.error === 'write_failed' ? 502 : 400
+    return json(status, { ok: false, error: result.error })
+  }
+  return json(200, { ok: true, masked: result.masked, ref: result.ref })
+}

--- a/tests/customer-yaml-validator.test.ts
+++ b/tests/customer-yaml-validator.test.ts
@@ -2044,3 +2044,150 @@ describe('validate — google_auth', () => {
     expect(r.errors.some((e) => e.path === 'google_auth' && e.code === 'TypeMismatch')).toBe(true)
   })
 })
+
+// -----------------------------------------------------------------------------
+// Authority posture (ADR 0041)
+// -----------------------------------------------------------------------------
+
+describe('validate — authority posture', () => {
+  it('defaults to managed/no-overrides when the block is absent', () => {
+    const r = validate(validFixture())
+    if (!r.ok) throw new Error(`expected ok; got: ${JSON.stringify(r.errors)}`)
+    expect(r.value.authority).toEqual({ default: 'managed', overrides: {} })
+  })
+
+  it('accepts a valid authority block with per-domain overrides', () => {
+    const f = validFixture()
+    f['authority'] = {
+      default: 'managed',
+      overrides: { people_access: 'client', connectors: 'client' },
+    }
+    const r = validate(f)
+    if (!r.ok) throw new Error(`expected ok; got: ${JSON.stringify(r.errors)}`)
+    expect(r.value.authority.default).toBe('managed')
+    expect(r.value.authority.overrides.people_access).toBe('client')
+    expect(r.value.authority.overrides.connectors).toBe('client')
+  })
+
+  it('accepts default: self_managed with an override pinning a domain back to managed', () => {
+    const f = validFixture()
+    f['authority'] = { default: 'self_managed', overrides: { connectors: 'managed' } }
+    const r = validate(f)
+    if (!r.ok) throw new Error(`expected ok; got: ${JSON.stringify(r.errors)}`)
+    expect(r.value.authority.default).toBe('self_managed')
+    expect(r.value.authority.overrides.connectors).toBe('managed')
+  })
+
+  it('rejects an unknown authority.default value', () => {
+    const f = validFixture()
+    f['authority'] = { default: 'fully_managed' }
+    const r = validate(f)
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(r.errors.some((e) => e.path === 'authority.default' && e.code === 'EnumViolation')).toBe(
+      true
+    )
+  })
+
+  it('rejects an unknown override domain', () => {
+    const f = validFixture()
+    f['authority'] = { default: 'managed', overrides: { not_a_domain: 'client' } }
+    const r = validate(f)
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(
+      r.errors.some(
+        (e) => e.path === 'authority.overrides.not_a_domain' && e.code === 'UnknownAuthorityDomain'
+      )
+    ).toBe(true)
+  })
+
+  it('rejects an SMD-only domain used as a client switch', () => {
+    const f = validFixture()
+    f['authority'] = { default: 'managed', overrides: { cost: 'client' } }
+    const r = validate(f)
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(
+      r.errors.some(
+        (e) => e.path === 'authority.overrides.cost' && e.code === 'UnknownAuthorityDomain'
+      )
+    ).toBe(true)
+  })
+
+  it('rejects an invalid override value', () => {
+    const f = validFixture()
+    f['authority'] = { default: 'managed', overrides: { connectors: 'smd' } }
+    const r = validate(f)
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(
+      r.errors.some(
+        (e) => e.path === 'authority.overrides.connectors' && e.code === 'EnumViolation'
+      )
+    ).toBe(true)
+  })
+
+  it('rejects a non-object authority block', () => {
+    const f = validFixture()
+    f['authority'] = 'managed'
+    const r = validate(f)
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(r.errors.some((e) => e.path === 'authority' && e.code === 'TypeMismatch')).toBe(true)
+  })
+})
+
+// -----------------------------------------------------------------------------
+// Credential custody (ADR 0042)
+// -----------------------------------------------------------------------------
+
+describe('validate — credential custody', () => {
+  it('defaults credential_custody_default to delegated when absent', () => {
+    const r = validate(validFixture())
+    if (!r.ok) throw new Error(`expected ok; got: ${JSON.stringify(r.errors)}`)
+    expect(r.value.credential_custody_default).toBe('delegated')
+  })
+
+  it('per-connector credential_custody defaults to null (inherit) when absent', () => {
+    const r = validate(validFixture())
+    if (!r.ok) throw new Error(`expected ok; got: ${JSON.stringify(r.errors)}`)
+    expect(r.value.connectors.Email?.credential_custody).toBeNull()
+  })
+
+  it('accepts an explicit client-level default and per-connector override', () => {
+    const f = validFixture()
+    f['credential_custody_default'] = 'self_held'
+    ;(f['connectors'] as Record<string, Record<string, unknown>>)['Email']['credential_custody'] =
+      'delegated'
+    const r = validate(f)
+    if (!r.ok) throw new Error(`expected ok; got: ${JSON.stringify(r.errors)}`)
+    expect(r.value.credential_custody_default).toBe('self_held')
+    expect(r.value.connectors.Email?.credential_custody).toBe('delegated')
+  })
+
+  it('rejects an invalid client-level default', () => {
+    const f = validFixture()
+    f['credential_custody_default'] = 'smd-holds'
+    const r = validate(f)
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(
+      r.errors.some((e) => e.path === 'credential_custody_default' && e.code === 'EnumViolation')
+    ).toBe(true)
+  })
+
+  it('rejects an invalid per-connector custody value', () => {
+    const f = validFixture()
+    ;(f['connectors'] as Record<string, Record<string, unknown>>)['Email']['credential_custody'] =
+      'shared'
+    const r = validate(f)
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(
+      r.errors.some(
+        (e) => e.path === 'connectors.Email.credential_custody' && e.code === 'EnumViolation'
+      )
+    ).toBe(true)
+  })
+})

--- a/tests/operator-authority.test.ts
+++ b/tests/operator-authority.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Tests for the frozen authority-posture contract
+ * (src/lib/operator/authority.ts) — ADR 0041.
+ *
+ * This is the Layer-1 keystone both portals import: it resolves, per client
+ * per domain, whether the client org may operate a domain (`client`) or only
+ * SMD does (`managed`). The two invariants under test are the ones the design
+ * never bends: launch-safe by construction (absent/unconfigured → managed for
+ * every domain) and read-everywhere-but-cost.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  ALL_AUTHORITY_DOMAINS,
+  DEFAULT_AUTHORITY_POSTURE,
+  SMD_ONLY_AUTHORITY_DOMAINS,
+  SWITCHABLE_AUTHORITY_DOMAINS,
+  canClientRead,
+  isClientOperable,
+  isSwitchableDomain,
+  parseAuthorityPosture,
+  resolveAllDomains,
+  resolveDomainAuthority,
+  type AuthorityPosture,
+} from '../src/lib/operator/authority'
+
+describe('authority domains', () => {
+  it('switchable and SMD-only domains are disjoint', () => {
+    const overlap = SWITCHABLE_AUTHORITY_DOMAINS.filter((d) =>
+      (SMD_ONLY_AUTHORITY_DOMAINS as readonly string[]).includes(d)
+    )
+    expect(overlap).toEqual([])
+  })
+
+  it('ALL_AUTHORITY_DOMAINS is the union of both sets', () => {
+    expect(ALL_AUTHORITY_DOMAINS.length).toBe(
+      SWITCHABLE_AUTHORITY_DOMAINS.length + SMD_ONLY_AUTHORITY_DOMAINS.length
+    )
+  })
+
+  it('cost and provisioning are SMD-only, never switchable', () => {
+    expect(isSwitchableDomain('cost')).toBe(false)
+    expect(isSwitchableDomain('provisioning')).toBe(false)
+    expect(isSwitchableDomain('people_access')).toBe(true)
+  })
+})
+
+describe('resolveDomainAuthority', () => {
+  it('a null posture resolves every switchable domain to managed (launch-safe)', () => {
+    for (const domain of SWITCHABLE_AUTHORITY_DOMAINS) {
+      expect(resolveDomainAuthority(null, domain)).toBe('managed')
+    }
+  })
+
+  it('default managed resolves to managed with no overrides', () => {
+    const posture: AuthorityPosture = { default: 'managed', overrides: {} }
+    expect(resolveDomainAuthority(posture, 'connectors')).toBe('managed')
+  })
+
+  it('an override wins over the managed default', () => {
+    const posture: AuthorityPosture = {
+      default: 'managed',
+      overrides: { people_access: 'client' },
+    }
+    expect(resolveDomainAuthority(posture, 'people_access')).toBe('client')
+    expect(resolveDomainAuthority(posture, 'connectors')).toBe('managed')
+  })
+
+  it('default self_managed resolves switchable domains to client', () => {
+    const posture: AuthorityPosture = { default: 'self_managed', overrides: {} }
+    expect(resolveDomainAuthority(posture, 'connectors')).toBe('client')
+  })
+
+  it('an override pins a domain back to managed under self_managed', () => {
+    const posture: AuthorityPosture = {
+      default: 'self_managed',
+      overrides: { connectors: 'managed' },
+    }
+    expect(resolveDomainAuthority(posture, 'connectors')).toBe('managed')
+    expect(resolveDomainAuthority(posture, 'people_access')).toBe('client')
+  })
+})
+
+describe('resolveAllDomains', () => {
+  it('returns one entry per switchable domain', () => {
+    const map = resolveAllDomains(DEFAULT_AUTHORITY_POSTURE)
+    expect(Object.keys(map).sort()).toEqual([...SWITCHABLE_AUTHORITY_DOMAINS].sort())
+  })
+
+  it('reflects a mixed (co-managed) posture', () => {
+    const posture: AuthorityPosture = {
+      default: 'managed',
+      overrides: { people_access: 'client', memory: 'client' },
+    }
+    const map = resolveAllDomains(posture)
+    expect(map.people_access).toBe('client')
+    expect(map.memory).toBe('client')
+    expect(map.connectors).toBe('managed')
+  })
+})
+
+describe('isClientOperable', () => {
+  it('is false for SMD-only domains regardless of posture', () => {
+    const selfManaged: AuthorityPosture = { default: 'self_managed', overrides: {} }
+    expect(isClientOperable(selfManaged, 'cost')).toBe(false)
+    expect(isClientOperable(selfManaged, 'provisioning')).toBe(false)
+  })
+
+  it('tracks the resolved switch for switchable domains', () => {
+    const posture: AuthorityPosture = {
+      default: 'managed',
+      overrides: { connectors: 'client' },
+    }
+    expect(isClientOperable(posture, 'connectors')).toBe(true)
+    expect(isClientOperable(posture, 'people_access')).toBe(false)
+  })
+
+  it('is false for every domain under a null posture', () => {
+    for (const domain of ALL_AUTHORITY_DOMAINS) {
+      expect(isClientOperable(null, domain)).toBe(false)
+    }
+  })
+})
+
+describe('canClientRead', () => {
+  it('is true for every domain except cost', () => {
+    for (const domain of ALL_AUTHORITY_DOMAINS) {
+      expect(canClientRead(domain)).toBe(domain !== 'cost')
+    }
+  })
+})
+
+describe('parseAuthorityPosture (fail-safe projection parse)', () => {
+  it('null/undefined/non-object resolves to the launch default', () => {
+    expect(parseAuthorityPosture(null)).toEqual(DEFAULT_AUTHORITY_POSTURE)
+    expect(parseAuthorityPosture(undefined)).toEqual(DEFAULT_AUTHORITY_POSTURE)
+    expect(parseAuthorityPosture('managed')).toEqual(DEFAULT_AUTHORITY_POSTURE)
+    expect(parseAuthorityPosture([])).toEqual(DEFAULT_AUTHORITY_POSTURE)
+  })
+
+  it('round-trips a well-formed posture', () => {
+    const raw = { default: 'self_managed', overrides: { connectors: 'managed' } }
+    expect(parseAuthorityPosture(raw)).toEqual({
+      default: 'self_managed',
+      overrides: { connectors: 'managed' },
+    })
+  })
+
+  it('drops unknown override keys and values rather than throwing', () => {
+    const raw = {
+      default: 'managed',
+      overrides: { people_access: 'client', cost: 'client', bogus: 'client', connectors: 'smd' },
+    }
+    const parsed = parseAuthorityPosture(raw)
+    expect(parsed.overrides).toEqual({ people_access: 'client' })
+  })
+
+  it('coerces an unknown default to managed', () => {
+    expect(parseAuthorityPosture({ default: 'whatever' }).default).toBe('managed')
+  })
+})

--- a/tests/operator-credential-custody.test.ts
+++ b/tests/operator-credential-custody.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Tests for the credential-custody contract (src/lib/operator/credential-custody.ts)
+ * and the write-only static-secret core (src/lib/operator/credential-secret-write.ts).
+ * ADR 0042.
+ *
+ * The custody tests lock the resolver precedence (per-connector → client
+ * default → delegated). The secret-write tests are the load-bearing ones: they
+ * prove the value never escapes into the result, the audit row, or a failure
+ * path — the §Verification 3 guarantee the whole privacy story rests on.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  createTestD1,
+  runMigrations,
+  discoverNumericMigrations,
+} from '@venturecrane/crane-test-harness'
+import { resolve } from 'path'
+import {
+  DEFAULT_CREDENTIAL_CUSTODY,
+  parseCredentialCustody,
+  resolveCredentialCustody,
+  smdCanReachSecret,
+} from '../src/lib/operator/credential-custody'
+import {
+  MAX_SECRET_LENGTH,
+  handleSecretWrite,
+  maskSecret,
+  validateSecretInput,
+  type CredentialSecretAudit,
+  type CustomerSecretWriter,
+  type SecretWriteResult,
+} from '../src/lib/operator/credential-secret-write'
+import { createSecretAudit } from '../src/lib/operator/credential-secret-transport'
+
+// ---------------------------------------------------------------------------
+// Custody resolver
+// ---------------------------------------------------------------------------
+
+describe('resolveCredentialCustody', () => {
+  it('defaults to delegated when nothing is set', () => {
+    expect(resolveCredentialCustody(null, null)).toBe('delegated')
+    expect(DEFAULT_CREDENTIAL_CUSTODY).toBe('delegated')
+  })
+
+  it('client default applies when the connector does not pin its own', () => {
+    expect(resolveCredentialCustody(null, 'self_held')).toBe('self_held')
+  })
+
+  it('per-connector value overrides the client default', () => {
+    expect(resolveCredentialCustody('delegated', 'self_held')).toBe('delegated')
+    expect(resolveCredentialCustody('self_held', 'delegated')).toBe('self_held')
+  })
+})
+
+describe('smdCanReachSecret', () => {
+  it('is true only for delegated', () => {
+    expect(smdCanReachSecret('delegated')).toBe(true)
+    expect(smdCanReachSecret('self_held')).toBe(false)
+  })
+})
+
+describe('parseCredentialCustody', () => {
+  it('accepts the two modes, returns null otherwise', () => {
+    expect(parseCredentialCustody('delegated')).toBe('delegated')
+    expect(parseCredentialCustody('self_held')).toBe('self_held')
+    expect(parseCredentialCustody('smd')).toBeNull()
+    expect(parseCredentialCustody(null)).toBeNull()
+    expect(parseCredentialCustody(42)).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// maskSecret
+// ---------------------------------------------------------------------------
+
+describe('maskSecret', () => {
+  it('reveals at most the last four characters', () => {
+    expect(maskSecret('sk-live-abcdef1234')).toBe('••••••1234')
+  })
+
+  it('fully masks short secrets (≤8 chars)', () => {
+    expect(maskSecret('short')).toBe('••••••••')
+    expect(maskSecret('12345678')).toBe('••••••••')
+  })
+
+  it('never contains the full secret', () => {
+    const secret = 'sk-live-supersecretvalue9999'
+    expect(maskSecret(secret).includes(secret)).toBe(false)
+    expect(maskSecret(secret).includes('supersecret')).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// validateSecretInput — rejections never echo the value
+// ---------------------------------------------------------------------------
+
+describe('validateSecretInput', () => {
+  it('rejects an unknown connector', () => {
+    expect(
+      validateSecretInput({ customerSlug: 's', connector: 'NotACapability', secret: 'x' })
+    ).toBe('invalid_connector')
+  })
+
+  it('rejects an empty secret', () => {
+    expect(validateSecretInput({ customerSlug: 's', connector: 'CallTracking', secret: '' })).toBe(
+      'empty_secret'
+    )
+  })
+
+  it('rejects an over-long secret', () => {
+    expect(
+      validateSecretInput({
+        customerSlug: 's',
+        connector: 'CallTracking',
+        secret: 'a'.repeat(MAX_SECRET_LENGTH + 1),
+      })
+    ).toBe('too_long')
+  })
+
+  it('accepts a well-formed input', () => {
+    expect(
+      validateSecretInput({ customerSlug: 's', connector: 'CourtAccess', secret: 'key-123' })
+    ).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleSecretWrite — the no-leak guarantee
+// ---------------------------------------------------------------------------
+
+const RAW_SECRET = 'sk-live-PrivilegedCourtListenerKey-7f3a9b2c1d'
+
+function makeSpies() {
+  const writes: Array<{ customerSlug: string; connector: string; secret: string }> = []
+  const audits: Array<Record<string, string>> = []
+  const writer: CustomerSecretWriter = {
+    write: async (input) => {
+      writes.push(input)
+      return { ref: `infisical:/operator/${input.customerSlug}/${input.connector}/api-key` }
+    },
+  }
+  const audit: CredentialSecretAudit = {
+    record: async (row) => {
+      audits.push(row)
+    },
+  }
+  return { writer, audit, writes, audits }
+}
+
+describe('handleSecretWrite', () => {
+  it('writes the value exactly once and returns only a masked confirmation', async () => {
+    const { writer, audit, writes } = makeSpies()
+    const result = await handleSecretWrite(
+      { writer, audit },
+      { customerSlug: 'smith-pi-firm', connector: 'CourtAccess', secret: RAW_SECRET },
+      { actor: 'partner@firm.com', actorRole: 'principal' }
+    )
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.masked).toBe(maskSecret(RAW_SECRET))
+    expect(result.ref).toContain('smith-pi-firm')
+    expect(writes).toHaveLength(1)
+    expect(writes[0].secret).toBe(RAW_SECRET)
+  })
+
+  it('NEVER lets the raw value escape into the result', async () => {
+    const { writer, audit } = makeSpies()
+    const result = await handleSecretWrite(
+      { writer, audit },
+      { customerSlug: 'smith-pi-firm', connector: 'CourtAccess', secret: RAW_SECRET },
+      { actor: 'partner@firm.com', actorRole: 'principal' }
+    )
+    expect(JSON.stringify(result).includes(RAW_SECRET)).toBe(false)
+  })
+
+  it('NEVER lets the raw value escape into the audit row', async () => {
+    const { writer, audit, audits } = makeSpies()
+    await handleSecretWrite(
+      { writer, audit },
+      { customerSlug: 'smith-pi-firm', connector: 'CourtAccess', secret: RAW_SECRET },
+      { actor: 'partner@firm.com', actorRole: 'principal' }
+    )
+    expect(audits).toHaveLength(1)
+    expect(JSON.stringify(audits[0]).includes(RAW_SECRET)).toBe(false)
+    expect(audits[0].masked).toBe(maskSecret(RAW_SECRET))
+    expect(audits[0].actor).toBe('partner@firm.com')
+  })
+
+  it('does not call the writer or audit on invalid input', async () => {
+    const { writer, audit, writes, audits } = makeSpies()
+    const result = await handleSecretWrite(
+      { writer, audit },
+      { customerSlug: 's', connector: 'NotReal', secret: RAW_SECRET },
+      { actor: 'x', actorRole: 'principal' }
+    )
+    expect(result).toEqual<SecretWriteResult>({ ok: false, error: 'invalid_connector' })
+    expect(writes).toHaveLength(0)
+    expect(audits).toHaveLength(0)
+  })
+
+  it('collapses a transport throw to write_failed without leaking the thrown detail', async () => {
+    // A hostile/buggy transport that embeds the secret in its thrown error —
+    // the core must not surface it.
+    const writer: CustomerSecretWriter = {
+      write: async (input) => {
+        throw new Error(`upstream rejected value=${input.secret}`)
+      },
+    }
+    const audits: Array<Record<string, string>> = []
+    const audit: CredentialSecretAudit = { record: async (r) => void audits.push(r) }
+    const result = await handleSecretWrite(
+      { writer, audit },
+      { customerSlug: 'smith-pi-firm', connector: 'CourtAccess', secret: RAW_SECRET },
+      { actor: 'partner@firm.com', actorRole: 'principal' }
+    )
+    expect(result).toEqual<SecretWriteResult>({ ok: false, error: 'write_failed' })
+    expect(JSON.stringify(result).includes(RAW_SECRET)).toBe(false)
+    // No audit row is written on failure (no secret was stored).
+    expect(audits).toHaveLength(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// createSecretAudit — D1-backed sink writes a value-free row
+// ---------------------------------------------------------------------------
+
+describe('createSecretAudit (D1)', () => {
+  it('persists a connector_secret_audit row with the masked tail and no value', async () => {
+    const db = createTestD1()
+    await runMigrations(db, {
+      files: discoverNumericMigrations(resolve(process.cwd(), 'migrations')),
+    })
+    const audit = createSecretAudit(db, { entityId: 'entity-1', actorUserId: 'user-1' })
+    await audit.record({
+      customerSlug: 'smith-pi-firm',
+      connector: 'CourtAccess',
+      actor: 'partner@firm.com',
+      actorRole: 'principal',
+      masked: maskSecret(RAW_SECRET),
+      ref: 'infisical:/operator/smith-pi-firm/CourtAccess/api-key',
+    })
+    const row = await db
+      .prepare('SELECT * FROM connector_secret_audit WHERE customer_slug = ?')
+      .bind('smith-pi-firm')
+      .first<Record<string, unknown>>()
+    expect(row).not.toBeNull()
+    expect(row?.connector).toBe('CourtAccess')
+    expect(row?.masked_tail).toBe(maskSecret(RAW_SECRET))
+    expect(row?.actor_email).toBe('partner@firm.com')
+    // The whole row, serialized, cannot contain the raw value — no column holds it.
+    expect(JSON.stringify(row).includes(RAW_SECRET)).toBe(false)
+  })
+})

--- a/tests/operator-domain-surface.test.ts
+++ b/tests/operator-domain-surface.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Tests for the dual-mode surface resolver (domain-surface.ts) and the
+ * change-request model (change-request.ts) — ADR 0041 §4.3, the Read+Request
+ * half of the authority design.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  createTestD1,
+  runMigrations,
+  discoverNumericMigrations,
+} from '@venturecrane/crane-test-harness'
+import { resolve } from 'path'
+import type { D1Database } from '@cloudflare/workers-types'
+import { ORG_ID } from '../src/lib/constants'
+import type { AuthorityPosture } from '../src/lib/operator/authority'
+import {
+  resolveDomainSurface,
+  resolveDomainSurfaceMode,
+} from '../src/lib/portal/operator/domain-surface'
+import {
+  createChangeRequest,
+  listChangeRequestsForCustomer,
+  listOpenChangeRequests,
+  updateChangeRequestStatus,
+} from '../src/lib/portal/operator/change-request'
+
+// ---------------------------------------------------------------------------
+// Dual-mode resolver
+// ---------------------------------------------------------------------------
+
+const MANAGED: AuthorityPosture = { default: 'managed', overrides: {} }
+const PEOPLE_CLIENT: AuthorityPosture = {
+  default: 'managed',
+  overrides: { people_access: 'client' },
+}
+
+describe('resolveDomainSurfaceMode (Layer 1 ∧ Layer 2)', () => {
+  it('is read_request when the authority switch is managed, even if the role permits', () => {
+    expect(resolveDomainSurfaceMode(MANAGED, 'people_access', true)).toBe('read_request')
+  })
+
+  it('is read_request when the switch is client but the role does not permit', () => {
+    expect(resolveDomainSurfaceMode(PEOPLE_CLIENT, 'people_access', false)).toBe('read_request')
+  })
+
+  it('is operable only when the switch is client AND the role permits', () => {
+    expect(resolveDomainSurfaceMode(PEOPLE_CLIENT, 'people_access', true)).toBe('operable')
+  })
+
+  it('a null posture is never operable (launch-safe)', () => {
+    expect(resolveDomainSurfaceMode(null, 'connectors', true)).toBe('read_request')
+  })
+})
+
+describe('resolveDomainSurface (visibility + mode)', () => {
+  it('cost is never visible to the client', () => {
+    const s = resolveDomainSurface(MANAGED, 'cost', true)
+    expect(s.visible).toBe(false)
+  })
+
+  it('provisioning is visible but never operable (SMD-only)', () => {
+    const s = resolveDomainSurface(MANAGED, 'provisioning', true)
+    expect(s).toEqual({ visible: true, mode: 'read_request' })
+  })
+
+  it('a switchable client domain with role permission is operable', () => {
+    const s = resolveDomainSurface(PEOPLE_CLIENT, 'people_access', true)
+    expect(s).toEqual({ visible: true, mode: 'operable' })
+  })
+
+  it('a switchable managed domain is visible read_request', () => {
+    const s = resolveDomainSurface(MANAGED, 'connectors', true)
+    expect(s).toEqual({ visible: true, mode: 'read_request' })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Change-request store
+// ---------------------------------------------------------------------------
+
+const migrationsDir = resolve(process.cwd(), 'migrations')
+const ENTITY_ID = 'entity-cr'
+const SLUG = 'smith-pi-firm'
+
+async function freshDb(): Promise<D1Database> {
+  const db = createTestD1()
+  await runMigrations(db, { files: discoverNumericMigrations(migrationsDir) })
+  await db
+    .prepare('INSERT INTO entities (id, org_id, name, slug) VALUES (?, ?, ?, ?)')
+    .bind(ENTITY_ID, ORG_ID, 'Smith PI Firm', SLUG)
+    .run()
+  return db
+}
+
+const baseInput = {
+  entity_id: ENTITY_ID,
+  customer_slug: SLUG,
+  requested_by_user_id: 'user-1',
+  requested_by_email: 'partner@firm.com',
+}
+
+describe('createChangeRequest', () => {
+  it('files a request for a valid switchable domain', async () => {
+    const db = await freshDb()
+    const r = await createChangeRequest(db, {
+      ...baseInput,
+      domain: 'connectors',
+      summary: 'Please connect our Clio.',
+    })
+    expect(r.ok).toBe(true)
+    if (!r.ok) return
+    expect(r.id).toBeGreaterThan(0)
+  })
+
+  it('rejects an invalid domain (not a switchable authority domain)', async () => {
+    const db = await freshDb()
+    const r = await createChangeRequest(db, {
+      ...baseInput,
+      domain: 'cost',
+      summary: 'show me cost',
+    })
+    expect(r).toEqual({ ok: false, error: 'invalid_domain' })
+  })
+
+  it('rejects an empty summary', async () => {
+    const db = await freshDb()
+    const r = await createChangeRequest(db, {
+      ...baseInput,
+      domain: 'people_access',
+      summary: '   ',
+    })
+    expect(r).toEqual({ ok: false, error: 'empty_summary' })
+  })
+})
+
+describe('change-request read + lifecycle', () => {
+  it('lists a customer’s own requests and the admin open inbox', async () => {
+    const db = await freshDb()
+    await createChangeRequest(db, { ...baseInput, domain: 'connectors', summary: 'connect Clio' })
+    await createChangeRequest(db, { ...baseInput, domain: 'memory', summary: 'review a rule' })
+    const mine = await listChangeRequestsForCustomer(db, SLUG)
+    expect(mine).toHaveLength(2)
+    const inbox = await listOpenChangeRequests(db)
+    expect(inbox).toHaveLength(2)
+    expect(inbox.every((r) => r.status === 'open')).toBe(true)
+  })
+
+  it('resolving stamps the resolver and drops it from the open inbox', async () => {
+    const db = await freshDb()
+    const created = await createChangeRequest(db, {
+      ...baseInput,
+      domain: 'connectors',
+      summary: 'connect Clio',
+    })
+    if (!created.ok) throw new Error('setup failed')
+    const ok = await updateChangeRequestStatus(db, {
+      id: created.id,
+      status: 'resolved',
+      resolved_by_email: 'smd@smd.services',
+      resolution_note: 'Connected.',
+    })
+    expect(ok).toBe(true)
+    const inbox = await listOpenChangeRequests(db)
+    expect(inbox).toHaveLength(0)
+    const mine = await listChangeRequestsForCustomer(db, SLUG)
+    expect(mine[0].status).toBe('resolved')
+    expect(mine[0].resolved_by_email).toBe('smd@smd.services')
+    expect(mine[0].resolved_at).not.toBeNull()
+  })
+
+  it('acknowledged keeps the request in the inbox without a resolver stamp', async () => {
+    const db = await freshDb()
+    const created = await createChangeRequest(db, {
+      ...baseInput,
+      domain: 'connectors',
+      summary: 'connect Clio',
+    })
+    if (!created.ok) throw new Error('setup failed')
+    await updateChangeRequestStatus(db, {
+      id: created.id,
+      status: 'acknowledged',
+      resolved_by_email: 'smd@smd.services',
+      resolution_note: null,
+    })
+    const inbox = await listOpenChangeRequests(db)
+    expect(inbox).toHaveLength(1)
+    expect(inbox[0].resolved_at).toBeNull()
+  })
+
+  it('returns false when updating a non-existent request', async () => {
+    const db = await freshDb()
+    const ok = await updateChangeRequestStatus(db, {
+      id: 9999,
+      status: 'resolved',
+      resolved_by_email: 'smd@smd.services',
+      resolution_note: null,
+    })
+    expect(ok).toBe(false)
+  })
+})

--- a/tests/operator-runtime-read.test.ts
+++ b/tests/operator-runtime-read.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Tests for the runtime read path (ADR 0043).
+ *  - path A: the live console→Machine read client (runtime-read.ts) — the
+ *    fail-closed, audited, single-customer contract.
+ *  - path B: the console-side summary reader + staleness (runtime-summary.ts).
+ *
+ * The load-bearing assertions are the path-A invariants: a read always audits,
+ * a transport failure fails closed (never throws into the caller), and an auth
+ * failure is distinguished from unreachability.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  createTestD1,
+  runMigrations,
+  discoverNumericMigrations,
+} from '@venturecrane/crane-test-harness'
+import { resolve } from 'path'
+import type { D1Database } from '@cloudflare/workers-types'
+import { ORG_ID } from '../src/lib/constants'
+import {
+  RuntimeReadUnauthorizedError,
+  readMachineRuntime,
+  type MachineRuntimeTransport,
+  type RuntimeReadAudit,
+  type RuntimeReadResult,
+} from '../src/lib/operator/runtime-read'
+import {
+  createRuntimeReadAudit,
+  isRuntimeReadConfigured,
+} from '../src/lib/operator/runtime-read-transport'
+import {
+  getRuntimeSummary,
+  listRuntimeSummary,
+  summaryFreshness,
+  DEFAULT_SUMMARY_STALE_SECONDS,
+} from '../src/lib/admin/runtime-summary'
+
+const migrationsDir = resolve(process.cwd(), 'migrations')
+
+async function freshDb(): Promise<D1Database> {
+  const db = createTestD1()
+  await runMigrations(db, { files: discoverNumericMigrations(migrationsDir) })
+  return db
+}
+
+const ACTOR = { actor: 'smd-staff@smd.services', actorRole: 'smd_operator' }
+
+function auditSpy() {
+  const rows: Array<Record<string, string>> = []
+  const audit: RuntimeReadAudit = { record: async (r) => void rows.push(r) }
+  return { audit, rows }
+}
+
+// ---------------------------------------------------------------------------
+// Path A — readMachineRuntime
+// ---------------------------------------------------------------------------
+
+describe('readMachineRuntime', () => {
+  it('returns the data and audits an ok outcome on success', async () => {
+    const transport: MachineRuntimeTransport = {
+      read: async (slug, query) => ({ data: { slug, kind: query.kind, rows: [] } }),
+    }
+    const { audit, rows } = auditSpy()
+    const result = await readMachineRuntime(
+      { transport, audit },
+      'smith-pi-firm',
+      { kind: 'audit_log' },
+      ACTOR
+    )
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.kind).toBe('audit_log')
+    expect(rows).toHaveLength(1)
+    expect(rows[0].outcome).toBe('ok')
+    expect(rows[0].customerSlug).toBe('smith-pi-firm')
+  })
+
+  it('fails closed (unreachable) when the transport throws — never throws into the caller', async () => {
+    const transport: MachineRuntimeTransport = {
+      read: async () => {
+        throw new Error('connect ETIMEDOUT')
+      },
+    }
+    const { audit, rows } = auditSpy()
+    const result = await readMachineRuntime(
+      { transport, audit },
+      'smith-pi-firm',
+      { kind: 'draft', id: 'd1' },
+      ACTOR
+    )
+    expect(result).toEqual<RuntimeReadResult>({
+      ok: false,
+      kind: 'draft',
+      reason: 'unreachable',
+    })
+    expect(rows[0].outcome).toBe('unreachable')
+  })
+
+  it('distinguishes unauthorized from unreachable', async () => {
+    const transport: MachineRuntimeTransport = {
+      read: async () => {
+        throw new RuntimeReadUnauthorizedError()
+      },
+    }
+    const { audit, rows } = auditSpy()
+    const result = await readMachineRuntime(
+      { transport, audit },
+      'smith-pi-firm',
+      { kind: 'matter', id: 'm1' },
+      ACTOR
+    )
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.reason).toBe('unauthorized')
+    expect(rows[0].outcome).toBe('unauthorized')
+  })
+
+  it('still returns the read result even when the audit write fails', async () => {
+    const transport: MachineRuntimeTransport = { read: async () => ({ data: { ok: true } }) }
+    const audit: RuntimeReadAudit = {
+      record: async () => {
+        throw new Error('audit D1 down')
+      },
+    }
+    const result = await readMachineRuntime(
+      { transport, audit },
+      'smith-pi-firm',
+      { kind: 'activity' },
+      ACTOR
+    )
+    expect(result.ok).toBe(true)
+  })
+
+  it('is not configured by default (no env binding)', () => {
+    expect(isRuntimeReadConfigured({})).toBe(false)
+    expect(isRuntimeReadConfigured({ OPERATOR_RUNTIME_READ_URL: 'https://x' })).toBe(true)
+  })
+})
+
+describe('createRuntimeReadAudit (D1)', () => {
+  it('writes one append-only read-audit row per attempt', async () => {
+    const db = await freshDb()
+    const audit = createRuntimeReadAudit(db, { actorUserId: 'user-9' })
+    await audit.record({
+      customerSlug: 'smith-pi-firm',
+      actor: 'smd-staff@smd.services',
+      actorRole: 'smd_operator',
+      kind: 'audit_log',
+      outcome: 'ok',
+    })
+    const row = await db
+      .prepare('SELECT * FROM operator_runtime_read_audit WHERE customer_slug = ?')
+      .bind('smith-pi-firm')
+      .first<Record<string, unknown>>()
+    expect(row?.actor_user_id).toBe('user-9')
+    expect(row?.kind).toBe('audit_log')
+    expect(row?.outcome).toBe('ok')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Path B — runtime summary store
+// ---------------------------------------------------------------------------
+
+async function seedEntity(db: D1Database, id: string, slug: string): Promise<void> {
+  await db
+    .prepare('INSERT INTO entities (id, org_id, name, slug) VALUES (?, ?, ?, ?)')
+    .bind(id, ORG_ID, slug, slug)
+    .run()
+}
+
+async function seedSummary(
+  db: D1Database,
+  opts: { entity_id: string; customer_slug: string; status?: string; open_alerts?: number }
+): Promise<void> {
+  await db
+    .prepare(
+      `INSERT INTO operator_runtime_summary
+         (entity_id, customer_slug, summary_status, open_alerts, draft_queue_depth,
+          last_activity_ts, pushed_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`
+    )
+    .bind(
+      opts.entity_id,
+      opts.customer_slug,
+      opts.status ?? 'green',
+      opts.open_alerts ?? 0,
+      null,
+      '2026-06-08T12:00:00.000Z',
+      '2026-06-08T12:00:00.000Z'
+    )
+    .run()
+}
+
+describe('runtime summary store', () => {
+  it('lists per-customer summaries ordered by slug', async () => {
+    const db = await freshDb()
+    await seedEntity(db, 'e-b', 'beta-firm')
+    await seedEntity(db, 'e-a', 'alpha-firm')
+    await seedSummary(db, { entity_id: 'e-b', customer_slug: 'beta-firm', open_alerts: 2 })
+    await seedSummary(db, { entity_id: 'e-a', customer_slug: 'alpha-firm' })
+    const rows = await listRuntimeSummary(db)
+    expect(rows.map((r) => r.customer_slug)).toEqual(['alpha-firm', 'beta-firm'])
+    expect(rows[1].open_alerts).toBe(2)
+  })
+
+  it('reads one summary by slug, null when absent', async () => {
+    const db = await freshDb()
+    await seedEntity(db, 'e-a', 'alpha-firm')
+    await seedSummary(db, { entity_id: 'e-a', customer_slug: 'alpha-firm', status: 'yellow' })
+    const found = await getRuntimeSummary(db, 'alpha-firm')
+    expect(found?.summary_status).toBe('yellow')
+    expect(await getRuntimeSummary(db, 'nobody')).toBeNull()
+  })
+})
+
+describe('summaryFreshness', () => {
+  const base = new Date('2026-06-08T12:00:00.000Z')
+
+  it('flags no-summary state', () => {
+    expect(summaryFreshness(null, DEFAULT_SUMMARY_STALE_SECONDS, base).stale).toBe(true)
+  })
+
+  it('is fresh within the staleness window', () => {
+    const pushed = new Date(base.getTime() - 60_000).toISOString()
+    const f = summaryFreshness(pushed, DEFAULT_SUMMARY_STALE_SECONDS, base)
+    expect(f.stale).toBe(false)
+    expect(f.label).toContain('ago')
+  })
+
+  it('is stale past the window and never lies reassuringly', () => {
+    const pushed = new Date(base.getTime() - 3600_000).toISOString()
+    const f = summaryFreshness(pushed, DEFAULT_SUMMARY_STALE_SECONDS, base)
+    expect(f.stale).toBe(true)
+    expect(f.label).toContain('stale')
+  })
+})


### PR DESCRIPTION
The shared, frozen contracts both Operator portals build against — authored seam-first so the admin and client portal teams can build leaf surfaces in parallel without diverging. Four interdependent units, built and verified together.

## What's in this PR

### 1. Authority posture — ADR 0041
The Layer-1 keystone every client surface and the admin per-client view import.
- `src/lib/operator/authority.ts` — pure resolver (`resolveDomainAuthority`, `isClientOperable`, `canClientRead`, `resolveAllDomains`) + fail-safe `parseAuthorityPosture`. Launch-safe by construction: absent/unconfigured → `managed` for every domain.
- Strict section validator (`sections-authority.ts`) + `customer_configs` projection (migration **0049**).
- Authority is **locked** in the client config editor — a client cannot self-grant authority (privilege-escalation guard).

### 2. Credential custody — ADR 0042
- Per-connector `credential_custody` + client-level `credential_custody_default` (migration **0050**) + resolver (per-connector → client default → `delegated`).
- **Write-only static-secret core** (`credential-secret-write.ts`): the §Verification 3 guarantee, proven in isolation — a client-entered key never reaches the result, the audit row, or a failure path; only a masked tail. Value-free audit table (**0051**).
- Portal endpoint with server-side connectors-authority enforcement + an honest `not_enabled` gate. The Fly-secret relay (ADR 0036) is an injected seam, never a silently-failing stub.

### 3. Runtime read path — ADR 0043 (A+B)
- **B** (mirror): console-side per-customer summary store (**0052**) generalizing the `fleet_status` pattern + reader with no-lie staleness + Machine push endpoint.
- **A** (live): the frozen console→Machine read client (`runtime-read.ts`) — single-customer, read-only, audited (**0053**), fail-closed on unreachable — behind an injected transport seam. Surfaces render honest empty states until wired.

### 4. Dual-mode surface — ADR 0041 §4.3
- `resolveDomainSurface` / `resolveDomainSurfaceMode` — Operable vs Read+Request (Layer 1 authority ∧ Layer 2 RBAC), the contract every client domain surface wraps.
- Change-request inbox model (**0054**) the Read+Request mode files into.

### Incidental hardening
`parseJsonNullable` now treats an absent column (`undefined`) like SQL `NULL`, so a row predating a projection column never crashes a render.

## Design posture
Security-sensitive transports (the Fly secret relay, the Machine read endpoint) are **injected seams gated `not_enabled` until wired** — never silently-failing stubs. No-leak and fail-closed invariants are tested against spies with zero infra. The two integration steps are isolated to one function each.

## Verification
- **3084 tests passing**, 0 type errors, 0 lint errors.
- New tests: `operator-authority`, `operator-credential-custody`, `operator-runtime-read`, `operator-domain-surface`, plus authority + custody cases in `customer-yaml-validator`.

## Follow-ons (leaf surfaces, build against these frozen contracts)
The admin and client portal leaf surfaces; the two transport integrations (Fly secret relay, Machine read endpoint); the Astro `<DomainSurface>` presentational wrapper over `resolveDomainSurface`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)