### PR TITLE
fix(operator): complete operator→staff role rename (predicate/type misses)

### DIFF
--- a/src/components/portal/operator/DraftDetail.astro
+++ b/src/components/portal/operator/DraftDetail.astro
@@ -47,7 +47,7 @@ interface Props {
    * component still guards the action in case future RBAC widens
    * the read path.
    */
-  callerRole: 'principal' | 'operator' | 'compliance'
+  callerRole: 'principal' | 'staff' | 'compliance'
   /**
    * Reviewer's email address — the identity the message will ship
    * from per ADR 0005. Shown in the sender strip and surfaced
@@ -84,7 +84,7 @@ const SEND_TONE: Record<DraftSendStatus, Tone> = {
 const sendTone = SEND_TONE[draft.sendStatus]
 const sendLabel = formatDraftSendStatus(draft.sendStatus).toUpperCase()
 
-const canApprove = callerRole === 'principal' || callerRole === 'operator'
+const canApprove = callerRole === 'principal' || callerRole === 'staff'
 
 // Human-friendly date for the "drafted by [persona] on [ts]" preamble.
 // We format on the server so the rendered HTML is deterministic and

--- a/src/lib/portal/operator/send-as.ts
+++ b/src/lib/portal/operator/send-as.ts
@@ -71,7 +71,7 @@ export interface Reviewer {
   userId: string
   email: string
   displayName: string | null
-  role: 'principal' | 'operator'
+  role: 'principal' | 'staff'
 }
 
 /**

--- a/src/pages/api/portal/operator/drafts/[id]/send.ts
+++ b/src/pages/api/portal/operator/drafts/[id]/send.ts
@@ -56,7 +56,7 @@ import {
   type Reviewer,
 } from '../../../../../../lib/portal/operator/send-as'
 
-const ROLES_THAT_CAN_SEND = ['principal', 'operator'] as const
+const ROLES_THAT_CAN_SEND = ['principal', 'staff'] as const
 
 function jsonResponse(status: number, payload: unknown): Response {
   return new Response(JSON.stringify(payload), {
@@ -111,7 +111,7 @@ export const POST: APIRoute = async ({ params, request, locals }) => {
   // present, so this find is total — but we keep the explicit guard
   // so a future widening of the allowed role list cannot silently
   // promote `compliance` into the send pathway.
-  const sendingRole = roles.find((r): r is 'principal' | 'operator' =>
+  const sendingRole = roles.find((r): r is 'principal' | 'staff' =>
     (ROLES_THAT_CAN_SEND as readonly string[]).includes(r)
   )
   if (!sendingRole) {

--- a/src/pages/api/portal/operator/drafts/[id]/teach.ts
+++ b/src/pages/api/portal/operator/drafts/[id]/teach.ts
@@ -55,7 +55,7 @@ import {
   validateTeachMarcusInput,
 } from '../../../../../../lib/portal/operator/teach-marcus'
 
-const ROLES_THAT_CAN_TEACH = ['principal', 'operator'] as const
+const ROLES_THAT_CAN_TEACH = ['principal', 'staff'] as const
 
 function jsonResponse(status: number, payload: unknown): Response {
   return new Response(JSON.stringify(payload), {
@@ -109,7 +109,7 @@ export const POST: APIRoute = async ({ params, request, locals }) => {
 
   const { user, client, subscription, roles } = access
 
-  const teachingRole = roles.find((r): r is 'principal' | 'operator' =>
+  const teachingRole = roles.find((r): r is 'principal' | 'staff' =>
     (ROLES_THAT_CAN_TEACH as readonly string[]).includes(r)
   )
   if (!teachingRole) {

--- a/src/pages/api/portal/products/operator/matter-assignment.ts
+++ b/src/pages/api/portal/products/operator/matter-assignment.ts
@@ -82,7 +82,7 @@ async function authorize(locals: App.Locals): Promise<Response | AuthorizedConte
 
   const { user, client } = portalData
   const roles = await listProductRoles(env.DB, user.id, client.id, PRODUCT_SLUG)
-  const canMutate = roles.includes('principal') || roles.includes('operator')
+  const canMutate = roles.includes('principal') || roles.includes('staff')
   if (!canMutate) return jsonError(403, 'Forbidden')
 
   const subscription = await getProductSubscription(env.DB, client.id, PRODUCT_SLUG)

--- a/src/pages/api/portal/products/operator/role-action.ts
+++ b/src/pages/api/portal/products/operator/role-action.ts
@@ -24,7 +24,7 @@ import { env } from 'cloudflare:workers'
  *
  *   action:  'grant' | 'revoke'  — which mutation to run
  *   userId:  TEXT                — target user's local users.id
- *   role:    'principal' | 'operator' | 'compliance'
+ *   role:    'principal' | 'staff' | 'compliance'
  *
  * Authorization:
  *   - Clerk session required (middleware enforces)

--- a/src/pages/portal/products/operator/drafts/[id].astro
+++ b/src/pages/portal/products/operator/drafts/[id].astro
@@ -73,7 +73,7 @@ const draft = await getDraft(subscription, draftId)
 // enforced that one of principal/operator is present; pick the more
 // powerful role when both are held so the surface labels reflect the
 // stronger grant.
-const callerRole: 'principal' | 'operator' = roles.includes('principal') ? 'principal' : 'operator'
+const callerRole: 'principal' | 'staff' = roles.includes('principal') ? 'principal' : 'staff'
 
 // Undo window — pending bridge wiring for the per-customer override.
 // DEFAULT_UNDO_WINDOW_MS is 5_000 per the issue's stated default.

--- a/src/pages/portal/products/operator/matters/[id].astro
+++ b/src/pages/portal/products/operator/matters/[id].astro
@@ -107,7 +107,7 @@ if (matter) {
 // any active product_role on (entity, 'operator') and is NOT already
 // assigned — those rows surface in the section's "Assign someone"
 // dropdown.
-const canMutateAssignments = roles.includes('principal') || roles.includes('operator')
+const canMutateAssignments = roles.includes('principal') || roles.includes('staff')
 let assignments: MatterAssignment[] = []
 let assignableMembers: Array<{ id: string; name: string; email: string }> = []
 if (matter) {


### PR DESCRIPTION
## Regression

PR #1248 (#0) renamed the client role enum value `operator → staff`, but the rename seds only matched the `['operator', 'principal']` / `'operator', 'compliance'` literals. They **missed**:
- the `['principal', 'operator']` ordering (`ROLES_THAT_CAN_SEND`, `ROLES_THAT_CAN_TEACH`)
- type unions `'principal' | 'operator'` (`DraftDetail`, `drafts/[id]`, `send-as`, teach/send guards)
- `.includes('operator')` / `=== 'operator'` predicates (`matters/[id]`, `matter-assignment`)

After #0, every one of these is **permanently false** — granted roles are now `staff` — silently stripping `staff` users of:
- **draft approval** (`DraftDetail.canApprove`)
- **draft send + memory-teach** (`ROLES_THAT_CAN_SEND` / `ROLES_THAT_CAN_TEACH` guards)
- **matter assignment mutation** (`matters/[id]` + the `matter-assignment` endpoint)

(How #0 missed them: my completeness rescan had a flawed exclusion that filtered out every line whose grep output contained the substring `/operator/` — i.e. every line in every file under an `operator/` path. This PR is the corrected sweep.)

## Fix

Every remaining role-value site → `staff` (8 files, 11 lines). Untouched, correctly: `product_slug = 'operator'` (the product), `smd_operator` (Layer-0 actor role), and the assessment `speaker: 'operator'` conversation enum.

## Verification

typecheck 0 errors · lint 0 errors · build clean · 3124 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)