### PR TITLE
feat(operator): admin change-request inbox (§4.4)

### DIFF
--- a/src/lib/admin/change-request-inbox.ts
+++ b/src/lib/admin/change-request-inbox.ts
@@ -1,0 +1,89 @@
+/**
+ * Change-request inbox view-model for the admin Operator console
+ * (`/admin/operator/requests`) — design doc §4.4.
+ *
+ * The receiving end of the authority model: when a client in an SMD-operated
+ * domain files a "request a change," it lands in `operator_change_requests` and
+ * SMD actions or declines it here. The store reader/writer
+ * (listOpenChangeRequests / updateChangeRequestStatus) is the frozen seam
+ * (src/lib/portal/operator/change-request.ts); this module owns only the
+ * admin-side action vocabulary and the pure display derivations.
+ *
+ * "This is what makes Managed real: the client asks, SMD does."
+ */
+
+import { relativeTimestamp } from './fleet-status'
+import { AUTHORITY_DOMAIN_LABELS } from './operator-overview'
+import type { ChangeRequestStatus } from '../portal/operator/change-request'
+import type { SwitchableAuthorityDomain } from '../operator/authority'
+
+/**
+ * The actions SMD can take on a request from the inbox. Each maps to a target
+ * status on the frozen updateChangeRequestStatus:
+ *   - acknowledge → 'acknowledged' (receipt; stays in the inbox, not closed)
+ *   - resolve     → 'resolved'     (terminal; SMD made the change)
+ *   - decline     → 'declined'     (terminal; with a note)
+ */
+export const CHANGE_REQUEST_ACTIONS = ['acknowledge', 'resolve', 'decline'] as const
+export type ChangeRequestAction = (typeof CHANGE_REQUEST_ACTIONS)[number]
+
+const ACTION_TO_STATUS: Record<ChangeRequestAction, ChangeRequestStatus> = {
+  acknowledge: 'acknowledged',
+  resolve: 'resolved',
+  decline: 'declined',
+}
+
+/** Validate an untrusted action string → the target status, or null. */
+export function actionToStatus(action: string): ChangeRequestStatus | null {
+  return (CHANGE_REQUEST_ACTIONS as readonly string[]).includes(action)
+    ? ACTION_TO_STATUS[action as ChangeRequestAction]
+    : null
+}
+
+/** Friendly label for a change-request domain (a switchable authority domain). */
+export function changeRequestDomainLabel(domain: SwitchableAuthorityDomain): string {
+  return AUTHORITY_DOMAIN_LABELS[domain]
+}
+
+export interface RequestStatusBadge {
+  label: string
+  classes: string
+}
+
+const STATUS_BADGE_STRUCTURE =
+  'inline-flex items-center px-2 py-0.5 rounded-[var(--ss-radius-badge)] ' +
+  'text-[10px] font-medium uppercase tracking-wide whitespace-nowrap'
+
+/**
+ * Badge for a request's status. Only open / acknowledged appear in the inbox
+ * (the reader filters to those), but resolved / declined are mapped too so the
+ * badge is total.
+ */
+export function requestStatusBadge(status: ChangeRequestStatus): RequestStatusBadge {
+  switch (status) {
+    case 'open':
+      return {
+        label: 'Open',
+        classes: `${STATUS_BADGE_STRUCTURE} bg-[color:var(--ss-color-attention)] text-white`,
+      }
+    case 'acknowledged':
+      return {
+        label: 'Acknowledged',
+        classes: `${STATUS_BADGE_STRUCTURE} bg-[color:var(--ss-color-primary)] text-white`,
+      }
+    case 'resolved':
+      return {
+        label: 'Resolved',
+        classes: `${STATUS_BADGE_STRUCTURE} bg-[color:var(--ss-color-complete)] text-white`,
+      }
+    case 'declined':
+      return {
+        label: 'Declined',
+        classes: `${STATUS_BADGE_STRUCTURE} bg-[color:var(--ss-color-border)] text-[color:var(--ss-color-text-secondary)]`,
+      }
+  }
+}
+
+export function requestAge(createdAt: string, now: Date = new Date()): string {
+  return relativeTimestamp(createdAt, now)
+}

