### PR TITLE
feat(operator-portal): Work surface (client-portal §5.3)

### DIFF
--- a/src/lib/portal/operator/work-read.ts
+++ b/src/lib/portal/operator/work-read.ts
@@ -1,0 +1,91 @@
+/**
+ * Work read path (client-portal §5.3). The items the operator's configuration
+ * routes to a human. Bridges the frozen ADR 0043 runtime read into a small
+ * work-item shape.
+ *
+ * Entirely entitlement-conditional: an item exists here ONLY because a skill
+ * was authored to route to a human (ADR 0035). This reader returns whatever the
+ * runtime produces — it never synthesizes a queue. At launch (read path not
+ * wired, and/or no skill authored to draft) it returns [], and the surface
+ * renders an honest empty state — not a broken queue.
+ *
+ * Same discipline as activity-read / matters-read: gated on
+ * isRuntimeReadConfigured so an unwired deploy returns [] without writing a
+ * read-audit row per view; defensive parse, never cast.
+ */
+
+import type { D1Database } from '@cloudflare/workers-types'
+import { readMachineRuntime, type RuntimeReadActor } from '../../operator/runtime-read'
+import {
+  createMachineRuntimeTransport,
+  createRuntimeReadAudit,
+  isRuntimeReadConfigured,
+  type RuntimeReadEnv,
+} from '../../operator/runtime-read-transport'
+
+export interface WorkItem {
+  id: string
+  subject: string
+  recipient: string
+  skill: string
+  createdAt: string
+}
+
+export interface WorkReadDeps {
+  db: D1Database
+  env: RuntimeReadEnv
+  actorUserId: string
+}
+
+/** Items routed to a human for this client. Fails closed to [] until wired. */
+export async function loadWorkItems(
+  deps: WorkReadDeps,
+  customerSlug: string,
+  actor: RuntimeReadActor
+): Promise<WorkItem[]> {
+  if (!isRuntimeReadConfigured(deps.env)) return []
+  const result = await readMachineRuntime(
+    {
+      transport: createMachineRuntimeTransport(deps.env),
+      audit: createRuntimeReadAudit(deps.db, { actorUserId: deps.actorUserId }),
+    },
+    customerSlug,
+    { kind: 'draft' },
+    actor
+  )
+  return result.ok ? parseWorkItems(result.data) : []
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v)
+}
+function reqString(v: unknown): string | null {
+  return typeof v === 'string' && v.length > 0 ? v : null
+}
+
+/** Parse the runtime payload (bare array or `{ items: [...] }`) into WorkItem[].
+ * Rows missing a required field are dropped — never a fabricated work card. */
+export function parseWorkItems(data: unknown): WorkItem[] {
+  const raw: unknown = isRecord(data) && Array.isArray(data['items']) ? data['items'] : data
+  if (!Array.isArray(raw)) return []
+  const out: WorkItem[] = []
+  for (const item of raw) {
+    if (!isRecord(item)) continue
+    const id = reqString(item['id'])
+    const subject = reqString(item['subject'])
+    const recipient = reqString(item['recipient'])
+    const skill = reqString(item['skill'])
+    const createdAt = reqString(item['createdAt'])
+    if (
+      id === null ||
+      subject === null ||
+      recipient === null ||
+      skill === null ||
+      createdAt === null
+    ) {
+      continue
+    }
+    out.push({ id, subject, recipient, skill, createdAt })
+  }
+  return out
+}

