### PR TITLE
feat(operator): admin config/lifecycle/memory drill-ins — console close-out (§5.2, §5.10, §5.6)

### DIFF
--- a/src/lib/admin/config-view.ts
+++ b/src/lib/admin/config-view.ts
@@ -1,0 +1,60 @@
+/**
+ * Config-display helpers for the admin Operator console configuration view
+ * (`/admin/operator/[customer]/config`) — design §5.2.
+ *
+ * The configuration surface is SMD's read view of a client's authored
+ * customer.yaml projection (personas, skills, scope, business hours, voice,
+ * escalation). Authoring writes go through the config write path (the governance
+ * surface already ships ceiling writes; broader field editing is a follow-on),
+ * so this surface displays what is authored.
+ *
+ * Several projected sections are opaque JSON (`scope`, `business_hours`,
+ * `voice_library`, `escalation` are typed `unknown` in the frozen projection).
+ * Rather than guess their shape and risk fabricating a rendering, this module
+ * answers only the honest question the surface can answer from any value:
+ * "is this section configured?" — presence, not invented structure.
+ */
+
+export type SectionPresence = 'configured' | 'not set'
+
+/**
+ * Is an opaque projected section configured? Null/undefined, an empty object,
+ * and an empty array all read as "not set"; any populated value is "configured".
+ * Pure and total — never throws on an unexpected shape.
+ */
+export function sectionPresence(value: unknown): SectionPresence {
+  if (value === null || value === undefined) return 'not set'
+  if (Array.isArray(value)) return value.length > 0 ? 'configured' : 'not set'
+  if (typeof value === 'object') {
+    return Object.keys(value).length > 0 ? 'configured' : 'not set'
+  }
+  // A scalar (string/number/bool) that isn't empty-string counts as configured.
+  return value === '' ? 'not set' : 'configured'
+}
+
+export interface PresenceBadge {
+  label: string
+  classes: string
+}
+
+const BADGE_STRUCTURE =
+  'inline-flex items-center px-2 py-0.5 rounded-[var(--ss-radius-badge)] ' +
+  'text-[10px] font-medium uppercase tracking-wide whitespace-nowrap'
+
+export function presenceBadge(p: SectionPresence): PresenceBadge {
+  return p === 'configured'
+    ? {
+        label: 'Configured',
+        classes: `${BADGE_STRUCTURE} bg-[color:var(--ss-color-complete)] text-white`,
+      }
+    : {
+        label: 'Not set',
+        classes: `${BADGE_STRUCTURE} bg-[color:var(--ss-color-border)] text-[color:var(--ss-color-text-secondary)]`,
+      }
+}
+
+/** "warm, professional" from a persona tone array, or "—" when none. */
+export function toneSummary(tone: readonly string[] | null | undefined): string {
+  if (!tone || tone.length === 0) return '—'
+  return tone.join(', ')
+}