--- a/src/pages/admin/operator/requests.astro
+++ b/src/pages/admin/operator/requests.astro
@@ -1,0 +1,186 @@
+---
+import AdminLayout from '../../../layouts/AdminLayout.astro'
+import { listOpenChangeRequests } from '../../../lib/portal/operator/change-request'
+import {
+  changeRequestDomainLabel,
+  requestStatusBadge,
+  requestAge,
+} from '../../../lib/admin/change-request-inbox'
+import { env } from 'cloudflare:workers'
+
+/**
+ * Operator admin console — change-request inbox (§4.4).
+ *
+ * The receiving end of the authority model. When a client in an SMD-operated
+ * domain files a change request, it lands here and SMD actions or declines it.
+ * Reads the console-side operator_change_requests store (not runtime D1, so the
+ * cross-customer inbox read is legitimate). Actioning a request stamps the
+ * Layer-0 SMD actor (resolved_by_email) — the inline audit (foundations §6).
+ *
+ * Honest state (foundations §7): an empty inbox is a real state — clients have
+ * filed nothing, not a fabricated to-do.
+ */
+
+const session = Astro.locals.session!
+if (session.role !== 'admin') {
+  return Astro.redirect('/auth/sign-in')
+}
+
+const requests = await listOpenChangeRequests(env.DB)
+---
+
+<AdminLayout
+  title="Operator — Change requests"
+  breadcrumbs={[
+    { label: 'Dashboard', href: '/admin' },
+    { label: 'Operator', href: '/admin/operator' },
+    { label: 'Change requests' },
+  ]}
+  maxWidth="max-w-6xl"
+>
+  <div class="space-y-card">
+    <header class="flex items-end justify-between gap-4">
+      <div>
+        <h2 class="text-xl font-semibold text-[color:var(--ss-color-text-primary)]">
+          Change requests
+        </h2>
+        <p class="text-sm text-[color:var(--ss-color-text-secondary)] mt-1">
+          Requests from clients in SMD-operated domains. Acknowledge to record receipt, resolve once
+          you have made the change through the normal config path, or decline with a note.
+        </p>
+      </div>
+      <div class="text-right">
+        <p class="text-xs uppercase tracking-wide text-[color:var(--ss-color-text-muted)]">Open</p>
+        <p class="text-2xl font-bold text-[color:var(--ss-color-text-primary)]">
+          {requests.length}
+        </p>
+      </div>
+    </header>
+
+    <div
+      class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card"
+      data-requests-inbox
+    >
+      {
+        requests.length === 0 ? (
+          <p class="text-sm text-[color:var(--ss-color-text-secondary)]">
+            No open change requests. Clients with SMD-operated domains file requests here; there are
+            none to action right now.
+          </p>
+        ) : (
+          <ul class="space-y-4 text-sm">
+            {requests.map((r) => {
+              const badge = requestStatusBadge(r.status)
+              return (
+                <li
+                  class="border-b border-[color:var(--ss-color-border-subtle)] pb-4 last:border-0 last:pb-0"
+                  data-request-id={r.id}
+                >
+                  <div class="flex items-start justify-between gap-4">
+                    <div class="flex-1 min-w-0">
+                      <div class="flex items-center gap-2 flex-wrap">
+                        <span class={badge.classes}>{badge.label}</span>
+                        <a
+                          href={`/admin/operator/${encodeURIComponent(r.customer_slug)}`}
+                          class="font-medium text-[color:var(--ss-color-text-primary)] hover:text-[color:var(--ss-color-primary)]"
+                        >
+                          {r.customer_slug}
+                        </a>
+                        <span class="text-[color:var(--ss-color-text-secondary)]">
+                          · {changeRequestDomainLabel(r.domain)}
+                        </span>
+                        <span class="text-[color:var(--ss-color-text-muted)]">
+                          · {requestAge(r.created_at)}
+                        </span>
+                      </div>
+                      <p class="text-[color:var(--ss-color-text-primary)] mt-1 whitespace-pre-wrap">
+                        {r.summary}
+                      </p>
+                      <p class="text-xs text-[color:var(--ss-color-text-muted)] mt-1">
+                        Requested by {r.requested_by_email}
+                      </p>
+                    </div>
+                  </div>
+                  <div class="flex flex-wrap items-center gap-2 mt-3">
+                    <input
+                      type="text"
+                      data-request-note
+                      placeholder="Note (used on resolve / decline)"
+                      class="flex-1 min-w-[12rem] rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-white px-2 py-1 text-xs"
+                    />
+                    <button
+                      type="button"
+                      data-request-action="acknowledge"
+                      class="text-xs text-[color:var(--ss-color-action)] hover:underline"
+                    >
+                      Acknowledge
+                    </button>
+                    <button
+                      type="button"
+                      data-request-action="resolve"
+                      class="text-xs text-[color:var(--ss-color-action)] hover:underline"
+                    >
+                      Resolve
+                    </button>
+                    <button
+                      type="button"
+                      data-request-action="decline"
+                      class="text-xs text-[color:var(--ss-color-error)] hover:underline"
+                    >
+                      Decline
+                    </button>
+                  </div>
+                </li>
+              )
+            })}
+          </ul>
+        )
+      }
+    </div>
+  </div>
+</AdminLayout>
+
+<script>
+  // Action a request via the admin API, then reload so the inbox reflects the
+  // new state (acknowledged rows stay; resolved/declined drop out). No
+  // optimistic UI — a reload confirms the backend applied it.
+  function init() {
+    const inbox = document.querySelector('[data-requests-inbox]')
+    if (!inbox) return
+
+    async function post(action: string, body: Record<string, unknown>) {
+      const res = await fetch(`/api/admin/operator/requests/${action}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+      if (!res.ok) {
+        const text = await res.text().catch(() => '')
+        alert(`Failed: ${res.status} ${text}`)
+        return false
+      }
+      return true
+    }
+
+    inbox.querySelectorAll<HTMLButtonElement>('[data-request-action]').forEach((btn) => {
+      btn.addEventListener('click', async () => {
+        const li = btn.closest<HTMLElement>('[data-request-id]')
+        if (!li) return
+        const id = Number(li.dataset.requestId)
+        const action = btn.dataset.requestAction ?? ''
+        const noteInput = li.querySelector<HTMLInputElement>('[data-request-note]')
+        const note = noteInput?.value.trim() || null
+        btn.disabled = true
+        const ok = await post(action, { id, resolution_note: note })
+        if (ok) window.location.reload()
+        else btn.disabled = false
+      })
+    })
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init)
+  } else {
+    init()
+  }
+</script>

--- a/src/pages/api/admin/operator/requests/[action].ts
+++ b/src/pages/api/admin/operator/requests/[action].ts
@@ -1,0 +1,85 @@
+/**
+ * POST /api/admin/operator/requests/acknowledge
+ * POST /api/admin/operator/requests/resolve
+ * POST /api/admin/operator/requests/decline
+ *
+ * SMD actions on a client change request (design §4.4). Body:
+ *
+ *   { id: number, resolution_note?: string | null }
+ *
+ * - acknowledge → records receipt (stays in the inbox, not closed)
+ * - resolve     → terminal; SMD made the change
+ * - decline     → terminal; note recommended
+ *
+ * The resolver (updateChangeRequestStatus) stamps resolved_by_email +
+ * resolved_at for terminal states — that is the inline audit of the Layer-0 SMD
+ * actor for this control-plane mutation (foundations §6). Admin-only, enforced
+ * by middleware on /api/admin/* and re-checked here.
+ */
+
+import type { APIContext, APIRoute } from 'astro'
+import { env } from 'cloudflare:workers'
+import { updateChangeRequestStatus } from '../../../../../lib/portal/operator/change-request'
+import { actionToStatus } from '../../../../../lib/admin/change-request-inbox'
+
+const MAX_NOTE_LENGTH = 4000
+
+function jsonResponse(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+interface ParsedBody {
+  id: number
+  resolution_note: string | null
+}
+
+function parseBody(body: unknown): ParsedBody | { error: string } {
+  if (!body || typeof body !== 'object') return { error: 'body must be a JSON object' }
+  const obj = body as Record<string, unknown>
+  const id = obj.id
+  if (typeof id !== 'number' || !Number.isInteger(id) || id <= 0) {
+    return { error: 'id is required and must be a positive integer' }
+  }
+  const note = obj.resolution_note
+  if (note === undefined || note === null) return { id, resolution_note: null }
+  if (typeof note !== 'string') return { error: 'resolution_note must be a string or null' }
+  if (note.length > MAX_NOTE_LENGTH) return { error: `resolution_note exceeds ${MAX_NOTE_LENGTH}` }
+  const trimmed = note.trim()
+  return { id, resolution_note: trimmed === '' ? null : trimmed }
+}
+
+async function handlePost(ctx: APIContext): Promise<Response> {
+  const session = ctx.locals.session
+  if (!session || session.role !== 'admin') {
+    return jsonResponse({ error: 'Unauthorized' }, 401)
+  }
+
+  const status = actionToStatus(ctx.params.action ?? '')
+  if (status === null) {
+    return jsonResponse({ error: `unknown action: ${ctx.params.action}` }, 404)
+  }
+
+  let body: unknown
+  try {
+    body = await ctx.request.json()
+  } catch {
+    return jsonResponse({ error: 'invalid JSON body' }, 400)
+  }
+
+  const parsed = parseBody(body)
+  if ('error' in parsed) return jsonResponse({ error: parsed.error }, 400)
+
+  const updated = await updateChangeRequestStatus(env.DB, {
+    id: parsed.id,
+    status,
+    resolved_by_email: session.email,
+    resolution_note: parsed.resolution_note,
+  })
+  if (!updated) return jsonResponse({ error: 'change request not found' }, 404)
+  return jsonResponse({ ok: true, id: parsed.id, status }, 200)
+}
+
+export const POST: APIRoute = (ctx) => handlePost(ctx)

--- a/tests/change-request-inbox.test.ts
+++ b/tests/change-request-inbox.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Tests for the change-request inbox — the view-model
+ * (src/lib/admin/change-request-inbox.ts) and the action endpoint
+ * (POST /api/admin/operator/requests/[action]). Design §4.4.
+ *
+ * The endpoint tests run against a real D1: seed a client-filed request via the
+ * frozen createChangeRequest, then action it through the handler and assert the
+ * store moved (resolver stamps the SMD actor — the inline audit, foundations §6).
+ */
+
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest'
+import {
+  createTestD1,
+  discoverNumericMigrations,
+  runMigrations,
+  installWorkerdPolyfills,
+} from '@venturecrane/crane-test-harness'
+import path from 'node:path'
+import { POST } from '../src/pages/api/admin/operator/requests/[action]'
+import { env as testEnv } from 'cloudflare:workers'
+import {
+  createChangeRequest,
+  listOpenChangeRequests,
+  listChangeRequestsForCustomer,
+} from '../src/lib/portal/operator/change-request'
+import {
+  actionToStatus,
+  changeRequestDomainLabel,
+  requestStatusBadge,
+} from '../src/lib/admin/change-request-inbox'
+
+installWorkerdPolyfills()
+
+const migrationsDir = path.resolve(__dirname, '../migrations')
+const ORG_ID = 'org-1'
+const ENTITY_ID = 'ent-cr'
+
+interface MinimalSession {
+  userId: string
+  orgId: string
+  role: string
+  email: string
+  expiresAt: string
+}
+
+function adminSession(): MinimalSession {
+  return {
+    userId: 'usr-captain',
+    orgId: ORG_ID,
+    role: 'admin',
+    email: 'captain@example.com',
+    expiresAt: '2099-12-31T00:00:00Z',
+  }
+}
+
+function buildCtx(opts: {
+  session: MinimalSession | null
+  action: string
+  body: unknown
+}): Parameters<typeof POST>[0] {
+  const request = new Request(`http://test.local/api/admin/operator/requests/${opts.action}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: typeof opts.body === 'string' ? opts.body : JSON.stringify(opts.body),
+  })
+  return {
+    request,
+    params: { action: opts.action },
+    locals: { session: opts.session },
+  } as unknown as Parameters<typeof POST>[0]
+}
+
+describe('change-request-inbox view-model', () => {
+  it('actionToStatus maps the three admin actions and rejects others', () => {
+    expect(actionToStatus('acknowledge')).toBe('acknowledged')
+    expect(actionToStatus('resolve')).toBe('resolved')
+    expect(actionToStatus('decline')).toBe('declined')
+    expect(actionToStatus('delete')).toBeNull()
+    expect(actionToStatus('')).toBeNull()
+  })
+
+  it('changeRequestDomainLabel renders a friendly domain label', () => {
+    expect(changeRequestDomainLabel('people_access')).toBe('People & access')
+    expect(changeRequestDomainLabel('connectors')).toBe('Connectors & credentials')
+  })
+
+  it('requestStatusBadge is total over the status union', () => {
+    for (const s of ['open', 'acknowledged', 'resolved', 'declined'] as const) {
+      const badge = requestStatusBadge(s)
+      expect(badge.label.length).toBeGreaterThan(0)
+      expect(badge.classes).toContain('rounded-[var(--ss-radius-badge)]')
+    }
+  })
+})
+
+describe('POST /api/admin/operator/requests/[action]', () => {
+  beforeAll(() => {
+    expect(discoverNumericMigrations(migrationsDir).length).toBeGreaterThan(0)
+  })
+
+  beforeEach(async () => {
+    const db = createTestD1()
+    await runMigrations(db, { files: discoverNumericMigrations(migrationsDir) })
+    await db
+      .prepare(
+        `INSERT INTO organizations (id, name, slug, created_at, updated_at)
+         VALUES (?, 'Test Org', 'test-org', datetime('now'), datetime('now'))`
+      )
+      .bind(ORG_ID)
+      .run()
+    await db
+      .prepare(`INSERT INTO entities (id, org_id, name, slug) VALUES (?, ?, 'Acme', 'acme')`)
+      .bind(ENTITY_ID, ORG_ID)
+      .run()
+    for (const k of Object.keys(testEnv)) delete (testEnv as unknown as Record<string, unknown>)[k]
+    Object.assign(testEnv, { DB: db })
+  })
+
+  async function seedRequest(): Promise<number> {
+    const res = await createChangeRequest(testEnv.DB, {
+      entity_id: ENTITY_ID,
+      customer_slug: 'acme',
+      domain: 'people_access',
+      requested_by_user_id: 'usr-client',
+      requested_by_email: 'owner@acme.test',
+      summary: 'Please add Jordan as a staff user.',
+    })
+    if (!res.ok) throw new Error(`seed failed: ${res.error}`)
+    return res.id
+  }
+
+  it('rejects a non-admin session', async () => {
+    const res = await POST(buildCtx({ session: null, action: 'resolve', body: { id: 1 } }))
+    expect(res.status).toBe(401)
+  })
+
+  it('rejects an unknown action', async () => {
+    const res = await POST(
+      buildCtx({ session: adminSession(), action: 'destroy', body: { id: 1 } })
+    )
+    expect(res.status).toBe(404)
+  })
+
+  it('rejects a missing / invalid id', async () => {
+    const res = await POST(
+      buildCtx({ session: adminSession(), action: 'resolve', body: { id: 'x' } })
+    )
+    expect(res.status).toBe(400)
+  })
+
+  it('404s when the request id does not exist', async () => {
+    const res = await POST(
+      buildCtx({ session: adminSession(), action: 'resolve', body: { id: 9999 } })
+    )
+    expect(res.status).toBe(404)
+  })
+
+  it('resolves a request, stamping the SMD actor and dropping it from the inbox', async () => {
+    const id = await seedRequest()
+    expect(await listOpenChangeRequests(testEnv.DB)).toHaveLength(1)
+
+    const res = await POST(
+      buildCtx({
+        session: adminSession(),
+        action: 'resolve',
+        body: { id, resolution_note: 'Added via config path.' },
+      })
+    )
+    expect(res.status).toBe(200)
+
+    // No longer open; the row carries the resolver identity + note.
+    expect(await listOpenChangeRequests(testEnv.DB)).toHaveLength(0)
+    const [row] = await listChangeRequestsForCustomer(testEnv.DB, 'acme')
+    expect(row.status).toBe('resolved')
+    expect(row.resolved_by_email).toBe('captain@example.com')
+    expect(row.resolution_note).toBe('Added via config path.')
+    expect(row.resolved_at).not.toBeNull()
+  })
+
+  it('acknowledge records receipt but keeps the request in the inbox', async () => {
+    const id = await seedRequest()
+    const res = await POST(
+      buildCtx({ session: adminSession(), action: 'acknowledge', body: { id } })
+    )
+    expect(res.status).toBe(200)
+    const open = await listOpenChangeRequests(testEnv.DB)
+    expect(open).toHaveLength(1)
+    expect(open[0].status).toBe('acknowledged')
+  })
+
+  it('declines a request with a note, dropping it from the inbox', async () => {
+    const id = await seedRequest()
+    const res = await POST(
+      buildCtx({
+        session: adminSession(),
+        action: 'decline',
+        body: { id, resolution_note: 'Out of current scope.' },
+      })
+    )
+    expect(res.status).toBe(200)
+    expect(await listOpenChangeRequests(testEnv.DB)).toHaveLength(0)
+    const [row] = await listChangeRequestsForCustomer(testEnv.DB, 'acme')
+    expect(row.status).toBe('declined')
+    expect(row.resolution_note).toBe('Out of current scope.')
+  })
+})


