### PR TITLE
feat(operator-portal): Account surface (client-portal §5.9)

### DIFF
--- a/src/lib/portal/operator/account-read.ts
+++ b/src/lib/portal/operator/account-read.ts
@@ -1,0 +1,118 @@
+/**
+ * Account read path (client-portal §5.9). Subscription state, escalation
+ * contacts, and the entry to notification preferences.
+ *
+ * Two read concerns, two authority domains:
+ *   - Subscription (provisioning / active / paused) is the `provisioning`
+ *     domain — SMD-only and non-switchable. The client watches it; it is never
+ *     operable, and the provisioning/paused states render as honest status
+ *     surfaces with no fabricated controls (§5.9).
+ *   - Escalation contacts (who the operator alerts on a red flag or a failure)
+ *     are authored config — the `configuration` domain. Read + Request at
+ *     launch, operable once SMD flips the switch.
+ *
+ * Notification preferences are self-service per-user and keep their existing
+ * page; Account links to them rather than re-implementing.
+ *
+ * Defensive throughout: a missing subscription row is a real state (not yet
+ * provisioned), and escalation parses from an `unknown` projection blob —
+ * non-string recipients are dropped, never a fabricated contact.
+ */
+
+import type { D1Database } from '@cloudflare/workers-types'
+import { getProductSubscription } from '../product-access'
+import { getCustomerConfig } from '../customer-config'
+
+const PRODUCT_SLUG = 'operator'
+
+export type SubscriptionStatus = 'provisioning' | 'active' | 'paused' | 'unknown'
+
+export interface SubscriptionView {
+  /** Present only when a subscription row exists. */
+  status: SubscriptionStatus
+  startedAt: string | null
+  endedAt: string | null
+}
+
+export interface EscalationView {
+  redFlagRecipients: string[]
+  failureRecipients: string[]
+  ackWindowMinutes: number | null
+}
+
+export interface AccountState {
+  /** Null when no subscription row exists yet (pre-provisioning). */
+  subscription: SubscriptionView | null
+  escalation: EscalationView
+}
+
+const KNOWN_STATUSES: ReadonlySet<string> = new Set(['provisioning', 'active', 'paused'])
+
+function normalizeStatus(raw: string): SubscriptionStatus {
+  return KNOWN_STATUSES.has(raw) ? (raw as SubscriptionStatus) : 'unknown'
+}
+
+export async function loadAccountState(db: D1Database, entityId: string): Promise<AccountState> {
+  const sub = await getProductSubscription(db, entityId, PRODUCT_SLUG)
+  const config = await getCustomerConfig(db, entityId)
+  return {
+    subscription: sub
+      ? { status: normalizeStatus(sub.status), startedAt: sub.started_at, endedAt: sub.ended_at }
+      : null,
+    escalation: parseEscalation(config?.escalation),
+  }
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v)
+}
+
+/** Keep only non-empty string entries — never a fabricated or blank contact. */
+function stringList(v: unknown): string[] {
+  if (!Array.isArray(v)) return []
+  return v.filter((x): x is string => typeof x === 'string' && x.trim().length > 0)
+}
+
+/**
+ * Parse the projected escalation blob (`unknown`) into a display shape. Total:
+ * any malformed field resolves to an empty list / null, never throws.
+ */
+export function parseEscalation(raw: unknown): EscalationView {
+  if (!isRecord(raw)) {
+    return { redFlagRecipients: [], failureRecipients: [], ackWindowMinutes: null }
+  }
+  const ack = raw['acknowledgement_window_minutes']
+  return {
+    redFlagRecipients: stringList(raw['red_flag_recipients']),
+    failureRecipients: stringList(raw['failure_recipients']),
+    ackWindowMinutes: typeof ack === 'number' && Number.isFinite(ack) && ack > 0 ? ack : null,
+  }
+}
+
+/** One-line human label for a subscription status. */
+export function subscriptionStatusLabel(status: SubscriptionStatus): string {
+  switch (status) {
+    case 'provisioning':
+      return 'Provisioning'
+    case 'active':
+      return 'Active'
+    case 'paused':
+      return 'Paused'
+    default:
+      return 'Unknown'
+  }
+}
+
+/** Honest one-sentence prose for each subscription state. */
+export function subscriptionStatusProse(status: SubscriptionStatus): string {
+  switch (status) {
+    case 'provisioning':
+      return 'Your operator is being set up. We will let you know the moment it is ready.'
+    case 'active':
+      return 'Your operator is running.'
+    case 'paused':
+      return 'Your operator is paused. Contact us to resume it.'
+    default:
+      return 'We could not read your subscription state. Contact us if this persists.'
+  }
+}

