### PR TITLE
ci: run verify + security suites on all PRs, not only main-base

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -3,8 +3,12 @@ name: Security
 on:
   push:
     branches: [main]
+  # Run on EVERY pull request regardless of base branch. A `branches: [main]`
+  # filter here (removed 2026-06-08) matched on the PR's *base*, so a stacked
+  # PR whose base was a feature branch skipped Semgrep, Secret Detection, and
+  # npm-audit entirely and merged with no security signal. Running on all PRs
+  # closes that hole; re-adding a base filter reopens it.
   pull_request:
-    branches: [main]
   schedule:
     # Daily at 13:00 UTC (06:00 Phoenix) so new advisories surface before the workday
     - cron: '0 13 * * *'

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -3,8 +3,12 @@ name: Verify
 on:
   push:
     branches: [main]
+  # Run on EVERY pull request regardless of base branch. A `branches: [main]`
+  # filter here (removed 2026-06-08) matched on the PR's *base*, so a stacked
+  # PR whose base was a feature branch silently skipped this entire suite and
+  # merged on lightweight gates only. Running on all PRs makes stacked and
+  # shallow PRs equally safe; re-adding a base filter reopens that hole.
   pull_request:
-    branches: [main]
 
 jobs:
   verify:


### PR DESCRIPTION
## Problem
`verify.yml` (Typecheck/Lint/Format/Test) and `security.yml` (Semgrep, Secret Detection, npm-audit, TypeScript Validation) triggered on `pull_request: branches: [main]`. That filter matches the PR's **base** branch — so any **stacked PR** (base = a feature branch, not `main`) silently skipped both suites entirely and merged on the four lightweight path-filtered gates + the author's local verification only.

Two parallel agent stacks (admin console + client portal) hit this simultaneously: their "CI-green" stacked PRs never ran the real test suite or any security gate in CI.

## Fix
Drop the `branches: [main]` base filter on the `pull_request:` trigger in both workflows so they run on **every** PR regardless of base. `push: branches: [main]` is retained; `deploy.yml` correctly stays main-push-only. The lightweight gates (adr-0022, scope-deferred-todo, ui-drift-audit, operator-substrate) already ran on all PRs via `paths:` filters with no base gate — this brings the heavy suites in line with them.

## Why a trigger fix and not a merge-train
Retargeting a stacked PR to `main` does **not** by itself re-run these suites — a base edit isn't a default `pull_request` activity type, so nothing fires until a push. The trigger is the correct lever; this makes stacked *and* shallow PRs equally safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)