--- a/src/pages/portal/products/operator/work/index.astro
+++ b/src/pages/portal/products/operator/work/index.astro
@@ -1,0 +1,171 @@
+---
+import '../../../../../styles/global.css'
+import { BRAND_NAME } from '../../../../../lib/config/brand'
+import { resolveOperatorAccess } from '../../../../../lib/portal/operator-access'
+import { getCustomerConfig } from '../../../../../lib/portal/customer-config'
+import { loadWorkItems } from '../../../../../lib/portal/operator/work-read'
+import PortalHeader from '../../../../../components/portal/PortalHeader.astro'
+import PortalTabs from '../../../../../components/portal/PortalTabs.astro'
+import PortalPageHead from '../../../../../components/portal/PortalPageHead.astro'
+import SkipToMain from '../../../../../components/SkipToMain.astro'
+import DomainSurface from '../../../../../components/portal/operator/DomainSurface.astro'
+import { env } from 'cloudflare:workers'
+
+/**
+ * Operator — Work (client-portal §5.3). Where a human handles what the
+ * operator's configuration routes to them.
+ *
+ * URL: portal.smd.services/portal/products/operator/work
+ *
+ * Entirely entitlement-conditional (ADR 0035): an item exists here ONLY because
+ * a skill was authored to route to a human. The surface imposes no stage of its
+ * own — it renders whatever the entitlements produced. Where no skill routes to
+ * a person, it is empty by design (not a broken queue), and the Home "what
+ * needs you" entry is likewise absent.
+ *
+ * Dual-mode via <DomainSurface domain="runtime">: when the runtime switch is on
+ * and the user's role permits (principal/staff), the assigned human acts on the
+ * item; when off (launch default), it is Read + Request and SMD handles the
+ * work. Compliance resolves to read_request here (its role does not operate the
+ * runtime domain). Fed by the frozen ADR 0043 read path — empty until wired.
+ */
+
+const access = await resolveOperatorAccess(env.DB, Astro.locals, {
+  allowedRoles: ['principal', 'staff', 'compliance'],
+})
+if (access.kind === 'redirect') {
+  return Astro.redirect(access.to)
+}
+const { user, client, roles } = access
+
+const config = await getCustomerConfig(env.DB, client.id)
+const customerSlug = config?.customer_slug ?? client.id
+const actorRole = roles.includes('principal')
+  ? 'principal'
+  : roles.includes('staff')
+    ? 'staff'
+    : 'compliance'
+const items = await loadWorkItems({ db: env.DB, env, actorUserId: user.id }, customerSlug, {
+  actor: user.email,
+  actorRole,
+})
+
+const RETURN_TO = '/portal/products/operator/work'
+const cr = Astro.url.searchParams.get('cr')
+const crMessage =
+  cr === 'filed'
+    ? 'Your request was sent.'
+    : cr === 'invalid'
+      ? "That request couldn't be filed. Please add a short description and try again."
+      : cr === 'error'
+        ? 'Something went wrong filing your request. Please try again.'
+        : null
+
+const listClass =
+  'm-0 list-none p-0 border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)]'
+const emptyClass =
+  'border-[3px] border-[color:var(--ss-color-text-primary)] p-8 md:p-12 text-center'
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;900&family=Archivo+Narrow:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap"
+      rel="stylesheet"
+    />
+    <title>Operator · Work | {BRAND_NAME}</title>
+  </head>
+  <body class="min-h-screen bg-[color:var(--ss-color-background)]">
+    <SkipToMain />
+    <PortalHeader clientName={client.name} />
+
+    <PortalTabs pathname={Astro.url.pathname} operatorActive={true} />
+
+    <main id="main" role="main" class="max-w-5xl mx-auto px-4 md:px-6 pb-24 md:pb-12">
+      <PortalPageHead
+        crumbHref="/portal/products/operator"
+        crumbLabel="Operator"
+        tag="Section"
+        h1="Work"
+        meta={items.length > 0 ? `${items.length} waiting` : null}
+      />
+
+      {
+        crMessage && (
+          <div
+            role="status"
+            class={`mt-6 border-[3px] px-5 py-3 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold ${
+              cr === 'filed'
+                ? 'border-[color:var(--ss-color-complete)] text-[color:var(--ss-color-complete)]'
+                : 'border-[color:var(--ss-color-error)] text-[color:var(--ss-color-error)]'
+            }`}
+          >
+            {crMessage}
+          </div>
+        )
+      }
+
+      <div class="mt-8">
+        {
+          items.length === 0 ? (
+            <section aria-label="Nothing waiting" class={emptyClass}>
+              <p class="font-['Archivo'] text-2xl md:text-3xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]">
+                Nothing needs a person
+              </p>
+              <p class="mt-3 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)]">
+                Your operator handles its work and routes something here only when it needs a human.
+              </p>
+            </section>
+          ) : (
+            <DomainSurface
+              authority={config?.authority ?? null}
+              domain="runtime"
+              roles={roles}
+              returnTo={RETURN_TO}
+              domainLabel="work routed to a person"
+            >
+              <ul slot="read" role="list" class={listClass}>
+                {items.map((it) => (
+                  <li class="border-b-[2px] border-[color:var(--ss-color-text-primary)] last:border-b-0 px-5 md:px-7 py-4">
+                    <p class="font-['Archivo'] font-bold text-[color:var(--ss-color-text-primary)] m-0">
+                      {it.subject}
+                    </p>
+                    <p class="mt-1 text-caption text-[color:var(--ss-color-text-secondary)] m-0">
+                      {it.recipient} · {it.skill}
+                    </p>
+                  </li>
+                ))}
+              </ul>
+              <ul slot="operable" role="list" class={listClass}>
+                {items.map((it) => (
+                  <li class="border-b-[2px] border-[color:var(--ss-color-text-primary)] last:border-b-0">
+                    <a
+                      href={`/portal/products/operator/drafts/${it.id}`}
+                      class="block px-5 md:px-7 py-4 hover:bg-[color:var(--ss-color-border-subtle)] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-inset"
+                    >
+                      <p class="font-['Archivo'] font-bold text-[color:var(--ss-color-text-primary)] m-0">
+                        {it.subject}
+                      </p>
+                      <p class="mt-1 text-caption text-[color:var(--ss-color-text-secondary)] m-0">
+                        {it.recipient} · {it.skill}
+                      </p>
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </DomainSurface>
+          )
+        }
+      </div>
+    </main>
+  </body>
+</html>

--- a/tests/forbidden-strings.test.ts
+++ b/tests/forbidden-strings.test.ts
@@ -477,6 +477,13 @@ const LIST_INDEX_ALLOWLIST: string[] = [
   // for N, shipped at 1 (roster-of-one shows the single operator without
   // switcher chrome). The .map( iterates personas into identity sections.
   resolve('src/pages/portal/products/operator/operators/index.astro'),
+  // `products/operator/work/index.astro` (§5.3) renders work items routed to a
+  // person as plain rows (subject + recipient/skill) inside the dual-mode
+  // read/operable slots — not the PortalListItem status/document record-row
+  // vocabulary (no money/status/document cell). The .map( iterates the
+  // entitlement-produced work items; empty by design until a skill routes to a
+  // human (ADR 0035).
+  resolve('src/pages/portal/products/operator/work/index.astro'),
 ]
 
 /** Collect every `index.astro` under `src/pages/portal/` EXCEPT the home. */

--- a/tests/operator-work-read.test.ts
+++ b/tests/operator-work-read.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+import type { D1Database } from '@cloudflare/workers-types'
+import { loadWorkItems, parseWorkItems } from '../src/lib/portal/operator/work-read'
+
+const NOOP_DB = {
+  prepare() {
+    throw new Error('DB must not be touched when the runtime read path is unconfigured')
+  },
+} as unknown as D1Database
+const ACTOR = { actor: 'pat@firm.com', actorRole: 'staff' }
+
+describe('loadWorkItems: fail-closed, never a fabricated queue', () => {
+  it('returns [] (and never touches D1) when the read path is unconfigured', async () => {
+    const items = await loadWorkItems(
+      { db: NOOP_DB, env: {}, actorUserId: 'u-1' },
+      'smith-pi',
+      ACTOR
+    )
+    expect(items).toEqual([])
+  })
+})
+
+describe('parseWorkItems: defensive parse', () => {
+  const good = {
+    id: 'd1',
+    subject: 'Demand letter',
+    recipient: 'adjuster@x.com',
+    skill: 'pi-demand-letter',
+    createdAt: '2026-06-01T00:00:00.000Z',
+  }
+  it('parses a bare array and an { items: [...] } envelope', () => {
+    expect(parseWorkItems([good])).toHaveLength(1)
+    expect(parseWorkItems({ items: [good] })).toHaveLength(1)
+  })
+  it('drops rows missing a required field', () => {
+    expect(parseWorkItems([{ ...good, subject: '' }])).toHaveLength(0)
+    expect(parseWorkItems([{ ...good, recipient: undefined }])).toHaveLength(0)
+  })
+  it('returns [] for non-array / non-envelope input', () => {
+    expect(parseWorkItems(null)).toEqual([])
+    expect(parseWorkItems('nope')).toEqual([])
+    expect(parseWorkItems({})).toEqual([])
+  })
+})


### PR DESCRIPTION
## Work (§5.3)

Where a human handles what the operator's configuration routes to them — the sixth client-portal surface, built on the frozen foundation seam.

### What it is
Entirely **entitlement-conditional** (ADR 0035): an item exists here only because a skill was authored to route to a person. The surface imposes no stage of its own and synthesizes no queue. Where nothing routes to a human, it is **empty by design** — an honest empty state ("Nothing needs a person"), not a broken queue.

### Dual-mode
Via `<DomainSurface domain="runtime">`:
- **Operable** (runtime switch on AND role is principal/staff): the assigned human opens the item and acts on it (`/drafts/[id]`).
- **Read + Request** (launch default, and always for compliance whose role does not operate the runtime domain): SMD handles the work; client can request a change.

### Data path
Fed by the frozen **ADR 0043** runtime read (`readMachineRuntime`, `kind: 'draft'`). Gated on `isRuntimeReadConfigured` so an unwired deploy returns `[]` without writing a read-audit row per view — same discipline as activity-read / matters-read. Defensive parse, never cast; rows missing a required field are dropped.

### Files
- `src/lib/portal/operator/work-read.ts` — `loadWorkItems` (fail-closed `[]`), `parseWorkItems` (defensive)
- `src/pages/portal/products/operator/work/index.astro` — dual-mode surface, honest empty
- `tests/operator-work-read.test.ts` — fail-closed + defensive-parse coverage
- `tests/forbidden-strings.test.ts` — R7 LIST_INDEX_ALLOWLIST entry (justified)

### Verification
typecheck 0 errors · build clean · lint 0 errors · tests green (97 in the two touched files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)