### PR TITLE
feat(operator): admin per-operator overview — drill-in hub (§5.1)

### DIFF
--- a/src/layouts/AdminLayout.astro
+++ b/src/layouts/AdminLayout.astro
@@ -42,6 +42,11 @@ const navItems = [
     href: '/admin/analytics',
     match: (p: string) => p.startsWith('/admin/analytics'),
   },
+  {
+    label: 'Operator',
+    href: '/admin/operator',
+    match: (p: string) => p.startsWith('/admin/operator'),
+  },
 ]
 ---
 

--- a/src/lib/admin/fleet-roster.ts
+++ b/src/lib/admin/fleet-roster.ts
@@ -1,0 +1,264 @@
+/**
+ * Fleet-roster reader for the admin Operator console landing
+ * (`/admin/operator`) — design doc docs/design/operator/01-admin-portal.md §4.1.
+ *
+ * The roster is the "is anything on fire across all my operators" view: one
+ * row per client, scannable as the fleet grows. It composes three console-side
+ * projections, never a cross-Machine runtime join (ADR 0009):
+ *
+ *   1. `customer_configs`            — identity, persona roster, authority posture
+ *   2. `operator_runtime_summary`    — health/alerts/last-activity mirror (ADR 0043 B)
+ *   3. `fleet_status`                — per-customer heartbeat liveness (ADR 0023)
+ *
+ * This module owns only #1's read + the pure derivations the page renders
+ * (posture label, combined health). The summary/heartbeat readers are the
+ * frozen seam (src/lib/admin/runtime-summary.ts, fleet-status.ts); the page
+ * joins them by entity_id (slug fallback), exactly as the costs page does.
+ *
+ * Fleet-view discipline (foundations §7, ADR 0043): one corrupt config row must
+ * never 500 the whole fleet view. `listFleetRoster` parses each row defensively
+ * — a malformed personas/authority column degrades that single row to a flagged
+ * `config_error` state with an empty persona list and the launch-default
+ * posture, and the rest of the fleet still renders.
+ */
+
+import type { D1Database } from '@cloudflare/workers-types'
+import {
+  DEFAULT_AUTHORITY_POSTURE,
+  parseAuthorityPosture,
+  resolveAllDomains,
+  type AuthorityPosture,
+} from '../operator/authority'
+import type { SummaryStatus } from './runtime-summary'
+
+export interface RosterPersona {
+  slug: string
+  name: string
+  status: string
+}
+
+export interface RosterCustomer {
+  entity_id: string
+  customer_slug: string
+  /** Display name from `entities.name`; null when no entity row joins. */
+  entity_name: string | null
+  /** Projected `customer_configs.vertical`; null before CI sync backfills it. */
+  vertical: string | null
+  personas: RosterPersona[]
+  authority: AuthorityPosture
+  /**
+   * Set when this row's projected JSON was malformed. The row still renders
+   * (degraded) so one corrupt config never blanks the fleet view — the flag
+   * lets the page surface "this operator's config needs attention" honestly
+   * instead of silently showing zero personas.
+   */
+  config_error: string | null
+}
+
+interface RosterDbRow {
+  entity_id: string
+  customer_slug: string
+  personas_json: string
+  authority_json: string | null
+  vertical: string | null
+}
+
+interface EntityNameRow {
+  id: string
+  name: string
+}
+
+/**
+ * Enumerate every Operator customer for the fleet roster, ordered by slug.
+ * One batched read of `customer_configs` + one batched name lookup — no
+ * per-row query and no per-customer Machine round-trip.
+ */
+export async function listFleetRoster(db: D1Database): Promise<RosterCustomer[]> {
+  const configResult = await db
+    .prepare(
+      `SELECT entity_id, customer_slug, personas_json, authority_json, vertical
+         FROM customer_configs
+        ORDER BY customer_slug ASC`
+    )
+    .all<RosterDbRow>()
+  const rows = configResult.results ?? []
+  if (rows.length === 0) return []
+
+  const namesByEntity = await loadEntityNames(
+    db,
+    rows.map((r) => r.entity_id)
+  )
+
+  return rows.map((row) => projectRosterRow(row, namesByEntity.get(row.entity_id) ?? null))
+}
+
+async function loadEntityNames(db: D1Database, entityIds: string[]): Promise<Map<string, string>> {
+  const placeholders = entityIds.map(() => '?').join(',')
+  const result = await db
+    .prepare(`SELECT id, name FROM entities WHERE id IN (${placeholders})`)
+    .bind(...entityIds)
+    .all<EntityNameRow>()
+  const map = new Map<string, string>()
+  for (const row of result.results ?? []) map.set(row.id, row.name)
+  return map
+}
+
+function projectRosterRow(row: RosterDbRow, entityName: string | null): RosterCustomer {
+  const base = {
+    entity_id: row.entity_id,
+    customer_slug: row.customer_slug,
+    entity_name: entityName,
+    vertical: row.vertical,
+  }
+  try {
+    return {
+      ...base,
+      personas: parsePersonas(row.personas_json),
+      // parseAuthorityPosture is total (never throws); a malformed personas
+      // column is what flips a row into the error state.
+      authority: parseAuthorityPosture(safeJsonParse(row.authority_json)),
+      config_error: null,
+    }
+  } catch (err) {
+    return {
+      ...base,
+      personas: [],
+      authority: { ...DEFAULT_AUTHORITY_POSTURE },
+      config_error: err instanceof Error ? err.message : String(err),
+    }
+  }
+}
+
+function parsePersonas(raw: string): RosterPersona[] {
+  const parsed: unknown = JSON.parse(raw)
+  if (!Array.isArray(parsed)) throw new Error('personas_json is not an array')
+  return parsed.map((p) => {
+    if (typeof p !== 'object' || p === null) throw new Error('persona entry is not an object')
+    const rec = p as Record<string, unknown>
+    return {
+      slug: typeof rec.slug === 'string' ? rec.slug : '',
+      name: typeof rec.name === 'string' ? rec.name : '',
+      status: typeof rec.status === 'string' ? rec.status : 'unknown',
+    }
+  })
+}
+
+/** Null-tolerant JSON parse; null/undefined → null, malformed → throws. */
+function safeJsonParse(value: string | null | undefined): unknown {
+  if (value === null || value === undefined) return null
+  return JSON.parse(value)
+}
+
+// ===========================================================================
+// Pure derivations the roster page renders
+// ===========================================================================
+
+export type PostureLabel = 'Managed' | 'Co-Managed' | 'Self-Managed'
+
+export interface PosturePill {
+  label: PostureLabel
+  classes: string
+}
+
+const POSTURE_BADGE_STRUCTURE =
+  'inline-flex items-center px-2 py-0.5 rounded-[var(--ss-radius-badge)] ' +
+  'text-[10px] font-medium uppercase tracking-wide whitespace-nowrap'
+
+/**
+ * Derive the posture chip from the resolved authority posture (foundations
+ * §4.1): the label is a description of the *switch pattern*, not a SKU —
+ * Managed (every client switch off), Self-Managed (every switch client),
+ * Co-Managed (a mix). SMD always retains full control regardless; this chip
+ * describes only the client org's operability.
+ */
+export function derivePostureLabel(posture: AuthorityPosture | null): PostureLabel {
+  const holders = Object.values(resolveAllDomains(posture))
+  const clientCount = holders.filter((h) => h === 'client').length
+  if (clientCount === 0) return 'Managed'
+  if (clientCount === holders.length) return 'Self-Managed'
+  return 'Co-Managed'
+}
+
+export function posturePill(posture: AuthorityPosture | null): PosturePill {
+  const label = derivePostureLabel(posture)
+  const tone =
+    label === 'Managed'
+      ? 'bg-[color:var(--ss-color-primary)] text-white'
+      : label === 'Self-Managed'
+        ? 'bg-[color:var(--ss-color-complete)] text-white'
+        : 'bg-[color:var(--ss-color-attention)] text-white'
+  return { label, classes: `${POSTURE_BADGE_STRUCTURE} ${tone}` }
+}
+
+export type RosterHealthColor = 'green' | 'yellow' | 'red' | 'gray'
+
+export interface RosterHealth {
+  color: RosterHealthColor
+  /** Relative liveness label from the heartbeat ("47s ago" / "stale 12m"). */
+  label: string
+  /** Secondary line when the summary mirror reports a non-green rollup. */
+  note: string | null
+}
+
+const HEALTH_RANK: Record<RosterHealthColor, number> = { gray: 0, green: 1, yellow: 2, red: 3 }
+
+/**
+ * Combine the heartbeat liveness ("is the process alive", fleet_status) with
+ * the runtime-summary rollup ("is the operator OK" — folds in sticky-stop,
+ * escalation pressure, connector health per migration 0052) into one fleet
+ * dot. Takes the more alarming of the two so the column never reads calmer
+ * than reality. `heartbeatColor` is the color from `heartbeatDisplay`;
+ * `summaryStatus` is null when no Machine has pushed a summary yet.
+ */
+export function rosterHealth(
+  heartbeatColor: RosterHealthColor,
+  heartbeatLabel: string,
+  summaryStatus: SummaryStatus | null
+): RosterHealth {
+  const summaryColor = summaryStatusToColor(summaryStatus)
+  const color =
+    HEALTH_RANK[summaryColor] > HEALTH_RANK[heartbeatColor] ? summaryColor : heartbeatColor
+  const note =
+    summaryStatus === 'red'
+      ? 'operator reports a problem'
+      : summaryStatus === 'yellow'
+        ? 'operator reports a warning'
+        : null
+  return { color, label: heartbeatLabel, note }
+}
+
+function summaryStatusToColor(status: SummaryStatus | null): RosterHealthColor {
+  switch (status) {
+    case 'green':
+      return 'green'
+    case 'yellow':
+      return 'yellow'
+    case 'red':
+      return 'red'
+    default:
+      return 'gray'
+  }
+}
+
+export function rosterHealthDotClass(color: RosterHealthColor): string {
+  switch (color) {
+    case 'green':
+      return 'bg-[color:var(--ss-color-complete)]'
+    case 'yellow':
+      return 'bg-[color:var(--ss-color-attention)]'
+    case 'red':
+      return 'bg-[color:var(--ss-color-error)]'
+    case 'gray':
+      return 'bg-[color:var(--ss-color-border)]'
+  }
+}
+
+/** "3 personas" / "1 persona" / "no personas". Pure, for the roster cell. */
+export function personaSummary(personas: RosterPersona[]): string {
+  const active = personas.filter((p) => p.status === 'active')
+  const count = personas.length
+  if (count === 0) return 'no personas'
+  const noun = count === 1 ? 'persona' : 'personas'
+  const archived = count - active.length
+  return archived > 0 ? `${count} ${noun} (${archived} archived)` : `${count} ${noun}`
+}

