### PR TITLE
feat(operator): wire console→Machine runtime read transport (ADR 0043 A)

### DIFF
--- a/operator/bin/provision-customer.sh
+++ b/operator/bin/provision-customer.sh
@@ -391,6 +391,24 @@ stage_secret_from_env R2_SKILL_BODIES_SECRET_ACCESS_KEY \
 stage_secret_from_env SENTRY_DSN            "${SENTRY_DSN:-}"            "Sentry DSN for the shared smd-operator project"
 stage_secret_from_env MACHINE_HEARTBEAT_KEY "${MACHINE_HEARTBEAT_KEY:-}" "shared bearer for POST /api/internal/heartbeat"
 
+# OPERATOR_RUNTIME_READ_KEY — PER-CUSTOMER bearer for the console→Machine runtime
+# read endpoint (ADR 0043 path A). Unlike the shared heartbeat key, this is
+# derived per customer: key = HMAC-SHA256(OPERATOR_RUNTIME_READ_SECRET, customer_id).
+# The master (OPERATOR_RUNTIME_READ_SECRET) lives ONLY on ss-web; each Machine
+# holds only its own derived key, so a key extracted from one Machine cannot read
+# another. The console derives the SAME value via WebCrypto
+# (src/lib/operator/runtime-read-transport.ts → deriveRuntimeReadKey); the HMAC
+# input MUST be byte-identical — the slug string with NO trailing newline
+# (printf '%s'), matching the TS TextEncoder. This exact command is pinned by
+# tests/runtime-read-transport.test.ts ("cross-side") so the two never drift.
+if [ -n "${OPERATOR_RUNTIME_READ_SECRET:-}" ]; then
+  _rt_key="$(printf '%s' "${SLUG}" | openssl dgst -sha256 -hmac "${OPERATOR_RUNTIME_READ_SECRET}" | sed 's/^.*= //')"
+  stage_secret_from_env OPERATOR_RUNTIME_READ_KEY "${_rt_key}" "per-customer runtime read bearer (ADR 0043 A)"
+  unset _rt_key
+else
+  log "WARN: OPERATOR_RUNTIME_READ_SECRET not set in operator env — skipping runtime read key (runtime drill-ins stay empty for this Machine)"
+fi
+
 # ---------- Step 6b-clio: connector secrets (law vertical + Google DWD) ----------
 # Staged from operator env (Infisical /ss, injected by reprovision.sh's
 # `infisical run --path=/ss`), same no-paste pattern as observability. Each is

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -233,14 +233,23 @@ declare namespace Cloudflare {
      */
     OPERATOR_SECRET_RELAY_URL?: string
     /**
-     * Base URL/credential locator for the live console→Machine runtime read
-     * path (ADR 0043 path A). When set, per-operator drill-ins fetch deep
-     * detail (audit log, drafts, matters) live from one customer's Machine;
-     * when unset, `isRuntimeReadConfigured` returns false and drill-in
-     * surfaces render honest empty states. Wired at the integration step —
-     * see src/lib/operator/runtime-read-transport.ts.
+     * Host template for the live console→Machine runtime read path (ADR 0043
+     * path A). A `{app}` placeholder is substituted with the registry-resolved
+     * Fly app (e.g. `https://{app}.fly.dev`); absent, it falls back to
+     * `https://<app>.fly.dev`. Enables the read path together with
+     * OPERATOR_RUNTIME_READ_SECRET — when either is unset,
+     * `isRuntimeReadConfigured` is false and drill-in surfaces render honest
+     * empty states. See src/lib/operator/runtime-read-transport.ts.
      */
     OPERATOR_RUNTIME_READ_URL?: string
+    /**
+     * Master secret for the per-customer runtime read key. The console sends
+     * `Bearer HMAC-SHA256(master, customer_slug)`; each Machine holds only its
+     * own derived key (set at provision). The master lives ONLY on the console.
+     * Required (with OPERATOR_RUNTIME_READ_URL) to enable the read path.
+     * See src/lib/operator/runtime-read-transport.ts (ADR 0043 path A).
+     */
+    OPERATOR_RUNTIME_READ_SECRET?: string
     /**
      * Sentry Internal Integration Client Secret used to verify
      * `Sentry-Hook-Signature` headers on inbound alert-rule webhook

--- a/src/lib/oauth/store.ts
+++ b/src/lib/oauth/store.ts
@@ -26,6 +26,7 @@
 import { env } from 'cloudflare:workers'
 
 import type { ProviderTokenResponse } from './providers.js'
+import { resolveCustomerFlyApp } from '../operator/fly-app-registry'
 
 export interface StoreTokenInput {
   customer_id: string
@@ -48,17 +49,6 @@ export interface OAuthTokenStore {
 const FLY_GRAPHQL_URL = 'https://api.fly.io/graphql'
 const FLY_MACHINES_API = 'https://api.machines.dev/v1'
 const GOOGLE_TOKEN_URI = 'https://oauth2.googleapis.com/token'
-
-/**
- * Explicit customer_id → Fly app registry. Deliberately NOT a `hermes-${id}`
- * string convention: setting a secret on the wrong app is a cross-tenant leak
- * vector, so an unlisted customer is rejected (`unknown_customer`) rather than
- * guessed. Graduates to a customer.yaml/D1 lookup as customers are added
- * (ADR 0012). customer-zero ("smd") → `hermes-smd`.
- */
-const CUSTOMER_FLY_APPS: Readonly<Record<string, string>> = Object.freeze({
-  smd: 'hermes-smd',
-})
 
 /** provider slug → the Fly secret name bootstrap.sh decodes to the volume. */
 const PROVIDER_SECRET_NAME: Readonly<Record<string, string>> = Object.freeze({
@@ -180,7 +170,7 @@ export function createFlySecretTokenStore(): OAuthTokenStore {
         )
         return { ok: false, reason: 'unavailable' }
       }
-      const app = CUSTOMER_FLY_APPS[input.customer_id]
+      const app = resolveCustomerFlyApp(input.customer_id)
       if (!app) {
         console.error(
           `[oauth/store] unknown customer_id=${input.customer_id}; refusing to target any app`

--- a/src/lib/operator/fly-app-registry.ts
+++ b/src/lib/operator/fly-app-registry.ts
@@ -1,0 +1,33 @@
+/**
+ * Explicit `customer_id → Fly app` registry — the single source of truth for
+ * mapping a customer to its per-customer Fly app.
+ *
+ * Deliberately NOT a `hermes-${id}` string convention: addressing the wrong app
+ * is a cross-tenant action (setting a secret on the wrong Machine, or reading
+ * the wrong Machine's runtime), so an unlisted customer is **rejected** rather
+ * than guessed (ADR 0036). Graduates to a customer.yaml/D1 lookup as customers
+ * are added (ADR 0012). customer-zero ("smd") → `hermes-smd`.
+ *
+ * Both the OAuth token relay (`src/lib/oauth/store.ts`, ADR 0036) and the
+ * console→Machine runtime read transport (`runtime-read-transport.ts`, ADR
+ * 0043) resolve through here so the two paths can never drift on which app a
+ * customer maps to.
+ */
+
+const CUSTOMER_FLY_APPS: Readonly<Record<string, string>> = Object.freeze({
+  smd: 'hermes-smd',
+})
+
+/**
+ * Resolve a customer_id to its Fly app name, or null when the customer is not
+ * in the registry. A null result MUST be treated as "refuse to target any app"
+ * — never fall back to a guessed name.
+ */
+export function resolveCustomerFlyApp(customerId: string): string | null {
+  return CUSTOMER_FLY_APPS[customerId] ?? null
+}
+
+/** Test/introspection helper: the registered customer_ids. */
+export function registeredCustomerIds(): string[] {
+  return Object.keys(CUSTOMER_FLY_APPS)
+}

--- a/src/lib/operator/runtime-read-transport.ts
+++ b/src/lib/operator/runtime-read-transport.ts
@@ -4,61 +4,125 @@
  *
  *   1. The console→Machine transport ({@link MachineRuntimeTransport}) — the
  *      authenticated, read-only HTTP call to one customer's Machine read
- *      endpoint. Until that endpoint + the per-customer console→Machine
- *      credential are wired, {@link isRuntimeReadConfigured} returns false and
- *      drill-in surfaces render honest empty states (the design's documented
- *      "until built, runtime surfaces render empty states"). The not-configured
- *      transport throws, and `readMachineRuntime` is fail-closed, so a caller
- *      always gets a clean empty result — never a crash.
+ *      endpoint (the overlay's `GET /runtime/<kind>`). Guarded by
+ *      {@link isRuntimeReadConfigured}: until `OPERATOR_RUNTIME_READ_URL` and
+ *      `OPERATOR_RUNTIME_READ_SECRET` are both set, drill-in surfaces render
+ *      honest empty states. `readMachineRuntime` is fail-closed, so a transport
+ *      throw always collapses to a clean empty result — never a crash.
  *
  *   2. The console-side read-audit sink ({@link RuntimeReadAudit}) — a D1
  *      insert into `operator_runtime_read_audit`.
  *
- * Keeping both here means the drill-in surfaces stay thin and the one piece the
- * integration team implements (the Machine read transport) is isolated.
+ * Per-customer key (no shared key): the bearer is `HMAC-SHA256(master, slug)`
+ * where the master (`OPERATOR_RUNTIME_READ_SECRET`) lives ONLY here and each
+ * Machine holds only its own derived key (set at provision). The canonical HMAC
+ * input is the customer slug (== customer_id); the provision script MUST derive
+ * over the identical string (see `operator/bin/provision-customer.sh`). A key
+ * extracted from one Machine cannot read another, and the master never leaves
+ * the console.
  */
 
-import type { MachineRuntimeTransport, RuntimeReadAudit } from './runtime-read'
+import type { MachineRuntimeTransport, RuntimeReadAudit, RuntimeReadQuery } from './runtime-read'
+import { RuntimeReadUnauthorizedError } from './runtime-read'
+import { resolveCustomerFlyApp } from './fly-app-registry'
 
 /**
- * Structural view of the env the transport needs. Optional field so this module
- * compiles before the binding is provisioned; declared in env.d.ts. When the
- * Machine read endpoint + per-customer credential land, this check returns true.
+ * Structural view of the env the transport needs. Optional fields so this
+ * module compiles before the bindings are provisioned; declared in env.d.ts.
  */
 export interface RuntimeReadEnv {
-  /** Base URL/credential locator for the console→Machine read calls. Absent
-   * until the live read path is wired. */
+  /** Enable flag + per-customer host template for the console→Machine read.
+   * A `{app}` placeholder is substituted with the registry-resolved Fly app;
+   * absent placeholder falls back to `https://<app>.fly.dev`. */
   OPERATOR_RUNTIME_READ_URL?: string
+  /** Master secret from which each Machine's per-customer read key is derived
+   * (`HMAC-SHA256(master, slug)`). Lives only on the console. */
+  OPERATOR_RUNTIME_READ_SECRET?: string
 }
 
+/**
+ * Wired only when BOTH the host template and the master secret are present.
+ * Either missing → not configured → surfaces fail closed to empty states.
+ */
 export function isRuntimeReadConfigured(env: RuntimeReadEnv): boolean {
   return (
-    typeof env.OPERATOR_RUNTIME_READ_URL === 'string' && env.OPERATOR_RUNTIME_READ_URL.length > 0
+    typeof env.OPERATOR_RUNTIME_READ_URL === 'string' &&
+    env.OPERATOR_RUNTIME_READ_URL.length > 0 &&
+    typeof env.OPERATOR_RUNTIME_READ_SECRET === 'string' &&
+    env.OPERATOR_RUNTIME_READ_SECRET.length > 0
   )
 }
 
 export class RuntimeReadNotConfiguredError extends Error {
   constructor() {
-    super('operator runtime read path is not configured (OPERATOR_RUNTIME_READ_URL unset)')
+    super(
+      'operator runtime read path is not configured ' +
+        '(OPERATOR_RUNTIME_READ_URL / OPERATOR_RUNTIME_READ_SECRET unset)'
+    )
     this.name = 'RuntimeReadNotConfiguredError'
   }
 }
 
 /**
- * Construct the production console→Machine transport. Until the Machine read
- * endpoint is wired (guarded by isRuntimeReadConfigured), `read` throws — which
- * `readMachineRuntime` collapses to a fail-closed empty result. Read-only by
- * construction: the only method is `read`, scoped to one customer per call.
- *
- * INTEGRATION STEP: replace the throwing body with the authenticated read —
- *   GET {OPERATOR_RUNTIME_READ_URL}/{customerSlug}/{query.kind}?... with the
- *   per-customer console→Machine credential (ADR 0043 §A). Throw
- *   RuntimeReadUnauthorizedError on 401/403; throw on any other failure so the
- *   client fails closed. The contract above this seam does not change.
+ * Derive a Machine's per-customer read key: `hex(HMAC-SHA256(master, slug))`.
+ * The canonical input is the customer slug with NO trailing newline — the
+ * provision script's `printf '%s'` must match exactly or every read 401s.
+ * Exported so the cross-side match test can pin it against the shell derivation.
  */
-export function createMachineRuntimeTransport(_env: RuntimeReadEnv): MachineRuntimeTransport {
+export async function deriveRuntimeReadKey(master: string, customerSlug: string): Promise<string> {
+  const enc = new TextEncoder()
+  const key = await crypto.subtle.importKey(
+    'raw',
+    enc.encode(master),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  )
+  const sig = await crypto.subtle.sign('HMAC', key, enc.encode(customerSlug))
+  return [...new Uint8Array(sig)].map((b) => b.toString(16).padStart(2, '0')).join('')
+}
+
+/** Build the per-customer Machine base URL from the host template + Fly app. */
+function machineBaseUrl(template: string, app: string): string {
+  return template.includes('{app}') ? template.replace('{app}', app) : `https://${app}.fly.dev`
+}
+
+/** Append the read query params the Machine endpoint understands. */
+function appendQuery(url: URL, query: RuntimeReadQuery): void {
+  if (query.cursor) url.searchParams.set('cursor', query.cursor)
+  if (typeof query.limit === 'number') url.searchParams.set('limit', String(query.limit))
+  if (query.id) url.searchParams.set('id', query.id)
+}
+
+/**
+ * Construct the production console→Machine transport. Read-only by construction
+ * (the only method is `read`, scoped to one customer per call). Throws on any
+ * failure so `readMachineRuntime` collapses it to a fail-closed empty result;
+ * a 401/403 throws {@link RuntimeReadUnauthorizedError} so the audit row records
+ * `unauthorized` rather than `unreachable`.
+ */
+export function createMachineRuntimeTransport(env: RuntimeReadEnv): MachineRuntimeTransport {
   return {
-    read: () => Promise.reject(new RuntimeReadNotConfiguredError()),
+    read: async (customerSlug, query) => {
+      if (!isRuntimeReadConfigured(env)) throw new RuntimeReadNotConfiguredError()
+      const app = resolveCustomerFlyApp(customerSlug)
+      // Unlisted customer → refuse to target any app (fail-closed unreachable).
+      if (!app) throw new Error(`runtime read: unknown customer ${customerSlug}`)
+
+      const url = new URL(
+        `${machineBaseUrl(env.OPERATOR_RUNTIME_READ_URL!, app)}/runtime/${query.kind}`
+      )
+      appendQuery(url, query)
+      const bearer = await deriveRuntimeReadKey(env.OPERATOR_RUNTIME_READ_SECRET!, customerSlug)
+
+      const resp = await fetch(url.toString(), {
+        method: 'GET',
+        headers: { Authorization: `Bearer ${bearer}`, 'X-Tenant-Slug': customerSlug },
+      })
+      if (resp.status === 401 || resp.status === 403) throw new RuntimeReadUnauthorizedError()
+      if (!resp.ok) throw new Error(`runtime read failed: ${resp.status}`)
+      return { data: await resp.json() }
+    },
   }
 }
 

--- a/tests/operator-home-feeds.test.ts
+++ b/tests/operator-home-feeds.test.ts
@@ -19,8 +19,15 @@ describe('loadHomeFeeds', () => {
   it('reflects whether the runtime read path is configured', () => {
     expect(loadHomeFeeds({}).runtimeConfigured).toBe(false)
     expect(loadHomeFeeds({ OPERATOR_RUNTIME_READ_URL: '' }).runtimeConfigured).toBe(false)
+    // Both the host template and the master secret are required now (ADR 0043 A).
     expect(
       loadHomeFeeds({ OPERATOR_RUNTIME_READ_URL: 'https://hermes-x.fly.dev' }).runtimeConfigured
+    ).toBe(false)
+    expect(
+      loadHomeFeeds({
+        OPERATOR_RUNTIME_READ_URL: 'https://hermes-x.fly.dev',
+        OPERATOR_RUNTIME_READ_SECRET: 'm',
+      }).runtimeConfigured
     ).toBe(true)
   })
 })

--- a/tests/operator-runtime-read.test.ts
+++ b/tests/operator-runtime-read.test.ts
@@ -132,9 +132,17 @@ describe('readMachineRuntime', () => {
     expect(result.ok).toBe(true)
   })
 
-  it('is not configured by default (no env binding)', () => {
+  it('requires BOTH the host template and the master secret (ADR 0043 A)', () => {
     expect(isRuntimeReadConfigured({})).toBe(false)
-    expect(isRuntimeReadConfigured({ OPERATOR_RUNTIME_READ_URL: 'https://x' })).toBe(true)
+    // URL alone is no longer sufficient — the per-customer key needs the master.
+    expect(isRuntimeReadConfigured({ OPERATOR_RUNTIME_READ_URL: 'https://x' })).toBe(false)
+    expect(isRuntimeReadConfigured({ OPERATOR_RUNTIME_READ_SECRET: 'm' })).toBe(false)
+    expect(
+      isRuntimeReadConfigured({
+        OPERATOR_RUNTIME_READ_URL: 'https://x',
+        OPERATOR_RUNTIME_READ_SECRET: 'm',
+      })
+    ).toBe(true)
   })
 })
 

--- a/tests/runtime-read-transport.test.ts
+++ b/tests/runtime-read-transport.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Tests for the production console→Machine runtime read transport
+ * (src/lib/operator/runtime-read-transport.ts) — ADR 0043 path A.
+ *
+ * Covers: the configured-gate truth table; the per-customer HMAC key derivation
+ * (incl. a CROSS-SIDE match against the shell derivation the provision script
+ * uses — the single most likely silent fail-closed cause); and the transport's
+ * success / unauthorized / unreachable / not-configured / unknown-customer
+ * behaviour, both directly and end-to-end through readMachineRuntime.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import {
+  createMachineRuntimeTransport,
+  deriveRuntimeReadKey,
+  isRuntimeReadConfigured,
+  RuntimeReadNotConfiguredError,
+  type RuntimeReadEnv,
+} from '../src/lib/operator/runtime-read-transport'
+import { readMachineRuntime, RuntimeReadUnauthorizedError } from '../src/lib/operator/runtime-read'
+
+const ENV: RuntimeReadEnv = {
+  OPERATOR_RUNTIME_READ_URL: 'https://{app}.fly.dev',
+  OPERATOR_RUNTIME_READ_SECRET: 'test-master-key-1234567890',
+}
+const ACTOR = { actor: 'captain@example.com', actorRole: 'admin' }
+const noopAudit = { record: () => Promise.resolve() }
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+function stubFetch(impl: (url: string, init: RequestInit) => Promise<Response> | Response): void {
+  vi.stubGlobal('fetch', vi.fn(impl as unknown as typeof fetch))
+}
+
+// ---------------------------------------------------------------------------
+// Config gate
+// ---------------------------------------------------------------------------
+
+describe('isRuntimeReadConfigured', () => {
+  it('requires BOTH url and secret', () => {
+    expect(isRuntimeReadConfigured(ENV)).toBe(true)
+    expect(isRuntimeReadConfigured({ OPERATOR_RUNTIME_READ_URL: 'x' })).toBe(false)
+    expect(isRuntimeReadConfigured({ OPERATOR_RUNTIME_READ_SECRET: 'x' })).toBe(false)
+    expect(isRuntimeReadConfigured({})).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Key derivation + cross-side match
+// ---------------------------------------------------------------------------
+
+describe('deriveRuntimeReadKey', () => {
+  it('is deterministic and produces a 64-hex key', async () => {
+    const a = await deriveRuntimeReadKey('master', 'smd')
+    const b = await deriveRuntimeReadKey('master', 'smd')
+    expect(a).toBe(b)
+    expect(a).toMatch(/^[0-9a-f]{64}$/)
+    expect(await deriveRuntimeReadKey('master', 'other')).not.toBe(a)
+  })
+
+  it('matches the shell derivation the provision script uses (cross-side)', () => {
+    // This is the byte-identity check Captain flagged: the console derives over
+    // the slug via WebCrypto; provision derives over customer_id via openssl.
+    // They MUST agree or every read silently 401s. Canonical input: the slug
+    // string with NO trailing newline (printf %s).
+    const master = 'test-master-key-1234567890'
+    const slug = 'smith-pi-firm'
+    const shell = execFileSync('bash', [
+      '-c',
+      `printf '%s' "${slug}" | openssl dgst -sha256 -hmac "${master}" | sed 's/^.*= //'`,
+    ])
+      .toString()
+      .trim()
+    return expect(deriveRuntimeReadKey(master, slug)).resolves.toBe(shell)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Transport
+// ---------------------------------------------------------------------------
+
+describe('createMachineRuntimeTransport.read', () => {
+  it('GETs the registry-resolved Machine with the derived bearer + tenant slug', async () => {
+    let seenUrl = ''
+    let seenHeaders: Record<string, string> = {}
+    stubFetch((url, init) => {
+      seenUrl = url
+      seenHeaders = (init.headers as Record<string, string>) ?? {}
+      return new Response(JSON.stringify({ entries: [], cursor: null }), { status: 200 })
+    })
+    const t = createMachineRuntimeTransport(ENV)
+    const { data } = await t.read('smd', { kind: 'audit_log', limit: 25 })
+    expect(seenUrl).toBe('https://hermes-smd.fly.dev/runtime/audit_log?limit=25')
+    expect(seenHeaders['X-Tenant-Slug']).toBe('smd')
+    expect(seenHeaders['Authorization']).toBe(
+      `Bearer ${await deriveRuntimeReadKey(ENV.OPERATOR_RUNTIME_READ_SECRET!, 'smd')}`
+    )
+    expect(data).toEqual({ entries: [], cursor: null })
+  })
+
+  it('throws RuntimeReadUnauthorizedError on 401/403 (→ unauthorized e2e)', async () => {
+    stubFetch(() => new Response('', { status: 401 }))
+    const t = createMachineRuntimeTransport(ENV)
+    await expect(t.read('smd', { kind: 'audit_log' })).rejects.toBeInstanceOf(
+      RuntimeReadUnauthorizedError
+    )
+    // End-to-end: readMachineRuntime maps it to reason 'unauthorized', not 'unreachable'.
+    const res = await readMachineRuntime(
+      { transport: t, audit: noopAudit },
+      'smd',
+      { kind: 'audit_log' },
+      ACTOR
+    )
+    expect(res).toEqual({ ok: false, kind: 'audit_log', reason: 'unauthorized' })
+  })
+
+  it('throws on a non-2xx (→ unreachable e2e, fail-closed)', async () => {
+    stubFetch(() => new Response('', { status: 500 }))
+    const t = createMachineRuntimeTransport(ENV)
+    const res = await readMachineRuntime(
+      { transport: t, audit: noopAudit },
+      'smd',
+      { kind: 'audit_log' },
+      ACTOR
+    )
+    expect(res).toEqual({ ok: false, kind: 'audit_log', reason: 'unreachable' })
+  })
+
+  it('throws on a network failure (→ unreachable)', async () => {
+    stubFetch(() => Promise.reject(new Error('ECONNREFUSED')))
+    const t = createMachineRuntimeTransport(ENV)
+    await expect(t.read('smd', { kind: 'audit_log' })).rejects.toThrow()
+  })
+
+  it('throws RuntimeReadNotConfiguredError when not configured', async () => {
+    const t = createMachineRuntimeTransport({})
+    await expect(t.read('smd', { kind: 'audit_log' })).rejects.toBeInstanceOf(
+      RuntimeReadNotConfiguredError
+    )
+  })
+
+  it('throws (→ unreachable) for a customer absent from the registry', async () => {
+    stubFetch(() => new Response('{}', { status: 200 }))
+    const t = createMachineRuntimeTransport(ENV)
+    await expect(t.read('ghost-firm', { kind: 'audit_log' })).rejects.toThrow(/unknown customer/)
+    // A registry miss is a per-call failure, NOT a config failure.
+    expect(isRuntimeReadConfigured(ENV)).toBe(true)
+  })
+
+  it('honors a host template without {app} by falling back to <app>.fly.dev', async () => {
+    let seenUrl = ''
+    stubFetch((url) => {
+      seenUrl = url
+      return new Response(JSON.stringify({ entries: [] }), { status: 200 })
+    })
+    const t = createMachineRuntimeTransport({
+      OPERATOR_RUNTIME_READ_URL: 'enabled',
+      OPERATOR_RUNTIME_READ_SECRET: 'm',
+    })
+    await t.read('smd', { kind: 'audit_log' })
+    expect(seenUrl).toBe('https://hermes-smd.fly.dev/runtime/audit_log')
+  })
+})

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -188,6 +188,13 @@ name = "ss-web-staging"
 # GOOGLE_CLIENT_SECRET     — Google Cloud OAuth 2.0 client secret
 # BOOKING_ENCRYPTION_KEY   — 32-byte base64 random; AES-GCM encryption of refresh tokens
 #
+# Operator runtime read (ADR 0043 path A):
+# OPERATOR_RUNTIME_READ_URL    — host template for the console→Machine read
+#                                (e.g. https://{app}.fly.dev); enables the path
+# OPERATOR_RUNTIME_READ_SECRET — master from which each Machine's per-customer
+#                                read key is derived (HMAC-SHA256(master, slug));
+#                                lives ONLY here, never on a Machine
+#
 # Bulk-load from Infisical:
 #   infisical export --env=prod --path=/ss --format=dotenv \
 #     | grep -vE '^(APP_|ADMIN_|PORTAL_|MEETING_|NEW_BUSINESS_|JOB_MONITOR_|REVIEW_MINING_|PUBLIC_)' \


### PR DESCRIPTION
## What

Implements the previously-throwing `createMachineRuntimeTransport` so the runtime drill-ins on **both** portals (admin §5.5 + client Activity) read live audit detail from one customer's Machine. Companion to the overlay's `GET /runtime/<kind>` endpoint (venturecrane/hermes-smd-overlay#39).

Until now the transport always threw → every runtime surface rendered an honest empty state. This makes it real, fail-closed.

## Security model — per-customer key (the spot to review)

The bearer is **`HMAC-SHA256(master, customer_slug)`**, derived via WebCrypto. The master (`OPERATOR_RUNTIME_READ_SECRET`) lives **only on the console**; each Machine holds only its own derived key (`OPERATOR_RUNTIME_READ_KEY`, set at provision). A key extracted from one Machine **cannot read another**, and the master never leaves the console. This avoids the shared-key blast radius where one leaked key + a slug header would read every tenant.

**The top silent-fail risk is HMAC input identity** — the console derives over the slug (WebCrypto), the provision script derives over `customer_id` (openssl). They must be byte-identical or every read 401s. `tests/runtime-read-transport.test.ts` has a **cross-side test** that shells out to the exact `openssl` command the provision script uses and asserts it equals `deriveRuntimeReadKey`. The canonical input is the slug string with no trailing newline (`printf '%s'` ↔ `TextEncoder`).

## Fail-closed mapping (the other review spot)

`401/403` → throw `RuntimeReadUnauthorizedError` **imported from the core** (`./runtime-read`) for `instanceof` identity, so auth failures stay `unauthorized` and never silently degrade to `unreachable`. Any other non-2xx or network failure → throw → `readMachineRuntime` collapses to fail-closed `unreachable`. A customer absent from the registry is a per-call failure, not a config failure.

## Changes

- **`src/lib/operator/fly-app-registry.ts`** (new) — explicit `customer_id→Fly app` registry, **extracted from `oauth/store.ts`** so the OAuth relay (ADR 0036) and runtime read share one source of truth; unlisted customer refused, never guessed.
- **`src/lib/oauth/store.ts`** — imports the shared registry (no behavior change; the `oauth-store` `unknown_customer` test is the regression guard).
- **`runtime-read-transport.ts`** — real transport + `deriveRuntimeReadKey`; `isRuntimeReadConfigured` now requires **both** the host template and the master secret.
- **`env.d.ts` + `wrangler.toml`** — `OPERATOR_RUNTIME_READ_SECRET`; refreshed `OPERATOR_RUNTIME_READ_URL` doc (host template, `{app}` substitution).
- **`operator/bin/provision-customer.sh`** — derives + stages each Machine's `OPERATOR_RUNTIME_READ_KEY` via the exact command the cross-side test pins.

## Scope note

Seam A lights up **audit_log / activity**. `draft`/`matter` have no Machine runtime table yet, so the client **Matters** surface stays correctly empty after this — it waits on a matter runtime table (separate future work).

## Verification

`npm run verify` green: typecheck 0 errors, prettier clean, **183 test files / 3280+ tests pass**. New transport suite + cross-side openssl match pass; `oauth-store` regression green. No surfaces changed — implementing the body lights up the four existing call sites.

Wired live by the ordered Fly step after this + the overlay PR merge (Machine + key + restart + curl-verify, *then* the `ss-web` secrets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)