### PR TITLE
feat(operator): Matters surface on the runtime read path (client portal PR3)

### DIFF
--- a/src/lib/portal/operator/matters-read.ts
+++ b/src/lib/portal/operator/matters-read.ts
@@ -1,0 +1,226 @@
+/**
+ * Matters read path (client-portal §5.4). Bridges the frozen ADR 0043 runtime
+ * read (readMachineRuntime) into the matter list + detail shapes (matters.ts).
+ *
+ * Same discipline as activity-read.ts: converge the deep per-customer read on
+ * the single audited, fail-closed, one-customer-per-call path (foundations §6).
+ * Gated on isRuntimeReadConfigured so an unwired deploy returns the honest empty
+ * shape WITHOUT writing a read-audit row on every page view. Once wired, every
+ * read is attempted and audited.
+ *
+ * `kind: 'matter'` serves both list and detail: a query with no `id` returns the
+ * list, a query with an `id` returns one matter's detail. The Machine read
+ * endpoint (overlay-side) defines the wire format; until it exists these return
+ * empty/null, so the parsers are dormant but written defensively (parse, never
+ * cast).
+ *
+ * `assigneeUserIds` is always [] from this resolver — the page stitches
+ * assignments from the portal D1 (see matters.ts Matter doc + matter-assignment.ts).
+ */
+
+import type { D1Database } from '@cloudflare/workers-types'
+import { readMachineRuntime, type RuntimeReadActor } from '../../operator/runtime-read'
+import {
+  createMachineRuntimeTransport,
+  createRuntimeReadAudit,
+  isRuntimeReadConfigured,
+  type RuntimeReadEnv,
+} from '../../operator/runtime-read-transport'
+import {
+  MATTER_PHASE_LABEL,
+  type Matter,
+  type MatterDetail,
+  type MatterPhase,
+  type MatterLastAction,
+  type MatterTimelineEntry,
+  type MatterDraftRef,
+  type MatterAuditRef,
+} from './matters'
+
+export interface MattersReadDeps {
+  db: D1Database
+  env: RuntimeReadEnv
+  actorUserId: string
+}
+
+/** List the matters the client's operator is tracking. Fails closed to []. */
+export async function loadMatters(
+  deps: MattersReadDeps,
+  customerSlug: string,
+  actor: RuntimeReadActor
+): Promise<Matter[]> {
+  if (!isRuntimeReadConfigured(deps.env)) return []
+  const result = await readMachineRuntime(buildDeps(deps), customerSlug, { kind: 'matter' }, actor)
+  return result.ok ? parseMatters(result.data) : []
+}
+
+/** Load one matter's detail. Fails closed to null. */
+export async function loadMatterDetail(
+  deps: MattersReadDeps,
+  customerSlug: string,
+  actor: RuntimeReadActor,
+  matterId: string
+): Promise<MatterDetail | null> {
+  if (!isRuntimeReadConfigured(deps.env)) return null
+  const result = await readMachineRuntime(
+    buildDeps(deps),
+    customerSlug,
+    { kind: 'matter', id: matterId },
+    actor
+  )
+  return result.ok ? parseMatterDetail(result.data) : null
+}
+
+function buildDeps(deps: MattersReadDeps) {
+  return {
+    transport: createMachineRuntimeTransport(deps.env),
+    audit: createRuntimeReadAudit(deps.db, { actorUserId: deps.actorUserId }),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Defensive parsing.
+// ---------------------------------------------------------------------------
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v)
+}
+function reqString(v: unknown): string | null {
+  return typeof v === 'string' && v.length > 0 ? v : null
+}
+function optString(v: unknown): string | null {
+  return typeof v === 'string' && v.length > 0 ? v : null
+}
+function asPhase(v: unknown): MatterPhase | null {
+  return typeof v === 'string' && v in MATTER_PHASE_LABEL ? (v as MatterPhase) : null
+}
+function asLastAction(v: unknown): MatterLastAction | null {
+  if (!isRecord(v)) return null
+  const skill = reqString(v['skill'])
+  const at = reqString(v['at'])
+  return skill !== null && at !== null ? { skill, at } : null
+}
+
+/** Parse the matter list payload (bare array or `{ matters: [...] }`). Rows
+ * missing any required scalar (id/clientName/matterType/phase/openedAt) are
+ * dropped — a malformed row never becomes a misleading matter card. */
+export function parseMatters(data: unknown): Matter[] {
+  const raw: unknown = isRecord(data) && Array.isArray(data['matters']) ? data['matters'] : data
+  if (!Array.isArray(raw)) return []
+  const out: Matter[] = []
+  for (const item of raw) {
+    const m = parseMatterCore(item)
+    if (m !== null) out.push({ ...m, lastAction: asLastAction(itemField(item, 'lastAction')) })
+  }
+  return out
+}
+
+function itemField(item: unknown, key: string): unknown {
+  return isRecord(item) ? item[key] : undefined
+}
+
+/** Shared scalar core of Matter (also the head of MatterDetail). */
+function parseMatterCore(
+  item: unknown
+): Pick<
+  Matter,
+  'id' | 'clientName' | 'matterType' | 'phase' | 'openedAt' | 'assigneeUserIds'
+> | null {
+  if (!isRecord(item)) return null
+  const id = reqString(item['id'])
+  const clientName = reqString(item['clientName'])
+  const matterType = reqString(item['matterType'])
+  const phase = asPhase(item['phase'])
+  const openedAt = reqString(item['openedAt'])
+  if (
+    id === null ||
+    clientName === null ||
+    matterType === null ||
+    phase === null ||
+    openedAt === null
+  ) {
+    return null
+  }
+  // The resolver never supplies assignees; the page stitches them from portal D1.
+  return { id, clientName, matterType, phase, openedAt, assigneeUserIds: [] }
+}
+
+const TIMELINE_KINDS: ReadonlySet<string> = new Set([
+  'communication',
+  'document',
+  'deadline',
+  'ai_action',
+  'note',
+])
+
+function parseTimeline(v: unknown): MatterTimelineEntry[] {
+  if (!Array.isArray(v)) return []
+  const out: MatterTimelineEntry[] = []
+  for (const e of v) {
+    if (!isRecord(e)) continue
+    const id = reqString(e['id'])
+    const at = reqString(e['at'])
+    const summary = reqString(e['summary'])
+    const kind = e['kind']
+    if (id === null || at === null || summary === null) continue
+    if (typeof kind !== 'string' || !TIMELINE_KINDS.has(kind)) continue
+    out.push({ id, at, kind: kind as MatterTimelineEntry['kind'], summary })
+  }
+  return out
+}
+
+function parseDrafts(v: unknown): MatterDraftRef[] {
+  if (!Array.isArray(v)) return []
+  const out: MatterDraftRef[] = []
+  for (const d of v) {
+    if (!isRecord(d)) continue
+    const id = reqString(d['id'])
+    const subject = reqString(d['subject'])
+    const recipient = reqString(d['recipient'])
+    const skill = reqString(d['skill'])
+    const createdAt = reqString(d['createdAt'])
+    if (
+      id === null ||
+      subject === null ||
+      recipient === null ||
+      skill === null ||
+      createdAt === null
+    ) {
+      continue
+    }
+    out.push({ id, subject, recipient, skill, createdAt })
+  }
+  return out
+}
+
+function parseAuditRefs(v: unknown): MatterAuditRef[] {
+  if (!Array.isArray(v)) return []
+  const out: MatterAuditRef[] = []
+  for (const a of v) {
+    if (!isRecord(a)) continue
+    const id = reqString(a['id'])
+    const at = reqString(a['at'])
+    const actor = reqString(a['actor'])
+    const action = reqString(a['action'])
+    const summary = reqString(a['summary'])
+    if (id === null || at === null || actor === null || action === null || summary === null)
+      continue
+    out.push({ id, at, actor, action, summary })
+  }
+  return out
+}
+
+/** Parse one matter's detail payload, or null when the core scalars are absent. */
+export function parseMatterDetail(data: unknown): MatterDetail | null {
+  const item: unknown = isRecord(data) && isRecord(data['matter']) ? data['matter'] : data
+  const core = parseMatterCore(item)
+  if (core === null || !isRecord(item)) return null
+  return {
+    ...core,
+    facts: optString(item['facts']),
+    timeline: parseTimeline(item['timeline']),
+    draftsInFlight: parseDrafts(item['draftsInFlight']),
+    recentAudit: parseAuditRefs(item['recentAudit']),
+    lastAction: asLastAction(item['lastAction']),
+  }
+}

