### PR TITLE
feat(operator): Connections + credential custody self-service (client portal PR4)

### DIFF
--- a/src/components/portal/operator/ConnectionRowCard.astro
+++ b/src/components/portal/operator/ConnectionRowCard.astro
@@ -1,0 +1,117 @@
+---
+/**
+ * One connector row on the Connections surface (client-portal §5.8). Renders in
+ * two modes from a single markup so both DomainSurface slots stay consistent:
+ *
+ *   - operable=false (Read + Request): status, health, and resolved custody.
+ *   - operable=true  (connections switch on, principal): adds the operable
+ *     controls — OAuth re-authorize and the write-only static-secret field.
+ *
+ * The write-only field is the highest-care element on the client side. It is a
+ * plain 0-JS form posting to the connector secret endpoint, which 303-redirects
+ * back; the raw value lives only in the POST body (never a URL, never logged,
+ * never stored in the console DB). `autocomplete="off"` keeps the browser from
+ * caching it. The custody note states honestly whether SMD can rotate it.
+ */
+
+import { formatConnectorHealth } from '../../../lib/portal/operator/settings'
+import {
+  formatCustody,
+  describeCustody,
+  type ConnectionRow,
+} from '../../../lib/portal/operator/connections'
+
+interface Props {
+  row: ConnectionRow
+  operable: boolean
+  returnTo: string
+}
+
+const { row, operable, returnTo } = Astro.props
+const connectorId = row.adapter || row.capabilityName
+const secretAction = `/api/portal/products/operator/connectors/${encodeURIComponent(connectorId)}/secret`
+const fieldId = `secret-${connectorId}`
+
+const btn =
+  "inline-flex items-center min-h-11 px-4 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2"
+---
+
+<li class="border-b-[2px] border-[color:var(--ss-color-text-primary)] last:border-b-0">
+  <div class="flex flex-col gap-2 px-5 md:px-7 py-5">
+    <div class="flex items-baseline justify-between gap-4 flex-wrap">
+      <p
+        class="font-['Archivo'] text-base md:text-lg font-black uppercase tracking-[-0.01em] text-[color:var(--ss-color-text-primary)] m-0"
+      >
+        {row.capabilityName}
+      </p>
+      <span
+        class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold text-[color:var(--ss-color-text-secondary)]"
+      >
+        {formatCustody(row.custody)}
+      </span>
+    </div>
+    <p class="text-caption text-[color:var(--ss-color-text-secondary)] m-0">
+      {row.adapter ? `${row.adapter} · ` : ''}{formatConnectorHealth(row.health)}
+    </p>
+    <p class="text-sm text-[color:var(--ss-color-text-secondary)] m-0">
+      {describeCustody(row.custody)}
+    </p>
+
+    {
+      operable && (
+        <div class="mt-2 flex flex-col gap-3">
+          <form
+            method="POST"
+            action="/api/portal/operator/settings/connector-reconsent"
+            class="m-0"
+          >
+            <input type="hidden" name="capabilityName" value={row.capabilityName} />
+            <button
+              type="submit"
+              class={`${btn} text-[color:var(--ss-color-text-primary)] border-[2px] border-[color:var(--ss-color-text-primary)] hover:bg-[color:var(--ss-color-text-primary)] hover:text-[color:var(--ss-color-background)]`}
+            >
+              Re-authorize (OAuth)
+            </button>
+          </form>
+
+          <details class="border-t-[2px] border-[color:var(--ss-color-border)]">
+            <summary class="cursor-pointer list-none py-2 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold text-[color:var(--ss-color-primary)] hover:text-[color:var(--ss-color-primary-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-inset">
+              Enter or update an API key
+            </summary>
+            <form method="POST" action={secretAction} class="flex flex-col gap-3 pt-2">
+              <input type="hidden" name="return_to" value={returnTo} />
+              <label
+                for={fieldId}
+                class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold text-[color:var(--ss-color-text-secondary)]"
+              >
+                API key for {row.capabilityName}
+              </label>
+              <input
+                id={fieldId}
+                type="password"
+                name="secret"
+                required
+                autocomplete="off"
+                spellcheck={false}
+                class="w-full border-[2px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)] px-3 py-2 text-sm text-[color:var(--ss-color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-inset"
+              />
+              <p class="text-sm text-[color:var(--ss-color-text-secondary)] m-0">
+                {row.smdReachable
+                  ? 'Stored so SMD can rotate it for you when needed.'
+                  : 'Stored write-only. Only your Operator can use it; SMD cannot read it back.'}
+              </p>
+              <div>
+                <button
+                  type="submit"
+                  class={`${btn} text-[color:var(--ss-color-background)] bg-[color:var(--ss-color-text-primary)] hover:bg-[color:var(--ss-color-primary)]`}
+                >
+                  Save key
+                </button>
+              </div>
+            </form>
+          </details>
+        </div>
+      )
+    }
+  </div>
+</li>