--- a/src/pages/admin/operator/[customer]/config.astro
+++ b/src/pages/admin/operator/[customer]/config.astro
@@ -1,0 +1,189 @@
+---
+import AdminLayout from '../../../../layouts/AdminLayout.astro'
+import { resolveEntityIdBySlug } from '../../../../lib/admin/operator-overview'
+import { sectionPresence, presenceBadge, toneSummary } from '../../../../lib/admin/config-view'
+import { personaStatusDisplay, skillCountLabel } from '../../../../lib/admin/operator-overview'
+import { getCustomerConfig, type CustomerConfigRow } from '../../../../lib/portal/customer-config'
+import { env } from 'cloudflare:workers'
+
+/**
+ * Operator admin console — configuration view (§5.2).
+ *
+ * SMD's read view of the client's authored customer.yaml projection: identity,
+ * personas (voice + skills), and which customer-scope sections are configured.
+ * Authoring of ceilings ships on the governance surface; broader field editing
+ * is a follow-on, so this surface is read. Opaque sections (scope, business
+ * hours, voice library, escalation are typed `unknown` in the projection) are
+ * shown as configured / not-set presence rather than a guessed structure
+ * (no fabrication, foundations §7).
+ */
+
+const session = Astro.locals.session!
+if (session.role !== 'admin') {
+  return Astro.redirect('/auth/sign-in')
+}
+
+const slug = Astro.params.customer ?? ''
+const entityId = await resolveEntityIdBySlug(env.DB, slug)
+
+let config: CustomerConfigRow | null = null
+let configError: string | null = null
+if (entityId) {
+  try {
+    config = await getCustomerConfig(env.DB, entityId)
+  } catch (err) {
+    configError = err instanceof Error ? err.message : String(err)
+  }
+}
+const notFound = entityId === null || (config === null && configError === null)
+
+const sections = config
+  ? [
+      { label: 'Scope envelope', presence: sectionPresence(config.scope) },
+      { label: 'Business hours', presence: sectionPresence(config.business_hours) },
+      { label: 'Voice library', presence: sectionPresence(config.voice_library) },
+      { label: 'Escalation', presence: sectionPresence(config.escalation) },
+    ]
+  : []
+---
+
+<AdminLayout
+  title={`Operator — Config — ${slug}`}
+  breadcrumbs={[
+    { label: 'Dashboard', href: '/admin' },
+    { label: 'Operator', href: '/admin/operator' },
+    { label: slug, href: `/admin/operator/${encodeURIComponent(slug)}` },
+    { label: 'Configuration' },
+  ]}
+  maxWidth="max-w-5xl"
+>
+  <div class="space-y-card">
+    {
+      notFound ? (
+        <div class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card">
+          <h2 class="text-xl font-semibold text-[color:var(--ss-color-text-primary)]">
+            Operator not found
+          </h2>
+          <p class="text-sm text-[color:var(--ss-color-text-secondary)] mt-1">
+            No operator is provisioned under <code>{slug}</code>.{' '}
+            <a href="/admin/operator" class="text-[color:var(--ss-color-action)] hover:underline">
+              Back to the fleet
+            </a>
+            .
+          </p>
+        </div>
+      ) : configError ? (
+        <div class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-error)] p-card">
+          <h2 class="text-xl font-semibold text-[color:var(--ss-color-error)]">
+            Config projection malformed
+          </h2>
+          <p class="text-xs text-[color:var(--ss-color-text-muted)] mt-2 font-mono">
+            {configError}
+          </p>
+        </div>
+      ) : (
+        config && (
+          <>
+            <header>
+              <h2 class="text-xl font-semibold text-[color:var(--ss-color-text-primary)]">
+                Configuration — {slug}
+              </h2>
+              <p class="text-sm text-[color:var(--ss-color-text-secondary)] mt-1">
+                The authored configuration for this operator (read view). Trust ceilings are edited
+                on the governance surface.
+              </p>
+            </header>
+
+            <div class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card">
+              <h3 class="text-base font-semibold text-[color:var(--ss-color-text-primary)] mb-3">
+                Identity
+              </h3>
+              <dl class="text-sm grid sm:grid-cols-2 gap-x-6 gap-y-1">
+                <div class="flex justify-between gap-4">
+                  <dt class="text-[color:var(--ss-color-text-secondary)]">Vertical</dt>
+                  <dd class="text-[color:var(--ss-color-text-primary)]">
+                    {config.vertical ?? '—'}
+                  </dd>
+                </div>
+                <div class="flex justify-between gap-4">
+                  <dt class="text-[color:var(--ss-color-text-secondary)]">Schema version</dt>
+                  <dd class="text-[color:var(--ss-color-text-primary)]">{config.schema_version}</dd>
+                </div>
+                <div class="flex justify-between gap-4">
+                  <dt class="text-[color:var(--ss-color-text-secondary)]">Compliance mode</dt>
+                  <dd class="text-[color:var(--ss-color-text-primary)]">
+                    {config.compliance_enabled ? 'On' : 'Off'}
+                  </dd>
+                </div>
+                <div class="flex justify-between gap-4">
+                  <dt class="text-[color:var(--ss-color-text-secondary)]">Synced</dt>
+                  <dd class="text-[color:var(--ss-color-text-primary)] font-mono text-xs">
+                    {config.git_sha.slice(0, 8)}
+                  </dd>
+                </div>
+              </dl>
+            </div>
+
+            <div class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card">
+              <h3 class="text-base font-semibold text-[color:var(--ss-color-text-primary)] mb-3">
+                Personas ({config.personas.length})
+              </h3>
+              {config.personas.length === 0 ? (
+                <p class="text-sm text-[color:var(--ss-color-text-secondary)]">
+                  No personas configured.
+                </p>
+              ) : (
+                <ul class="space-y-3">
+                  {config.personas.map((p) => {
+                    const st = personaStatusDisplay(p.status)
+                    return (
+                      <li class="border-b border-[color:var(--ss-color-border-subtle)] pb-3 last:border-0 last:pb-0">
+                        <div class="flex items-center justify-between gap-2">
+                          <span class="font-medium text-[color:var(--ss-color-text-primary)]">
+                            {p.name}
+                          </span>
+                          <span class="inline-flex items-center gap-1.5 text-xs text-[color:var(--ss-color-text-secondary)]">
+                            <span
+                              class={`inline-block h-2 w-2 rounded-full ${st.dotClass}`}
+                              aria-hidden="true"
+                            />
+                            {st.label}
+                          </span>
+                        </div>
+                        <p class="text-xs text-[color:var(--ss-color-text-muted)]">
+                          {p.title ? `${p.title} · ` : ''}
+                          {skillCountLabel(p.skills.length)} · tone: {toneSummary(p.tone)}
+                        </p>
+                      </li>
+                    )
+                  })}
+                </ul>
+              )}
+            </div>
+
+            <div class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card">
+              <h3 class="text-base font-semibold text-[color:var(--ss-color-text-primary)] mb-3">
+                Customer scope
+              </h3>
+              <ul class="space-y-2 text-sm">
+                {sections.map((s) => {
+                  const b = presenceBadge(s.presence)
+                  return (
+                    <li class="flex items-center justify-between gap-4">
+                      <span class="text-[color:var(--ss-color-text-primary)]">{s.label}</span>
+                      <span class={b.classes}>{b.label}</span>
+                    </li>
+                  )
+                })}
+              </ul>
+              <p class="text-xs text-[color:var(--ss-color-text-muted)] mt-3">
+                These sections are shown as configured / not set; their detailed editors land with
+                the config-authoring write path.
+              </p>
+            </div>
+          </>
+        )
+      )
+    }
+  </div>
+</AdminLayout>

