### PR TITLE
feat(operator): admin runtime observe surface (§5.5, ADR 0043 path A)

### DIFF
--- a/src/lib/admin/runtime-observe.ts
+++ b/src/lib/admin/runtime-observe.ts
@@ -1,0 +1,95 @@
+/**
+ * Runtime-observe view-model for the admin Operator console
+ * (`/admin/operator/[customer]/runtime`) — design §5.5, ADR 0043 path A.
+ *
+ * SMD observes what one operator is actually doing — activity/drafts, audit
+ * log, matters — read across the isolation boundary via the live per-customer
+ * read path (readMachineRuntime). That path is fail-closed: until the Machine
+ * read endpoint is wired (OPERATOR_RUNTIME_READ_URL), it returns empty, so this
+ * surface renders honest empty / not-enabled states now — the documented design,
+ * not a gap (foundations §6/§7).
+ *
+ * This module owns the view IA (the three sub-views → RuntimeReadKind) and a
+ * thin loader that maps a read result to a display status. The transport, audit
+ * sink, and readMachineRuntime are the frozen seam; the page injects them.
+ *
+ * No audit noise for a dark feature: when the read path is not configured the
+ * loader returns `not_enabled` WITHOUT attempting a read, so we don't write a
+ * runtime-read-audit row on every page load for a path that cannot answer.
+ */
+
+import {
+  readMachineRuntime,
+  type MachineRuntimeTransport,
+  type RuntimeReadAudit,
+  type RuntimeReadActor,
+  type RuntimeReadKind,
+} from '../operator/runtime-read'
+
+export type RuntimeViewId = 'activity' | 'audit' | 'matters'
+
+export interface RuntimeViewDef {
+  id: RuntimeViewId
+  label: string
+  kind: RuntimeReadKind
+  /** What this view shows, for the empty-state copy. */
+  noun: string
+}
+
+export const RUNTIME_VIEWS: readonly RuntimeViewDef[] = [
+  { id: 'activity', label: 'Activity & drafts', kind: 'activity', noun: 'activity' },
+  { id: 'audit', label: 'Audit log', kind: 'audit_log', noun: 'audit entries' },
+  { id: 'matters', label: 'Matters', kind: 'matter', noun: 'matters' },
+]
+
+/** Resolve a `?view=` param to a view def; defaults to activity. Total. */
+export function parseRuntimeView(raw: string | null | undefined): RuntimeViewDef {
+  const found = RUNTIME_VIEWS.find((v) => v.id === raw)
+  return found ?? RUNTIME_VIEWS[0]
+}
+
+export type RuntimeViewResult =
+  | { status: 'not_enabled' }
+  | { status: 'unreachable'; reason: string }
+  | { status: 'empty' }
+  | { status: 'items'; count: number; data: unknown }
+
+interface RuntimeReadDeps {
+  transport: MachineRuntimeTransport
+  audit: RuntimeReadAudit
+}
+
+/**
+ * Load one runtime view for one customer. When the read path is not configured,
+ * returns `not_enabled` without a read attempt (no audit noise). Otherwise reads
+ * via the frozen fail-closed path and classifies the outcome:
+ *   - read failed (unreachable/unauthorized/not_configured) → `unreachable`
+ *   - read ok, no rows                                       → `empty`
+ *   - read ok, rows                                          → `items` (+ count)
+ *
+ * `data` is opaque (the Machine endpoint defines the row shape, a follow-on);
+ * we surface a count honestly and leave the detailed renderer for when the
+ * endpoint lands rather than fabricating a shape.
+ */
+export async function loadRuntimeView(
+  deps: RuntimeReadDeps,
+  customerSlug: string,
+  view: RuntimeViewDef,
+  actor: RuntimeReadActor,
+  configured: boolean
+): Promise<RuntimeViewResult> {
+  if (!configured) return { status: 'not_enabled' }
+  const result = await readMachineRuntime(deps, customerSlug, { kind: view.kind }, actor)
+  if (!result.ok) return { status: 'unreachable', reason: result.reason }
+  const count = countRows(result.data)
+  return count === 0 ? { status: 'empty' } : { status: 'items', count, data: result.data }
+}
+
+/** Best-effort row count from an opaque read payload (array, or {items:[]}). */
+function countRows(data: unknown): number {
+  if (Array.isArray(data)) return data.length
+  if (data && typeof data === 'object' && Array.isArray((data as { items?: unknown }).items)) {
+    return (data as { items: unknown[] }).items.length
+  }
+  return 0
+}

