### PR TITLE
feat(operator): admin people & access surface (§5.7)

### DIFF
--- a/src/lib/admin/people-view.ts
+++ b/src/lib/admin/people-view.ts
@@ -1,0 +1,110 @@
+/**
+ * People & access view-model for the admin Operator console
+ * (`/admin/operator/[customer]/people`) — design §5.7.
+ *
+ * Lists a client's own users and their client-internal Operator roles
+ * (principal / staff / compliance — the role vocabulary the client portal owns
+ * in src/lib/portal/operator/client-rbac.ts, imported read-only here).
+ *
+ * Scope (deliberate, this PR): READ-ONLY. The design lets SMD add/remove client
+ * users and set roles, but that mutates access controls — a guardrailed action
+ * that needs an explicit Captain directive to wire. So this surface shows who
+ * has what, and defers the grant/revoke write to a follow-on rather than
+ * shipping an unauthorized access-control mutation. The page says so plainly.
+ */
+
+import type { D1Database } from '@cloudflare/workers-types'
+import { isClientRole, type ClientRole } from '../portal/operator/client-rbac'
+
+export const OPERATOR_PRODUCT_SLUG = 'operator'
+
+export interface OperatorUser {
+  user_id: string
+  email: string
+  name: string | null
+  /** Active operator roles, in the canonical order principal → staff → compliance. */
+  roles: ClientRole[]
+}
+
+interface RoleUserRow {
+  user_id: string
+  email: string
+  name: string | null
+  role: string
+}
+
+const ROLE_ORDER: Record<ClientRole, number> = { principal: 0, staff: 1, compliance: 2 }
+
+/**
+ * List every user who holds at least one active (non-revoked) Operator role on
+ * this client, with their roles grouped. One batched read of product_roles
+ * joined to users; SMD-side, scoped to one entity. Unknown role strings (a role
+ * added to the schema but not to client-rbac yet) are dropped from display
+ * rather than guessed.
+ */
+export async function listOperatorUsers(db: D1Database, entityId: string): Promise<OperatorUser[]> {
+  const result = await db
+    .prepare(
+      `SELECT pr.user_id AS user_id, u.email AS email, u.name AS name, pr.role AS role
+         FROM product_roles pr
+         JOIN users u ON u.id = pr.user_id
+        WHERE pr.entity_id = ? AND pr.product_slug = ? AND pr.revoked_at IS NULL
+        ORDER BY u.email ASC`
+    )
+    .bind(entityId, OPERATOR_PRODUCT_SLUG)
+    .all<RoleUserRow>()
+
+  const byUser = new Map<string, OperatorUser>()
+  for (const row of result.results ?? []) {
+    if (!isClientRole(row.role)) continue
+    const existing = byUser.get(row.user_id)
+    if (existing) {
+      if (!existing.roles.includes(row.role)) existing.roles.push(row.role)
+    } else {
+      byUser.set(row.user_id, {
+        user_id: row.user_id,
+        email: row.email,
+        name: row.name,
+        roles: [row.role],
+      })
+    }
+  }
+  const users = [...byUser.values()]
+  for (const u of users) u.roles.sort((a, b) => ROLE_ORDER[a] - ROLE_ORDER[b])
+  return users
+}
+
+export interface RoleBadge {
+  label: string
+  classes: string
+}
+
+const BADGE_STRUCTURE =
+  'inline-flex items-center px-2 py-0.5 rounded-[var(--ss-radius-badge)] ' +
+  'text-[10px] font-medium uppercase tracking-wide whitespace-nowrap'
+
+/** Badge for a client-internal role. */
+export function roleBadge(role: ClientRole): RoleBadge {
+  switch (role) {
+    case 'principal':
+      return {
+        label: 'Principal',
+        classes: `${BADGE_STRUCTURE} bg-[color:var(--ss-color-primary)] text-white`,
+      }
+    case 'staff':
+      return {
+        label: 'Staff',
+        classes: `${BADGE_STRUCTURE} bg-[color:var(--ss-color-complete)] text-white`,
+      }
+    case 'compliance':
+      return {
+        label: 'Compliance',
+        classes: `${BADGE_STRUCTURE} bg-[color:var(--ss-color-attention)] text-white`,
+      }
+  }
+}
+
+/** Count of users holding the principal role — onboarding seeds exactly one. */
+export function principalCount(users: readonly OperatorUser[]): number {
+  return users.filter((u) => u.roles.includes('principal')).length
+}

