### PR TITLE
feat(operator): add IDENTIFIER_UNVERIFIED to audit action-type vocabulary

### DIFF
--- a/operator/adapter/audit_log.py
+++ b/operator/adapter/audit_log.py
@@ -131,6 +131,7 @@ ACCEPTED_ACTION_TYPES = frozenset(
         "VOICE_GATE_FAILED",
         # Fabrication and escalation
         "FABRICATION_FILTER_TRIGGERED",
+        "IDENTIFIER_UNVERIFIED",  # A1 report-only identifier gate (tier3, non-blocking)
         "ESCALATION_FIRED",
         "ESCALATION_ACKNOWLEDGED",
         # Decommission lifecycle


### PR DESCRIPTION
One-line vocabulary addition: the A1 report-only identifier gate (overlay `hermes-smd-trust`, separate PR) emits an `IDENTIFIER_UNVERIFIED` audit row when an outbound draft carries an identifier not traceable to a source read this session. This adds it to the canonical `ACCEPTED_ACTION_TYPES` in `operator/adapter/audit_log.py` — the source of truth the overlay `schemas.py` vendors.

Report-only, non-blocking. Companion to the overlay A1 live-wiring PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)