### PR DESCRIPTION
## What

PR 4 of the SMD-side **Operator Admin Console**. The **change-request inbox** at `/admin/operator/requests` — the receiving end of the authority model. When a client in an SMD-operated domain files a "request a change," it lands here and SMD acknowledges, resolves, or declines it. *"This is what makes Managed real: the client asks, SMD does."* Design: §4.4.

## ⚠️ Stacked on #1252 → #1250 → #1249

Base is `feat/operator-admin-alerts` (#1252). Merge the stack bottom-up.

## How it works

Reads the console-side `operator_change_requests` store via the frozen `listOpenChangeRequests` (a legitimate cross-customer read — control-plane, not runtime D1). Actions it through the frozen `updateChangeRequestStatus` behind a new admin endpoint: `POST /api/admin/operator/requests/[action]` (acknowledge / resolve / decline), admin-gated with defense-in-depth. New `src/lib/admin/change-request-inbox.ts` owns the action vocabulary + display derivations.

## Discipline

- **Audit (foundations §6):** the resolver stamps `resolved_by_email` + `resolved_at` for terminal states — the inline audit of the Layer-0 SMD actor for this control-plane mutation. No separate audit write needed; the store row carries who/when/why.
- **Acknowledge ≠ close:** acknowledge records receipt and keeps the request in the inbox; resolve/decline are terminal and drop it. Decline carries a note.
- **Parse, never cast:** the endpoint validates action, id, and note without casting client input.
- **Honest state:** an empty inbox is a real state, not a fabricated to-do.

## Verification

- `npm run verify` green. Main suite: 3137 passed / 2 skipped.
- 10 unit + endpoint tests (`tests/change-request-inbox.test.ts`): auth, action/id validation, 404, and resolve/acknowledge/decline round-trips against a real D1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)