--- a/src/pages/admin/operator/[customer]/index.astro
+++ b/src/pages/admin/operator/[customer]/index.astro
@@ -290,6 +290,14 @@ const personas = config?.personas ?? []
                 </li>
                 <li>
                   <a
+                    href={`/admin/operator/${encodeURIComponent(slug)}/runtime`}
+                    class="text-[color:var(--ss-color-action)] hover:underline"
+                  >
+                    Runtime
+                  </a>
+                </li>
+                <li>
+                  <a
                     href={`/admin/operator/costs/${encodeURIComponent(slug)}`}
                     class="text-[color:var(--ss-color-action)] hover:underline"
                   >
@@ -306,8 +314,7 @@ const personas = config?.personas ?? []
                 </li>
               </ul>
               <p class="text-xs text-[color:var(--ss-color-text-muted)] mt-3">
-                Configuration, runtime, memory, people, and lifecycle drill-ins land as their
-                surfaces ship.
+                Configuration, memory, people, and lifecycle drill-ins land as their surfaces ship.
               </p>
             </div>
           </>

--- a/src/pages/admin/operator/[customer]/runtime.astro
+++ b/src/pages/admin/operator/[customer]/runtime.astro
@@ -1,0 +1,150 @@
+---
+import AdminLayout from '../../../../layouts/AdminLayout.astro'
+import { resolveEntityIdBySlug } from '../../../../lib/admin/operator-overview'
+import {
+  RUNTIME_VIEWS,
+  parseRuntimeView,
+  loadRuntimeView,
+  type RuntimeViewResult,
+} from '../../../../lib/admin/runtime-observe'
+import {
+  isRuntimeReadConfigured,
+  createMachineRuntimeTransport,
+  createRuntimeReadAudit,
+} from '../../../../lib/operator/runtime-read-transport'
+import { env } from 'cloudflare:workers'
+
+/**
+ * Operator admin console — runtime observe (§5.5, ADR 0043 path A).
+ *
+ * SMD observes what one operator is doing — activity/drafts, audit log, matters
+ * — read across the isolation boundary via the live per-customer read path. That
+ * path is fail-closed: until the Machine read endpoint is wired
+ * (OPERATOR_RUNTIME_READ_URL), every view renders an honest "not enabled" state.
+ * This is the documented design (foundations §6/§7), not a gap to fill — the IA
+ * and the read wiring are here, so the views light up the moment the endpoint
+ * lands. Each real read attempt is audited (operator_runtime_read_audit); a
+ * not-enabled path performs no read and writes no audit noise.
+ */
+
+const session = Astro.locals.session!
+if (session.role !== 'admin') {
+  return Astro.redirect('/auth/sign-in')
+}
+
+const slug = Astro.params.customer ?? ''
+const entityId = await resolveEntityIdBySlug(env.DB, slug)
+const notFound = entityId === null
+
+const view = parseRuntimeView(Astro.url.searchParams.get('view'))
+const configured = isRuntimeReadConfigured(env)
+
+let result: RuntimeViewResult = { status: 'not_enabled' }
+if (!notFound) {
+  result = await loadRuntimeView(
+    {
+      transport: createMachineRuntimeTransport(env),
+      audit: createRuntimeReadAudit(env.DB, { actorUserId: session.userId }),
+    },
+    slug,
+    view,
+    { actor: session.email, actorRole: session.role },
+    configured
+  )
+}
+---
+
+<AdminLayout
+  title={`Operator — Runtime — ${slug}`}
+  breadcrumbs={[
+    { label: 'Dashboard', href: '/admin' },
+    { label: 'Operator', href: '/admin/operator' },
+    { label: slug, href: `/admin/operator/${encodeURIComponent(slug)}` },
+    { label: 'Runtime' },
+  ]}
+  maxWidth="max-w-5xl"
+>
+  <div class="space-y-card">
+    {
+      notFound ? (
+        <div class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card">
+          <h2 class="text-xl font-semibold text-[color:var(--ss-color-text-primary)]">
+            Operator not found
+          </h2>
+          <p class="text-sm text-[color:var(--ss-color-text-secondary)] mt-1">
+            No operator is provisioned under <code>{slug}</code>.{' '}
+            <a href="/admin/operator" class="text-[color:var(--ss-color-action)] hover:underline">
+              Back to the fleet
+            </a>
+            .
+          </p>
+        </div>
+      ) : (
+        <>
+          <header>
+            <h2 class="text-xl font-semibold text-[color:var(--ss-color-text-primary)]">
+              Runtime — {slug}
+            </h2>
+            <p class="text-sm text-[color:var(--ss-color-text-secondary)] mt-1">
+              What this operator is doing, read live from its Machine. Read-only observe; every read
+              is audited.
+            </p>
+          </header>
+
+          <nav class="flex gap-2 border-b border-[color:var(--ss-color-border)]">
+            {RUNTIME_VIEWS.map((v) => (
+              <a
+                href={`/admin/operator/${encodeURIComponent(slug)}/runtime?view=${v.id}`}
+                class={`px-3 py-2 text-sm -mb-px border-b-2 ${
+                  v.id === view.id
+                    ? 'border-[color:var(--ss-color-primary)] text-[color:var(--ss-color-text-primary)] font-medium'
+                    : 'border-transparent text-[color:var(--ss-color-text-secondary)] hover:text-[color:var(--ss-color-text-primary)]'
+                }`}
+              >
+                {v.label}
+              </a>
+            ))}
+          </nav>
+
+          <div class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card">
+            {result.status === 'not_enabled' ? (
+              <div>
+                <p class="text-sm text-[color:var(--ss-color-text-primary)]">
+                  The runtime read path is not enabled yet.
+                </p>
+                <p class="text-xs text-[color:var(--ss-color-text-muted)] mt-1">
+                  Live {view.noun} appear here once a Machine read endpoint is wired (
+                  <code>OPERATOR_RUNTIME_READ_URL</code>, ADR 0043 path A). The view is dark, not
+                  empty — no data has been read.
+                </p>
+              </div>
+            ) : result.status === 'unreachable' ? (
+              <div>
+                <p class="text-sm text-[color:var(--ss-color-text-primary)]">
+                  This operator's runtime is unreachable right now.
+                </p>
+                <p class="text-xs text-[color:var(--ss-color-text-muted)] mt-1">
+                  Reason: {result.reason}. The read fails closed — try again, or check the
+                  operator's health on the overview.
+                </p>
+              </div>
+            ) : result.status === 'empty' ? (
+              <p class="text-sm text-[color:var(--ss-color-text-secondary)]">
+                No {view.noun} recorded for this operator.
+              </p>
+            ) : (
+              <div>
+                <p class="text-sm text-[color:var(--ss-color-text-primary)]">
+                  {result.count} {view.noun}.
+                </p>
+                <p class="text-xs text-[color:var(--ss-color-text-muted)] mt-1">
+                  The detailed {view.noun} view ships with the Machine read endpoint.
+                </p>
+              </div>
+            )}
+          </div>
+        </>
+      )
+    }
+  </div>
+</AdminLayout>