--- a/src/pages/portal/products/operator/account/index.astro
+++ b/src/pages/portal/products/operator/account/index.astro
@@ -1,0 +1,244 @@
+---
+import '../../../../../styles/global.css'
+import { BRAND_NAME } from '../../../../../lib/config/brand'
+import { resolveOperatorAccess } from '../../../../../lib/portal/operator-access'
+import { getCustomerConfig } from '../../../../../lib/portal/customer-config'
+import {
+  loadAccountState,
+  subscriptionStatusLabel,
+  subscriptionStatusProse,
+} from '../../../../../lib/portal/operator/account-read'
+import PortalHeader from '../../../../../components/portal/PortalHeader.astro'
+import PortalTabs from '../../../../../components/portal/PortalTabs.astro'
+import PortalPageHead from '../../../../../components/portal/PortalPageHead.astro'
+import SkipToMain from '../../../../../components/SkipToMain.astro'
+import DomainSurface from '../../../../../components/portal/operator/DomainSurface.astro'
+import { env } from 'cloudflare:workers'
+
+/**
+ * Operator — Account (client-portal §5.9). Subscription state, escalation
+ * contacts, and the entry to notification preferences.
+ *
+ * URL: portal.smd.services/portal/products/operator/account
+ *
+ * Two read concerns under two authority domains:
+ *   - Subscription is the `provisioning` domain — SMD-only, non-switchable.
+ *     <DomainSurface> renders it read-only with NO request form (there is no
+ *     client switch to request). The provisioning/paused states are honest
+ *     status surfaces, not fabricated controls (§5.9).
+ *   - Escalation contacts are authored config — the `configuration` domain.
+ *     Read + Request at launch; operable once SMD flips the switch.
+ *
+ * Notification preferences are self-service per-user and keep their own page;
+ * Account links to them. Readable by all three client roles.
+ */
+
+const access = await resolveOperatorAccess(env.DB, Astro.locals, {
+  allowedRoles: ['principal', 'staff', 'compliance'],
+})
+if (access.kind === 'redirect') {
+  return Astro.redirect(access.to)
+}
+const { client, roles } = access
+
+const config = await getCustomerConfig(env.DB, client.id)
+const account = await loadAccountState(env.DB, client.id)
+
+const RETURN_TO = '/portal/products/operator/account'
+const cr = Astro.url.searchParams.get('cr')
+const crMessage =
+  cr === 'filed'
+    ? 'Your request was sent.'
+    : cr === 'invalid'
+      ? "That request couldn't be filed. Please add a short description and try again."
+      : cr === 'error'
+        ? 'Something went wrong filing your request. Please try again.'
+        : null
+
+const subStatus = account.subscription?.status ?? null
+const statusToneClass =
+  subStatus === 'active'
+    ? 'border-[color:var(--ss-color-complete)] text-[color:var(--ss-color-complete)]'
+    : subStatus === 'paused'
+      ? 'border-[color:var(--ss-color-warning)] text-[color:var(--ss-color-warning)]'
+      : 'border-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-text-primary)]'
+
+const cardClass = 'border-[3px] border-[color:var(--ss-color-text-primary)] p-6 md:p-8'
+const sectionLabelClass =
+  "mb-4 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold text-[color:var(--ss-color-text-secondary)]"
+const recipientListClass =
+  'm-0 list-none p-0 border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)]'
+const recipientRowClass =
+  "border-b-[2px] border-[color:var(--ss-color-text-primary)] last:border-b-0 px-5 py-3 font-['Archivo'] text-[color:var(--ss-color-text-primary)]"
+const manageLinkClass =
+  "inline-flex items-center gap-2 px-5 py-3 font-['Archivo_Narrow'] uppercase tracking-[0.12em] font-bold text-sm border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] hover:bg-[color:var(--ss-color-primary)] hover:border-[color:var(--ss-color-primary)] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2"
+const emptyNoteClass =
+  "font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)]"
+
+const hasEscalation =
+  account.escalation.redFlagRecipients.length > 0 ||
+  account.escalation.failureRecipients.length > 0 ||
+  account.escalation.ackWindowMinutes !== null
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;900&family=Archivo+Narrow:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap"
+      rel="stylesheet"
+    />
+    <title>Operator · Account | {BRAND_NAME}</title>
+  </head>
+  <body class="min-h-screen bg-[color:var(--ss-color-background)]">
+    <SkipToMain />
+    <PortalHeader clientName={client.name} />
+
+    <PortalTabs pathname={Astro.url.pathname} operatorActive={true} />
+
+    <main id="main" role="main" class="max-w-5xl mx-auto px-4 md:px-6 pb-24 md:pb-12">
+      <PortalPageHead
+        crumbHref="/portal/products/operator"
+        crumbLabel="Operator"
+        tag="Section"
+        h1="Account"
+        meta={subStatus ? subscriptionStatusLabel(account.subscription!.status) : null}
+      />
+
+      {
+        crMessage && (
+          <div
+            role="status"
+            class={`mt-6 border-[3px] px-5 py-3 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold ${
+              cr === 'filed'
+                ? 'border-[color:var(--ss-color-complete)] text-[color:var(--ss-color-complete)]'
+                : 'border-[color:var(--ss-color-error)] text-[color:var(--ss-color-error)]'
+            }`}
+          >
+            {crMessage}
+          </div>
+        )
+      }
+
+      <!-- Subscription — provisioning domain: SMD-only, read-only, no request form -->
+      <section class="mt-8" aria-label="Subscription">
+        <p class={sectionLabelClass}>Subscription</p>
+        <DomainSurface
+          authority={config?.authority ?? null}
+          domain="provisioning"
+          roles={roles}
+          returnTo={RETURN_TO}
+          domainLabel="your subscription"
+        >
+          <div slot="read" class={cardClass}>
+            {
+              account.subscription ? (
+                <div class="flex flex-col gap-3">
+                  <span
+                    class={`inline-flex w-fit items-center px-3 py-1.5 text-caption font-['Archivo_Narrow'] uppercase tracking-[0.12em] font-bold border-[2px] ${statusToneClass}`}
+                  >
+                    {subscriptionStatusLabel(account.subscription.status)}
+                  </span>
+                  <p class="m-0 font-['Archivo'] text-[color:var(--ss-color-text-primary)]">
+                    {subscriptionStatusProse(account.subscription.status)}
+                  </p>
+                </div>
+              ) : (
+                <div class="flex flex-col gap-2">
+                  <p class="m-0 font-['Archivo'] text-xl font-black uppercase tracking-[-0.01em] text-[color:var(--ss-color-text-primary)]">
+                    Not provisioned yet
+                  </p>
+                  <p class={`m-0 ${emptyNoteClass}`}>
+                    Your operator subscription has not been set up yet. We will let you know when it
+                    is ready.
+                  </p>
+                </div>
+              )
+            }
+          </div>
+        </DomainSurface>
+      </section>
+
+      <!-- Escalation contacts — configuration domain: read + request at launch -->
+      <section class="mt-10" aria-label="Escalation contacts">
+        <p class={sectionLabelClass}>Escalation contacts</p>
+        <DomainSurface
+          authority={config?.authority ?? null}
+          domain="configuration"
+          roles={roles}
+          returnTo={RETURN_TO}
+          domainLabel="who your operator alerts on a red flag or failure"
+        >
+          <div slot="read">
+            {
+              hasEscalation ? (
+                <div class="flex flex-col gap-6">
+                  {account.escalation.redFlagRecipients.length > 0 && (
+                    <div>
+                      <p class="mb-2 font-['Archivo'] font-bold text-[color:var(--ss-color-text-primary)]">
+                        Red-flag alerts
+                      </p>
+                      <ul role="list" class={recipientListClass}>
+                        {account.escalation.redFlagRecipients.map((r) => (
+                          <li class={recipientRowClass}>{r}</li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+                  {account.escalation.failureRecipients.length > 0 && (
+                    <div>
+                      <p class="mb-2 font-['Archivo'] font-bold text-[color:var(--ss-color-text-primary)]">
+                        Failure alerts
+                      </p>
+                      <ul role="list" class={recipientListClass}>
+                        {account.escalation.failureRecipients.map((r) => (
+                          <li class={recipientRowClass}>{r}</li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+                  {account.escalation.ackWindowMinutes !== null && (
+                    <p class="m-0 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)]">
+                      Acknowledgement window: {account.escalation.ackWindowMinutes} minutes
+                    </p>
+                  )}
+                </div>
+              ) : (
+                <div class={cardClass}>
+                  <p class="m-0 font-['Archivo'] text-xl font-black uppercase tracking-[-0.01em] text-[color:var(--ss-color-text-primary)]">
+                    No escalation contacts set
+                  </p>
+                  <p class={`mt-2 m-0 ${emptyNoteClass}`}>
+                    No one is configured to be alerted on a red flag or failure yet.
+                  </p>
+                </div>
+              )
+            }
+          </div>
+        </DomainSurface>
+      </section>
+
+      <!-- Notification preferences — self-service per-user, own page -->
+      <section class="mt-10" aria-label="Notifications">
+        <p class={sectionLabelClass}>Notifications</p>
+        <div class={cardClass}>
+          <p class="m-0 mb-4 font-['Archivo'] text-[color:var(--ss-color-text-primary)]">
+            Choose which events you want to hear about, and where.
+          </p>
+          <a href="/portal/products/operator/settings/notifications" class={manageLinkClass}>
+            <span class="material-symbols-outlined" aria-hidden="true">notifications</span>
+            Notification preferences
+          </a>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/src/pages/portal/products/operator/index.astro
+++ b/src/pages/portal/products/operator/index.astro
@@ -157,6 +157,11 @@ if (access) {
     label: 'Team',
     description: 'The people on your account, their roles, and who is covering for whom.',
   })
+  sectionCards.push({
+    href: '/portal/products/operator/account',
+    label: 'Account',
+    description: 'Your subscription, escalation contacts, and notification preferences.',
+  })
   const isCompliance = userRoles.includes('compliance')
   const isPrincipal = userRoles.includes('principal')
   const showComplianceCard =

--- a/tests/forbidden-strings.test.ts
+++ b/tests/forbidden-strings.test.ts
@@ -490,6 +490,12 @@ const LIST_INDEX_ALLOWLIST: string[] = [
   // status/document record-row vocabulary. The .map( iterates members; the
   // people_access domain is Read + Request at launch (ADR 0041).
   resolve('src/pages/portal/products/operator/team/index.astro'),
+  // `products/operator/account/index.astro` (§5.9) renders escalation
+  // recipients as plain contact rows (one email per row) inside read-only
+  // domain surfaces — not the PortalListItem status/document record-row
+  // vocabulary. The .map( iterates authored escalation recipients; subscription
+  // is the SMD-only provisioning domain shown as an honest status surface.
+  resolve('src/pages/portal/products/operator/account/index.astro'),
 ]
 
 /** Collect every `index.astro` under `src/pages/portal/` EXCEPT the home. */

--- a/tests/operator-account.test.ts
+++ b/tests/operator-account.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Account surface (client-portal §5.9) — subscription + escalation projection.
+ *
+ * The defensive escalation parse and the honest subscription states are the
+ * load-bearing pieces: §5.9 requires provisioning/paused to be honest status
+ * surfaces (never fabricated controls), and escalation parses from an `unknown`
+ * projection blob that must never produce a fabricated contact.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  parseEscalation,
+  subscriptionStatusLabel,
+  subscriptionStatusProse,
+  type SubscriptionStatus,
+} from '../src/lib/portal/operator/account-read'
+
+describe('parseEscalation: defensive, never a fabricated contact', () => {
+  it('parses a well-formed blob', () => {
+    const e = parseEscalation({
+      red_flag_recipients: ['partner@firm.com'],
+      failure_recipients: ['ops@firm.com', 'principal@firm.com'],
+      acknowledgement_window_minutes: 30,
+    })
+    expect(e.redFlagRecipients).toEqual(['partner@firm.com'])
+    expect(e.failureRecipients).toHaveLength(2)
+    expect(e.ackWindowMinutes).toBe(30)
+  })
+
+  it('drops non-string / blank recipients', () => {
+    const e = parseEscalation({
+      red_flag_recipients: ['a@firm.com', '', 42, null, '   '],
+      failure_recipients: 'not-an-array',
+    })
+    expect(e.redFlagRecipients).toEqual(['a@firm.com'])
+    expect(e.failureRecipients).toEqual([])
+  })
+
+  it('rejects non-positive / non-finite ack windows', () => {
+    expect(parseEscalation({ acknowledgement_window_minutes: 0 }).ackWindowMinutes).toBeNull()
+    expect(parseEscalation({ acknowledgement_window_minutes: -5 }).ackWindowMinutes).toBeNull()
+    expect(parseEscalation({ acknowledgement_window_minutes: 'soon' }).ackWindowMinutes).toBeNull()
+  })
+
+  it('returns an empty view for null / non-object input', () => {
+    for (const bad of [null, undefined, 'x', 7, []]) {
+      const e = parseEscalation(bad)
+      expect(e.redFlagRecipients).toEqual([])
+      expect(e.failureRecipients).toEqual([])
+      expect(e.ackWindowMinutes).toBeNull()
+    }
+  })
+})
+
+describe('subscription status display', () => {
+  it('labels every known status and falls back to Unknown', () => {
+    expect(subscriptionStatusLabel('provisioning')).toBe('Provisioning')
+    expect(subscriptionStatusLabel('active')).toBe('Active')
+    expect(subscriptionStatusLabel('paused')).toBe('Paused')
+    expect(subscriptionStatusLabel('unknown')).toBe('Unknown')
+  })
+
+  it('gives honest prose for each state (no fabricated controls)', () => {
+    const statuses: SubscriptionStatus[] = ['provisioning', 'active', 'paused', 'unknown']
+    for (const s of statuses) {
+      expect(subscriptionStatusProse(s).length).toBeGreaterThan(0)
+    }
+    expect(subscriptionStatusProse('paused')).toMatch(/contact us/i)
+  })
+})


### PR DESCRIPTION
## Account (§5.9)

Subscription state, escalation contacts, and the entry to notification preferences — the eighth client-portal surface.

### Two read concerns, two authority domains
- **Subscription** (provisioning / active / paused) is the `provisioning` domain — **SMD-only and non-switchable**. `<DomainSurface>` renders it read-only with **no request form** (there is no client switch to request). Provisioning / paused / not-yet-provisioned are honest status surfaces, never fabricated controls (§5.9).
- **Escalation contacts** (who the operator alerts on a red flag or a failure) are authored config — the `configuration` domain. Read + Request at launch; operable once SMD flips the switch.

### Notifications
Notification preferences stay self-service per-user on their existing page (`settings/notifications`); Account links to them rather than re-implementing. Readable by all three client roles.

### Defensive
A missing subscription row is a real "not provisioned yet" state. Escalation parses from the `unknown` projection blob — non-string / blank recipients and non-positive / non-finite ack windows are dropped, never a fabricated contact.

### Files
- `src/lib/portal/operator/account-read.ts` — `loadAccountState`, `parseEscalation`, status label/prose
- `src/pages/portal/products/operator/account/index.astro` — subscription + escalation + notifications
- `src/pages/portal/products/operator/index.astro` — Account section card
- `tests/operator-account.test.ts` — defensive parse + honest status coverage
- `tests/forbidden-strings.test.ts` — R7 allowlist entry (justified)

### Verification
typecheck 0 errors · build clean · lint 0 errors · tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)