### PR TITLE
refactor(operator): rename client role operator→staff (portal foundation #0)

### DIFF
--- a/migrations/0065_rename_product_role_operator_to_staff.sql
+++ b/migrations/0065_rename_product_role_operator_to_staff.sql
@@ -1,0 +1,37 @@
+-- ============================================================================
+-- Migration 0065: rename product_roles.role 'operator' -> 'staff'
+-- ============================================================================
+--
+-- The client-internal human role formerly named 'operator' is renamed to
+-- 'staff' to stop it colliding with the product name "Operator". The role
+-- vocabulary is now principal | staff | compliance.
+--   - docs/design/operator/02-client-portal.md §2 (Captain-resolved 2026-06-08)
+--   - docs/design/operator/00-foundations.md §2 (Layer 2 RBAC)
+--
+-- Migration 0048 deliberately DEFERRED this rename. It migrated
+-- subscriptions/product_roles.product_slug to 'operator' (the product) but
+-- explicitly left product_roles.role = 'operator' (the HUMAN role) untouched,
+-- noting it was unrelated to the product slug. This migration completes that
+-- deferred rename.
+--
+-- TABLE TOUCHED:
+--   product_roles.role  — the human-role value ONLY.
+--
+-- NOT TOUCHED:
+--   product_roles.product_slug / subscriptions.product_slug  — the value
+--     'operator' there is the PRODUCT, set by migration 0048. It stays.
+--
+-- There is no CHECK constraint on product_roles.role (migration 0038), so this
+-- is a pure data UPDATE — no schema change. Idempotent and safe on zero rows
+-- (pre-launch: no client role grants are expected in production yet).
+--
+-- DEPLOY COORDINATION: ships in the same deploy as the role-rename code, which
+-- now resolves access against the 'staff' role. After the code lands, an
+-- existing grant of 'operator' would no longer match any allowedRoles list;
+-- this migration realigns existing rows. Code + migration must land together.
+--
+-- ROLLBACK (manual, if the code PR is reverted):
+--   UPDATE product_roles SET role = 'operator' WHERE role = 'staff';
+-- ============================================================================
+
+UPDATE product_roles SET role = 'staff' WHERE role = 'operator';

--- a/src/lib/operator/customer-yaml/types.ts
+++ b/src/lib/operator/customer-yaml/types.ts
@@ -166,7 +166,7 @@ export const ACCEPTED_ACTION_CLASSES = [
 ] as const
 export type ActionClass = (typeof ACCEPTED_ACTION_CLASSES)[number]
 
-export const ACCEPTED_USER_ROLES = ['principal', 'operator', 'compliance'] as const
+export const ACCEPTED_USER_ROLES = ['principal', 'staff', 'compliance'] as const
 export type UserRole = (typeof ACCEPTED_USER_ROLES)[number]
 
 export const ACCEPTED_PERSONA_STATUSES = ['active', 'archived'] as const

--- a/src/lib/portal/operator-access.ts
+++ b/src/lib/portal/operator-access.ts
@@ -11,7 +11,7 @@
  *   4. Caller holds at least one allowed role → otherwise landing page (no_role state)
  *
  * Each surface differs only in which roles it accepts. Drafts, matters, and calendar are
- * for active users (operator or principal); audit is open to all three roles since
+ * for active users (staff or principal); audit is open to all three roles since
  * compliance is the dedicated viewer; settings is principal-only.
  *
  * Status check: this helper treats provisioning, active, and paused subscriptions as
@@ -44,7 +44,7 @@ export type OperatorAccess =
 export interface ResolveOperatorAccessOptions {
   /**
    * Roles that grant access to the surface. Any one match is enough. Pass the
-   * canonical product_roles vocabulary values (`principal`, `operator`,
+   * canonical product_roles vocabulary values (`principal`, `staff`,
    * `compliance`) — typos will silently 401 every visitor.
    */
   allowedRoles: readonly string[]

--- a/src/lib/portal/operator/audit.ts
+++ b/src/lib/portal/operator/audit.ts
@@ -135,11 +135,11 @@ export const AUDIT_DECISIONS: readonly AuditDecision[] = [
  * action. Mirrors `operator/adapter/audit_log.py::ActorRole`. The
  * column itself is nullable in the writer; null surfaces as `null` here.
  */
-export type AuditActorRole = 'principal' | 'operator' | 'compliance' | 'agent' | 'captain'
+export type AuditActorRole = 'principal' | 'staff' | 'compliance' | 'agent' | 'captain'
 
 export const AUDIT_ACTOR_ROLES: readonly AuditActorRole[] = [
   'principal',
-  'operator',
+  'staff',
   'compliance',
   'agent',
   'captain',

--- a/src/lib/portal/product-roles-mutations.ts
+++ b/src/lib/portal/product-roles-mutations.ts
@@ -12,7 +12,7 @@
  * returns true.
  */
 
-const ALLOWED_OPERATOR_ROLES = ['principal', 'operator', 'compliance'] as const
+const ALLOWED_OPERATOR_ROLES = ['principal', 'staff', 'compliance'] as const
 export type OperatorRole = (typeof ALLOWED_OPERATOR_ROLES)[number]
 
 export function isOperatorRole(value: unknown): value is OperatorRole {

--- a/src/pages/api/portal/operator/notifications/[id]/mark-read.ts
+++ b/src/pages/api/portal/operator/notifications/[id]/mark-read.ts
@@ -72,7 +72,7 @@ export const POST: APIRoute = async ({ params, request, locals }) => {
   }
 
   const access = await resolveOperatorAccess(env.DB, locals, {
-    allowedRoles: ['principal', 'operator', 'compliance'],
+    allowedRoles: ['principal', 'staff', 'compliance'],
   })
   if (access.kind === 'redirect') {
     // Auth failure: the caller must sign in / pick an org / activate

--- a/src/pages/api/portal/operator/notifications/mark-all-read.ts
+++ b/src/pages/api/portal/operator/notifications/mark-all-read.ts
@@ -60,7 +60,7 @@ function withMarkedParam(target: string, marked: number): string {
 
 export const POST: APIRoute = async ({ request, locals }) => {
   const access = await resolveOperatorAccess(env.DB, locals, {
-    allowedRoles: ['principal', 'operator', 'compliance'],
+    allowedRoles: ['principal', 'staff', 'compliance'],
   })
   if (access.kind === 'redirect') {
     return new Response(null, {

--- a/src/pages/portal/products/operator/audit/index.astro
+++ b/src/pages/portal/products/operator/audit/index.astro
@@ -76,7 +76,7 @@ const { client, subscription, roles } = access
 // Belt-and-braces role check per the issue's explicit requirement: the
 // audit log is sensitive and the surface must verify the resolved role
 // is principal OR compliance even though resolveOperatorAccess
-// already enforces this via allowedRoles. The failure mode (operator
+// already enforces this via allowedRoles. The failure mode (staff
 // or a future role accidentally seeing org-wide audit) is bad enough
 // that the redundant assertion is worth keeping.
 const hasAuditRole = roles.includes('principal') || roles.includes('compliance')

--- a/src/pages/portal/products/operator/calendar/index.astro
+++ b/src/pages/portal/products/operator/calendar/index.astro
@@ -61,7 +61,7 @@ import { env } from 'cloudflare:workers'
  */
 
 const access = await resolveOperatorAccess(env.DB, Astro.locals, {
-  allowedRoles: ['principal', 'operator', 'compliance'],
+  allowedRoles: ['principal', 'staff', 'compliance'],
 })
 if (access.kind === 'redirect') {
   return Astro.redirect(access.to)

--- a/src/pages/portal/products/operator/drafts/[id].astro
+++ b/src/pages/portal/products/operator/drafts/[id].astro
@@ -55,7 +55,7 @@ import { env } from 'cloudflare:workers'
  */
 
 const access = await resolveOperatorAccess(env.DB, Astro.locals, {
-  allowedRoles: ['operator', 'principal'],
+  allowedRoles: ['staff', 'principal'],
 })
 if (access.kind === 'redirect') {
   return Astro.redirect(access.to)

--- a/src/pages/portal/products/operator/drafts/index.astro
+++ b/src/pages/portal/products/operator/drafts/index.astro
@@ -48,7 +48,7 @@ import { env } from 'cloudflare:workers'
  */
 
 const access = await resolveOperatorAccess(env.DB, Astro.locals, {
-  allowedRoles: ['operator', 'principal'],
+  allowedRoles: ['staff', 'principal'],
 })
 if (access.kind === 'redirect') {
   return Astro.redirect(access.to)

--- a/src/pages/portal/products/operator/index.astro
+++ b/src/pages/portal/products/operator/index.astro
@@ -36,7 +36,7 @@ import { env } from 'cloudflare:workers'
  *   3. Active subscription on (entity, 'operator') in the
  *      subscriptions table
  *   4. At least one role granted on (user, entity, 'operator') in
- *      product_roles — vocabulary: principal | operator | compliance
+ *      product_roles — vocabulary: principal | staff | compliance
  *
  * Anything less degrades to the appropriate empty state per
  * docs/style/empty-state-pattern.md. No fabrication.
@@ -116,7 +116,7 @@ const customerConfig = access ? await getCustomerConfig(env.DB, client.id) : nul
 const complianceViewEnabled = customerConfig?.compliance_enabled ?? false
 if (access) {
   const userRoles = access.roles
-  const ACTIVE_DOER_ROLES = ['operator', 'principal']
+  const ACTIVE_DOER_ROLES = ['staff', 'principal']
   const canAct = userRoles.some((r) => ACTIVE_DOER_ROLES.includes(r))
   if (canAct) {
     sectionCards.push({

--- a/src/pages/portal/products/operator/matters/[id].astro
+++ b/src/pages/portal/products/operator/matters/[id].astro
@@ -72,7 +72,7 @@ import {
 const PRODUCT_SLUG = 'operator'
 
 const access = await resolveOperatorAccess(env.DB, Astro.locals, {
-  allowedRoles: ['principal', 'operator', 'compliance'],
+  allowedRoles: ['principal', 'staff', 'compliance'],
 })
 if (access.kind === 'redirect') {
   return Astro.redirect(access.to)

--- a/src/pages/portal/products/operator/matters/index.astro
+++ b/src/pages/portal/products/operator/matters/index.astro
@@ -62,7 +62,7 @@ import {
  */
 
 const access = await resolveOperatorAccess(env.DB, Astro.locals, {
-  allowedRoles: ['principal', 'operator', 'compliance'],
+  allowedRoles: ['principal', 'staff', 'compliance'],
 })
 if (access.kind === 'redirect') {
   return Astro.redirect(access.to)

--- a/src/pages/portal/products/operator/notifications/index.astro
+++ b/src/pages/portal/products/operator/notifications/index.astro
@@ -66,7 +66,7 @@ import { env } from 'cloudflare:workers'
  */
 
 const access = await resolveOperatorAccess(env.DB, Astro.locals, {
-  allowedRoles: ['principal', 'operator', 'compliance'],
+  allowedRoles: ['principal', 'staff', 'compliance'],
 })
 if (access.kind === 'redirect') {
   return Astro.redirect(access.to)

--- a/src/pages/portal/products/operator/settings/notifications.astro
+++ b/src/pages/portal/products/operator/settings/notifications.astro
@@ -59,7 +59,7 @@ import {
  */
 
 const access = await resolveOperatorAccess(env.DB, Astro.locals, {
-  allowedRoles: ['principal', 'operator', 'compliance'],
+  allowedRoles: ['principal', 'staff', 'compliance'],
 })
 if (access.kind === 'redirect') {
   return Astro.redirect(access.to)

--- a/src/pages/portal/products/operator/settings/pto.astro
+++ b/src/pages/portal/products/operator/settings/pto.astro
@@ -41,7 +41,7 @@ import { getActivePto, listActivePto } from '../../../../../lib/portal/operator/
 const PRODUCT_SLUG = 'operator'
 
 const access = await resolveOperatorAccess(env.DB, Astro.locals, {
-  allowedRoles: ['principal', 'operator', 'compliance'],
+  allowedRoles: ['principal', 'staff', 'compliance'],
 })
 if (access.kind === 'redirect') {
   return Astro.redirect(access.to)

--- a/src/pages/portal/products/operator/settings/users.astro
+++ b/src/pages/portal/products/operator/settings/users.astro
@@ -145,7 +145,7 @@ for (const m of members) {
   m.roles.sort((a, b) => (ROLE_ORDER[a] ?? 99) - (ROLE_ORDER[b] ?? 99))
 }
 
-const ALL_ROLES = ['principal', 'operator', 'compliance'] as const
+const ALL_ROLES = ['principal', 'staff', 'compliance'] as const
 
 function formatLastLogin(iso: string | null): string {
   if (!iso) return 'Never'

--- a/tests/customer-yaml-validator.test.ts
+++ b/tests/customer-yaml-validator.test.ts
@@ -54,7 +54,7 @@ function validFixture(): Record<string, unknown> {
     },
     users: [
       { email: 'partner@firm.com', role: 'principal', full_name: 'Jane Smith' },
-      { email: 'paralegal@firm.com', role: 'operator', full_name: 'Pat Lee' },
+      { email: 'paralegal@firm.com', role: 'staff', full_name: 'Pat Lee' },
     ],
     personas: [
       {

--- a/tests/forbidden-strings.test.ts
+++ b/tests/forbidden-strings.test.ts
@@ -406,7 +406,7 @@ const LIST_INDEX_ALLOWLIST: string[] = [
   // `products/operator/index.astro` is the Operator dashboard
   // landing (one customer per render), not a list of products. The
   // small `.map(roles, …)` inside the sidebar renders a bullet list of
-  // granted role names (principal / operator / compliance) — text
+  // granted role names (principal / staff / compliance) — text
   // items inside a chrome card, not a list-row card surface.
   resolve('src/pages/portal/products/operator/index.astro'),
   // `products/operator/matters/index.astro` (#871) iterates matters

--- a/tests/operator-access.test.ts
+++ b/tests/operator-access.test.ts
@@ -139,7 +139,7 @@ describe('resolveOperatorAccess', () => {
     vi.mocked(getPortalClient).mockResolvedValue(null)
 
     const result = await resolveOperatorAccess(db, fakeLocals, {
-      allowedRoles: ['operator', 'principal'],
+      allowedRoles: ['staff', 'principal'],
     })
 
     expect(result.kind).toBe('redirect')
@@ -155,7 +155,7 @@ describe('resolveOperatorAccess', () => {
     })
 
     const result = await resolveOperatorAccess(db, fakeLocals, {
-      allowedRoles: ['operator', 'principal'],
+      allowedRoles: ['staff', 'principal'],
     })
 
     expect(result.kind).toBe('redirect')
@@ -173,7 +173,7 @@ describe('resolveOperatorAccess', () => {
     })
 
     const result = await resolveOperatorAccess(db, fakeLocals, {
-      allowedRoles: ['operator', 'principal'],
+      allowedRoles: ['staff', 'principal'],
     })
 
     expect(result.kind).toBe('redirect')
@@ -193,7 +193,7 @@ describe('resolveOperatorAccess', () => {
     })
 
     const result = await resolveOperatorAccess(db, fakeLocals, {
-      allowedRoles: ['operator', 'principal'],
+      allowedRoles: ['staff', 'principal'],
     })
 
     expect(result.kind).toBe('redirect')
@@ -213,7 +213,7 @@ describe('resolveOperatorAccess', () => {
     })
 
     const result = await resolveOperatorAccess(db, fakeLocals, {
-      allowedRoles: ['operator', 'principal'],
+      allowedRoles: ['staff', 'principal'],
     })
 
     expect(result.kind).toBe('redirect')
@@ -234,7 +234,7 @@ describe('resolveOperatorAccess', () => {
 
     // Drafts allows operator | principal only — compliance must be redirected
     const result = await resolveOperatorAccess(db, fakeLocals, {
-      allowedRoles: ['operator', 'principal'],
+      allowedRoles: ['staff', 'principal'],
     })
 
     expect(result.kind).toBe('redirect')
@@ -254,7 +254,7 @@ describe('resolveOperatorAccess', () => {
     })
 
     const result = await resolveOperatorAccess(db, fakeLocals, {
-      allowedRoles: ['operator', 'principal'],
+      allowedRoles: ['staff', 'principal'],
     })
 
     expect(result.kind).toBe('allowed')
@@ -270,19 +270,19 @@ describe('resolveOperatorAccess', () => {
     await seedEntity(db)
     await seedUser(db, USER_ID, 'operator@firm.com')
     await seedSubscription(db, 'active')
-    await grantRole(db, USER_ID, 'operator')
+    await grantRole(db, USER_ID, 'staff')
     vi.mocked(getPortalClient).mockResolvedValue({
       user: mockUser(USER_ID, 'operator@firm.com'),
       client: mockClient(),
     })
 
     const result = await resolveOperatorAccess(db, fakeLocals, {
-      allowedRoles: ['operator', 'principal'],
+      allowedRoles: ['staff', 'principal'],
     })
 
     expect(result.kind).toBe('allowed')
     if (result.kind === 'allowed') {
-      expect(result.roles).toContain('operator')
+      expect(result.roles).toContain('staff')
     }
   })
 
@@ -297,7 +297,7 @@ describe('resolveOperatorAccess', () => {
     })
 
     const result = await resolveOperatorAccess(db, fakeLocals, {
-      allowedRoles: ['operator', 'principal'],
+      allowedRoles: ['staff', 'principal'],
     })
 
     // Provisioning subscriptions DO return — the helper matches getProductSubscription
@@ -320,7 +320,7 @@ describe('resolveOperatorAccess', () => {
     })
 
     const result = await resolveOperatorAccess(db, fakeLocals, {
-      allowedRoles: ['operator', 'principal'],
+      allowedRoles: ['staff', 'principal'],
     })
 
     expect(result.kind).toBe('allowed')
@@ -341,7 +341,7 @@ describe('resolveOperatorAccess', () => {
 
     // Audit accepts principal | operator | compliance
     const result = await resolveOperatorAccess(db, fakeLocals, {
-      allowedRoles: ['principal', 'operator', 'compliance'],
+      allowedRoles: ['principal', 'staff', 'compliance'],
     })
 
     expect(result.kind).toBe('allowed')

--- a/tests/portal-operator-audit.test.ts
+++ b/tests/portal-operator-audit.test.ts
@@ -46,7 +46,7 @@ function makeEntry(overrides: Partial<AuditEntry> = {}): AuditEntry {
     id: '01HX5N3K2A',
     ts: '2026-05-20T10:00:00.000Z',
     actor: 'person-1',
-    actorRole: 'operator',
+    actorRole: 'staff',
     action: 'DRAFT_CREATED',
     target: 'draft-9',
     decision: 'draft_for_review',

--- a/tests/portal-operator-pto.test.ts
+++ b/tests/portal-operator-pto.test.ts
@@ -80,8 +80,8 @@ async function grantRole(db: D1Database, userId: string, role: string): Promise<
 describe('setPto', () => {
   it('inserts a fresh PTO row when no active one exists', async () => {
     const db = await freshDb()
-    await grantRole(db, USER_ALEX, 'operator')
-    await grantRole(db, USER_JAMIE, 'operator')
+    await grantRole(db, USER_ALEX, 'staff')
+    await grantRole(db, USER_JAMIE, 'staff')
     const result = await setPto(db, {
       orgId: ORG_ID,
       entityId: ENTITY_A,
@@ -98,7 +98,7 @@ describe('setPto', () => {
 
   it('accepts a null backup (queue for principal handoff)', async () => {
     const db = await freshDb()
-    await grantRole(db, USER_ALEX, 'operator')
+    await grantRole(db, USER_ALEX, 'staff')
     const result = await setPto(db, {
       orgId: ORG_ID,
       entityId: ENTITY_A,
@@ -114,7 +114,7 @@ describe('setPto', () => {
 
   it('rejects a backup who is the same as the away user (self loop)', async () => {
     const db = await freshDb()
-    await grantRole(db, USER_ALEX, 'operator')
+    await grantRole(db, USER_ALEX, 'staff')
     const result = await setPto(db, {
       orgId: ORG_ID,
       entityId: ENTITY_A,
@@ -129,7 +129,7 @@ describe('setPto', () => {
 
   it('rejects a backup with no Operator product role', async () => {
     const db = await freshDb()
-    await grantRole(db, USER_ALEX, 'operator')
+    await grantRole(db, USER_ALEX, 'staff')
     const result = await setPto(db, {
       orgId: ORG_ID,
       entityId: ENTITY_A,
@@ -144,7 +144,7 @@ describe('setPto', () => {
 
   it('rejects an unknown backup user id', async () => {
     const db = await freshDb()
-    await grantRole(db, USER_ALEX, 'operator')
+    await grantRole(db, USER_ALEX, 'staff')
     const result = await setPto(db, {
       orgId: ORG_ID,
       entityId: ENTITY_A,
@@ -159,8 +159,8 @@ describe('setPto', () => {
 
   it('returns already_active when a PTO row exists for the user', async () => {
     const db = await freshDb()
-    await grantRole(db, USER_ALEX, 'operator')
-    await grantRole(db, USER_JAMIE, 'operator')
+    await grantRole(db, USER_ALEX, 'staff')
+    await grantRole(db, USER_JAMIE, 'staff')
     await setPto(db, {
       orgId: ORG_ID,
       entityId: ENTITY_A,
@@ -184,7 +184,7 @@ describe('setPto', () => {
 describe('clearPto', () => {
   it('returns true when an active row flips to cleared', async () => {
     const db = await freshDb()
-    await grantRole(db, USER_ALEX, 'operator')
+    await grantRole(db, USER_ALEX, 'staff')
     await setPto(db, {
       orgId: ORG_ID,
       entityId: ENTITY_A,
@@ -213,7 +213,7 @@ describe('clearPto', () => {
 
   it('allows a fresh setPto after a clear', async () => {
     const db = await freshDb()
-    await grantRole(db, USER_ALEX, 'operator')
+    await grantRole(db, USER_ALEX, 'staff')
     await setPto(db, {
       orgId: ORG_ID,
       entityId: ENTITY_A,
@@ -240,8 +240,8 @@ describe('clearPto', () => {
 describe('updatePtoBackup', () => {
   it('updates the backup on an active row', async () => {
     const db = await freshDb()
-    await grantRole(db, USER_ALEX, 'operator')
-    await grantRole(db, USER_JAMIE, 'operator')
+    await grantRole(db, USER_ALEX, 'staff')
+    await grantRole(db, USER_JAMIE, 'staff')
     await grantRole(db, USER_PAT, 'principal')
     await setPto(db, {
       orgId: ORG_ID,
@@ -274,7 +274,7 @@ describe('updatePtoBackup', () => {
 
   it('returns backup_invalid when the new backup has no role', async () => {
     const db = await freshDb()
-    await grantRole(db, USER_ALEX, 'operator')
+    await grantRole(db, USER_ALEX, 'staff')
     await setPto(db, {
       orgId: ORG_ID,
       entityId: ENTITY_A,
@@ -295,8 +295,8 @@ describe('updatePtoBackup', () => {
 describe('listActivePto', () => {
   it('returns every active away user for the entity', async () => {
     const db = await freshDb()
-    await grantRole(db, USER_ALEX, 'operator')
-    await grantRole(db, USER_JAMIE, 'operator')
+    await grantRole(db, USER_ALEX, 'staff')
+    await grantRole(db, USER_JAMIE, 'staff')
     await setPto(db, {
       orgId: ORG_ID,
       entityId: ENTITY_A,
@@ -317,7 +317,7 @@ describe('listActivePto', () => {
 
   it('omits cleared rows', async () => {
     const db = await freshDb()
-    await grantRole(db, USER_ALEX, 'operator')
+    await grantRole(db, USER_ALEX, 'staff')
     await setPto(db, {
       orgId: ORG_ID,
       entityId: ENTITY_A,

--- a/tests/portal-rbac-audit.test.ts
+++ b/tests/portal-rbac-audit.test.ts
@@ -191,7 +191,7 @@ describe('buildRoleAuditEvent', () => {
     actorEmail: 'pat.owner@smithlaw.com',
     targetUserId: 'u-alex-002',
     targetEmail: 'alex.paralegal@smithlaw.com',
-    role: 'operator',
+    role: 'staff',
     now: new Date('2026-05-23T10:00:00.000Z'),
   }
 
@@ -207,7 +207,7 @@ describe('buildRoleAuditEvent', () => {
     expect(event.actorEmail).toBe('pat.owner@smithlaw.com')
     expect(event.targetUserId).toBe('u-alex-002')
     expect(event.targetEmail).toBe('alex.paralegal@smithlaw.com')
-    expect(event.role).toBe('operator')
+    expect(event.role).toBe('staff')
     expect(event.timestamp).toBe('2026-05-23T10:00:00.000Z')
   })
 
@@ -293,7 +293,7 @@ describe('recordRbacAuditEvent — emission contract', () => {
           actorEmail: 'pat@x.com',
           targetUserId: 'u-alex',
           targetEmail: 'alex@x.com',
-          role: 'operator',
+          role: 'staff',
           now: new Date('2026-05-23T12:00:00.000Z'),
         })
       )
@@ -306,7 +306,7 @@ describe('recordRbacAuditEvent — emission contract', () => {
     expect(parsed.type).toBe('audit:rbac_event')
     expect(parsed.subAction).toBe('role_granted')
     expect(parsed.customer_id).toBe('cust-1')
-    expect(parsed.role).toBe('operator')
+    expect(parsed.role).toBe('staff')
     expect(parsed.timestamp).toBe('2026-05-23T12:00:00.000Z')
   })
 


### PR DESCRIPTION
## What

Renames the client-internal **Layer-2 RBAC human role** from `operator` to `staff`. The legacy name collided with the product name "Operator". Role vocabulary is now **`principal | staff | compliance`**.

This is PR **#0** in the Operator **client portal** build — a small, standalone, coordinated shared-foundation change that the surface PRs build on. Resolved by Captain 2026-06-08 (`docs/design/operator/02-client-portal.md` §2, `00-foundations.md` §2).

## Changes

- **Foundation enum:** `ACCEPTED_USER_ROLES` (`src/lib/operator/customer-yaml/types.ts`)
- **Data-layer vocab:** `ALLOWED_OPERATOR_ROLES` (`src/lib/portal/product-roles-mutations.ts`)
- **Audit actor role:** `AuditActorRole` type + `AUDIT_ACTOR_ROLES` array (`src/lib/portal/operator/audit.ts`)
- **Access gates:** every `allowedRoles` literal in portal pages + the two notification API endpoints
- **Migration `0065`:** `UPDATE product_roles SET role='staff' WHERE role='operator'` — completes the rename that migration **0048 deliberately deferred** (0048 noted `role` `'operator'` was the human role, unrelated to the `product_slug` it migrated). No CHECK constraint exists on `product_roles.role`, so this is a pure data update.
- Tests + drift-only comments updated to match.

## Explicitly NOT touched

- `product_slug = 'operator'` (the **product** — set by migration 0048)
- `smd_operator` (the **SMD-internal Layer-0** actor role)

## Back-compat

No `customer.yaml` shim needed: every authored `users[].role` in committed config is `principal` — there are zero `operator`-role grants in authored data.

## Verification

- `npm run typecheck` — 0 errors
- `npm run lint` — 0 errors
- `npm run test` — 3083 passing (the only red, `build-output.test.ts`, is the build-artifact guard satisfied by CI's build step)
- `npm run build` — clean

## ⚠️ Merge coordination

The parallel **admin portal** agent's People surface (§5.7) reads roles. **Flag the admin agent before merging** so they rebase after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)