--- a/src/lib/portal/operator/connections.ts
+++ b/src/lib/portal/operator/connections.ts
@@ -1,0 +1,66 @@
+/**
+ * Connections surface model (client-portal §5.8). Joins the connector status
+ * rows (settings.ts) with each connector's resolved credential custody
+ * (ADR 0042) so the /connections surface can show, per connector: status,
+ * health, and whether SMD can reach the secret.
+ *
+ * Pure — no I/O. Reuses connectorRowsFromCustomerYaml for the base rows
+ * (capability, adapter, health) and layers custody on top by re-reading the
+ * per-connector `credential_custody` from the same projected YAML, resolved
+ * against the client-level default.
+ */
+
+import { connectorRowsFromCustomerYaml, type ConnectorStatusRow } from './settings'
+import {
+  resolveCredentialCustody,
+  smdCanReachSecret,
+  parseCredentialCustody,
+  type CredentialCustody,
+} from '../../operator/credential-custody'
+
+export interface ConnectionRow extends ConnectorStatusRow {
+  /** Resolved custody: per-connector value → client default → delegated. */
+  custody: CredentialCustody
+  /** True when SMD staff may reach/rotate the secret (delegated only). */
+  smdReachable: boolean
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v)
+}
+
+/**
+ * Build the connections rows for a customer: the connector status rows plus
+ * each connector's resolved custody. `connectorsYaml` is the projected
+ * `connectors` map (Partial<Record<CapabilityName, Connector>>); the per-row
+ * custody is read back from it by capability key.
+ */
+export function buildConnectionRows(
+  connectorsYaml: unknown,
+  clientDefault: CredentialCustody
+): ConnectionRow[] {
+  const base = connectorRowsFromCustomerYaml(connectorsYaml)
+  return base.map((row) => {
+    const entry = isRecord(connectorsYaml) ? connectorsYaml[row.capabilityName] : undefined
+    const perConnector = isRecord(entry)
+      ? parseCredentialCustody(entry['credential_custody'])
+      : null
+    const custody = resolveCredentialCustody(perConnector, clientDefault)
+    return { ...row, custody, smdReachable: smdCanReachSecret(custody) }
+  })
+}
+
+/** Client-facing label for a custody mode. */
+export function formatCustody(custody: CredentialCustody): string {
+  return custody === 'self_held' ? 'Self-held' : 'Delegated to SMD'
+}
+
+/**
+ * One-line explanation of what a custody mode means for help/recovery, shown at
+ * the connector. Honest about the trade (ADR 0042 §boundaries).
+ */
+export function describeCustody(custody: CredentialCustody): string {
+  return custody === 'self_held'
+    ? 'Only you can re-establish this connection. SMD cannot read or rotate the secret.'
+    : 'SMD monitors this connection and can re-establish it for you.'
+}

--- a/src/pages/api/portal/products/operator/connectors/[connector]/secret.ts
+++ b/src/pages/api/portal/products/operator/connectors/[connector]/secret.ts
@@ -9,6 +9,7 @@ import {
   createSecretWriter,
   isSecretTransportConfigured,
 } from '../../../../../../../lib/operator/credential-secret-transport'