--- a/src/pages/admin/operator/[customer]/index.astro
+++ b/src/pages/admin/operator/[customer]/index.astro
@@ -298,6 +298,14 @@ const personas = config?.personas ?? []
                 </li>
                 <li>
                   <a
+                    href={`/admin/operator/${encodeURIComponent(slug)}/people`}
+                    class="text-[color:var(--ss-color-action)] hover:underline"
+                  >
+                    People
+                  </a>
+                </li>
+                <li>
+                  <a
                     href={`/admin/operator/costs/${encodeURIComponent(slug)}`}
                     class="text-[color:var(--ss-color-action)] hover:underline"
                   >
@@ -314,7 +322,7 @@ const personas = config?.personas ?? []
                 </li>
               </ul>
               <p class="text-xs text-[color:var(--ss-color-text-muted)] mt-3">
-                Configuration, memory, people, and lifecycle drill-ins land as their surfaces ship.
+                Configuration, memory, and lifecycle drill-ins land as their surfaces ship.
               </p>
             </div>
           </>

--- a/src/pages/admin/operator/[customer]/people.astro
+++ b/src/pages/admin/operator/[customer]/people.astro
@@ -1,0 +1,119 @@
+---
+import AdminLayout from '../../../../layouts/AdminLayout.astro'
+import { resolveEntityIdBySlug } from '../../../../lib/admin/operator-overview'
+import { listOperatorUsers, roleBadge, principalCount } from '../../../../lib/admin/people-view'
+import { env } from 'cloudflare:workers'
+
+/**
+ * Operator admin console — people & access (§5.7).
+ *
+ * The client's own users and their client-internal Operator roles
+ * (principal / staff / compliance). Read-only this PR: granting/revoking roles
+ * mutates access controls (a guardrailed action needing an explicit directive),
+ * so the surface shows who has what and defers the write rather than shipping an
+ * unauthorized access-control mutation. SMD always retains the ability via the
+ * foundation; it is simply not wired into a button here yet.
+ *
+ * Honest state (foundations §7): a client with no users yet is a real
+ * pre-onboarding state. A missing principal is surfaced as a real signal
+ * (onboarding seeds exactly one), not hidden.
+ */
+
+const session = Astro.locals.session!
+if (session.role !== 'admin') {
+  return Astro.redirect('/auth/sign-in')
+}
+
+const slug = Astro.params.customer ?? ''
+const entityId = await resolveEntityIdBySlug(env.DB, slug)
+const notFound = entityId === null
+const users = entityId ? await listOperatorUsers(env.DB, entityId) : []
+const principals = principalCount(users)
+---
+
+<AdminLayout
+  title={`Operator — People — ${slug}`}
+  breadcrumbs={[
+    { label: 'Dashboard', href: '/admin' },
+    { label: 'Operator', href: '/admin/operator' },
+    { label: slug, href: `/admin/operator/${encodeURIComponent(slug)}` },
+    { label: 'People' },
+  ]}
+  maxWidth="max-w-5xl"
+>
+  <div class="space-y-card">
+    {
+      notFound ? (
+        <div class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card">
+          <h2 class="text-xl font-semibold text-[color:var(--ss-color-text-primary)]">
+            Operator not found
+          </h2>
+          <p class="text-sm text-[color:var(--ss-color-text-secondary)] mt-1">
+            No operator is provisioned under <code>{slug}</code>.{' '}
+            <a href="/admin/operator" class="text-[color:var(--ss-color-action)] hover:underline">
+              Back to the fleet
+            </a>
+            .
+          </p>
+        </div>
+      ) : (
+        <>
+          <header>
+            <h2 class="text-xl font-semibold text-[color:var(--ss-color-text-primary)]">
+              People &amp; access — {slug}
+            </h2>
+            <p class="text-sm text-[color:var(--ss-color-text-secondary)] mt-1">
+              The client's own users and their Operator roles. Read-only here; role grants and
+              revokes are an access-control change handled on directive.
+            </p>
+          </header>
+
+          {principals === 0 && users.length > 0 && (
+            <div class="rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-attention)] bg-white p-card text-sm text-[color:var(--ss-color-text-primary)]">
+              No principal is assigned. Onboarding seeds exactly one principal — this client needs
+              one set.
+            </div>
+          )}
+
+          <div class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card">
+            {users.length === 0 ? (
+              <p class="text-sm text-[color:var(--ss-color-text-secondary)]">
+                No client users have Operator roles yet. Onboarding seeds the first principal.
+              </p>
+            ) : (
+              <table class="w-full text-sm">
+                <thead>
+                  <tr class="text-left text-xs text-[color:var(--ss-color-text-secondary)] border-b border-[color:var(--ss-color-border)]">
+                    <th class="pb-2 font-medium">User</th>
+                    <th class="pb-2 font-medium">Email</th>
+                    <th class="pb-2 font-medium">Roles</th>
+                  </tr>
+                </thead>
+                <tbody class="divide-y divide-[color:var(--ss-color-border-subtle)]">
+                  {users.map((u) => (
+                    <tr>
+                      <td class="py-2 pr-4 text-[color:var(--ss-color-text-primary)]">
+                        {u.name ?? '—'}
+                      </td>
+                      <td class="py-2 pr-4 text-[color:var(--ss-color-text-secondary)]">
+                        {u.email}
+                      </td>
+                      <td class="py-2">
+                        <span class="inline-flex flex-wrap gap-1">
+                          {u.roles.map((r) => {
+                            const b = roleBadge(r)
+                            return <span class={b.classes}>{b.label}</span>
+                          })}
+                        </span>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+          </div>
+        </>
+      )
+    }
+  </div>
+</AdminLayout>

--- a/tests/people-view.test.ts
+++ b/tests/people-view.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Tests for the people & access view-model (src/lib/admin/people-view.ts) —
+ * admin Operator console §5.7.
+ *
+ * Seeds product_roles + users in a test D1 and asserts: roles group per user in
+ * canonical order, revoked roles are excluded, non-operator product roles are
+ * ignored, unknown role strings are dropped (not guessed), and principalCount
+ * reflects the onboarding invariant.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  createTestD1,
+  runMigrations,
+  discoverNumericMigrations,
+} from '@venturecrane/crane-test-harness'
+import { resolve } from 'path'
+import type { D1Database } from '@cloudflare/workers-types'
+import { ORG_ID } from '../src/lib/constants'
+import { listOperatorUsers, principalCount, roleBadge } from '../src/lib/admin/people-view'
+
+const migrationsDir = resolve(process.cwd(), 'migrations')
+const ENTITY_ID = 'ent-people'
+
+async function freshDb(): Promise<D1Database> {
+  const db = createTestD1()
+  await runMigrations(db, { files: discoverNumericMigrations(migrationsDir) })
+  // ORG_ID (the SMD org) is seeded by migrations — do not re-insert it.
+  await db
+    .prepare(`INSERT INTO entities (id, org_id, name, slug) VALUES (?, ?, 'Acme', 'acme')`)
+    .bind(ENTITY_ID, ORG_ID)
+    .run()
+  return db
+}
+
+async function addUser(db: D1Database, id: string, email: string, name: string): Promise<void> {
+  await db
+    .prepare(
+      `INSERT INTO users (id, org_id, email, name, role, created_at)
+       VALUES (?, ?, ?, ?, 'client', datetime('now'))`
+    )
+    .bind(id, ORG_ID, email, name)
+    .run()
+}
+
+async function grant(
+  db: D1Database,
+  id: string,
+  userId: string,
+  role: string,
+  opts: { product?: string; revoked?: boolean } = {}
+): Promise<void> {
+  await db
+    .prepare(
+      `INSERT INTO product_roles
+         (id, org_id, user_id, entity_id, product_slug, role, granted_by, granted_at, revoked_at)
+       VALUES (?, ?, ?, ?, ?, ?, NULL, datetime('now'), ?)`
+    )
+    .bind(
+      id,
+      ORG_ID,
+      userId,
+      ENTITY_ID,
+      opts.product ?? 'operator',
+      role,
+      opts.revoked ? '2026-06-01T00:00:00Z' : null
+    )
+    .run()
+}
+
+describe('listOperatorUsers', () => {
+  let db: D1Database
+  beforeEach(async () => {
+    db = await freshDb()
+  })
+
+  it('returns [] when no users hold operator roles', async () => {
+    expect(await listOperatorUsers(db, ENTITY_ID)).toEqual([])
+  })
+
+  it('groups multiple roles per user in canonical order', async () => {
+    await addUser(db, 'u1', 'owner@acme.test', 'Owner')
+    await grant(db, 'r1', 'u1', 'compliance')
+    await grant(db, 'r2', 'u1', 'principal')
+    const users = await listOperatorUsers(db, ENTITY_ID)
+    expect(users).toHaveLength(1)
+    expect(users[0].roles).toEqual(['principal', 'compliance']) // canonical order
+    expect(users[0].email).toBe('owner@acme.test')
+  })
+
+  it('excludes revoked roles and non-operator product roles', async () => {
+    await addUser(db, 'u1', 'a@acme.test', 'A')
+    await grant(db, 'r1', 'u1', 'staff', { revoked: true })
+    await grant(db, 'r2', 'u1', 'principal', { product: 'some-other-product' })
+    // u1 has only a revoked operator role and a different-product role → not listed.
+    expect(await listOperatorUsers(db, ENTITY_ID)).toEqual([])
+  })
+
+  it('drops unknown role strings rather than guessing', async () => {
+    await addUser(db, 'u1', 'a@acme.test', 'A')
+    await grant(db, 'r1', 'u1', 'staff')
+    await grant(db, 'r2', 'u1', 'superuser') // not a client role
+    const users = await listOperatorUsers(db, ENTITY_ID)
+    expect(users[0].roles).toEqual(['staff'])
+  })
+
+  it('lists multiple users ordered by email', async () => {
+    await addUser(db, 'u2', 'zed@acme.test', 'Zed')
+    await addUser(db, 'u1', 'amy@acme.test', 'Amy')
+    await grant(db, 'r1', 'u2', 'staff')
+    await grant(db, 'r2', 'u1', 'principal')
+    const users = await listOperatorUsers(db, ENTITY_ID)
+    expect(users.map((u) => u.email)).toEqual(['amy@acme.test', 'zed@acme.test'])
+  })
+})
+
+describe('principalCount', () => {
+  it('counts users holding the principal role', () => {
+    expect(
+      principalCount([
+        { user_id: 'a', email: 'a', name: null, roles: ['principal'] },
+        { user_id: 'b', email: 'b', name: null, roles: ['staff', 'compliance'] },
+        { user_id: 'c', email: 'c', name: null, roles: ['principal', 'staff'] },
+      ])
+    ).toBe(2)
+    expect(principalCount([])).toBe(0)
+  })
+})
+
+describe('roleBadge', () => {
+  it('maps every client role to a token-based badge', () => {
+    expect(roleBadge('principal').label).toBe('Principal')
+    expect(roleBadge('staff').classes).toContain('--ss-color-complete')
+    expect(roleBadge('compliance').label).toBe('Compliance')
+  })
+})


### PR DESCRIPTION
## What

Per-operator **people & access** at `/admin/operator/[customer]/people` — the client's own users and their Operator roles (principal / staff / compliance), grouped per user. Design: §5.7. Independent PR off main.

## Read-only by design (guardrail)

The design lets SMD add/remove client users and set roles, but that **mutates access controls** — a guardrailed action needing an explicit directive to wire. So this surface shows who has what and **defers the grant/revoke write** rather than shipping an unauthorized access-control mutation. SMD retains the ability via the foundation; it's simply not a button here yet, and the page says so.

## Notes

- `src/lib/admin/people-view.ts` reads `product_roles ⋈ users` (one entity, operator product, non-revoked), groups roles in canonical order, and **drops unknown role strings** rather than guessing. Imports the client-owned role vocabulary (`client-rbac` `CLIENT_ROLES`) read-only.
- Surfaces the missing-principal signal (onboarding seeds exactly one).
- Honest empty state for a pre-onboarding client with no users.
- Overview links the People drill-in.

## Verification

- `npm run verify` green (3246 passed / 2 skipped).
- 7 unit tests (grouping, revoked/other-product exclusion, unknown-role drop, ordering, principal count).

🤖 Generated with [Claude Code](https://claude.com/claude-code)