### PR TITLE
feat(operator): admin fleet alerts feed (§4.2)

### DIFF
--- a/src/layouts/AdminLayout.astro
+++ b/src/layouts/AdminLayout.astro
@@ -42,6 +42,11 @@ const navItems = [
     href: '/admin/analytics',
     match: (p: string) => p.startsWith('/admin/analytics'),
   },
+  {
+    label: 'Operator',
+    href: '/admin/operator',
+    match: (p: string) => p.startsWith('/admin/operator'),
+  },
 ]
 ---
 

--- a/src/lib/admin/fleet-alerts.ts
+++ b/src/lib/admin/fleet-alerts.ts
@@ -1,0 +1,178 @@
+/**
+ * Fleet alert-feed view-model for the admin Operator console
+ * (`/admin/operator/alerts`) — design doc §4.2.
+ *
+ * The single feed of everything that needs SMD attention across every operator.
+ * It reads the shared `cost_anomaly_alerts` store (ADR 0023 §"Cross-cutting
+ * calls" #9) via the frozen `listOpenAlerts` reader — that table is already
+ * multi-source (cost / sentry / healthchecks / audit_integrity), and the
+ * existing snooze/acknowledge API keys on (entity_id, alert_date, driver), so it
+ * generalizes to every source row for free.
+ *
+ * This module owns only the pure view derivations: severity (the table has no
+ * severity column, so it is derived per source), the deep-link target per
+ * source, the detail line, filtering, and counts. The reader and the
+ * snooze/ack writers are the frozen seam.
+ *
+ * Honest-scope note (foundations §7): the feed renders the alert sources that
+ * flow into the store today. Sticky-stop transitions, connector auth-expired,
+ * boot-check failures, and structural-config-deferred (design §4.2) light up
+ * here as their receiver/writer paths land — the page says so rather than
+ * fabricating rows for sources not yet wired.
+ */
+
+import type { CostAnomalyAlertRow } from './cost-anomaly'
+import { costAnomalyDetail, relativeTimestamp } from './fleet-status'
+
+export type AlertSeverity = 'critical' | 'warning' | 'info'
+
+const SEVERITY_RANK: Record<AlertSeverity, number> = { critical: 2, warning: 1, info: 0 }
+
+/**
+ * Derive a severity from the alert source (and, for cost, whether the breach
+ * is over its configured threshold). Audit-integrity drift is always critical
+ * — a D1-vs-mirror mismatch is a compliance signal. Cost is critical only when
+ * the day actually breached its threshold; otherwise it is a warning-grade
+ * watch. Operational sources (sentry, healthchecks) are warnings.
+ */
+export function alertSeverity(row: CostAnomalyAlertRow): AlertSeverity {
+  switch (row.source) {
+    case 'audit_integrity':
+      return 'critical'
+    case 'cost':
+      return row.ratio_bps >= row.threshold_bps ? 'critical' : 'warning'
+    case 'sentry':
+    case 'healthchecks':
+      return 'warning'
+    default:
+      return 'info'
+  }
+}
+
+/**
+ * The per-operator surface this alert deep-links to. Cost anomalies open the
+ * cost drill-in; everything else opens the operator overview (the hub from
+ * which the relevant domain drill-in is reachable). Always one customer.
+ */
+export function alertLink(row: CostAnomalyAlertRow): string {
+  const slug = encodeURIComponent(row.customer_slug)
+  if (row.source === 'cost') return `/admin/operator/costs/${slug}`
+  return `/admin/operator/${slug}`
+}
+
+/**
+ * The human detail line. Cost rows render the numeric breach via the shared
+ * costAnomalyDetail; every other source carries its own authored `summary`.
+ * Never fabricates a detail for a row that has none.
+ */
+export function alertDetail(
+  row: CostAnomalyAlertRow,
+  formatCurrency: (cents: number) => string
+): string {
+  if (row.source === 'cost') {
+    return costAnomalyDetail({
+      driver: row.driver,
+      daily_cents: row.daily_cents,
+      rolling_avg_cents: row.rolling_avg_cents,
+      ratio_bps: row.ratio_bps,
+      formatCurrency,
+    })
+  }
+  return row.summary ?? '(no detail recorded)'
+}
+
+export function alertAge(row: CostAnomalyAlertRow, now: Date = new Date()): string {
+  return relativeTimestamp(row.detected_at, now)
+}
+
+export interface SeverityBadge {
+  label: string
+  classes: string
+}
+
+const SEVERITY_BADGE_STRUCTURE =
+  'inline-flex items-center px-2 py-0.5 rounded-[var(--ss-radius-badge)] ' +
+  'text-[10px] font-medium uppercase tracking-wide whitespace-nowrap'
+
+export function severityBadge(severity: AlertSeverity): SeverityBadge {
+  switch (severity) {
+    case 'critical':
+      return {
+        label: 'Critical',
+        classes: `${SEVERITY_BADGE_STRUCTURE} bg-[color:var(--ss-color-error)] text-white`,
+      }
+    case 'warning':
+      return {
+        label: 'Warning',
+        classes: `${SEVERITY_BADGE_STRUCTURE} bg-[color:var(--ss-color-attention)] text-white`,
+      }
+    case 'info':
+      return {
+        label: 'Info',
+        classes: `${SEVERITY_BADGE_STRUCTURE} bg-[color:var(--ss-color-border)] text-[color:var(--ss-color-text-secondary)]`,
+      }
+  }
+}
+
+export interface AlertFilters {
+  source?: string | null
+  severity?: string | null
+  customer?: string | null
+}
+
+/**
+ * Apply the (optional) source / severity / customer filters. Severity is
+ * derived per row, so the severity filter computes it; an empty / null filter
+ * value matches everything. Pure — own unit test.
+ */
+export function filterAlerts(
+  rows: readonly CostAnomalyAlertRow[],
+  filters: AlertFilters
+): CostAnomalyAlertRow[] {
+  const source = normalize(filters.source)
+  const severity = normalize(filters.severity)
+  const customer = normalize(filters.customer)
+  return rows.filter((row) => {
+    if (source && row.source !== source) return false
+    if (customer && row.customer_slug !== customer) return false
+    if (severity && alertSeverity(row) !== severity) return false
+    return true
+  })
+}
+
+function normalize(v: string | null | undefined): string | null {
+  if (v === null || v === undefined) return null
+  const trimmed = v.trim()
+  return trimmed === '' || trimmed === 'all' ? null : trimmed
+}
+
+export interface SeverityCounts {
+  critical: number
+  warning: number
+  info: number
+  total: number
+}
+
+/** Count rows by derived severity — drives the header summary. */
+export function countBySeverity(rows: readonly CostAnomalyAlertRow[]): SeverityCounts {
+  const counts: SeverityCounts = { critical: 0, warning: 0, info: 0, total: rows.length }
+  for (const row of rows) counts[alertSeverity(row)] += 1
+  return counts
+}
+
+/**
+ * Sort for display: most severe first, then freshest (detected_at desc). The
+ * eye lands on the worst, newest thing — same discipline as the roster sort.
+ */
+export function sortAlerts(rows: readonly CostAnomalyAlertRow[]): CostAnomalyAlertRow[] {
+  return [...rows].sort((a, b) => {
+    const sev = SEVERITY_RANK[alertSeverity(b)] - SEVERITY_RANK[alertSeverity(a)]
+    if (sev !== 0) return sev
+    return b.detected_at.localeCompare(a.detected_at)
+  })
+}
+
+/** Distinct customer slugs present in the feed, for the customer filter. */
+export function distinctCustomers(rows: readonly CostAnomalyAlertRow[]): string[] {
+  return [...new Set(rows.map((r) => r.customer_slug))].sort()
+}

