### PR TITLE
feat(operator): admin fleet roster — Operator console landing (§4.1)

### DIFF
--- a/src/layouts/AdminLayout.astro
+++ b/src/layouts/AdminLayout.astro
@@ -42,6 +42,11 @@ const navItems = [
     href: '/admin/analytics',
     match: (p: string) => p.startsWith('/admin/analytics'),
   },
+  {
+    label: 'Operator',
+    href: '/admin/operator',
+    match: (p: string) => p.startsWith('/admin/operator'),
+  },
 ]
 ---
 

--- a/src/lib/admin/fleet-roster.ts
+++ b/src/lib/admin/fleet-roster.ts
@@ -1,0 +1,264 @@
+/**
+ * Fleet-roster reader for the admin Operator console landing
+ * (`/admin/operator`) — design doc docs/design/operator/01-admin-portal.md §4.1.
+ *
+ * The roster is the "is anything on fire across all my operators" view: one
+ * row per client, scannable as the fleet grows. It composes three console-side
+ * projections, never a cross-Machine runtime join (ADR 0009):
+ *
+ *   1. `customer_configs`            — identity, persona roster, authority posture
+ *   2. `operator_runtime_summary`    — health/alerts/last-activity mirror (ADR 0043 B)
+ *   3. `fleet_status`                — per-customer heartbeat liveness (ADR 0023)
+ *
+ * This module owns only #1's read + the pure derivations the page renders
+ * (posture label, combined health). The summary/heartbeat readers are the
+ * frozen seam (src/lib/admin/runtime-summary.ts, fleet-status.ts); the page
+ * joins them by entity_id (slug fallback), exactly as the costs page does.
+ *
+ * Fleet-view discipline (foundations §7, ADR 0043): one corrupt config row must
+ * never 500 the whole fleet view. `listFleetRoster` parses each row defensively
+ * — a malformed personas/authority column degrades that single row to a flagged
+ * `config_error` state with an empty persona list and the launch-default
+ * posture, and the rest of the fleet still renders.
+ */
+
+import type { D1Database } from '@cloudflare/workers-types'
+import {
+  DEFAULT_AUTHORITY_POSTURE,
+  parseAuthorityPosture,
+  resolveAllDomains,
+  type AuthorityPosture,
+} from '../operator/authority'
+import type { SummaryStatus } from './runtime-summary'
+
+export interface RosterPersona {
+  slug: string
+  name: string
+  status: string
+}
+
+export interface RosterCustomer {
+  entity_id: string
+  customer_slug: string
+  /** Display name from `entities.name`; null when no entity row joins. */
+  entity_name: string | null
+  /** Projected `customer_configs.vertical`; null before CI sync backfills it. */
+  vertical: string | null
+  personas: RosterPersona[]
+  authority: AuthorityPosture
+  /**
+   * Set when this row's projected JSON was malformed. The row still renders
+   * (degraded) so one corrupt config never blanks the fleet view — the flag
+   * lets the page surface "this operator's config needs attention" honestly
+   * instead of silently showing zero personas.
+   */
+  config_error: string | null
+}
+
+interface RosterDbRow {
+  entity_id: string
+  customer_slug: string
+  personas_json: string
+  authority_json: string | null
+  vertical: string | null
+}
+
+interface EntityNameRow {
+  id: string
+  name: string
+}
+
+/**
+ * Enumerate every Operator customer for the fleet roster, ordered by slug.
+ * One batched read of `customer_configs` + one batched name lookup — no
+ * per-row query and no per-customer Machine round-trip.
+ */
+export async function listFleetRoster(db: D1Database): Promise<RosterCustomer[]> {
+  const configResult = await db
+    .prepare(
+      `SELECT entity_id, customer_slug, personas_json, authority_json, vertical
+         FROM customer_configs
+        ORDER BY customer_slug ASC`
+    )
+    .all<RosterDbRow>()
+  const rows = configResult.results ?? []
+  if (rows.length === 0) return []
+
+  const namesByEntity = await loadEntityNames(
+    db,
+    rows.map((r) => r.entity_id)
+  )
+
+  return rows.map((row) => projectRosterRow(row, namesByEntity.get(row.entity_id) ?? null))
+}
+
+async function loadEntityNames(db: D1Database, entityIds: string[]): Promise<Map<string, string>> {
+  const placeholders = entityIds.map(() => '?').join(',')
+  const result = await db
+    .prepare(`SELECT id, name FROM entities WHERE id IN (${placeholders})`)
+    .bind(...entityIds)
+    .all<EntityNameRow>()
+  const map = new Map<string, string>()
+  for (const row of result.results ?? []) map.set(row.id, row.name)
+  return map
+}
+
+function projectRosterRow(row: RosterDbRow, entityName: string | null): RosterCustomer {
+  const base = {
+    entity_id: row.entity_id,
+    customer_slug: row.customer_slug,
+    entity_name: entityName,
+    vertical: row.vertical,
+  }
+  try {
+    return {
+      ...base,
+      personas: parsePersonas(row.personas_json),
+      // parseAuthorityPosture is total (never throws); a malformed personas
+      // column is what flips a row into the error state.
+      authority: parseAuthorityPosture(safeJsonParse(row.authority_json)),
+      config_error: null,
+    }
+  } catch (err) {
+    return {
+      ...base,
+      personas: [],
+      authority: { ...DEFAULT_AUTHORITY_POSTURE },
+      config_error: err instanceof Error ? err.message : String(err),
+    }
+  }
+}
+
+function parsePersonas(raw: string): RosterPersona[] {
+  const parsed: unknown = JSON.parse(raw)
+  if (!Array.isArray(parsed)) throw new Error('personas_json is not an array')
+  return parsed.map((p) => {
+    if (typeof p !== 'object' || p === null) throw new Error('persona entry is not an object')
+    const rec = p as Record<string, unknown>
+    return {
+      slug: typeof rec.slug === 'string' ? rec.slug : '',
+      name: typeof rec.name === 'string' ? rec.name : '',
+      status: typeof rec.status === 'string' ? rec.status : 'unknown',
+    }
+  })
+}
+
+/** Null-tolerant JSON parse; null/undefined → null, malformed → throws. */
+function safeJsonParse(value: string | null | undefined): unknown {
+  if (value === null || value === undefined) return null
+  return JSON.parse(value)
+}
+
+// ===========================================================================
+// Pure derivations the roster page renders
+// ===========================================================================
+
+export type PostureLabel = 'Managed' | 'Co-Managed' | 'Self-Managed'
+
+export interface PosturePill {
+  label: PostureLabel
+  classes: string
+}
+
+const POSTURE_BADGE_STRUCTURE =
+  'inline-flex items-center px-2 py-0.5 rounded-[var(--ss-radius-badge)] ' +
+  'text-[10px] font-medium uppercase tracking-wide whitespace-nowrap'
+
+/**
+ * Derive the posture chip from the resolved authority posture (foundations
+ * §4.1): the label is a description of the *switch pattern*, not a SKU —
+ * Managed (every client switch off), Self-Managed (every switch client),
+ * Co-Managed (a mix). SMD always retains full control regardless; this chip
+ * describes only the client org's operability.
+ */
+export function derivePostureLabel(posture: AuthorityPosture | null): PostureLabel {
+  const holders = Object.values(resolveAllDomains(posture))
+  const clientCount = holders.filter((h) => h === 'client').length
+  if (clientCount === 0) return 'Managed'
+  if (clientCount === holders.length) return 'Self-Managed'
+  return 'Co-Managed'
+}
+
+export function posturePill(posture: AuthorityPosture | null): PosturePill {
+  const label = derivePostureLabel(posture)
+  const tone =
+    label === 'Managed'
+      ? 'bg-[color:var(--ss-color-primary)] text-white'
+      : label === 'Self-Managed'
+        ? 'bg-[color:var(--ss-color-complete)] text-white'
+        : 'bg-[color:var(--ss-color-attention)] text-white'
+  return { label, classes: `${POSTURE_BADGE_STRUCTURE} ${tone}` }
+}
+
+export type RosterHealthColor = 'green' | 'yellow' | 'red' | 'gray'
+
+export interface RosterHealth {
+  color: RosterHealthColor
+  /** Relative liveness label from the heartbeat ("47s ago" / "stale 12m"). */
+  label: string
+  /** Secondary line when the summary mirror reports a non-green rollup. */
+  note: string | null
+}
+
+const HEALTH_RANK: Record<RosterHealthColor, number> = { gray: 0, green: 1, yellow: 2, red: 3 }
+
+/**
+ * Combine the heartbeat liveness ("is the process alive", fleet_status) with
+ * the runtime-summary rollup ("is the operator OK" — folds in sticky-stop,
+ * escalation pressure, connector health per migration 0052) into one fleet
+ * dot. Takes the more alarming of the two so the column never reads calmer
+ * than reality. `heartbeatColor` is the color from `heartbeatDisplay`;
+ * `summaryStatus` is null when no Machine has pushed a summary yet.
+ */
+export function rosterHealth(
+  heartbeatColor: RosterHealthColor,
+  heartbeatLabel: string,
+  summaryStatus: SummaryStatus | null
+): RosterHealth {
+  const summaryColor = summaryStatusToColor(summaryStatus)
+  const color =
+    HEALTH_RANK[summaryColor] > HEALTH_RANK[heartbeatColor] ? summaryColor : heartbeatColor
+  const note =
+    summaryStatus === 'red'
+      ? 'operator reports a problem'
+      : summaryStatus === 'yellow'
+        ? 'operator reports a warning'
+        : null
+  return { color, label: heartbeatLabel, note }
+}
+
+function summaryStatusToColor(status: SummaryStatus | null): RosterHealthColor {
+  switch (status) {
+    case 'green':
+      return 'green'
+    case 'yellow':
+      return 'yellow'
+    case 'red':
+      return 'red'
+    default:
+      return 'gray'
+  }
+}
+
+export function rosterHealthDotClass(color: RosterHealthColor): string {
+  switch (color) {
+    case 'green':
+      return 'bg-[color:var(--ss-color-complete)]'
+    case 'yellow':
+      return 'bg-[color:var(--ss-color-attention)]'
+    case 'red':
+      return 'bg-[color:var(--ss-color-error)]'
+    case 'gray':
+      return 'bg-[color:var(--ss-color-border)]'
+  }
+}
+
+/** "3 personas" / "1 persona" / "no personas". Pure, for the roster cell. */
+export function personaSummary(personas: RosterPersona[]): string {
+  const active = personas.filter((p) => p.status === 'active')
+  const count = personas.length
+  if (count === 0) return 'no personas'
+  const noun = count === 1 ? 'persona' : 'personas'
+  const archived = count - active.length
+  return archived > 0 ? `${count} ${noun} (${archived} archived)` : `${count} ${noun}`
+}