--- a/src/pages/admin/operator/[customer]/index.astro
+++ b/src/pages/admin/operator/[customer]/index.astro
@@ -266,6 +266,14 @@ const personas = config?.personas ?? []
               <ul class="flex flex-wrap gap-x-6 gap-y-2 text-sm">
                 <li>
                   <a
+                    href={`/admin/operator/${encodeURIComponent(slug)}/config`}
+                    class="text-[color:var(--ss-color-action)] hover:underline"
+                  >
+                    Configuration
+                  </a>
+                </li>
+                <li>
+                  <a
                     href={`/admin/operator/${encodeURIComponent(slug)}/governance`}
                     class="text-[color:var(--ss-color-action)] hover:underline"
                   >
@@ -298,10 +306,26 @@ const personas = config?.personas ?? []
                 </li>
                 <li>
                   <a
+                    href={`/admin/operator/${encodeURIComponent(slug)}/memory`}
+                    class="text-[color:var(--ss-color-action)] hover:underline"
+                  >
+                    Memory
+                  </a>
+                </li>
+                <li>
+                  <a
                     href={`/admin/operator/${encodeURIComponent(slug)}/people`}
                     class="text-[color:var(--ss-color-action)] hover:underline"
                   >
                     People
+                  </a>
+                </li>
+                <li>
+                  <a
+                    href={`/admin/operator/${encodeURIComponent(slug)}/lifecycle`}
+                    class="text-[color:var(--ss-color-action)] hover:underline"
+                  >
+                    Lifecycle
                   </a>
                 </li>
                 <li>
@@ -321,9 +345,6 @@ const personas = config?.personas ?? []
                   </a>
                 </li>
               </ul>
-              <p class="text-xs text-[color:var(--ss-color-text-muted)] mt-3">
-                Configuration, memory, and lifecycle drill-ins land as their surfaces ship.
-              </p>
             </div>
           </>
         )