--- a/src/lib/admin/operator-overview.ts
+++ b/src/lib/admin/operator-overview.ts
@@ -1,0 +1,177 @@
+/**
+ * Per-operator overview reader + derivations for the admin Operator console
+ * drill-in (`/admin/operator/[customer]`) — design doc §5.1.
+ *
+ * The overview is the hub for one operator: identity, the persona roster (built
+ * for N, shows one at v1 per ADR 0011), the authority posture + per-domain
+ * switch summary, a health summary, and subscription state. Like the fleet
+ * roster it reads only console-side projections — `customer_configs` (via the
+ * frozen getCustomerConfig read path), the runtime-summary mirror, fleet_status,
+ * and subscriptions. Deep runtime detail (audit log, drafts, matters) is the
+ * §5.5 surface and uses the live per-customer read path; the overview never
+ * crosses the isolation boundary.
+ *
+ * This module owns the slug→entity_id resolution and the pure derivations the
+ * page renders. The config/summary/heartbeat/subscription readers are the
+ * frozen seam; the page composes them.
+ */
+
+import type { D1Database } from '@cloudflare/workers-types'
+import {
+  resolveAllDomains,
+  SMD_ONLY_AUTHORITY_DOMAINS,
+  type AuthorityPosture,
+  type AuthorityHolder,
+  type SwitchableAuthorityDomain,
+  type SmdOnlyAuthorityDomain,
+} from '../operator/authority'
+
+/**
+ * Resolve a customer slug to its entity_id via `customer_configs`. The
+ * `[customer]` route segment is the slug (human-stable, URL-safe); the frozen
+ * config/subscription readers key on entity_id. Returns null when no operator
+ * has that slug.
+ */
+export async function resolveEntityIdBySlug(db: D1Database, slug: string): Promise<string | null> {
+  const row = await db
+    .prepare('SELECT entity_id FROM customer_configs WHERE customer_slug = ?')
+    .bind(slug)
+    .first<{ entity_id: string }>()
+  return row?.entity_id ?? null
+}
+
+// ===========================================================================
+// Per-domain authority summary (foundations §4.2)
+// ===========================================================================
+
+/** Display labels for every authority domain (switchable + SMD-only). */
+export const AUTHORITY_DOMAIN_LABELS: Record<
+  SwitchableAuthorityDomain | SmdOnlyAuthorityDomain,
+  string
+> = {
+  configuration: 'Configuration authoring',
+  trust: 'Trust & governance',
+  connectors: 'Connectors & credentials',
+  runtime: 'Runtime operations',
+  memory: 'Memory & agent-skills',
+  people_access: 'People & access',
+  compliance: 'Compliance & audit',
+  observability: 'Observability & health',
+  provisioning: 'Provisioning & lifecycle',
+  cost: 'Cost & economics',
+}
+
+export interface DomainAuthorityRow {
+  domain: SwitchableAuthorityDomain
+  label: string
+  holder: AuthorityHolder
+  /** true → the client org also operates this domain (switch on). */
+  clientOperable: boolean
+}
+
+/**
+ * The per-domain switch summary the overview renders: one row per switchable
+ * domain with who operates it. SMD operates every domain regardless (Layer 0);
+ * `holder === 'client'` means the client org *also* has operable controls.
+ */
+export function domainAuthoritySummary(posture: AuthorityPosture | null): DomainAuthorityRow[] {
+  const resolved = resolveAllDomains(posture)
+  return (Object.keys(resolved) as SwitchableAuthorityDomain[]).map((domain) => ({
+    domain,
+    label: AUTHORITY_DOMAIN_LABELS[domain],
+    holder: resolved[domain],
+    clientOperable: resolved[domain] === 'client',
+  }))
+}
+
+/** The two SMD-only domains, labelled — shown as always SMD-operated. */
+export function smdOnlyDomains(): { domain: SmdOnlyAuthorityDomain; label: string }[] {
+  return SMD_ONLY_AUTHORITY_DOMAINS.map((domain) => ({
+    domain,
+    label: AUTHORITY_DOMAIN_LABELS[domain],
+  }))
+}
+
+export interface AuthorityHolderBadge {
+  label: string
+  classes: string
+}
+
+const HOLDER_BADGE_STRUCTURE =
+  'inline-flex items-center px-2 py-0.5 rounded-[var(--ss-radius-badge)] ' +
+  'text-[10px] font-medium uppercase tracking-wide whitespace-nowrap'
+
+/**
+ * Badge for who operates a domain. "SMD" (managed — the client sees Read +
+ * Request) vs "Client + SMD" (client switch on — additive, never instead of
+ * SMD). The wording never implies SMD lost control.
+ */
+export function authorityHolderBadge(holder: AuthorityHolder): AuthorityHolderBadge {
+  if (holder === 'client') {
+    return {
+      label: 'Client + SMD',
+      classes: `${HOLDER_BADGE_STRUCTURE} bg-[color:var(--ss-color-complete)] text-white`,
+    }
+  }
+  return {
+    label: 'SMD',
+    classes: `${HOLDER_BADGE_STRUCTURE} bg-[color:var(--ss-color-primary)] text-white`,
+  }
+}
+
+// ===========================================================================
+// Subscription state (single-item detail → prose, UI-PATTERNS Rule 1)
+// ===========================================================================
+
+export interface SubscriptionState {
+  label: string
+  /** Token-based text color so the prose carries the semantic, not a pill. */
+  colorClass: string
+}
+
+/**
+ * Map a subscription status to display prose for the detail header. Null when
+ * no Operator subscription exists yet (a real pre-activation state, not an
+ * error). Statuses match getProductSubscription: provisioning / active / paused.
+ */
+export function subscriptionState(status: string | null): SubscriptionState {
+  switch (status) {
+    case 'active':
+      return { label: 'Active', colorClass: 'text-[color:var(--ss-color-complete)]' }
+    case 'provisioning':
+      return { label: 'Provisioning', colorClass: 'text-[color:var(--ss-color-attention)]' }
+    case 'paused':
+      return { label: 'Paused', colorClass: 'text-[color:var(--ss-color-attention)]' }
+    case null:
+      return { label: 'No subscription yet', colorClass: 'text-[color:var(--ss-color-text-muted)]' }
+    default:
+      return { label: status, colorClass: 'text-[color:var(--ss-color-text-secondary)]' }
+  }
+}
+
+// ===========================================================================
+// Persona roster cell helpers
+// ===========================================================================
+
+export interface PersonaStatusDisplay {
+  label: string
+  dotClass: string
+}
+
+/** Dot + label for a persona's status (active / archived / other). */
+export function personaStatusDisplay(status: string): PersonaStatusDisplay {
+  switch (status) {
+    case 'active':
+      return { label: 'Active', dotClass: 'bg-[color:var(--ss-color-complete)]' }
+    case 'archived':
+      return { label: 'Archived', dotClass: 'bg-[color:var(--ss-color-border)]' }
+    default:
+      return { label: status, dotClass: 'bg-[color:var(--ss-color-attention)]' }
+  }
+}
+
+/** "3 skills" / "1 skill" / "no skills" for a persona card. */
+export function skillCountLabel(count: number): string {
+  if (count <= 0) return 'no skills'
+  return count === 1 ? '1 skill' : `${count} skills`
+}