+import { safeReturnTo } from '../../../../../../../lib/portal/operator/return-to'
 
 /**
  * POST /api/portal/products/operator/connectors/{connector}/secret
@@ -16,9 +17,15 @@ import {
  * Write-only static-secret entry (ADR 0042). A client (principal) enters a raw
  * API key for a connector; the value relays straight into the per-customer
  * isolated vault and NEVER touches the console DB, a log, or this transcript.
- * Only a masked confirmation is returned. The no-leak orchestration lives in
- * `handleSecretWrite`; the vault transport + audit are wired in
- * credential-secret-transport.ts.
+ * The no-leak orchestration lives in `handleSecretWrite`; the vault transport +
+ * audit are wired in credential-secret-transport.ts.
+ *
+ * Submission model: a plain 0-JS HTML form (the portal ships no client JS). The
+ * endpoint 303-redirects back to the form's `return_to` with a `?cs=` status
+ * the surface reads to show a banner. The raw value lives ONLY in the POST body
+ * — it is never placed in a URL, never reflected in the response, never logged.
+ * (This replaced the prior JSON response, which a plain form cannot consume; no
+ * other caller depended on it.)
  *
  * Gates (all server-side, never client-only hiding):
  *   - principal role (ADR 0011) — the agent can never reach this surface.
@@ -29,42 +36,41 @@ import {
  *   - the vault transport must be configured (ADR 0036 relay): until wired,
  *     returns an honest `not_enabled` rather than half-storing the value.
  *
- * Body: form field `secret` (the raw value). Never logged.
- * Returns JSON: { ok: true, masked, ref } | { ok: false, error }.
+ * Body: form fields `secret` (the raw value, never logged) + `return_to`.
  */
 