--- a/tests/runtime-observe.test.ts
+++ b/tests/runtime-observe.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Tests for the runtime-observe view-model (src/lib/admin/runtime-observe.ts) —
+ * admin Operator console §5.5, ADR 0043 path A.
+ *
+ * The loader's contract is what matters: a not-configured read path returns
+ * `not_enabled` WITHOUT attempting a read (no audit noise on a dark feature);
+ * a configured read fails closed to `unreachable`, and ok results classify into
+ * empty / items. The transport + audit are injected stubs (the real path is the
+ * frozen seam, already tested in operator-runtime-read.test.ts).
+ */
+
+import { describe, it, expect } from 'vitest'
+import { RUNTIME_VIEWS, parseRuntimeView, loadRuntimeView } from '../src/lib/admin/runtime-observe'
+import type {
+  MachineRuntimeTransport,
+  RuntimeReadAudit,
+  RuntimeReadActor,
+} from '../src/lib/operator/runtime-read'
+
+const actor: RuntimeReadActor = { actor: 'captain@example.com', actorRole: 'admin' }
+const activity = RUNTIME_VIEWS[0]
+
+function countingAudit(): { audit: RuntimeReadAudit; getCalls: () => number } {
+  let calls = 0
+  const audit: RuntimeReadAudit = {
+    record: async () => {
+      calls += 1
+    },
+  }
+  return { audit, getCalls: () => calls }
+}
+
+describe('parseRuntimeView', () => {
+  it('resolves known ids and defaults to activity', () => {
+    expect(parseRuntimeView('audit').id).toBe('audit')
+    expect(parseRuntimeView('matters').id).toBe('matters')
+    expect(parseRuntimeView('activity').id).toBe('activity')
+    expect(parseRuntimeView(null).id).toBe('activity')
+    expect(parseRuntimeView('bogus').id).toBe('activity')
+  })
+
+  it('every view maps to a runtime-read kind and a noun', () => {
+    for (const v of RUNTIME_VIEWS) {
+      expect(v.kind.length).toBeGreaterThan(0)
+      expect(v.noun.length).toBeGreaterThan(0)
+    }
+  })
+})
+
+describe('loadRuntimeView', () => {
+  it('returns not_enabled WITHOUT reading or auditing when the path is not configured', async () => {
+    let readCalls = 0
+    const transport: MachineRuntimeTransport = {
+      read: async () => {
+        readCalls += 1
+        return { data: [] }
+      },
+    }
+    const a = countingAudit()
+    const res = await loadRuntimeView({ transport, audit: a.audit }, 'acme', activity, actor, false)
+    expect(res).toEqual({ status: 'not_enabled' })
+    expect(readCalls).toBe(0)
+    expect(a.getCalls()).toBe(0) // no audit noise on a dark feature
+  })
+
+  it('fails closed to unreachable when the (configured) transport throws', async () => {
+    const transport: MachineRuntimeTransport = {
+      read: async () => {
+        throw new Error('machine down')
+      },
+    }
+    const a = countingAudit()
+    const res = await loadRuntimeView({ transport, audit: a.audit }, 'acme', activity, actor, true)
+    expect(res).toEqual({ status: 'unreachable', reason: 'unreachable' })
+    expect(a.getCalls()).toBe(1) // a real attempt IS audited
+  })
+
+  it('classifies an ok-but-empty read as empty', async () => {
+    const transport: MachineRuntimeTransport = { read: async () => ({ data: [] }) }
+    const a = countingAudit()
+    const res = await loadRuntimeView({ transport, audit: a.audit }, 'acme', activity, actor, true)
+    expect(res).toEqual({ status: 'empty' })
+  })
+
+  it('classifies rows as items with a count (array or {items:[]})', async () => {
+    const arr: MachineRuntimeTransport = { read: async () => ({ data: [1, 2, 3] }) }
+    const r1 = await loadRuntimeView(
+      { transport: arr, audit: countingAudit().audit },
+      'acme',
+      activity,
+      actor,
+      true
+    )
+    expect(r1).toEqual({ status: 'items', count: 3, data: [1, 2, 3] })
+
+    const wrapped: MachineRuntimeTransport = { read: async () => ({ data: { items: [1, 2] } }) }
+    const r2 = await loadRuntimeView(
+      { transport: wrapped, audit: countingAudit().audit },
+      'acme',
+      activity,
+      actor,
+      true
+    )
+    expect(r2.status).toBe('items')
+    if (r2.status === 'items') expect(r2.count).toBe(2)
+  })
+})


