### PR TITLE
feat(operator): dual-mode DomainSurface wrapper + Home/Today (client portal PR1)

### DIFF
--- a/src/components/portal/operator/DomainSurface.astro
+++ b/src/components/portal/operator/DomainSurface.astro
@@ -1,0 +1,95 @@
+---
+/**
+ * Dual-mode surface wrapper (client-portal §3 — the heart of the portal). Every
+ * client-portal domain surface wraps its content in this. It composes the three
+ * access layers (foundations §2) into one of two render modes:
+ *
+ *   - operable     → the client edits directly. Renders the `operable` slot.
+ *   - read_request → identical data, read-only, plus a "Request a change" form
+ *                    that files into the admin inbox. Renders the `read` slot.
+ *
+ * The decision is NOT made here — it is the frozen logic in
+ * `resolveDomainSurface` (Layer 1 authority ∧ Layer 2 role). This component is
+ * the presentational shell over that decision; the server-side write endpoints
+ * re-check the same composition (never trust a client-rendered mode). At launch
+ * every authority switch is off, so every surface renders read_request
+ * regardless of role — flipping a switch (an SMD action) turns it operable with
+ * no rebuild.
+ *
+ * Visibility: a domain the client may not read (only `cost`) renders nothing.
+ * Non-switchable visible domains (e.g. provisioning) render read-only with no
+ * change-request form — there is no client switch to request for them.
+ *
+ * Slots:
+ *   - `read`     — the read-only data view. Always authored by the caller.
+ *   - `operable` — the editable controls. Authored by surfaces that have an
+ *                  operable build; omitted by read-only surfaces, in which case
+ *                  operable mode falls back to the `read` slot so the surface is
+ *                  never blank.
+ */
+
+import {
+  resolveDomainSurface,
+  type DomainSurfaceMode,
+} from '../../../lib/portal/operator/domain-surface'
+import {
+  isSwitchableDomain,
+  type AuthorityDomain,
+  type AuthorityPosture,
+} from '../../../lib/operator/authority'
+import { clientRolePermits } from '../../../lib/portal/operator/client-rbac'
+import { OPERATOR_ROOT } from '../../../lib/portal/operator/return-to'
+import RequestChangeForm from './RequestChangeForm.astro'
+
+interface Props {
+  /** Resolved authority posture for this customer (CustomerConfigRow.authority). */
+  authority: AuthorityPosture | null
+  /** The domain this surface governs. */
+  domain: AuthorityDomain
+  /** The acting user's client-internal roles (principal | staff | compliance). */
+  roles: readonly string[]
+  /** Same-origin path the change-request form returns to. Defaults to operator root. */
+  returnTo?: string
+  /** Human-readable domain name for the request prompt. */
+  domainLabel?: string | null
+  /** Suppress the "Request a change" form even in read_request mode (default false). */
+  hideRequest?: boolean
+}
+
+const {
+  authority,
+  domain,
+  roles,
+  returnTo = OPERATOR_ROOT,
+  domainLabel = null,
+  hideRequest = false,
+} = Astro.props
+
+const permits = clientRolePermits(roles, domain)
+const { visible, mode }: { visible: boolean; mode: DomainSurfaceMode } = resolveDomainSurface(
+  authority,
+  domain,
+  permits
+)
+
+// The operable slot is optional. When a read-only surface (no operable build)
+// somehow resolves operable, fall back to the read slot rather than render blank.
+const hasOperable = Astro.slots.has('operable')
+const renderOperable = mode === 'operable' && hasOperable
+
+// "Request a change" only makes sense for a switchable domain the client cannot
+// currently operate. Non-switchable domains (provisioning) have no switch to
+// request; operable mode needs no request.
+const showRequest = !hideRequest && mode === 'read_request' && isSwitchableDomain(domain)
+---
+
+{
+  visible && (
+    <div data-domain-surface={domain} data-mode={mode}>
+      {renderOperable ? <slot name="operable" /> : <slot name="read" />}
+      {showRequest && (
+        <RequestChangeForm domain={domain} domainLabel={domainLabel} returnTo={returnTo} />
+      )}
+    </div>
+  )
+}

