### PR TITLE
feat(operator-portal): Team surface (client-portal §5.7)

### DIFF
--- a/src/lib/portal/operator/people-access-gate.ts
+++ b/src/lib/portal/operator/people-access-gate.ts
@@ -1,0 +1,34 @@
+/**
+ * Server-side people_access composition gate (client-portal §5.7).
+ *
+ * The Team surface (users, roles, PTO, voice profiles) is governed by the
+ * `people_access` switchable authority domain (ADR 0041). At launch every
+ * client switch is off (posture `managed`), so the client org does NOT operate
+ * its own roster — SMD does, and the client sees Read + Request.
+ *
+ * The portal renders that decision (via <DomainSurface domain="people_access">),
+ * but rendering is not enforcement. Every write endpoint that mutates the roster
+ * — grant/revoke a role, send an invitation, set PTO — MUST re-check the same
+ * composition here. A client-rendered read-only view is never trusted as the
+ * gate; a hand-crafted POST to the mutation endpoint is refused on the same
+ * authority logic. This mirrors the connectors-secret precedent (PR4), where the
+ * write endpoint re-checks `isClientOperable` rather than trusting the UI.
+ *
+ * Pure read of the projected authority posture + the frozen `isClientOperable`
+ * predicate. No mutation, no audit (the caller audits its own action).
+ */
+
+import type { D1Database } from '@cloudflare/workers-types'
+import { getCustomerConfig } from '../customer-config'
+import { isClientOperable } from '../../operator/authority'
+
+/**
+ * Is the client org allowed to operate its own people_access domain (roster,
+ * roles, PTO) for this entity? `false` at launch (managed posture) and whenever
+ * the config row is absent — fail-closed. When `false`, the client portal shows
+ * Read + Request and the mutation endpoints refuse.
+ */
+export async function isPeopleAccessOperable(db: D1Database, entityId: string): Promise<boolean> {
+  const config = await getCustomerConfig(db, entityId)
+  return isClientOperable(config?.authority ?? null, 'people_access')
+}