--- a/src/pages/portal/products/operator/matters/[id].astro
+++ b/src/pages/portal/products/operator/matters/[id].astro
@@ -14,12 +14,13 @@ import MatterAssignmentSection from '../../../../../components/portal/operator/M
 import SkipToMain from '../../../../../components/SkipToMain.astro'
 import { env } from 'cloudflare:workers'
 import {
-  getMatter,
   formatMatterAge,
   resolveMatterPhaseStamp,
   resolveMatterPhaseTone,
   MATTER_PHASE_LABEL,
 } from '../../../../../lib/portal/operator/matters'
+import { loadMatterDetail } from '../../../../../lib/portal/operator/matters-read'
+import { getCustomerConfig } from '../../../../../lib/portal/customer-config'
 import {
   listMatterAssignments,
   type MatterAssignment,
@@ -77,14 +78,30 @@ const access = await resolveOperatorAccess(env.DB, Astro.locals, {
 if (access.kind === 'redirect') {
   return Astro.redirect(access.to)
 }
-const { client, roles } = access
+const { client, user, roles } = access
 
 const matterId = Astro.params.id
 if (!matterId || typeof matterId !== 'string') {
   return Astro.redirect('/portal/products/operator/matters')
 }
 
-const matter = await getMatter(env.DB, client.id, matterId)
+// Route detail through the frozen ADR 0043 runtime read path
+// (matters-read.loadMatterDetail → readMachineRuntime). Null until
+// OPERATOR_RUNTIME_READ_URL is wired (client-portal §5.4); the page renders the
+// honest not-found branch.
+const config = await getCustomerConfig(env.DB, client.id)
+const customerSlug = config?.customer_slug ?? client.id
+const actorRole = roles.includes('principal')
+  ? 'principal'
+  : roles.includes('compliance')
+    ? 'compliance'
+    : 'staff'
+const matter = await loadMatterDetail(
+  { db: env.DB, env, actorUserId: user.id },
+  customerSlug,
+  { actor: user.email, actorRole },
+  matterId
+)
 
 // Pre-compute the header meta column once. The page renders the
 // not-found branch when matter === null, otherwise the full detail

--- a/src/pages/portal/products/operator/matters/index.astro
+++ b/src/pages/portal/products/operator/matters/index.astro
@@ -8,11 +8,9 @@ import PortalPageHead from '../../../../../components/portal/PortalPageHead.astr
 import MattersListTable from '../../../../../components/portal/operator/MattersListTable.astro'
 import SkipToMain from '../../../../../components/SkipToMain.astro'
 import { env } from 'cloudflare:workers'
-import {
-  filterMattersByAssignee,
-  listMatters,
-  type Matter,
-} from '../../../../../lib/portal/operator/matters'
+import { filterMattersByAssignee, type Matter } from '../../../../../lib/portal/operator/matters'
+import { loadMatters } from '../../../../../lib/portal/operator/matters-read'
+import { getCustomerConfig } from '../../../../../lib/portal/customer-config'
 import {
   listAssignedMatterIdsForUser,
   parseMatterScope,
@@ -67,9 +65,24 @@ const access = await resolveOperatorAccess(env.DB, Astro.locals, {
 if (access.kind === 'redirect') {
   return Astro.redirect(access.to)
 }
-const { client, user } = access
+const { client, user, roles } = access
 
-const allMatters: Matter[] = await listMatters(env.DB, client.id)
+// Route the matter list through the frozen ADR 0043 runtime read path
+// (matters-read.loadMatters → readMachineRuntime). Fails closed to an empty
+// list until OPERATOR_RUNTIME_READ_URL is wired (client-portal §5.4).
+const config = await getCustomerConfig(env.DB, client.id)
+const customerSlug = config?.customer_slug ?? client.id
+const actorRole = roles.includes('principal')
+  ? 'principal'
+  : roles.includes('compliance')
+    ? 'compliance'
+    : 'staff'
+
+const allMatters: Matter[] = await loadMatters(
+  { db: env.DB, env, actorUserId: user.id },
+  customerSlug,
+  { actor: user.email, actorRole }
+)
 
 const assignedMatterIds = await listAssignedMatterIdsForUser(env.DB, client.id, user.id)
 const myMatters = filterMattersByAssignee(allMatters, assignedMatterIds)

--- a/tests/operator-matters-read.test.ts
+++ b/tests/operator-matters-read.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from 'vitest'
+import type { D1Database } from '@cloudflare/workers-types'
+import {
+  loadMatters,
+  loadMatterDetail,
+  parseMatters,
+  parseMatterDetail,
+} from '../src/lib/portal/operator/matters-read'
+
+// A DB that throws if touched — proves the not-configured path never queries.
+const NOOP_DB = {
+  prepare() {
+    throw new Error('DB must not be touched when the runtime read path is unconfigured')
+  },
+} as unknown as D1Database
+const ACTOR = { actor: 'partner@firm.com', actorRole: 'principal' }
+
+describe('loadMatters / loadMatterDetail: fail-closed until wired', () => {
+  it('loadMatters returns [] (and never touches D1) when the read URL is unset', async () => {
+    const out = await loadMatters({ db: NOOP_DB, env: {}, actorUserId: 'u-1' }, 'smith-pi', ACTOR)
+    expect(out).toEqual([])
+  })
+
+  it('loadMatterDetail returns null when the read URL is unset', async () => {
+    const out = await loadMatterDetail(
+      { db: NOOP_DB, env: {}, actorUserId: 'u-1' },
+      'smith-pi',
+      ACTOR,
+      'M-1'
+    )
+    expect(out).toBeNull()
+  })
+})
+
+describe('parseMatters: defensive parse', () => {
+  const good = {
+    id: 'M-1',
+    clientName: 'Jane Roe',
+    matterType: 'Auto Accident',
+    phase: 'discovery',
+    openedAt: '2026-05-01T00:00:00.000Z',
+    lastAction: { skill: 'pi-demand-letter', at: '2026-06-01T00:00:00.000Z' },
+  }
+
+  it('parses a bare array and an { matters: [...] } envelope', () => {
+    expect(parseMatters([good])).toHaveLength(1)
+    expect(parseMatters({ matters: [good] })).toHaveLength(1)
+  })
+
+  it('resolver never supplies assignees (page stitches them)', () => {
+    expect(parseMatters([good])[0].assigneeUserIds).toEqual([])
+  })
+
+  it('keeps a valid lastAction and nulls a malformed one', () => {
+    expect(parseMatters([good])[0].lastAction).toEqual(good.lastAction)
+    expect(parseMatters([{ ...good, lastAction: { skill: 'x' } }])[0].lastAction).toBeNull()
+  })
+
+  it('drops rows missing a required scalar or with an unknown phase', () => {
+    expect(parseMatters([{ ...good, id: '' }])).toHaveLength(0)
+    expect(parseMatters([{ ...good, phase: 'appeal' }])).toHaveLength(0)
+    expect(parseMatters([{ ...good, openedAt: 123 }])).toHaveLength(0)
+  })
+
+  it('returns [] for non-array / non-envelope input', () => {
+    expect(parseMatters(null)).toEqual([])
+    expect(parseMatters('nope')).toEqual([])
+    expect(parseMatters({})).toEqual([])
+  })
+})
+
+describe('parseMatterDetail: defensive parse', () => {
+  const detail = {
+    id: 'M-1',
+    clientName: 'Jane Roe',
+    matterType: 'Auto Accident',
+    phase: 'pre_suit',
+    openedAt: '2026-05-01T00:00:00.000Z',
+    facts: 'Rear-ended at a light.',
+    timeline: [
+      { id: 't1', at: '2026-05-02', kind: 'communication', summary: 'Intake call' },
+      { id: 't2', at: '2026-05-03', kind: 'bogus_kind', summary: 'dropped' },
+    ],
+    draftsInFlight: [
+      {
+        id: 'd1',
+        subject: 'Demand',
+        recipient: 'adjuster@x.com',
+        skill: 'pi',
+        createdAt: '2026-05-04',
+      },
+    ],
+    recentAudit: [
+      { id: 'a1', at: '2026-05-05', actor: 'marcus', action: 'DRAFT_CREATED', summary: 'created' },
+    ],
+    lastAction: { skill: 'pi', at: '2026-05-04' },
+  }
+
+  it('parses the full detail and accepts a { matter: {...} } envelope', () => {
+    const d = parseMatterDetail(detail)
+    expect(d?.id).toBe('M-1')
+    expect(parseMatterDetail({ matter: detail })?.id).toBe('M-1')
+  })
+
+  it('drops timeline entries with an unknown kind, keeps valid ones', () => {
+    const d = parseMatterDetail(detail)
+    expect(d?.timeline).toHaveLength(1)
+    expect(d?.timeline[0].kind).toBe('communication')
+  })
+
+  it('returns null when the core scalars are absent', () => {
+    expect(parseMatterDetail({ facts: 'x' })).toBeNull()
+    expect(parseMatterDetail(null)).toBeNull()
+    expect(parseMatterDetail({ ...detail, phase: 'nope' })).toBeNull()
+  })
+})


### PR DESCRIPTION
## What

PR **3** of the Operator client portal. Evolves the `/matters` list + detail surfaces to `02-client-portal.md` §5.4. Unlike `/activity` (a new route), the new-IA `/matters` path **is** the legacy path — so this adapts the surface in place, reusing every matter component (`MattersListTable`, `MatterRow`, the five detail sections) and the existing mine/all scope toggle. Based on `main` (PR2 + the rename-completeness fix merged).

## Highlights

- **Routes list + detail through the frozen ADR 0043 path** (`matters-read.ts`: `loadMatters` / `loadMatterDetail` → `readMachineRuntime`), replacing the legacy per-feature stubs. Gated on `isRuntimeReadConfigured` → fails closed to empty/not-found **without** a read-audit row per page view; once wired, every read is attempted + audited.
- **`parseMatters` / `parseMatterDetail` defensively parse** the runtime payload (parse, never cast): drop rows missing required scalars or with an unknown phase; drop timeline entries with an unknown kind; null a malformed `lastAction`. The resolver never supplies assignees — the page still stitches them from the portal D1.
- **Read for all three roles**; the existing `filterMattersByAssignee` mine/all toggle covers §5.4 "staff may be scoped to assigned workstreams."

## Decision worth a reviewer's eye

The legacy `listMatters` / `getMatter` stubs + their contract test are **retained** (now page-unused), to be retired alongside `/audit` in a dedicated cleanup — same supersede-then-retire posture as PR2.

## Verification

typecheck 0 · lint 0 · build clean · 3134 tests pass (new `operator-matters-read` coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)