### PR TITLE
feat(operator): Operators roster (client portal PR6a, §5.2)

### DIFF
--- a/src/lib/portal/operator/roster.ts
+++ b/src/lib/portal/operator/roster.ts
@@ -1,0 +1,47 @@
+/**
+ * Operator roster model (client-portal §5.2). Projects the customer's personas
+ * into roster entries — one per operator (persona = Hermes profile, ADR 0011).
+ *
+ * Built for N, shipped at 1: the validator locks personas[] to length 1 at v1,
+ * so today this returns a roster of one. The surface suppresses roster chrome
+ * for a single operator (it is the default scope, not a placeholder) and shows
+ * the full roster once v2 unlocks N personas — a validator flip, not a
+ * rearchitecture.
+ *
+ * Pure — no I/O. "What it handles" is the set of enabled (non-refused) skill
+ * names; a refused skill is configured but never runs, so it is not surfaced as
+ * something the operator handles.
+ */
+
+import type { PersonaConfig, PersonaStatus } from '../customer-config'
+
+export interface OperatorRosterEntry {
+  slug: string
+  name: string
+  title: string | null
+  status: PersonaStatus
+  /** Enabled skill names (ceiling other than refused) — what this operator handles. */
+  handles: string[]
+  tone: string[]
+}
+
+export function buildOperatorRoster(personas: readonly PersonaConfig[]): OperatorRosterEntry[] {
+  return personas.map((p) => ({
+    slug: p.slug,
+    name: p.name,
+    title: p.title,
+    status: p.status,
+    handles: p.skills.filter((s) => s.trust_ceiling !== 'refused').map((s) => s.name),
+    tone: p.tone,
+  }))
+}
+
+/**
+ * True when the roster is a single operator — the surface shows it as the
+ * default scope without switcher chrome (§5.2 roster-of-one). An empty roster
+ * is also "single" for chrome purposes (nothing to switch between); the page
+ * handles the empty case with its own honest state.
+ */
+export function isRosterOfOne(roster: readonly OperatorRosterEntry[]): boolean {
+  return roster.length <= 1
+}

--- a/src/pages/portal/products/operator/operators/index.astro
+++ b/src/pages/portal/products/operator/operators/index.astro
@@ -1,0 +1,127 @@
+---
+import '../../../../../styles/global.css'
+import { BRAND_NAME } from '../../../../../lib/config/brand'
+import { resolveOperatorAccess } from '../../../../../lib/portal/operator-access'
+import { getCustomerConfig } from '../../../../../lib/portal/customer-config'
+import { buildOperatorRoster, isRosterOfOne } from '../../../../../lib/portal/operator/roster'
+import PortalHeader from '../../../../../components/portal/PortalHeader.astro'
+import PortalTabs from '../../../../../components/portal/PortalTabs.astro'
+import PortalPageHead from '../../../../../components/portal/PortalPageHead.astro'
+import SkipToMain from '../../../../../components/SkipToMain.astro'
+import { env } from 'cloudflare:workers'
+
+/**
+ * Operator — Operators roster (client-portal §5.2). The multi-operator surface
+ * (persona = Hermes profile, ADR 0011). Built for N, shipped at 1.
+ *
+ * URL: portal.smd.services/portal/products/operator/operators
+ *
+ * Roster-of-one: no switcher chrome — the single operator is the default scope
+ * (§5.2). The page still shows that operator's identity + what it handles as an
+ * honest "about your operator" view. When v2 unlocks N personas (a validator
+ * flip), the roster lists them; persona-scoped filtering of the other surfaces
+ * is the v2 follow-on (selection, not a mid-session /handoff — §3.3).
+ *
+ * Read for all roles. Reads the customer_configs projection.
+ */
+
+const access = await resolveOperatorAccess(env.DB, Astro.locals, {
+  allowedRoles: ['principal', 'staff', 'compliance'],
+})
+if (access.kind === 'redirect') {
+  return Astro.redirect(access.to)
+}
+const { client } = access
+
+const config = await getCustomerConfig(env.DB, client.id)
+const roster = buildOperatorRoster(config?.personas ?? [])
+const single = isRosterOfOne(roster)
+
+const cardClass =
+  'border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)]'
+const barClass =
+  "bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] px-5 py-2.5 font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold flex items-center justify-between gap-4"
+const labelClass =
+  "font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold text-[color:var(--ss-color-text-secondary)]"
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;900&family=Archivo+Narrow:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap"
+      rel="stylesheet"
+    />
+    <title>Operator · Operators | {BRAND_NAME}</title>
+  </head>
+  <body class="min-h-screen bg-[color:var(--ss-color-background)]">
+    <SkipToMain />
+    <PortalHeader clientName={client.name} />
+
+    <PortalTabs pathname={Astro.url.pathname} operatorActive={true} />
+
+    <main id="main" role="main" class="max-w-5xl mx-auto px-4 md:px-6 pb-24 md:pb-12">
+      <PortalPageHead
+        crumbHref="/portal/products/operator"
+        crumbLabel="Operator"
+        tag="Section"
+        h1={single ? 'Your operator' : 'Operators'}
+        meta={!single ? `${roster.length} operators` : null}
+      />
+
+      <div class="mt-8 flex flex-col gap-6">
+        {
+          roster.length === 0 ? (
+            <section
+              aria-label="No operator configured"
+              class="border-[3px] border-[color:var(--ss-color-text-primary)] p-8 md:p-12 text-center"
+            >
+              <p class="font-['Archivo'] text-2xl md:text-3xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]">
+                No operator yet
+              </p>
+              <p class="mt-3 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)]">
+                Your operator's identity appears here once it is configured.
+              </p>
+            </section>
+          ) : (
+            roster.map((op) => (
+              <section class={cardClass}>
+                <div class={barClass}>
+                  <span>{op.name}</span>
+                  <span>{op.status === 'active' ? 'Active' : 'Archived'}</span>
+                </div>
+                <div class="px-5 md:px-7 py-6 flex flex-col gap-4">
+                  {op.title ? (
+                    <p class="text-sm text-[color:var(--ss-color-text-primary)]">{op.title}</p>
+                  ) : null}
+                  <div>
+                    <p class={labelClass}>Handles</p>
+                    <p class="mt-1 text-sm text-[color:var(--ss-color-text-primary)]">
+                      {op.handles.length > 0 ? op.handles.join(', ') : 'No skills enabled yet'}
+                    </p>
+                  </div>
+                  {op.tone.length > 0 ? (
+                    <div>
+                      <p class={labelClass}>Tone</p>
+                      <p class="mt-1 text-sm text-[color:var(--ss-color-text-primary)]">
+                        {op.tone.join(', ')}
+                      </p>
+                    </div>
+                  ) : null}
+                </div>
+              </section>
+            ))
+          )
+        }
+      </div>
+    </main>
+  </body>
+</html>