--- a/src/components/portal/operator/RequestChangeForm.astro
+++ b/src/components/portal/operator/RequestChangeForm.astro
@@ -1,0 +1,71 @@
+---
+/**
+ * "Request a change" affordance — the Read + Request half of the dual-mode
+ * surface (client-portal §3, ADR 0041 §4.3). When a domain is SMD-operated
+ * (its authority switch is off — the launch default for every domain), the
+ * client cannot edit directly; this disclosure lets them file a change request
+ * that lands in the admin change-request inbox.
+ *
+ * Plain HTML <form method="POST"> — no client JS (the portal ships 0KB JS).
+ * Posts to /api/portal/operator/change-request, which validates the domain and
+ * summary server-side (createChangeRequest) and 303-redirects back to
+ * `returnTo` with a `?cr=` status the host surface reads to show a banner.
+ *
+ * This is never the *only* path to SMD — every surface also carries the
+ * page-level contact affordance — but it is the structured one that becomes an
+ * inbox item with a domain and a lifecycle.
+ */
+
+import { OPERATOR_ROOT } from '../../../lib/portal/operator/return-to'
+
+interface Props {
+  /** The switchable authority domain this request concerns. */
+  domain: string
+  /** Human-readable domain name for the prompt; falls back to the slug. */
+  domainLabel?: string | null
+  /** Same-origin path to return to after filing (validated server-side too). */
+  returnTo?: string
+}
+
+const { domain, domainLabel = null, returnTo = OPERATOR_ROOT } = Astro.props
+const label = domainLabel ?? domain.replace(/_/g, ' ')
+const fieldId = `change-request-${domain}`
+---
+
+<details class="border-t-[2px] border-[color:var(--ss-color-border)]">
+  <summary
+    class="cursor-pointer list-none px-5 md:px-7 py-3 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold text-[color:var(--ss-color-primary)] hover:bg-[color:var(--ss-color-border-subtle)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-inset"
+  >
+    Request a change
+  </summary>
+  <form
+    method="POST"
+    action="/api/portal/operator/change-request"
+    class="flex flex-col gap-3 px-5 md:px-7 pb-5 pt-2"
+  >
+    <input type="hidden" name="domain" value={domain} />
+    <input type="hidden" name="return_to" value={returnTo} />
+    <label
+      for={fieldId}
+      class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold text-[color:var(--ss-color-text-secondary)]"
+    >
+      What would you like changed about {label}?
+    </label>
+    <textarea
+      id={fieldId}
+      name="summary"
+      required
+      rows="3"
+      maxlength="4000"
+      class="w-full border-[2px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)] px-3 py-2 text-sm text-[color:var(--ss-color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-inset"
+    ></textarea>
+    <div>
+      <button
+        type="submit"
+        class="inline-flex items-center min-h-11 px-4 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold text-[color:var(--ss-color-background)] bg-[color:var(--ss-color-text-primary)] hover:bg-[color:var(--ss-color-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2"
+      >
+        Send request
+      </button>
+    </div>
+  </form>
+</details>