--- a/src/lib/admin/fleet-roster.ts
+++ b/src/lib/admin/fleet-roster.ts
@@ -1,0 +1,264 @@
+/**
+ * Fleet-roster reader for the admin Operator console landing
+ * (`/admin/operator`) — design doc docs/design/operator/01-admin-portal.md §4.1.
+ *
+ * The roster is the "is anything on fire across all my operators" view: one
+ * row per client, scannable as the fleet grows. It composes three console-side
+ * projections, never a cross-Machine runtime join (ADR 0009):
+ *
+ *   1. `customer_configs`            — identity, persona roster, authority posture
+ *   2. `operator_runtime_summary`    — health/alerts/last-activity mirror (ADR 0043 B)
+ *   3. `fleet_status`                — per-customer heartbeat liveness (ADR 0023)
+ *
+ * This module owns only #1's read + the pure derivations the page renders
+ * (posture label, combined health). The summary/heartbeat readers are the
+ * frozen seam (src/lib/admin/runtime-summary.ts, fleet-status.ts); the page
+ * joins them by entity_id (slug fallback), exactly as the costs page does.
+ *
+ * Fleet-view discipline (foundations §7, ADR 0043): one corrupt config row must
+ * never 500 the whole fleet view. `listFleetRoster` parses each row defensively
+ * — a malformed personas/authority column degrades that single row to a flagged
+ * `config_error` state with an empty persona list and the launch-default
+ * posture, and the rest of the fleet still renders.
+ */
+
+import type { D1Database } from '@cloudflare/workers-types'
+import {
+  DEFAULT_AUTHORITY_POSTURE,
+  parseAuthorityPosture,
+  resolveAllDomains,
+  type AuthorityPosture,
+} from '../operator/authority'
+import type { SummaryStatus } from './runtime-summary'
+
+export interface RosterPersona {
+  slug: string
+  name: string
+  status: string
+}
+
+export interface RosterCustomer {
+  entity_id: string
+  customer_slug: string
+  /** Display name from `entities.name`; null when no entity row joins. */
+  entity_name: string | null
+  /** Projected `customer_configs.vertical`; null before CI sync backfills it. */
+  vertical: string | null
+  personas: RosterPersona[]
+  authority: AuthorityPosture
+  /**
+   * Set when this row's projected JSON was malformed. The row still renders
+   * (degraded) so one corrupt config never blanks the fleet view — the flag
+   * lets the page surface "this operator's config needs attention" honestly
+   * instead of silently showing zero personas.
+   */
+  config_error: string | null
+}
+
+interface RosterDbRow {
+  entity_id: string
+  customer_slug: string
+  personas_json: string
+  authority_json: string | null
+  vertical: string | null
+}
+
+interface EntityNameRow {
+  id: string
+  name: string
+}
+
+/**
+ * Enumerate every Operator customer for the fleet roster, ordered by slug.
+ * One batched read of `customer_configs` + one batched name lookup — no
+ * per-row query and no per-customer Machine round-trip.
+ */
+export async function listFleetRoster(db: D1Database): Promise<RosterCustomer[]> {
+  const configResult = await db
+    .prepare(
+      `SELECT entity_id, customer_slug, personas_json, authority_json, vertical
+         FROM customer_configs
+        ORDER BY customer_slug ASC`
+    )
+    .all<RosterDbRow>()
+  const rows = configResult.results ?? []
+  if (rows.length === 0) return []
+
+  const namesByEntity = await loadEntityNames(
+    db,
+    rows.map((r) => r.entity_id)
+  )
+
+  return rows.map((row) => projectRosterRow(row, namesByEntity.get(row.entity_id) ?? null))
+}
+
+async function loadEntityNames(db: D1Database, entityIds: string[]): Promise<Map<string, string>> {
+  const placeholders = entityIds.map(() => '?').join(',')
+  const result = await db
+    .prepare(`SELECT id, name FROM entities WHERE id IN (${placeholders})`)
+    .bind(...entityIds)
+    .all<EntityNameRow>()
+  const map = new Map<string, string>()
+  for (const row of result.results ?? []) map.set(row.id, row.name)
+  return map
+}
+
+function projectRosterRow(row: RosterDbRow, entityName: string | null): RosterCustomer {
+  const base = {
+    entity_id: row.entity_id,
+    customer_slug: row.customer_slug,
+    entity_name: entityName,
+    vertical: row.vertical,
+  }
+  try {
+    return {
+      ...base,
+      personas: parsePersonas(row.personas_json),
+      // parseAuthorityPosture is total (never throws); a malformed personas
+      // column is what flips a row into the error state.
+      authority: parseAuthorityPosture(safeJsonParse(row.authority_json)),
+      config_error: null,
+    }
+  } catch (err) {
+    return {
+      ...base,
+      personas: [],
+      authority: { ...DEFAULT_AUTHORITY_POSTURE },
+      config_error: err instanceof Error ? err.message : String(err),
+    }
+  }
+}
+
+function parsePersonas(raw: string): RosterPersona[] {
+  const parsed: unknown = JSON.parse(raw)
+  if (!Array.isArray(parsed)) throw new Error('personas_json is not an array')
+  return parsed.map((p) => {
+    if (typeof p !== 'object' || p === null) throw new Error('persona entry is not an object')
+    const rec = p as Record<string, unknown>
+    return {
+      slug: typeof rec.slug === 'string' ? rec.slug : '',
+      name: typeof rec.name === 'string' ? rec.name : '',
+      status: typeof rec.status === 'string' ? rec.status : 'unknown',
+    }
+  })
+}
+
+/** Null-tolerant JSON parse; null/undefined → null, malformed → throws. */
+function safeJsonParse(value: string | null | undefined): unknown {
+  if (value === null || value === undefined) return null
+  return JSON.parse(value)
+}
+
+// ===========================================================================
+// Pure derivations the roster page renders
+// ===========================================================================
+
+export type PostureLabel = 'Managed' | 'Co-Managed' | 'Self-Managed'
+
+export interface PosturePill {
+  label: PostureLabel
+  classes: string
+}
+
+const POSTURE_BADGE_STRUCTURE =
+  'inline-flex items-center px-2 py-0.5 rounded-[var(--ss-radius-badge)] ' +
+  'text-[10px] font-medium uppercase tracking-wide whitespace-nowrap'
+
+/**
+ * Derive the posture chip from the resolved authority posture (foundations
+ * §4.1): the label is a description of the *switch pattern*, not a SKU —
+ * Managed (every client switch off), Self-Managed (every switch client),
+ * Co-Managed (a mix). SMD always retains full control regardless; this chip
+ * describes only the client org's operability.
+ */
+export function derivePostureLabel(posture: AuthorityPosture | null): PostureLabel {
+  const holders = Object.values(resolveAllDomains(posture))
+  const clientCount = holders.filter((h) => h === 'client').length
+  if (clientCount === 0) return 'Managed'
+  if (clientCount === holders.length) return 'Self-Managed'
+  return 'Co-Managed'
+}
+
+export function posturePill(posture: AuthorityPosture | null): PosturePill {
+  const label = derivePostureLabel(posture)
+  const tone =
+    label === 'Managed'
+      ? 'bg-[color:var(--ss-color-primary)] text-white'
+      : label === 'Self-Managed'
+        ? 'bg-[color:var(--ss-color-complete)] text-white'
+        : 'bg-[color:var(--ss-color-attention)] text-white'
+  return { label, classes: `${POSTURE_BADGE_STRUCTURE} ${tone}` }
+}
+
+export type RosterHealthColor = 'green' | 'yellow' | 'red' | 'gray'
+
+export interface RosterHealth {
+  color: RosterHealthColor
+  /** Relative liveness label from the heartbeat ("47s ago" / "stale 12m"). */
+  label: string
+  /** Secondary line when the summary mirror reports a non-green rollup. */
+  note: string | null
+}
+
+const HEALTH_RANK: Record<RosterHealthColor, number> = { gray: 0, green: 1, yellow: 2, red: 3 }
+
+/**
+ * Combine the heartbeat liveness ("is the process alive", fleet_status) with
+ * the runtime-summary rollup ("is the operator OK" — folds in sticky-stop,
+ * escalation pressure, connector health per migration 0052) into one fleet
+ * dot. Takes the more alarming of the two so the column never reads calmer
+ * than reality. `heartbeatColor` is the color from `heartbeatDisplay`;
+ * `summaryStatus` is null when no Machine has pushed a summary yet.
+ */
+export function rosterHealth(
+  heartbeatColor: RosterHealthColor,
+  heartbeatLabel: string,
+  summaryStatus: SummaryStatus | null
+): RosterHealth {
+  const summaryColor = summaryStatusToColor(summaryStatus)
+  const color =
+    HEALTH_RANK[summaryColor] > HEALTH_RANK[heartbeatColor] ? summaryColor : heartbeatColor
+  const note =
+    summaryStatus === 'red'
+      ? 'operator reports a problem'
+      : summaryStatus === 'yellow'
+        ? 'operator reports a warning'
+        : null
+  return { color, label: heartbeatLabel, note }
+}
+
+function summaryStatusToColor(status: SummaryStatus | null): RosterHealthColor {
+  switch (status) {
+    case 'green':
+      return 'green'
+    case 'yellow':
+      return 'yellow'
+    case 'red':
+      return 'red'
+    default:
+      return 'gray'
+  }
+}
+
+export function rosterHealthDotClass(color: RosterHealthColor): string {
+  switch (color) {
+    case 'green':
+      return 'bg-[color:var(--ss-color-complete)]'
+    case 'yellow':
+      return 'bg-[color:var(--ss-color-attention)]'
+    case 'red':
+      return 'bg-[color:var(--ss-color-error)]'
+    case 'gray':
+      return 'bg-[color:var(--ss-color-border)]'
+  }
+}
+
+/** "3 personas" / "1 persona" / "no personas". Pure, for the roster cell. */
+export function personaSummary(personas: RosterPersona[]): string {
+  const active = personas.filter((p) => p.status === 'active')
+  const count = personas.length
+  if (count === 0) return 'no personas'
+  const noun = count === 1 ? 'persona' : 'personas'
+  const archived = count - active.length
+  return archived > 0 ? `${count} ${noun} (${archived} archived)` : `${count} ${noun}`
+}

