### PR TITLE
feat(operator): Activity & Audit surface (client portal PR2)

### DIFF
--- a/src/lib/portal/operator/activity-read.ts
+++ b/src/lib/portal/operator/activity-read.ts
@@ -1,0 +1,136 @@
+/**
+ * Activity & Audit read path (client-portal §5.5). Bridges the frozen ADR 0043
+ * live runtime read (readMachineRuntime) into the existing audit display
+ * machinery (filters / sort / pagination / formatters in audit.ts).
+ *
+ * Why route through readMachineRuntime rather than the legacy
+ * `listAuditEntries` stub: the foundation converges every deep per-customer
+ * read on the single audited, fail-closed, one-customer-per-call path
+ * (foundations §6, ADR 0043). Activity is one of those drill-ins.
+ *
+ * Until OPERATOR_RUNTIME_READ_URL is wired, the read path is not configured.
+ * We short-circuit to an empty page BEFORE calling readMachineRuntime, so an
+ * unwired deployment does not write an `unreachable` read-audit row on every
+ * page view. Once wired, every read is attempted and audited per ADR 0043.
+ *
+ * The Machine read endpoint (overlay-side) defines the wire format; until it
+ * exists this path returns empty, so `parseAuditEntries` is dormant but written
+ * defensively (parse, never cast) for the documented row shape.
+ */
+
+import type { D1Database } from '@cloudflare/workers-types'
+import { readMachineRuntime, type RuntimeReadActor } from '../../operator/runtime-read'
+import {
+  createMachineRuntimeTransport,
+  createRuntimeReadAudit,
+  isRuntimeReadConfigured,
+  type RuntimeReadEnv,
+} from '../../operator/runtime-read-transport'
+import {
+  buildAuditListPage,
+  AUDIT_ACTOR_ROLES,
+  AUDIT_DECISIONS,
+  type AuditEntry,
+  type AuditActorRole,
+  type AuditDecision,
+  type AuditListParams,
+  type AuditListPage,
+} from './audit'
+
+export interface ActivityReadDeps {
+  db: D1Database
+  env: RuntimeReadEnv
+  /** Console-side actor id for the read-audit row (distinct from the operator's log). */
+  actorUserId: string
+}
+
+/**
+ * Load one filtered/paginated page of activity for the signed-in client's own
+ * operator. Fails closed to an empty page on any transport failure or when the
+ * read path is not configured — never throws into the page render.
+ */
+export async function loadActivityPage(
+  deps: ActivityReadDeps,
+  customerSlug: string,
+  actor: RuntimeReadActor,
+  params: AuditListParams
+): Promise<AuditListPage> {
+  if (!isRuntimeReadConfigured(deps.env)) {
+    return buildAuditListPage([], params)
+  }
+  const result = await readMachineRuntime(
+    {
+      transport: createMachineRuntimeTransport(deps.env),
+      audit: createRuntimeReadAudit(deps.db, { actorUserId: deps.actorUserId }),
+    },
+    customerSlug,
+    { kind: 'audit_log' },
+    actor
+  )
+  const rows = result.ok ? parseAuditEntries(result.data) : []
+  return buildAuditListPage(rows, params)
+}
+
+// ---------------------------------------------------------------------------
+// Defensive parsing of the runtime read payload into AuditEntry[].
+// ---------------------------------------------------------------------------
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v)
+}
+
+/** A required non-empty string field; returns null when absent/empty so the
+ * caller can drop a malformed row rather than render a blank cell. */
+function reqString(v: unknown): string | null {
+  return typeof v === 'string' && v.length > 0 ? v : null
+}
+
+/** An optional string field: a present string or null (anything else → null). */
+function optString(v: unknown): string | null {
+  return typeof v === 'string' && v.length > 0 ? v : null
+}
+
+function asActorRole(v: unknown): AuditActorRole | null {
+  return typeof v === 'string' && (AUDIT_ACTOR_ROLES as readonly string[]).includes(v)
+    ? (v as AuditActorRole)
+    : null
+}
+
+function asDecision(v: unknown): AuditDecision | null {
+  return typeof v === 'string' && (AUDIT_DECISIONS as readonly string[]).includes(v)
+    ? (v as AuditDecision)
+    : null
+}
+
+/**
+ * Parse an unknown runtime payload into AuditEntry[]. Accepts either a bare
+ * array of rows or an `{ entries: [...] }` envelope. Rows missing a required
+ * `id`/`ts`/`actor`/`action` are dropped, not coerced — a malformed row never
+ * becomes a misleading audit line. Exported for unit testing.
+ */
+export function parseAuditEntries(data: unknown): AuditEntry[] {
+  const raw: unknown = isRecord(data) && Array.isArray(data['entries']) ? data['entries'] : data
+  if (!Array.isArray(raw)) return []
+  const out: AuditEntry[] = []
+  for (const item of raw) {
+    if (!isRecord(item)) continue
+    const id = reqString(item['id'])
+    const ts = reqString(item['ts'])
+    const actor = reqString(item['actor'])
+    const action = reqString(item['action'])
+    if (id === null || ts === null || actor === null || action === null) continue
+    out.push({
+      id,
+      ts,
+      actor,
+      action,
+      actorRole: asActorRole(item['actorRole']),
+      target: optString(item['target']),
+      decision: asDecision(item['decision']),
+      reason: optString(item['reason']),
+      skill: optString(item['skill']),
+      matterRef: optString(item['matterRef']),
+    })
+  }
+  return out
+}

