### PR TITLE
fix(operator): set SMD_CUSTOMER_SLUG in the Machine env (#1285)

### DIFF
--- a/operator/templates/fly.toml.template
+++ b/operator/templates/fly.toml.template
@@ -46,6 +46,13 @@ primary_region = "{{FLY_REGION}}"
   # Hermes runtime
   HERMES_HOME = "/opt/data"
   CUSTOMER_SLUG = "{{CUSTOMER_SLUG}}"
+  # The SMD overlay plugins (audit, voice, webhook-router, trust, memory-mirror)
+  # resolve the per-customer namespace via require("SMD_CUSTOMER_SLUG", ...). It
+  # was never set here — only CUSTOMER_SLUG was — so every one of those plugins
+  # bailed to its degraded no-op branch on customer-zero: audit emission never
+  # wrote, so the runtime-read seam (ADR 0043) read a dry well (ss-console#1285).
+  # Set it to the same slug so the whole SMD suite registers cleanly.
+  SMD_CUSTOMER_SLUG = "{{CUSTOMER_SLUG}}"
   HERMES_LOG_LEVEL = "info"
 
   # R2 config bucket — bucket NAME is not a credential; the keys are

--- a/tests/operator-fly-template-env.test.ts
+++ b/tests/operator-fly-template-env.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Guard: the per-customer Machine fly.toml template must set every env var the
+ * SMD overlay plugins REQUIRE at register.
+ *
+ * The overlay plugins (audit, voice, webhook-router, trust, memory-mirror) call
+ * `require("SMD_CUSTOMER_SLUG", "SMD_D1_AUDIT_BINDING")` at register and bail to
+ * a degraded no-op branch if either is missing. `SMD_CUSTOMER_SLUG` was once
+ * omitted from the template (only `CUSTOMER_SLUG` was set), which silently
+ * disabled the entire SMD plugin suite on customer-zero — audit emission never
+ * wrote, so the ADR 0043 runtime-read seam read a dry well (ss-console#1285).
+ * This test fails loudly if a required SMD_* var is dropped from the template.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const template = readFileSync(resolve(__dirname, '../operator/templates/fly.toml.template'), 'utf8')
+
+// Env vars the overlay plugins require() at register. Dropping any silently
+// degrades the whole suite — keep this list in lockstep with the plugins'
+// require(...) calls in venturecrane/hermes-smd-overlay.
+const REQUIRED_PLUGIN_ENV = ['SMD_CUSTOMER_SLUG', 'SMD_D1_AUDIT_BINDING'] as const
+
+describe('operator fly.toml template — required plugin env', () => {
+  for (const key of REQUIRED_PLUGIN_ENV) {
+    it(`declares ${key} in [env]`, () => {
+      // A key=value assignment for this var must appear in the template.
+      expect(template).toMatch(new RegExp(`^\\s*${key}\\s*=`, 'm'))
+    })
+  }
+
+  it('binds SMD_CUSTOMER_SLUG to the customer slug placeholder', () => {
+    expect(template).toMatch(/SMD_CUSTOMER_SLUG\s*=\s*"\{\{CUSTOMER_SLUG\}\}"/)
+  })
+})


### PR DESCRIPTION
**Root cause of audit emission never writing on customer-zero** — the third and deepest layer of #1285.

The SMD overlay plugins (audit, voice, webhook-router, trust, memory-mirror) resolve the per-customer namespace via `require("SMD_CUSTOMER_SLUG", ...)` at register, but the fly.toml template set only `CUSTOMER_SLUG` — never `SMD_CUSTOMER_SLUG`. So every one of those plugins raised `KeyError` and bailed to its degraded no-op branch: the audit plugin never built its writer, never ran `ensure_schema`, never wrote a row. The ADR 0043 runtime-read seam was reading a dry well.

The prior fixes were necessary but *upstream of the bail*: #41 (D1Client direct-path) and #42 (`ensure_schema`) only matter once register gets past `require()`. This sets `SMD_CUSTOMER_SLUG = "{{CUSTOMER_SLUG}}"` in the fly.toml `[env]` so the whole SMD suite registers cleanly.

+ regression guard (`tests/operator-fly-template-env.test.ts`): the template must declare every SMD_* var the plugins require, so this silent degradation can't recur.

After merge: redeploy `hermes-smd` → confirm the audit plugin registers clean + `audit_log` is created → land one benign row, seen end-to-end → close #1285.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