--- a/src/pages/admin/operator/[customer]/lifecycle.astro
+++ b/src/pages/admin/operator/[customer]/lifecycle.astro
@@ -1,0 +1,133 @@
+---
+import AdminLayout from '../../../../layouts/AdminLayout.astro'
+import { resolveEntityIdBySlug, subscriptionState } from '../../../../lib/admin/operator-overview'
+import {
+  listFleetStatus,
+  heartbeatDisplay,
+  formatUptime,
+  relativeTimestamp,
+} from '../../../../lib/admin/fleet-status'
+import { getProductSubscription } from '../../../../lib/portal/product-access'
+import { env } from 'cloudflare:workers'
+
+/**
+ * Operator admin console — lifecycle (§5.10).
+ *
+ * Provision status, Machine liveness (heartbeat / uptime / version), and the
+ * config-history trail. SMD-only domain.
+ *
+ * Read this PR: pin/repin, resize, pause/resume, and decommission are SMD-only
+ * lifecycle operations — decommission is destructive and the others are
+ * guardrailed lifecycle changes that need an explicit Captain directive to wire.
+ * So this surface shows status and links the existing config-history; the
+ * mutating actions are deferred rather than shipped as un-directed controls.
+ */
+
+const session = Astro.locals.session!
+if (session.role !== 'admin') {
+  return Astro.redirect('/auth/sign-in')
+}
+
+const slug = Astro.params.customer ?? ''
+const entityId = await resolveEntityIdBySlug(env.DB, slug)
+const notFound = entityId === null
+
+const subscription = entityId ? await getProductSubscription(env.DB, entityId, 'operator') : null
+const sub = subscriptionState(subscription?.status ?? null)
+const fleetRows = entityId ? await listFleetStatus(env.DB) : []
+const fleet =
+  fleetRows.find((r) => r.entity_id === entityId) ?? fleetRows.find((r) => r.customer_slug === slug)
+const hb = heartbeatDisplay(fleet?.last_heartbeat_ts ?? null)
+---
+
+<AdminLayout
+  title={`Operator — Lifecycle — ${slug}`}
+  breadcrumbs={[
+    { label: 'Dashboard', href: '/admin' },
+    { label: 'Operator', href: '/admin/operator' },
+    { label: slug, href: `/admin/operator/${encodeURIComponent(slug)}` },
+    { label: 'Lifecycle' },
+  ]}
+  maxWidth="max-w-5xl"
+>
+  <div class="space-y-card">
+    {
+      notFound ? (
+        <div class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card">
+          <h2 class="text-xl font-semibold text-[color:var(--ss-color-text-primary)]">
+            Operator not found
+          </h2>
+          <p class="text-sm text-[color:var(--ss-color-text-secondary)] mt-1">
+            No operator is provisioned under <code>{slug}</code>.{' '}
+            <a href="/admin/operator" class="text-[color:var(--ss-color-action)] hover:underline">
+              Back to the fleet
+            </a>
+            .
+          </p>
+        </div>
+      ) : (
+        <>
+          <header>
+            <h2 class="text-xl font-semibold text-[color:var(--ss-color-text-primary)]">
+              Lifecycle — {slug}
+            </h2>
+            <p class="text-sm text-[color:var(--ss-color-text-secondary)] mt-1">
+              Provision status and Machine liveness. SMD-only domain.
+            </p>
+          </header>
+
+          <div class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card">
+            <h3 class="text-base font-semibold text-[color:var(--ss-color-text-primary)] mb-3">
+              Status
+            </h3>
+            <dl class="text-sm grid sm:grid-cols-2 gap-x-6 gap-y-1">
+              <div class="flex justify-between gap-4">
+                <dt class="text-[color:var(--ss-color-text-secondary)]">Subscription</dt>
+                <dd class={sub.colorClass}>{sub.label}</dd>
+              </div>
+              <div class="flex justify-between gap-4">
+                <dt class="text-[color:var(--ss-color-text-secondary)]">Heartbeat</dt>
+                <dd class="text-[color:var(--ss-color-text-primary)]">{hb.label}</dd>
+              </div>
+              <div class="flex justify-between gap-4">
+                <dt class="text-[color:var(--ss-color-text-secondary)]">Uptime</dt>
+                <dd class="text-[color:var(--ss-color-text-primary)]">
+                  {formatUptime(fleet?.process_uptime_seconds ?? null)}
+                </dd>
+              </div>
+              <div class="flex justify-between gap-4">
+                <dt class="text-[color:var(--ss-color-text-secondary)]">Version</dt>
+                <dd class="text-[color:var(--ss-color-text-primary)] font-mono text-xs">
+                  {fleet?.version ?? '—'}
+                </dd>
+              </div>
+              <div class="flex justify-between gap-4">
+                <dt class="text-[color:var(--ss-color-text-secondary)]">Last audit</dt>
+                <dd class="text-[color:var(--ss-color-text-primary)]">
+                  {relativeTimestamp(fleet?.last_audit_ts ?? null)}
+                </dd>
+              </div>
+            </dl>
+          </div>
+
+          <div class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card">
+            <h3 class="text-base font-semibold text-[color:var(--ss-color-text-primary)] mb-3">
+              History &amp; operations
+            </h3>
+            <a
+              href={`/admin/operator/config-history/${encodeURIComponent(slug)}`}
+              class="text-sm text-[color:var(--ss-color-action)] hover:underline"
+            >
+              View config-history (customer.yaml sync log)
+            </a>
+            <p class="text-xs text-[color:var(--ss-color-text-muted)] mt-3">
+              Pin / repin Hermes, resize, pause / resume, and decommission are SMD-only lifecycle
+              operations handled on directive (decommission is destructive); they are not wired as
+              controls here.
+            </p>
+          </div>
+        </>
+      )
+    }
+  </div>
+</AdminLayout>