--- a/src/pages/portal/products/operator/activity/index.astro
+++ b/src/pages/portal/products/operator/activity/index.astro
@@ -1,0 +1,224 @@
+---
+import '../../../../../styles/global.css'
+import { BRAND_NAME } from '../../../../../lib/config/brand'
+import { resolveOperatorAccess } from '../../../../../lib/portal/operator-access'
+import {
+  defaultAuditDateRange,
+  distinctAuditSkills,
+  parseAuditListParams,
+} from '../../../../../lib/portal/operator/audit'
+import { loadActivityPage } from '../../../../../lib/portal/operator/activity-read'
+import { getCustomerConfig } from '../../../../../lib/portal/customer-config'
+import {
+  resolveComplianceView,
+  formatRetentionWindow,
+} from '../../../../../lib/portal/operator/compliance'
+import { ACCEPTED_VERTICALS, type Vertical } from '../../../../../lib/operator/customer-yaml/types'
+import PortalHeader from '../../../../../components/portal/PortalHeader.astro'
+import PortalTabs from '../../../../../components/portal/PortalTabs.astro'
+import PortalPageHead from '../../../../../components/portal/PortalPageHead.astro'
+import SkipToMain from '../../../../../components/SkipToMain.astro'
+import AuditFilterBar from '../../../../../components/portal/operator/AuditFilterBar.astro'
+import AuditLogTable from '../../../../../components/portal/operator/AuditLogTable.astro'
+import DomainSurface from '../../../../../components/portal/operator/DomainSurface.astro'
+import { env } from 'cloudflare:workers'
+
+/**
+ * Operator — Activity & Audit (client-portal §5.5). The new-IA surface that
+ * answers "you can see and prove everything your operator did."
+ *
+ * URL: portal.smd.services/portal/products/operator/activity
+ *
+ * Differences from the legacy /audit viewer (which this supersedes):
+ *   - Read for ALL THREE client roles (principal | staff | compliance). The
+ *     activity record is a trust centerpiece; everyone in the firm may read it
+ *     (§5.5). Compliance is read-only by definition; the evidence-export entry
+ *     is the only operable element, gated to principal/compliance.
+ *   - Fed by the frozen ADR 0043 runtime read path (loadActivityPage →
+ *     readMachineRuntime), not the legacy per-feature stub. Fails closed to an
+ *     honest empty list until OPERATOR_RUNTIME_READ_URL is wired.
+ *   - The compliance evidence-export + retention posture render through the
+ *     dual-mode <DomainSurface> for the `compliance` domain — the first live
+ *     consumer of the PR1 wrapper. At launch (switch off) it is Read + Request:
+ *     the firm reads its retention posture and can request an evidence packet
+ *     from SMD. Self-serve export lands when the compliance switch is flipped
+ *     AND the export trigger backend ships (a follow-on); until then the
+ *     operable build is intentionally absent, so the wrapper falls back to the
+ *     read view.
+ *
+ * Access: Clerk session + bound entity + active subscription + any one role.
+ */
+
+const access = await resolveOperatorAccess(env.DB, Astro.locals, {
+  allowedRoles: ['principal', 'staff', 'compliance'],
+})
+if (access.kind === 'redirect') {
+  return Astro.redirect(access.to)
+}
+const { user, client, roles } = access
+
+const isPrincipal = roles.includes('principal')
+const isCompliance = roles.includes('compliance')
+// Most-privileged role label for the runtime read-audit row.
+const actorRole = isPrincipal ? 'principal' : isCompliance ? 'compliance' : 'staff'
+
+const config = await getCustomerConfig(env.DB, client.id)
+const customerSlug = config?.customer_slug ?? client.id
+
+const params = parseAuditListParams(Astro.url.searchParams)
+// Default "last 7 days" window when no explicit range was requested, mirroring
+// the legacy viewer — keeps the surface responsive over long histories.
+const resolvedParams = (() => {
+  if (params.from === null && params.to === null) {
+    const range = defaultAuditDateRange()
+    return { ...params, from: range.from, to: range.to }
+  }
+  return params
+})()
+
+const activityPage = await loadActivityPage(
+  { db: env.DB, env, actorUserId: user.id },
+  customerSlug,
+  { actor: user.email, actorRole },
+  resolvedParams
+)
+const availableSkills = distinctAuditSkills(activityPage.rows)
+
+const matterFilter = resolvedParams.matter
+const emptyHeading = matterFilter ? 'No activity for this matter' : 'No activity yet'
+const emptyBody = matterFilter
+  ? 'No actions in the selected window reference this matter. Clear the matter filter to see the full record.'
+  : 'Every action your Operator takes is recorded here: drafts created, sends approved, identity changes, memory access.'
+
+// Compliance & retention block (principal/compliance only). Resolve the
+// retention posture for display; the override projection is not wired yet, so
+// pass null and fall back to the vertical default (honest, no fabrication).
+const rawVertical = config?.vertical ?? null
+const vertical: Vertical | null =
+  rawVertical !== null && (ACCEPTED_VERTICALS as readonly string[]).includes(rawVertical)
+    ? (rawVertical as Vertical)
+    : null
+const complianceView =
+  isPrincipal || isCompliance
+    ? resolveComplianceView({
+        complianceEnabled: config?.compliance_enabled ?? false,
+        vertical,
+        auditLogDaysOverride: null,
+        callerRoles: roles,
+      })
+    : null
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;900&family=Archivo+Narrow:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap"
+      rel="stylesheet"
+    />
+    <title>Operator · Activity | {BRAND_NAME}</title>
+  </head>
+  <body class="min-h-screen bg-[color:var(--ss-color-background)]">
+    <SkipToMain />
+    <PortalHeader clientName={client.name} />
+
+    <PortalTabs pathname={Astro.url.pathname} operatorActive={true} />
+
+    <main id="main" role="main" class="max-w-5xl mx-auto px-4 md:px-6 pb-24 md:pb-12">
+      <PortalPageHead
+        crumbHref="/portal/products/operator"
+        crumbLabel="Operator"
+        tag="Section"
+        h1="Activity"
+        meta={activityPage.totalCount > 0 ? `${activityPage.totalCount} total` : null}
+      />
+
+      <div class="mt-8 flex flex-col gap-6">
+        <AuditFilterBar
+          skills={resolvedParams.skills}
+          actions={resolvedParams.actions}
+          from={resolvedParams.from}
+          to={resolvedParams.to}
+          matter={resolvedParams.matter}
+          q={resolvedParams.q}
+          sort={resolvedParams.sort}
+          availableSkills={availableSkills}
+        />
+
+        {
+          activityPage.totalCount === 0 ? (
+            <section
+              aria-label="No activity"
+              class="border-[3px] border-[color:var(--ss-color-text-primary)] p-8 md:p-12 text-center"
+            >
+              <p class="font-['Archivo'] text-2xl md:text-3xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]">
+                {emptyHeading}
+              </p>
+              <p class="mt-3 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)]">
+                {emptyBody}
+              </p>
+            </section>
+          ) : (
+            <AuditLogTable
+              rows={activityPage.rows}
+              totalCount={activityPage.totalCount}
+              page={activityPage.page}
+              pageSize={activityPage.pageSize}
+              pageCount={activityPage.pageCount}
+              searchParams={Astro.url.searchParams}
+            />
+          )
+        }
+
+        {
+          complianceView && (
+            <DomainSurface
+              authority={config?.authority ?? null}
+              domain="compliance"
+              roles={roles}
+              returnTo="/portal/products/operator/activity"
+              domainLabel="audit retention and evidence"
+            >
+              <div
+                slot="read"
+                class="border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)]"
+              >
+                <div class="bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] px-5 py-2.5 font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold">
+                  Retention & evidence
+                </div>
+                <div class="flex flex-col gap-4 px-5 md:px-7 py-6">
+                  {complianceView.retention ? (
+                    <div>
+                      <p class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold text-[color:var(--ss-color-text-secondary)]">
+                        Audit retention
+                      </p>
+                      <p class="mt-1 text-sm text-[color:var(--ss-color-text-primary)]">
+                        {formatRetentionWindow(complianceView.retention.effectiveDays)}
+                      </p>
+                    </div>
+                  ) : (
+                    <p class="text-sm text-[color:var(--ss-color-text-secondary)]">
+                      Retention posture appears here once your firm's profile is on file.
+                    </p>
+                  )}
+                  <p class="text-sm text-[color:var(--ss-color-text-secondary)]">
+                    An evidence packet of this record can be produced for verification. Use Request
+                    a change to ask your SMD team to prepare one.
+                  </p>
+                </div>
+              </div>
+            </DomainSurface>
+          )
+        }
+      </div>
+    </main>
+  </body>
+</html>