--- a/src/lib/portal/operator/client-rbac.ts
+++ b/src/lib/portal/operator/client-rbac.ts
@@ -1,0 +1,100 @@
+/**
+ * Client-internal RBAC — the Layer-2 capability matrix (foundations §2,
+ * client-portal §2). Answers one question: among a client's OWN people, which
+ * roles may *operate* a given authority domain.
+ *
+ * This is one of the three independent layers that compose into a client
+ * action (foundations §2). It is NOT authority (Layer 1, who-turns-the-dial:
+ * SMD vs client org — src/lib/operator/authority.ts) and NOT entitlements
+ * (Layer 3, what-the-operator-does — ADR 0035). A client action is permitted
+ * iff Layer 1 grants the client org the domain AND this layer grants the
+ * acting user's role the domain. The dual-mode wrapper composes the two via
+ * resolveDomainSurfaceMode (domain-surface.ts); this module supplies the
+ * Layer-2 half (`clientRolePermits`).
+ *
+ * Re-derived from the role definitions in client-portal §2 — deliberately NOT
+ * inherited from the legacy dashboard-roles.md permission matrix (foundations
+ * §8 marks that artifact "do not adopt"). The role vocabulary is
+ * `principal | staff | compliance` (foundations §2; the `staff` value replaced
+ * the legacy `operator` to stop colliding with the product name).
+ *
+ * Pure — no I/O, no D1. The matrix is operability only; read access is governed
+ * separately by canClientRead (authority.ts) and is on for every domain except
+ * cost. A `true` cell means "this role MAY operate this domain when the Layer-1
+ * switch is also on"; at launch every switch is off, so every surface is
+ * Read + Request regardless of role, but the matrix is the correct contract for
+ * when SMD flips a switch.
+ */
+
+import {
+  isSwitchableDomain,
+  SWITCHABLE_AUTHORITY_DOMAINS,
+  type SwitchableAuthorityDomain,
+} from '../../operator/authority'
+
+/** The client-internal roles (client-portal §2). Mirrors ACCEPTED_USER_ROLES
+ * in the customer.yaml validator; kept as a local const so this module stays
+ * pure of the validator graph. */
+export const CLIENT_ROLES = ['principal', 'staff', 'compliance'] as const
+export type ClientRole = (typeof CLIENT_ROLES)[number]
+
+export function isClientRole(value: string): value is ClientRole {
+  return (CLIENT_ROLES as readonly string[]).includes(value)
+}
+
+/**
+ * Which client-internal roles may operate each switchable domain. The cell
+ * rationale, grounded in client-portal §2 (role definitions), §4.2 (domain
+ * controls), and §5 (per-surface notes):
+ *
+ *   - principal — "control the operator within authority; manage the team; set
+ *     ceilings within floors; be the escalation target." Operates every
+ *     switchable domain.
+ *   - staff — "handle work the operator routes to a human; manage matters; see
+ *     activity." Operates `runtime` (§5.3: the routed work is acted on by
+ *     "principal or staff, per role") and the limited `observability` actions
+ *     (§4.2: "Read for all; limited actions (ack, pause) gated by Layer 2").
+ *     Configuration, governance, connectors, memory, people, and compliance are
+ *     not the day-to-day role's to operate.
+ *   - compliance — "read-only audit + evidence access; separation of duties"
+ *     (§2). The one action this role performs is exporting an evidence packet
+ *     (§5.5), which is the operable half of the `compliance` domain. Everything
+ *     else is read-only by definition of the role.
+ *
+ * Absent (false) by construction: a role with no `true` cell for a domain
+ * cannot operate it even when the authority switch is on. Fail-closed.
+ */
+const OPERABILITY: Readonly<Record<ClientRole, ReadonlySet<SwitchableAuthorityDomain>>> = {
+  principal: new Set<SwitchableAuthorityDomain>(SWITCHABLE_AUTHORITY_DOMAINS),
+  staff: new Set<SwitchableAuthorityDomain>(['runtime', 'observability']),
+  compliance: new Set<SwitchableAuthorityDomain>(['compliance']),
+}
+
+/**
+ * Does any of the acting user's client-internal roles permit operating this
+ * domain? This is the Layer-2 input to resolveDomainSurfaceMode. Unknown role
+ * strings (not in CLIENT_ROLES) and unknown domains contribute nothing — the
+ * function is total and fail-closed: a malformed role never grants operability.
+ *
+ * A user may hold multiple roles (the grant model is additive); operability is
+ * the union — permitted if ANY held role permits the domain.
+ */
+export function clientRolePermits(roles: readonly string[], domain: string): boolean {
+  if (!isSwitchableDomain(domain)) return false
+  for (const role of roles) {
+    if (isClientRole(role) && OPERABILITY[role].has(domain)) return true
+  }
+  return false
+}
+
+/**
+ * The set of switchable domains a single role may operate. Exposed for surfaces
+ * that need to reason over a role's full operability footprint (e.g. a nav that
+ * dims domains a role can never act on). Returns an empty array for unknown
+ * roles. Order follows SWITCHABLE_AUTHORITY_DOMAINS for stable rendering.
+ */
+export function operableDomainsForRole(role: string): SwitchableAuthorityDomain[] {
+  if (!isClientRole(role)) return []
+  const set = OPERABILITY[role]
+  return SWITCHABLE_AUTHORITY_DOMAINS.filter((d) => set.has(d))
+}

--- a/src/lib/portal/operator/home.ts
+++ b/src/lib/portal/operator/home.ts
@@ -1,0 +1,61 @@
+/**
+ * Home / Today runtime feeds (client-portal §5.1). The Home surface answers
+ * "what's happening" with four elements: aliveness (resolved separately via the
+ * summary mirror), recent activity, what-needs-you, and escalations. The latter
+ * three are fed by the live runtime read path (ADR 0043 path A).
+ *
+ * Until OPERATOR_RUNTIME_READ_URL is wired, the read path fails closed, so this
+ * returns empty feeds — the design's documented honest empty state
+ * (foundations §6: "until built, runtime surfaces render honest empty states").
+ *
+ * `needsAttentionCount` stays 0 by construction here. The Home must never
+ * fabricate a review queue the entitlements did not author (ADR 0035 /
+ * client-portal §5.1): a "what needs you" entry exists only when a skill was
+ * authored to route to a human AND the runtime switch hands it to the client.
+ * Absent that authored routing, there is nothing — not a zeroed queue implying
+ * one exists, but no surface at all.
+ *
+ * PR2 (Activity & Audit) wires the actual readMachineRuntime call + payload
+ * parse into this function; the Home page consumes this typed shape and does
+ * not change when that lands.
+ */
+
+import { isRuntimeReadConfigured, type RuntimeReadEnv } from '../../operator/runtime-read-transport'
+
+export interface HomeActivityItem {
+  id: string
+  summary: string
+  at: string
+}
+
+export interface HomeEscalationItem {
+  id: string
+  summary: string
+  at: string
+}
+
+export interface HomeFeeds {
+  /** Whether the live runtime read path is wired. When false, every feed is empty. */
+  runtimeConfigured: boolean
+  /** Recent completed actions, plain-language. Empty until the read path is wired. */
+  recentActivity: HomeActivityItem[]
+  /** Count of items routed to a human for THIS client. 0 unless authored + switched on. */
+  needsAttentionCount: number
+  /** Items the operator flagged to a human per the escalation config. */
+  escalations: HomeEscalationItem[]
+}
+
+/**
+ * Assemble the Home/Today feeds for the signed-in client's own operator.
+ * Currently returns honest empty feeds (the runtime read path is not wired);
+ * `runtimeConfigured` reflects whether it is, so the surface can distinguish
+ * "wired but quiet" from "not wired" if it ever needs to.
+ */
+export function loadHomeFeeds(env: RuntimeReadEnv): HomeFeeds {
+  return {
+    runtimeConfigured: isRuntimeReadConfigured(env),
+    recentActivity: [],
+    needsAttentionCount: 0,
+    escalations: [],
+  }
+}

