### PR TITLE
feat(operator): admin fleet alerts feed (§4.2)

### DIFF
--- a/src/lib/admin/fleet-alerts.ts
+++ b/src/lib/admin/fleet-alerts.ts
@@ -1,0 +1,178 @@
+/**
+ * Fleet alert-feed view-model for the admin Operator console
+ * (`/admin/operator/alerts`) — design doc §4.2.
+ *
+ * The single feed of everything that needs SMD attention across every operator.
+ * It reads the shared `cost_anomaly_alerts` store (ADR 0023 §"Cross-cutting
+ * calls" #9) via the frozen `listOpenAlerts` reader — that table is already
+ * multi-source (cost / sentry / healthchecks / audit_integrity), and the
+ * existing snooze/acknowledge API keys on (entity_id, alert_date, driver), so it
+ * generalizes to every source row for free.
+ *
+ * This module owns only the pure view derivations: severity (the table has no
+ * severity column, so it is derived per source), the deep-link target per
+ * source, the detail line, filtering, and counts. The reader and the
+ * snooze/ack writers are the frozen seam.
+ *
+ * Honest-scope note (foundations §7): the feed renders the alert sources that
+ * flow into the store today. Sticky-stop transitions, connector auth-expired,
+ * boot-check failures, and structural-config-deferred (design §4.2) light up
+ * here as their receiver/writer paths land — the page says so rather than
+ * fabricating rows for sources not yet wired.
+ */
+
+import type { CostAnomalyAlertRow } from './cost-anomaly'
+import { costAnomalyDetail, relativeTimestamp } from './fleet-status'
+
+export type AlertSeverity = 'critical' | 'warning' | 'info'
+
+const SEVERITY_RANK: Record<AlertSeverity, number> = { critical: 2, warning: 1, info: 0 }
+
+/**
+ * Derive a severity from the alert source (and, for cost, whether the breach
+ * is over its configured threshold). Audit-integrity drift is always critical
+ * — a D1-vs-mirror mismatch is a compliance signal. Cost is critical only when
+ * the day actually breached its threshold; otherwise it is a warning-grade
+ * watch. Operational sources (sentry, healthchecks) are warnings.
+ */
+export function alertSeverity(row: CostAnomalyAlertRow): AlertSeverity {
+  switch (row.source) {
+    case 'audit_integrity':
+      return 'critical'
+    case 'cost':
+      return row.ratio_bps >= row.threshold_bps ? 'critical' : 'warning'
+    case 'sentry':
+    case 'healthchecks':
+      return 'warning'
+    default:
+      return 'info'
+  }
+}
+
+/**
+ * The per-operator surface this alert deep-links to. Cost anomalies open the
+ * cost drill-in; everything else opens the operator overview (the hub from
+ * which the relevant domain drill-in is reachable). Always one customer.
+ */
+export function alertLink(row: CostAnomalyAlertRow): string {
+  const slug = encodeURIComponent(row.customer_slug)
+  if (row.source === 'cost') return `/admin/operator/costs/${slug}`
+  return `/admin/operator/${slug}`
+}
+
+/**
+ * The human detail line. Cost rows render the numeric breach via the shared
+ * costAnomalyDetail; every other source carries its own authored `summary`.
+ * Never fabricates a detail for a row that has none.
+ */
+export function alertDetail(
+  row: CostAnomalyAlertRow,
+  formatCurrency: (cents: number) => string
+): string {
+  if (row.source === 'cost') {
+    return costAnomalyDetail({
+      driver: row.driver,
+      daily_cents: row.daily_cents,
+      rolling_avg_cents: row.rolling_avg_cents,
+      ratio_bps: row.ratio_bps,
+      formatCurrency,
+    })
+  }
+  return row.summary ?? '(no detail recorded)'
+}
+
+export function alertAge(row: CostAnomalyAlertRow, now: Date = new Date()): string {
+  return relativeTimestamp(row.detected_at, now)
+}
+
+export interface SeverityBadge {
+  label: string
+  classes: string
+}
+
+const SEVERITY_BADGE_STRUCTURE =
+  'inline-flex items-center px-2 py-0.5 rounded-[var(--ss-radius-badge)] ' +
+  'text-[10px] font-medium uppercase tracking-wide whitespace-nowrap'
+
+export function severityBadge(severity: AlertSeverity): SeverityBadge {
+  switch (severity) {
+    case 'critical':
+      return {
+        label: 'Critical',
+        classes: `${SEVERITY_BADGE_STRUCTURE} bg-[color:var(--ss-color-error)] text-white`,
+      }
+    case 'warning':
+      return {
+        label: 'Warning',
+        classes: `${SEVERITY_BADGE_STRUCTURE} bg-[color:var(--ss-color-attention)] text-white`,
+      }
+    case 'info':
+      return {
+        label: 'Info',
+        classes: `${SEVERITY_BADGE_STRUCTURE} bg-[color:var(--ss-color-border)] text-[color:var(--ss-color-text-secondary)]`,
+      }
+  }
+}
+
+export interface AlertFilters {
+  source?: string | null
+  severity?: string | null
+  customer?: string | null
+}
+
+/**
+ * Apply the (optional) source / severity / customer filters. Severity is
+ * derived per row, so the severity filter computes it; an empty / null filter
+ * value matches everything. Pure — own unit test.
+ */
+export function filterAlerts(
+  rows: readonly CostAnomalyAlertRow[],
+  filters: AlertFilters
+): CostAnomalyAlertRow[] {
+  const source = normalize(filters.source)
+  const severity = normalize(filters.severity)
+  const customer = normalize(filters.customer)
+  return rows.filter((row) => {
+    if (source && row.source !== source) return false
+    if (customer && row.customer_slug !== customer) return false
+    if (severity && alertSeverity(row) !== severity) return false
+    return true
+  })
+}
+
+function normalize(v: string | null | undefined): string | null {
+  if (v === null || v === undefined) return null
+  const trimmed = v.trim()
+  return trimmed === '' || trimmed === 'all' ? null : trimmed
+}
+
+export interface SeverityCounts {
+  critical: number
+  warning: number
+  info: number
+  total: number
+}
+
+/** Count rows by derived severity — drives the header summary. */
+export function countBySeverity(rows: readonly CostAnomalyAlertRow[]): SeverityCounts {
+  const counts: SeverityCounts = { critical: 0, warning: 0, info: 0, total: rows.length }
+  for (const row of rows) counts[alertSeverity(row)] += 1
+  return counts
+}
+
+/**
+ * Sort for display: most severe first, then freshest (detected_at desc). The
+ * eye lands on the worst, newest thing — same discipline as the roster sort.
+ */
+export function sortAlerts(rows: readonly CostAnomalyAlertRow[]): CostAnomalyAlertRow[] {
+  return [...rows].sort((a, b) => {
+    const sev = SEVERITY_RANK[alertSeverity(b)] - SEVERITY_RANK[alertSeverity(a)]
+    if (sev !== 0) return sev
+    return b.detected_at.localeCompare(a.detected_at)
+  })
+}
+
+/** Distinct customer slugs present in the feed, for the customer filter. */
+export function distinctCustomers(rows: readonly CostAnomalyAlertRow[]): string[] {
+  return [...new Set(rows.map((r) => r.customer_slug))].sort()
+}