-function json(status: number, body: Record<string, unknown>): Response {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: { 'Content-Type': 'application/json' },
-  })
+function back(returnTo: string, cs: string): Response {
+  const sep = returnTo.includes('?') ? '&' : '?'
+  return new Response(null, { status: 303, headers: { Location: `${returnTo}${sep}cs=${cs}` } })
 }
 
 export const POST: APIRoute = async ({ locals, params, request }) => {
   const access = await resolveOperatorAccess(env.DB, locals, { allowedRoles: ['principal'] })
   if (access.kind === 'redirect') {
-    return json(403, { ok: false, error: 'forbidden' })
+    return new Response(null, { status: 303, headers: { Location: access.to } })
   }
+
+  const form = await request.formData()
+  const returnTo = safeReturnTo(form.get('return_to'))
 
   const connector = params.connector
   if (typeof connector !== 'string' || connector.length === 0) {
-    return json(400, { ok: false, error: 'invalid_connector' })
+    return back(returnTo, 'invalid_connector')
   }
 
   const config = await getCustomerConfig(env.DB, access.client.id)
   if (!isClientOperable(config?.authority ?? null, 'connectors')) {
     // ADR 0041 Verification 5 — reject server-side, not merely hide.
-    return json(403, { ok: false, error: 'not_permitted' })
+    return back(returnTo, 'not_permitted')
   }
 
   if (!isSecretTransportConfigured(env)) {
-    return json(503, { ok: false, error: 'not_enabled' })
+    return back(returnTo, 'not_enabled')
   }
 
-  const form = await request.formData()
   const secret = form.get('secret')
-  if (typeof secret !== 'string') {
-    return json(400, { ok: false, error: 'empty_secret' })
+  if (typeof secret !== 'string' || secret.length === 0) {
+    return back(returnTo, 'empty_secret')
   }
 
   const result = await handleSecretWrite(
@@ -77,8 +83,8 @@ export const POST: APIRoute = async ({ locals, params, request }) => {
   )
 
   if (!result.ok) {
-    const status = result.error === 'write_failed' ? 502 : 400
-    return json(status, { ok: false, error: result.error })
+    return back(returnTo, result.error === 'write_failed' ? 'write_failed' : 'invalid')
   }
-  return json(200, { ok: true, masked: result.masked, ref: result.ref })
+  // Success carries no value and no ref — only that the write landed.
+  return back(returnTo, 'saved')
 }

--- a/src/pages/portal/products/operator/connections/index.astro
+++ b/src/pages/portal/products/operator/connections/index.astro
@@ -1,0 +1,180 @@
+---
+import '../../../../../styles/global.css'
+import { BRAND_NAME } from '../../../../../lib/config/brand'
+import { resolveOperatorAccess } from '../../../../../lib/portal/operator-access'
+import { getCustomerConfig } from '../../../../../lib/portal/customer-config'
+import { buildConnectionRows } from '../../../../../lib/portal/operator/connections'
+import PortalHeader from '../../../../../components/portal/PortalHeader.astro'
+import PortalTabs from '../../../../../components/portal/PortalTabs.astro'
+import PortalPageHead from '../../../../../components/portal/PortalPageHead.astro'
+import SkipToMain from '../../../../../components/SkipToMain.astro'
+import DomainSurface from '../../../../../components/portal/operator/DomainSurface.astro'
+import ConnectionRowCard from '../../../../../components/portal/operator/ConnectionRowCard.astro'
+import { env } from 'cloudflare:workers'
+
+/**
+ * Operator — Connections + credential custody (client-portal §5.8). The one
+ * domain where client self-service is a security UPGRADE, so it is the first
+ * surface built for client operability (gated by the connections switch).
+ *
+ * URL: portal.smd.services/portal/products/operator/connections
+ *
+ * Dual-mode via <DomainSurface domain="connectors">:
+ *   - Read + Request (launch, switch off): every connector's status, health,
+ *     and resolved custody, read-only, with "Request a change" to ask SMD to
+ *     connect or change a connector.
+ *   - Operable (switch on, principal): adds OAuth re-authorize and the
+ *     write-only static-secret field per connector (ConnectionRowCard).
+ *
+ * Read access is all three roles (a firm may see what it is connected to);
+ * the operable controls are principal-only (the secret endpoint re-checks
+ * principal + the connectors switch server-side — never client-only hiding).
+ *
+ * The write-only secret field posts to the connector secret endpoint, which
+ * 303-redirects back here with `?cs=`; the raw value never enters a URL, a log,
+ * or the console DB (ADR 0042). The DomainSurface "Request a change" form posts
+ * to the change-request endpoint, which redirects with `?cr=`.
+ */
+
+const access = await resolveOperatorAccess(env.DB, Astro.locals, {
+  allowedRoles: ['principal', 'staff', 'compliance'],
+})
+if (access.kind === 'redirect') {
+  return Astro.redirect(access.to)
+}
+const { client, roles } = access
+
+const config = await getCustomerConfig(env.DB, client.id)
+const rows = buildConnectionRows(
+  config?.connectors,
+  config?.credential_custody_default ?? 'delegated'
+)
+
+const RETURN_TO = '/portal/products/operator/connections'
+
+// Secret-write outcome banner (from the connector secret endpoint redirect).
+const cs = Astro.url.searchParams.get('cs')
+const CS_MESSAGES: Record<string, string> = {
+  saved: 'API key saved.',
+  not_permitted: 'Connector self-service is managed by SMD for your firm. Use Request a change.',
+  not_enabled: 'Secret entry is not available yet. Use Request a change and SMD will set it up.',
+  empty_secret: 'Enter a key before saving.',
+  write_failed: 'The key could not be saved. Please try again.',
+  invalid: 'That request was invalid. Please try again.',
+  invalid_connector: 'Unknown connector.',
+}
+const csMessage = cs ? (CS_MESSAGES[cs] ?? null) : null
+const csOk = cs === 'saved'
+
+// Change-request outcome banner (from the DomainSurface request form).
+const cr = Astro.url.searchParams.get('cr')
+const crMessage =
+  cr === 'filed'
+    ? 'Your request was sent.'
+    : cr === 'invalid'
+      ? "That request couldn't be filed. Please add a short description and try again."
+      : cr === 'error'
+        ? 'Something went wrong filing your request. Please try again.'
+        : null
+
+const banner = csMessage
+  ? { text: csMessage, ok: csOk }
+  : crMessage
+    ? { text: crMessage, ok: cr === 'filed' }
+    : null
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;900&family=Archivo+Narrow:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap"
+      rel="stylesheet"
+    />
+    <title>Operator · Connections | {BRAND_NAME}</title>
+  </head>
+  <body class="min-h-screen bg-[color:var(--ss-color-background)]">
+    <SkipToMain />
+    <PortalHeader clientName={client.name} />
+
+    <PortalTabs pathname={Astro.url.pathname} operatorActive={true} />
+
+    <main id="main" role="main" class="max-w-5xl mx-auto px-4 md:px-6 pb-24 md:pb-12">
+      <PortalPageHead
+        crumbHref="/portal/products/operator"
+        crumbLabel="Operator"
+        tag="Section"
+        h1="Connections"
+        meta={rows.length > 0 ? `${rows.length} connector${rows.length === 1 ? '' : 's'}` : null}
+      />
+
+      {
+        banner && (
+          <div
+            role="status"
+            class={`mt-6 border-[3px] px-5 py-3 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold ${
+              banner.ok
+                ? 'border-[color:var(--ss-color-complete)] text-[color:var(--ss-color-complete)]'
+                : 'border-[color:var(--ss-color-error)] text-[color:var(--ss-color-error)]'
+            }`}
+          >
+            {banner.text}
+          </div>
+        )
+      }
+
+      <div class="mt-8">
+        {
+          rows.length === 0 ? (
+            <section
+              aria-label="No connectors"
+              class="border-[3px] border-[color:var(--ss-color-text-primary)] p-8 md:p-12 text-center"
+            >
+              <p class="font-['Archivo'] text-2xl md:text-3xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]">
+                No connections yet
+              </p>
+              <p class="mt-3 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)]">
+                The systems your Operator connects to appear here once they are set up.
+              </p>
+            </section>
+          ) : (
+            <DomainSurface
+              authority={config?.authority ?? null}
+              domain="connectors"
+              roles={roles}
+              returnTo={RETURN_TO}
+              domainLabel="connections"
+            >
+              <ul
+                slot="read"
+                role="list"
+                class="m-0 list-none p-0 border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)]"
+              >
+                {rows.map((row) => (
+                  <ConnectionRowCard row={row} operable={false} returnTo={RETURN_TO} />
+                ))}
+              </ul>
+              <ul
+                slot="operable"
+                role="list"
+                class="m-0 list-none p-0 border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)]"
+              >
+                {rows.map((row) => (
+                  <ConnectionRowCard row={row} operable={true} returnTo={RETURN_TO} />
+                ))}
+              </ul>
+            </DomainSurface>
+          )
+        }
+      </div>
+    </main>
+  </body>
+</html>

--- a/src/pages/portal/products/operator/index.astro
+++ b/src/pages/portal/products/operator/index.astro
@@ -137,10 +137,15 @@ if (access) {
     })
   }
   sectionCards.push({
-    href: '/portal/products/operator/audit',
-    label: 'Audit',
+    href: '/portal/products/operator/activity',
+    label: 'Activity',
     description:
       'A full record of every action your Operator takes: drafts created, sends approved, identity changes.',
+  })
+  sectionCards.push({
+    href: '/portal/products/operator/connections',
+    label: 'Connections',
+    description: 'The systems your Operator connects to, and how their credentials are held.',
   })
   const isCompliance = userRoles.includes('compliance')
   const isPrincipal = userRoles.includes('principal')

