### PR TITLE
feat(operator): admin connectors & credentials surface (§5.4, ADR 0042)

### DIFF
--- a/src/lib/admin/connectors-view.ts
+++ b/src/lib/admin/connectors-view.ts
@@ -1,0 +1,142 @@
+/**
+ * Connectors & credentials view-model for the admin Operator console
+ * (`/admin/operator/[customer]/connectors`) — design §5.4, ADR 0042 (custody) /
+ * ADR 0020 (connector backends).
+ *
+ * Reads the connector bindings out of `customer_configs.connectors_json` (the
+ * `capability → Connector` map, ADR 0019) and resolves each connector's
+ * effective credential custody (delegated / self-held) over the client-level
+ * default. The custody contract and the secret-relay gate are the frozen
+ * foundation; this module owns only the parse + the pure display derivations.
+ *
+ * Two honesty rules the surface obeys:
+ *   - connectors_json carries infra keys (e.g. per_customer_d1_database_id)
+ *     alongside the capability bindings; only keys in ACCEPTED_CAPABILITY_NAMES
+ *     are connectors. Everything else is skipped, never rendered as a connector.
+ *   - Live connector HEALTH (reachable / auth-expired) needs a per-customer
+ *     runtime read; the console does not have it here. We surface the AUTHORED
+ *     state (configured vs not, from token_ref) and say health is pending —
+ *     never a fabricated "connected/green".
+ */
+
+import {
+  resolveCredentialCustody,
+  smdCanReachSecret,
+  parseCredentialCustody,
+  type CredentialCustody,
+} from '../operator/credential-custody'
+import { ACCEPTED_CAPABILITY_NAMES } from '../operator/customer-yaml/types'
+import type { CapabilityName } from '../operator/capabilities/types'
+
+export interface ConnectorView {
+  capability: CapabilityName
+  /** Backend prefix family: mcp / build / synthetic (ADR 0020), or 'unknown'. */
+  backend: string
+  backendKind: 'mcp' | 'build' | 'synthetic' | 'unknown'
+  scopes: string[]
+  /** A credential reference is present (the connector has been wired). */
+  configured: boolean
+  custody: CredentialCustody
+  /** Whether SMD staff can reach/rotate the secret (delegated only). */
+  smdCanReach: boolean
+}
+
+/**
+ * Parse the connector bindings for the connectors surface. `clientDefault` is
+ * the client-level credential_custody_default (already resolved by the projection).
+ * Returns one view per capability binding, in a stable order; infra keys are
+ * skipped. Defensive: a malformed connectors_json yields an empty list rather
+ * than throwing (the surface renders "no connectors configured").
+ */
+export function parseConnectorViews(
+  connectorsJson: unknown,
+  clientDefault: CredentialCustody
+): ConnectorView[] {
+  if (typeof connectorsJson !== 'object' || connectorsJson === null) return []
+  const rec = connectorsJson as Record<string, unknown>
+  const views: ConnectorView[] = []
+  for (const key of Object.keys(rec)) {
+    if (!ACCEPTED_CAPABILITY_NAMES.has(key as CapabilityName)) continue
+    const view = parseOneConnector(key as CapabilityName, rec[key], clientDefault)
+    if (view) views.push(view)
+  }
+  return views.sort((a, b) => a.capability.localeCompare(b.capability))
+}
+
+function parseOneConnector(
+  capability: CapabilityName,
+  raw: unknown,
+  clientDefault: CredentialCustody
+): ConnectorView | null {
+  if (typeof raw !== 'object' || raw === null) return null
+  const c = raw as Record<string, unknown>
+  const backend = typeof c.backend === 'string' ? c.backend : ''
+  const perConnector = parseCredentialCustody(c.credential_custody)
+  const custody = resolveCredentialCustody(perConnector, clientDefault)
+  return {
+    capability,
+    backend,
+    backendKind: backendKind(backend),
+    scopes: Array.isArray(c.scopes)
+      ? c.scopes.filter((s): s is string => typeof s === 'string')
+      : [],
+    configured: typeof c.token_ref === 'string' && c.token_ref.length > 0,
+    custody,
+    smdCanReach: smdCanReachSecret(custody),
+  }
+}
+
+function backendKind(backend: string): ConnectorView['backendKind'] {
+  if (backend.startsWith('mcp:')) return 'mcp'
+  if (backend.startsWith('build:')) return 'build'
+  if (backend.startsWith('synthetic:')) return 'synthetic'
+  return 'unknown'
+}
+
+// ===========================================================================
+// Pure display helpers
+// ===========================================================================
+
+export interface CustodyBadge {
+  label: string
+  classes: string
+  /** One-line explanation of what this custody means for re-establishment. */
+  detail: string
+}
+
+const BADGE_STRUCTURE =
+  'inline-flex items-center px-2 py-0.5 rounded-[var(--ss-radius-badge)] ' +
+  'text-[10px] font-medium uppercase tracking-wide whitespace-nowrap'
+
+export function custodyBadge(custody: CredentialCustody): CustodyBadge {
+  if (custody === 'delegated') {
+    return {
+      label: 'Delegated',
+      classes: `${BADGE_STRUCTURE} bg-[color:var(--ss-color-primary)] text-white`,
+      detail: 'SMD monitors and drives re-establishment.',
+    }
+  }
+  return {
+    label: 'Self-held',
+    classes: `${BADGE_STRUCTURE} bg-[color:var(--ss-color-complete)] text-white`,
+    detail: 'SMD cannot reach the value; the client re-establishes it.',
+  }
+}
+
+export function backendLabel(kind: ConnectorView['backendKind']): string {
+  switch (kind) {
+    case 'mcp':
+      return 'MCP server'
+    case 'build':
+      return 'Built adapter'
+    case 'synthetic':
+      return 'Synthetic (no-PM)'
+    case 'unknown':
+      return 'Unknown backend'
+  }
+}
+
+/** Connection state from the authored binding (not live health). */
+export function connectionStateLabel(configured: boolean): string {
+  return configured ? 'Configured' : 'Not connected'
+}