--- a/src/pages/admin/operator/alerts.astro
+++ b/src/pages/admin/operator/alerts.astro
@@ -1,0 +1,315 @@
+---
+import AdminLayout from '../../../layouts/AdminLayout.astro'
+import { listOpenAlerts } from '../../../lib/admin/cost-anomaly'
+import { sourcePill } from '../../../lib/admin/fleet-status'
+import {
+  alertSeverity,
+  alertLink,
+  alertDetail,
+  alertAge,
+  severityBadge,
+  filterAlerts,
+  countBySeverity,
+  sortAlerts,
+  distinctCustomers,
+} from '../../../lib/admin/fleet-alerts'
+import { env } from 'cloudflare:workers'
+
+/**
+ * Operator admin console — fleet alerts (§4.2).
+ *
+ * The single feed of everything that needs SMD attention across every operator.
+ * Reads the shared multi-source alert store (cost_anomaly_alerts) via the frozen
+ * listOpenAlerts reader and generalizes the existing snooze/acknowledge flow to
+ * every source. Each alert deep-links to the relevant per-operator surface.
+ *
+ * Honest scope (foundations §7): the feed shows the sources that flow into the
+ * store today (cost anomalies, Sentry spikes, heartbeat grace, audit-integrity
+ * drift). Sticky-stop transitions, connector auth-expired, boot-check failures,
+ * and structural-config-deferred (design §4.2) light up here as their writer
+ * paths land — the footnote says so rather than fabricating rows.
+ */
+
+const session = Astro.locals.session!
+if (session.role !== 'admin') {
+  return Astro.redirect('/auth/sign-in')
+}
+
+const allOpen = await listOpenAlerts(env.DB)
+const customers = distinctCustomers(allOpen)
+
+const filters = {
+  source: Astro.url.searchParams.get('source'),
+  severity: Astro.url.searchParams.get('severity'),
+  customer: Astro.url.searchParams.get('customer'),
+}
+const filtered = sortAlerts(filterAlerts(allOpen, filters))
+const counts = countBySeverity(filtered)
+
+function formatCurrency(cents: number): string {
+  return (cents / 100).toLocaleString('en-US', { style: 'currency', currency: 'USD' })
+}
+
+const SOURCE_OPTIONS = [
+  { value: 'all', label: 'All sources' },
+  { value: 'cost', label: 'Cost' },
+  { value: 'sentry', label: 'Sentry' },
+  { value: 'healthchecks', label: 'Heartbeat' },
+  { value: 'audit_integrity', label: 'Audit integrity' },
+]
+const SEVERITY_OPTIONS = [
+  { value: 'all', label: 'All severities' },
+  { value: 'critical', label: 'Critical' },
+  { value: 'warning', label: 'Warning' },
+  { value: 'info', label: 'Info' },
+]
+
+const curSource = filters.source ?? 'all'
+const curSeverity = filters.severity ?? 'all'
+const curCustomer = filters.customer ?? 'all'
+---
+
+<AdminLayout
+  title="Operator — Alerts"
+  breadcrumbs={[
+    { label: 'Dashboard', href: '/admin' },
+    { label: 'Operator', href: '/admin/operator' },
+    { label: 'Alerts' },
+  ]}
+  maxWidth="max-w-6xl"
+>
+  <div class="space-y-card">
+    <header class="flex items-end justify-between gap-4">
+      <div>
+        <h2 class="text-xl font-semibold text-[color:var(--ss-color-text-primary)]">
+          Fleet alerts
+        </h2>
+        <p class="text-sm text-[color:var(--ss-color-text-secondary)] mt-1">
+          Everything that needs SMD attention across every operator. Each alert links to the
+          operator it concerns. Snooze or acknowledge to clear it from the feed.
+        </p>
+      </div>
+      <div class="text-right">
+        <p class="text-xs uppercase tracking-wide text-[color:var(--ss-color-text-muted)]">Open</p>
+        <p class="text-2xl font-bold text-[color:var(--ss-color-text-primary)]">{counts.total}</p>
+        {
+          counts.critical > 0 && (
+            <p class="text-xs text-[color:var(--ss-color-error)] font-semibold">
+              {counts.critical} critical
+            </p>
+          )
+        }
+      </div>
+    </header>
+
+    <form method="get" class="flex flex-wrap items-end gap-3">
+      <label class="text-xs text-[color:var(--ss-color-text-secondary)]">
+        <span class="block mb-1">Source</span>
+        <select
+          name="source"
+          class="rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-white px-2 py-1 text-sm"
+        >
+          {
+            SOURCE_OPTIONS.map((o) => (
+              <option value={o.value} selected={o.value === curSource}>
+                {o.label}
+              </option>
+            ))
+          }
+        </select>
+      </label>
+      <label class="text-xs text-[color:var(--ss-color-text-secondary)]">
+        <span class="block mb-1">Severity</span>
+        <select
+          name="severity"
+          class="rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-white px-2 py-1 text-sm"
+        >
+          {
+            SEVERITY_OPTIONS.map((o) => (
+              <option value={o.value} selected={o.value === curSeverity}>
+                {o.label}
+              </option>
+            ))
+          }
+        </select>
+      </label>
+      <label class="text-xs text-[color:var(--ss-color-text-secondary)]">
+        <span class="block mb-1">Customer</span>
+        <select
+          name="customer"
+          class="rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-white px-2 py-1 text-sm"
+        >
+          <option value="all" selected={curCustomer === 'all'}>All customers</option>
+          {
+            customers.map((c) => (
+              <option value={c} selected={c === curCustomer}>
+                {c}
+              </option>
+            ))
+          }
+        </select>
+      </label>
+      <button
+        type="submit"
+        class="rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-white px-3 py-1.5 text-sm text-[color:var(--ss-color-text-primary)] hover:border-[color:var(--ss-color-primary)]"
+      >
+        Apply
+      </button>
+    </form>
+
+    <div
+      class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card"
+      data-alerts-feed
+    >
+      {
+        allOpen.length === 0 ? (
+          <p class="text-sm text-[color:var(--ss-color-text-secondary)]">
+            No open alerts across the fleet. Nothing needs SMD attention right now.
+          </p>
+        ) : filtered.length === 0 ? (
+          <p class="text-sm text-[color:var(--ss-color-text-secondary)]">
+            No alerts match the current filters.{' '}
+            <a
+              href="/admin/operator/alerts"
+              class="text-[color:var(--ss-color-action)] hover:underline"
+            >
+              Clear filters
+            </a>
+            .
+          </p>
+        ) : (
+          <ul class="space-y-3 text-sm">
+            {filtered.map((row) => {
+              const sev = severityBadge(alertSeverity(row))
+              const pill = sourcePill(row.source)
+              return (
+                <li
+                  class="flex items-start justify-between gap-4 border-b border-[color:var(--ss-color-border-subtle)] pb-3 last:border-0 last:pb-0"
+                  data-alert-entity={row.entity_id}
+                  data-alert-date={row.alert_date}
+                  data-alert-driver={row.driver}
+                >
+                  <div class="flex-1 min-w-0">
+                    <div class="flex items-center gap-2 flex-wrap">
+                      <span class={sev.classes}>{sev.label}</span>
+                      <span
+                        class={`text-[10px] px-1.5 py-0.5 rounded font-medium uppercase tracking-wide ${pill.classes}`}
+                      >
+                        {pill.label}
+                      </span>
+                      <a
+                        href={alertLink(row)}
+                        class="font-medium text-[color:var(--ss-color-text-primary)] hover:text-[color:var(--ss-color-primary)]"
+                      >
+                        {row.customer_slug}
+                      </a>
+                      <span class="text-[color:var(--ss-color-text-muted)]">· {alertAge(row)}</span>
+                    </div>
+                    <p class="text-xs text-[color:var(--ss-color-text-secondary)] mt-0.5">
+                      {alertDetail(row, formatCurrency)}
+                    </p>
+                  </div>
+                  <div class="flex gap-2 shrink-0">
+                    <button
+                      type="button"
+                      data-alert-snooze
+                      class="text-xs text-[color:var(--ss-color-action)] hover:underline"
+                    >
+                      Snooze 7d
+                    </button>
+                    <button
+                      type="button"
+                      data-alert-ack
+                      class="text-xs text-[color:var(--ss-color-action)] hover:underline"
+                    >
+                      Acknowledge
+                    </button>
+                  </div>
+                </li>
+              )
+            })}
+          </ul>
+        )
+      }
+
+      <div
+        class="mt-4 pt-4 border-t border-[color:var(--ss-color-border-subtle)] text-xs text-[color:var(--ss-color-text-muted)]"
+      >
+        <p>
+          Wired sources: cost anomalies, Sentry spikes, heartbeat grace, audit-integrity drift.
+          Sticky-stop transitions, connector auth-expired, boot-check failures, and
+          structural-config-deferred surface here as their writer paths land.
+        </p>
+      </div>
+    </div>
+  </div>
+</AdminLayout>
+
+<script>
+  // Snooze/acknowledge reuse the cost-anomaly action API — it keys on
+  // (entity_id, alert_date, driver) and operates on any source row. Reload
+  // after a successful action so the feed reflects the cleared alert (no
+  // optimistic UI: a reload confirms the backend actually applied it).
+  function init() {
+    const feed = document.querySelector('[data-alerts-feed]')
+    if (!feed) return
+
+    function readIdentity(li: HTMLElement) {
+      return {
+        entity_id: li.dataset.alertEntity ?? '',
+        alert_date: li.dataset.alertDate ?? '',
+        driver: li.dataset.alertDriver ?? '',
+      }
+    }
+
+    function sevenDaysFromNowIso(): string {
+      const d = new Date(Date.now() + 7 * 86_400_000)
+      return d.toISOString().replace(/\.\d{3}Z$/, 'Z')
+    }
+
+    async function post(action: 'snooze' | 'acknowledge', body: Record<string, unknown>) {
+      const res = await fetch(`/api/admin/operator/costs/anomalies/${action}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+      if (!res.ok) {
+        const text = await res.text().catch(() => '')
+        alert(`Failed: ${res.status} ${text}`)
+        return false
+      }
+      return true
+    }
+
+    feed.querySelectorAll<HTMLButtonElement>('[data-alert-snooze]').forEach((btn) => {
+      btn.addEventListener('click', async () => {
+        const li = btn.closest<HTMLElement>('[data-alert-entity]')
+        if (!li) return
+        btn.disabled = true
+        const ok = await post('snooze', {
+          ...readIdentity(li),
+          snoozed_until: sevenDaysFromNowIso(),
+        })
+        if (ok) window.location.reload()
+        else btn.disabled = false
+      })
+    })
+
+    feed.querySelectorAll<HTMLButtonElement>('[data-alert-ack]').forEach((btn) => {
+      btn.addEventListener('click', async () => {
+        const li = btn.closest<HTMLElement>('[data-alert-entity]')
+        if (!li) return
+        btn.disabled = true
+        const ok = await post('acknowledge', readIdentity(li))
+        if (ok) window.location.reload()
+        else btn.disabled = false
+      })
+    })
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init)
+  } else {
+    init()
+  }
+</script>

--- a/tests/fleet-alerts.test.ts
+++ b/tests/fleet-alerts.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Tests for the fleet alert-feed view-model (src/lib/admin/fleet-alerts.ts) —
+ * admin Operator console §4.2.
+ *
+ * All pure derivations over the shared cost_anomaly_alerts row shape: severity
+ * derivation per source, deep-link target, detail line, filtering, counts, and
+ * sort order. No DB — the reader (listOpenAlerts) is the frozen seam.
+ */
+
+import { describe, it, expect } from 'vitest'
+import type { CostAnomalyAlertRow } from '../src/lib/admin/cost-anomaly'
+import {
+  alertSeverity,
+  alertLink,
+  alertDetail,
+  severityBadge,
+  filterAlerts,
+  countBySeverity,
+  sortAlerts,
+  distinctCustomers,
+} from '../src/lib/admin/fleet-alerts'
+
+function row(overrides: Partial<CostAnomalyAlertRow> = {}): CostAnomalyAlertRow {
+  return {
+    entity_id: 'ent-1',
+    customer_slug: 'acme',
+    alert_date: '2026-06-08',
+    driver: '',
+    source: 'cost',
+    daily_cents: 5000,
+    rolling_avg_cents: 2000,
+    ratio_bps: 25000,
+    threshold_bps: 15000,
+    summary: null,
+    details_json: null,
+    detected_at: '2026-06-08T12:00:00Z',
+    snoozed_until: null,
+    acknowledged_at: null,
+    acknowledged_by: null,
+    ...overrides,
+  }
+}
+
+const usd = (cents: number) => `$${(cents / 100).toFixed(2)}`
+
+describe('alertSeverity', () => {
+  it('audit-integrity drift is always critical', () => {
+    expect(alertSeverity(row({ source: 'audit_integrity' }))).toBe('critical')
+  })
+
+  it('cost is critical only when over threshold, else warning', () => {
+    expect(alertSeverity(row({ source: 'cost', ratio_bps: 25000, threshold_bps: 15000 }))).toBe(
+      'critical'
+    )
+    expect(alertSeverity(row({ source: 'cost', ratio_bps: 10000, threshold_bps: 15000 }))).toBe(
+      'warning'
+    )
+  })
+
+  it('operational sources are warnings', () => {
+    expect(alertSeverity(row({ source: 'sentry' }))).toBe('warning')
+    expect(alertSeverity(row({ source: 'healthchecks' }))).toBe('warning')
+  })
+})
+
+describe('alertLink', () => {
+  it('cost alerts deep-link to the cost drill-in', () => {
+    expect(alertLink(row({ source: 'cost', customer_slug: 'acme' }))).toBe(
+      '/admin/operator/costs/acme'
+    )
+  })
+
+  it('non-cost alerts deep-link to the operator overview', () => {
+    expect(alertLink(row({ source: 'sentry', customer_slug: 'beta' }))).toBe('/admin/operator/beta')
+  })
+
+  it('encodes the slug', () => {
+    expect(alertLink(row({ source: 'sentry', customer_slug: 'a b' }))).toBe('/admin/operator/a%20b')
+  })
+})
+
+describe('alertDetail', () => {
+  it('renders the numeric breach for cost rows', () => {
+    const detail = alertDetail(row({ source: 'cost' }), usd)
+    expect(detail).toContain('$50.00')
+    expect(detail).toContain('$20.00')
+  })
+
+  it('uses the authored summary for non-cost rows and never fabricates', () => {
+    expect(alertDetail(row({ source: 'sentry', summary: '12 new errors' }), usd)).toBe(
+      '12 new errors'
+    )
+    expect(alertDetail(row({ source: 'sentry', summary: null }), usd)).toBe('(no detail recorded)')
+  })
+})
+
+describe('filterAlerts', () => {
+  const rows = [
+    row({ customer_slug: 'acme', source: 'cost', ratio_bps: 25000, threshold_bps: 15000 }),
+    row({ customer_slug: 'beta', source: 'sentry' }),
+    row({ customer_slug: 'acme', source: 'audit_integrity' }),
+  ]
+
+  it('empty / all filters match everything', () => {
+    expect(filterAlerts(rows, {})).toHaveLength(3)
+    expect(filterAlerts(rows, { source: 'all', severity: 'all', customer: 'all' })).toHaveLength(3)
+    expect(filterAlerts(rows, { source: '', customer: null })).toHaveLength(3)
+  })
+
+  it('filters by source, customer, and derived severity', () => {
+    expect(filterAlerts(rows, { source: 'cost' })).toHaveLength(1)
+    expect(filterAlerts(rows, { customer: 'acme' })).toHaveLength(2)
+    expect(filterAlerts(rows, { severity: 'critical' })).toHaveLength(2) // cost-over + audit
+    expect(filterAlerts(rows, { severity: 'warning' })).toHaveLength(1) // sentry
+  })
+
+  it('combines filters (AND)', () => {
+    expect(filterAlerts(rows, { customer: 'acme', severity: 'critical' })).toHaveLength(2)
+    expect(filterAlerts(rows, { customer: 'beta', severity: 'critical' })).toHaveLength(0)
+  })
+})
+
+describe('countBySeverity', () => {
+  it('counts derived severities', () => {
+    const rows = [
+      row({ source: 'audit_integrity' }),
+      row({ source: 'cost', ratio_bps: 25000, threshold_bps: 15000 }),
+      row({ source: 'sentry' }),
+    ]
+    expect(countBySeverity(rows)).toEqual({ critical: 2, warning: 1, info: 0, total: 3 })
+  })
+})
+
+describe('sortAlerts', () => {
+  it('orders most-severe first, then freshest', () => {
+    const warnOld = row({ source: 'sentry', detected_at: '2026-06-01T00:00:00Z' })
+    const critOld = row({ source: 'audit_integrity', detected_at: '2026-06-01T00:00:00Z' })
+    const critNew = row({ source: 'audit_integrity', detected_at: '2026-06-08T00:00:00Z' })
+    const sorted = sortAlerts([warnOld, critOld, critNew])
+    expect(sorted[0].detected_at).toBe('2026-06-08T00:00:00Z') // critical, newest
+    expect(sorted[1].source).toBe('audit_integrity') // critical, older
+    expect(sorted[2].source).toBe('sentry') // warning last
+  })
+
+  it('does not mutate the input', () => {
+    const input = [row({ source: 'sentry' }), row({ source: 'audit_integrity' })]
+    const before = input.map((r) => r.source)
+    sortAlerts(input)
+    expect(input.map((r) => r.source)).toEqual(before)
+  })
+})
+
+describe('distinctCustomers', () => {
+  it('returns sorted unique slugs', () => {
+    expect(
+      distinctCustomers([
+        row({ customer_slug: 'beta' }),
+        row({ customer_slug: 'acme' }),
+        row({ customer_slug: 'beta' }),
+      ])
+    ).toEqual(['acme', 'beta'])
+  })
+})
+
+describe('severityBadge', () => {
+  it('every severity carries a token-based class and a label', () => {
+    expect(severityBadge('critical').classes).toContain('--ss-color-error')
+    expect(severityBadge('warning').classes).toContain('--ss-color-attention')
+    expect(severityBadge('info').label).toBe('Info')
+  })
+})


### PR DESCRIPTION
## What

PR 3 of the SMD-side **Operator Admin Console**. The **fleet alert feed** at `/admin/operator/alerts` — the single cross-operator view of everything that needs SMD attention, each alert deep-linking to the operator it concerns, with source / severity / customer filters and snooze / acknowledge. Design: §4.2.

## ⚠️ Stacked on #1250 → #1249

Base is `feat/operator-admin-overview` (#1250). **Merge #1249, then #1250, then this.** GitHub auto-retargets as each merges.

## How it works

Reads the shared multi-source alert store (`cost_anomaly_alerts`) via the frozen `listOpenAlerts` reader — that table already carries `cost` / `sentry` / `healthchecks` / `audit_integrity` rows. The **existing** snooze/acknowledge API (`/api/admin/operator/costs/anomalies/[action]`) keys on `(entity_id, alert_date, driver)` and operates on any source row, so the flow generalizes with **no new API**. New `src/lib/admin/fleet-alerts.ts` owns the pure view derivations.

## Discipline

- **Severity is derived** (no column): audit-integrity drift always critical; cost critical only when over its threshold, else warning; operational sources warnings. Documented as a derivation.
- **No fabricated detail:** cost rows render the numeric breach; other sources render their authored `summary`, falling back to "(no detail recorded)" — never invented.
- **Honest scope (foundations §7):** the feed renders the sources flowing today. Sticky-stop transitions, connector auth-expired, boot-check failures, and structural-config-deferred (all in the §4.2 list) surface here as their writer paths land — stated in a footnote, not faked.
- Empty state distinguishes "nothing needs attention" from "no match for filters."

## Verification

- `npm run verify` green. Main suite: 3127 passed / 2 skipped.
- 16 new unit tests (`tests/fleet-alerts.test.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)