--- a/src/pages/admin/operator/[customer]/index.astro
+++ b/src/pages/admin/operator/[customer]/index.astro
@@ -1,0 +1,294 @@
+---
+import AdminLayout from '../../../../layouts/AdminLayout.astro'
+import { posturePill, rosterHealth, rosterHealthDotClass } from '../../../../lib/admin/fleet-roster'
+import {
+  resolveEntityIdBySlug,
+  domainAuthoritySummary,
+  smdOnlyDomains,
+  authorityHolderBadge,
+  subscriptionState,
+  personaStatusDisplay,
+  skillCountLabel,
+} from '../../../../lib/admin/operator-overview'
+import { getRuntimeSummary } from '../../../../lib/admin/runtime-summary'
+import {
+  listFleetStatus,
+  heartbeatDisplay,
+  relativeTimestamp,
+} from '../../../../lib/admin/fleet-status'
+import { getCustomerConfig, type CustomerConfigRow } from '../../../../lib/portal/customer-config'
+import { getProductSubscription } from '../../../../lib/portal/product-access'
+import { env } from 'cloudflare:workers'
+
+/**
+ * Operator admin console — per-operator overview (the drill-in hub).
+ *
+ * The hub for one operator: identity, persona roster (built for N, shows one at
+ * v1), authority posture + per-domain switch summary, health summary, and
+ * subscription state. Reads only console-side projections — never a Machine's
+ * runtime D1 (ADR 0009). Deep runtime detail is the §5.5 surface.
+ *
+ * Design: docs/design/operator/01-admin-portal.md §5.1.
+ *
+ * Honest states (foundations §7): a missing operator is a real 404; a corrupt
+ * config projection renders an explicit error, not a fabricated page; a
+ * roster-of-one and a not-yet-activated subscription are real v1 states.
+ */
+
+const session = Astro.locals.session!
+if (session.role !== 'admin') {
+  return Astro.redirect('/auth/sign-in')
+}
+
+const slug = Astro.params.customer ?? ''
+
+const entityId = await resolveEntityIdBySlug(env.DB, slug)
+
+let config: CustomerConfigRow | null = null
+let configError: string | null = null
+if (entityId) {
+  try {
+    config = await getCustomerConfig(env.DB, entityId)
+  } catch (err) {
+    configError = err instanceof Error ? err.message : String(err)
+  }
+}
+
+// Not found: no operator with this slug. A real 404 (foundations §7), not a
+// fabricated empty operator.
+const notFound = entityId === null || (config === null && configError === null)
+if (notFound) {
+  Astro.response.status = 404
+}
+
+const summary = config ? await getRuntimeSummary(env.DB, slug) : null
+const fleetRows = config ? await listFleetStatus(env.DB) : []
+const fleet =
+  fleetRows.find((r) => r.entity_id === entityId) ?? fleetRows.find((r) => r.customer_slug === slug)
+const subscription =
+  config && entityId ? await getProductSubscription(env.DB, entityId, 'operator') : null
+
+const hb = heartbeatDisplay(fleet?.last_heartbeat_ts ?? null)
+const health = rosterHealth(hb.color, hb.label, summary?.summary_status ?? null)
+const posture = config ? posturePill(config.authority) : null
+const domainRows = config ? domainAuthoritySummary(config.authority) : []
+const smdOnly = smdOnlyDomains()
+const sub = subscriptionState(subscription?.status ?? null)
+const lastActivity = summary?.last_activity_ts ? relativeTimestamp(summary.last_activity_ts) : null
+
+const headerName = slug
+const personas = config?.personas ?? []
+---
+
+<AdminLayout
+  title={`Operator — ${headerName}`}
+  breadcrumbs={[
+    { label: 'Dashboard', href: '/admin' },
+    { label: 'Operator', href: '/admin/operator' },
+    { label: headerName },
+  ]}
+  maxWidth="max-w-6xl"
+>
+  <div class="space-y-card">
+    {
+      notFound ? (
+        <div class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card">
+          <h2 class="text-xl font-semibold text-[color:var(--ss-color-text-primary)]">
+            Operator not found
+          </h2>
+          <p class="text-sm text-[color:var(--ss-color-text-secondary)] mt-1">
+            No operator is provisioned under <code>{slug}</code>.{' '}
+            <a href="/admin/operator" class="text-[color:var(--ss-color-action)] hover:underline">
+              Back to the fleet
+            </a>
+            .
+          </p>
+        </div>
+      ) : configError ? (
+        <div class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-error)] p-card">
+          <h2 class="text-xl font-semibold text-[color:var(--ss-color-error)]">
+            Config projection malformed
+          </h2>
+          <p class="text-sm text-[color:var(--ss-color-text-secondary)] mt-1">
+            The <code>customer_configs</code> row for <code>{slug}</code> could not be parsed. This
+            is a projection corruption signal, not a routine state — the customer.yaml sync needs
+            attention.
+          </p>
+          <p class="text-xs text-[color:var(--ss-color-text-muted)] mt-2 font-mono">
+            {configError}
+          </p>
+        </div>
+      ) : (
+        config && (
+          <>
+            <header class="flex items-start justify-between gap-4">
+              <div>
+                <h2 class="text-xl font-semibold text-[color:var(--ss-color-text-primary)]">
+                  {headerName}
+                </h2>
+                <p class="text-sm text-[color:var(--ss-color-text-secondary)] mt-1">
+                  {config.vertical ? `${config.vertical} · ` : ''}
+                  <code>{config.entity_id}</code>
+                </p>
+                <p class="text-sm mt-1">
+                  <span class="text-[color:var(--ss-color-text-muted)]">Subscription:</span>{' '}
+                  <span class={sub.colorClass}>{sub.label}</span>
+                </p>
+              </div>
+              {posture && <span class={posture.classes}>{posture.label}</span>}
+            </header>
+
+            <div class="grid gap-card md:grid-cols-2">
+              {/* Health summary */}
+              <div class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card">
+                <h3 class="text-base font-semibold text-[color:var(--ss-color-text-primary)] mb-3">
+                  Health
+                </h3>
+                <div class="flex items-center gap-2 mb-2">
+                  <span
+                    class={`inline-block h-2.5 w-2.5 rounded-full ${rosterHealthDotClass(health.color)}`}
+                    aria-hidden="true"
+                  />
+                  <span class="text-sm text-[color:var(--ss-color-text-primary)]">
+                    Heartbeat {health.label}
+                  </span>
+                </div>
+                {health.note && (
+                  <p class="text-xs text-[color:var(--ss-color-text-muted)] mb-2">{health.note}</p>
+                )}
+                <dl class="text-sm space-y-1">
+                  <div class="flex justify-between gap-4">
+                    <dt class="text-[color:var(--ss-color-text-secondary)]">Open alerts</dt>
+                    <dd
+                      class={
+                        summary && summary.open_alerts > 0
+                          ? 'font-semibold text-[color:var(--ss-color-error)]'
+                          : 'text-[color:var(--ss-color-text-primary)]'
+                      }
+                    >
+                      {summary ? summary.open_alerts : '—'}
+                    </dd>
+                  </div>
+                  <div class="flex justify-between gap-4">
+                    <dt class="text-[color:var(--ss-color-text-secondary)]">Last activity</dt>
+                    <dd class="text-[color:var(--ss-color-text-primary)]">{lastActivity ?? '—'}</dd>
+                  </div>
+                  <div class="flex justify-between gap-4">
+                    <dt class="text-[color:var(--ss-color-text-secondary)]">Draft queue</dt>
+                    <dd class="text-[color:var(--ss-color-text-primary)]">
+                      {summary && summary.draft_queue_depth !== null
+                        ? summary.draft_queue_depth
+                        : '—'}
+                    </dd>
+                  </div>
+                </dl>
+                <p class="text-xs text-[color:var(--ss-color-text-muted)] mt-3">
+                  Health reads the per-customer summary mirror and heartbeat. A "—" draft queue
+                  means no skill is authored to draft, not zero pending.
+                </p>
+              </div>
+
+              {/* Persona roster (built for N, shows one at v1) */}
+              <div class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card">
+                <h3 class="text-base font-semibold text-[color:var(--ss-color-text-primary)] mb-3">
+                  Personas ({personas.length})
+                </h3>
+                {personas.length === 0 ? (
+                  <p class="text-sm text-[color:var(--ss-color-text-secondary)]">
+                    No personas configured.
+                  </p>
+                ) : (
+                  <ul class="space-y-3">
+                    {personas.map((p) => {
+                      const st = personaStatusDisplay(p.status)
+                      return (
+                        <li class="border-b border-[color:var(--ss-color-border-subtle)] pb-3 last:border-0 last:pb-0">
+                          <div class="flex items-center justify-between gap-2">
+                            <span class="font-medium text-[color:var(--ss-color-text-primary)]">
+                              {p.name}
+                            </span>
+                            <span class="inline-flex items-center gap-1.5 text-xs text-[color:var(--ss-color-text-secondary)]">
+                              <span
+                                class={`inline-block h-2 w-2 rounded-full ${st.dotClass}`}
+                                aria-hidden="true"
+                              />
+                              {st.label}
+                            </span>
+                          </div>
+                          <p class="text-xs text-[color:var(--ss-color-text-muted)]">
+                            {p.title ? `${p.title} · ` : ''}
+                            {skillCountLabel(p.skills.length)}
+                          </p>
+                        </li>
+                      )
+                    })}
+                  </ul>
+                )}
+              </div>
+            </div>
+
+            {/* Authority posture — per-domain switch summary */}
+            <div class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card">
+              <h3 class="text-base font-semibold text-[color:var(--ss-color-text-primary)] mb-1">
+                Authority posture
+              </h3>
+              <p class="text-xs text-[color:var(--ss-color-text-muted)] mb-3">
+                SMD operates every domain in every state. A "Client + SMD" badge means the client
+                org also holds operable controls for that domain (an additive switch), never instead
+                of SMD. Flip switches on the Authority surface.
+              </p>
+              <ul class="grid gap-2 sm:grid-cols-2 text-sm">
+                {domainRows.map((d) => {
+                  const badge = authorityHolderBadge(d.holder)
+                  return (
+                    <li class="flex items-center justify-between gap-2">
+                      <span class="text-[color:var(--ss-color-text-primary)]">{d.label}</span>
+                      <span class={badge.classes}>{badge.label}</span>
+                    </li>
+                  )
+                })}
+                {smdOnly.map((d) => (
+                  <li class="flex items-center justify-between gap-2">
+                    <span class="text-[color:var(--ss-color-text-secondary)]">{d.label}</span>
+                    <span class="text-[10px] uppercase tracking-wide text-[color:var(--ss-color-text-muted)]">
+                      SMD only
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+
+            {/* Drill-ins */}
+            <div class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card">
+              <h3 class="text-base font-semibold text-[color:var(--ss-color-text-primary)] mb-3">
+                Drill-ins
+              </h3>
+              <ul class="flex flex-wrap gap-x-6 gap-y-2 text-sm">
+                <li>
+                  <a
+                    href={`/admin/operator/costs/${encodeURIComponent(slug)}`}
+                    class="text-[color:var(--ss-color-action)] hover:underline"
+                  >
+                    Cost
+                  </a>
+                </li>
+                <li>
+                  <a
+                    href={`/admin/operator/config-history/${encodeURIComponent(slug)}`}
+                    class="text-[color:var(--ss-color-action)] hover:underline"
+                  >
+                    Config history
+                  </a>
+                </li>
+              </ul>
+              <p class="text-xs text-[color:var(--ss-color-text-muted)] mt-3">
+                Configuration, governance, connectors, runtime, memory, people, authority, and
+                lifecycle drill-ins land as their surfaces ship.
+              </p>
+            </div>
+          </>
+        )
+      )
+    }
+  </div>
+</AdminLayout>

--- a/src/pages/admin/operator/index.astro
+++ b/src/pages/admin/operator/index.astro
@@ -1,0 +1,257 @@
+---
+import AdminLayout from '../../../layouts/AdminLayout.astro'
+import { listFleetRoster, type RosterCustomer } from '../../../lib/admin/fleet-roster'
+import {
+  posturePill,
+  rosterHealth,
+  rosterHealthDotClass,
+  personaSummary,
+} from '../../../lib/admin/fleet-roster'
+import { listRuntimeSummary, type RuntimeSummaryRow } from '../../../lib/admin/runtime-summary'
+import {
+  listFleetStatus,
+  heartbeatDisplay,
+  relativeTimestamp,
+  type FleetStatusRow,
+} from '../../../lib/admin/fleet-status'
+import { env } from 'cloudflare:workers'
+
+/**
+ * Operator admin console — fleet home (the roster).
+ *
+ * The default landing for `/admin/operator`. One row per operator (per
+ * client), built for scanning a growing fleet: "is anything on fire across all
+ * my operators." Composes three console-side projections only — customer_configs
+ * (identity, personas, posture), operator_runtime_summary (health/alerts/last
+ * activity mirror, ADR 0043 B), and fleet_status (heartbeat). It never reads a
+ * Machine's runtime D1 directly and never joins two customers (ADR 0009).
+ *
+ * Design: docs/design/operator/01-admin-portal.md §4.1.
+ *
+ * Empty / honest states (foundations §7): a fleet of zero is a real state, not
+ * an error. Before any Machine pushes a summary, health falls back to the
+ * heartbeat alone and last-activity / alert columns read "—" rather than
+ * fabricating activity. A roster-of-one client with one persona is the normal
+ * v1 state, not a placeholder.
+ *
+ * Connector health (§5.4) and per-operator cost (§4.3 / §5.8) are deliberately
+ * not roster columns: connector liveness needs the per-operator runtime read,
+ * and cost is the SMD-only economics surface with its own page. Both are one
+ * click away from each row's overview.
+ */
+
+const session = Astro.locals.session!
+
+// /admin/* already requires the admin role at the middleware layer; re-check
+// here so a routing misconfig can't silently fall through (mirrors the costs
+// page). Today admin === Captain; the smd_admin/smd_operator seam (§2) layers
+// on later without reworking this gate.
+if (session.role !== 'admin') {
+  return Astro.redirect('/auth/sign-in')
+}
+
+const roster = await listFleetRoster(env.DB)
+const summaryRows = await listRuntimeSummary(env.DB)
+const fleetStatusRows = await listFleetStatus(env.DB)
+
+const summaryByEntity = new Map<string, RuntimeSummaryRow>(summaryRows.map((r) => [r.entity_id, r]))
+const summaryBySlug = new Map<string, RuntimeSummaryRow>(
+  summaryRows.map((r) => [r.customer_slug, r])
+)
+const fleetByEntity = new Map<string, FleetStatusRow>(fleetStatusRows.map((r) => [r.entity_id, r]))
+const fleetBySlug = new Map<string, FleetStatusRow>(
+  fleetStatusRows.map((r) => [r.customer_slug, r])
+)
+
+function summaryFor(c: RosterCustomer): RuntimeSummaryRow | undefined {
+  return summaryByEntity.get(c.entity_id) ?? summaryBySlug.get(c.customer_slug)
+}
+function fleetFor(c: RosterCustomer): FleetStatusRow | undefined {
+  return fleetByEntity.get(c.entity_id) ?? fleetBySlug.get(c.customer_slug)
+}
+
+interface RosterView {
+  customer: RosterCustomer
+  personaLine: string
+  personaNames: string
+  posture: ReturnType<typeof posturePill>
+  health: ReturnType<typeof rosterHealth>
+  openAlerts: number | null
+  lastActivity: string | null
+}
+
+const views: RosterView[] = roster.map((customer) => {
+  const summary = summaryFor(customer)
+  const fleet = fleetFor(customer)
+  const hb = heartbeatDisplay(fleet?.last_heartbeat_ts ?? null)
+  const health = rosterHealth(hb.color, hb.label, summary?.summary_status ?? null)
+  const names = customer.personas.map((p) => p.name).filter(Boolean)
+  return {
+    customer,
+    personaLine: personaSummary(customer.personas),
+    personaNames: names.join(', '),
+    posture: posturePill(customer.authority),
+    health,
+    openAlerts: summary ? summary.open_alerts : null,
+    lastActivity: summary?.last_activity_ts ? relativeTimestamp(summary.last_activity_ts) : null,
+  }
+})
+
+// Sort: rows needing attention first (config error, then red/yellow health,
+// then open alerts), then alphabetical by slug. Same "eye lands on trouble"
+// ordering as the costs page.
+const HEALTH_SORT: Record<string, number> = { red: 3, yellow: 2, gray: 1, green: 0 }
+views.sort((a, b) => {
+  const aErr = a.customer.config_error ? 1 : 0
+  const bErr = b.customer.config_error ? 1 : 0
+  if (aErr !== bErr) return bErr - aErr
+  const h = (HEALTH_SORT[b.health.color] ?? 0) - (HEALTH_SORT[a.health.color] ?? 0)
+  if (h !== 0) return h
+  const alerts = (b.openAlerts ?? 0) - (a.openAlerts ?? 0)
+  if (alerts !== 0) return alerts
+  return a.customer.customer_slug.localeCompare(b.customer.customer_slug)
+})
+
+const totalOperators = roster.length
+---
+
+<AdminLayout
+  title="Operator — Fleet"
+  breadcrumbs={[{ label: 'Dashboard', href: '/admin' }, { label: 'Operator' }]}
+  maxWidth="max-w-6xl"
+>
+  <div class="space-y-card">
+    <header class="flex items-end justify-between gap-4">
+      <div>
+        <h2 class="text-xl font-semibold text-[color:var(--ss-color-text-primary)]">
+          Operator fleet
+        </h2>
+        <p class="text-sm text-[color:var(--ss-color-text-secondary)] mt-1">
+          Every operator at a glance: persona roster, authority posture, health, and open alerts.
+          Health and activity read the per-customer summary mirror (ADR 0043); deep detail lives in
+          each operator's drill-in.
+        </p>
+      </div>
+      <div class="text-right">
+        <p class="text-xs uppercase tracking-wide text-[color:var(--ss-color-text-muted)]">
+          Operators
+        </p>
+        <p class="text-2xl font-bold text-[color:var(--ss-color-text-primary)]">
+          {totalOperators}
+        </p>
+      </div>
+    </header>
+
+    <div
+      class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card"
+    >
+      {
+        roster.length === 0 ? (
+          <p class="text-sm text-[color:var(--ss-color-text-secondary)]">
+            No operators provisioned yet. The fleet is empty until <code>customer_configs</code> has
+            at least one row.
+          </p>
+        ) : (
+          <div class="overflow-x-auto">
+            <table class="w-full text-sm">
+              <thead>
+                <tr class="text-left text-xs text-[color:var(--ss-color-text-secondary)] border-b border-[color:var(--ss-color-border)]">
+                  <th class="pb-2 font-medium">Operator</th>
+                  <th class="pb-2 font-medium">Personas</th>
+                  <th class="pb-2 font-medium">Posture</th>
+                  <th class="pb-2 font-medium">Health</th>
+                  <th class="pb-2 font-medium text-right">Open alerts</th>
+                  <th class="pb-2 font-medium text-right">Last activity</th>
+                </tr>
+              </thead>
+              <tbody class="divide-y divide-[color:var(--ss-color-border-subtle)]">
+                {views.map((v) => (
+                  <tr class="align-top">
+                    <td class="py-3 pr-4">
+                      <a
+                        href={`/admin/operator/${encodeURIComponent(v.customer.customer_slug)}`}
+                        class="font-medium text-[color:var(--ss-color-text-primary)] hover:text-[color:var(--ss-color-primary)]"
+                      >
+                        {v.customer.entity_name ?? v.customer.customer_slug}
+                      </a>
+                      <p class="text-xs text-[color:var(--ss-color-text-muted)]">
+                        {v.customer.customer_slug}
+                        {v.customer.vertical ? ` · ${v.customer.vertical}` : ''}
+                      </p>
+                      {v.customer.config_error && (
+                        <p class="text-xs text-[color:var(--ss-color-error)] mt-0.5">
+                          Config needs attention — projection malformed
+                        </p>
+                      )}
+                    </td>
+                    <td class="py-3 pr-4">
+                      <span class="text-[color:var(--ss-color-text-primary)]">{v.personaLine}</span>
+                      {v.personaNames && (
+                        <p class="text-xs text-[color:var(--ss-color-text-muted)]">
+                          {v.personaNames}
+                        </p>
+                      )}
+                    </td>
+                    <td class="py-3 pr-4">
+                      <span class={v.posture.classes}>{v.posture.label}</span>
+                    </td>
+                    <td class="py-3 pr-4">
+                      <span class="inline-flex items-center gap-2">
+                        <span
+                          class={`inline-block h-2 w-2 rounded-full ${rosterHealthDotClass(v.health.color)}`}
+                          aria-hidden="true"
+                        />
+                        <span class="text-[color:var(--ss-color-text-secondary)]">
+                          {v.health.label}
+                        </span>
+                      </span>
+                      {v.health.note && (
+                        <p class="text-xs text-[color:var(--ss-color-text-muted)] mt-0.5">
+                          {v.health.note}
+                        </p>
+                      )}
+                    </td>
+                    <td class="py-3 pr-4 text-right">
+                      {v.openAlerts === null ? (
+                        <span class="text-[color:var(--ss-color-text-muted)]">—</span>
+                      ) : v.openAlerts > 0 ? (
+                        <span class="font-semibold text-[color:var(--ss-color-error)]">
+                          {v.openAlerts}
+                        </span>
+                      ) : (
+                        <span class="text-[color:var(--ss-color-text-secondary)]">0</span>
+                      )}
+                    </td>
+                    <td class="py-3 text-right text-[color:var(--ss-color-text-secondary)]">
+                      {v.lastActivity ?? '—'}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )
+      }
+
+      <div
+        class="mt-4 pt-4 border-t border-[color:var(--ss-color-border-subtle)] space-y-2 text-xs text-[color:var(--ss-color-text-muted)]"
+      >
+        <p>
+          <strong>Health</strong> takes the more alarming of the per-customer heartbeat (<code
+            >fleet_status</code
+          >) and the summary rollup (<code>operator_runtime_summary</code>, which folds in
+          sticky-stop, escalation pressure, and connector health). A gray dot with "no signal yet"
+          means no heartbeat has arrived; it does not mean the operator is healthy.
+        </p>
+        <p>
+          <strong>Connector health</strong> and <strong>cost</strong> are per-operator surfaces: connector
+          liveness needs a live read against the operator's Machine, and cost is the SMD-only economics
+          view at <a
+            href="/admin/operator/costs"
+            class="text-[color:var(--ss-color-action)] hover:underline">Operator costs</a
+          >.
+        </p>
+      </div>
+    </div>
+  </div>
+</AdminLayout>

--- a/tests/fleet-roster.test.ts
+++ b/tests/fleet-roster.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Tests for the fleet-roster reader + pure derivations
+ * (src/lib/admin/fleet-roster.ts) — admin Operator console §4.1.
+ *
+ * Two properties matter most and are exercised here:
+ *
+ *   1. Fleet-view resilience (ADR 0043, foundations §7): one corrupt
+ *      `customer_configs` row degrades to a flagged `config_error` row — it
+ *      never throws and blanks the whole fleet view.
+ *   2. Posture + health derivations never read calmer than reality: posture
+ *      labels follow the switch pattern (foundations §4.1) and `rosterHealth`
+ *      takes the more alarming of heartbeat vs summary rollup.
+ *
+ * DB-touching tests seed `customer_configs` + `entities` directly via the test
+ * D1 (same posture as customer-config.test.ts — CI sync lands separately).
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  createTestD1,
+  runMigrations,
+  discoverNumericMigrations,
+} from '@venturecrane/crane-test-harness'
+import { resolve } from 'path'
+import type { D1Database } from '@cloudflare/workers-types'
+import { ORG_ID } from '../src/lib/constants'
+import {
+  listFleetRoster,
+  derivePostureLabel,
+  posturePill,
+  rosterHealth,
+  rosterHealthDotClass,
+  personaSummary,
+  type RosterPersona,
+} from '../src/lib/admin/fleet-roster'
+import { DEFAULT_AUTHORITY_POSTURE, type AuthorityPosture } from '../src/lib/operator/authority'
+
+const migrationsDir = resolve(process.cwd(), 'migrations')
+
+async function freshDb(): Promise<D1Database> {
+  const db = createTestD1()
+  await runMigrations(db, { files: discoverNumericMigrations(migrationsDir) })
+  return db
+}
+
+async function seedEntity(db: D1Database, id: string, name: string, slug: string): Promise<void> {
+  await db
+    .prepare('INSERT INTO entities (id, org_id, name, slug) VALUES (?, ?, ?, ?)')
+    .bind(id, ORG_ID, name, slug)
+    .run()
+}
+
+function persona(overrides: Partial<RosterPersona> = {}): RosterPersona {
+  return { slug: 'marcus', name: 'Marcus', status: 'active', ...overrides }
+}
+
+interface SeedConfig {
+  entity_id: string
+  customer_slug: string
+  personas_json?: string
+  authority_json?: string | null
+  vertical?: string | null
+}
+
+async function seedConfig(db: D1Database, c: SeedConfig): Promise<void> {
+  await db
+    .prepare(
+      `INSERT INTO customer_configs
+        (entity_id, org_id, customer_slug, schema_version, personas_json,
+         authority_json, vertical, git_sha, synced_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    )
+    .bind(
+      c.entity_id,
+      ORG_ID,
+      c.customer_slug,
+      '1.0.0',
+      c.personas_json ?? JSON.stringify([persona()]),
+      c.authority_json === undefined ? null : c.authority_json,
+      c.vertical ?? null,
+      'a1b2c3d4',
+      '2026-06-08T12:00:00Z'
+    )
+    .run()
+}
+
+describe('listFleetRoster', () => {
+  let db: D1Database
+  beforeEach(async () => {
+    db = await freshDb()
+  })
+
+  it('returns [] for an empty fleet', async () => {
+    expect(await listFleetRoster(db)).toEqual([])
+  })
+
+  it('lists customers ordered by slug with entity name joined and personas parsed', async () => {
+    await seedEntity(db, 'ent-b', 'Beta Firm', 'beta-firm')
+    await seedEntity(db, 'ent-a', 'Alpha Firm', 'alpha-firm')
+    await seedConfig(db, { entity_id: 'ent-b', customer_slug: 'beta-firm', vertical: 'law' })
+    await seedConfig(db, {
+      entity_id: 'ent-a',
+      customer_slug: 'alpha-firm',
+      personas_json: JSON.stringify([persona(), persona({ slug: 'nova', name: 'Nova' })]),
+    })
+
+    const roster = await listFleetRoster(db)
+    expect(roster.map((r) => r.customer_slug)).toEqual(['alpha-firm', 'beta-firm'])
+
+    const alpha = roster[0]
+    expect(alpha.entity_name).toBe('Alpha Firm')
+    expect(alpha.personas).toHaveLength(2)
+    expect(alpha.personas[1]).toEqual({ slug: 'nova', name: 'Nova', status: 'active' })
+    expect(alpha.config_error).toBeNull()
+
+    const beta = roster[1]
+    expect(beta.vertical).toBe('law')
+    expect(beta.authority).toEqual(DEFAULT_AUTHORITY_POSTURE)
+  })
+
+  it('resolves an authored authority posture from authority_json', async () => {
+    await seedEntity(db, 'ent-1', 'Gamma Firm', 'gamma-firm')
+    await seedConfig(db, {
+      entity_id: 'ent-1',
+      customer_slug: 'gamma-firm',
+      authority_json: JSON.stringify({
+        default: 'managed',
+        overrides: { people_access: 'client' },
+      }),
+    })
+    const [row] = await listFleetRoster(db)
+    expect(row.authority.overrides.people_access).toBe('client')
+  })
+
+  it('degrades a malformed personas_json row to a flagged config_error, never throwing', async () => {
+    await seedEntity(db, 'ent-ok', 'OK Firm', 'ok-firm')
+    await seedEntity(db, 'ent-bad', 'Bad Firm', 'bad-firm')
+    await seedConfig(db, { entity_id: 'ent-ok', customer_slug: 'ok-firm' })
+    await seedConfig(db, {
+      entity_id: 'ent-bad',
+      customer_slug: 'bad-firm',
+      personas_json: '{not valid json',
+    })
+
+    const roster = await listFleetRoster(db)
+    expect(roster).toHaveLength(2)
+    const bad = roster.find((r) => r.customer_slug === 'bad-firm')!
+    expect(bad.config_error).not.toBeNull()
+    expect(bad.personas).toEqual([])
+    expect(bad.authority).toEqual(DEFAULT_AUTHORITY_POSTURE)
+    // The healthy row is unaffected.
+    const ok = roster.find((r) => r.customer_slug === 'ok-firm')!
+    expect(ok.config_error).toBeNull()
+    expect(ok.personas).toHaveLength(1)
+  })
+
+  it('flags a personas_json that is valid JSON but not an array', async () => {
+    await seedEntity(db, 'ent-x', 'X Firm', 'x-firm')
+    await seedConfig(db, {
+      entity_id: 'ent-x',
+      customer_slug: 'x-firm',
+      personas_json: JSON.stringify({ slug: 'oops' }),
+    })
+    const [row] = await listFleetRoster(db)
+    expect(row.config_error).toMatch(/not an array/)
+  })
+})
+
+describe('derivePostureLabel', () => {
+  it('null / launch-default posture is Managed (every client switch off)', () => {
+    expect(derivePostureLabel(null)).toBe('Managed')
+    expect(derivePostureLabel(DEFAULT_AUTHORITY_POSTURE)).toBe('Managed')
+  })
+
+  it('a self_managed default with no overrides is Self-Managed', () => {
+    const posture: AuthorityPosture = { default: 'self_managed', overrides: {} }
+    expect(derivePostureLabel(posture)).toBe('Self-Managed')
+  })
+
+  it('a managed default with at least one client override is Co-Managed', () => {
+    const posture: AuthorityPosture = { default: 'managed', overrides: { connectors: 'client' } }
+    expect(derivePostureLabel(posture)).toBe('Co-Managed')
+  })
+
+  it('a self_managed default with one domain pinned back to managed is Co-Managed', () => {
+    const posture: AuthorityPosture = { default: 'self_managed', overrides: { trust: 'managed' } }
+    expect(derivePostureLabel(posture)).toBe('Co-Managed')
+  })
+})
+
+describe('posturePill', () => {
+  it('carries the label and a non-empty class string', () => {
+    const pill = posturePill(DEFAULT_AUTHORITY_POSTURE)
+    expect(pill.label).toBe('Managed')
+    expect(pill.classes).toContain('rounded-[var(--ss-radius-badge)]')
+  })
+})
+
+describe('rosterHealth', () => {
+  it('takes the more alarming of heartbeat vs summary rollup', () => {
+    // Heartbeat green but summary red → red.
+    expect(rosterHealth('green', '20s ago', 'red').color).toBe('red')
+    // Heartbeat red but summary green → red (heartbeat is worse).
+    expect(rosterHealth('red', 'stale 9m', 'green').color).toBe('red')
+    // Both benign → green.
+    expect(rosterHealth('green', '5s ago', 'green').color).toBe('green')
+  })
+
+  it('keeps the heartbeat label and adds a note only for non-green summaries', () => {
+    expect(rosterHealth('green', '20s ago', null).note).toBeNull()
+    expect(rosterHealth('green', '20s ago', 'red').note).toMatch(/problem/)
+    expect(rosterHealth('green', '20s ago', 'yellow').note).toMatch(/warning/)
+    expect(rosterHealth('green', '20s ago', 'yellow').label).toBe('20s ago')
+  })
+
+  it('a missing summary (null) leaves the heartbeat color unchanged', () => {
+    expect(rosterHealth('yellow', '3m ago', null).color).toBe('yellow')
+    expect(rosterHealth('gray', 'no signal yet', null).color).toBe('gray')
+  })
+})
+
+describe('rosterHealthDotClass', () => {
+  it('maps every color to a token-based background class', () => {
+    expect(rosterHealthDotClass('green')).toContain('--ss-color-complete')
+    expect(rosterHealthDotClass('yellow')).toContain('--ss-color-attention')
+    expect(rosterHealthDotClass('red')).toContain('--ss-color-error')
+    expect(rosterHealthDotClass('gray')).toContain('--ss-color-border')
+  })
+})
+
+describe('personaSummary', () => {
+  it('renders count with archived suffix and an honest zero state', () => {
+    expect(personaSummary([])).toBe('no personas')
+    expect(personaSummary([persona()])).toBe('1 persona')
+    expect(personaSummary([persona(), persona({ slug: 'n', name: 'N' })])).toBe('2 personas')
+    expect(personaSummary([persona(), persona({ slug: 'a', status: 'archived' })])).toBe(
+      '2 personas (1 archived)'
+    )
+  })
+})

--- a/tests/operator-overview.test.ts
+++ b/tests/operator-overview.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Tests for the per-operator overview reader + derivations
+ * (src/lib/admin/operator-overview.ts) — admin Operator console §5.1.
+ *
+ * Covers the slug→entity_id resolution against a seeded customer_configs row,
+ * and the pure derivations the overview renders: the per-domain authority
+ * summary (every switchable domain + holder), the holder badge wording (never
+ * implying SMD lost control), subscription-state prose, and persona cell
+ * helpers.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  createTestD1,
+  runMigrations,
+  discoverNumericMigrations,
+} from '@venturecrane/crane-test-harness'
+import { resolve } from 'path'
+import type { D1Database } from '@cloudflare/workers-types'
+import { ORG_ID } from '../src/lib/constants'
+import {
+  resolveEntityIdBySlug,
+  domainAuthoritySummary,
+  smdOnlyDomains,
+  authorityHolderBadge,
+  subscriptionState,
+  personaStatusDisplay,
+  skillCountLabel,
+  AUTHORITY_DOMAIN_LABELS,
+} from '../src/lib/admin/operator-overview'
+import {
+  DEFAULT_AUTHORITY_POSTURE,
+  SWITCHABLE_AUTHORITY_DOMAINS,
+  type AuthorityPosture,
+} from '../src/lib/operator/authority'
+
+const migrationsDir = resolve(process.cwd(), 'migrations')
+
+async function freshDb(): Promise<D1Database> {
+  const db = createTestD1()
+  await runMigrations(db, { files: discoverNumericMigrations(migrationsDir) })
+  return db
+}
+
+describe('resolveEntityIdBySlug', () => {
+  let db: D1Database
+  beforeEach(async () => {
+    db = await freshDb()
+  })
+
+  it('returns the entity_id for a known slug and null otherwise', async () => {
+    await db
+      .prepare('INSERT INTO entities (id, org_id, name, slug) VALUES (?, ?, ?, ?)')
+      .bind('ent-1', ORG_ID, 'Acme Law', 'acme-law')
+      .run()
+    await db
+      .prepare(
+        `INSERT INTO customer_configs
+          (entity_id, org_id, customer_slug, schema_version, personas_json, git_sha, synced_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`
+      )
+      .bind('ent-1', ORG_ID, 'acme-law', '1.0.0', '[]', 'sha', '2026-06-08T00:00:00Z')
+      .run()
+
+    expect(await resolveEntityIdBySlug(db, 'acme-law')).toBe('ent-1')
+    expect(await resolveEntityIdBySlug(db, 'nope')).toBeNull()
+  })
+})
+
+describe('domainAuthoritySummary', () => {
+  it('covers every switchable domain with a label', () => {
+    const rows = domainAuthoritySummary(DEFAULT_AUTHORITY_POSTURE)
+    expect(rows).toHaveLength(SWITCHABLE_AUTHORITY_DOMAINS.length)
+    for (const row of rows) {
+      expect(row.label).toBe(AUTHORITY_DOMAIN_LABELS[row.domain])
+      expect(typeof row.label).toBe('string')
+    }
+  })
+
+  it('launch-default posture marks every domain SMD-operated (not client-operable)', () => {
+    const rows = domainAuthoritySummary(DEFAULT_AUTHORITY_POSTURE)
+    expect(rows.every((r) => r.holder === 'managed')).toBe(true)
+    expect(rows.every((r) => r.clientOperable === false)).toBe(true)
+  })
+
+  it('reflects an authored client override as client-operable', () => {
+    const posture: AuthorityPosture = {
+      default: 'managed',
+      overrides: { people_access: 'client' },
+    }
+    const rows = domainAuthoritySummary(posture)
+    const people = rows.find((r) => r.domain === 'people_access')!
+    expect(people.holder).toBe('client')
+    expect(people.clientOperable).toBe(true)
+    // Other domains stay SMD-operated.
+    expect(rows.filter((r) => r.clientOperable)).toHaveLength(1)
+  })
+
+  it('a null posture resolves to the launch default', () => {
+    const rows = domainAuthoritySummary(null)
+    expect(rows.every((r) => r.holder === 'managed')).toBe(true)
+  })
+})
+
+describe('smdOnlyDomains', () => {
+  it('lists provisioning and cost with labels', () => {
+    const rows = smdOnlyDomains()
+    expect(rows.map((r) => r.domain).sort()).toEqual(['cost', 'provisioning'])
+    expect(rows.every((r) => r.label.length > 0)).toBe(true)
+  })
+})
+
+describe('authorityHolderBadge', () => {
+  it('client holder reads as additive ("Client + SMD"), never replacing SMD', () => {
+    const badge = authorityHolderBadge('client')
+    expect(badge.label).toBe('Client + SMD')
+    expect(badge.classes).toContain('rounded-[var(--ss-radius-badge)]')
+  })
+
+  it('managed holder reads as SMD', () => {
+    expect(authorityHolderBadge('managed').label).toBe('SMD')
+  })
+})
+
+describe('subscriptionState', () => {
+  it('maps known statuses and treats null as a real pre-activation state', () => {
+    expect(subscriptionState('active').label).toBe('Active')
+    expect(subscriptionState('provisioning').label).toBe('Provisioning')
+    expect(subscriptionState('paused').label).toBe('Paused')
+    expect(subscriptionState(null).label).toBe('No subscription yet')
+    expect(subscriptionState('weird').label).toBe('weird')
+  })
+
+  it('every state carries a token-based color class', () => {
+    for (const s of ['active', 'provisioning', 'paused', null, 'weird'] as const) {
+      expect(subscriptionState(s).colorClass).toContain('var(--ss-color-')
+    }
+  })
+})
+
+describe('persona cell helpers', () => {
+  it('personaStatusDisplay maps status to label + dot', () => {
+    expect(personaStatusDisplay('active').label).toBe('Active')
+    expect(personaStatusDisplay('archived').label).toBe('Archived')
+    expect(personaStatusDisplay('draft').label).toBe('draft')
+    expect(personaStatusDisplay('active').dotClass).toContain('--ss-color-complete')
+  })
+
+  it('skillCountLabel pluralizes and has an honest zero state', () => {
+    expect(skillCountLabel(0)).toBe('no skills')
+    expect(skillCountLabel(1)).toBe('1 skill')
+    expect(skillCountLabel(4)).toBe('4 skills')
+  })
+})


### PR DESCRIPTION
## What

PR 2 of the SMD-side **Operator Admin Console**. The **per-operator overview** at `/admin/operator/[customer]` — the hub for one operator (identity, persona roster, authority posture, health, subscription) and the jump-off to every per-domain drill-in. Design: `docs/design/operator/01-admin-portal.md` §5.1.

## ⚠️ Stacked on #1249

Base is `feat/operator-admin-fleet-roster` (PR #1249), not `main` — this surface reuses `posturePill` / `rosterHealth` from that PR's `fleet-roster.ts`, and the roster's rows link here. **Merge #1249 first**; GitHub will auto-retarget this PR to `main`.

## Sections

Identity (name / vertical / entity_id) + subscription state · Health summary (heartbeat, summary rollup, open alerts, last activity, draft queue) · Persona roster (built for N, shows one at v1) · Authority posture per-domain switch summary · Drill-in links.

## Sources — console-side projections only

Per ADR 0009, reads `customer_configs` (frozen `getCustomerConfig`), the runtime-summary mirror, `fleet_status`, and `subscriptions`. Deep runtime detail (audit/drafts/matters) is the §5.5 surface on the live read path — not here. New `src/lib/admin/operator-overview.ts` owns slug→entity_id resolution + the pure derivations.

## Discipline

- **Persona roster built for N, shows one at v1** (ADR 0011) — a roster-of-one is a real state, not a placeholder.
- **Authority never implies SMD lost control:** a client switch reads "Client + SMD" (additive); the two SMD-only domains (provisioning, cost) are labelled as such. SMD operates every domain in every state.
- **Honest states:** a missing operator is a real 404; a corrupt config projection renders an explicit error, not a fabricated page; "no subscription yet" and a "—" draft queue (no draft-authored skill, vs zero pending) are real states.
- **No imposed entitlement default (ADR 0035):** the authority summary describes who *operates* a domain (Layer 1); it asserts nothing about what the operator may *do* (Layer 3 / entitlements).
- Subscription status as detail-page prose, not a pill (UI-PATTERNS Rule 1).

## Scope notes

- Drill-in links point only to surfaces that exist today (Cost, Config history). Configuration, governance, connectors, runtime, memory, people, authority, and lifecycle links land as those surfaces ship (PRs 5–7).
- Lane: only `src/pages/admin/operator/*`, `src/lib/admin/*`, admin tests.

## Verification

- `npm run verify` green end-to-end. Main suite: 3111 passed / 2 skipped.
- 12 new unit tests (`tests/operator-overview.test.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)