--- a/src/lib/admin/operator-overview.ts
+++ b/src/lib/admin/operator-overview.ts
@@ -1,0 +1,177 @@
+/**
+ * Per-operator overview reader + derivations for the admin Operator console
+ * drill-in (`/admin/operator/[customer]`) — design doc §5.1.
+ *
+ * The overview is the hub for one operator: identity, the persona roster (built
+ * for N, shows one at v1 per ADR 0011), the authority posture + per-domain
+ * switch summary, a health summary, and subscription state. Like the fleet
+ * roster it reads only console-side projections — `customer_configs` (via the
+ * frozen getCustomerConfig read path), the runtime-summary mirror, fleet_status,
+ * and subscriptions. Deep runtime detail (audit log, drafts, matters) is the
+ * §5.5 surface and uses the live per-customer read path; the overview never
+ * crosses the isolation boundary.
+ *
+ * This module owns the slug→entity_id resolution and the pure derivations the
+ * page renders. The config/summary/heartbeat/subscription readers are the
+ * frozen seam; the page composes them.
+ */
+
+import type { D1Database } from '@cloudflare/workers-types'
+import {
+  resolveAllDomains,
+  SMD_ONLY_AUTHORITY_DOMAINS,
+  type AuthorityPosture,
+  type AuthorityHolder,
+  type SwitchableAuthorityDomain,
+  type SmdOnlyAuthorityDomain,
+} from '../operator/authority'
+
+/**
+ * Resolve a customer slug to its entity_id via `customer_configs`. The
+ * `[customer]` route segment is the slug (human-stable, URL-safe); the frozen
+ * config/subscription readers key on entity_id. Returns null when no operator
+ * has that slug.
+ */
+export async function resolveEntityIdBySlug(db: D1Database, slug: string): Promise<string | null> {
+  const row = await db
+    .prepare('SELECT entity_id FROM customer_configs WHERE customer_slug = ?')
+    .bind(slug)
+    .first<{ entity_id: string }>()
+  return row?.entity_id ?? null
+}
+
+// ===========================================================================
+// Per-domain authority summary (foundations §4.2)
+// ===========================================================================
+
+/** Display labels for every authority domain (switchable + SMD-only). */
+export const AUTHORITY_DOMAIN_LABELS: Record<
+  SwitchableAuthorityDomain | SmdOnlyAuthorityDomain,
+  string
+> = {
+  configuration: 'Configuration authoring',
+  trust: 'Trust & governance',
+  connectors: 'Connectors & credentials',
+  runtime: 'Runtime operations',
+  memory: 'Memory & agent-skills',
+  people_access: 'People & access',
+  compliance: 'Compliance & audit',
+  observability: 'Observability & health',
+  provisioning: 'Provisioning & lifecycle',
+  cost: 'Cost & economics',
+}
+
+export interface DomainAuthorityRow {
+  domain: SwitchableAuthorityDomain
+  label: string
+  holder: AuthorityHolder
+  /** true → the client org also operates this domain (switch on). */
+  clientOperable: boolean
+}
+
+/**
+ * The per-domain switch summary the overview renders: one row per switchable
+ * domain with who operates it. SMD operates every domain regardless (Layer 0);
+ * `holder === 'client'` means the client org *also* has operable controls.
+ */
+export function domainAuthoritySummary(posture: AuthorityPosture | null): DomainAuthorityRow[] {
+  const resolved = resolveAllDomains(posture)
+  return (Object.keys(resolved) as SwitchableAuthorityDomain[]).map((domain) => ({
+    domain,
+    label: AUTHORITY_DOMAIN_LABELS[domain],
+    holder: resolved[domain],
+    clientOperable: resolved[domain] === 'client',
+  }))
+}
+
+/** The two SMD-only domains, labelled — shown as always SMD-operated. */
+export function smdOnlyDomains(): { domain: SmdOnlyAuthorityDomain; label: string }[] {
+  return SMD_ONLY_AUTHORITY_DOMAINS.map((domain) => ({
+    domain,
+    label: AUTHORITY_DOMAIN_LABELS[domain],
+  }))
+}
+
+export interface AuthorityHolderBadge {
+  label: string
+  classes: string
+}
+
+const HOLDER_BADGE_STRUCTURE =
+  'inline-flex items-center px-2 py-0.5 rounded-[var(--ss-radius-badge)] ' +
+  'text-[10px] font-medium uppercase tracking-wide whitespace-nowrap'
+
+/**
+ * Badge for who operates a domain. "SMD" (managed — the client sees Read +
+ * Request) vs "Client + SMD" (client switch on — additive, never instead of
+ * SMD). The wording never implies SMD lost control.
+ */
+export function authorityHolderBadge(holder: AuthorityHolder): AuthorityHolderBadge {
+  if (holder === 'client') {
+    return {
+      label: 'Client + SMD',
+      classes: `${HOLDER_BADGE_STRUCTURE} bg-[color:var(--ss-color-complete)] text-white`,
+    }
+  }
+  return {
+    label: 'SMD',
+    classes: `${HOLDER_BADGE_STRUCTURE} bg-[color:var(--ss-color-primary)] text-white`,
+  }
+}
+
+// ===========================================================================
+// Subscription state (single-item detail → prose, UI-PATTERNS Rule 1)
+// ===========================================================================
+
+export interface SubscriptionState {
+  label: string
+  /** Token-based text color so the prose carries the semantic, not a pill. */
+  colorClass: string
+}
+
+/**
+ * Map a subscription status to display prose for the detail header. Null when
+ * no Operator subscription exists yet (a real pre-activation state, not an
+ * error). Statuses match getProductSubscription: provisioning / active / paused.
+ */
+export function subscriptionState(status: string | null): SubscriptionState {
+  switch (status) {
+    case 'active':
+      return { label: 'Active', colorClass: 'text-[color:var(--ss-color-complete)]' }
+    case 'provisioning':
+      return { label: 'Provisioning', colorClass: 'text-[color:var(--ss-color-attention)]' }
+    case 'paused':
+      return { label: 'Paused', colorClass: 'text-[color:var(--ss-color-attention)]' }
+    case null:
+      return { label: 'No subscription yet', colorClass: 'text-[color:var(--ss-color-text-muted)]' }
+    default:
+      return { label: status, colorClass: 'text-[color:var(--ss-color-text-secondary)]' }
+  }
+}
+
+// ===========================================================================
+// Persona roster cell helpers
+// ===========================================================================
+
+export interface PersonaStatusDisplay {
+  label: string
+  dotClass: string
+}
+
+/** Dot + label for a persona's status (active / archived / other). */
+export function personaStatusDisplay(status: string): PersonaStatusDisplay {
+  switch (status) {
+    case 'active':
+      return { label: 'Active', dotClass: 'bg-[color:var(--ss-color-complete)]' }
+    case 'archived':
+      return { label: 'Archived', dotClass: 'bg-[color:var(--ss-color-border)]' }
+    default:
+      return { label: status, dotClass: 'bg-[color:var(--ss-color-attention)]' }
+  }
+}
+
+/** "3 skills" / "1 skill" / "no skills" for a persona card. */
+export function skillCountLabel(count: number): string {
+  if (count <= 0) return 'no skills'
+  return count === 1 ? '1 skill' : `${count} skills`
+}