--- a/src/lib/portal/operator/team-read.ts
+++ b/src/lib/portal/operator/team-read.ts
@@ -1,0 +1,116 @@
+/**
+ * Team read path (client-portal §5.7). The people on this account — who holds
+ * which role, and who is currently away — projected read-only for the Team
+ * surface.
+ *
+ * This is the read half of the `people_access` domain. The write half (grant /
+ * revoke / invite / set-PTO) lives in the existing mutation endpoints, now gated
+ * by `isPeopleAccessOperable`. At launch the surface is Read + Request, so this
+ * projection is the load-bearing view: a principal seeing the roster SMD
+ * manages, with a path to request a change.
+ *
+ * The roster query mirrors the legacy users page (one row per person, roles
+ * aggregated) but returns plain data, not markup — the dual-mode surface decides
+ * how to render it. PTO reuses `listActivePto`. Defensive throughout: a missing
+ * name falls back to the email; never a fabricated member.
+ */
+
+import type { D1Database } from '@cloudflare/workers-types'
+import { listActivePto, type UserPtoRow } from './pto'
+
+/** Canonical client role display order: principal, then staff, then compliance. */
+const ROLE_ORDER: Record<string, number> = { principal: 0, staff: 1, compliance: 2 }
+
+export interface TeamMember {
+  id: string
+  name: string
+  email: string
+  lastLoginAt: string | null
+  roles: string[]
+}
+
+export interface TeamRoster {
+  members: TeamMember[]
+  awayCount: number
+  pto: UserPtoRow[]
+}
+
+interface MemberDbRow {
+  id: string
+  email: string
+  name: string | null
+  last_login_at: string | null
+  role: string
+  granted_at: string
+}
+
+/**
+ * Every local user with at least one active (non-revoked) Operator role on this
+ * entity, one entry per person with roles aggregated and ordered. Plus the
+ * firm-wide active-PTO roster. Read-only; never mutates.
+ */
+export async function loadTeamRoster(
+  db: D1Database,
+  entityId: string,
+  orgId: string
+): Promise<TeamRoster> {
+  const rows = await db
+    .prepare(
+      `SELECT u.id            AS id,
+              u.email         AS email,
+              u.name          AS name,
+              u.last_login_at AS last_login_at,
+              pr.role         AS role,
+              pr.granted_at   AS granted_at
+         FROM product_roles pr
+         JOIN users u ON u.id = pr.user_id
+        WHERE pr.entity_id = ?
+          AND pr.org_id = ?
+          AND pr.product_slug = 'operator'
+          AND pr.revoked_at IS NULL
+        ORDER BY u.name, pr.granted_at ASC`
+    )
+    .bind(entityId, orgId)
+    .all<MemberDbRow>()
+
+  const members = aggregateMembers(rows.results ?? [])
+  const pto = await listActivePto(db, entityId)
+  return { members, awayCount: pto.length, pto }
+}
+
+/**
+ * Collapse per-role DB rows into one TeamMember per person, roles ordered.
+ * Exported for unit testing the aggregation independent of D1.
+ */
+export function aggregateMembers(rows: readonly MemberDbRow[]): TeamMember[] {
+  const byUser = new Map<string, TeamMember>()
+  for (const row of rows) {
+    if (typeof row.id !== 'string' || row.id.length === 0) continue
+    if (typeof row.email !== 'string' || row.email.length === 0) continue
+    const existing = byUser.get(row.id)
+    if (existing) {
+      if (row.role && !existing.roles.includes(row.role)) existing.roles.push(row.role)
+    } else {
+      byUser.set(row.id, {
+        id: row.id,
+        email: row.email,
+        name: row.name && row.name.length > 0 ? row.name : row.email,
+        lastLoginAt: row.last_login_at,
+        roles: row.role ? [row.role] : [],
+      })
+    }
+  }
+  const members = Array.from(byUser.values())
+  for (const m of members) {
+    m.roles.sort((a, b) => (ROLE_ORDER[a] ?? 99) - (ROLE_ORDER[b] ?? 99))
+  }
+  return members
+}
+
+/** Human-readable last-login date, or "Never". Total — never throws on bad input. */
+export function formatLastLogin(iso: string | null): string {
+  if (!iso) return 'Never'
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return 'Never'
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+}

--- a/src/pages/api/portal/products/operator/invitations.ts
+++ b/src/pages/api/portal/products/operator/invitations.ts
@@ -8,6 +8,7 @@ import {
   buildInviteAuditEvent,
   recordRbacAuditEvent,
 } from '../../../../../lib/portal/operator/rbac-audit'
