### PR TITLE
feat(operator): voice preference corrections — capture + reconcile + guarded apply (A2)

### DIFF
--- a/operator/adapter/voice/corrections.py
+++ b/operator/adapter/voice/corrections.py
@@ -1,0 +1,170 @@
+"""Voice preference corrections — the deterministic half of A2.
+
+A *correction* is an attorney-authored, must-apply substitution preference:
+greeting / signoff / honorific / lexical "say X instead of Y" rules captured
+from a live edit-then-send diff or a calibration session and stored in the
+``voice_corrections`` table (migration 0010). This is **preference capture**,
+not semantic "voice learning" — a ``(before -> after)`` rule is a glossary, and
+the plan is explicit that semantic/stylistic voice is captured as exemplars
+feeding the structural transform, not as rows here.
+
+This module is the read + apply side:
+
+* :class:`Correction` — the in-memory row.
+* :func:`select_active` — given the active rows (``superseded_by IS NULL``)
+  loaded for a customer, resolve the set that applies to one ``(reviewer,
+  cohort)`` draft, with conflict reconciliation by **scope-specificity →
+  priority → recency**. Cross-cohort corrections coexist; only rules targeting
+  the *same* text conflict.
+* :func:`apply_corrections` — apply the selected rules to a draft as guarded
+  substitutions. A rule whose substitution would introduce a disallowed
+  entity-shaped token (a name/date/amount the source didn't contain) is
+  **neutralized** — skipped and recorded — never forced. The guard is injected
+  (the transform owns ``_has_introduced_entity_tokens``) so this module
+  stays free of a circular import and free of the transform's structural logic.
+
+Pure module: no I/O. The D1 loader and the live runtime call site land in the
+overlay (Wave 2); this is the canonical primitive they vendor.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Callable, Sequence
+
+# Closed sets mirroring the migration-0010 CHECK constraints.
+CORRECTION_KINDS = ("greeting", "signoff", "honorific", "lexical")
+PATTERN_KINDS = ("literal", "literal_ci", "regex")
+CORRECTION_SOURCES = ("calibration_session", "live_edit")
+
+
+@dataclass(frozen=True)
+class Correction:
+    """One attorney-authored substitution preference (a ``voice_corrections`` row).
+
+    ``reviewer_user_id`` / ``recipient_cohort`` of ``None`` mean firm-wide / all
+    cohorts respectively. ``priority`` (higher wins) and ``created_at`` (ISO
+    string; later wins) break ties between two rules targeting the same text.
+    """
+
+    id: str
+    correction_kind: str
+    pattern_kind: str
+    before_pattern: str
+    after_text: str
+    reviewer_user_id: str | None = None
+    recipient_cohort: str | None = None
+    priority: int = 0
+    source: str = "calibration_session"
+    created_at: str = ""
+
+
+@dataclass(frozen=True)
+class CorrectionApplyResult:
+    """Outcome of applying a set of corrections to a draft."""
+
+    draft: str
+    applied: list = field(default_factory=list)  # list[Correction] that changed the draft
+    neutralized: list = field(default_factory=list)  # list[Correction] the guard refused
+
+
+def _applies_to(c: Correction, reviewer_user_id: str | None, recipient_cohort: str | None) -> bool:
+    """A correction applies iff its scope is firm-wide or matches the draft's
+    reviewer, AND cohort-agnostic or matches the draft's cohort."""
+    reviewer_ok = c.reviewer_user_id is None or c.reviewer_user_id == reviewer_user_id
+    cohort_ok = c.recipient_cohort is None or c.recipient_cohort == recipient_cohort
+    return reviewer_ok and cohort_ok
+
+
+def _conflict_key(c: Correction) -> tuple:
+    """Two corrections conflict iff they target the same text the same way."""
+    target = c.before_pattern.lower() if c.pattern_kind == "literal_ci" else c.before_pattern
+    return (c.pattern_kind, target)
+
+
+def _specificity_rank(c: Correction) -> tuple:
+    """Higher tuple wins reconciliation: most-specific scope, then priority, then
+    recency. Scope specificity = how many of (reviewer, cohort) are pinned."""
+    scope = (c.reviewer_user_id is not None) + (c.recipient_cohort is not None)
+    return (scope, c.priority, c.created_at)
+
+
+def select_active(
+    corrections: Sequence[Correction],
+    reviewer_user_id: str | None,
+    recipient_cohort: str | None,
+) -> list:
+    """Resolve the corrections that apply to one ``(reviewer, cohort)`` draft.
+
+    ``corrections`` should already be the active set (``superseded_by IS NULL``)
+    loaded for the customer. Returns one winner per conflict group (same
+    pattern_kind + target text), chosen by scope-specificity → priority →
+    recency. Independent rules (different targets) all survive. Result is sorted
+    for deterministic application order.
+    """
+    applicable = [c for c in corrections if _applies_to(c, reviewer_user_id, recipient_cohort)]
+    groups: dict[tuple, list] = {}
+    for c in applicable:
+        groups.setdefault(_conflict_key(c), []).append(c)
+    winners = [max(group, key=_specificity_rank) for group in groups.values()]
+    return sorted(winners, key=lambda c: (c.before_pattern, c.id))
+
+
+def _substitute(text: str, c: Correction) -> str:
+    """Apply one correction's substitution. ``after_text`` is treated as a
+    literal replacement for literal / literal_ci kinds (no backreference
+    surprises); a ``regex`` correction's ``after_text`` is used as a real
+    re replacement so the firm can author capture-group rewrites. A malformed
+    regex is a no-op (the rule is skipped, never crashes the draft path)."""
+    if c.pattern_kind == "literal":
+        return text.replace(c.before_pattern, c.after_text)
+    try:
+        if c.pattern_kind == "literal_ci":
+            return re.sub(re.escape(c.before_pattern), lambda _m: c.after_text, text, flags=re.IGNORECASE)
+        if c.pattern_kind == "regex":
+            return re.sub(c.before_pattern, c.after_text, text)
+    except re.error:
+        return text
+    return text
+
+
+def apply_corrections(
+    draft: str,
+    corrections: Sequence[Correction],
+    guard: Callable[[str, str], bool],
+) -> CorrectionApplyResult:
+    """Apply ``corrections`` to ``draft`` as guarded substitutions.
+
+    Each correction is applied in turn. A correction that matches nothing is a
+    no-op. A correction whose result would introduce a disallowed entity-shaped
+    token — per ``guard(before, after) -> bool`` (the transform's
+    ``_has_introduced_entity_tokens``) — is **neutralized**: skipped and
+    recorded, never forced. This holds a learned preference to the same
+    fabrication discipline as the structural transform, and surfaces a
+    correction that silently failed to take rather than hiding it.
+    """
+    current = draft
+    applied: list = []
+    neutralized: list = []
+    for c in corrections:
+        candidate = _substitute(current, c)
+        if candidate == current:
+            continue  # no match → nothing to apply
+        if guard(current, candidate):
+            neutralized.append(c)
+            continue
+        current = candidate
+        applied.append(c)
+    return CorrectionApplyResult(draft=current, applied=applied, neutralized=neutralized)
+
+
+__all__ = [
+    "CORRECTION_KINDS",
+    "CORRECTION_SOURCES",
+    "PATTERN_KINDS",
+    "Correction",
+    "CorrectionApplyResult",
+    "apply_corrections",
+    "select_active",
+]