--- a/tests/forbidden-strings.test.ts
+++ b/tests/forbidden-strings.test.ts
@@ -454,6 +454,15 @@ const LIST_INDEX_ALLOWLIST: string[] = [
   // alongside the row iteration; row rendering itself goes through
   // <NotificationRow>.
   resolve('src/pages/portal/products/operator/notifications/index.astro'),
+  // `products/operator/connections/index.astro` (§5.8) iterates connectors
+  // through the dedicated <ConnectionRowCard> primitive, not PortalListItem. A
+  // connection row's vocabulary (capability + adapter/health + custody badge +
+  // custody description + the operable OAuth/write-only-secret controls) does
+  // not fit either of PortalListItem's two variants (status / document). Same
+  // justification as DraftRow / MatterRow / AuditEntryRow / CalendarItemRow /
+  // NotificationRow. The .map( hits render the read-slot and operable-slot
+  // connector lists; both go through <ConnectionRowCard>.
+  resolve('src/pages/portal/products/operator/connections/index.astro'),
 ]
 
 /** Collect every `index.astro` under `src/pages/portal/` EXCEPT the home. */

--- a/tests/operator-connections.test.ts
+++ b/tests/operator-connections.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest'
+import {
+  buildConnectionRows,
+  formatCustody,
+  describeCustody,
+} from '../src/lib/portal/operator/connections'
+
+describe('buildConnectionRows', () => {
+  const connectors = {
+    PracticeManagement: { adapter: 'clio', credential_custody: 'self_held' },
+    Email: { adapter: 'google-workspace', credential_custody: null },
+    CallTracking: { adapter: 'callrail' }, // no custody field → inherit default
+  }
+
+  it('joins status rows with resolved per-connector custody', () => {
+    const rows = buildConnectionRows(connectors, 'delegated')
+    const byCap = Object.fromEntries(rows.map((r) => [r.capabilityName, r]))
+    // explicit self_held pins
+    expect(byCap['PracticeManagement'].custody).toBe('self_held')
+    expect(byCap['PracticeManagement'].smdReachable).toBe(false)
+    // null per-connector → client default
+    expect(byCap['Email'].custody).toBe('delegated')
+    expect(byCap['Email'].smdReachable).toBe(true)
+    // absent field → client default
+    expect(byCap['CallTracking'].custody).toBe('delegated')
+  })
+
+  it('honors a self_held client default for connectors that do not override', () => {
+    const rows = buildConnectionRows(connectors, 'self_held')
+    const byCap = Object.fromEntries(rows.map((r) => [r.capabilityName, r]))
+    expect(byCap['Email'].custody).toBe('self_held')
+    expect(byCap['CallTracking'].smdReachable).toBe(false)
+    // explicit value still wins (here it matches anyway)
+    expect(byCap['PracticeManagement'].custody).toBe('self_held')
+  })
+
+  it('returns an empty list when there are no connectors', () => {
+    expect(buildConnectionRows(null, 'delegated')).toEqual([])
+    expect(buildConnectionRows({}, 'delegated')).toEqual([])
+  })
+
+  it('every row reports unconfigured health until the harness is portal-bound', () => {
+    const rows = buildConnectionRows(connectors, 'delegated')
+    expect(rows.every((r) => r.health === 'unconfigured')).toBe(true)
+  })
+})
+
+describe('custody labels', () => {
+  it('formatCustody', () => {
+    expect(formatCustody('self_held')).toBe('Self-held')
+    expect(formatCustody('delegated')).toBe('Delegated to SMD')
+  })
+  it('describeCustody is honest about the recovery trade', () => {
+    expect(describeCustody('self_held')).toContain('Only you')
+    expect(describeCustody('delegated')).toContain('SMD')
+  })
+})