--- a/src/lib/portal/operator/return-to.ts
+++ b/src/lib/portal/operator/return-to.ts
@@ -1,0 +1,34 @@
+/**
+ * Same-origin return-path guard for client-portal form posts.
+ *
+ * Form-driven endpoints (e.g. the change-request filing path) carry a
+ * `return_to` field so the 303 lands the client back on the surface they acted
+ * from. An attacker-supplied `return_to` is an open-redirect vector, so the
+ * value is never trusted: it must be a relative path inside the client operator
+ * surface subtree. Anything else collapses to the operator root.
+ *
+ * Pure and total — accepts the raw FormDataEntryValue (string | File | null)
+ * and always returns a safe path.
+ */
+
+/** The only subtree a return path may point at — the client operator surface. */
+export const OPERATOR_ROOT = '/portal/products/operator'
+
+export function safeReturnTo(raw: unknown): string {
+  if (typeof raw !== 'string') return OPERATOR_ROOT
+  const value = raw.trim()
+  // Must be a root-relative path into the operator surface. Reject anything
+  // that could escape origin: protocol-relative ("//host"), backslashes
+  // (browser-normalized to "/"), or whitespace/control characters smuggled in.
+  if (!value.startsWith(OPERATOR_ROOT)) return OPERATOR_ROOT
+  if (value.includes('//') || value.includes('\\')) return OPERATOR_ROOT
+  // Reject any whitespace or control character (code point <= 0x20).
+  for (let i = 0; i < value.length; i++) {
+    if (value.charCodeAt(i) <= 0x20) return OPERATOR_ROOT
+  }
+  // The char after the root must be a path boundary, so "/portal/products/operatorX"
+  // (a sibling prefix) cannot pass as the operator subtree.
+  const next = value.charAt(OPERATOR_ROOT.length)
+  if (next !== '' && next !== '/' && next !== '?' && next !== '#') return OPERATOR_ROOT
+  return value
+}

--- a/src/pages/api/portal/operator/change-request.ts
+++ b/src/pages/api/portal/operator/change-request.ts
@@ -1,0 +1,71 @@
+import type { APIRoute } from 'astro'
+import { env } from 'cloudflare:workers'
+import { resolveOperatorAccess } from '../../../../lib/portal/operator-access'
+import { getCustomerConfig } from '../../../../lib/portal/customer-config'
+import { createChangeRequest } from '../../../../lib/portal/operator/change-request'
+import { safeReturnTo } from '../../../../lib/portal/operator/return-to'
+
+/**
+ * POST /api/portal/operator/change-request
+ *
+ * The Read + Request filing path (client-portal §3, ADR 0041 §4.3). When a
+ * domain is SMD-operated (its authority switch is off — the launch default for
+ * every domain), the dual-mode surface renders read-only with a "Request a
+ * change" form that posts here. The request lands in `operator_change_requests`;
+ * the admin change-request inbox reads it.
+ *
+ * Driven by a plain HTML <form method="POST"> from RequestChangeForm.astro — no
+ * JSON / fetch, no client JS (the portal ships 0KB JS). Form fields:
+ *   domain     — the switchable authority domain the request concerns
+ *   summary    — the client's request text
+ *   return_to  — same-origin path to redirect back to (validated)
+ *
+ * Authorization: any client-internal role may FILE a request — it is a message
+ * to SMD, not an operation on the operator. The domain/summary validation lives
+ * in createChangeRequest (parse-and-validate; never cast a client value). The
+ * row itself carries the actor (user id + email) + timestamp as its record.
+ *
+ * Returns a 303 redirect to `return_to` with a `?cr=` status the surface reads
+ * to render a confirmation or error banner.
+ */
+
+const ALL_CLIENT_ROLES = ['principal', 'staff', 'compliance'] as const
+
+function redirect(returnTo: string, status: 'filed' | 'invalid' | 'error'): Response {
+  const sep = returnTo.includes('?') ? '&' : '?'
+  return new Response(null, {
+    status: 303,
+    headers: { Location: `${returnTo}${sep}cr=${status}` },
+  })
+}
+
+export const POST: APIRoute = async ({ locals, request }) => {
+  const access = await resolveOperatorAccess(env.DB, locals, { allowedRoles: ALL_CLIENT_ROLES })
+  if (access.kind === 'redirect') {
+    return new Response(null, { status: 303, headers: { Location: access.to } })
+  }
+
+  const form = await request.formData()
+  const domain = form.get('domain')
+  const summary = form.get('summary')
+  const returnTo = safeReturnTo(form.get('return_to'))
+
+  if (typeof domain !== 'string' || typeof summary !== 'string') {
+    return redirect(returnTo, 'invalid')
+  }
+
+  const config = await getCustomerConfig(env.DB, access.client.id)
+  const result = await createChangeRequest(env.DB, {
+    entity_id: access.client.id,
+    customer_slug: config?.customer_slug ?? access.client.id,
+    domain,
+    requested_by_user_id: access.user.id,
+    requested_by_email: access.user.email,
+    summary,
+  })
+
+  if (!result.ok) {
+    return redirect(returnTo, 'invalid')
+  }
+  return redirect(returnTo, 'filed')
+}