--- a/operator/adapter/voice/tests/test_corrections.py
+++ b/operator/adapter/voice/tests/test_corrections.py
@@ -1,0 +1,171 @@
+"""Voice preference corrections — reconciliation + guarded application (A2).
+
+select_active: scope filtering + conflict reconciliation (scope-specificity →
+priority → recency) + cross-cohort coexistence. apply_corrections: literal /
+literal_ci / regex substitution, and — using the REAL transform fabrication
+guard — neutralization of any rule that would introduce a disallowed entity.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))  # operator/ on path
+
+from adapter.voice.corrections import (  # noqa: E402
+    Correction,
+    apply_corrections,
+    select_active,
+)
+from adapter.voice.transform import _has_introduced_entity_tokens  # noqa: E402
+
+
+def _c(**over) -> Correction:
+    base = dict(
+        id="c0",
+        correction_kind="lexical",
+        pattern_kind="literal_ci",
+        before_pattern="pursuant to",
+        after_text="under",
+        reviewer_user_id=None,
+        recipient_cohort=None,
+        priority=0,
+        source="calibration_session",
+        created_at="2026-06-01T00:00:00Z",
+    )
+    base.update(over)
+    return Correction(**base)
+
+
+# ---------------------------------------------------------------------------
+# select_active — scope filtering
+# ---------------------------------------------------------------------------
+
+
+def test_firm_wide_rule_applies_to_everyone():
+    rules = [_c(id="a", reviewer_user_id=None, recipient_cohort=None)]
+    assert len(select_active(rules, "avery", "client")) == 1
+
+
+def test_reviewer_scoped_rule_does_not_apply_to_other_reviewer():
+    rules = [_c(id="a", reviewer_user_id="avery")]
+    assert select_active(rules, "jordan", "client") == []
+    assert len(select_active(rules, "avery", "client")) == 1
+
+
+def test_cohort_scoped_rule_does_not_apply_to_other_cohort():
+    rules = [_c(id="a", recipient_cohort="opposing-counsel")]
+    assert select_active(rules, "avery", "client") == []
+    assert len(select_active(rules, "avery", "opposing-counsel")) == 1
+
+
+def test_independent_rules_all_survive():
+    rules = [
+        _c(id="a", before_pattern="pursuant to", after_text="under"),
+        _c(id="b", before_pattern="hereinafter", after_text="from now on"),
+    ]
+    out = select_active(rules, "avery", "client")
+    assert {c.id for c in out} == {"a", "b"}
+
+
+# ---------------------------------------------------------------------------
+# select_active — reconciliation (scope-specificity → priority → recency)
+# ---------------------------------------------------------------------------
+
+
+def test_more_specific_scope_wins_over_firm_wide():
+    rules = [
+        _c(id="firm", after_text="under", reviewer_user_id=None, recipient_cohort=None),
+        _c(id="scoped", after_text="per", reviewer_user_id="avery", recipient_cohort="client"),
+    ]
+    out = select_active(rules, "avery", "client")
+    assert len(out) == 1 and out[0].id == "scoped"
+
+
+def test_priority_breaks_tie_at_equal_scope():
+    rules = [
+        _c(id="low", after_text="under", priority=1),
+        _c(id="high", after_text="per", priority=5),
+    ]
+    out = select_active(rules, "avery", "client")
+    assert len(out) == 1 and out[0].id == "high"
+
+
+def test_recency_breaks_tie_at_equal_scope_and_priority():
+    rules = [
+        _c(id="old", after_text="under", created_at="2026-06-01T00:00:00Z"),
+        _c(id="new", after_text="per", created_at="2026-06-08T00:00:00Z"),
+    ]
+    out = select_active(rules, "avery", "client")
+    assert len(out) == 1 and out[0].id == "new"
+
+
+def test_cross_cohort_opposing_rules_coexist():
+    """A client-cohort rule and an opposing-counsel-cohort rule on the same text
+    do NOT conflict — each applies in its lane."""
+    rules = [
+        _c(id="client", before_pattern="Dear", after_text="Hi", recipient_cohort="client"),
+        _c(id="oc", before_pattern="Dear", after_text="Counsel,", recipient_cohort="opposing-counsel"),
+    ]
+    assert [c.id for c in select_active(rules, "avery", "client")] == ["client"]
+    assert [c.id for c in select_active(rules, "avery", "opposing-counsel")] == ["oc"]
+
+
+# ---------------------------------------------------------------------------
+# apply_corrections — substitution + the guard
+# ---------------------------------------------------------------------------
+
+
+def test_literal_ci_substitution_applies():
+    rules = [_c(before_pattern="pursuant to", after_text="under", pattern_kind="literal_ci")]
+    res = apply_corrections("Pursuant to the agreement, we will file.", rules, _has_introduced_entity_tokens)
+    assert res.draft == "under the agreement, we will file."
+    assert len(res.applied) == 1 and not res.neutralized
+
+
+def test_literal_substitution_is_case_sensitive():
+    rules = [_c(before_pattern="Re:", after_text="Subject:", pattern_kind="literal")]
+    res = apply_corrections("Re: your matter", rules, _has_introduced_entity_tokens)
+    assert res.draft == "Subject: your matter"
+
+
+def test_regex_substitution_with_capture_group():
+    rules = [_c(before_pattern=r"\bthx\b", after_text="thanks", pattern_kind="regex")]
+    res = apply_corrections("ok thx", rules, _has_introduced_entity_tokens)
+    assert res.draft == "ok thanks"
+
+
+def test_no_match_is_a_noop():
+    rules = [_c(before_pattern="nonexistent phrase", after_text="x")]
+    res = apply_corrections("a clean draft", rules, _has_introduced_entity_tokens)
+    assert res.draft == "a clean draft"
+    assert not res.applied and not res.neutralized
+
+
+def test_correction_that_introduces_a_date_is_neutralized():
+    """The guard reuse: a rule whose replacement injects an entity-shaped token
+    (here a date) is neutralized, not forced — and recorded so a silently-failed
+    correction is visible."""
+    rules = [_c(before_pattern="soon", after_text="on June 8, 2026", pattern_kind="literal_ci")]
+    res = apply_corrections("We will follow up soon.", rules, _has_introduced_entity_tokens)
+    assert res.draft == "We will follow up soon."  # unchanged
+    assert not res.applied
+    assert len(res.neutralized) == 1
+
+
+def test_malformed_regex_is_a_safe_noop():
+    rules = [_c(before_pattern="(unclosed", after_text="x", pattern_kind="regex")]
+    res = apply_corrections("text with (unclosed literally", rules, _has_introduced_entity_tokens)
+    assert res.draft == "text with (unclosed literally"
+    assert not res.applied and not res.neutralized
+
+
+def test_multiple_corrections_apply_in_order():
+    rules = [
+        _c(id="a", before_pattern="pursuant to", after_text="under", pattern_kind="literal_ci"),
+        _c(id="b", before_pattern="hereinafter", after_text="from now on", pattern_kind="literal_ci"),
+    ]
+    res = apply_corrections("Pursuant to it, hereinafter the Firm.", rules, _has_introduced_entity_tokens)
+    assert res.draft == "under it, from now on the Firm."
+    assert len(res.applied) == 2

--- a/operator/adapter/voice/transform.py
+++ b/operator/adapter/voice/transform.py
@@ -1241,28 +1241,42 @@ def _first_nonempty_index(lines: list) -> Optional[int]:
 # ---------------------------------------------------------------------------
 
 
-def _has_introduced_disallowed_tokens(before: str, after: str) -> bool:
+def _has_introduced_entity_tokens(before: str, after: str) -> bool:
     """Return True if ``after`` contains entity-shaped tokens not in ``before``.
 