--- a/src/pages/portal/products/operator/index.astro
+++ b/src/pages/portal/products/operator/index.astro
@@ -344,7 +344,7 @@ const crTone = crStatus === 'filed' ? 'complete' : 'error'
                       Recent activity
                     </span>
                     <a
-                      href="/portal/products/operator/audit"
+                      href="/portal/products/operator/activity"
                       class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold underline underline-offset-2 hover:text-[color:var(--ss-color-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-background)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--ss-color-text-primary)]"
                     >
                       Full record

--- a/tests/operator-activity-read.test.ts
+++ b/tests/operator-activity-read.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest'
+import type { D1Database } from '@cloudflare/workers-types'
+import { loadActivityPage, parseAuditEntries } from '../src/lib/portal/operator/activity-read'
+import { parseAuditListParams } from '../src/lib/portal/operator/audit'
+
+const PARAMS = parseAuditListParams(new URLSearchParams())
+// A DB that throws if touched — proves the not-configured path never queries.
+const NOOP_DB = {
+  prepare() {
+    throw new Error('DB must not be touched when the runtime read path is unconfigured')
+  },
+} as unknown as D1Database
+
+const ACTOR = { actor: 'partner@firm.com', actorRole: 'principal' }
+
+describe('loadActivityPage: fail-closed empty until wired', () => {
+  it('returns an empty page (and never touches D1) when OPERATOR_RUNTIME_READ_URL is unset', async () => {
+    const page = await loadActivityPage(
+      { db: NOOP_DB, env: {}, actorUserId: 'u-1' },
+      'smith-pi',
+      ACTOR,
+      PARAMS
+    )
+    expect(page.totalCount).toBe(0)
+    expect(page.rows).toEqual([])
+  })
+
+  it('returns an empty page when the read URL is empty string', async () => {
+    const page = await loadActivityPage(
+      { db: NOOP_DB, env: { OPERATOR_RUNTIME_READ_URL: '' }, actorUserId: 'u-1' },
+      'smith-pi',
+      ACTOR,
+      PARAMS
+    )
+    expect(page.totalCount).toBe(0)
+  })
+})
+
+describe('parseAuditEntries: defensive parse, never cast', () => {
+  it('parses a bare array of well-formed rows', () => {
+    const rows = parseAuditEntries([
+      {
+        id: 'a1',
+        ts: '2026-06-01T10:00:00.000Z',
+        actor: 'marcus',
+        action: 'DRAFT_CREATED',
+        actorRole: 'agent',
+        target: 'draft-9',
+        decision: 'draft_for_review',
+        reason: 'client email',
+        skill: 'inbox-triage',
+        matterRef: 'M-1',
+      },
+    ])
+    expect(rows).toHaveLength(1)
+    expect(rows[0].id).toBe('a1')
+    expect(rows[0].actorRole).toBe('agent')
+    expect(rows[0].decision).toBe('draft_for_review')
+  })
+
+  it('accepts an { entries: [...] } envelope', () => {
+    const rows = parseAuditEntries({
+      entries: [{ id: 'a1', ts: '2026-06-01T10:00:00.000Z', actor: 'm', action: 'X' }],
+    })
+    expect(rows).toHaveLength(1)
+  })
+
+  it('drops rows missing any required field (id/ts/actor/action)', () => {
+    const rows = parseAuditEntries([
+      { ts: '2026-06-01', actor: 'm', action: 'X' }, // no id
+      { id: 'a', actor: 'm', action: 'X' }, // no ts
+      { id: 'a', ts: '2026-06-01', action: 'X' }, // no actor
+      { id: 'a', ts: '2026-06-01', actor: 'm' }, // no action
+      { id: 'ok', ts: '2026-06-01', actor: 'm', action: 'X' },
+    ])
+    expect(rows).toHaveLength(1)
+    expect(rows[0].id).toBe('ok')
+  })
+
+  it('coerces unknown actorRole / decision to null rather than passing them through', () => {
+    const rows = parseAuditEntries([
+      {
+        id: 'a',
+        ts: '2026-06-01',
+        actor: 'm',
+        action: 'X',
+        actorRole: 'operator', // legacy role value — not in the vocabulary
+        decision: 'bogus',
+      },
+    ])
+    expect(rows[0].actorRole).toBeNull()
+    expect(rows[0].decision).toBeNull()
+  })
+
+  it('returns [] for non-array / non-envelope input', () => {
+    expect(parseAuditEntries(null)).toEqual([])
+    expect(parseAuditEntries(undefined)).toEqual([])
+    expect(parseAuditEntries('nope')).toEqual([])
+    expect(parseAuditEntries({})).toEqual([])
+    expect(parseAuditEntries(42)).toEqual([])
+  })
+})