### PR DESCRIPTION
## What

Per-operator **runtime observe** at `/admin/operator/[customer]/runtime` — SMD watches what one operator is doing across three sub-views (**activity & drafts**, **audit log**, **matters**), read live from its Machine via the frozen path-A read. Design: §5.5, ADR 0043.

Independent PR off `main` (the admin-console foundation is merged, so no more stacking).

## Fail-closed by design (not a gap)

The read path is fail-closed: until the Machine read endpoint is wired (`OPERATOR_RUNTIME_READ_URL`), every view renders an honest **"not enabled"** state — the documented design (foundations §6/§7). The IA (tabs) and the read wiring are in place, so the views light up the moment the endpoint lands.

`src/lib/admin/runtime-observe.ts` owns the view IA + a loader that:
- returns `not_enabled` **without a read** when the path is unconfigured (no audit noise on a dark feature),
- fails closed to `unreachable` on a configured-but-failed read,
- classifies ok reads into `empty` / `items(count)`.

Every *real* read attempt is audited (`operator_runtime_read_audit`). Data shape is opaque (defined by the Machine endpoint, a follow-on) — the surface surfaces a count honestly rather than fabricating a row renderer.

## Verification

- `npm run verify` green (3230 passed / 2 skipped).
- 6 unit tests, including the "no read + no audit when the path is dark" contract.
- Overview links the Runtime drill-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)