+import { isPeopleAccessOperable } from '../../../../../lib/portal/operator/people-access-gate'
 import { env } from 'cloudflare:workers'
 
 /**
@@ -77,6 +78,13 @@ async function authorize(locals: App.Locals): Promise<Response | AuthorizedConte
 
   const subscription = await getProductSubscription(env.DB, client.id, PRODUCT_SLUG)
   if (!subscription) return jsonError(404, 'No active subscription')
+
+  // Layer-1 authority gate (ADR 0041): inviting people is the people_access
+  // domain. At launch (managed posture) SMD operates the roster; refuse the
+  // mutation server-side rather than trust the portal's read-only render.
+  if (!(await isPeopleAccessOperable(env.DB, client.id))) {
+    return redirectWithStatus('not_permitted')
+  }
 
   return { user, client }
 }

--- a/src/pages/api/portal/products/operator/pto.ts
+++ b/src/pages/api/portal/products/operator/pto.ts
@@ -9,6 +9,7 @@ import {
 } from '../../../../../lib/portal/operator/rbac-audit'
 import type { PortalUserRow } from '../../../../../lib/auth/clerk-bridge'
 import type { Entity } from '../../../../../lib/db/entities'
+import { isPeopleAccessOperable } from '../../../../../lib/portal/operator/people-access-gate'
 import { env } from 'cloudflare:workers'
 
 /**
@@ -77,6 +78,14 @@ async function authorize(locals: App.Locals): Promise<Response | AuthorizedConte
 
   const subscription = await getProductSubscription(env.DB, client.id, PRODUCT_SLUG)
   if (!subscription) return jsonError(404, 'No active subscription')
+
+  // Layer-1 authority gate (ADR 0041): PTO / coverage is the people_access
+  // domain. At launch (managed posture) SMD operates the roster and its
+  // coverage; self-service PTO becomes Read + Request. Refuse the mutation
+  // server-side rather than trust the portal's read-only render.
+  if (!(await isPeopleAccessOperable(env.DB, client.id))) {
+    return redirectWithStatus('not_permitted')
+  }
 
   return { user, client, orgId: user.org_id, isPrincipal: roles.includes('principal') }
 }

--- a/src/pages/api/portal/products/operator/role-action.ts
+++ b/src/pages/api/portal/products/operator/role-action.ts
@@ -13,6 +13,7 @@ import {
   buildRoleAuditEvent,
   recordRbacAuditEvent,
 } from '../../../../../lib/portal/operator/rbac-audit'
+import { isPeopleAccessOperable } from '../../../../../lib/portal/operator/people-access-gate'
 import { env } from 'cloudflare:workers'
 
 /**
@@ -85,6 +86,14 @@ async function authorize(locals: App.Locals): Promise<Response | AuthorizedConte
 
   const subscription = await getProductSubscription(env.DB, client.id, PRODUCT_SLUG)
   if (!subscription) return jsonError(404, 'No active subscription')
+
+  // Layer-1 authority gate (ADR 0041): roles live in the people_access domain.
+  // At launch (managed posture) the client org does not operate its own roster
+  // — SMD does. Refuse the mutation server-side rather than trust the portal's
+  // read-only render. Mirrors the connectors-secret precedent.
+  if (!(await isPeopleAccessOperable(env.DB, client.id))) {
+    return redirectWithStatus('not_permitted')
+  }
 
   return { user, client, orgId: user.org_id }
 }

--- a/src/pages/portal/products/operator/index.astro
+++ b/src/pages/portal/products/operator/index.astro
@@ -152,6 +152,11 @@ if (access) {
     label: 'Configure',
     description: "Your Operator's skills, governance, voice, scope, and hours.",
   })
+  sectionCards.push({
+    href: '/portal/products/operator/team',
+    label: 'Team',
+    description: 'The people on your account, their roles, and who is covering for whom.',
+  })
   const isCompliance = userRoles.includes('compliance')
   const isPrincipal = userRoles.includes('principal')
   const showComplianceCard =

--- a/src/pages/portal/products/operator/settings/pto.astro
+++ b/src/pages/portal/products/operator/settings/pto.astro
@@ -8,6 +8,7 @@ import PortalPageHead from '../../../../../components/portal/PortalPageHead.astr
 import SkipToMain from '../../../../../components/SkipToMain.astro'
 import { env } from 'cloudflare:workers'
 import { getActivePto, listActivePto } from '../../../../../lib/portal/operator/pto'
+import { isPeopleAccessOperable } from '../../../../../lib/portal/operator/people-access-gate'
 
 /**
  * Operator — PTO / OOO self-service.
@@ -48,6 +49,14 @@ if (access.kind === 'redirect') {
 }
 const { client, user, roles } = access
 const isPrincipal = roles.includes('principal')
+
+// Layer-1 authority gate (ADR 0041): coverage/PTO is the people_access operable
+// detail page. When the domain is not client-operable (managed posture — the
+// launch default), there is no direct-management door: send to the read-only
+// Team surface, where coverage is visible and a change can be requested.
+if (!(await isPeopleAccessOperable(env.DB, client.id))) {
+  return Astro.redirect('/portal/products/operator/team')
+}
 
 const myPto = await getActivePto(env.DB, client.id, user.id)
 const firmWidePto = isPrincipal ? await listActivePto(env.DB, client.id) : []

--- a/src/pages/portal/products/operator/settings/users.astro
+++ b/src/pages/portal/products/operator/settings/users.astro
@@ -4,6 +4,7 @@ import { BRAND_NAME } from '../../../../../lib/config/brand'
 import { getPortalClient } from '../../../../../lib/portal/session'
 import { getProductSubscription, listProductRoles } from '../../../../../lib/portal/product-access'
 import { listClerkOrgParticipants } from '../../../../../lib/portal/clerk-org-members'
+import { isPeopleAccessOperable } from '../../../../../lib/portal/operator/people-access-gate'
 import PortalHeader from '../../../../../components/portal/PortalHeader.astro'
 import PortalTabs from '../../../../../components/portal/PortalTabs.astro'
 import PortalPageHead from '../../../../../components/portal/PortalPageHead.astro'
@@ -82,6 +83,14 @@ if (!isPrincipal) {
   return Astro.redirect('/portal/products/operator')
 }
 
+// Layer-1 authority gate (ADR 0041): this is the people_access operable detail
+// page. When the domain is not client-operable (managed posture — the launch
+// default), there is no direct-management door: send the principal to the
+// read-only Team surface, where they see the roster and can request a change.
+if (!(await isPeopleAccessOperable(env.DB, client.id))) {
+  return Astro.redirect('/portal/products/operator/team')
+}
+
 // Aggregate roles per user. A single user can hold multiple roles
 // (e.g., principal AND compliance); we group rows here so the UI
 // renders one row per person with a comma-joined role list.
@@ -140,7 +149,7 @@ for (const row of memberRowsRaw.results ?? []) {
 }
 const members = Array.from(memberMap.values())
 
-const ROLE_ORDER: Record<string, number> = { principal: 0, operator: 1, compliance: 2 }
+const ROLE_ORDER: Record<string, number> = { principal: 0, staff: 1, compliance: 2 }
 for (const m of members) {
   m.roles.sort((a, b) => (ROLE_ORDER[a] ?? 99) - (ROLE_ORDER[b] ?? 99))
 }
@@ -222,6 +231,10 @@ const STATUS_BANNERS: Record<string, BannerStatus> = {
   invite_failed: {
     text: 'We could not send the invitation. Try again or contact us if the problem persists.',
     tone: 'error',
+  },
+  not_permitted: {
+    text: 'Your team is managed by SMD right now. Use Team to request a change.',
+    tone: 'info',
   },
 }
 const banner = status ? (STATUS_BANNERS[status] ?? null) : null

--- a/src/pages/portal/products/operator/team/index.astro
+++ b/src/pages/portal/products/operator/team/index.astro
@@ -1,0 +1,226 @@
+---
+import '../../../../../styles/global.css'
+import { BRAND_NAME } from '../../../../../lib/config/brand'
+import { resolveOperatorAccess } from '../../../../../lib/portal/operator-access'
+import { getCustomerConfig } from '../../../../../lib/portal/customer-config'
+import { loadTeamRoster, formatLastLogin } from '../../../../../lib/portal/operator/team-read'
+import PortalHeader from '../../../../../components/portal/PortalHeader.astro'
+import PortalTabs from '../../../../../components/portal/PortalTabs.astro'
+import PortalPageHead from '../../../../../components/portal/PortalPageHead.astro'
+import SkipToMain from '../../../../../components/SkipToMain.astro'
+import DomainSurface from '../../../../../components/portal/operator/DomainSurface.astro'
+import { env } from 'cloudflare:workers'
+
+/**
+ * Operator — Team (client-portal §5.7). The people on this account: who holds
+ * which role, and who is currently away.
+ *
+ * URL: portal.smd.services/portal/products/operator/team
+ *
+ * Governed by the `people_access` authority domain (ADR 0041). At launch the
+ * switch is off (managed) so this is Read + Request: SMD manages the roster and
+ * the client requests a change. When SMD flips the switch, principals get the
+ * operable controls — which live in the detail pages (settings/users for roles
+ * & invites, settings/pto for coverage), themselves gated by the same
+ * people_access composition so there is no ungated direct door.
+ *
+ * Read access is on for every role from day one (foundations §4.1): all three
+ * client roles see the roster. Only `principal` permits operability of
+ * people_access (client-rbac matrix), so only a principal ever sees the operable
+ * slot — and only once the switch is on.
+ */
+
+const access = await resolveOperatorAccess(env.DB, Astro.locals, {
+  allowedRoles: ['principal', 'staff', 'compliance'],
+})
+if (access.kind === 'redirect') {
+  return Astro.redirect(access.to)
+}
+const { user, client, roles } = access
+
+const config = await getCustomerConfig(env.DB, client.id)
+const roster = await loadTeamRoster(env.DB, client.id, user.org_id)
+
+const RETURN_TO = '/portal/products/operator/team'
+const cr = Astro.url.searchParams.get('cr')
+const crMessage =
+  cr === 'filed'
+    ? 'Your request was sent.'
+    : cr === 'invalid'
+      ? "That request couldn't be filed. Please add a short description and try again."
+      : cr === 'error'
+        ? 'Something went wrong filing your request. Please try again.'
+        : null
+
+const ROLE_LABEL: Record<string, string> = {
+  principal: 'Principal',
+  staff: 'Staff',
+  compliance: 'Compliance',
+}
+
+const listClass =
+  'm-0 list-none p-0 border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)]'
+const rowClass =
+  'border-b-[2px] border-[color:var(--ss-color-text-primary)] last:border-b-0 px-5 md:px-7 py-4'
+const chipClass =
+  "inline-flex items-center px-2.5 py-1 text-caption font-['Archivo_Narrow'] uppercase tracking-[0.12em] font-bold border-[2px] border-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-text-primary)]"
+const manageLinkClass =
+  "inline-flex items-center gap-2 px-5 py-3 font-['Archivo_Narrow'] uppercase tracking-[0.12em] font-bold text-sm border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] hover:bg-[color:var(--ss-color-primary)] hover:border-[color:var(--ss-color-primary)] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2"
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;900&family=Archivo+Narrow:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap"
+      rel="stylesheet"
+    />
+    <title>Operator · Team | {BRAND_NAME}</title>
+  </head>
+  <body class="min-h-screen bg-[color:var(--ss-color-background)]">
+    <SkipToMain />
+    <PortalHeader clientName={client.name} />
+
+    <PortalTabs pathname={Astro.url.pathname} operatorActive={true} />
+
+    <main id="main" role="main" class="max-w-5xl mx-auto px-4 md:px-6 pb-24 md:pb-12">
+      <PortalPageHead
+        crumbHref="/portal/products/operator"
+        crumbLabel="Operator"
+        tag="Section"
+        h1="Team"
+        meta={`${roster.members.length} ${roster.members.length === 1 ? 'person' : 'people'}${
+          roster.awayCount > 0 ? ` · ${roster.awayCount} away` : ''
+        }`}
+      />
+
+      {
+        crMessage && (
+          <div
+            role="status"
+            class={`mt-6 border-[3px] px-5 py-3 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold ${
+              cr === 'filed'
+                ? 'border-[color:var(--ss-color-complete)] text-[color:var(--ss-color-complete)]'
+                : 'border-[color:var(--ss-color-error)] text-[color:var(--ss-color-error)]'
+            }`}
+          >
+            {crMessage}
+          </div>
+        )
+      }
+
+      <div class="mt-8">
+        <DomainSurface
+          authority={config?.authority ?? null}
+          domain="people_access"
+          roles={roles}
+          returnTo={RETURN_TO}
+          domainLabel="who's on this account, their roles, and coverage"
+        >
+          <Fragment slot="read">
+            {
+              roster.members.length === 0 ? (
+                <section
+                  aria-label="No members yet"
+                  class="border-[3px] border-[color:var(--ss-color-text-primary)] p-8 md:p-12 text-center"
+                >
+                  <p class="font-['Archivo'] text-2xl md:text-3xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]">
+                    No one on the account yet
+                  </p>
+                  <p class="mt-3 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)]">
+                    As people are added to your account, they appear here with their role.
+                  </p>
+                </section>
+              ) : (
+                <ul role="list" class={listClass}>
+                  {roster.members.map((m) => {
+                    const away = roster.pto.find((p) => p.userId === m.id)
+                    return (
+                      <li class={rowClass}>
+                        <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-3 md:gap-6">
+                          <div class="min-w-0">
+                            <p class="font-['Archivo'] font-bold text-[color:var(--ss-color-text-primary)] m-0 truncate">
+                              {m.name}
+                            </p>
+                            <p class="mt-0.5 text-caption text-[color:var(--ss-color-text-secondary)] m-0 truncate">
+                              {m.email} · Last login {formatLastLogin(m.lastLoginAt)}
+                            </p>
+                          </div>
+                          <div class="flex flex-wrap gap-2 md:justify-end">
+                            {away && (
+                              <span class="inline-flex items-center px-2.5 py-1 text-caption font-['Archivo_Narrow'] uppercase tracking-[0.12em] font-bold border-[2px] border-[color:var(--ss-color-warning)] text-[color:var(--ss-color-warning)]">
+                                Away
+                                {away.backupName ? ` · backup ${away.backupName}` : ''}
+                              </span>
+                            )}
+                            {m.roles.map((r) => (
+                              <span class={chipClass}>{ROLE_LABEL[r] ?? r}</span>
+                            ))}
+                          </div>
+                        </div>
+                      </li>
+                    )
+                  })}
+                </ul>
+              )
+            }
+          </Fragment>
+
+          <Fragment slot="operable">
+            {
+              roster.members.length > 0 && (
+                <ul role="list" class={`${listClass} mb-6`}>
+                  {roster.members.map((m) => {
+                    const away = roster.pto.find((p) => p.userId === m.id)
+                    return (
+                      <li class={rowClass}>
+                        <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-3 md:gap-6">
+                          <div class="min-w-0">
+                            <p class="font-['Archivo'] font-bold text-[color:var(--ss-color-text-primary)] m-0 truncate">
+                              {m.name}
+                            </p>
+                            <p class="mt-0.5 text-caption text-[color:var(--ss-color-text-secondary)] m-0 truncate">
+                              {m.email} · Last login {formatLastLogin(m.lastLoginAt)}
+                            </p>
+                          </div>
+                          <div class="flex flex-wrap gap-2 md:justify-end">
+                            {away && (
+                              <span class="inline-flex items-center px-2.5 py-1 text-caption font-['Archivo_Narrow'] uppercase tracking-[0.12em] font-bold border-[2px] border-[color:var(--ss-color-warning)] text-[color:var(--ss-color-warning)]">
+                                Away
+                              </span>
+                            )}
+                            {m.roles.map((r) => (
+                              <span class={chipClass}>{ROLE_LABEL[r] ?? r}</span>
+                            ))}
+                          </div>
+                        </div>
+                      </li>
+                    )
+                  })}
+                </ul>
+              )
+            }
+            <div class="flex flex-col sm:flex-row gap-3">
+              <a href="/portal/products/operator/settings/users" class={manageLinkClass}>
+                <span class="material-symbols-outlined" aria-hidden="true">group</span>
+                Manage roles &amp; invites
+              </a>
+              <a href="/portal/products/operator/settings/pto" class={manageLinkClass}>
+                <span class="material-symbols-outlined" aria-hidden="true">event_busy</span>
+                Manage coverage
+              </a>
+            </div>
+          </Fragment>
+        </DomainSurface>
+      </div>
+    </main>
+  </body>
+</html>