--- a/src/pages/admin/operator/[customer]/memory.astro
+++ b/src/pages/admin/operator/[customer]/memory.astro
@@ -1,0 +1,93 @@
+---
+import AdminLayout from '../../../../layouts/AdminLayout.astro'
+import { resolveEntityIdBySlug } from '../../../../lib/admin/operator-overview'
+import { env } from 'cloudflare:workers'
+
+/**
+ * Operator admin console — memory & agent-skills (§5.6).
+ *
+ * The operator's learned state: memory observations (with evidence status) and
+ * agent-authored skills (with provenance + Captain-approval), mirrored from the
+ * runtime with SMD dismiss / disable as a platform-safety capability.
+ *
+ * Honest state (foundations §7, §5.6): Honcho memory inference is Phase-2, and
+ * the memory/agent-skill read path is not in the runtime read contract yet
+ * (RUNTIME_READ_KINDS covers audit/draft/matter/activity only). So this surface
+ * states that plainly rather than fabricating observations or a skill inventory.
+ * It lights up when the memory read + mirror land; the dismiss/disable controls
+ * are platform-safety actions wired with that path.
+ */
+
+const session = Astro.locals.session!
+if (session.role !== 'admin') {
+  return Astro.redirect('/auth/sign-in')
+}
+
+const slug = Astro.params.customer ?? ''
+const entityId = await resolveEntityIdBySlug(env.DB, slug)
+const notFound = entityId === null
+---
+
+<AdminLayout
+  title={`Operator — Memory — ${slug}`}
+  breadcrumbs={[
+    { label: 'Dashboard', href: '/admin' },
+    { label: 'Operator', href: '/admin/operator' },
+    { label: slug, href: `/admin/operator/${encodeURIComponent(slug)}` },
+    { label: 'Memory' },
+  ]}
+  maxWidth="max-w-5xl"
+>
+  <div class="space-y-card">
+    {
+      notFound ? (
+        <div class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card">
+          <h2 class="text-xl font-semibold text-[color:var(--ss-color-text-primary)]">
+            Operator not found
+          </h2>
+          <p class="text-sm text-[color:var(--ss-color-text-secondary)] mt-1">
+            No operator is provisioned under <code>{slug}</code>.{' '}
+            <a href="/admin/operator" class="text-[color:var(--ss-color-action)] hover:underline">
+              Back to the fleet
+            </a>
+            .
+          </p>
+        </div>
+      ) : (
+        <>
+          <header>
+            <h2 class="text-xl font-semibold text-[color:var(--ss-color-text-primary)]">
+              Memory &amp; agent-skills — {slug}
+            </h2>
+            <p class="text-sm text-[color:var(--ss-color-text-secondary)] mt-1">
+              The operator's learned observations and agent-authored skills.
+            </p>
+          </header>
+
+          <div class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card space-y-stack">
+            <div>
+              <h3 class="text-base font-semibold text-[color:var(--ss-color-text-primary)]">
+                Observations
+              </h3>
+              <p class="text-sm text-[color:var(--ss-color-text-secondary)] mt-1">
+                Memory inference is Phase-2. Observations with their evidence status appear here
+                once the memory mirror lands; SMD dismiss (removal from the learning loop) is wired
+                with it.
+              </p>
+            </div>
+            <div>
+              <h3 class="text-base font-semibold text-[color:var(--ss-color-text-primary)]">
+                Agent-authored skills
+              </h3>
+              <p class="text-sm text-[color:var(--ss-color-text-secondary)] mt-1">
+                Skills the operator wrote for itself, with provenance and Captain-approval state,
+                appear here once the skill-inventory mirror lands; SMD approve / disable (a
+                platform- safety capability) is wired with it.
+              </p>
+            </div>
+          </div>
+        </>
+      )
+    }
+  </div>
+</AdminLayout>