-    The guard checks for new dollar amounts, dates, phone numbers, URLs,
-    and email addresses. Any of these appearing in ``after`` but not in
-    ``before`` is treated as fabrication and aborts the change.
+    The shared fabrication FLOOR: new dollar amounts, dates, phone numbers,
+    URLs, or email addresses appearing in ``after`` but not in ``before`` are
+    fabrication and must abort the change. Both the structural transform and the
+    preference corrections (``adapter.voice.corrections``) hold to this floor —
+    neither may inject a date/amount/contact the source didn't contain.
 
-    Note: tokens may be REARRANGED between before and after (a sentence
-    split moves a phone number to the next sentence); only NEW tokens
-    are disallowed. The check uses set membership of the matched strings.
+    Note: tokens may be REARRANGED between before and after (a sentence split
+    moves a phone number to the next sentence); only NEW tokens are disallowed.
     """
     for pattern in (_DOLLAR_RE, _DATE_RE, _PHONE_RE, _URL_RE, _EMAIL_RE):
-        before_matches = set(pattern.findall(before))
-        after_matches = set(pattern.findall(after))
-        new_tokens = after_matches - before_matches
+        new_tokens = set(pattern.findall(after)) - set(pattern.findall(before))
         if new_tokens:
             log.warning(
-                "voice transform aborted: introduced %r — %s",
+                "voice change aborted: introduced %r — %s",
                 sorted(new_tokens),
                 pattern.pattern[:40],
             )
             return True
+    return False
+
+
+def _has_introduced_disallowed_tokens(before: str, after: str) -> bool:
+    """Stricter guard for the STRUCTURAL transform: no new entity tokens AND no
+    new content words beyond the closed structural-connector set.
+
+    The structural transform only *reshapes* — it never adds words — so any new
+    word outside ``_ALLOWED_CONNECTORS`` is a fabrication here. Preference
+    corrections use the looser :func:`_has_introduced_entity_tokens` floor
+    instead, because a lexical substitution ("under" for "pursuant to")
+    legitimately introduces a new non-entity word the firm authored.
+    """
+    if _has_introduced_entity_tokens(before, after):
+        return True
 
     before_word_set = {w.lower() for w in _WORD_SPLIT.findall(before)}
     after_word_set = {w.lower() for w in _WORD_SPLIT.findall(after)}

--- a/operator/migrations/0010_voice_corrections.sql
+++ b/operator/migrations/0010_voice_corrections.sql
@@ -1,0 +1,77 @@
+-- ============================================================================
+-- Migration 0010: voice_corrections table (A2 — preference capture)
+-- ============================================================================
+--
+-- Per-customer table holding DETERMINISTIC voice preferences an attorney taught
+-- the Operator: greeting / signoff / honorific / lexical phrase substitutions
+-- the firm wants applied to drafts. This is "preference capture," NOT semantic
+-- "voice learning" — a (before -> after) substitution is a glossary, and the
+-- plan is explicit that semantic/stylistic voice is captured as exemplars
+-- feeding the structural transform + blind-test harness, not as rows here.
+--
+-- Why a dedicated table, not persona_observations / Honcho (migration 0007):
+--   * Honcho is off the boot path in Phase 1 (ADR 0016 revision) — a correction
+--     loop built on it would not run for customer-zero. Disqualifying.
+--   * persona_observations mirrors Honcho's INFERRED conclusions and its own
+--     read-discipline comment forbids agent-runtime reads ("No skill ... reads
+--     from this table at agent runtime"). A correction the transform must APPLY
+--     at runtime is exactly a runtime read. Reusing it violates that contract.
+--   Corrections are deterministic, attorney-AUTHORED, must-apply facts — the
+--   opposite of Honcho's inferred, reviewable conclusions.
+--
+-- Capture (two seams, both writers land in later PRs):
+--   * live edit-then-send — the voice pipeline diffs an agent draft against the
+--     attorney's sent version (source='live_edit').
+--   * calibration session #2 — attorney edits + stated rules (source=
+--     'calibration_session'), gated on #821.
+--
+-- Runtime application: adapter/voice/corrections.py::select_active resolves the
+-- active set for a (reviewer, cohort) by scope-specificity -> priority ->
+-- recency, and the transform applies them as a guarded pre-pass (a substitution
+-- that would introduce a disallowed entity is neutralized, never forced).
+--
+-- Reconciliation: a correction overridden by a newer/more-specific one has its
+-- `superseded_by` set to the winner's id (an auditable, restorable chain — this
+-- is also the substrate for Track-C "wrong-learned-rule governance"). Active =
+-- superseded_by IS NULL. Cross-cohort corrections coexist (a client-cohort and
+-- an opposing-counsel-cohort rule do not conflict).
+--
+-- Privacy posture (ADR 0009): per-customer D1; isolation is the binding
+-- boundary. `customer_slug` denormalized for query ergonomics (per 0007).
+-- Forward-only (migrations README): no rollback path.
+-- ============================================================================
+
+CREATE TABLE voice_corrections (
+  id               TEXT PRIMARY KEY,                          -- ULID
+  customer_slug    TEXT NOT NULL,
+  correction_kind  TEXT NOT NULL,                             -- label (closed set)
+  pattern_kind     TEXT NOT NULL,                             -- how before_pattern matches
+  before_pattern   TEXT NOT NULL,                             -- what to detect
+  after_text       TEXT NOT NULL,                             -- the replacement
+  reviewer_user_id TEXT,                                      -- voice_profile_id slug; NULL = firm-wide
+  recipient_cohort TEXT,                                      -- cohort scope; NULL = all cohorts
+  priority         INTEGER NOT NULL DEFAULT 0,                -- tiebreak; higher wins
+  source           TEXT NOT NULL,                             -- where the correction came from
+  source_ref       TEXT,                                      -- calibration_cycle_id / sent-message digest
+  created_at       TEXT NOT NULL DEFAULT (datetime('now')),
+  superseded_by    TEXT,                                      -- id of the correction that overrode this one
+  active           BOOLEAN GENERATED ALWAYS AS (superseded_by IS NULL) VIRTUAL,
+  CHECK (correction_kind IN ('greeting', 'signoff', 'honorific', 'lexical')),
+  CHECK (pattern_kind IN ('literal', 'literal_ci', 'regex')),
+  CHECK (source IN ('calibration_session', 'live_edit'))
+);
+
+-- Runtime selection: the active corrections for a (reviewer, cohort). The
+-- transform's pre-pass walks this; the partial predicate bounds it to the
+-- live set (generated columns cannot appear in a partial-index predicate, so
+-- the physical superseded_by predicate is used, per 0007's convention).
+CREATE INDEX voice_corrections_active_scope
+  ON voice_corrections (reviewer_user_id, recipient_cohort)
+  WHERE superseded_by IS NULL;
+
+-- Audit / export / the supersession chain walk.
+CREATE INDEX voice_corrections_by_created
+  ON voice_corrections (customer_slug, created_at);
+
+-- ---------- Schema version ----------
+PRAGMA user_version = 10;

--- a/operator/tests/test_migration_0010_voice_corrections.py
+++ b/operator/tests/test_migration_0010_voice_corrections.py
@@ -1,0 +1,151 @@
+"""Migration 0010 — voice_corrections table (A2 preference capture).
+
+Verifies the table, its CHECK constraints, the `active` generated column
+(driven by superseded_by), the two indexes, and the version bump, applied
+against a clean SQLite database that ran migrations 0001..0009 first.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MIGRATIONS_DIR = REPO_ROOT / "operator" / "migrations"
+
+
+def _connect_with_migrations(through: int) -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    for n in range(1, through + 1):
+        path = next(MIGRATIONS_DIR.glob(f"{n:04d}_*.sql"))
+        conn.executescript(path.read_text(encoding="utf-8"))
+    conn.commit()
+    return conn
+
+
+def _columns(conn: sqlite3.Connection) -> dict[str, dict]:
+    rows = conn.execute("PRAGMA table_info(voice_corrections)").fetchall()
+    return {r[1]: {"type": r[2], "notnull": bool(r[3]), "dflt": r[4]} for r in rows}
+
+
+def _indexes(conn: sqlite3.Connection) -> set[str]:
+    rows = conn.execute("PRAGMA index_list(voice_corrections)").fetchall()
+    return {r[1] for r in rows}
+
+
+def _insert(conn: sqlite3.Connection, **over) -> None:
+    row = {
+        "id": "01HVOICE0000000000000000AA",
+        "customer_slug": "pilot-law",
+        "correction_kind": "lexical",
+        "pattern_kind": "literal_ci",
+        "before_pattern": "pursuant to",
+        "after_text": "under",
+        "reviewer_user_id": None,
+        "recipient_cohort": None,
+        "priority": 0,
+        "source": "calibration_session",
+        "source_ref": None,
+        "superseded_by": None,
+    }
+    row.update(over)
+    conn.execute(
+        """
+        INSERT INTO voice_corrections
+          (id, customer_slug, correction_kind, pattern_kind, before_pattern,
+           after_text, reviewer_user_id, recipient_cohort, priority, source,
+           source_ref, superseded_by)
+        VALUES (:id, :customer_slug, :correction_kind, :pattern_kind,
+                :before_pattern, :after_text, :reviewer_user_id,
+                :recipient_cohort, :priority, :source, :source_ref,
+                :superseded_by)
+        """,
+        row,
+    )
+
+
+def test_table_and_columns_present() -> None:
+    conn = _connect_with_migrations(10)
+    cols = _columns(conn)
+    for name in (
+        "id",
+        "customer_slug",
+        "correction_kind",
+        "pattern_kind",
+        "before_pattern",
+        "after_text",
+        "reviewer_user_id",
+        "recipient_cohort",
+        "priority",
+        "source",
+        "source_ref",
+        "created_at",
+        "superseded_by",
+        # `active` is a VIRTUAL generated column — not listed by table_info on
+        # this SQLite; its behavior is locked by
+        # test_active_generated_column_tracks_superseded_by below.
+    ):
+        assert name in cols, name
+    assert cols["after_text"]["notnull"] is True
+    assert cols["reviewer_user_id"]["notnull"] is False  # NULL = firm-wide
+    assert cols["recipient_cohort"]["notnull"] is False  # NULL = all cohorts
+
+
+def test_indexes_added() -> None:
+    idx = _indexes(_connect_with_migrations(10))
+    assert "voice_corrections_active_scope" in idx
+    assert "voice_corrections_by_created" in idx
+
+
+def test_active_generated_column_tracks_superseded_by() -> None:
+    conn = _connect_with_migrations(10)
+    _insert(conn, id="a", superseded_by=None)
+    _insert(conn, id="b", before_pattern="hereinafter", after_text="from now on", superseded_by="a")
+    conn.commit()
+    rows = dict(conn.execute("SELECT id, active FROM voice_corrections").fetchall())
+    assert rows["a"] == 1  # not superseded → active
+    assert rows["b"] == 0  # superseded → inactive
+
+
+def test_check_rejects_bad_correction_kind() -> None:
+    conn = _connect_with_migrations(10)
+    try:
+        _insert(conn, correction_kind="semantic")  # not in the closed set
+        conn.commit()
+        raise AssertionError("expected CHECK violation for correction_kind")
+    except sqlite3.IntegrityError as e:
+        assert "constraint" in str(e).lower() or "CHECK" in str(e)
+
+
+def test_check_rejects_bad_pattern_kind() -> None:
+    conn = _connect_with_migrations(10)
+    try:
+        _insert(conn, pattern_kind="glob")
+        conn.commit()
+        raise AssertionError("expected CHECK violation for pattern_kind")
+    except sqlite3.IntegrityError as e:
+        assert "constraint" in str(e).lower() or "CHECK" in str(e)
+
+
+def test_check_rejects_bad_source() -> None:
+    conn = _connect_with_migrations(10)
+    try:
+        _insert(conn, source="model_guess")
+        conn.commit()
+        raise AssertionError("expected CHECK violation for source")
+    except sqlite3.IntegrityError as e:
+        assert "constraint" in str(e).lower() or "CHECK" in str(e)
+
+
+def test_each_valid_kind_accepted() -> None:
+    conn = _connect_with_migrations(10)
+    for i, kind in enumerate(("greeting", "signoff", "honorific", "lexical")):
+        _insert(conn, id=f"k{i}", correction_kind=kind, before_pattern=f"p{i}", after_text=f"a{i}")
+    conn.commit()
+    n = conn.execute("SELECT COUNT(*) FROM voice_corrections").fetchone()[0]
+    assert n == 4
+
+
+def test_schema_version_bumped_to_10() -> None:
+    v = _connect_with_migrations(10).execute("PRAGMA user_version").fetchone()[0]
+    assert v == 10