--- a/tests/forbidden-strings.test.ts
+++ b/tests/forbidden-strings.test.ts
@@ -484,6 +484,12 @@ const LIST_INDEX_ALLOWLIST: string[] = [
   // entitlement-produced work items; empty by design until a skill routes to a
   // human (ADR 0035).
   resolve('src/pages/portal/products/operator/work/index.astro'),
+  // `products/operator/team/index.astro` (§5.7) renders the people-on-this-
+  // account roster as identity rows (name + email/last-login, away badge, role
+  // chips) inside the dual-mode read/operable slots — not the PortalListItem
+  // status/document record-row vocabulary. The .map( iterates members; the
+  // people_access domain is Read + Request at launch (ADR 0041).
+  resolve('src/pages/portal/products/operator/team/index.astro'),
 ]
 
 /** Collect every `index.astro` under `src/pages/portal/` EXCEPT the home. */

--- a/tests/operator-team.test.ts
+++ b/tests/operator-team.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Team surface (client-portal §5.7) — roster projection + the people_access
+ * authority gate.
+ *
+ * The pure aggregation (one member per person, roles ordered, name→email
+ * fallback) and the fail-closed gate are the load-bearing pieces: at launch the
+ * surface is Read + Request, so the roster projection IS the view, and the gate
+ * is what stops a hand-crafted POST from mutating a managed roster.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  createTestD1,
+  runMigrations,
+  discoverNumericMigrations,
+} from '@venturecrane/crane-test-harness'
+import { resolve } from 'path'
+import type { D1Database } from '@cloudflare/workers-types'
+import { ORG_ID } from '../src/lib/constants'
+import { aggregateMembers, formatLastLogin } from '../src/lib/portal/operator/team-read'
+import { isPeopleAccessOperable } from '../src/lib/portal/operator/people-access-gate'
+
+const migrationsDir = resolve(process.cwd(), 'migrations')
+
+async function freshDb(): Promise<D1Database> {
+  const db = createTestD1()
+  await runMigrations(db, { files: discoverNumericMigrations(migrationsDir) })
+  return db
+}
+
+function row(over: Record<string, unknown> = {}) {
+  return {
+    id: 'u-1',
+    email: 'pat@firm.com',
+    name: 'Pat Paralegal',
+    last_login_at: '2026-06-01T00:00:00.000Z',
+    role: 'staff',
+    granted_at: '2026-05-01T00:00:00.000Z',
+    ...over,
+  } as Parameters<typeof aggregateMembers>[0][number]
+}
+
+describe('aggregateMembers', () => {
+  it('collapses per-role rows into one member with roles ordered principal→staff→compliance', () => {
+    const members = aggregateMembers([
+      row({ id: 'u-1', role: 'compliance' }),
+      row({ id: 'u-1', role: 'principal' }),
+      row({ id: 'u-1', role: 'staff' }),
+    ])
+    expect(members).toHaveLength(1)
+    expect(members[0].roles).toEqual(['principal', 'staff', 'compliance'])
+  })
+
+  it('falls back to email when name is empty — never a blank member', () => {
+    const members = aggregateMembers([row({ name: '' })])
+    expect(members[0].name).toBe('pat@firm.com')
+  })
+
+  it('drops rows missing id or email (never a fabricated person)', () => {
+    expect(aggregateMembers([row({ id: '' })])).toHaveLength(0)
+    expect(aggregateMembers([row({ email: '' })])).toHaveLength(0)
+  })
+
+  it('keeps distinct people separate', () => {
+    const members = aggregateMembers([
+      row({ id: 'u-1', email: 'a@firm.com', name: 'A' }),
+      row({ id: 'u-2', email: 'b@firm.com', name: 'B' }),
+    ])
+    expect(members.map((m) => m.id).sort()).toEqual(['u-1', 'u-2'])
+  })
+})
+
+describe('formatLastLogin', () => {
+  it('renders Never for null/invalid and a date otherwise', () => {
+    expect(formatLastLogin(null)).toBe('Never')
+    expect(formatLastLogin('not-a-date')).toBe('Never')
+    expect(formatLastLogin('2026-06-01T00:00:00.000Z')).toContain('2026')
+  })
+})
+
+describe('isPeopleAccessOperable: fail-closed authority gate', () => {
+  let db: D1Database
+  beforeEach(async () => {
+    db = await freshDb()
+  })
+
+  async function seedConfig(authorityJson: string | null): Promise<void> {
+    await db
+      .prepare('INSERT INTO entities (id, org_id, name, slug) VALUES (?, ?, ?, ?)')
+      .bind('ent-1', ORG_ID, 'Acme Law', 'acme-law')
+      .run()
+    await db
+      .prepare(
+        `INSERT INTO customer_configs
+          (entity_id, org_id, customer_slug, schema_version, personas_json, authority_json, git_sha, synced_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+      )
+      .bind(
+        'ent-1',
+        ORG_ID,
+        'acme-law',
+        '1.0.0',
+        '[]',
+        authorityJson,
+        'sha',
+        '2026-06-08T00:00:00Z'
+      )
+      .run()
+  }
+
+  it('is false when no config row exists (fail-closed)', async () => {
+    expect(await isPeopleAccessOperable(db, 'ent-missing')).toBe(false)
+  })
+
+  it('is false under the launch-default (managed) posture', async () => {
+    await seedConfig(null)
+    expect(await isPeopleAccessOperable(db, 'ent-1')).toBe(false)
+  })
+
+  it('is false when another domain is client-operable but people_access is not', async () => {
+    await seedConfig(JSON.stringify({ default: 'managed', overrides: { runtime: 'client' } }))
+    expect(await isPeopleAccessOperable(db, 'ent-1')).toBe(false)
+  })
+
+  it('is true only when people_access is explicitly client-operable', async () => {
+    await seedConfig(JSON.stringify({ default: 'managed', overrides: { people_access: 'client' } }))
+    expect(await isPeopleAccessOperable(db, 'ent-1')).toBe(true)
+  })
+})


### PR DESCRIPTION
## Team (§5.7)

The people on the account — who holds which role, and who is covering for whom — the seventh client-portal surface. Governed by the **people_access** authority domain (ADR 0041), which foundations §4.2 defines as "users, roles, PTO, voice profiles."

### Dual-mode
New `/team` surface via `<DomainSurface domain="people_access">`:
- **Read + Request** (launch default — managed posture): SMD manages the roster; the client sees it read-only and can request a change. All three client roles read it.
- **Operable** (switch on AND principal): the operable slot links to the management detail pages.

Only `principal` permits operability of people_access (client-rbac matrix), so only a principal ever sees the operable slot — and only once SMD flips the switch.

### Server-enforced composition, not UI hiding
Rendering read-only is not enforcement. The three roster-mutation endpoints now re-check `isPeopleAccessOperable` and refuse (`303 not_permitted`) when the domain is managed:
- `role-action` (grant/revoke)
- `invitations` (invite)
- `pto` (set/clear coverage)

The two legacy operable detail pages (`settings/users`, `settings/pto`) **redirect to the read-only Team surface** when not operable — no ungated direct door. **Fail-closed**: an absent config row resolves to not-operable.

### Also
- Fixed a stale `operator`→`staff` leftover in the users-page role sort order (`ROLE_ORDER`).

### Files
- `src/lib/portal/operator/people-access-gate.ts` — `isPeopleAccessOperable` (the shared server-side gate)
- `src/lib/portal/operator/team-read.ts` — `loadTeamRoster`, `aggregateMembers`, `formatLastLogin`
- `src/pages/portal/products/operator/team/index.astro` — dual-mode surface
- `src/pages/api/portal/products/operator/{role-action,invitations,pto}.ts` — people_access gate
- `src/pages/portal/products/operator/settings/{users,pto}.astro` — gate + redirect; ROLE_ORDER fix
- `src/pages/portal/products/operator/index.astro` — Team section card
- `tests/operator-team.test.ts` — aggregation + fail-closed gate coverage
- `tests/forbidden-strings.test.ts` — R7 allowlist entry (justified)

### Verification
typecheck 0 errors · build clean · lint 0 errors · full suite 3267 passed / 2 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)