### PR TITLE
feat(operator-portal): Onboarding & calibration hub (client-portal §6)

### DIFF
--- a/src/lib/portal/operator/onboarding-read.ts
+++ b/src/lib/portal/operator/onboarding-read.ts
@@ -1,0 +1,114 @@
+/**
+ * Onboarding & calibration read path (client-portal §6). The guided "how a
+ * client gets a working operator" path, derived from real state — never a
+ * fabricated checklist.
+ *
+ * Three steps (§6):
+ *   1. Invite & roles   → the Team surface (people_access)
+ *   2. Connect systems  → the Connections surface (§5.8)
+ *   3. Calibrate        → the Calibration surface (principal-led tuning)
+ *
+ * Each step's status is computed from the same readers the destination surfaces
+ * use, so the hub never disagrees with the surface it links to. Honesty is the
+ * rule: a step with no real signal is "not started," not a fabricated
+ * completion — calibration in particular reads as "not started" until a cycle
+ * exists (its runtime wiring lands with #821), exactly as §6 requires.
+ */
+
+import type { D1Database } from '@cloudflare/workers-types'
+import { getCustomerConfig, getActivePersona } from '../customer-config'
+import { loadTeamRoster } from './team-read'
+import { buildConnectionRows } from './connections'
+import { getActiveCalibrationCycle } from './calibration'
+
+export type StepStatus = 'done' | 'not_started'
+
+export type OnboardingStepKey = 'invite' | 'connect' | 'calibrate'
+
+export interface OnboardingStep {
+  key: OnboardingStepKey
+  title: string
+  description: string
+  href: string
+  status: StepStatus
+  /** Honest one-line current-state detail. */
+  detail: string
+}
+
+export interface OnboardingState {
+  steps: OnboardingStep[]
+  doneCount: number
+  total: number
+}
+
+/** The real signals the three steps derive from — keeps derivation pure. */
+export interface OnboardingSignals {
+  memberCount: number
+  connectedCount: number
+  totalConnectors: number
+  cycleStarted: boolean
+}
+
+const OPERATOR_ROOT = '/portal/products/operator'
+
+export async function loadOnboardingState(
+  db: D1Database,
+  entityId: string,
+  orgId: string
+): Promise<OnboardingState> {
+  const config = await getCustomerConfig(db, entityId)
+  const roster = await loadTeamRoster(db, entityId, orgId)
+  const connectors = buildConnectionRows(
+    config?.connectors,
+    config?.credential_custody_default ?? 'delegated'
+  )
+  const persona = await getActivePersona(db, entityId)
+  const cycle = await getActiveCalibrationCycle(db, entityId, persona)
+
+  return deriveOnboardingState({
+    memberCount: roster.members.length,
+    connectedCount: connectors.filter((c) => c.health === 'ok').length,
+    totalConnectors: connectors.length,
+    cycleStarted: cycle !== null && cycle.state !== 'not_started',
+  })
+}
+
+/** Pure step derivation from the resolved signals. Honest: no signal → not started. */
+export function deriveOnboardingState(signals: OnboardingSignals): OnboardingState {
+  const { memberCount, connectedCount, totalConnectors, cycleStarted } = signals
+  const steps: OnboardingStep[] = [
+    {
+      key: 'invite',
+      title: 'Invite & roles',
+      description: 'Add the people who will work with your operator, and set what each can do.',
+      href: `${OPERATOR_ROOT}/team`,
+      status: memberCount > 0 ? 'done' : 'not_started',
+      detail:
+        memberCount > 0
+          ? `${memberCount} ${memberCount === 1 ? 'person' : 'people'} on the account`
+          : 'No one on the account yet',
+    },
+    {
+      key: 'connect',
+      title: 'Connect systems',
+      description: 'Connect the tools your operator works across, and choose how each is held.',
+      href: `${OPERATOR_ROOT}/connections`,
+      status: connectedCount > 0 ? 'done' : 'not_started',
+      detail:
+        totalConnectors === 0
+          ? 'No systems configured yet'
+          : `${connectedCount} of ${totalConnectors} connected`,
+    },
+    {
+      key: 'calibrate',
+      title: 'Calibrate',
+      description:
+        "Tune your operator's voice and confirm its behavior before it works externally.",
+      href: `${OPERATOR_ROOT}/calibration`,
+      status: cycleStarted ? 'done' : 'not_started',
+      detail: cycleStarted ? 'Calibration underway' : 'Not started',
+    },
+  ]
+
+  return { steps, doneCount: steps.filter((s) => s.status === 'done').length, total: steps.length }
+}