### PR DESCRIPTION
The deterministic half of **A2** (plan: `.claude/plans/golden-kindling-honey.md`) — *preference capture*, honestly named, **not** semantic "voice learning."

## Summary
- **`migration 0010_voice_corrections.sql`** — per-customer table for attorney-authored `(before → after)` substitution preferences (greeting/signoff/honorific/lexical), with scope (`reviewer_user_id`/`recipient_cohort`, NULL = firm-wide/all-cohorts), `priority`, `source`, and a `superseded_by` chain + `active` generated column. **Not** `persona_observations`/Honcho — that's off-boot-path in Phase 1 and its read-discipline forbids agent-runtime reads, which is exactly what applying a correction requires.
- **`adapter/voice/corrections.py`** — `Correction` model; `select_active()` reconciliation (**scope-specificity → priority → recency**; cross-cohort rules coexist, only same-target rules conflict); `apply_corrections()` guarded substitution with the **`correction_neutralized` signal**.
- **Guard split (design discovery):** the structural transform's guard forbade *any* new word — correct for reshaping, wrong for a lexical substitution that legitimately introduces "under" for "pursuant to." Split into `_has_introduced_entity_tokens` (the shared floor: never inject a date/amount/phone/URL/email) and the stricter `_has_introduced_disallowed_tokens` (the no-new-words rule the structural transform keeps). Corrections ride the entity floor — a rule that would inject an entity is **neutralized, recorded, never forced**.

## Scope
Pure module + migration. The D1 loader, the corrections→transform runtime sequence, and the `voice_transform_draft` tool are the **Wave-2 overlay** wiring. **Semantic/stylistic voice (class b)** stays exemplar-driven + observe-mode, gated on real `pilot-law` traffic — not claimed here.

## Test plan
- [x] 23 tests (8 migration: constraints + `active` column + version; 15 corrections: scope filtering, reconciliation, cross-cohort coexistence, literal/literal_ci/regex apply, entity-neutralization via the real guard, malformed-regex no-op). Transform suite unchanged-green; ruff clean.
- [ ] Live correction-capture attribution validated on real edit-then-send traffic before class-b leaves observe-mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)