--- a/src/pages/admin/operator/index.astro
+++ b/src/pages/admin/operator/index.astro
@@ -1,0 +1,257 @@
+---
+import AdminLayout from '../../../layouts/AdminLayout.astro'
+import { listFleetRoster, type RosterCustomer } from '../../../lib/admin/fleet-roster'
+import {
+  posturePill,
+  rosterHealth,
+  rosterHealthDotClass,
+  personaSummary,
+} from '../../../lib/admin/fleet-roster'
+import { listRuntimeSummary, type RuntimeSummaryRow } from '../../../lib/admin/runtime-summary'
+import {
+  listFleetStatus,
+  heartbeatDisplay,
+  relativeTimestamp,
+  type FleetStatusRow,
+} from '../../../lib/admin/fleet-status'
+import { env } from 'cloudflare:workers'
+
+/**
+ * Operator admin console — fleet home (the roster).
+ *
+ * The default landing for `/admin/operator`. One row per operator (per
+ * client), built for scanning a growing fleet: "is anything on fire across all
+ * my operators." Composes three console-side projections only — customer_configs
+ * (identity, personas, posture), operator_runtime_summary (health/alerts/last
+ * activity mirror, ADR 0043 B), and fleet_status (heartbeat). It never reads a
+ * Machine's runtime D1 directly and never joins two customers (ADR 0009).
+ *
+ * Design: docs/design/operator/01-admin-portal.md §4.1.
+ *
+ * Empty / honest states (foundations §7): a fleet of zero is a real state, not
+ * an error. Before any Machine pushes a summary, health falls back to the
+ * heartbeat alone and last-activity / alert columns read "—" rather than
+ * fabricating activity. A roster-of-one client with one persona is the normal
+ * v1 state, not a placeholder.
+ *
+ * Connector health (§5.4) and per-operator cost (§4.3 / §5.8) are deliberately
+ * not roster columns: connector liveness needs the per-operator runtime read,
+ * and cost is the SMD-only economics surface with its own page. Both are one
+ * click away from each row's overview.
+ */
+
+const session = Astro.locals.session!
+
+// /admin/* already requires the admin role at the middleware layer; re-check
+// here so a routing misconfig can't silently fall through (mirrors the costs
+// page). Today admin === Captain; the smd_admin/smd_operator seam (§2) layers
+// on later without reworking this gate.
+if (session.role !== 'admin') {
+  return Astro.redirect('/auth/sign-in')
+}
+
+const roster = await listFleetRoster(env.DB)
+const summaryRows = await listRuntimeSummary(env.DB)
+const fleetStatusRows = await listFleetStatus(env.DB)
+
+const summaryByEntity = new Map<string, RuntimeSummaryRow>(summaryRows.map((r) => [r.entity_id, r]))
+const summaryBySlug = new Map<string, RuntimeSummaryRow>(
+  summaryRows.map((r) => [r.customer_slug, r])
+)
+const fleetByEntity = new Map<string, FleetStatusRow>(fleetStatusRows.map((r) => [r.entity_id, r]))
+const fleetBySlug = new Map<string, FleetStatusRow>(
+  fleetStatusRows.map((r) => [r.customer_slug, r])
+)
+
+function summaryFor(c: RosterCustomer): RuntimeSummaryRow | undefined {
+  return summaryByEntity.get(c.entity_id) ?? summaryBySlug.get(c.customer_slug)
+}
+function fleetFor(c: RosterCustomer): FleetStatusRow | undefined {
+  return fleetByEntity.get(c.entity_id) ?? fleetBySlug.get(c.customer_slug)
+}
+
+interface RosterView {
+  customer: RosterCustomer
+  personaLine: string
+  personaNames: string
+  posture: ReturnType<typeof posturePill>
+  health: ReturnType<typeof rosterHealth>
+  openAlerts: number | null
+  lastActivity: string | null
+}
+
+const views: RosterView[] = roster.map((customer) => {
+  const summary = summaryFor(customer)
+  const fleet = fleetFor(customer)
+  const hb = heartbeatDisplay(fleet?.last_heartbeat_ts ?? null)
+  const health = rosterHealth(hb.color, hb.label, summary?.summary_status ?? null)
+  const names = customer.personas.map((p) => p.name).filter(Boolean)
+  return {
+    customer,
+    personaLine: personaSummary(customer.personas),
+    personaNames: names.join(', '),
+    posture: posturePill(customer.authority),
+    health,
+    openAlerts: summary ? summary.open_alerts : null,
+    lastActivity: summary?.last_activity_ts ? relativeTimestamp(summary.last_activity_ts) : null,
+  }
+})
+
+// Sort: rows needing attention first (config error, then red/yellow health,
+// then open alerts), then alphabetical by slug. Same "eye lands on trouble"
+// ordering as the costs page.
+const HEALTH_SORT: Record<string, number> = { red: 3, yellow: 2, gray: 1, green: 0 }
+views.sort((a, b) => {
+  const aErr = a.customer.config_error ? 1 : 0
+  const bErr = b.customer.config_error ? 1 : 0
+  if (aErr !== bErr) return bErr - aErr
+  const h = (HEALTH_SORT[b.health.color] ?? 0) - (HEALTH_SORT[a.health.color] ?? 0)
+  if (h !== 0) return h
+  const alerts = (b.openAlerts ?? 0) - (a.openAlerts ?? 0)
+  if (alerts !== 0) return alerts
+  return a.customer.customer_slug.localeCompare(b.customer.customer_slug)
+})
+
+const totalOperators = roster.length
+---
+
+<AdminLayout
+  title="Operator — Fleet"
+  breadcrumbs={[{ label: 'Dashboard', href: '/admin' }, { label: 'Operator' }]}
+  maxWidth="max-w-6xl"
+>
+  <div class="space-y-card">
+    <header class="flex items-end justify-between gap-4">
+      <div>
+        <h2 class="text-xl font-semibold text-[color:var(--ss-color-text-primary)]">
+          Operator fleet
+        </h2>
+        <p class="text-sm text-[color:var(--ss-color-text-secondary)] mt-1">
+          Every operator at a glance: persona roster, authority posture, health, and open alerts.
+          Health and activity read the per-customer summary mirror (ADR 0043); deep detail lives in
+          each operator's drill-in.
+        </p>
+      </div>
+      <div class="text-right">
+        <p class="text-xs uppercase tracking-wide text-[color:var(--ss-color-text-muted)]">
+          Operators
+        </p>
+        <p class="text-2xl font-bold text-[color:var(--ss-color-text-primary)]">
+          {totalOperators}
+        </p>
+      </div>
+    </header>
+
+    <div
+      class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card"
+    >
+      {
+        roster.length === 0 ? (
+          <p class="text-sm text-[color:var(--ss-color-text-secondary)]">
+            No operators provisioned yet. The fleet is empty until <code>customer_configs</code> has
+            at least one row.
+          </p>
+        ) : (
+          <div class="overflow-x-auto">
+            <table class="w-full text-sm">
+              <thead>
+                <tr class="text-left text-xs text-[color:var(--ss-color-text-secondary)] border-b border-[color:var(--ss-color-border)]">
+                  <th class="pb-2 font-medium">Operator</th>
+                  <th class="pb-2 font-medium">Personas</th>
+                  <th class="pb-2 font-medium">Posture</th>
+                  <th class="pb-2 font-medium">Health</th>
+                  <th class="pb-2 font-medium text-right">Open alerts</th>
+                  <th class="pb-2 font-medium text-right">Last activity</th>
+                </tr>
+              </thead>
+              <tbody class="divide-y divide-[color:var(--ss-color-border-subtle)]">
+                {views.map((v) => (
+                  <tr class="align-top">
+                    <td class="py-3 pr-4">
+                      <a
+                        href={`/admin/operator/${encodeURIComponent(v.customer.customer_slug)}`}
+                        class="font-medium text-[color:var(--ss-color-text-primary)] hover:text-[color:var(--ss-color-primary)]"
+                      >
+                        {v.customer.entity_name ?? v.customer.customer_slug}
+                      </a>
+                      <p class="text-xs text-[color:var(--ss-color-text-muted)]">
+                        {v.customer.customer_slug}
+                        {v.customer.vertical ? ` · ${v.customer.vertical}` : ''}
+                      </p>
+                      {v.customer.config_error && (
+                        <p class="text-xs text-[color:var(--ss-color-error)] mt-0.5">
+                          Config needs attention — projection malformed
+                        </p>
+                      )}
+                    </td>
+                    <td class="py-3 pr-4">
+                      <span class="text-[color:var(--ss-color-text-primary)]">{v.personaLine}</span>
+                      {v.personaNames && (
+                        <p class="text-xs text-[color:var(--ss-color-text-muted)]">
+                          {v.personaNames}
+                        </p>
+                      )}
+                    </td>
+                    <td class="py-3 pr-4">
+                      <span class={v.posture.classes}>{v.posture.label}</span>
+                    </td>
+                    <td class="py-3 pr-4">
+                      <span class="inline-flex items-center gap-2">
+                        <span
+                          class={`inline-block h-2 w-2 rounded-full ${rosterHealthDotClass(v.health.color)}`}
+                          aria-hidden="true"
+                        />
+                        <span class="text-[color:var(--ss-color-text-secondary)]">
+                          {v.health.label}
+                        </span>
+                      </span>
+                      {v.health.note && (
+                        <p class="text-xs text-[color:var(--ss-color-text-muted)] mt-0.5">
+                          {v.health.note}
+                        </p>
+                      )}
+                    </td>
+                    <td class="py-3 pr-4 text-right">
+                      {v.openAlerts === null ? (
+                        <span class="text-[color:var(--ss-color-text-muted)]">—</span>
+                      ) : v.openAlerts > 0 ? (
+                        <span class="font-semibold text-[color:var(--ss-color-error)]">
+                          {v.openAlerts}
+                        </span>
+                      ) : (
+                        <span class="text-[color:var(--ss-color-text-secondary)]">0</span>
+                      )}
+                    </td>
+                    <td class="py-3 text-right text-[color:var(--ss-color-text-secondary)]">
+                      {v.lastActivity ?? '—'}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )
+      }
+
+      <div
+        class="mt-4 pt-4 border-t border-[color:var(--ss-color-border-subtle)] space-y-2 text-xs text-[color:var(--ss-color-text-muted)]"
+      >
+        <p>
+          <strong>Health</strong> takes the more alarming of the per-customer heartbeat (<code
+            >fleet_status</code
+          >) and the summary rollup (<code>operator_runtime_summary</code>, which folds in
+          sticky-stop, escalation pressure, and connector health). A gray dot with "no signal yet"
+          means no heartbeat has arrived; it does not mean the operator is healthy.
+        </p>
+        <p>
+          <strong>Connector health</strong> and <strong>cost</strong> are per-operator surfaces: connector
+          liveness needs a live read against the operator's Machine, and cost is the SMD-only economics
+          view at <a
+            href="/admin/operator/costs"
+            class="text-[color:var(--ss-color-action)] hover:underline">Operator costs</a
+          >.
+        </p>
+      </div>
+    </div>
+  </div>
+</AdminLayout>

--- a/tests/fleet-roster.test.ts
+++ b/tests/fleet-roster.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Tests for the fleet-roster reader + pure derivations
+ * (src/lib/admin/fleet-roster.ts) — admin Operator console §4.1.
+ *
+ * Two properties matter most and are exercised here:
+ *
+ *   1. Fleet-view resilience (ADR 0043, foundations §7): one corrupt
+ *      `customer_configs` row degrades to a flagged `config_error` row — it
+ *      never throws and blanks the whole fleet view.
+ *   2. Posture + health derivations never read calmer than reality: posture
+ *      labels follow the switch pattern (foundations §4.1) and `rosterHealth`
+ *      takes the more alarming of heartbeat vs summary rollup.
+ *
+ * DB-touching tests seed `customer_configs` + `entities` directly via the test
+ * D1 (same posture as customer-config.test.ts — CI sync lands separately).
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  createTestD1,
+  runMigrations,
+  discoverNumericMigrations,
+} from '@venturecrane/crane-test-harness'
+import { resolve } from 'path'
+import type { D1Database } from '@cloudflare/workers-types'
+import { ORG_ID } from '../src/lib/constants'
+import {
+  listFleetRoster,
+  derivePostureLabel,
+  posturePill,
+  rosterHealth,
+  rosterHealthDotClass,
+  personaSummary,
+  type RosterPersona,
+} from '../src/lib/admin/fleet-roster'
+import { DEFAULT_AUTHORITY_POSTURE, type AuthorityPosture } from '../src/lib/operator/authority'
+
+const migrationsDir = resolve(process.cwd(), 'migrations')
+
+async function freshDb(): Promise<D1Database> {
+  const db = createTestD1()
+  await runMigrations(db, { files: discoverNumericMigrations(migrationsDir) })
+  return db
+}
+
+async function seedEntity(db: D1Database, id: string, name: string, slug: string): Promise<void> {
+  await db
+    .prepare('INSERT INTO entities (id, org_id, name, slug) VALUES (?, ?, ?, ?)')
+    .bind(id, ORG_ID, name, slug)
+    .run()
+}
+
+function persona(overrides: Partial<RosterPersona> = {}): RosterPersona {
+  return { slug: 'marcus', name: 'Marcus', status: 'active', ...overrides }
+}
+
+interface SeedConfig {
+  entity_id: string
+  customer_slug: string
+  personas_json?: string
+  authority_json?: string | null
+  vertical?: string | null
+}
+
+async function seedConfig(db: D1Database, c: SeedConfig): Promise<void> {
+  await db
+    .prepare(
+      `INSERT INTO customer_configs
+        (entity_id, org_id, customer_slug, schema_version, personas_json,
+         authority_json, vertical, git_sha, synced_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    )
+    .bind(
+      c.entity_id,
+      ORG_ID,
+      c.customer_slug,
+      '1.0.0',
+      c.personas_json ?? JSON.stringify([persona()]),
+      c.authority_json === undefined ? null : c.authority_json,
+      c.vertical ?? null,
+      'a1b2c3d4',
+      '2026-06-08T12:00:00Z'
+    )
+    .run()
+}
+
+describe('listFleetRoster', () => {
+  let db: D1Database
+  beforeEach(async () => {
+    db = await freshDb()
+  })
+
+  it('returns [] for an empty fleet', async () => {
+    expect(await listFleetRoster(db)).toEqual([])
+  })
+
+  it('lists customers ordered by slug with entity name joined and personas parsed', async () => {
+    await seedEntity(db, 'ent-b', 'Beta Firm', 'beta-firm')
+    await seedEntity(db, 'ent-a', 'Alpha Firm', 'alpha-firm')
+    await seedConfig(db, { entity_id: 'ent-b', customer_slug: 'beta-firm', vertical: 'law' })
+    await seedConfig(db, {
+      entity_id: 'ent-a',
+      customer_slug: 'alpha-firm',
+      personas_json: JSON.stringify([persona(), persona({ slug: 'nova', name: 'Nova' })]),
+    })
+
+    const roster = await listFleetRoster(db)
+    expect(roster.map((r) => r.customer_slug)).toEqual(['alpha-firm', 'beta-firm'])
+
+    const alpha = roster[0]
+    expect(alpha.entity_name).toBe('Alpha Firm')
+    expect(alpha.personas).toHaveLength(2)
+    expect(alpha.personas[1]).toEqual({ slug: 'nova', name: 'Nova', status: 'active' })
+    expect(alpha.config_error).toBeNull()
+
+    const beta = roster[1]
+    expect(beta.vertical).toBe('law')
+    expect(beta.authority).toEqual(DEFAULT_AUTHORITY_POSTURE)
+  })
+
+  it('resolves an authored authority posture from authority_json', async () => {
+    await seedEntity(db, 'ent-1', 'Gamma Firm', 'gamma-firm')
+    await seedConfig(db, {
+      entity_id: 'ent-1',
+      customer_slug: 'gamma-firm',
+      authority_json: JSON.stringify({
+        default: 'managed',
+        overrides: { people_access: 'client' },
+      }),
+    })
+    const [row] = await listFleetRoster(db)
+    expect(row.authority.overrides.people_access).toBe('client')
+  })
+
+  it('degrades a malformed personas_json row to a flagged config_error, never throwing', async () => {
+    await seedEntity(db, 'ent-ok', 'OK Firm', 'ok-firm')
+    await seedEntity(db, 'ent-bad', 'Bad Firm', 'bad-firm')
+    await seedConfig(db, { entity_id: 'ent-ok', customer_slug: 'ok-firm' })
+    await seedConfig(db, {
+      entity_id: 'ent-bad',
+      customer_slug: 'bad-firm',
+      personas_json: '{not valid json',
+    })
+
+    const roster = await listFleetRoster(db)
+    expect(roster).toHaveLength(2)
+    const bad = roster.find((r) => r.customer_slug === 'bad-firm')!
+    expect(bad.config_error).not.toBeNull()
+    expect(bad.personas).toEqual([])
+    expect(bad.authority).toEqual(DEFAULT_AUTHORITY_POSTURE)
+    // The healthy row is unaffected.
+    const ok = roster.find((r) => r.customer_slug === 'ok-firm')!
+    expect(ok.config_error).toBeNull()
+    expect(ok.personas).toHaveLength(1)
+  })
+
+  it('flags a personas_json that is valid JSON but not an array', async () => {
+    await seedEntity(db, 'ent-x', 'X Firm', 'x-firm')
+    await seedConfig(db, {
+      entity_id: 'ent-x',
+      customer_slug: 'x-firm',
+      personas_json: JSON.stringify({ slug: 'oops' }),
+    })
+    const [row] = await listFleetRoster(db)
+    expect(row.config_error).toMatch(/not an array/)
+  })
+})
+
+describe('derivePostureLabel', () => {
+  it('null / launch-default posture is Managed (every client switch off)', () => {
+    expect(derivePostureLabel(null)).toBe('Managed')
+    expect(derivePostureLabel(DEFAULT_AUTHORITY_POSTURE)).toBe('Managed')
+  })
+
+  it('a self_managed default with no overrides is Self-Managed', () => {
+    const posture: AuthorityPosture = { default: 'self_managed', overrides: {} }
+    expect(derivePostureLabel(posture)).toBe('Self-Managed')
+  })
+
+  it('a managed default with at least one client override is Co-Managed', () => {
+    const posture: AuthorityPosture = { default: 'managed', overrides: { connectors: 'client' } }
+    expect(derivePostureLabel(posture)).toBe('Co-Managed')
+  })
+
+  it('a self_managed default with one domain pinned back to managed is Co-Managed', () => {
+    const posture: AuthorityPosture = { default: 'self_managed', overrides: { trust: 'managed' } }
+    expect(derivePostureLabel(posture)).toBe('Co-Managed')
+  })
+})
+
+describe('posturePill', () => {
+  it('carries the label and a non-empty class string', () => {
+    const pill = posturePill(DEFAULT_AUTHORITY_POSTURE)
+    expect(pill.label).toBe('Managed')
+    expect(pill.classes).toContain('rounded-[var(--ss-radius-badge)]')
+  })
+})
+
+describe('rosterHealth', () => {
+  it('takes the more alarming of heartbeat vs summary rollup', () => {
+    // Heartbeat green but summary red → red.
+    expect(rosterHealth('green', '20s ago', 'red').color).toBe('red')
+    // Heartbeat red but summary green → red (heartbeat is worse).
+    expect(rosterHealth('red', 'stale 9m', 'green').color).toBe('red')
+    // Both benign → green.
+    expect(rosterHealth('green', '5s ago', 'green').color).toBe('green')
+  })
+
+  it('keeps the heartbeat label and adds a note only for non-green summaries', () => {
+    expect(rosterHealth('green', '20s ago', null).note).toBeNull()
+    expect(rosterHealth('green', '20s ago', 'red').note).toMatch(/problem/)
+    expect(rosterHealth('green', '20s ago', 'yellow').note).toMatch(/warning/)
+    expect(rosterHealth('green', '20s ago', 'yellow').label).toBe('20s ago')
+  })
+
+  it('a missing summary (null) leaves the heartbeat color unchanged', () => {
+    expect(rosterHealth('yellow', '3m ago', null).color).toBe('yellow')
+    expect(rosterHealth('gray', 'no signal yet', null).color).toBe('gray')
+  })
+})
+
+describe('rosterHealthDotClass', () => {
+  it('maps every color to a token-based background class', () => {
+    expect(rosterHealthDotClass('green')).toContain('--ss-color-complete')
+    expect(rosterHealthDotClass('yellow')).toContain('--ss-color-attention')
+    expect(rosterHealthDotClass('red')).toContain('--ss-color-error')
+    expect(rosterHealthDotClass('gray')).toContain('--ss-color-border')
+  })
+})
+
+describe('personaSummary', () => {
+  it('renders count with archived suffix and an honest zero state', () => {
+    expect(personaSummary([])).toBe('no personas')
+    expect(personaSummary([persona()])).toBe('1 persona')
+    expect(personaSummary([persona(), persona({ slug: 'n', name: 'N' })])).toBe('2 personas')
+    expect(personaSummary([persona(), persona({ slug: 'a', status: 'archived' })])).toBe(
+      '2 personas (1 archived)'
+    )
+  })
+})


### PR DESCRIPTION
## What

PR 1 of the SMD-side **Operator Admin Console** (handoff: build surface by surface on the frozen foundation seam, #1245). The **fleet home / roster** at `/admin/operator` — one row per operator, built for scanning a growing fleet ("is anything on fire across all my operators"). Design: `docs/design/operator/01-admin-portal.md` §4.1.

## Columns

Operator (name + slug + vertical) · Personas (count + names) · Posture chip (Managed / Co-Managed / Self-Managed) · Health (dot + label) · Open alerts · Last activity.

## Sources — console-side projections only

Per ADR 0009 (no cross-Machine query), the roster composes three projections and never reads a Machine's runtime D1 directly:

- `customer_configs` — identity, persona roster, authority posture
- `operator_runtime_summary` — health/alerts/last-activity mirror (ADR 0043 path B)
- `fleet_status` — per-customer heartbeat liveness (ADR 0023)

New `src/lib/admin/fleet-roster.ts` owns the `customer_configs` read + the pure derivations (posture label, combined health). It joins the **frozen** summary/heartbeat readers by `entity_id` (slug fallback), exactly as the costs page does. No frozen-seam files modified.

## Discipline

- **Fleet-view resilience** (foundations §7 / ADR 0043): one corrupt `customer_configs` row degrades to a flagged `config_error` row — it never throws and blanks the whole fleet view. Test covers malformed + non-array `personas_json`.
- **Honest empty states** (no fabrication): a fleet of zero, a roster-of-one, and "no signal yet" are real v1 states. A gray health dot explicitly does **not** mean healthy.
- **No fabricated columns:** connector-health and cost are deliberately *not* roster columns — connector liveness needs a live per-operator read (§5.4), and cost is the SMD-only economics surface with its own page (§4.3). Both are one click from each row's overview. (Footnote links to Operator costs.)
- **Health never reads calmer than reality:** takes the more alarming of heartbeat vs the summary rollup (which folds in sticky-stop / escalation / connector health).

## Scope notes

- Row links target the per-operator overview (`/admin/operator/[customer]`), which ships in PR 2 (next in sequence).
- Adds the **Operator** nav item to `AdminLayout`.
- Lane: only `src/pages/admin/operator/*`, `src/lib/admin/*`, admin tests, and the admin nav touched.

## Verification

- `npm run verify` green end-to-end (typecheck + workers typecheck + format + lint + build + test + workers test). Main suite: 3099 passed / 2 skipped.
- 15 new unit tests (`tests/fleet-roster.test.ts`) for the reader + every derivation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)