--- a/src/pages/admin/operator/[customer]/connectors.astro
+++ b/src/pages/admin/operator/[customer]/connectors.astro
@@ -1,0 +1,146 @@
+---
+import AdminLayout from '../../../../layouts/AdminLayout.astro'
+import { resolveEntityIdBySlug } from '../../../../lib/admin/operator-overview'
+import {
+  parseConnectorViews,
+  custodyBadge,
+  backendLabel,
+  connectionStateLabel,
+} from '../../../../lib/admin/connectors-view'
+import { getCustomerConfig } from '../../../../lib/portal/customer-config'
+import { isSecretTransportConfigured } from '../../../../lib/operator/credential-secret-transport'
+import { env } from 'cloudflare:workers'
+
+/**
+ * Operator admin console — connectors & credentials (§5.4, ADR 0042 / 0020).
+ *
+ * Per connector: backend, scopes, credential custody (delegated / self-held),
+ * and connection state. Reads the authored bindings from customer_configs; it
+ * does not reach the per-customer Machine, so it shows the AUTHORED state and is
+ * explicit that live health needs the runtime read path — never a fabricated
+ * "connected/green."
+ *
+ * Honest gating (handoff landmine): the static-secret rotation + OAuth re-consent
+ * execution ride the secret relay (ADR 0036), which is gated until
+ * OPERATOR_SECRET_RELAY_URL is wired. When it is not configured, the surface
+ * says "not enabled" rather than offering a button onto a half-built relay.
+ */
+
+const session = Astro.locals.session!
+if (session.role !== 'admin') {
+  return Astro.redirect('/auth/sign-in')
+}
+
+const slug = Astro.params.customer ?? ''
+const entityId = await resolveEntityIdBySlug(env.DB, slug)
+const config = entityId ? await getCustomerConfig(env.DB, entityId) : null
+const notFound = !entityId || !config
+
+const connectors = config
+  ? parseConnectorViews(config.connectors, config.credential_custody_default)
+  : []
+const relayEnabled = isSecretTransportConfigured(env)
+---
+
+<AdminLayout
+  title={`Operator — Connectors — ${slug}`}
+  breadcrumbs={[
+    { label: 'Dashboard', href: '/admin' },
+    { label: 'Operator', href: '/admin/operator' },
+    { label: slug, href: `/admin/operator/${encodeURIComponent(slug)}` },
+    { label: 'Connectors' },
+  ]}
+  maxWidth="max-w-5xl"
+>
+  <div class="space-y-card">
+    {
+      notFound ? (
+        <div class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card">
+          <h2 class="text-xl font-semibold text-[color:var(--ss-color-text-primary)]">
+            Operator not found
+          </h2>
+          <p class="text-sm text-[color:var(--ss-color-text-secondary)] mt-1">
+            No operator is provisioned under <code>{slug}</code>.{' '}
+            <a href="/admin/operator" class="text-[color:var(--ss-color-action)] hover:underline">
+              Back to the fleet
+            </a>
+            .
+          </p>
+        </div>
+      ) : (
+        <>
+          <header>
+            <h2 class="text-xl font-semibold text-[color:var(--ss-color-text-primary)]">
+              Connectors &amp; credentials — {slug}
+            </h2>
+            <p class="text-sm text-[color:var(--ss-color-text-secondary)] mt-1">
+              The systems this operator connects to, and who holds each credential. Custody is the
+              client-level default unless a connector pins its own.
+            </p>
+          </header>
+
+          {connectors.length === 0 ? (
+            <div class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card">
+              <p class="text-sm text-[color:var(--ss-color-text-secondary)]">
+                No connectors configured for this operator yet.
+              </p>
+            </div>
+          ) : (
+            <div class="grid gap-card md:grid-cols-2">
+              {connectors.map((c) => {
+                const badge = custodyBadge(c.custody)
+                return (
+                  <div class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card">
+                    <div class="flex items-center justify-between gap-2 mb-2">
+                      <span class="font-medium text-[color:var(--ss-color-text-primary)]">
+                        {c.capability}
+                      </span>
+                      <span class={badge.classes}>{badge.label}</span>
+                    </div>
+                    <dl class="text-sm space-y-1">
+                      <div class="flex justify-between gap-4">
+                        <dt class="text-[color:var(--ss-color-text-secondary)]">Backend</dt>
+                        <dd class="text-[color:var(--ss-color-text-primary)]">
+                          {backendLabel(c.backendKind)}
+                        </dd>
+                      </div>
+                      <div class="flex justify-between gap-4">
+                        <dt class="text-[color:var(--ss-color-text-secondary)]">State</dt>
+                        <dd class="text-[color:var(--ss-color-text-primary)]">
+                          {connectionStateLabel(c.configured)}
+                        </dd>
+                      </div>
+                      <div class="flex justify-between gap-4">
+                        <dt class="text-[color:var(--ss-color-text-secondary)]">Scopes</dt>
+                        <dd class="text-[color:var(--ss-color-text-primary)] text-right">
+                          {c.scopes.length > 0 ? c.scopes.join(', ') : '—'}
+                        </dd>
+                      </div>
+                    </dl>
+                    <p class="text-xs text-[color:var(--ss-color-text-muted)] mt-2">
+                      {badge.detail}
+                    </p>
+                    <p class="text-xs text-[color:var(--ss-color-text-muted)] mt-2">
+                      {c.smdCanReach
+                        ? relayEnabled
+                          ? 'SMD can rotate / re-establish this credential.'
+                          : 'Re-establishment not enabled here yet (secret relay not configured).'
+                        : 'Re-establishment is client-initiated (self-held).'}
+                    </p>
+                  </div>
+                )
+              })}
+            </div>
+          )}
+
+          <p class="text-xs text-[color:var(--ss-color-text-muted)]">
+            Connection state is the authored binding, not a live probe — live connector health and
+            token freshness come from the per-operator runtime read. Static-secret rotation and
+            OAuth re-consent execution ride the secret relay (ADR 0036); they light up here once it
+            is configured.
+          </p>
+        </>
+      )
+    }
+  </div>
+</AdminLayout>