--- a/tests/forbidden-strings.test.ts
+++ b/tests/forbidden-strings.test.ts
@@ -471,6 +471,12 @@ const LIST_INDEX_ALLOWLIST: string[] = [
   // the skill list and the action-class governance rows; neither carries a
   // money/status/document cell that PortalListItem's variants model.
   resolve('src/pages/portal/products/operator/configure/index.astro'),
+  // `products/operator/operators/index.astro` (§5.2) renders the persona roster
+  // as operator IDENTITY cards (name + status header, title, what-it-handles,
+  // tone) — not the PortalListItem status/document record-row vocabulary. Built
+  // for N, shipped at 1 (roster-of-one shows the single operator without
+  // switcher chrome). The .map( iterates personas into identity sections.
+  resolve('src/pages/portal/products/operator/operators/index.astro'),
 ]
 
 /** Collect every `index.astro` under `src/pages/portal/` EXCEPT the home. */

--- a/tests/operator-roster.test.ts
+++ b/tests/operator-roster.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest'
+import { buildOperatorRoster, isRosterOfOne } from '../src/lib/portal/operator/roster'
+import type { PersonaConfig } from '../src/lib/portal/customer-config'
+
+function persona(over: Partial<PersonaConfig> = {}): PersonaConfig {
+  return {
+    slug: 'marcus',
+    status: 'active',
+    name: 'Marcus',
+    title: 'Intake Coordinator',
+    signature_html: null,
+    tone: ['warm', 'concise'],
+    send_as: null,
+    skills: [
+      { name: 'inbox-triage', trust_ceiling: 'draft_for_review' },
+      { name: 'pi-demand-letter', trust_ceiling: 'refused' },
+    ],
+    channel_bindings: [],
+    ...over,
+  }
+}
+
+describe('buildOperatorRoster', () => {
+  it('projects persona identity + enabled skills as what it handles', () => {
+    const roster = buildOperatorRoster([persona()])
+    expect(roster).toHaveLength(1)
+    expect(roster[0].name).toBe('Marcus')
+    expect(roster[0].title).toBe('Intake Coordinator')
+    expect(roster[0].status).toBe('active')
+    expect(roster[0].tone).toEqual(['warm', 'concise'])
+    // refused skill is configured but not "handled"
+    expect(roster[0].handles).toEqual(['inbox-triage'])
+  })
+
+  it('handles N personas (built for N, shipped at 1)', () => {
+    const roster = buildOperatorRoster([
+      persona({ slug: 'a', name: 'A' }),
+      persona({ slug: 'b', name: 'B' }),
+    ])
+    expect(roster.map((r) => r.name)).toEqual(['A', 'B'])
+  })
+})
+
+describe('isRosterOfOne', () => {
+  it('is true for zero or one operator (no switcher chrome)', () => {
+    expect(isRosterOfOne([])).toBe(true)
+    expect(isRosterOfOne(buildOperatorRoster([persona()]))).toBe(true)
+  })
+  it('is false for two or more', () => {
+    expect(
+      isRosterOfOne(buildOperatorRoster([persona({ slug: 'a' }), persona({ slug: 'b' })]))
+    ).toBe(false)
+  })
+})


### PR DESCRIPTION
## What

The persona roster surface (§5.2) — persona = Hermes profile (ADR 0011). **Built for N, shipped at 1.** First of the PR6 tail surfaces (split into shallow PRs per the merge-before-next cadence).

- `/operators` reads the projected personas and shows each operator's identity: name, status, title, **what it handles** (enabled skills), tone.
- **Roster-of-one: no switcher chrome** — the single operator is the default scope (§5.2), shown as an honest "your operator" view. Per the spec, roster-of-one clients see no `/operators` nav chrome, so Home gains **no** Operators card at v1; the surface lights up for N once the validator unlocks multi-persona. Persona-scoped filtering of other surfaces is the v2 follow-on (selection, not a mid-session `/handoff` — foundations §3.3).
- `roster.ts`: `buildOperatorRoster` + `isRosterOfOne`. Read for all roles.

## Verification

typecheck 0 · lint 0 · build clean · 3237 tests pass (new `operator-roster` coverage; R7 allowlist entry for the identity cards).

🤖 Generated with [Claude Code](https://claude.com/claude-code)