--- a/src/pages/admin/operator/[customer]/index.astro
+++ b/src/pages/admin/operator/[customer]/index.astro
@@ -1,0 +1,294 @@
+---
+import AdminLayout from '../../../../layouts/AdminLayout.astro'
+import { posturePill, rosterHealth, rosterHealthDotClass } from '../../../../lib/admin/fleet-roster'
+import {
+  resolveEntityIdBySlug,
+  domainAuthoritySummary,
+  smdOnlyDomains,
+  authorityHolderBadge,
+  subscriptionState,
+  personaStatusDisplay,
+  skillCountLabel,
+} from '../../../../lib/admin/operator-overview'
+import { getRuntimeSummary } from '../../../../lib/admin/runtime-summary'
+import {
+  listFleetStatus,
+  heartbeatDisplay,
+  relativeTimestamp,
+} from '../../../../lib/admin/fleet-status'
+import { getCustomerConfig, type CustomerConfigRow } from '../../../../lib/portal/customer-config'
+import { getProductSubscription } from '../../../../lib/portal/product-access'
+import { env } from 'cloudflare:workers'
+
+/**
+ * Operator admin console — per-operator overview (the drill-in hub).
+ *
+ * The hub for one operator: identity, persona roster (built for N, shows one at
+ * v1), authority posture + per-domain switch summary, health summary, and
+ * subscription state. Reads only console-side projections — never a Machine's
+ * runtime D1 (ADR 0009). Deep runtime detail is the §5.5 surface.
+ *
+ * Design: docs/design/operator/01-admin-portal.md §5.1.
+ *
+ * Honest states (foundations §7): a missing operator is a real 404; a corrupt
+ * config projection renders an explicit error, not a fabricated page; a
+ * roster-of-one and a not-yet-activated subscription are real v1 states.
+ */
+
+const session = Astro.locals.session!
+if (session.role !== 'admin') {
+  return Astro.redirect('/auth/sign-in')
+}
+
+const slug = Astro.params.customer ?? ''
+
+const entityId = await resolveEntityIdBySlug(env.DB, slug)
+
+let config: CustomerConfigRow | null = null
+let configError: string | null = null
+if (entityId) {
+  try {
+    config = await getCustomerConfig(env.DB, entityId)
+  } catch (err) {
+    configError = err instanceof Error ? err.message : String(err)
+  }
+}
+
+// Not found: no operator with this slug. A real 404 (foundations §7), not a
+// fabricated empty operator.
+const notFound = entityId === null || (config === null && configError === null)
+if (notFound) {
+  Astro.response.status = 404
+}
+
+const summary = config ? await getRuntimeSummary(env.DB, slug) : null
+const fleetRows = config ? await listFleetStatus(env.DB) : []
+const fleet =
+  fleetRows.find((r) => r.entity_id === entityId) ?? fleetRows.find((r) => r.customer_slug === slug)
+const subscription =
+  config && entityId ? await getProductSubscription(env.DB, entityId, 'operator') : null
+
+const hb = heartbeatDisplay(fleet?.last_heartbeat_ts ?? null)
+const health = rosterHealth(hb.color, hb.label, summary?.summary_status ?? null)
+const posture = config ? posturePill(config.authority) : null
+const domainRows = config ? domainAuthoritySummary(config.authority) : []
+const smdOnly = smdOnlyDomains()
+const sub = subscriptionState(subscription?.status ?? null)
+const lastActivity = summary?.last_activity_ts ? relativeTimestamp(summary.last_activity_ts) : null
+
+const headerName = slug
+const personas = config?.personas ?? []
+---
+
+<AdminLayout
+  title={`Operator — ${headerName}`}
+  breadcrumbs={[
+    { label: 'Dashboard', href: '/admin' },
+    { label: 'Operator', href: '/admin/operator' },
+    { label: headerName },
+  ]}
+  maxWidth="max-w-6xl"
+>
+  <div class="space-y-card">
+    {
+      notFound ? (
+        <div class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card">
+          <h2 class="text-xl font-semibold text-[color:var(--ss-color-text-primary)]">
+            Operator not found
+          </h2>
+          <p class="text-sm text-[color:var(--ss-color-text-secondary)] mt-1">
+            No operator is provisioned under <code>{slug}</code>.{' '}
+            <a href="/admin/operator" class="text-[color:var(--ss-color-action)] hover:underline">
+              Back to the fleet
+            </a>
+            .
+          </p>
+        </div>
+      ) : configError ? (
+        <div class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-error)] p-card">
+          <h2 class="text-xl font-semibold text-[color:var(--ss-color-error)]">
+            Config projection malformed
+          </h2>
+          <p class="text-sm text-[color:var(--ss-color-text-secondary)] mt-1">
+            The <code>customer_configs</code> row for <code>{slug}</code> could not be parsed. This
+            is a projection corruption signal, not a routine state — the customer.yaml sync needs
+            attention.
+          </p>
+          <p class="text-xs text-[color:var(--ss-color-text-muted)] mt-2 font-mono">
+            {configError}
+          </p>
+        </div>
+      ) : (
+        config && (
+          <>
+            <header class="flex items-start justify-between gap-4">
+              <div>
+                <h2 class="text-xl font-semibold text-[color:var(--ss-color-text-primary)]">
+                  {headerName}
+                </h2>
+                <p class="text-sm text-[color:var(--ss-color-text-secondary)] mt-1">
+                  {config.vertical ? `${config.vertical} · ` : ''}
+                  <code>{config.entity_id}</code>
+                </p>
+                <p class="text-sm mt-1">
+                  <span class="text-[color:var(--ss-color-text-muted)]">Subscription:</span>{' '}
+                  <span class={sub.colorClass}>{sub.label}</span>
+                </p>
+              </div>
+              {posture && <span class={posture.classes}>{posture.label}</span>}
+            </header>
+
+            <div class="grid gap-card md:grid-cols-2">
+              {/* Health summary */}
+              <div class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card">
+                <h3 class="text-base font-semibold text-[color:var(--ss-color-text-primary)] mb-3">
+                  Health
+                </h3>
+                <div class="flex items-center gap-2 mb-2">
+                  <span
+                    class={`inline-block h-2.5 w-2.5 rounded-full ${rosterHealthDotClass(health.color)}`}
+                    aria-hidden="true"
+                  />
+                  <span class="text-sm text-[color:var(--ss-color-text-primary)]">
+                    Heartbeat {health.label}
+                  </span>
+                </div>
+                {health.note && (
+                  <p class="text-xs text-[color:var(--ss-color-text-muted)] mb-2">{health.note}</p>
+                )}
+                <dl class="text-sm space-y-1">
+                  <div class="flex justify-between gap-4">
+                    <dt class="text-[color:var(--ss-color-text-secondary)]">Open alerts</dt>
+                    <dd
+                      class={
+                        summary && summary.open_alerts > 0
+                          ? 'font-semibold text-[color:var(--ss-color-error)]'
+                          : 'text-[color:var(--ss-color-text-primary)]'
+                      }
+                    >
+                      {summary ? summary.open_alerts : '—'}
+                    </dd>
+                  </div>
+                  <div class="flex justify-between gap-4">
+                    <dt class="text-[color:var(--ss-color-text-secondary)]">Last activity</dt>
+                    <dd class="text-[color:var(--ss-color-text-primary)]">{lastActivity ?? '—'}</dd>
+                  </div>
+                  <div class="flex justify-between gap-4">
+                    <dt class="text-[color:var(--ss-color-text-secondary)]">Draft queue</dt>
+                    <dd class="text-[color:var(--ss-color-text-primary)]">
+                      {summary && summary.draft_queue_depth !== null
+                        ? summary.draft_queue_depth
+                        : '—'}
+                    </dd>
+                  </div>
+                </dl>
+                <p class="text-xs text-[color:var(--ss-color-text-muted)] mt-3">
+                  Health reads the per-customer summary mirror and heartbeat. A "—" draft queue
+                  means no skill is authored to draft, not zero pending.
+                </p>
+              </div>
+
+              {/* Persona roster (built for N, shows one at v1) */}
+              <div class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card">
+                <h3 class="text-base font-semibold text-[color:var(--ss-color-text-primary)] mb-3">
+                  Personas ({personas.length})
+                </h3>
+                {personas.length === 0 ? (
+                  <p class="text-sm text-[color:var(--ss-color-text-secondary)]">
+                    No personas configured.
+                  </p>
+                ) : (
+                  <ul class="space-y-3">
+                    {personas.map((p) => {
+                      const st = personaStatusDisplay(p.status)
+                      return (
+                        <li class="border-b border-[color:var(--ss-color-border-subtle)] pb-3 last:border-0 last:pb-0">
+                          <div class="flex items-center justify-between gap-2">
+                            <span class="font-medium text-[color:var(--ss-color-text-primary)]">
+                              {p.name}
+                            </span>
+                            <span class="inline-flex items-center gap-1.5 text-xs text-[color:var(--ss-color-text-secondary)]">
+                              <span
+                                class={`inline-block h-2 w-2 rounded-full ${st.dotClass}`}
+                                aria-hidden="true"
+                              />
+                              {st.label}
+                            </span>
+                          </div>
+                          <p class="text-xs text-[color:var(--ss-color-text-muted)]">
+                            {p.title ? `${p.title} · ` : ''}
+                            {skillCountLabel(p.skills.length)}
+                          </p>
+                        </li>
+                      )
+                    })}
+                  </ul>
+                )}
+              </div>
+            </div>
+
+            {/* Authority posture — per-domain switch summary */}
+            <div class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card">
+              <h3 class="text-base font-semibold text-[color:var(--ss-color-text-primary)] mb-1">
+                Authority posture
+              </h3>
+              <p class="text-xs text-[color:var(--ss-color-text-muted)] mb-3">
+                SMD operates every domain in every state. A "Client + SMD" badge means the client
+                org also holds operable controls for that domain (an additive switch), never instead
+                of SMD. Flip switches on the Authority surface.
+              </p>
+              <ul class="grid gap-2 sm:grid-cols-2 text-sm">
+                {domainRows.map((d) => {
+                  const badge = authorityHolderBadge(d.holder)
+                  return (
+                    <li class="flex items-center justify-between gap-2">
+                      <span class="text-[color:var(--ss-color-text-primary)]">{d.label}</span>
+                      <span class={badge.classes}>{badge.label}</span>
+                    </li>
+                  )
+                })}
+                {smdOnly.map((d) => (
+                  <li class="flex items-center justify-between gap-2">
+                    <span class="text-[color:var(--ss-color-text-secondary)]">{d.label}</span>
+                    <span class="text-[10px] uppercase tracking-wide text-[color:var(--ss-color-text-muted)]">
+                      SMD only
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+
+            {/* Drill-ins */}
+            <div class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card">
+              <h3 class="text-base font-semibold text-[color:var(--ss-color-text-primary)] mb-3">
+                Drill-ins
+              </h3>
+              <ul class="flex flex-wrap gap-x-6 gap-y-2 text-sm">
+                <li>
+                  <a
+                    href={`/admin/operator/costs/${encodeURIComponent(slug)}`}
+                    class="text-[color:var(--ss-color-action)] hover:underline"
+                  >
+                    Cost
+                  </a>
+                </li>
+                <li>
+                  <a
+                    href={`/admin/operator/config-history/${encodeURIComponent(slug)}`}
+                    class="text-[color:var(--ss-color-action)] hover:underline"
+                  >
+                    Config history
+                  </a>
+                </li>
+              </ul>
+              <p class="text-xs text-[color:var(--ss-color-text-muted)] mt-3">
+                Configuration, governance, connectors, runtime, memory, people, authority, and
+                lifecycle drill-ins land as their surfaces ship.
+              </p>
+            </div>
+          </>
+        )
+      )
+    }
+  </div>
+</AdminLayout>

--- a/src/pages/admin/operator/alerts.astro
+++ b/src/pages/admin/operator/alerts.astro
@@ -1,0 +1,315 @@
+---
+import AdminLayout from '../../../layouts/AdminLayout.astro'
+import { listOpenAlerts } from '../../../lib/admin/cost-anomaly'
+import { sourcePill } from '../../../lib/admin/fleet-status'
+import {
+  alertSeverity,
+  alertLink,
+  alertDetail,
+  alertAge,
+  severityBadge,
+  filterAlerts,
+  countBySeverity,
+  sortAlerts,
+  distinctCustomers,
+} from '../../../lib/admin/fleet-alerts'
+import { env } from 'cloudflare:workers'
+
+/**
+ * Operator admin console — fleet alerts (§4.2).
+ *
+ * The single feed of everything that needs SMD attention across every operator.
+ * Reads the shared multi-source alert store (cost_anomaly_alerts) via the frozen
+ * listOpenAlerts reader and generalizes the existing snooze/acknowledge flow to
+ * every source. Each alert deep-links to the relevant per-operator surface.
+ *
+ * Honest scope (foundations §7): the feed shows the sources that flow into the
+ * store today (cost anomalies, Sentry spikes, heartbeat grace, audit-integrity
+ * drift). Sticky-stop transitions, connector auth-expired, boot-check failures,
+ * and structural-config-deferred (design §4.2) light up here as their writer
+ * paths land — the footnote says so rather than fabricating rows.
+ */
+
+const session = Astro.locals.session!
+if (session.role !== 'admin') {
+  return Astro.redirect('/auth/sign-in')
+}
+
+const allOpen = await listOpenAlerts(env.DB)
+const customers = distinctCustomers(allOpen)
+
+const filters = {
+  source: Astro.url.searchParams.get('source'),
+  severity: Astro.url.searchParams.get('severity'),
+  customer: Astro.url.searchParams.get('customer'),
+}
+const filtered = sortAlerts(filterAlerts(allOpen, filters))
+const counts = countBySeverity(filtered)
+
+function formatCurrency(cents: number): string {
+  return (cents / 100).toLocaleString('en-US', { style: 'currency', currency: 'USD' })
+}
+
+const SOURCE_OPTIONS = [
+  { value: 'all', label: 'All sources' },
+  { value: 'cost', label: 'Cost' },
+  { value: 'sentry', label: 'Sentry' },
+  { value: 'healthchecks', label: 'Heartbeat' },
+  { value: 'audit_integrity', label: 'Audit integrity' },
+]
+const SEVERITY_OPTIONS = [
+  { value: 'all', label: 'All severities' },
+  { value: 'critical', label: 'Critical' },
+  { value: 'warning', label: 'Warning' },
+  { value: 'info', label: 'Info' },
+]
+
+const curSource = filters.source ?? 'all'
+const curSeverity = filters.severity ?? 'all'
+const curCustomer = filters.customer ?? 'all'
+---
+
+<AdminLayout
+  title="Operator — Alerts"
+  breadcrumbs={[
+    { label: 'Dashboard', href: '/admin' },
+    { label: 'Operator', href: '/admin/operator' },
+    { label: 'Alerts' },
+  ]}
+  maxWidth="max-w-6xl"
+>
+  <div class="space-y-card">
+    <header class="flex items-end justify-between gap-4">
+      <div>
+        <h2 class="text-xl font-semibold text-[color:var(--ss-color-text-primary)]">
+          Fleet alerts
+        </h2>
+        <p class="text-sm text-[color:var(--ss-color-text-secondary)] mt-1">
+          Everything that needs SMD attention across every operator. Each alert links to the
+          operator it concerns. Snooze or acknowledge to clear it from the feed.
+        </p>
+      </div>
+      <div class="text-right">
+        <p class="text-xs uppercase tracking-wide text-[color:var(--ss-color-text-muted)]">Open</p>
+        <p class="text-2xl font-bold text-[color:var(--ss-color-text-primary)]">{counts.total}</p>
+        {
+          counts.critical > 0 && (
+            <p class="text-xs text-[color:var(--ss-color-error)] font-semibold">
+              {counts.critical} critical
+            </p>
+          )
+        }
+      </div>
+    </header>
+
+    <form method="get" class="flex flex-wrap items-end gap-3">
+      <label class="text-xs text-[color:var(--ss-color-text-secondary)]">
+        <span class="block mb-1">Source</span>
+        <select
+          name="source"
+          class="rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-white px-2 py-1 text-sm"
+        >
+          {
+            SOURCE_OPTIONS.map((o) => (
+              <option value={o.value} selected={o.value === curSource}>
+                {o.label}
+              </option>
+            ))
+          }
+        </select>
+      </label>
+      <label class="text-xs text-[color:var(--ss-color-text-secondary)]">
+        <span class="block mb-1">Severity</span>
+        <select
+          name="severity"
+          class="rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-white px-2 py-1 text-sm"
+        >
+          {
+            SEVERITY_OPTIONS.map((o) => (
+              <option value={o.value} selected={o.value === curSeverity}>
+                {o.label}
+              </option>
+            ))
+          }
+        </select>
+      </label>
+      <label class="text-xs text-[color:var(--ss-color-text-secondary)]">
+        <span class="block mb-1">Customer</span>
+        <select
+          name="customer"
+          class="rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-white px-2 py-1 text-sm"
+        >
+          <option value="all" selected={curCustomer === 'all'}>All customers</option>
+          {
+            customers.map((c) => (
+              <option value={c} selected={c === curCustomer}>
+                {c}
+              </option>
+            ))
+          }
+        </select>
+      </label>
+      <button
+        type="submit"
+        class="rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-white px-3 py-1.5 text-sm text-[color:var(--ss-color-text-primary)] hover:border-[color:var(--ss-color-primary)]"
+      >
+        Apply
+      </button>
+    </form>
+
+    <div
+      class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card"
+      data-alerts-feed
+    >
+      {
+        allOpen.length === 0 ? (
+          <p class="text-sm text-[color:var(--ss-color-text-secondary)]">
+            No open alerts across the fleet. Nothing needs SMD attention right now.
+          </p>
+        ) : filtered.length === 0 ? (
+          <p class="text-sm text-[color:var(--ss-color-text-secondary)]">
+            No alerts match the current filters.{' '}
+            <a
+              href="/admin/operator/alerts"
+              class="text-[color:var(--ss-color-action)] hover:underline"
+            >
+              Clear filters
+            </a>
+            .
+          </p>
+        ) : (
+          <ul class="space-y-3 text-sm">
+            {filtered.map((row) => {
+              const sev = severityBadge(alertSeverity(row))
+              const pill = sourcePill(row.source)
+              return (
+                <li
+                  class="flex items-start justify-between gap-4 border-b border-[color:var(--ss-color-border-subtle)] pb-3 last:border-0 last:pb-0"
+                  data-alert-entity={row.entity_id}
+                  data-alert-date={row.alert_date}
+                  data-alert-driver={row.driver}
+                >
+                  <div class="flex-1 min-w-0">
+                    <div class="flex items-center gap-2 flex-wrap">
+                      <span class={sev.classes}>{sev.label}</span>
+                      <span
+                        class={`text-[10px] px-1.5 py-0.5 rounded font-medium uppercase tracking-wide ${pill.classes}`}
+                      >
+                        {pill.label}
+                      </span>
+                      <a
+                        href={alertLink(row)}
+                        class="font-medium text-[color:var(--ss-color-text-primary)] hover:text-[color:var(--ss-color-primary)]"
+                      >
+                        {row.customer_slug}
+                      </a>
+                      <span class="text-[color:var(--ss-color-text-muted)]">· {alertAge(row)}</span>
+                    </div>
+                    <p class="text-xs text-[color:var(--ss-color-text-secondary)] mt-0.5">
+                      {alertDetail(row, formatCurrency)}
+                    </p>
+                  </div>
+                  <div class="flex gap-2 shrink-0">
+                    <button
+                      type="button"
+                      data-alert-snooze
+                      class="text-xs text-[color:var(--ss-color-action)] hover:underline"
+                    >
+                      Snooze 7d
+                    </button>
+                    <button
+                      type="button"
+                      data-alert-ack
+                      class="text-xs text-[color:var(--ss-color-action)] hover:underline"
+                    >
+                      Acknowledge
+                    </button>
+                  </div>
+                </li>
+              )
+            })}
+          </ul>
+        )
+      }
+
+      <div
+        class="mt-4 pt-4 border-t border-[color:var(--ss-color-border-subtle)] text-xs text-[color:var(--ss-color-text-muted)]"
+      >
+        <p>
+          Wired sources: cost anomalies, Sentry spikes, heartbeat grace, audit-integrity drift.
+          Sticky-stop transitions, connector auth-expired, boot-check failures, and
+          structural-config-deferred surface here as their writer paths land.
+        </p>
+      </div>
+    </div>
+  </div>
+</AdminLayout>
+
+<script>
+  // Snooze/acknowledge reuse the cost-anomaly action API — it keys on
+  // (entity_id, alert_date, driver) and operates on any source row. Reload
+  // after a successful action so the feed reflects the cleared alert (no
+  // optimistic UI: a reload confirms the backend actually applied it).
+  function init() {
+    const feed = document.querySelector('[data-alerts-feed]')
+    if (!feed) return
+
+    function readIdentity(li: HTMLElement) {
+      return {
+        entity_id: li.dataset.alertEntity ?? '',
+        alert_date: li.dataset.alertDate ?? '',
+        driver: li.dataset.alertDriver ?? '',
+      }
+    }
+
+    function sevenDaysFromNowIso(): string {
+      const d = new Date(Date.now() + 7 * 86_400_000)
+      return d.toISOString().replace(/\.\d{3}Z$/, 'Z')
+    }
+
+    async function post(action: 'snooze' | 'acknowledge', body: Record<string, unknown>) {
+      const res = await fetch(`/api/admin/operator/costs/anomalies/${action}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+      if (!res.ok) {
+        const text = await res.text().catch(() => '')
+        alert(`Failed: ${res.status} ${text}`)
+        return false
+      }
+      return true
+    }
+
+    feed.querySelectorAll<HTMLButtonElement>('[data-alert-snooze]').forEach((btn) => {
+      btn.addEventListener('click', async () => {
+        const li = btn.closest<HTMLElement>('[data-alert-entity]')
+        if (!li) return
+        btn.disabled = true
+        const ok = await post('snooze', {
+          ...readIdentity(li),
+          snoozed_until: sevenDaysFromNowIso(),
+        })
+        if (ok) window.location.reload()
+        else btn.disabled = false
+      })
+    })
+
+    feed.querySelectorAll<HTMLButtonElement>('[data-alert-ack]').forEach((btn) => {
+      btn.addEventListener('click', async () => {
+        const li = btn.closest<HTMLElement>('[data-alert-entity]')
+        if (!li) return
+        btn.disabled = true
+        const ok = await post('acknowledge', readIdentity(li))
+        if (ok) window.location.reload()
+        else btn.disabled = false
+      })
+    })
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init)
+  } else {
+    init()
+  }
+</script>

--- a/src/pages/admin/operator/index.astro
+++ b/src/pages/admin/operator/index.astro
@@ -1,0 +1,257 @@
+---
+import AdminLayout from '../../../layouts/AdminLayout.astro'
+import { listFleetRoster, type RosterCustomer } from '../../../lib/admin/fleet-roster'
+import {
+  posturePill,
+  rosterHealth,
+  rosterHealthDotClass,
+  personaSummary,
+} from '../../../lib/admin/fleet-roster'
+import { listRuntimeSummary, type RuntimeSummaryRow } from '../../../lib/admin/runtime-summary'
+import {
+  listFleetStatus,
+  heartbeatDisplay,
+  relativeTimestamp,
+  type FleetStatusRow,
+} from '../../../lib/admin/fleet-status'
+import { env } from 'cloudflare:workers'
+
+/**
+ * Operator admin console — fleet home (the roster).
+ *
+ * The default landing for `/admin/operator`. One row per operator (per
+ * client), built for scanning a growing fleet: "is anything on fire across all
+ * my operators." Composes three console-side projections only — customer_configs
+ * (identity, personas, posture), operator_runtime_summary (health/alerts/last
+ * activity mirror, ADR 0043 B), and fleet_status (heartbeat). It never reads a
+ * Machine's runtime D1 directly and never joins two customers (ADR 0009).
+ *
+ * Design: docs/design/operator/01-admin-portal.md §4.1.
+ *
+ * Empty / honest states (foundations §7): a fleet of zero is a real state, not
+ * an error. Before any Machine pushes a summary, health falls back to the
+ * heartbeat alone and last-activity / alert columns read "—" rather than
+ * fabricating activity. A roster-of-one client with one persona is the normal
+ * v1 state, not a placeholder.
+ *
+ * Connector health (§5.4) and per-operator cost (§4.3 / §5.8) are deliberately
+ * not roster columns: connector liveness needs the per-operator runtime read,
+ * and cost is the SMD-only economics surface with its own page. Both are one
+ * click away from each row's overview.
+ */
+
+const session = Astro.locals.session!
+
+// /admin/* already requires the admin role at the middleware layer; re-check
+// here so a routing misconfig can't silently fall through (mirrors the costs
+// page). Today admin === Captain; the smd_admin/smd_operator seam (§2) layers
+// on later without reworking this gate.
+if (session.role !== 'admin') {
+  return Astro.redirect('/auth/sign-in')
+}
+
+const roster = await listFleetRoster(env.DB)
+const summaryRows = await listRuntimeSummary(env.DB)
+const fleetStatusRows = await listFleetStatus(env.DB)
+
+const summaryByEntity = new Map<string, RuntimeSummaryRow>(summaryRows.map((r) => [r.entity_id, r]))
+const summaryBySlug = new Map<string, RuntimeSummaryRow>(
+  summaryRows.map((r) => [r.customer_slug, r])
+)
+const fleetByEntity = new Map<string, FleetStatusRow>(fleetStatusRows.map((r) => [r.entity_id, r]))
+const fleetBySlug = new Map<string, FleetStatusRow>(
+  fleetStatusRows.map((r) => [r.customer_slug, r])
+)
+
+function summaryFor(c: RosterCustomer): RuntimeSummaryRow | undefined {
+  return summaryByEntity.get(c.entity_id) ?? summaryBySlug.get(c.customer_slug)
+}
+function fleetFor(c: RosterCustomer): FleetStatusRow | undefined {
+  return fleetByEntity.get(c.entity_id) ?? fleetBySlug.get(c.customer_slug)
+}
+
+interface RosterView {
+  customer: RosterCustomer
+  personaLine: string
+  personaNames: string
+  posture: ReturnType<typeof posturePill>
+  health: ReturnType<typeof rosterHealth>
+  openAlerts: number | null
+  lastActivity: string | null
+}
+
+const views: RosterView[] = roster.map((customer) => {
+  const summary = summaryFor(customer)
+  const fleet = fleetFor(customer)
+  const hb = heartbeatDisplay(fleet?.last_heartbeat_ts ?? null)
+  const health = rosterHealth(hb.color, hb.label, summary?.summary_status ?? null)
+  const names = customer.personas.map((p) => p.name).filter(Boolean)
+  return {
+    customer,
+    personaLine: personaSummary(customer.personas),
+    personaNames: names.join(', '),
+    posture: posturePill(customer.authority),
+    health,
+    openAlerts: summary ? summary.open_alerts : null,
+    lastActivity: summary?.last_activity_ts ? relativeTimestamp(summary.last_activity_ts) : null,
+  }
+})
+
+// Sort: rows needing attention first (config error, then red/yellow health,
+// then open alerts), then alphabetical by slug. Same "eye lands on trouble"
+// ordering as the costs page.
+const HEALTH_SORT: Record<string, number> = { red: 3, yellow: 2, gray: 1, green: 0 }
+views.sort((a, b) => {
+  const aErr = a.customer.config_error ? 1 : 0
+  const bErr = b.customer.config_error ? 1 : 0
+  if (aErr !== bErr) return bErr - aErr
+  const h = (HEALTH_SORT[b.health.color] ?? 0) - (HEALTH_SORT[a.health.color] ?? 0)
+  if (h !== 0) return h
+  const alerts = (b.openAlerts ?? 0) - (a.openAlerts ?? 0)
+  if (alerts !== 0) return alerts
+  return a.customer.customer_slug.localeCompare(b.customer.customer_slug)
+})
+
+const totalOperators = roster.length
+---
+
+<AdminLayout
+  title="Operator — Fleet"
+  breadcrumbs={[{ label: 'Dashboard', href: '/admin' }, { label: 'Operator' }]}
+  maxWidth="max-w-6xl"
+>
+  <div class="space-y-card">
+    <header class="flex items-end justify-between gap-4">
+      <div>
+        <h2 class="text-xl font-semibold text-[color:var(--ss-color-text-primary)]">
+          Operator fleet
+        </h2>
+        <p class="text-sm text-[color:var(--ss-color-text-secondary)] mt-1">
+          Every operator at a glance: persona roster, authority posture, health, and open alerts.
+          Health and activity read the per-customer summary mirror (ADR 0043); deep detail lives in
+          each operator's drill-in.
+        </p>
+      </div>
+      <div class="text-right">
+        <p class="text-xs uppercase tracking-wide text-[color:var(--ss-color-text-muted)]">
+          Operators
+        </p>
+        <p class="text-2xl font-bold text-[color:var(--ss-color-text-primary)]">
+          {totalOperators}
+        </p>
+      </div>
+    </header>
+
+    <div
+      class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card"
+    >
+      {
+        roster.length === 0 ? (
+          <p class="text-sm text-[color:var(--ss-color-text-secondary)]">
+            No operators provisioned yet. The fleet is empty until <code>customer_configs</code> has
+            at least one row.
+          </p>
+        ) : (
+          <div class="overflow-x-auto">
+            <table class="w-full text-sm">
+              <thead>
+                <tr class="text-left text-xs text-[color:var(--ss-color-text-secondary)] border-b border-[color:var(--ss-color-border)]">
+                  <th class="pb-2 font-medium">Operator</th>
+                  <th class="pb-2 font-medium">Personas</th>
+                  <th class="pb-2 font-medium">Posture</th>
+                  <th class="pb-2 font-medium">Health</th>
+                  <th class="pb-2 font-medium text-right">Open alerts</th>
+                  <th class="pb-2 font-medium text-right">Last activity</th>
+                </tr>
+              </thead>
+              <tbody class="divide-y divide-[color:var(--ss-color-border-subtle)]">
+                {views.map((v) => (
+                  <tr class="align-top">
+                    <td class="py-3 pr-4">
+                      <a
+                        href={`/admin/operator/${encodeURIComponent(v.customer.customer_slug)}`}
+                        class="font-medium text-[color:var(--ss-color-text-primary)] hover:text-[color:var(--ss-color-primary)]"
+                      >
+                        {v.customer.entity_name ?? v.customer.customer_slug}
+                      </a>
+                      <p class="text-xs text-[color:var(--ss-color-text-muted)]">
+                        {v.customer.customer_slug}
+                        {v.customer.vertical ? ` · ${v.customer.vertical}` : ''}
+                      </p>
+                      {v.customer.config_error && (
+                        <p class="text-xs text-[color:var(--ss-color-error)] mt-0.5">
+                          Config needs attention — projection malformed
+                        </p>
+                      )}
+                    </td>
+                    <td class="py-3 pr-4">
+                      <span class="text-[color:var(--ss-color-text-primary)]">{v.personaLine}</span>
+                      {v.personaNames && (
+                        <p class="text-xs text-[color:var(--ss-color-text-muted)]">
+                          {v.personaNames}
+                        </p>
+                      )}
+                    </td>
+                    <td class="py-3 pr-4">
+                      <span class={v.posture.classes}>{v.posture.label}</span>
+                    </td>
+                    <td class="py-3 pr-4">
+                      <span class="inline-flex items-center gap-2">
+                        <span
+                          class={`inline-block h-2 w-2 rounded-full ${rosterHealthDotClass(v.health.color)}`}
+                          aria-hidden="true"
+                        />
+                        <span class="text-[color:var(--ss-color-text-secondary)]">
+                          {v.health.label}
+                        </span>
+                      </span>
+                      {v.health.note && (
+                        <p class="text-xs text-[color:var(--ss-color-text-muted)] mt-0.5">
+                          {v.health.note}
+                        </p>
+                      )}
+                    </td>
+                    <td class="py-3 pr-4 text-right">
+                      {v.openAlerts === null ? (
+                        <span class="text-[color:var(--ss-color-text-muted)]">—</span>
+                      ) : v.openAlerts > 0 ? (
+                        <span class="font-semibold text-[color:var(--ss-color-error)]">
+                          {v.openAlerts}
+                        </span>
+                      ) : (
+                        <span class="text-[color:var(--ss-color-text-secondary)]">0</span>
+                      )}
+                    </td>
+                    <td class="py-3 text-right text-[color:var(--ss-color-text-secondary)]">
+                      {v.lastActivity ?? '—'}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )
+      }
+
+      <div
+        class="mt-4 pt-4 border-t border-[color:var(--ss-color-border-subtle)] space-y-2 text-xs text-[color:var(--ss-color-text-muted)]"
+      >
+        <p>
+          <strong>Health</strong> takes the more alarming of the per-customer heartbeat (<code
+            >fleet_status</code
+          >) and the summary rollup (<code>operator_runtime_summary</code>, which folds in
+          sticky-stop, escalation pressure, and connector health). A gray dot with "no signal yet"
+          means no heartbeat has arrived; it does not mean the operator is healthy.
+        </p>
+        <p>
+          <strong>Connector health</strong> and <strong>cost</strong> are per-operator surfaces: connector
+          liveness needs a live read against the operator's Machine, and cost is the SMD-only economics
+          view at <a
+            href="/admin/operator/costs"
+            class="text-[color:var(--ss-color-action)] hover:underline">Operator costs</a
+          >.
+        </p>
+      </div>
+    </div>
+  </div>
+</AdminLayout>

--- a/tests/fleet-alerts.test.ts
+++ b/tests/fleet-alerts.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Tests for the fleet alert-feed view-model (src/lib/admin/fleet-alerts.ts) —
+ * admin Operator console §4.2.
+ *
+ * All pure derivations over the shared cost_anomaly_alerts row shape: severity
+ * derivation per source, deep-link target, detail line, filtering, counts, and
+ * sort order. No DB — the reader (listOpenAlerts) is the frozen seam.
+ */
+
+import { describe, it, expect } from 'vitest'
+import type { CostAnomalyAlertRow } from '../src/lib/admin/cost-anomaly'
+import {
+  alertSeverity,
+  alertLink,
+  alertDetail,
+  severityBadge,
+  filterAlerts,
+  countBySeverity,
+  sortAlerts,
+  distinctCustomers,
+} from '../src/lib/admin/fleet-alerts'
+
+function row(overrides: Partial<CostAnomalyAlertRow> = {}): CostAnomalyAlertRow {
+  return {
+    entity_id: 'ent-1',
+    customer_slug: 'acme',
+    alert_date: '2026-06-08',
+    driver: '',
+    source: 'cost',
+    daily_cents: 5000,
+    rolling_avg_cents: 2000,
+    ratio_bps: 25000,
+    threshold_bps: 15000,
+    summary: null,
+    details_json: null,
+    detected_at: '2026-06-08T12:00:00Z',
+    snoozed_until: null,
+    acknowledged_at: null,
+    acknowledged_by: null,
+    ...overrides,
+  }
+}
+
+const usd = (cents: number) => `$${(cents / 100).toFixed(2)}`
+
+describe('alertSeverity', () => {
+  it('audit-integrity drift is always critical', () => {
+    expect(alertSeverity(row({ source: 'audit_integrity' }))).toBe('critical')
+  })
+
+  it('cost is critical only when over threshold, else warning', () => {
+    expect(alertSeverity(row({ source: 'cost', ratio_bps: 25000, threshold_bps: 15000 }))).toBe(
+      'critical'
+    )
+    expect(alertSeverity(row({ source: 'cost', ratio_bps: 10000, threshold_bps: 15000 }))).toBe(
+      'warning'
+    )
+  })
+
+  it('operational sources are warnings', () => {
+    expect(alertSeverity(row({ source: 'sentry' }))).toBe('warning')
+    expect(alertSeverity(row({ source: 'healthchecks' }))).toBe('warning')
+  })
+})
+
+describe('alertLink', () => {
+  it('cost alerts deep-link to the cost drill-in', () => {
+    expect(alertLink(row({ source: 'cost', customer_slug: 'acme' }))).toBe(
+      '/admin/operator/costs/acme'
+    )
+  })
+
+  it('non-cost alerts deep-link to the operator overview', () => {
+    expect(alertLink(row({ source: 'sentry', customer_slug: 'beta' }))).toBe('/admin/operator/beta')
+  })
+
+  it('encodes the slug', () => {
+    expect(alertLink(row({ source: 'sentry', customer_slug: 'a b' }))).toBe('/admin/operator/a%20b')
+  })
+})
+
+describe('alertDetail', () => {
+  it('renders the numeric breach for cost rows', () => {
+    const detail = alertDetail(row({ source: 'cost' }), usd)
+    expect(detail).toContain('$50.00')
+    expect(detail).toContain('$20.00')
+  })
+
+  it('uses the authored summary for non-cost rows and never fabricates', () => {
+    expect(alertDetail(row({ source: 'sentry', summary: '12 new errors' }), usd)).toBe(
+      '12 new errors'
+    )
+    expect(alertDetail(row({ source: 'sentry', summary: null }), usd)).toBe('(no detail recorded)')
+  })
+})
+
+describe('filterAlerts', () => {
+  const rows = [
+    row({ customer_slug: 'acme', source: 'cost', ratio_bps: 25000, threshold_bps: 15000 }),
+    row({ customer_slug: 'beta', source: 'sentry' }),
+    row({ customer_slug: 'acme', source: 'audit_integrity' }),
+  ]
+
+  it('empty / all filters match everything', () => {
+    expect(filterAlerts(rows, {})).toHaveLength(3)
+    expect(filterAlerts(rows, { source: 'all', severity: 'all', customer: 'all' })).toHaveLength(3)
+    expect(filterAlerts(rows, { source: '', customer: null })).toHaveLength(3)
+  })
+
+  it('filters by source, customer, and derived severity', () => {
+    expect(filterAlerts(rows, { source: 'cost' })).toHaveLength(1)
+    expect(filterAlerts(rows, { customer: 'acme' })).toHaveLength(2)
+    expect(filterAlerts(rows, { severity: 'critical' })).toHaveLength(2) // cost-over + audit
+    expect(filterAlerts(rows, { severity: 'warning' })).toHaveLength(1) // sentry
+  })
+
+  it('combines filters (AND)', () => {
+    expect(filterAlerts(rows, { customer: 'acme', severity: 'critical' })).toHaveLength(2)
+    expect(filterAlerts(rows, { customer: 'beta', severity: 'critical' })).toHaveLength(0)
+  })
+})
+
+describe('countBySeverity', () => {
+  it('counts derived severities', () => {
+    const rows = [
+      row({ source: 'audit_integrity' }),
+      row({ source: 'cost', ratio_bps: 25000, threshold_bps: 15000 }),
+      row({ source: 'sentry' }),
+    ]
+    expect(countBySeverity(rows)).toEqual({ critical: 2, warning: 1, info: 0, total: 3 })
+  })
+})
+
+describe('sortAlerts', () => {
+  it('orders most-severe first, then freshest', () => {
+    const warnOld = row({ source: 'sentry', detected_at: '2026-06-01T00:00:00Z' })
+    const critOld = row({ source: 'audit_integrity', detected_at: '2026-06-01T00:00:00Z' })
+    const critNew = row({ source: 'audit_integrity', detected_at: '2026-06-08T00:00:00Z' })
+    const sorted = sortAlerts([warnOld, critOld, critNew])
+    expect(sorted[0].detected_at).toBe('2026-06-08T00:00:00Z') // critical, newest
+    expect(sorted[1].source).toBe('audit_integrity') // critical, older
+    expect(sorted[2].source).toBe('sentry') // warning last
+  })
+
+  it('does not mutate the input', () => {
+    const input = [row({ source: 'sentry' }), row({ source: 'audit_integrity' })]
+    const before = input.map((r) => r.source)
+    sortAlerts(input)
+    expect(input.map((r) => r.source)).toEqual(before)
+  })
+})
+
+describe('distinctCustomers', () => {
+  it('returns sorted unique slugs', () => {
+    expect(
+      distinctCustomers([
+        row({ customer_slug: 'beta' }),
+        row({ customer_slug: 'acme' }),
+        row({ customer_slug: 'beta' }),
+      ])
+    ).toEqual(['acme', 'beta'])
+  })
+})
+
+describe('severityBadge', () => {
+  it('every severity carries a token-based class and a label', () => {
+    expect(severityBadge('critical').classes).toContain('--ss-color-error')
+    expect(severityBadge('warning').classes).toContain('--ss-color-attention')
+    expect(severityBadge('info').label).toBe('Info')
+  })
+})

--- a/tests/fleet-roster.test.ts
+++ b/tests/fleet-roster.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Tests for the fleet-roster reader + pure derivations
+ * (src/lib/admin/fleet-roster.ts) — admin Operator console §4.1.
+ *
+ * Two properties matter most and are exercised here:
+ *
+ *   1. Fleet-view resilience (ADR 0043, foundations §7): one corrupt
+ *      `customer_configs` row degrades to a flagged `config_error` row — it
+ *      never throws and blanks the whole fleet view.
+ *   2. Posture + health derivations never read calmer than reality: posture
+ *      labels follow the switch pattern (foundations §4.1) and `rosterHealth`
+ *      takes the more alarming of heartbeat vs summary rollup.
+ *
+ * DB-touching tests seed `customer_configs` + `entities` directly via the test
+ * D1 (same posture as customer-config.test.ts — CI sync lands separately).
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  createTestD1,
+  runMigrations,
+  discoverNumericMigrations,
+} from '@venturecrane/crane-test-harness'
+import { resolve } from 'path'
+import type { D1Database } from '@cloudflare/workers-types'
+import { ORG_ID } from '../src/lib/constants'
+import {
+  listFleetRoster,
+  derivePostureLabel,
+  posturePill,
+  rosterHealth,
+  rosterHealthDotClass,
+  personaSummary,
+  type RosterPersona,
+} from '../src/lib/admin/fleet-roster'
+import { DEFAULT_AUTHORITY_POSTURE, type AuthorityPosture } from '../src/lib/operator/authority'
+
+const migrationsDir = resolve(process.cwd(), 'migrations')
+
+async function freshDb(): Promise<D1Database> {
+  const db = createTestD1()
+  await runMigrations(db, { files: discoverNumericMigrations(migrationsDir) })
+  return db
+}
+
+async function seedEntity(db: D1Database, id: string, name: string, slug: string): Promise<void> {
+  await db
+    .prepare('INSERT INTO entities (id, org_id, name, slug) VALUES (?, ?, ?, ?)')
+    .bind(id, ORG_ID, name, slug)
+    .run()
+}
+
+function persona(overrides: Partial<RosterPersona> = {}): RosterPersona {
+  return { slug: 'marcus', name: 'Marcus', status: 'active', ...overrides }
+}
+
+interface SeedConfig {
+  entity_id: string
+  customer_slug: string
+  personas_json?: string
+  authority_json?: string | null
+  vertical?: string | null
+}
+
+async function seedConfig(db: D1Database, c: SeedConfig): Promise<void> {
+  await db
+    .prepare(
+      `INSERT INTO customer_configs
+        (entity_id, org_id, customer_slug, schema_version, personas_json,
+         authority_json, vertical, git_sha, synced_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    )
+    .bind(
+      c.entity_id,
+      ORG_ID,
+      c.customer_slug,
+      '1.0.0',
+      c.personas_json ?? JSON.stringify([persona()]),
+      c.authority_json === undefined ? null : c.authority_json,
+      c.vertical ?? null,
+      'a1b2c3d4',
+      '2026-06-08T12:00:00Z'
+    )
+    .run()
+}
+
+describe('listFleetRoster', () => {
+  let db: D1Database
+  beforeEach(async () => {
+    db = await freshDb()
+  })
+
+  it('returns [] for an empty fleet', async () => {
+    expect(await listFleetRoster(db)).toEqual([])
+  })
+
+  it('lists customers ordered by slug with entity name joined and personas parsed', async () => {
+    await seedEntity(db, 'ent-b', 'Beta Firm', 'beta-firm')
+    await seedEntity(db, 'ent-a', 'Alpha Firm', 'alpha-firm')
+    await seedConfig(db, { entity_id: 'ent-b', customer_slug: 'beta-firm', vertical: 'law' })
+    await seedConfig(db, {
+      entity_id: 'ent-a',
+      customer_slug: 'alpha-firm',
+      personas_json: JSON.stringify([persona(), persona({ slug: 'nova', name: 'Nova' })]),
+    })
+
+    const roster = await listFleetRoster(db)
+    expect(roster.map((r) => r.customer_slug)).toEqual(['alpha-firm', 'beta-firm'])
+
+    const alpha = roster[0]
+    expect(alpha.entity_name).toBe('Alpha Firm')
+    expect(alpha.personas).toHaveLength(2)
+    expect(alpha.personas[1]).toEqual({ slug: 'nova', name: 'Nova', status: 'active' })
+    expect(alpha.config_error).toBeNull()
+
+    const beta = roster[1]
+    expect(beta.vertical).toBe('law')
+    expect(beta.authority).toEqual(DEFAULT_AUTHORITY_POSTURE)
+  })
+
+  it('resolves an authored authority posture from authority_json', async () => {
+    await seedEntity(db, 'ent-1', 'Gamma Firm', 'gamma-firm')
+    await seedConfig(db, {
+      entity_id: 'ent-1',
+      customer_slug: 'gamma-firm',
+      authority_json: JSON.stringify({
+        default: 'managed',
+        overrides: { people_access: 'client' },
+      }),
+    })
+    const [row] = await listFleetRoster(db)
+    expect(row.authority.overrides.people_access).toBe('client')
+  })
+
+  it('degrades a malformed personas_json row to a flagged config_error, never throwing', async () => {
+    await seedEntity(db, 'ent-ok', 'OK Firm', 'ok-firm')
+    await seedEntity(db, 'ent-bad', 'Bad Firm', 'bad-firm')
+    await seedConfig(db, { entity_id: 'ent-ok', customer_slug: 'ok-firm' })
+    await seedConfig(db, {
+      entity_id: 'ent-bad',
+      customer_slug: 'bad-firm',
+      personas_json: '{not valid json',
+    })
+
+    const roster = await listFleetRoster(db)
+    expect(roster).toHaveLength(2)
+    const bad = roster.find((r) => r.customer_slug === 'bad-firm')!
+    expect(bad.config_error).not.toBeNull()
+    expect(bad.personas).toEqual([])
+    expect(bad.authority).toEqual(DEFAULT_AUTHORITY_POSTURE)
+    // The healthy row is unaffected.
+    const ok = roster.find((r) => r.customer_slug === 'ok-firm')!
+    expect(ok.config_error).toBeNull()
+    expect(ok.personas).toHaveLength(1)
+  })
+
+  it('flags a personas_json that is valid JSON but not an array', async () => {
+    await seedEntity(db, 'ent-x', 'X Firm', 'x-firm')
+    await seedConfig(db, {
+      entity_id: 'ent-x',
+      customer_slug: 'x-firm',
+      personas_json: JSON.stringify({ slug: 'oops' }),
+    })
+    const [row] = await listFleetRoster(db)
+    expect(row.config_error).toMatch(/not an array/)
+  })
+})
+
+describe('derivePostureLabel', () => {
+  it('null / launch-default posture is Managed (every client switch off)', () => {
+    expect(derivePostureLabel(null)).toBe('Managed')
+    expect(derivePostureLabel(DEFAULT_AUTHORITY_POSTURE)).toBe('Managed')
+  })
+
+  it('a self_managed default with no overrides is Self-Managed', () => {
+    const posture: AuthorityPosture = { default: 'self_managed', overrides: {} }
+    expect(derivePostureLabel(posture)).toBe('Self-Managed')
+  })
+
+  it('a managed default with at least one client override is Co-Managed', () => {
+    const posture: AuthorityPosture = { default: 'managed', overrides: { connectors: 'client' } }
+    expect(derivePostureLabel(posture)).toBe('Co-Managed')
+  })
+
+  it('a self_managed default with one domain pinned back to managed is Co-Managed', () => {
+    const posture: AuthorityPosture = { default: 'self_managed', overrides: { trust: 'managed' } }
+    expect(derivePostureLabel(posture)).toBe('Co-Managed')
+  })
+})
+
+describe('posturePill', () => {
+  it('carries the label and a non-empty class string', () => {
+    const pill = posturePill(DEFAULT_AUTHORITY_POSTURE)
+    expect(pill.label).toBe('Managed')
+    expect(pill.classes).toContain('rounded-[var(--ss-radius-badge)]')
+  })
+})
+
+describe('rosterHealth', () => {
+  it('takes the more alarming of heartbeat vs summary rollup', () => {
+    // Heartbeat green but summary red → red.
+    expect(rosterHealth('green', '20s ago', 'red').color).toBe('red')
+    // Heartbeat red but summary green → red (heartbeat is worse).
+    expect(rosterHealth('red', 'stale 9m', 'green').color).toBe('red')
+    // Both benign → green.
+    expect(rosterHealth('green', '5s ago', 'green').color).toBe('green')
+  })
+
+  it('keeps the heartbeat label and adds a note only for non-green summaries', () => {
+    expect(rosterHealth('green', '20s ago', null).note).toBeNull()
+    expect(rosterHealth('green', '20s ago', 'red').note).toMatch(/problem/)
+    expect(rosterHealth('green', '20s ago', 'yellow').note).toMatch(/warning/)
+    expect(rosterHealth('green', '20s ago', 'yellow').label).toBe('20s ago')
+  })
+
+  it('a missing summary (null) leaves the heartbeat color unchanged', () => {
+    expect(rosterHealth('yellow', '3m ago', null).color).toBe('yellow')
+    expect(rosterHealth('gray', 'no signal yet', null).color).toBe('gray')
+  })
+})
+
+describe('rosterHealthDotClass', () => {
+  it('maps every color to a token-based background class', () => {
+    expect(rosterHealthDotClass('green')).toContain('--ss-color-complete')
+    expect(rosterHealthDotClass('yellow')).toContain('--ss-color-attention')
+    expect(rosterHealthDotClass('red')).toContain('--ss-color-error')
+    expect(rosterHealthDotClass('gray')).toContain('--ss-color-border')
+  })
+})
+
+describe('personaSummary', () => {
+  it('renders count with archived suffix and an honest zero state', () => {
+    expect(personaSummary([])).toBe('no personas')
+    expect(personaSummary([persona()])).toBe('1 persona')
+    expect(personaSummary([persona(), persona({ slug: 'n', name: 'N' })])).toBe('2 personas')
+    expect(personaSummary([persona(), persona({ slug: 'a', status: 'archived' })])).toBe(
+      '2 personas (1 archived)'
+    )
+  })
+})

--- a/tests/operator-overview.test.ts
+++ b/tests/operator-overview.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Tests for the per-operator overview reader + derivations
+ * (src/lib/admin/operator-overview.ts) — admin Operator console §5.1.
+ *
+ * Covers the slug→entity_id resolution against a seeded customer_configs row,
+ * and the pure derivations the overview renders: the per-domain authority
+ * summary (every switchable domain + holder), the holder badge wording (never
+ * implying SMD lost control), subscription-state prose, and persona cell
+ * helpers.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  createTestD1,
+  runMigrations,
+  discoverNumericMigrations,
+} from '@venturecrane/crane-test-harness'
+import { resolve } from 'path'
+import type { D1Database } from '@cloudflare/workers-types'
+import { ORG_ID } from '../src/lib/constants'
+import {
+  resolveEntityIdBySlug,
+  domainAuthoritySummary,
+  smdOnlyDomains,
+  authorityHolderBadge,
+  subscriptionState,
+  personaStatusDisplay,
+  skillCountLabel,
+  AUTHORITY_DOMAIN_LABELS,
+} from '../src/lib/admin/operator-overview'
+import {
+  DEFAULT_AUTHORITY_POSTURE,
+  SWITCHABLE_AUTHORITY_DOMAINS,
+  type AuthorityPosture,
+} from '../src/lib/operator/authority'
+
+const migrationsDir = resolve(process.cwd(), 'migrations')
+
+async function freshDb(): Promise<D1Database> {
+  const db = createTestD1()
+  await runMigrations(db, { files: discoverNumericMigrations(migrationsDir) })
+  return db
+}
+
+describe('resolveEntityIdBySlug', () => {
+  let db: D1Database
+  beforeEach(async () => {
+    db = await freshDb()
+  })
+
+  it('returns the entity_id for a known slug and null otherwise', async () => {
+    await db
+      .prepare('INSERT INTO entities (id, org_id, name, slug) VALUES (?, ?, ?, ?)')
+      .bind('ent-1', ORG_ID, 'Acme Law', 'acme-law')
+      .run()
+    await db
+      .prepare(
+        `INSERT INTO customer_configs
+          (entity_id, org_id, customer_slug, schema_version, personas_json, git_sha, synced_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`
+      )
+      .bind('ent-1', ORG_ID, 'acme-law', '1.0.0', '[]', 'sha', '2026-06-08T00:00:00Z')
+      .run()
+
+    expect(await resolveEntityIdBySlug(db, 'acme-law')).toBe('ent-1')
+    expect(await resolveEntityIdBySlug(db, 'nope')).toBeNull()
+  })
+})
+
+describe('domainAuthoritySummary', () => {
+  it('covers every switchable domain with a label', () => {
+    const rows = domainAuthoritySummary(DEFAULT_AUTHORITY_POSTURE)
+    expect(rows).toHaveLength(SWITCHABLE_AUTHORITY_DOMAINS.length)
+    for (const row of rows) {
+      expect(row.label).toBe(AUTHORITY_DOMAIN_LABELS[row.domain])
+      expect(typeof row.label).toBe('string')
+    }
+  })
+
+  it('launch-default posture marks every domain SMD-operated (not client-operable)', () => {
+    const rows = domainAuthoritySummary(DEFAULT_AUTHORITY_POSTURE)
+    expect(rows.every((r) => r.holder === 'managed')).toBe(true)
+    expect(rows.every((r) => r.clientOperable === false)).toBe(true)
+  })
+
+  it('reflects an authored client override as client-operable', () => {
+    const posture: AuthorityPosture = {
+      default: 'managed',
+      overrides: { people_access: 'client' },
+    }
+    const rows = domainAuthoritySummary(posture)
+    const people = rows.find((r) => r.domain === 'people_access')!
+    expect(people.holder).toBe('client')
+    expect(people.clientOperable).toBe(true)
+    // Other domains stay SMD-operated.
+    expect(rows.filter((r) => r.clientOperable)).toHaveLength(1)
+  })
+
+  it('a null posture resolves to the launch default', () => {
+    const rows = domainAuthoritySummary(null)
+    expect(rows.every((r) => r.holder === 'managed')).toBe(true)
+  })
+})
+
+describe('smdOnlyDomains', () => {
+  it('lists provisioning and cost with labels', () => {
+    const rows = smdOnlyDomains()
+    expect(rows.map((r) => r.domain).sort()).toEqual(['cost', 'provisioning'])
+    expect(rows.every((r) => r.label.length > 0)).toBe(true)
+  })
+})
+
+describe('authorityHolderBadge', () => {
+  it('client holder reads as additive ("Client + SMD"), never replacing SMD', () => {
+    const badge = authorityHolderBadge('client')
+    expect(badge.label).toBe('Client + SMD')
+    expect(badge.classes).toContain('rounded-[var(--ss-radius-badge)]')
+  })
+
+  it('managed holder reads as SMD', () => {
+    expect(authorityHolderBadge('managed').label).toBe('SMD')
+  })
+})
+
+describe('subscriptionState', () => {
+  it('maps known statuses and treats null as a real pre-activation state', () => {
+    expect(subscriptionState('active').label).toBe('Active')
+    expect(subscriptionState('provisioning').label).toBe('Provisioning')
+    expect(subscriptionState('paused').label).toBe('Paused')
+    expect(subscriptionState(null).label).toBe('No subscription yet')
+    expect(subscriptionState('weird').label).toBe('weird')
+  })
+
+  it('every state carries a token-based color class', () => {
+    for (const s of ['active', 'provisioning', 'paused', null, 'weird'] as const) {
+      expect(subscriptionState(s).colorClass).toContain('var(--ss-color-')
+    }
+  })
+})
+
+describe('persona cell helpers', () => {
+  it('personaStatusDisplay maps status to label + dot', () => {
+    expect(personaStatusDisplay('active').label).toBe('Active')
+    expect(personaStatusDisplay('archived').label).toBe('Archived')
+    expect(personaStatusDisplay('draft').label).toBe('draft')
+    expect(personaStatusDisplay('active').dotClass).toContain('--ss-color-complete')
+  })
+
+  it('skillCountLabel pluralizes and has an honest zero state', () => {
+    expect(skillCountLabel(0)).toBe('no skills')
+    expect(skillCountLabel(1)).toBe('1 skill')
+    expect(skillCountLabel(4)).toBe('4 skills')
+  })
+})


### PR DESCRIPTION
PR 3 of the SMD-side Operator Admin Console — fleet alert feed at /admin/operator/alerts. Supersedes #1252 (auto-closed when its stacked base branch was deleted during the bottom-up merge; recreated against main). Content unchanged and CI-green.

See #1252 for the full description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)