--- a/src/pages/portal/products/operator/index.astro
+++ b/src/pages/portal/products/operator/index.astro
@@ -117,6 +117,12 @@ const customerConfig = access ? await getCustomerConfig(env.DB, client.id) : nul
 const complianceViewEnabled = customerConfig?.compliance_enabled ?? false
 if (access) {
   const userRoles = access.roles
+  sectionCards.push({
+    href: '/portal/products/operator/onboarding',
+    label: 'Get started',
+    description:
+      'The three steps to a working operator: invite your team, connect systems, calibrate.',
+  })
   const ACTIVE_DOER_ROLES = ['staff', 'principal']
   const canAct = userRoles.some((r) => ACTIVE_DOER_ROLES.includes(r))
   if (canAct) {

--- a/src/pages/portal/products/operator/onboarding/index.astro
+++ b/src/pages/portal/products/operator/onboarding/index.astro
@@ -1,0 +1,131 @@
+---
+import '../../../../../styles/global.css'
+import { BRAND_NAME } from '../../../../../lib/config/brand'
+import { resolveOperatorAccess } from '../../../../../lib/portal/operator-access'
+import { loadOnboardingState } from '../../../../../lib/portal/operator/onboarding-read'
+import PortalHeader from '../../../../../components/portal/PortalHeader.astro'
+import PortalTabs from '../../../../../components/portal/PortalTabs.astro'
+import PortalPageHead from '../../../../../components/portal/PortalPageHead.astro'
+import SkipToMain from '../../../../../components/SkipToMain.astro'
+import { env } from 'cloudflare:workers'
+
+/**
+ * Operator — Onboarding & calibration (client-portal §6). The guided path from
+ * a fresh account to a working operator: invite & roles, connect systems,
+ * calibrate.
+ *
+ * URL: portal.smd.services/portal/products/operator/onboarding
+ *
+ * A hub, not a new authority surface: each step links to the surface that owns
+ * it (Team, Connections, Calibration), and each step's status is computed from
+ * the same readers those surfaces use, so the hub never disagrees with its
+ * destination. Honest by construction (§6): a step with no real signal reads
+ * "not started," never a fabricated completion — calibration in particular is
+ * "not started" until a cycle exists.
+ *
+ * Readable by all three client roles; the destinations enforce their own gates.
+ */
+
+const access = await resolveOperatorAccess(env.DB, Astro.locals, {
+  allowedRoles: ['principal', 'staff', 'compliance'],
+})
+if (access.kind === 'redirect') {
+  return Astro.redirect(access.to)
+}
+const { user, client } = access
+
+const onboarding = await loadOnboardingState(env.DB, client.id, user.org_id)
+
+const cardClass = 'block border-[3px] border-[color:var(--ss-color-text-primary)] p-6 md:p-7'
+const doneBadge =
+  "inline-flex items-center gap-1.5 px-2.5 py-1 text-caption font-['Archivo_Narrow'] uppercase tracking-[0.12em] font-bold border-[2px] border-[color:var(--ss-color-complete)] text-[color:var(--ss-color-complete)]"
+const todoBadge =
+  "inline-flex items-center gap-1.5 px-2.5 py-1 text-caption font-['Archivo_Narrow'] uppercase tracking-[0.12em] font-bold border-[2px] border-[color:var(--ss-color-text-secondary)] text-[color:var(--ss-color-text-secondary)]"
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;900&family=Archivo+Narrow:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap"
+      rel="stylesheet"
+    />
+    <title>Operator · Get started | {BRAND_NAME}</title>
+  </head>
+  <body class="min-h-screen bg-[color:var(--ss-color-background)]">
+    <SkipToMain />
+    <PortalHeader clientName={client.name} />
+
+    <PortalTabs pathname={Astro.url.pathname} operatorActive={true} />
+
+    <main id="main" role="main" class="max-w-5xl mx-auto px-4 md:px-6 pb-24 md:pb-12">
+      <PortalPageHead
+        crumbHref="/portal/products/operator"
+        crumbLabel="Operator"
+        tag="Section"
+        h1="Get started"
+        meta={`${onboarding.doneCount} of ${onboarding.total} done`}
+      />
+
+      <p class="mt-6 max-w-2xl font-['Archivo'] text-lg text-[color:var(--ss-color-text-primary)]">
+        Three steps to a working operator. You can do them in any order, and we will be alongside
+        you the whole way.
+      </p>
+
+      <ol class="mt-8 list-none p-0 m-0 flex flex-col gap-4">
+        {
+          onboarding.steps.map((step, i) => (
+            <li>
+              <a
+                href={step.href}
+                class={`${cardClass} hover:bg-[color:var(--ss-color-border-subtle)] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-inset`}
+              >
+                <div class="flex items-start justify-between gap-4">
+                  <div class="flex items-start gap-4 min-w-0">
+                    <span
+                      class="shrink-0 w-9 h-9 flex items-center justify-center border-[3px] border-[color:var(--ss-color-text-primary)] font-['Archivo'] font-black text-[color:var(--ss-color-text-primary)]"
+                      aria-hidden="true"
+                    >
+                      {i + 1}
+                    </span>
+                    <div class="min-w-0">
+                      <p class="m-0 font-['Archivo'] text-xl font-black uppercase tracking-[-0.01em] text-[color:var(--ss-color-text-primary)]">
+                        {step.title}
+                      </p>
+                      <p class="mt-1 m-0 font-['Archivo'] text-[color:var(--ss-color-text-secondary)]">
+                        {step.description}
+                      </p>
+                      <p class="mt-2 m-0 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold text-[color:var(--ss-color-text-muted)]">
+                        {step.detail}
+                      </p>
+                    </div>
+                  </div>
+                  <span class={step.status === 'done' ? doneBadge : todoBadge}>
+                    {step.status === 'done' ? (
+                      <>
+                        <span class="material-symbols-outlined text-[16px]" aria-hidden="true">
+                          check
+                        </span>
+                        Done
+                      </>
+                    ) : (
+                      'To do'
+                    )}
+                  </span>
+                </div>
+              </a>
+            </li>
+          ))
+        }
+      </ol>
+    </main>
+  </body>
+</html>

--- a/tests/forbidden-strings.test.ts
+++ b/tests/forbidden-strings.test.ts
@@ -496,6 +496,13 @@ const LIST_INDEX_ALLOWLIST: string[] = [
   // vocabulary. The .map( iterates authored escalation recipients; subscription
   // is the SMD-only provisioning domain shown as an honest status surface.
   resolve('src/pages/portal/products/operator/account/index.astro'),
+  // `products/operator/onboarding/index.astro` (§6) renders the three
+  // get-started steps as numbered guidance cards (step number, title,
+  // description, honest status badge) linking to Team/Connections/Calibration —
+  // not the PortalListItem status/document record-row vocabulary. The .map(
+  // iterates the derived steps; a step with no signal reads "to do", never a
+  // fabricated completion.
+  resolve('src/pages/portal/products/operator/onboarding/index.astro'),
 ]
 
 /** Collect every `index.astro` under `src/pages/portal/` EXCEPT the home. */

--- a/tests/operator-onboarding.test.ts
+++ b/tests/operator-onboarding.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Onboarding & calibration (client-portal §6) — pure step derivation.
+ *
+ * §6 requires the get-started path to be honest: a step with no real signal is
+ * "not started," never a fabricated completion. These tests pin that contract
+ * against the resolved signals, independent of D1.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { deriveOnboardingState } from '../src/lib/portal/operator/onboarding-read'
+
+const ZERO = { memberCount: 0, connectedCount: 0, totalConnectors: 0, cycleStarted: false }
+
+describe('deriveOnboardingState', () => {
+  it('a fresh account is all "not started" — no fabricated completion', () => {
+    const { steps, doneCount, total } = deriveOnboardingState(ZERO)
+    expect(total).toBe(3)
+    expect(doneCount).toBe(0)
+    expect(steps.every((s) => s.status === 'not_started')).toBe(true)
+    expect(steps.map((s) => s.key)).toEqual(['invite', 'connect', 'calibrate'])
+  })
+
+  it('marks invite done once anyone is on the account', () => {
+    const { steps } = deriveOnboardingState({ ...ZERO, memberCount: 2 })
+    const invite = steps.find((s) => s.key === 'invite')!
+    expect(invite.status).toBe('done')
+    expect(invite.detail).toContain('2')
+  })
+
+  it('connect is done only when at least one connector is healthy', () => {
+    const noneOk = deriveOnboardingState({ ...ZERO, totalConnectors: 3, connectedCount: 0 })
+    expect(noneOk.steps.find((s) => s.key === 'connect')!.status).toBe('not_started')
+    expect(noneOk.steps.find((s) => s.key === 'connect')!.detail).toContain('0 of 3')
+
+    const someOk = deriveOnboardingState({ ...ZERO, totalConnectors: 3, connectedCount: 1 })
+    expect(someOk.steps.find((s) => s.key === 'connect')!.status).toBe('done')
+  })
+
+  it('reports "no systems configured" when there are no connectors at all', () => {
+    const { steps } = deriveOnboardingState(ZERO)
+    expect(steps.find((s) => s.key === 'connect')!.detail).toMatch(/no systems/i)
+  })
+
+  it('calibrate is done only when a cycle is underway', () => {
+    expect(
+      deriveOnboardingState({ ...ZERO, cycleStarted: true }).steps.find(
+        (s) => s.key === 'calibrate'
+      )!.status
+    ).toBe('done')
+    expect(deriveOnboardingState(ZERO).steps.find((s) => s.key === 'calibrate')!.detail).toMatch(
+      /not started/i
+    )
+  })
+
+  it('every step links into the operator portal', () => {
+    for (const s of deriveOnboardingState(ZERO).steps) {
+      expect(s.href.startsWith('/portal/products/operator/')).toBe(true)
+    }
+  })
+})


### PR DESCRIPTION
## Onboarding & calibration (§6) — the final client-portal surface

The guided path from a fresh account to a working operator: **invite & roles → connect systems → calibrate.**

### A hub, not a new authority surface
Each step links to the surface that owns it (Team, Connections, Calibration), and each step's status is **derived from the same readers those surfaces use**, so the hub never disagrees with its destination.

### Honest by construction (§6)
A step with no real signal reads **"to do,"** never a fabricated completion:
- **Invite & roles** — done once anyone is on the account (links to Team).
- **Connect systems** — done only when at least one connector is healthy; otherwise "0 of N connected" or "no systems configured yet" (links to Connections).
- **Calibrate** — done only when a calibration cycle is underway; **"not started"** until a cycle exists (its runtime wiring lands with #821). Links to the existing Calibration surface.

### Pure derivation
`deriveOnboardingState(signals)` computes the three steps from resolved signals (member count, healthy-connector count, cycle state) and is unit-tested independently of D1. `loadOnboardingState` wires the real readers. A "Get started" card leads the Home section list.

### Files
- `src/lib/portal/operator/onboarding-read.ts` — `loadOnboardingState`, pure `deriveOnboardingState`
- `src/pages/portal/products/operator/onboarding/index.astro` — the get-started hub
- `src/pages/portal/products/operator/index.astro` — "Get started" Home card
- `tests/operator-onboarding.test.ts` — honest-status derivation coverage
- `tests/forbidden-strings.test.ts` — R7 allowlist entry (justified)

### Verification
typecheck 0 errors · build clean · lint 0 errors · tests green

This completes the client-portal surface build (§3 + §5.1–5.9 + §6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)