--- a/src/pages/admin/operator/[customer]/index.astro
+++ b/src/pages/admin/operator/[customer]/index.astro
@@ -282,6 +282,14 @@ const personas = config?.personas ?? []
                 </li>
                 <li>
                   <a
+                    href={`/admin/operator/${encodeURIComponent(slug)}/connectors`}
+                    class="text-[color:var(--ss-color-action)] hover:underline"
+                  >
+                    Connectors
+                  </a>
+                </li>
+                <li>
+                  <a
                     href={`/admin/operator/costs/${encodeURIComponent(slug)}`}
                     class="text-[color:var(--ss-color-action)] hover:underline"
                   >
@@ -298,8 +306,8 @@ const personas = config?.personas ?? []
                 </li>
               </ul>
               <p class="text-xs text-[color:var(--ss-color-text-muted)] mt-3">
-                Configuration, connectors, runtime, memory, people, and lifecycle drill-ins land as
-                their surfaces ship.
+                Configuration, runtime, memory, people, and lifecycle drill-ins land as their
+                surfaces ship.
               </p>
             </div>
           </>

--- a/tests/connectors-view.test.ts
+++ b/tests/connectors-view.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Tests for the connectors view-model (src/lib/admin/connectors-view.ts) —
+ * admin Operator console §5.4, ADR 0042 (custody) / 0020 (backends).
+ *
+ * Pure derivations over the connectors_json shape: only real capability
+ * bindings are connectors (infra keys are skipped), effective custody resolves
+ * per-connector → client-default → delegated, and the SMD-reach predicate
+ * tracks delegated-only. No DB — the custody/transport contracts are frozen.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  parseConnectorViews,
+  custodyBadge,
+  backendLabel,
+  connectionStateLabel,
+} from '../src/lib/admin/connectors-view'
+
+describe('parseConnectorViews', () => {
+  it('skips infra keys and parses only real capability bindings', () => {
+    const json = {
+      per_customer_d1_database_id: 'db-123', // infra, not a connector
+      Email: {
+        backend: 'mcp:google',
+        scopes: ['gmail.send'],
+        token_ref: 'ref-1',
+        credential_custody: null,
+      },
+      Calendar: {
+        backend: 'mcp:google',
+        scopes: [],
+        token_ref: null,
+        credential_custody: 'self_held',
+      },
+    }
+    const views = parseConnectorViews(json, 'delegated')
+    expect(views.map((v) => v.capability)).toEqual(['Calendar', 'Email']) // sorted, infra dropped
+  })
+
+  it('resolves effective custody: per-connector → client default → delegated', () => {
+    const json = {
+      Email: { backend: 'mcp:x', scopes: [], token_ref: 'r', credential_custody: null }, // inherits
+      Payments: {
+        backend: 'build:stripe',
+        scopes: [],
+        token_ref: 'r',
+        credential_custody: 'self_held',
+      },
+    }
+    // Client default self_held: Email inherits self_held; Payments pins self_held.
+    const selfDefault = parseConnectorViews(json, 'self_held')
+    expect(selfDefault.find((v) => v.capability === 'Email')!.custody).toBe('self_held')
+    // Client default delegated: Email is delegated; Payments still self_held.
+    const delegatedDefault = parseConnectorViews(json, 'delegated')
+    expect(delegatedDefault.find((v) => v.capability === 'Email')!.custody).toBe('delegated')
+    expect(delegatedDefault.find((v) => v.capability === 'Payments')!.custody).toBe('self_held')
+  })
+
+  it('smdCanReach is true only for delegated custody', () => {
+    const json = {
+      Email: { backend: 'mcp:x', scopes: [], token_ref: 'r', credential_custody: 'delegated' },
+      Payments: { backend: 'build:y', scopes: [], token_ref: 'r', credential_custody: 'self_held' },
+    }
+    const views = parseConnectorViews(json, 'delegated')
+    expect(views.find((v) => v.capability === 'Email')!.smdCanReach).toBe(true)
+    expect(views.find((v) => v.capability === 'Payments')!.smdCanReach).toBe(false)
+  })
+
+  it('classifies backend kind and configured state from token_ref', () => {
+    const json = {
+      Email: { backend: 'mcp:google', scopes: [], token_ref: 'r', credential_custody: null },
+      Accounting: { backend: 'build:qbo', scopes: [], token_ref: null, credential_custody: null },
+      IntakeCRM: {
+        backend: 'synthetic:no_pm',
+        scopes: [],
+        token_ref: '',
+        credential_custody: null,
+      },
+    }
+    const views = parseConnectorViews(json, 'delegated')
+    const byName = Object.fromEntries(views.map((v) => [v.capability, v]))
+    expect(byName.Email.backendKind).toBe('mcp')
+    expect(byName.Email.configured).toBe(true)
+    expect(byName.Accounting.backendKind).toBe('build')
+    expect(byName.Accounting.configured).toBe(false)
+    expect(byName.IntakeCRM.backendKind).toBe('synthetic')
+    expect(byName.IntakeCRM.configured).toBe(false) // empty token_ref is not configured
+  })
+
+  it('returns [] for malformed or empty input', () => {
+    expect(parseConnectorViews(null, 'delegated')).toEqual([])
+    expect(parseConnectorViews('nope', 'delegated')).toEqual([])
+    expect(parseConnectorViews({}, 'delegated')).toEqual([])
+  })
+
+  it('tolerates a malformed single connector value without throwing', () => {
+    const json = {
+      Email: 'not-an-object',
+      Calendar: { backend: 'mcp:x', scopes: [], token_ref: 'r' },
+    }
+    const views = parseConnectorViews(json, 'delegated')
+    expect(views.map((v) => v.capability)).toEqual(['Calendar'])
+  })
+})
+
+describe('display helpers', () => {
+  it('custodyBadge distinguishes delegated vs self-held with honest detail', () => {
+    expect(custodyBadge('delegated').label).toBe('Delegated')
+    expect(custodyBadge('delegated').detail).toMatch(/SMD/)
+    expect(custodyBadge('self_held').label).toBe('Self-held')
+    expect(custodyBadge('self_held').detail).toMatch(/cannot reach/)
+  })
+
+  it('backendLabel maps each kind', () => {
+    expect(backendLabel('mcp')).toBe('MCP server')
+    expect(backendLabel('build')).toBe('Built adapter')
+    expect(backendLabel('synthetic')).toBe('Synthetic (no-PM)')
+    expect(backendLabel('unknown')).toBe('Unknown backend')
+  })
+
+  it('connectionStateLabel reflects authored state', () => {
+    expect(connectionStateLabel(true)).toBe('Configured')
+    expect(connectionStateLabel(false)).toBe('Not connected')
+  })
+})


