### PR TITLE
feat(operator): provisioning authoring + validation surface (§4.5)

### DIFF
--- a/migrations/0067_operator_provisioning_intent.sql
+++ b/migrations/0067_operator_provisioning_intent.sql
@@ -1,0 +1,69 @@
+-- Operator provisioning-intent ledger — design §4.5
+-- ============================================================================
+--
+-- Records every SMD attempt to stand up a new operator from the admin console:
+-- the authored customer.yaml essentials, validated by the existing validator +
+-- secret-exclusion scan, with the rendered candidate YAML captured on success.
+--
+-- WHY THIS LEDGER HAS NO entities() FK (unlike operator_authority_audit and
+-- config_change_audit):
+--   Provisioning is the one admin action whose subject does NOT exist yet — the
+--   customer (its entity, its customer_configs row) is created downstream by the
+--   stand-up tooling (operator/bin/provision-customer.sh). So this ledger keys on
+--   the PROPOSED customer_id, not an entity_id. A future reconciliation can link
+--   a row to the entity once provisioned; v1 does not.
+--
+-- WHY AN INTENT LEDGER (not a config write):
+--   A Cloudflare Worker cannot commit the git source of truth (ADR 0012 §2 —
+--   configs-repo write-back is OUT OF SCOPE at v1) or call Fly. The console
+--   authors + validates; the actual commit + Machine stand-up is the existing
+--   tooling (#1262). This row records that an authored candidate passed (or
+--   failed) validation, and on success preserves the exact YAML the operator
+--   drops into operator/customers/<slug>/customer.yaml before running the tool.
+--   `source` scopes a row as 'portal_intent' so a reader never treats it as a
+--   provisioned-and-running fact.
+--
+-- ISOLATION / SCOPE: a console-side control-plane table (like config_change_audit
+-- and operator_authority_audit), NOT per-customer runtime D1. No live secrets:
+-- the candidate_yaml is the secret-SCANNED config (token_refs are pointers, never
+-- values — the validator's secret detector rejects inline secrets before a row is
+-- ever written on the success path).
+--
+-- Append-only by convention: no UPDATE/DELETE code path. Forward-only, additive.
+--
+-- Refers to: docs/design/operator/01-admin-portal.md §4.5
+--            docs/adr/0012-customer-yaml-storage.md (git source of truth)
+--            docs/adr/0019-customer-yaml-to-profile-config-translation.md
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS operator_provisioning_intent (
+  id              INTEGER PRIMARY KEY AUTOINCREMENT,
+  -- Provenance scope. 'portal_intent' = SMD console action (the only source
+  -- today). Reserved 'runtime_confirmed' for a future provisioned-link pass.
+  source          TEXT NOT NULL DEFAULT 'portal_intent'
+                    CHECK (source IN ('portal_intent', 'runtime_confirmed')),
+  -- The PROPOSED customer slug (^[a-z0-9][a-z0-9-]{0,31}$, enforced in code via
+  -- the customer.yaml validator). Not an entity_id — the entity does not exist
+  -- yet at authoring time.
+  customer_id     TEXT NOT NULL,
+  customer_name   TEXT NOT NULL,
+  vertical        TEXT NOT NULL,
+  -- Who: the authenticated SMD staff actor (Layer 0).
+  actor_user_id   TEXT NOT NULL,
+  actor_email     TEXT NOT NULL,
+  actor_role      TEXT NOT NULL,
+  -- Did the authored candidate pass validation?
+  outcome         TEXT NOT NULL CHECK (outcome IN ('validated', 'rejected')),
+  -- Count of validation errors (0 on the validated path).
+  error_count     INTEGER NOT NULL DEFAULT 0,
+  -- The rendered, secret-scanned candidate customer.yaml. Populated on the
+  -- validated path; may be empty text on a rejected attempt.
+  candidate_yaml  TEXT NOT NULL DEFAULT '',
+  created_at      TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_operator_provisioning_intent_created
+  ON operator_provisioning_intent (created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_operator_provisioning_intent_customer
+  ON operator_provisioning_intent (customer_id, created_at DESC);

--- a/src/lib/admin/provisioning.ts
+++ b/src/lib/admin/provisioning.ts
@@ -1,0 +1,394 @@
+/**
+ * Provisioning authoring + validation for the admin Operator console (§4.5).
+ *
+ * Stands up a new operator. The console's job is steps 1-3 of the §4.5 flow:
+ * pick a vertical pack, author the customer.yaml essentials, and validate them
+ * with the existing validator + secret-exclusion scan. Step 4+ (commit to the
+ * configs repo, Machine stand-up, connector consent, subscription activation)
+ * is the existing provisioning tooling (`operator/bin/provision-customer.sh`,
+ * being made agent-runnable on a separate track, #1262) — NOT a Worker
+ * capability. A Cloudflare Worker cannot write the git source of truth or call
+ * Fly; git write-back is explicitly OUT OF SCOPE at v1 (ADR 0012 §2, mirrored by
+ * the customer-side customer-yaml-update endpoint).
+ *
+ * So this module is honest about the seam: it ASSEMBLES a candidate customer.yaml
+ * from the authored essentials, VALIDATES the parsed object (and scans the
+ * rendered text for leaked secrets) via the real `validate()`, and emits the
+ * validated YAML text as the deliverable the operator drops into
+ * `operator/customers/<slug>/customer.yaml` before running the stand-up tooling.
+ * The attempt is recorded as provisioning INTENT (its own ledger) — at this
+ * point no entity_id exists yet (the customer is being created), so the ledger
+ * keys on the proposed customer_id and carries no entities() FK.
+ *
+ * Pure assembly/validation/serialization helpers + the append-only intent
+ * writer live here; the admin page is the only caller and is admin-gated.
+ *
+ * What the vertical pick seeds vs. what the admin authors: a Worker cannot read
+ * the on-disk pack manifests (`operator/verticals/<v>/vertical.yaml`), so the
+ * pack's personas/skills/connectors are materialized from the pack by the
+ * stand-up tooling, not re-typed here. The pick drives the vertical + add-on
+ * selection (real constants); the admin authors identity, the primary persona,
+ * the primary user, and the connector capability set per §4.5 step 2. Per-domain
+ * authority flips happen on the §5.9 authority surface post-provision; the
+ * candidate omits an `authority:` block, which the validator resolves to the
+ * fail-closed all-managed default (DEFAULT_AUTHORITY_POSTURE).
+ */
+
+import type { D1Database } from '@cloudflare/workers-types'
+import {
+  validate,
+  ACCEPTED_VERTICALS,
+  ACCEPTED_ADDONS,
+  ACCEPTED_TRUST_CEILINGS,
+  ACCEPTED_USER_ROLES,
+  type ValidationResult,
+} from '../operator/customer-yaml'
+import { ACCEPTED_CAPABILITY_NAMES } from '../operator/customer-yaml/types'
+import type { CapabilityName } from '../operator/capabilities/types'
+
+// ---------------------------------------------------------------------------
+// Authored input
+// ---------------------------------------------------------------------------
+
+export interface ConnectorInput {
+  capability: string
+  adapter: string
+  backend: string
+  enabled: boolean
+}
+
+export interface ProvisioningInput {
+  customer_id: string
+  customer_name: string
+  vertical: string
+  addons: string[]
+  practice_areas: string[]
+  fly_region: string
+  model: string
+  hermes_ref: string
+  machine_size: string
+  machine_memory_mb: number
+  user_email: string
+  user_role: string
+  user_full_name: string
+  persona_slug: string
+  persona_name: string
+  persona_title: string
+  persona_tone: string[]
+  skill_name: string
+  skill_trust_ceiling: string
+  connectors: ConnectorInput[]
+}
+
+/** Split a textarea/CSV field into a trimmed, non-empty string list. */
+export function splitList(raw: string): string[] {
+  return raw
+    .split(/[\n,]/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0)
+}
+
+function str(form: FormData, key: string): string {
+  const v = form.get(key)
+  return typeof v === 'string' ? v.trim() : ''
+}
+
+/**
+ * Parse the provisioning form into a typed input. Never casts untrusted values:
+ * unparseable numbers become NaN so the validator reports them rather than a
+ * coerced default silently passing. Connector rows are read positionally from
+ * the parallel `connector_*[]` field arrays.
+ */
+export function parseProvisioningForm(form: FormData): ProvisioningInput {
+  const memRaw = str(form, 'machine_memory_mb')
+  const memNum = Number.parseInt(memRaw, 10)
+  return {
+    customer_id: str(form, 'customer_id'),
+    customer_name: str(form, 'customer_name'),
+    vertical: str(form, 'vertical'),
+    addons: form.getAll('addons').filter((a): a is string => typeof a === 'string' && a.length > 0),
+    practice_areas: splitList(str(form, 'practice_areas')),
+    fly_region: str(form, 'fly_region'),
+    model: str(form, 'model'),
+    hermes_ref: str(form, 'hermes_ref'),
+    machine_size: str(form, 'machine_size'),
+    machine_memory_mb: Number.isFinite(memNum) ? memNum : Number.NaN,
+    user_email: str(form, 'user_email'),
+    user_role: str(form, 'user_role'),
+    user_full_name: str(form, 'user_full_name'),
+    persona_slug: str(form, 'persona_slug'),
+    persona_name: str(form, 'persona_name'),
+    persona_title: str(form, 'persona_title'),
+    persona_tone: splitList(str(form, 'persona_tone')),
+    skill_name: str(form, 'skill_name'),
+    skill_trust_ceiling: str(form, 'skill_trust_ceiling'),
+    connectors: parseConnectorRows(form),
+  }
+}
+
+function parseConnectorRows(form: FormData): ConnectorInput[] {
+  const caps = form.getAll('connector_capability')
+  const adapters = form.getAll('connector_adapter')
+  const backends = form.getAll('connector_backend')
+  const out: ConnectorInput[] = []
+  for (let i = 0; i < caps.length; i++) {
+    const capability = typeof caps[i] === 'string' ? (caps[i] as string).trim() : ''
+    const adapter = typeof adapters[i] === 'string' ? (adapters[i] as string).trim() : ''
+    const backend = typeof backends[i] === 'string' ? (backends[i] as string).trim() : ''
+    // A wholly blank row is an unfilled form slot, not a connector — skip it.
+    if (!capability && !adapter && !backend) continue
+    out.push({ capability, adapter, backend, enabled: true })
+  }
+  return out
+}
+
+// ---------------------------------------------------------------------------
+// Candidate assembly
+// ---------------------------------------------------------------------------
+
+/**
+ * Assemble the authored essentials into a customer.yaml-shaped object. Derived
+ * isolation invariants (memory namespaces) come from the slug so the validator's
+ * customer_id-equality checks pass; scope/escalation get safe defaults the
+ * config-authoring surface (§5.2) refines later. The object is the validation
+ * input; `serializeCustomerYaml` renders it to the deliverable text.
+ */
+export function buildCandidateDoc(input: ProvisioningInput): Record<string, unknown> {
+  const slug = input.customer_id
+  const persona: Record<string, unknown> = {
+    slug: input.persona_slug,
+    status: 'active',
+    name: input.persona_name,
+    tone: input.persona_tone,
+    skills: [{ name: input.skill_name, trust_ceiling: input.skill_trust_ceiling, enabled: true }],
+  }
+  if (input.persona_title) persona['title'] = input.persona_title
+
+  return {
+    schema_version: 1,
+    customer_id: slug,
+    customer_name: input.customer_name,
+    vertical: input.vertical,
+    addons: input.addons,
+    practice_areas: input.practice_areas,
+    fly_region: input.fly_region,
+    model: input.model,
+    hermes_ref: input.hermes_ref,
+    machine: { size: input.machine_size, memory_mb: input.machine_memory_mb },
+    users: [{ email: input.user_email, role: input.user_role, full_name: input.user_full_name }],
+    personas: [persona],
+    connectors: buildConnectorMap(input.connectors),
+    scope: {
+      email_folders_visible: ['Inbox', 'Sent'],
+      email_folders_blind: [],
+      email_keyword_blocks: [],
+      domain_blocks: [],
+    },
+    escalation: {
+      red_flag_recipients: [input.user_email],
+      failure_recipients: [input.user_email],
+    },
+    memory: {
+      d1_namespace: slug,
+      r2_vault_path: `vaults/${slug}/`,
+      vectorize_index: `hermes-${slug}-vault`,
+    },
+  }
+}
+
+function buildConnectorMap(rows: ConnectorInput[]): Record<string, unknown> {
+  const map: Record<string, unknown> = {}
+  for (const c of rows) {
+    if (!c.capability) continue
+    map[c.capability] = { adapter: c.adapter, backend: c.backend, enabled: c.enabled }
+  }
+  return map
+}
+
+// ---------------------------------------------------------------------------
+// YAML serialization (scoped emitter — no YAML lib in the Worker bundle)
+// ---------------------------------------------------------------------------
+
+function isPlainObj(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v)
+}
+
+/** A single scalar rendered for YAML. Strings are always single-quoted (with
+ * internal quotes doubled) so no string ever needs the "does this need
+ * quoting?" decision tree — single-quoting is always valid YAML. */
+function emitScalar(value: unknown): string {
+  if (value === null || value === undefined) return 'null'
+  if (typeof value === 'boolean') return value ? 'true' : 'false'
+  if (typeof value === 'number') return String(value)
+  if (typeof value === 'string') return `'${value.replace(/'/g, "''")}'`
+  // Defensive: the emitter routes arrays/objects elsewhere, so this branch is
+  // unreachable for a well-formed doc; render through JSON so a stray non-scalar
+  // never emits '[object Object]'.
+  return `'${JSON.stringify(value).replace(/'/g, "''")}'`
+}
+
+function emitNode(key: string, value: unknown, indent: number): string[] {
+  const pad = '  '.repeat(indent)
+  if (Array.isArray(value)) {
+    if (value.length === 0) return [`${pad}${key}: []`]
+    return [`${pad}${key}:`, ...emitListItems(value, indent + 1)]
+  }
+  if (isPlainObj(value)) {
+    const inner = emitMapEntries(value, indent + 1)
+    return inner.length === 0 ? [`${pad}${key}: {}`] : [`${pad}${key}:`, ...inner]
+  }
+  return [`${pad}${key}: ${emitScalar(value)}`]
+}
+
+function emitMapEntries(obj: Record<string, unknown>, indent: number): string[] {
+  const out: string[] = []
+  for (const [k, v] of Object.entries(obj)) {
+    if (v === undefined) continue
+    out.push(...emitNode(k, v, indent))
+  }
+  return out
+}
+
+function emitListItems(arr: unknown[], indent: number): string[] {
+  const pad = '  '.repeat(indent)
+  const out: string[] = []
+  for (const item of arr) {
+    if (isPlainObj(item)) {
+      const lines = emitMapEntries(item, indent + 1)
+      // The first entry carries the "- " bullet; the rest align under it.
+      lines[0] = `${pad}- ${lines[0].slice(pad.length + 2)}`
+      out.push(...lines)
+    } else {
+      out.push(`${pad}- ${emitScalar(item)}`)
+    }
+  }
+  return out
+}
+
+/** Render a customer.yaml-shaped object to YAML text. */
+export function serializeCustomerYaml(doc: Record<string, unknown>): string {
+  return `${emitMapEntries(doc, 0).join('\n')}\n`
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+export interface CandidateValidation {
+  result: ValidationResult
+  yamlText: string
+}
+
+/**
+ * Validate an assembled candidate. Renders the YAML once and passes it as
+ * `rawText` so `validate()` runs the raw-text secret scan first (fails closed on
+ * a leaked secret even if the structure is otherwise valid) and then the
+ * structural + parsed-value checks — the "validator + secret-scan" pass §4.5
+ * step 3 calls for, in a single documented call.
+ */
+export function validateCandidate(doc: Record<string, unknown>): CandidateValidation {
+  const yamlText = serializeCustomerYaml(doc)
+  const result = validate(doc, { rawText: yamlText })
+  return { result, yamlText }
+}
+
+// ---------------------------------------------------------------------------
+// Form option sources (all from real schema constants)
+// ---------------------------------------------------------------------------
+
+export function verticalOptions(): readonly string[] {
+  return ACCEPTED_VERTICALS
+}
+
+export function addonOptionsFor(vertical: string): readonly string[] {
+  return ACCEPTED_ADDONS[vertical as keyof typeof ACCEPTED_ADDONS] ?? []
+}
+
+export function trustCeilingOptions(): readonly string[] {
+  return ACCEPTED_TRUST_CEILINGS
+}
+
+export function userRoleOptions(): readonly string[] {
+  return ACCEPTED_USER_ROLES
+}
+
+export function capabilityOptions(): CapabilityName[] {
+  return [...ACCEPTED_CAPABILITY_NAMES]
+}
+
+// ---------------------------------------------------------------------------
+// Intent ledger (no entities() FK — the customer does not exist yet)
+// ---------------------------------------------------------------------------
+
+export type ProvisioningOutcome = 'validated' | 'rejected'
+
+export interface ProvisioningIntentEvent {
+  customer_id: string
+  customer_name: string
+  vertical: string
+  actor_user_id: string
+  actor_email: string
+  actor_role: string
+  outcome: ProvisioningOutcome
+  error_count: number
+  candidate_yaml: string
+}
+
+/**
+ * Append a provisioning attempt to the intent ledger. Always
+ * `source='portal_intent'`: nothing here stands up a Machine or writes git — the
+ * row records that SMD authored + validated a candidate config, and (on success)
+ * the exact YAML handed to the stand-up tooling.
+ */
+export async function recordProvisioningIntent(
+  db: D1Database,
+  event: ProvisioningIntentEvent
+): Promise<number> {
+  const res = await db
+    .prepare(
+      'INSERT INTO operator_provisioning_intent ' +
+        '(source, customer_id, customer_name, vertical, actor_user_id, actor_email, ' +
+        'actor_role, outcome, error_count, candidate_yaml) ' +
+        "VALUES ('portal_intent', ?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING id"
+    )
+    .bind(
+      event.customer_id,
+      event.customer_name,
+      event.vertical,
+      event.actor_user_id,
+      event.actor_email,
+      event.actor_role,
+      event.outcome,
+      event.error_count,
+      event.candidate_yaml
+    )
+    .first<{ id: number }>()
+  return res?.id ?? 0
+}
+
+export interface ProvisioningIntentRow {
+  id: number
+  customer_id: string
+  customer_name: string
+  vertical: string
+  outcome: ProvisioningOutcome
+  error_count: number
+  actor_email: string
+  created_at: string
+}
+
+/** Most-recent N provisioning attempts, newest first. Read-only. */
+export async function listProvisioningIntent(
+  db: D1Database,
+  limit = 25
+): Promise<ProvisioningIntentRow[]> {
+  const result = await db
+    .prepare(
+      'SELECT id, customer_id, customer_name, vertical, outcome, error_count, ' +
+        'actor_email, created_at FROM operator_provisioning_intent ' +
+        'ORDER BY created_at DESC, id DESC LIMIT ?'
+    )
+    .bind(limit)
+    .all<ProvisioningIntentRow>()
+  return result.results ?? []
+}

--- a/src/pages/admin/operator/index.astro
+++ b/src/pages/admin/operator/index.astro
@@ -132,13 +132,21 @@ const totalOperators = roster.length
           each operator's drill-in.
         </p>
       </div>
-      <div class="text-right">
-        <p class="text-xs uppercase tracking-wide text-[color:var(--ss-color-text-muted)]">
-          Operators
-        </p>
-        <p class="text-2xl font-bold text-[color:var(--ss-color-text-primary)]">
-          {totalOperators}
-        </p>
+      <div class="flex items-center gap-4">
+        <div class="text-right">
+          <p class="text-xs uppercase tracking-wide text-[color:var(--ss-color-text-muted)]">
+            Operators
+          </p>
+          <p class="text-2xl font-bold text-[color:var(--ss-color-text-primary)]">
+            {totalOperators}
+          </p>
+        </div>
+        <a
+          href="/admin/operator/provision"
+          class="rounded-[var(--ss-radius-badge)] bg-[color:var(--ss-color-action)] px-4 py-2 text-sm font-medium text-white hover:opacity-90 whitespace-nowrap"
+        >
+          Provision operator
+        </a>
       </div>
     </header>
 
@@ -149,7 +157,14 @@ const totalOperators = roster.length
         roster.length === 0 ? (
           <p class="text-sm text-[color:var(--ss-color-text-secondary)]">
             No operators provisioned yet. The fleet is empty until <code>customer_configs</code> has
-            at least one row.
+            at least one row.{' '}
+            <a
+              href="/admin/operator/provision"
+              class="text-[color:var(--ss-color-action)] hover:underline"
+            >
+              Provision the first operator
+            </a>
+            .
           </p>
         ) : (
           <div class="overflow-x-auto">

--- a/src/pages/admin/operator/provision.astro
+++ b/src/pages/admin/operator/provision.astro
@@ -1,0 +1,526 @@
+---
+import AdminLayout from '../../../layouts/AdminLayout.astro'
+import {
+  parseProvisioningForm,
+  buildCandidateDoc,
+  validateCandidate,
+  recordProvisioningIntent,
+  listProvisioningIntent,
+  verticalOptions,
+  trustCeilingOptions,
+  userRoleOptions,
+  capabilityOptions,
+  type ProvisioningInput,
+  type CandidateValidation,
+} from '../../../lib/admin/provisioning'
+import { env } from 'cloudflare:workers'
+
+/**
+ * Operator admin console — provisioning (§4.5).
+ *
+ * Stands up a new operator. Steps 1-3 of the §4.5 flow live here: pick a
+ * vertical, author the customer.yaml essentials, validate via the existing
+ * validator + secret-exclusion scan. Step 4+ (commit to the configs repo,
+ * Machine stand-up, connector consent, subscription activation) is the existing
+ * provisioning tooling — a Worker cannot write git or call Fly (ADR 0012 §2;
+ * git write-back is OUT OF SCOPE at v1). So on a clean validation this surface
+ * emits the validated customer.yaml as the deliverable the operator drops into
+ * operator/customers/<slug>/customer.yaml before running
+ * operator/bin/reprovision.sh <slug> (#1262 is making that agent-runnable).
+ *
+ * Honest seam (foundations §7): the surface never claims a Machine was stood up
+ * or git was committed. It records the authoring + validation attempt as
+ * provisioning intent and hands the validated config to the tooling explicitly.
+ *
+ * smd_admin-only (today admin === Captain). In-page POST so the form redisplays
+ * with the entered values and inline validation results without a redirect.
+ */
+
+const session = Astro.locals.session!
+if (session.role !== 'admin') {
+  return Astro.redirect('/auth/sign-in')
+}
+
+const DEFAULTS = {
+  model: 'claude-opus-4-7',
+  machine_size: 'shared-cpu-1x',
+  machine_memory_mb: 1024,
+}
+// The common capability set authored at stand-up; the pack materializes the rest.
+const CONNECTOR_SLOTS = ['Email', 'Calendar', 'PracticeManagement', 'DocumentStorage']
+
+let input: ProvisioningInput | null = null
+let validation: CandidateValidation | null = null
+
+if (Astro.request.method === 'POST') {
+  const form = await Astro.request.formData()
+  input = parseProvisioningForm(form)
+  validation = validateCandidate(buildCandidateDoc(input))
+  await recordProvisioningIntent(env.DB, {
+    customer_id: input.customer_id,
+    customer_name: input.customer_name,
+    vertical: input.vertical,
+    actor_user_id: session.userId,
+    actor_email: session.email,
+    actor_role: session.role,
+    outcome: validation.result.ok ? 'validated' : 'rejected',
+    error_count: validation.result.ok ? 0 : validation.result.errors.length,
+    candidate_yaml: validation.result.ok ? validation.yamlText : '',
+  })
+}
+
+const recent = await listProvisioningIntent(env.DB, 10)
+
+// Field value helper: repopulate from the submitted input, else the default.
+function fv(key: keyof ProvisioningInput, fallback = ''): string {
+  if (!input) return fallback
+  const v = input[key]
+  if (Array.isArray(v)) return v.join(', ')
+  return v === undefined || v === null || Number.isNaN(v) ? fallback : String(v)
+}
+function connectorAt(i: number): { capability: string; adapter: string; backend: string } {
+  const row = input?.connectors[i]
+  return {
+    capability: row?.capability ?? CONNECTOR_SLOTS[i] ?? '',
+    adapter: row?.adapter ?? '',
+    backend: row?.backend ?? '',
+  }
+}
+
+const ok = validation?.result.ok === true
+const errors = validation && !validation.result.ok ? validation.result.errors : []
+
+const inputClass =
+  'w-full rounded-[var(--ss-radius-badge)] border border-[color:var(--ss-color-border)] ' +
+  'px-3 py-2 text-sm text-[color:var(--ss-color-text-primary)] ' +
+  'focus:outline-none focus:ring-2 focus:ring-[color:var(--ss-color-action)]'
+const labelClass = 'block text-xs font-medium text-[color:var(--ss-color-text-secondary)] mb-1'
+const cardClass =
+  'bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card'
+---
+
+<AdminLayout
+  title="Operator — Provision"
+  breadcrumbs={[
+    { label: 'Dashboard', href: '/admin' },
+    { label: 'Operator', href: '/admin/operator' },
+    { label: 'Provision' },
+  ]}
+  maxWidth="max-w-5xl"
+>
+  <div class="space-y-card">
+    <header>
+      <h2 class="text-xl font-semibold text-[color:var(--ss-color-text-primary)]">
+        Provision a new operator
+      </h2>
+      <p class="text-sm text-[color:var(--ss-color-text-secondary)] mt-1">
+        Author the customer.yaml essentials and validate them. On a clean pass this emits the
+        validated config to drop into <code>operator/customers/&lt;slug&gt;/customer.yaml</code> and hand
+        to the stand-up tooling — the console does not stand up the Machine or commit to git.
+      </p>
+    </header>
+
+    {
+      ok && validation && (
+        <div class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-complete)] p-card space-y-stack">
+          <div>
+            <h3 class="text-base font-semibold text-[color:var(--ss-color-complete)]">
+              Validated — ready for stand-up
+            </h3>
+            <p class="text-sm text-[color:var(--ss-color-text-secondary)] mt-1">
+              The candidate passed the validator and secret-exclusion scan. Recorded as provisioning
+              intent. Next, the operator (or #1262 tooling) commits this and runs the stand-up:
+            </p>
+          </div>
+          <ol class="text-sm text-[color:var(--ss-color-text-primary)] list-decimal pl-5 space-y-1">
+            <li>
+              Save the YAML below to{' '}
+              <code>operator/customers/{fv('customer_id')}/customer.yaml</code> and commit it (git
+              is the source of truth, ADR 0012).
+            </li>
+            <li>
+              Run <code>operator/bin/reprovision.sh {fv('customer_id')}</code> to stand up the Fly
+              Machine.
+            </li>
+            <li>
+              Drive connector consent and activate the subscription from this operator's drill-in.
+            </li>
+          </ol>
+          {/* prettier-ignore */}
+          <pre class="text-xs font-mono bg-[color:var(--ss-color-surface)] border border-[color:var(--ss-color-border-subtle)] rounded-[var(--ss-radius-badge)] p-4 overflow-x-auto whitespace-pre">{validation.yamlText}</pre>
+        </div>
+      )
+    }
+
+    {
+      errors.length > 0 && (
+        <div class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-error)] p-card">
+          <h3 class="text-base font-semibold text-[color:var(--ss-color-error)]">
+            {errors.length} validation {errors.length === 1 ? 'error' : 'errors'} — not ready
+          </h3>
+          <p class="text-sm text-[color:var(--ss-color-text-secondary)] mt-1 mb-3">
+            Fix these and resubmit. Nothing was stood up. The attempt is recorded as a rejected
+            provisioning intent.
+          </p>
+          <ul class="space-y-1.5 text-sm">
+            {errors.map((e) => (
+              <li class="flex gap-3">
+                <code class="text-xs text-[color:var(--ss-color-text-muted)] shrink-0 w-40 truncate">
+                  {e.path}
+                </code>
+                <span class="text-[color:var(--ss-color-text-primary)]">{e.message}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )
+    }
+
+    <form method="POST" class="space-y-card">
+      <div class={cardClass}>
+        <h3 class="text-base font-semibold text-[color:var(--ss-color-text-primary)] mb-3">
+          Identity
+        </h3>
+        <div class="grid sm:grid-cols-2 gap-4">
+          <div>
+            <label class={labelClass} for="customer_id">Customer slug</label>
+            <input
+              class={inputClass}
+              id="customer_id"
+              name="customer_id"
+              value={fv('customer_id')}
+              placeholder="smith-pi-firm"
+              pattern="[a-z0-9][a-z0-9-]{0,31}"
+              required
+            />
+          </div>
+          <div>
+            <label class={labelClass} for="customer_name">Legal name</label>
+            <input
+              class={inputClass}
+              id="customer_name"
+              name="customer_name"
+              value={fv('customer_name')}
+              placeholder="Smith PI Firm"
+              required
+            />
+          </div>
+          <div>
+            <label class={labelClass} for="vertical">Vertical pack</label>
+            <select class={inputClass} id="vertical" name="vertical" required>
+              <option value="">Select…</option>
+              {
+                verticalOptions().map((v) => (
+                  <option value={v} selected={fv('vertical') === v}>
+                    {v}
+                  </option>
+                ))
+              }
+            </select>
+          </div>
+          <div>
+            <label class={labelClass} for="practice_areas">Practice areas (comma-separated)</label>
+            <input
+              class={inputClass}
+              id="practice_areas"
+              name="practice_areas"
+              value={fv('practice_areas')}
+              placeholder="personal-injury, workers-comp"
+              required
+            />
+          </div>
+          <div>
+            <label class={labelClass} for="fly_region">Fly region</label>
+            <input
+              class={inputClass}
+              id="fly_region"
+              name="fly_region"
+              value={fv('fly_region')}
+              placeholder="lax"
+              required
+            />
+          </div>
+        </div>
+      </div>
+
+      <div class={cardClass}>
+        <h3 class="text-base font-semibold text-[color:var(--ss-color-text-primary)] mb-3">
+          Runtime
+        </h3>
+        <div class="grid sm:grid-cols-2 gap-4">
+          <div>
+            <label class={labelClass} for="model">Model</label>
+            <input
+              class={inputClass}
+              id="model"
+              name="model"
+              value={fv('model', DEFAULTS.model)}
+              required
+            />
+          </div>
+          <div>
+            <label class={labelClass} for="hermes_ref">Hermes ref (upstream pin)</label>
+            <input
+              class={inputClass}
+              id="hermes_ref"
+              name="hermes_ref"
+              value={fv('hermes_ref')}
+              placeholder="v2026.5.7@<40-hex-sha>"
+              required
+            />
+          </div>
+          <div>
+            <label class={labelClass} for="machine_size">Machine size</label>
+            <input
+              class={inputClass}
+              id="machine_size"
+              name="machine_size"
+              value={fv('machine_size', DEFAULTS.machine_size)}
+              required
+            />
+          </div>
+          <div>
+            <label class={labelClass} for="machine_memory_mb">Memory (MB, 256–8192)</label>
+            <input
+              class={inputClass}
+              id="machine_memory_mb"
+              name="machine_memory_mb"
+              type="number"
+              min="256"
+              max="8192"
+              value={fv('machine_memory_mb', String(DEFAULTS.machine_memory_mb))}
+              required
+            />
+          </div>
+        </div>
+      </div>
+
+      <div class={cardClass}>
+        <h3 class="text-base font-semibold text-[color:var(--ss-color-text-primary)] mb-3">
+          Primary user (portal access)
+        </h3>
+        <div class="grid sm:grid-cols-3 gap-4">
+          <div>
+            <label class={labelClass} for="user_email">Email</label>
+            <input
+              class={inputClass}
+              id="user_email"
+              name="user_email"
+              type="email"
+              value={fv('user_email')}
+              required
+            />
+          </div>
+          <div>
+            <label class={labelClass} for="user_full_name">Full name</label>
+            <input
+              class={inputClass}
+              id="user_full_name"
+              name="user_full_name"
+              value={fv('user_full_name')}
+              required
+            />
+          </div>
+          <div>
+            <label class={labelClass} for="user_role">Role</label>
+            <select class={inputClass} id="user_role" name="user_role" required>
+              {
+                userRoleOptions().map((r) => (
+                  <option value={r} selected={fv('user_role', 'principal') === r}>
+                    {r}
+                  </option>
+                ))
+              }
+            </select>
+          </div>
+        </div>
+      </div>
+
+      <div class={cardClass}>
+        <h3 class="text-base font-semibold text-[color:var(--ss-color-text-primary)] mb-3">
+          Primary persona
+        </h3>
+        <div class="grid sm:grid-cols-2 gap-4">
+          <div>
+            <label class={labelClass} for="persona_slug">Slug</label>
+            <input
+              class={inputClass}
+              id="persona_slug"
+              name="persona_slug"
+              value={fv('persona_slug')}
+              placeholder="marcus"
+              pattern="[a-z0-9][a-z0-9-]{0,31}"
+              required
+            />
+          </div>
+          <div>
+            <label class={labelClass} for="persona_name">Name</label>
+            <input
+              class={inputClass}
+              id="persona_name"
+              name="persona_name"
+              value={fv('persona_name')}
+              placeholder="Marcus"
+              required
+            />
+          </div>
+          <div>
+            <label class={labelClass} for="persona_title">Title (optional)</label>
+            <input
+              class={inputClass}
+              id="persona_title"
+              name="persona_title"
+              value={fv('persona_title')}
+              placeholder="AI Associate"
+            />
+          </div>
+          <div>
+            <label class={labelClass} for="persona_tone">Tone (comma-separated, 3–5)</label>
+            <input
+              class={inputClass}
+              id="persona_tone"
+              name="persona_tone"
+              value={fv('persona_tone')}
+              placeholder="warm-but-professional, concise"
+              required
+            />
+          </div>
+          <div>
+            <label class={labelClass} for="skill_name">Lead skill</label>
+            <input
+              class={inputClass}
+              id="skill_name"
+              name="skill_name"
+              value={fv('skill_name')}
+              placeholder="matter-inbox-router"
+              required
+            />
+          </div>
+          <div>
+            <label class={labelClass} for="skill_trust_ceiling">Skill trust ceiling</label>
+            <select class={inputClass} id="skill_trust_ceiling" name="skill_trust_ceiling" required>
+              {
+                trustCeilingOptions().map((c) => (
+                  <option value={c} selected={fv('skill_trust_ceiling', 'draft_for_review') === c}>
+                    {c}
+                  </option>
+                ))
+              }
+            </select>
+          </div>
+        </div>
+      </div>
+
+      <div class={cardClass}>
+        <h3 class="text-base font-semibold text-[color:var(--ss-color-text-primary)] mb-1">
+          Connectors
+        </h3>
+        <p class="text-xs text-[color:var(--ss-color-text-muted)] mb-3">
+          The capability set authored at stand-up. Fill the ones in scope; leave a row blank to skip
+          it. Backend must be prefixed <code>mcp:</code>, <code>build:</code>, or
+          <code>synthetic:</code>.
+        </p>
+        <div class="space-y-3">
+          {
+            CONNECTOR_SLOTS.map((_, i) => {
+              const c = connectorAt(i)
+              return (
+                <div class="grid sm:grid-cols-3 gap-3">
+                  <select class={inputClass} name="connector_capability">
+                    <option value="">— none —</option>
+                    {capabilityOptions().map((cap) => (
+                      <option value={cap} selected={c.capability === cap}>
+                        {cap}
+                      </option>
+                    ))}
+                  </select>
+                  <input
+                    class={inputClass}
+                    name="connector_adapter"
+                    value={c.adapter}
+                    placeholder="adapter (e.g. clio)"
+                  />
+                  <input
+                    class={inputClass}
+                    name="connector_backend"
+                    value={c.backend}
+                    placeholder="mcp:clio-oktopeak"
+                  />
+                </div>
+              )
+            })
+          }
+        </div>
+      </div>
+
+      <div class="flex items-center gap-3">
+        <button
+          type="submit"
+          class="rounded-[var(--ss-radius-badge)] bg-[color:var(--ss-color-action)] px-4 py-2 text-sm font-medium text-white hover:opacity-90"
+        >
+          Validate candidate
+        </button>
+        <p class="text-xs text-[color:var(--ss-color-text-muted)]">
+          Per-domain authority defaults to SMD-managed (fail-closed); flip on the authority surface
+          after stand-up.
+        </p>
+      </div>
+    </form>
+
+    <div class={cardClass}>
+      <h3 class="text-base font-semibold text-[color:var(--ss-color-text-primary)] mb-3">
+        Recent provisioning attempts
+      </h3>
+      {
+        recent.length === 0 ? (
+          <p class="text-sm text-[color:var(--ss-color-text-secondary)]">
+            No provisioning attempts yet.
+          </p>
+        ) : (
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="text-left text-xs text-[color:var(--ss-color-text-secondary)] border-b border-[color:var(--ss-color-border)]">
+                <th class="pb-2 font-medium">Customer</th>
+                <th class="pb-2 font-medium">Vertical</th>
+                <th class="pb-2 font-medium">Outcome</th>
+                <th class="pb-2 font-medium">By</th>
+                <th class="pb-2 font-medium text-right">When</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-[color:var(--ss-color-border-subtle)]">
+              {recent.map((r) => (
+                <tr>
+                  <td class="py-2 pr-4 text-[color:var(--ss-color-text-primary)]">
+                    {r.customer_name}
+                    <span class="text-xs text-[color:var(--ss-color-text-muted)]">
+                      {' '}
+                      · {r.customer_id}
+                    </span>
+                  </td>
+                  <td class="py-2 pr-4 text-[color:var(--ss-color-text-secondary)]">
+                    {r.vertical}
+                  </td>
+                  <td class="py-2 pr-4">
+                    {r.outcome === 'validated' ? (
+                      <span class="text-[color:var(--ss-color-complete)]">Validated</span>
+                    ) : (
+                      <span class="text-[color:var(--ss-color-error)]">
+                        Rejected ({r.error_count})
+                      </span>
+                    )}
+                  </td>
+                  <td class="py-2 pr-4 text-[color:var(--ss-color-text-secondary)]">
+                    {r.actor_email}
+                  </td>
+                  <td class="py-2 text-right text-[color:var(--ss-color-text-muted)] font-mono text-xs">
+                    {r.created_at.slice(0, 16).replace('T', ' ')}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )
+      }
+    </div>
+  </div>
+</AdminLayout>

--- a/tests/provisioning.test.ts
+++ b/tests/provisioning.test.ts
@@ -1,0 +1,279 @@
+/**
+ * Tests for the provisioning authoring + validation path
+ * (src/lib/admin/provisioning.ts) — admin Operator console §4.5.
+ *
+ * Two halves: the pure assembly/serialization/validation helpers (no DB), and
+ * the intent ledger against a real D1. The invariant that matters: the surface
+ * VALIDATES (via the real validator + secret scan) and RECORDS INTENT — it never
+ * stands up a Machine or writes git. The ledger has no entities() FK because the
+ * customer does not exist yet at authoring time.
+ */
+
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest'
+import {
+  createTestD1,
+  discoverNumericMigrations,
+  runMigrations,
+  installWorkerdPolyfills,
+} from '@venturecrane/crane-test-harness'
+import path from 'node:path'
+import { env as testEnv } from 'cloudflare:workers'
+import {
+  splitList,
+  parseProvisioningForm,
+  buildCandidateDoc,
+  serializeCustomerYaml,
+  validateCandidate,
+  verticalOptions,
+  addonOptionsFor,
+  trustCeilingOptions,
+  userRoleOptions,
+  capabilityOptions,
+  recordProvisioningIntent,
+  listProvisioningIntent,
+  type ProvisioningInput,
+} from '../src/lib/admin/provisioning'
+
+installWorkerdPolyfills()
+const migrationsDir = path.resolve(__dirname, '../migrations')
+
+function validInput(): ProvisioningInput {
+  return {
+    customer_id: 'smith-pi-firm',
+    customer_name: 'Smith PI Firm',
+    vertical: 'law-firm',
+    addons: [],
+    practice_areas: ['personal-injury'],
+    fly_region: 'lax',
+    model: 'claude-opus-4-7',
+    hermes_ref: 'v2026.5.7@a91a57fa5a13d516c38b07a141a9ce8a3daabeb0',
+    machine_size: 'shared-cpu-1x',
+    machine_memory_mb: 1024,
+    user_email: 'partner@firm.com',
+    user_role: 'principal',
+    user_full_name: 'Jane Smith',
+    persona_slug: 'marcus',
+    persona_name: 'Marcus',
+    persona_title: 'AI Associate',
+    persona_tone: ['warm-but-professional', 'concise'],
+    skill_name: 'matter-inbox-router',
+    skill_trust_ceiling: 'draft_for_review',
+    connectors: [
+      { capability: 'Email', adapter: 'm365-mail', backend: 'mcp:m365-mail', enabled: true },
+    ],
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+describe('splitList', () => {
+  it('splits on commas and newlines, trims, drops empties', () => {
+    expect(splitList('a, b\nc ,, ')).toEqual(['a', 'b', 'c'])
+    expect(splitList('   ')).toEqual([])
+  })
+})
+
+describe('option sources are real schema constants', () => {
+  it('exposes verticals, ceilings, roles, capabilities', () => {
+    expect(verticalOptions()).toContain('law-firm')
+    expect(trustCeilingOptions()).toEqual(['autonomous', 'draft_for_review', 'refused'])
+    expect(userRoleOptions()).toEqual(['principal', 'staff', 'compliance'])
+    expect(capabilityOptions()).toContain('Email')
+    expect(addonOptionsFor('law-firm')).toContain('pi')
+    expect(addonOptionsFor('mixed')).toEqual([])
+  })
+})
+
+describe('parseProvisioningForm', () => {
+  it('parses scalars, lists, and positional connector rows', () => {
+    const form = new FormData()
+    form.set('customer_id', ' smith-pi-firm ')
+    form.set('customer_name', 'Smith PI Firm')
+    form.set('vertical', 'law-firm')
+    form.set('practice_areas', 'personal-injury, workers-comp')
+    form.set('fly_region', 'lax')
+    form.set('model', 'claude-opus-4-7')
+    form.set('hermes_ref', 'v2026.5.7@a91a57fa5a13d516c38b07a141a9ce8a3daabeb0')
+    form.set('machine_size', 'shared-cpu-1x')
+    form.set('machine_memory_mb', '1024')
+    form.set('user_email', 'partner@firm.com')
+    form.set('user_role', 'principal')
+    form.set('user_full_name', 'Jane Smith')
+    form.set('persona_slug', 'marcus')
+    form.set('persona_name', 'Marcus')
+    form.set('persona_title', 'AI Associate')
+    form.set('persona_tone', 'warm, concise')
+    form.set('skill_name', 'matter-inbox-router')
+    form.set('skill_trust_ceiling', 'draft_for_review')
+    // Two connector rows + one wholly-blank slot that must be skipped.
+    form.append('connector_capability', 'Email')
+    form.append('connector_adapter', 'm365-mail')
+    form.append('connector_backend', 'mcp:m365-mail')
+    form.append('connector_capability', 'Calendar')
+    form.append('connector_adapter', 'm365-calendar')
+    form.append('connector_backend', 'mcp:m365-calendar')
+    form.append('connector_capability', '')
+    form.append('connector_adapter', '')
+    form.append('connector_backend', '')
+
+    const input = parseProvisioningForm(form)
+    expect(input.customer_id).toBe('smith-pi-firm') // trimmed
+    expect(input.practice_areas).toEqual(['personal-injury', 'workers-comp'])
+    expect(input.machine_memory_mb).toBe(1024)
+    expect(input.connectors).toHaveLength(2)
+    expect(input.connectors[1]).toEqual({
+      capability: 'Calendar',
+      adapter: 'm365-calendar',
+      backend: 'mcp:m365-calendar',
+      enabled: true,
+    })
+  })
+
+  it('represents an unparseable memory value as NaN (not a coerced default)', () => {
+    const form = new FormData()
+    form.set('machine_memory_mb', 'lots')
+    expect(Number.isNaN(parseProvisioningForm(form).machine_memory_mb)).toBe(true)
+  })
+})
+
+describe('buildCandidateDoc + validateCandidate', () => {
+  it('a complete authored input validates clean', () => {
+    const { result } = validateCandidate(buildCandidateDoc(validInput()))
+    expect(result.ok).toBe(true)
+  })
+
+  it('derives isolation invariants from the slug', () => {
+    const doc = buildCandidateDoc(validInput())
+    expect(doc.memory).toEqual({
+      d1_namespace: 'smith-pi-firm',
+      r2_vault_path: 'vaults/smith-pi-firm/',
+      vectorize_index: 'hermes-smith-pi-firm-vault',
+    })
+  })
+
+  it('omits authority so the validator resolves the fail-closed default', () => {
+    const doc = buildCandidateDoc(validInput())
+    expect('authority' in doc).toBe(false)
+    const { result } = validateCandidate(doc)
+    expect(result.ok).toBe(true)
+  })
+
+  it('reports validator errors for a bad slug and a bad hermes_ref', () => {
+    const bad = validInput()
+    bad.customer_id = 'Bad Slug!'
+    bad.hermes_ref = 'not-a-pin'
+    const { result } = validateCandidate(buildCandidateDoc(bad))
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      const paths = result.errors.map((e) => e.path)
+      expect(paths).toContain('customer_id')
+      expect(paths).toContain('hermes_ref')
+    }
+  })
+
+  it('fails closed when an authored field carries an inline secret', () => {
+    const planted = validInput()
+    planted.user_full_name = 'Jane AKIAIOSFODNN7EXAMPLE Smith'
+    const { result } = validateCandidate(buildCandidateDoc(planted))
+    expect(result.ok).toBe(false)
+  })
+})
+
+describe('serializeCustomerYaml', () => {
+  it('renders scalars, string lists, nested maps, and list-of-objects', () => {
+    const yaml = serializeCustomerYaml(buildCandidateDoc(validInput()))
+    expect(yaml).toContain("customer_id: 'smith-pi-firm'")
+    expect(yaml).toContain('schema_version: 1')
+    // list-of-objects: the bullet carries the first key, the rest align under it
+    expect(yaml).toMatch(/personas:\n {2}- slug: 'marcus'\n {4}status: 'active'/)
+    // empty list renders inline
+    expect(yaml).toContain('addons: []')
+    // nested map
+    expect(yaml).toMatch(/machine:\n {2}size: 'shared-cpu-1x'\n {2}memory_mb: 1024/)
+  })
+
+  it('single-quotes strings and doubles internal quotes', () => {
+    const yaml = serializeCustomerYaml({ name: "O'Brien & Co" })
+    expect(yaml).toBe("name: 'O''Brien & Co'\n")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Intent ledger (real D1)
+// ---------------------------------------------------------------------------
+
+describe('provisioning intent ledger', () => {
+  beforeAll(() => {
+    expect(discoverNumericMigrations(migrationsDir).length).toBeGreaterThan(0)
+  })
+
+  beforeEach(async () => {
+    const db = createTestD1()
+    await runMigrations(db, { files: discoverNumericMigrations(migrationsDir) })
+    for (const k of Object.keys(testEnv)) delete (testEnv as unknown as Record<string, unknown>)[k]
+    Object.assign(testEnv, { DB: db })
+  })
+
+  it('records a validated attempt with the candidate YAML and the SMD actor', async () => {
+    const { result, yamlText } = validateCandidate(buildCandidateDoc(validInput()))
+    expect(result.ok).toBe(true)
+    const id = await recordProvisioningIntent(testEnv.DB, {
+      customer_id: 'smith-pi-firm',
+      customer_name: 'Smith PI Firm',
+      vertical: 'law-firm',
+      actor_user_id: 'usr-captain',
+      actor_email: 'captain@example.com',
+      actor_role: 'admin',
+      outcome: 'validated',
+      error_count: 0,
+      candidate_yaml: yamlText,
+    })
+    expect(id).toBeGreaterThan(0)
+
+    const rows = await listProvisioningIntent(testEnv.DB)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({
+      customer_id: 'smith-pi-firm',
+      vertical: 'law-firm',
+      outcome: 'validated',
+      error_count: 0,
+      actor_email: 'captain@example.com',
+    })
+  })
+
+  it('records a rejected attempt with the error count and empty YAML', async () => {
+    await recordProvisioningIntent(testEnv.DB, {
+      customer_id: 'broken',
+      customer_name: 'Broken Co',
+      vertical: 'law-firm',
+      actor_user_id: 'usr-captain',
+      actor_email: 'captain@example.com',
+      actor_role: 'admin',
+      outcome: 'rejected',
+      error_count: 3,
+      candidate_yaml: '',
+    })
+    const rows = await listProvisioningIntent(testEnv.DB)
+    expect(rows[0]).toMatchObject({ outcome: 'rejected', error_count: 3 })
+  })
+
+  it('returns newest first', async () => {
+    for (const slug of ['a-co', 'b-co', 'c-co']) {
+      await recordProvisioningIntent(testEnv.DB, {
+        customer_id: slug,
+        customer_name: slug,
+        vertical: 'mixed',
+        actor_user_id: 'usr-captain',
+        actor_email: 'captain@example.com',
+        actor_role: 'admin',
+        outcome: 'validated',
+        error_count: 0,
+        candidate_yaml: 'x',
+      })
+    }
+    const rows = await listProvisioningIntent(testEnv.DB)
+    expect(rows.map((r) => r.customer_id)).toEqual(['c-co', 'b-co', 'a-co'])
+  })
+})


### PR DESCRIPTION
## What

The admin Operator console **provisioning** surface (`/admin/operator/provision`) — steps 1-3 of the §4.5 stand-up flow: pick a vertical, author the customer.yaml essentials, and validate them via the existing validator + secret-exclusion scan.

## The honest seam

A Cloudflare Worker cannot write the git source of truth (ADR 0012 §2 — configs-repo write-back is explicitly OUT OF SCOPE at v1, confirmed in the customer-side `customer-yaml-update` endpoint) or call Fly. So the console **authors + validates only**. On a clean pass it emits the validated `customer.yaml` as the deliverable the operator drops into `operator/customers/<slug>/customer.yaml` before running the existing stand-up tooling (`operator/bin/reprovision.sh`, being made agent-runnable on #1262). The surface never claims a Machine was stood up or git was committed — it records the attempt as provisioning **intent** and hands off explicitly (foundations §7).

What the vertical pick seeds vs. what the admin authors: the Worker can't read the on-disk pack manifests, so the pack's personas/skills/connectors are materialized from the pack by the stand-up tooling, not re-typed here. The pick drives the vertical selection (real `ACCEPTED_VERTICALS`); the admin authors identity, the primary persona, the primary user, and the connector capability set per §4.5 step 2.

## Changes

- **`src/lib/admin/provisioning.ts`** — pure form-parse, candidate assembly, a scoped YAML emitter (no YAML lib in the Worker bundle), validation via the real `validate()` with the `rawText` secret scan (the "validator + secret-scan" pass in one documented call), and the intent ledger writer/reader. Per-domain authority is **omitted** so the validator resolves the fail-closed all-managed default (DEFAULT_AUTHORITY_POSTURE); flips happen on the §5.9 authority surface post-provision.
- **`migrations/0067_operator_provisioning_intent.sql`** — the intent ledger. **No `entities()` FK**: provisioning is the one admin action whose subject doesn't exist yet, so it keys on the proposed `customer_id`. Records `validated`/`rejected` attempts; preserves the secret-scanned candidate YAML on the success path.
- **`src/pages/admin/operator/provision.astro`** — in-page POST form that redisplays entered values with inline validation results and the emitted YAML; recent-attempts table. `smd_admin`-only.
- **Fleet roster** (`index.astro`) — "Provision operator" CTA in the header + empty state.
- **`tests/provisioning.test.ts`** — 14 tests across the pure helpers (incl. fail-closed on a planted inline secret, slug/hermes_ref validator errors, the YAML emitter's list-of-objects + quoting) and the intent ledger (validated/rejected/ordering).

## Verification

`npm run verify` green: typecheck 0 errors, Prettier clean, build OK, main suite **3268 passed / 2 skipped**, all worker suites pass. New surface: 14/14.

## Out of scope (follow-ons)

§4.5 step 5 (connector consent, ADR 0042) and step 6 (subscription activation, client-user + smd_operator assignment) — separable surfaces touching credential-custody flows and subscription state. `smd_operator` role seam is held per launch posture (admin === Captain today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)