### PR DESCRIPTION
## What

PR **2** of the Operator client portal. The new-IA **`/activity`** surface (`02-client-portal.md` §5.5) — "you can see and prove everything your operator did." Supersedes the legacy `/audit` viewer. Based on `main` (PR1 merged).

## Highlights

- **Read for all three roles** (`principal | staff | compliance`), broadening the legacy principal+compliance gate — the activity record is a trust centerpiece the whole firm may read. Compliance stays read-only; the evidence-export entry is the only operable element.
- **Routed through the frozen ADR 0043 path** (`activity-read.ts` → `readMachineRuntime`), not the legacy per-feature stub. Gated on `isRuntimeReadConfigured` so an unwired deploy returns an **honest empty list without spamming an `unreachable` read-audit row** on every page view. `parseAuditEntries` defensively parses the runtime payload (parse, never cast; drops rows missing required fields; coerces unknown role/decision to null).
- **First live consumer of the PR1 `<DomainSurface>` wrapper**: the retention + evidence block renders for the `compliance` domain. At launch (switch off) it is **Read + Request** — the firm reads its retention posture and can request an evidence packet from SMD via the dual-mode form. Self-serve export lands when the compliance switch flips **and** the export-trigger backend ships (a follow-on); until then the operable build is intentionally absent and the wrapper falls back to the read view.
- **Reuses** the audit lib (parse/filter/sort/paginate/format) and `AuditFilterBar` / `AuditLogTable`.

## Decisions worth a reviewer's eye

- **Legacy `/audit` is left in place but unlinked** (Home's "Full record" now points to `/activity`). Retiring `/audit` is deferred to a cleanup PR rather than redirecting a working surface mid-sequence.
- **Evidence export is request-based at launch**, not a disabled button — it rides the dual-mode "Request a change" path, which is both honest (the export backend isn't built) and a real demonstration of the wrapper.

## Verification

- `npm run typecheck` — 0 errors
- `npm run lint` — 0 errors
- `npm run build` — clean
- New `operator-activity-read` tests pass (parser + fail-closed-empty path).
- Full suite green except a pre-existing `operator-skill-deploy` **timeout flake** (slow subprocess test; passes in isolation and was green in CI for #0/#1) — unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)