--- a/src/pages/portal/products/operator/index.astro
+++ b/src/pages/portal/products/operator/index.astro
@@ -22,6 +22,7 @@ import {
   type AlivenessSignal,
 } from '../../../../lib/portal/operator/aliveness'
 import { getCustomerConfig } from '../../../../lib/portal/customer-config'
+import { loadHomeFeeds, type HomeFeeds } from '../../../../lib/portal/operator/home'
 import { env } from 'cloudflare:workers'
 
 /**
@@ -180,6 +181,27 @@ let promotionCandidates: PromotionCandidate[] = []
 if (access?.roles.includes('principal')) {
   promotionCandidates = await listPromotionReadySkills(env.DB, client.id)
 }
+
+// Home/Today runtime feeds (client-portal §5.1): recent activity, what-needs-you,
+// escalations. Fed by the live runtime read path (ADR 0043), which fails closed
+// until OPERATOR_RUNTIME_READ_URL is wired — so these render honest empty states
+// today. needsAttentionCount stays 0 by construction, so Home never fabricates a
+// review queue the entitlements did not author (ADR 0035). PR2 wires the read.
+const homeFeeds: HomeFeeds | null = access ? loadHomeFeeds(env) : null
+
+// Change-request filing outcome (client-portal §3). The dual-mode "Request a
+// change" form 303s back with ?cr=filed|invalid|error so the surface it returned
+// to can show a banner.
+const crStatus = Astro.url.searchParams.get('cr')
+const crMessage =
+  crStatus === 'filed'
+    ? 'Your request was sent.'
+    : crStatus === 'invalid'
+      ? "That request couldn't be filed. Please add a short description and try again."
+      : crStatus === 'error'
+        ? 'Something went wrong filing your request. Please try again.'
+        : null
+const crTone = crStatus === 'filed' ? 'complete' : 'error'
 ---
 
 <!doctype html>
@@ -213,6 +235,21 @@ if (access?.roles.includes('principal')) {
         h1="Operator"
         meta={null}
       />
+
+      {
+        crMessage && (
+          <div
+            role="status"
+            class={`mt-6 border-[3px] px-5 py-3 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold ${
+              crTone === 'complete'
+                ? 'border-[color:var(--ss-color-complete)] text-[color:var(--ss-color-complete)]'
+                : 'border-[color:var(--ss-color-error)] text-[color:var(--ss-color-error)]'
+            }`}
+          >
+            {crMessage}
+          </div>
+        )
+      }
 
       {
         surfaceState === 'no_subscription' && (
@@ -275,6 +312,80 @@ if (access?.roles.includes('principal')) {
             <div class="mt-8">
               <AlivenessHeader signal={alivenessSignal} />
             </div>
+
+            {/* Home / Today (client-portal §5.1): what needs you, what it did,
+                escalations. Runtime-fed; honest empty until the read path is
+                wired. "What needs you" appears ONLY when work is genuinely
+                routed to a human for this client — never a fabricated queue
+                (ADR 0035). */}
+            {homeFeeds && (
+              <section class="mt-8 flex flex-col gap-8" aria-label="What's happening">
+                {homeFeeds.needsAttentionCount > 0 && (
+                  <section class="border-[3px] border-[color:var(--ss-color-primary)] bg-[color:var(--ss-color-background)]">
+                    <div class="bg-[color:var(--ss-color-primary)] text-[color:var(--ss-color-background)] px-5 py-2.5 font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold">
+                      What needs you
+                    </div>
+                    <a
+                      href="/portal/products/operator/drafts"
+                      class="block px-5 md:px-7 py-5 hover:bg-[color:var(--ss-color-border-subtle)] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-inset"
+                    >
+                      <p class="font-['Archivo'] text-xl font-black uppercase tracking-[-0.01em] text-[color:var(--ss-color-text-primary)]">
+                        {homeFeeds.needsAttentionCount}{' '}
+                        {homeFeeds.needsAttentionCount === 1 ? 'item needs' : 'items need'} your
+                        review
+                      </p>
+                    </a>
+                  </section>
+                )}
+
+                <section class="border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)]">
+                  <div class="flex items-center justify-between gap-4 bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] px-5 py-2.5">
+                    <span class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold">
+                      Recent activity
+                    </span>
+                    <a
+                      href="/portal/products/operator/audit"
+                      class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold underline underline-offset-2 hover:text-[color:var(--ss-color-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-background)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--ss-color-text-primary)]"
+                    >
+                      Full record
+                    </a>
+                  </div>
+                  {homeFeeds.recentActivity.length === 0 ? (
+                    <p class="px-5 md:px-7 py-8 text-sm text-[color:var(--ss-color-text-secondary)]">
+                      No activity to show yet.
+                    </p>
+                  ) : (
+                    <ul role="list" class="divide-y-[2px] divide-[color:var(--ss-color-border)]">
+                      {homeFeeds.recentActivity.map((item) => (
+                        <li class="px-5 md:px-7 py-4">
+                          <p class="text-sm text-[color:var(--ss-color-text-primary)]">
+                            {item.summary}
+                          </p>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </section>
+
+                {homeFeeds.escalations.length > 0 && (
+                  <section class="border-[3px] border-[color:var(--ss-color-error)] bg-[color:var(--ss-color-background)]">
+                    <div class="bg-[color:var(--ss-color-error)] text-[color:var(--ss-color-background)] px-5 py-2.5 font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold">
+                      Escalations
+                    </div>
+                    <ul role="list" class="divide-y-[2px] divide-[color:var(--ss-color-border)]">
+                      {homeFeeds.escalations.map((item) => (
+                        <li class="px-5 md:px-7 py-4">
+                          <p class="text-sm text-[color:var(--ss-color-text-primary)]">
+                            {item.summary}
+                          </p>
+                        </li>
+                      ))}
+                    </ul>
+                  </section>
+                )}
+              </section>
+            )}
+
             <div class="mt-10 grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_360px] gap-10 lg:gap-12 lg:items-start">
               <div class="flex flex-col gap-8 min-w-0">
                 <PromotionCardList candidates={promotionCandidates} />

--- a/tests/operator-client-rbac.test.ts
+++ b/tests/operator-client-rbac.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest'
+import {
+  clientRolePermits,
+  operableDomainsForRole,
+  isClientRole,
+  CLIENT_ROLES,
+} from '../src/lib/portal/operator/client-rbac'
+import {
+  SWITCHABLE_AUTHORITY_DOMAINS,
+  SMD_ONLY_AUTHORITY_DOMAINS,
+} from '../src/lib/operator/authority'
+
+describe('client-rbac: role vocabulary', () => {
+  it('exposes exactly principal | staff | compliance (no legacy operator)', () => {
+    expect([...CLIENT_ROLES]).toEqual(['principal', 'staff', 'compliance'])
+    expect(isClientRole('operator')).toBe(false)
+    expect(isClientRole('staff')).toBe(true)
+    expect(isClientRole('principal')).toBe(true)
+    expect(isClientRole('compliance')).toBe(true)
+    expect(isClientRole('captain')).toBe(false)
+  })
+})
+
+describe('client-rbac: principal operates every switchable domain', () => {
+  for (const domain of SWITCHABLE_AUTHORITY_DOMAINS) {
+    it(`principal permits ${domain}`, () => {
+      expect(clientRolePermits(['principal'], domain)).toBe(true)
+    })
+  }
+  it('operableDomainsForRole(principal) === the full switchable set', () => {
+    expect(operableDomainsForRole('principal')).toEqual([...SWITCHABLE_AUTHORITY_DOMAINS])
+  })
+})
+
+describe('client-rbac: staff operates only runtime + observability', () => {
+  it('permits runtime and observability', () => {
+    expect(clientRolePermits(['staff'], 'runtime')).toBe(true)
+    expect(clientRolePermits(['staff'], 'observability')).toBe(true)
+  })
+  it('does NOT permit configuration / trust / connectors / memory / people_access / compliance', () => {
+    for (const domain of [
+      'configuration',
+      'trust',
+      'connectors',
+      'memory',
+      'people_access',
+      'compliance',
+    ] as const) {
+      expect(clientRolePermits(['staff'], domain)).toBe(false)
+    }
+  })
+  it('operableDomainsForRole(staff) is exactly [runtime, observability] in canonical order', () => {
+    expect(operableDomainsForRole('staff')).toEqual(['runtime', 'observability'])
+  })
+})
+
+describe('client-rbac: compliance operates only the compliance domain (evidence export)', () => {
+  it('permits compliance', () => {
+    expect(clientRolePermits(['compliance'], 'compliance')).toBe(true)
+  })
+  it('does NOT permit any other switchable domain (read-only by definition)', () => {
+    for (const domain of SWITCHABLE_AUTHORITY_DOMAINS) {
+      if (domain === 'compliance') continue
+      expect(clientRolePermits(['compliance'], domain)).toBe(false)
+    }
+  })
+})
+
+describe('client-rbac: composition and fail-closed behavior', () => {
+  it('SMD-only domains (provisioning, cost) are never client-operable for any role', () => {
+    for (const role of CLIENT_ROLES) {
+      for (const domain of SMD_ONLY_AUTHORITY_DOMAINS) {
+        expect(clientRolePermits([role], domain)).toBe(false)
+      }
+    }
+  })
+
+  it('multiple roles union their operability', () => {
+    // staff cannot operate compliance; compliance cannot operate runtime;
+    // holding both grants both.
+    expect(clientRolePermits(['staff', 'compliance'], 'compliance')).toBe(true)
+    expect(clientRolePermits(['staff', 'compliance'], 'runtime')).toBe(true)
+  })
+
+  it('unknown role strings contribute nothing', () => {
+    expect(clientRolePermits(['operator'], 'runtime')).toBe(false)
+    expect(clientRolePermits([''], 'runtime')).toBe(false)
+    expect(clientRolePermits([], 'runtime')).toBe(false)
+  })
+
+  it('unknown / non-switchable domains are never operable', () => {
+    expect(clientRolePermits(['principal'], 'not_a_domain')).toBe(false)
+    expect(clientRolePermits(['principal'], 'cost')).toBe(false)
+    expect(operableDomainsForRole('nope')).toEqual([])
+  })
+})

--- a/tests/operator-home-feeds.test.ts
+++ b/tests/operator-home-feeds.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest'
+import { loadHomeFeeds } from '../src/lib/portal/operator/home'
+
+describe('loadHomeFeeds', () => {
+  it('returns honest empty feeds when the runtime read path is not wired', () => {
+    const feeds = loadHomeFeeds({})
+    expect(feeds.runtimeConfigured).toBe(false)
+    expect(feeds.recentActivity).toEqual([])
+    expect(feeds.escalations).toEqual([])
+  })
+
+  it('never fabricates a review queue: needsAttentionCount is 0 (ADR 0035)', () => {
+    expect(loadHomeFeeds({}).needsAttentionCount).toBe(0)
+    expect(
+      loadHomeFeeds({ OPERATOR_RUNTIME_READ_URL: 'https://example.invalid' }).needsAttentionCount
+    ).toBe(0)
+  })
+
+  it('reflects whether the runtime read path is configured', () => {
+    expect(loadHomeFeeds({}).runtimeConfigured).toBe(false)
+    expect(loadHomeFeeds({ OPERATOR_RUNTIME_READ_URL: '' }).runtimeConfigured).toBe(false)
+    expect(
+      loadHomeFeeds({ OPERATOR_RUNTIME_READ_URL: 'https://hermes-x.fly.dev' }).runtimeConfigured
+    ).toBe(true)
+  })
+})

--- a/tests/operator-return-to.test.ts
+++ b/tests/operator-return-to.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest'
+import { safeReturnTo, OPERATOR_ROOT } from '../src/lib/portal/operator/return-to'
+
+describe('safeReturnTo', () => {
+  it('passes through a valid operator-subtree path', () => {
+    expect(safeReturnTo('/portal/products/operator')).toBe('/portal/products/operator')
+    expect(safeReturnTo('/portal/products/operator/connections')).toBe(
+      '/portal/products/operator/connections'
+    )
+    expect(safeReturnTo('/portal/products/operator/matters?cr=filed')).toBe(
+      '/portal/products/operator/matters?cr=filed'
+    )
+    expect(safeReturnTo('/portal/products/operator#top')).toBe('/portal/products/operator#top')
+  })
+
+  it('trims surrounding whitespace before validating', () => {
+    expect(safeReturnTo('  /portal/products/operator/team  ')).toBe(
+      '/portal/products/operator/team'
+    )
+  })
+
+  it('falls back to the operator root for non-string input', () => {
+    expect(safeReturnTo(null)).toBe(OPERATOR_ROOT)
+    expect(safeReturnTo(undefined)).toBe(OPERATOR_ROOT)
+    expect(safeReturnTo(42)).toBe(OPERATOR_ROOT)
+    expect(safeReturnTo({})).toBe(OPERATOR_ROOT)
+  })
+
+  it('rejects open-redirect vectors', () => {
+    // protocol-relative + absolute external
+    expect(safeReturnTo('//evil.com')).toBe(OPERATOR_ROOT)
+    expect(safeReturnTo('https://evil.com')).toBe(OPERATOR_ROOT)
+    expect(safeReturnTo('http://evil.com/portal/products/operator')).toBe(OPERATOR_ROOT)
+    // backslash normalization trick
+    expect(safeReturnTo('/portal/products/operator\\@evil.com')).toBe(OPERATOR_ROOT)
+    // embedded double slash anywhere
+    expect(safeReturnTo('/portal/products/operator//evil')).toBe(OPERATOR_ROOT)
+    // sibling-prefix escape
+    expect(safeReturnTo('/portal/products/operatorX/steal')).toBe(OPERATOR_ROOT)
+    // wrong subtree entirely
+    expect(safeReturnTo('/admin/operator')).toBe(OPERATOR_ROOT)
+    expect(safeReturnTo('/portal/invoices')).toBe(OPERATOR_ROOT)
+  })
+
+  it('rejects smuggled whitespace / control characters', () => {
+    expect(safeReturnTo('/portal/products/operator/x\ny')).toBe(OPERATOR_ROOT)
+    expect(safeReturnTo('/portal/products/operator/x\ty')).toBe(OPERATOR_ROOT)
+    expect(safeReturnTo('/portal/products/operator/x y')).toBe(OPERATOR_ROOT)
+  })
+})


### PR DESCRIPTION
## What

PR **1** of the Operator **client portal** build. Delivers the core mechanic — the **dual-mode surface wrapper** every domain surface will use — plus the read-only **Home/Today** surface (`docs/design/operator/02-client-portal.md` §3 + §5.1), on the frozen foundation (PR #1245).

**Stacked on `feat/operator-client-role-rename`** (#0, PR #1248). Base it on #0; merge #0 first. Uses the `principal | staff | compliance` vocabulary throughout.

## Net-new

- **`src/lib/portal/operator/client-rbac.ts`** — the **Layer-2 capability matrix** (role × switchable domain → operable), re-derived fresh from §2 (not the legacy `dashboard-roles.md` matrix, per foundations §8). `principal`: every switchable domain; `staff`: `runtime` + `observability`; `compliance`: `compliance` only (evidence export). Fail-closed; unknown role/domain grants nothing. Each cell cited to §2/§4.2/§5.
- **`src/components/portal/operator/DomainSurface.astro`** — the presentational dual-mode wrapper over the frozen `resolveDomainSurface` (Layer 1 authority ∧ Layer 2 role). Renders the `operable` slot vs the `read` slot + "Request a change". The decision logic stays in the foundation; this is the shell. Server endpoints re-check composition (never trust a client-rendered mode).
- **`src/components/portal/operator/RequestChangeForm.astro`** — the Read+Request filing affordance. Plain HTML form, **0KB JS**.
- **`POST /api/portal/operator/change-request`** — files via `createChangeRequest`; any client role may *request*; 303s back with a `?cr=` banner status.
- **`src/lib/portal/operator/return-to.ts`** — open-redirect guard for the form's return path (same-origin operator-subtree only). Security-tested.
- **`src/lib/portal/operator/home.ts`** — Home/Today runtime feeds. Honest empty until the runtime read path (ADR 0043) is wired; `needsAttentionCount` stays **0** so Home never fabricates a review queue (**ADR 0035**). PR2 wires the read here without changing the page.

## Home/Today (`index.astro` active branch)

Aliveness (existing) + recent activity (honest empty) + what-needs-you (**absent** unless work is genuinely routed — no fabricated queue) + escalations (absent unless flagged). The four landing states (`no_subscription`/`provisioning`/`paused`/`no_role`) and existing nav are preserved; the transitional section grid is replaced as the new IA surfaces land across PR2–6.

## Decisions worth a reviewer's eye

- **DomainSurface ships unconsumed-by-a-page here**, fully unit-tested as the shared primitive; its first live consumer is **PR2 (Activity & Audit)**. This matches the handoff sequencing.
- **`PromotionCardList` + the legacy section grid are kept** on Home for navigation continuity (they render nothing dormant today). Removing them is deferred to the IA-replacement PRs rather than ripped out here, to avoid a navigation gap during the stacked rollout.

## Verification

- `npm run typecheck` — 0 errors
- `npm run lint` — 0 errors
- `npm run test` — 3111 passing (new coverage: `operator-client-rbac`, `operator-return-to`, `operator-home-feeds`; existing `operator-domain-surface` covers the resolver + change-request store)
- `npm run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)