### PR DESCRIPTION
## What

PR **4** of the Operator client portal. The `/connections` surface (§5.8) — the one domain where client self-service is a security **upgrade**, so it is the first surface built for client operability (gated by the connections switch). Based on `main` (rebased past the admin agent's #1249/#1250/#1266/#1267).

## Highlights

- **Dual-mode** via `<DomainSurface domain="connectors">`: Read + Request at launch (status / health / resolved custody per connector, read-only, + Request-a-change); **Operable** when SMD flips the connections switch (principal) — adds OAuth re-authorize + the write-only static-secret field per connector. Read for all three roles; operable controls principal-only. **First operable hand-over** and the first surface to exercise both `DomainSurface` slots.
- **Highest-care — the write-only static-secret field.** The connector secret endpoint now **303-redirects** (was JSON; a 0-JS form can't consume JSON, and nothing else depended on it). The raw value lives **only in the POST body** — never a URL, never reflected, never logged, never in the console DB. The no-leak core (`handleSecretWrite`) and every server-side gate (principal + connectors switch + transport-configured, ADR 0041 V5 / ADR 0042) are **unchanged** — only the response shape. `autocomplete=off` on the field.
- `connections.ts` joins connector status with resolved custody (`resolveCredentialCustody` → `smdCanReachSecret`) and states honestly whether SMD can rotate the key.
- `ConnectionRowCard` renders read vs operable from one markup. Home gains a Connections card; the legacy Audit card is repointed to `/activity`.

## Verification

typecheck 0 · lint 0 · build clean · 3183 tests pass (new `operator-connections` coverage; R7 allowlist entry for the dedicated row card).

🤖 Generated with [Claude Code](https://claude.com/claude-code)