--- a/tests/config-view.test.ts
+++ b/tests/config-view.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Tests for the config-display helpers (src/lib/admin/config-view.ts) —
+ * admin Operator console §5.2.
+ *
+ * sectionPresence answers the one honest question the surface can ask of an
+ * opaque projected section ("is it configured?") without guessing structure.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { sectionPresence, presenceBadge, toneSummary } from '../src/lib/admin/config-view'
+
+describe('sectionPresence', () => {
+  it('treats null / undefined / empty as not set', () => {
+    expect(sectionPresence(null)).toBe('not set')
+    expect(sectionPresence(undefined)).toBe('not set')
+    expect(sectionPresence({})).toBe('not set')
+    expect(sectionPresence([])).toBe('not set')
+    expect(sectionPresence('')).toBe('not set')
+  })
+
+  it('treats any populated value as configured', () => {
+    expect(sectionPresence({ a: 1 })).toBe('configured')
+    expect(sectionPresence([1])).toBe('configured')
+    expect(sectionPresence('x')).toBe('configured')
+    expect(sectionPresence(0)).toBe('configured') // a scalar 0 is a value
+  })
+})
+
+describe('presenceBadge', () => {
+  it('maps presence to a token-based badge', () => {
+    expect(presenceBadge('configured').label).toBe('Configured')
+    expect(presenceBadge('configured').classes).toContain('--ss-color-complete')
+    expect(presenceBadge('not set').label).toBe('Not set')
+  })
+})
+
+describe('toneSummary', () => {
+  it('joins tone entries and handles empty', () => {
+    expect(toneSummary(['warm', 'professional'])).toBe('warm, professional')
+    expect(toneSummary([])).toBe('—')
+    expect(toneSummary(null)).toBe('—')
+    expect(toneSummary(undefined)).toBe('—')
+  })
+})


### PR DESCRIPTION
## What

The final three read-only per-operator surfaces, completing the admin console IA. Independent PR off main.

- **Configuration (§5.2)** `/[customer]/config` — read view of the authored `customer.yaml` projection: identity, personas (voice + skills), and customer-scope sections shown as **configured / not-set presence** (scope/business-hours/voice/escalation are opaque `unknown` in the projection, so presence is the honest answer — no guessed structure). Ceiling authoring stays on the governance surface.
- **Lifecycle (§5.10)** `/[customer]/lifecycle` — provision status, Machine liveness (heartbeat / uptime / version), and the config-history link. Pin/repin, resize, pause/resume, decommission are SMD-only ops handled on directive (decommission is destructive) — shown as status, **not wired** as un-directed controls.
- **Memory & agent-skills (§5.6)** `/[customer]/memory` — honest **Phase-2** state: Honcho memory inference is Phase-2 and the memory/agent-skill read path isn't in the runtime read contract yet, so the surface says so rather than fabricating observations or a skill inventory.

## Notes

- New `src/lib/admin/config-view.ts` (`sectionPresence` / `presenceBadge` / `toneSummary`), 4 unit tests.
- Overview now links **every** drill-in — the console IA is complete (Configuration, Governance, Authority, Connectors, Runtime, Memory, People, Lifecycle, Cost, Config history).
- No fabrication: opaque sections → presence; Phase-2 memory → stated; destructive lifecycle ops → deferred to directive.

## Verification

- `npm run verify` green (3254 passed / 2 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)