### PR DESCRIPTION
## What

PR 7 of the SMD-side **Operator Admin Console**. The **connectors & credentials** surface at `/admin/operator/[customer]/connectors` — per connector: backend (MCP / built / synthetic), scopes, credential **custody** (delegated / self-held), and connection state. Design: §5.4, ADR 0042 / 0020.

## ⚠️ Stacked on #1258 → … → #1249

Base is `feat/operator-admin-governance` (#1258). Merge the stack bottom-up.

## How it works

New `src/lib/admin/connectors-view.ts` parses `customer_configs.connectors_json` via the frozen custody contract: only `ACCEPTED_CAPABILITY_NAMES` keys are connectors (infra keys like `per_customer_d1_database_id` are skipped), and effective custody resolves per-connector → client default → delegated.

## Honesty rules (handoff landmines)

- **No fabricated health:** the surface does not reach the per-customer Machine, so it shows the *authored* state (configured vs not, from `token_ref`) and explicitly says live connector health + token freshness come from the runtime read path — never a fake "connected/green."
- **No fake relay:** static-secret rotation + OAuth re-consent execution ride the secret relay (ADR 0036), gated by `isSecretTransportConfigured` until `OPERATOR_SECRET_RELAY_URL` is wired. When unconfigured, the surface renders **"not enabled"** rather than offering a button onto a half-built relay. No write endpoint is built against the unwired transport.
- Custody badge states plainly what each mode means for re-establishment (delegated = SMD drives; self-held = SMD cannot reach the value).

## Notes

- Overview now links the Connectors drill-in.
- Scope: §5.4. Remaining drill-ins (runtime observe §5.5, memory §5.6, people §5.7, lifecycle §5.10, config display §5.2) follow as focused PRs.

## Verification

- `npm run verify` green. Main suite: 3168 passed / 2 skipped.
- 9 unit tests (`tests/connectors-view.test.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)