### PR TITLE
feat(operator): Configure surface — skills/governance/voice/scope/hours (client portal PR5)

### DIFF
--- a/src/lib/portal/operator/configure.ts
+++ b/src/lib/portal/operator/configure.ts
@@ -1,0 +1,89 @@
+/**
+ * Configure surface model (client-portal §5.6). Read-side helpers for the
+ * skills / governance / voice / scope / hours sub-domains. Pure — no I/O.
+ *
+ * Governance is rendered on the ACTION-CLASS model (ADR 0025), not the legacy
+ * per-skill scalar. At launch every config domain is Read + Request, so this
+ * surface shows the non-raisable vertical FLOORS (the hard stops the client
+ * can never cross) per action class — the accurate, always-available half of
+ * the model. The per-action configured ceilings surface when the projection
+ * carries `action_ceilings` AND the configuration/trust switch is flipped
+ * operable; until then the runtime treats an unconfigured action class as
+ * fail-closed (refused) — never "drafts for review" (ADR 0035 landmine).
+ */
+
+import { getVerticalFloor, type Ceiling } from './config-governance'
+import {
+  ACCEPTED_ACTION_CLASSES,
+  type ActionClass,
+  type Scope,
+  type BusinessHours,
+} from '../../operator/customer-yaml/types'
+
+export const ACTION_CLASS_LABEL: Record<ActionClass, string> = {
+  read: 'Read',
+  internal_write: 'Internal write',
+  external_send: 'External send',
+  commitment: 'Commitment',
+  destructive: 'Destructive',
+}
+
+export interface GovernanceFloorRow {
+  actionClass: ActionClass
+  label: string
+  /** The non-raisable floor for this action class, or null when none applies. */
+  floor: Ceiling | null
+}
+
+/**
+ * The action-class governance rows: every action class with its vertical floor.
+ * A null floor means the vertical sets no hard stop for that class (the client,
+ * once operable, may set any ceiling); a non-null floor is the hard stop the
+ * client cannot raise above (e.g. law-firm external_send floored at
+ * draft_for_review).
+ */
+export function buildGovernanceFloorRows(vertical: string | null): GovernanceFloorRow[] {
+  return ACCEPTED_ACTION_CLASSES.map((ac) => ({
+    actionClass: ac,
+    label: ACTION_CLASS_LABEL[ac],
+    floor: getVerticalFloor(vertical, ac),
+  }))
+}
+
+export function formatCeiling(c: Ceiling): string {
+  return c === 'autonomous'
+    ? 'Autonomous'
+    : c === 'draft_for_review'
+      ? 'Draft for review'
+      : 'Refused'
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v)
+}
+
+function strArray(v: unknown): string[] {
+  return Array.isArray(v) ? v.filter((x): x is string => typeof x === 'string') : []
+}
+
+/** Parse the projected `scope` blob into a Scope, or null when absent/malformed. */
+export function parseScope(raw: unknown): Scope | null {
+  if (!isRecord(raw)) return null
+  return {
+    email_folders_visible: strArray(raw['email_folders_visible']),
+    email_folders_blind: strArray(raw['email_folders_blind']),
+    email_keyword_blocks: strArray(raw['email_keyword_blocks']),
+    domain_blocks: strArray(raw['domain_blocks']),
+    matter_blocks: strArray(raw['matter_blocks']),
+  }
+}
+
+/** Parse the projected `business_hours` blob, or null when absent/malformed. */
+export function parseBusinessHours(raw: unknown): BusinessHours | null {
+  if (!isRecord(raw)) return null
+  const timezone = typeof raw['timezone'] === 'string' ? raw['timezone'] : null
+  const start = typeof raw['start'] === 'string' ? raw['start'] : null
+  const end = typeof raw['end'] === 'string' ? raw['end'] : null
+  if (timezone === null || start === null || end === null) return null
+  return { timezone, days: strArray(raw['days']), start, end }
+}

--- a/src/pages/portal/products/operator/configure/index.astro
+++ b/src/pages/portal/products/operator/configure/index.astro
@@ -1,0 +1,285 @@
+---
+import '../../../../../styles/global.css'
+import { BRAND_NAME } from '../../../../../lib/config/brand'
+import { resolveOperatorAccess } from '../../../../../lib/portal/operator-access'
+import { getCustomerConfig } from '../../../../../lib/portal/customer-config'
+import { skillToggleRowsFromPersona } from '../../../../../lib/portal/operator/settings'
+import {
+  buildGovernanceFloorRows,
+  parseScope,
+  parseBusinessHours,
+  formatCeiling,
+} from '../../../../../lib/portal/operator/configure'
+import PortalHeader from '../../../../../components/portal/PortalHeader.astro'
+import PortalTabs from '../../../../../components/portal/PortalTabs.astro'
+import PortalPageHead from '../../../../../components/portal/PortalPageHead.astro'
+import SkipToMain from '../../../../../components/SkipToMain.astro'
+import DomainSurface from '../../../../../components/portal/operator/DomainSurface.astro'
+import { env } from 'cloudflare:workers'
+
+/**
+ * Operator — Configure (client-portal §5.6). Shape the operator: skills,
+ * governance, voice, scope, hours. Read for all roles; all Read + Request at
+ * launch (these are the LAST domains SMD hands over — they shape what the
+ * operator may do).
+ *
+ * URL: portal.smd.services/portal/products/operator/configure
+ *
+ * Two authority domains (foundations §4.2): `configuration` (skills / voice /
+ * scope / hours authoring) and `trust` (governance ceilings). Each renders via
+ * its own <DomainSurface>, so there is one "Request a change" path per domain.
+ *
+ * Governance is the action-class model (ADR 0025), NOT the legacy scalar. It
+ * shows the non-raisable vertical FLOORS (the hard stops) per action class. An
+ * unconfigured action class is fail-closed (refused) at runtime — never
+ * "drafts for review" (ADR 0035 landmine). Per-action configured ceilings
+ * surface when the projection carries action_ceilings and the trust switch is
+ * flipped operable.
+ *
+ * Reads the customer_configs projection (real authored data — unlike the
+ * runtime-gated activity/matters surfaces).
+ */
+
+const access = await resolveOperatorAccess(env.DB, Astro.locals, {
+  allowedRoles: ['principal', 'staff', 'compliance'],
+})
+if (access.kind === 'redirect') {
+  return Astro.redirect(access.to)
+}
+const { client, roles } = access
+
+const config = await getCustomerConfig(env.DB, client.id)
+const activePersona = config?.personas.find((p) => p.status === 'active') ?? null
+const skillRows = skillToggleRowsFromPersona(activePersona)
+const tone = activePersona?.tone ?? []
+const govRows = buildGovernanceFloorRows(config?.vertical ?? null)
+const scope = parseScope(config?.scope)
+const hours = parseBusinessHours(config?.business_hours)
+
+const RETURN_TO = '/portal/products/operator/configure'
+
+const cr = Astro.url.searchParams.get('cr')
+const crMessage =
+  cr === 'filed'
+    ? 'Your request was sent.'
+    : cr === 'invalid'
+      ? "That request couldn't be filed. Please add a short description and try again."
+      : cr === 'error'
+        ? 'Something went wrong filing your request. Please try again.'
+        : null
+
+const cardClass =
+  'border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)]'
+const barClass =
+  "bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] px-5 py-2.5 font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold"
+const labelClass =
+  "font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold text-[color:var(--ss-color-text-secondary)]"
+const emptyClass = 'text-sm text-[color:var(--ss-color-text-secondary)]'
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;900&family=Archivo+Narrow:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap"
+      rel="stylesheet"
+    />
+    <title>Operator · Configure | {BRAND_NAME}</title>
+  </head>
+  <body class="min-h-screen bg-[color:var(--ss-color-background)]">
+    <SkipToMain />
+    <PortalHeader clientName={client.name} />
+
+    <PortalTabs pathname={Astro.url.pathname} operatorActive={true} />
+
+    <main id="main" role="main" class="max-w-5xl mx-auto px-4 md:px-6 pb-24 md:pb-12">
+      <PortalPageHead
+        crumbHref="/portal/products/operator"
+        crumbLabel="Operator"
+        tag="Section"
+        h1="Configure"
+        meta={null}
+      />
+
+      {
+        crMessage && (
+          <div
+            role="status"
+            class={`mt-6 border-[3px] px-5 py-3 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold ${
+              cr === 'filed'
+                ? 'border-[color:var(--ss-color-complete)] text-[color:var(--ss-color-complete)]'
+                : 'border-[color:var(--ss-color-error)] text-[color:var(--ss-color-error)]'
+            }`}
+          >
+            {crMessage}
+          </div>
+        )
+      }
+
+      <div class="mt-8 flex flex-col gap-8">
+        {/* Configuration domain: skills, voice, scope, hours. */}
+        <DomainSurface
+          authority={config?.authority ?? null}
+          domain="configuration"
+          roles={roles}
+          returnTo={RETURN_TO}
+          domainLabel="skills, voice, scope and hours"
+        >
+          <div slot="read" class="flex flex-col gap-8">
+            <section class={cardClass}>
+              <div class={barClass}>Skills</div>
+              <div class="px-5 md:px-7 py-6">
+                {
+                  skillRows.length === 0 ? (
+                    <p class={emptyClass}>
+                      Your operator's skills appear here once they are configured.
+                    </p>
+                  ) : (
+                    <ul role="list" class="flex flex-col gap-2">
+                      {skillRows.map((s) => (
+                        <li class="flex items-baseline justify-between gap-4">
+                          <span class="text-sm text-[color:var(--ss-color-text-primary)]">
+                            {s.skillName}
+                          </span>
+                          <span class={labelClass}>{s.enabled ? 'On' : 'Off'}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  )
+                }
+              </div>
+            </section>
+
+            <section class={cardClass}>
+              <div class={barClass}>Voice</div>
+              <div class="px-5 md:px-7 py-6 flex flex-col gap-3">
+                {
+                  tone.length > 0 ? (
+                    <div>
+                      <p class={labelClass}>Tone</p>
+                      <p class="mt-1 text-sm text-[color:var(--ss-color-text-primary)]">
+                        {tone.join(', ')}
+                      </p>
+                    </div>
+                  ) : null
+                }
+                <p class={emptyClass}>
+                  Voice samples and calibration are tuned with your SMD team. Calibration status
+                  appears here once a session is scheduled.
+                </p>
+              </div>
+            </section>
+
+            <section class={cardClass}>
+              <div class={barClass}>Scope</div>
+              <div class="px-5 md:px-7 py-6 flex flex-col gap-4">
+                {
+                  scope === null ? (
+                    <p class={emptyClass}>
+                      Your operator's visibility and blocks appear here once scope is set.
+                    </p>
+                  ) : (
+                    <>
+                      <div>
+                        <p class={labelClass}>Visible folders</p>
+                        <p class="mt-1 text-sm text-[color:var(--ss-color-text-primary)]">
+                          {scope.email_folders_visible.length > 0
+                            ? scope.email_folders_visible.join(', ')
+                            : 'None set'}
+                        </p>
+                      </div>
+                      <div>
+                        <p class={labelClass}>Blind folders</p>
+                        <p class="mt-1 text-sm text-[color:var(--ss-color-text-primary)]">
+                          {scope.email_folders_blind.length > 0
+                            ? scope.email_folders_blind.join(', ')
+                            : 'None set'}
+                        </p>
+                      </div>
+                      <div>
+                        <p class={labelClass}>Blocks</p>
+                        <p class="mt-1 text-sm text-[color:var(--ss-color-text-primary)]">
+                          {[
+                            ...scope.email_keyword_blocks,
+                            ...scope.domain_blocks,
+                            ...scope.matter_blocks,
+                          ].length > 0
+                            ? [
+                                ...scope.email_keyword_blocks,
+                                ...scope.domain_blocks,
+                                ...scope.matter_blocks,
+                              ].join(', ')
+                            : 'None set'}
+                        </p>
+                      </div>
+                    </>
+                  )
+                }
+              </div>
+            </section>
+
+            <section class={cardClass}>
+              <div class={barClass}>Business hours</div>
+              <div class="px-5 md:px-7 py-6">
+                {
+                  hours === null ? (
+                    <p class={emptyClass}>
+                      Your operator's working hours appear here once they are set.
+                    </p>
+                  ) : (
+                    <p class="text-sm text-[color:var(--ss-color-text-primary)]">
+                      {hours.days.length > 0 ? `${hours.days.join(', ')} · ` : ''}
+                      {hours.start}–{hours.end} ({hours.timezone})
+                    </p>
+                  )
+                }
+              </div>
+            </section>
+          </div>
+        </DomainSurface>
+
+        {/* Trust domain: governance ceilings on the action-class model. */}
+        <DomainSurface
+          authority={config?.authority ?? null}
+          domain="trust"
+          roles={roles}
+          returnTo={RETURN_TO}
+          domainLabel="governance ceilings"
+        >
+          <section slot="read" class={cardClass}>
+            <div class={barClass}>Governance</div>
+            <div class="px-5 md:px-7 py-6 flex flex-col gap-4">
+              <p class={emptyClass}>
+                Each action class has a hard floor your operator can never cross. SMD sets the
+                ceiling within that floor. An action class with no configured ceiling is refused by
+                default.
+              </p>
+              <ul role="list" class="flex flex-col gap-2">
+                {
+                  govRows.map((g) => (
+                    <li class="flex items-baseline justify-between gap-4">
+                      <span class="text-sm text-[color:var(--ss-color-text-primary)]">
+                        {g.label}
+                      </span>
+                      <span class={labelClass}>
+                        {g.floor ? `Floor: ${formatCeiling(g.floor)}` : 'No hard floor'}
+                      </span>
+                    </li>
+                  ))
+                }
+              </ul>
+            </div>
+          </section>
+        </DomainSurface>
+      </div>
+    </main>
+  </body>
+</html>

--- a/src/pages/portal/products/operator/index.astro
+++ b/src/pages/portal/products/operator/index.astro
@@ -147,6 +147,11 @@ if (access) {
     label: 'Connections',
     description: 'The systems your Operator connects to, and how their credentials are held.',
   })
+  sectionCards.push({
+    href: '/portal/products/operator/configure',
+    label: 'Configure',
+    description: "Your Operator's skills, governance, voice, scope, and hours.",
+  })
   const isCompliance = userRoles.includes('compliance')
   const isPrincipal = userRoles.includes('principal')
   const showComplianceCard =

--- a/tests/forbidden-strings.test.ts
+++ b/tests/forbidden-strings.test.ts
@@ -463,6 +463,14 @@ const LIST_INDEX_ALLOWLIST: string[] = [
   // NotificationRow. The .map( hits render the read-slot and operable-slot
   // connector lists; both go through <ConnectionRowCard>.
   resolve('src/pages/portal/products/operator/connections/index.astro'),
+  // `products/operator/configure/index.astro` (§5.6) renders config FIELD rows
+  // (skill name + on/off, action-class + governance floor) as plain text <li>s
+  // inside config section cards — not the PortalListItem status/document
+  // repeating-card vocabulary. Same justification as settings/advanced (a
+  // structured config surface, not a list of records). The .map( hits iterate
+  // the skill list and the action-class governance rows; neither carries a
+  // money/status/document cell that PortalListItem's variants model.
+  resolve('src/pages/portal/products/operator/configure/index.astro'),
 ]
 
 /** Collect every `index.astro` under `src/pages/portal/` EXCEPT the home. */

--- a/tests/operator-configure.test.ts
+++ b/tests/operator-configure.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest'
+import {
+  buildGovernanceFloorRows,
+  parseScope,
+  parseBusinessHours,
+  formatCeiling,
+  ACTION_CLASS_LABEL,
+} from '../src/lib/portal/operator/configure'
+import { ACCEPTED_ACTION_CLASSES } from '../src/lib/operator/customer-yaml/types'
+
+describe('buildGovernanceFloorRows (action-class model)', () => {
+  it('returns one row per action class, in canonical order', () => {
+    const rows = buildGovernanceFloorRows('law-firm')
+    expect(rows.map((r) => r.actionClass)).toEqual([...ACCEPTED_ACTION_CLASSES])
+    expect(rows.every((r) => r.label === ACTION_CLASS_LABEL[r.actionClass])).toBe(true)
+  })
+
+  it('surfaces the law-firm external_send floor (draft_for_review), the others null', () => {
+    const byClass = Object.fromEntries(
+      buildGovernanceFloorRows('law-firm').map((r) => [r.actionClass, r.floor])
+    )
+    expect(byClass['external_send']).toBe('draft_for_review')
+    expect(byClass['read']).toBeNull()
+    expect(byClass['destructive']).toBeNull()
+  })
+
+  it('a null/unknown vertical has no floors (all null) — never a fabricated default', () => {
+    expect(buildGovernanceFloorRows(null).every((r) => r.floor === null)).toBe(true)
+    expect(buildGovernanceFloorRows('unknown-vertical').every((r) => r.floor === null)).toBe(true)
+  })
+})
+
+describe('parseScope', () => {
+  it('parses a full scope blob', () => {
+    const s = parseScope({
+      email_folders_visible: ['Inbox', 'Matters'],
+      email_folders_blind: ['Personal'],
+      email_keyword_blocks: ['settlement'],
+      domain_blocks: ['opposing.com'],
+      matter_blocks: ['M-99'],
+    })
+    expect(s?.email_folders_visible).toEqual(['Inbox', 'Matters'])
+    expect(s?.domain_blocks).toEqual(['opposing.com'])
+  })
+  it('coerces missing/!array fields to [] and non-objects to null', () => {
+    expect(parseScope({})).toEqual({
+      email_folders_visible: [],
+      email_folders_blind: [],
+      email_keyword_blocks: [],
+      domain_blocks: [],
+      matter_blocks: [],
+    })
+    expect(parseScope(null)).toBeNull()
+    expect(parseScope('nope')).toBeNull()
+  })
+  it('drops non-string entries from arrays', () => {
+    const s = parseScope({ email_folders_visible: ['Inbox', 3, null, 'Sent'] })
+    expect(s?.email_folders_visible).toEqual(['Inbox', 'Sent'])
+  })
+})
+
+describe('parseBusinessHours', () => {
+  it('parses a full block', () => {
+    const h = parseBusinessHours({
+      timezone: 'America/Phoenix',
+      days: ['Mon', 'Tue'],
+      start: '09:00',
+      end: '17:00',
+    })
+    expect(h).toEqual({
+      timezone: 'America/Phoenix',
+      days: ['Mon', 'Tue'],
+      start: '09:00',
+      end: '17:00',
+    })
+  })
+  it('returns null when a required field is missing', () => {
+    expect(parseBusinessHours({ days: ['Mon'], start: '09:00', end: '17:00' })).toBeNull()
+    expect(parseBusinessHours({ timezone: 'X', start: '09:00' })).toBeNull()
+    expect(parseBusinessHours(null)).toBeNull()
+  })
+})
+
+describe('formatCeiling', () => {
+  it('labels every ceiling', () => {
+    expect(formatCeiling('autonomous')).toBe('Autonomous')
+    expect(formatCeiling('draft_for_review')).toBe('Draft for review')
+    expect(formatCeiling('refused')).toBe('Refused')
+  })
+})


### PR DESCRIPTION
## What

PR **5** of the Operator client portal. The `/configure` surface (§5.6) — shape the operator. Read for all roles; **all Read + Request at launch** (these shape what the operator may do and are the last domains SMD hands over). Reads the `customer_configs` projection — real authored data, unlike the runtime-gated activity/matters surfaces.

## Highlights

- **Two `<DomainSurface>` sections matching the authority domains** (foundations §4.2): `configuration` (skills / voice / scope / hours) and `trust` (governance). One Request-a-change path per domain.
- **Governance on the action-class model** (ADR 0025), not the legacy scalar. Shows the non-raisable vertical **floors** per action class (the hard stops) and states that an unconfigured action class is **refused by default** — never "drafts for review" (ADR 0035 landmine). Per-action *configured* ceilings surface when the projection carries `action_ceilings` and the trust switch flips operable; the CI materializer that would project `action_ceilings` is **out of the client lane** — tracked as a follow-on. Floors come from `config-governance` `VERTICAL_FLOORS`.
- `configure.ts`: action-class floor rows + defensive `parseScope` / `parseBusinessHours`. Skills reuse `skillToggleRowsFromPersona`; voice shows the projected persona tone + an honest calibration empty-state.
- Home gains a Configure card.

## Verification

typecheck 0 · lint 0 · build clean · 3224 tests pass (new `operator-configure` coverage; R7 allowlist entry for the config field rows). Rebased past the admin agent's #1256/#1258.

🤖 Generated with [Claude Code](https://claude.com/claude-code)