### PR TITLE
feat(operator): overlay-activation boot gate (invariant 8) + OVERLAY_REF v0.4.11 (#1285)

### DIFF
--- a/operator/safety-substrate/tests/test_invariant_8_overlay_activation.py
+++ b/operator/safety-substrate/tests/test_invariant_8_overlay_activation.py
@@ -1,0 +1,178 @@
+"""Invariant 8 — overlay ACTIVATION (the governance layer is actually ON).
+
+Invariants 1-7 verify the safety LOGIC is correct. Every one of them passed
+while the SMD overlay was completely inert on the live gateway — because they
+test the library in isolation, not whether the plugins are wired into the
+running agent. That gap shipped an operator with no audit emission and, worse,
+no trust/ceiling enforcement (ss-console#1285). This invariant closes it.
+
+It asserts the overlay actually activates: the umbrella `register(ctx)` fans
+out, all five functional plugins (audit, trust, voice, webhook-router,
+memory-mirror) register their hooks (including the trust `pre_tool_call`
+ceiling gate), the audit schema is created, AND trust actually refuses an
+action that must be gated (a permanently-banned send tool).
+
+HARD BOOT GATE: run via run_invariants.py --strict, a False here halts boot —
+an ungoverned operator must never start. A future Hermes re-pin that breaks the
+plugin-load contract (the original failure mode) fails loudly here instead of
+silently shipping an inert overlay.
+
+Environment handling: the activation assertions run whenever the overlay is
+installed (the Machine boot context, and any env where it's present). When the
+overlay is NOT installed (CI / bare checkout), there is nothing to activate, so
+the check is N/A and passes — "overlay present but inert" is the failure mode
+this guards; "overlay absent entirely" is already caught by the image build and
+the `hermes-plugins-installed` boot-smoke check.
+
+Boot-gated: exposes run() -> (ok, message); imports no pytest.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sqlite3
+import sys
+import types
+from pathlib import Path
+
+# The five functional plugins whose activation IS the governance guarantee.
+_FUNCTIONAL = [
+    "hermes-smd-audit",
+    "hermes-smd-trust",
+    "hermes-smd-voice",
+    "hermes-smd-memory-mirror",
+    "hermes-smd-webhook-router",
+]
+
+# Hooks that must land for the layer to be governing (union across the five).
+_REQUIRED_HOOKS = {
+    "pre_tool_call",  # trust ceiling gate — the safety-critical one
+    "post_tool_call",  # audit + trust
+    "post_llm_call",  # audit + voice
+    "pre_llm_call",  # voice
+    "subagent_stop",  # audit
+    "on_session_end",  # memory-mirror
+    "pre_gateway_dispatch",  # webhook-router
+}
+
+# A permanently-banned tool (BANNED_TOOLS, ADR 0005 reviewer-as-sender): the
+# trust gate must refuse it regardless of the customer's authored ceiling, so it
+# is a deterministic "this must be gated" probe.
+_BANNED_PROBE_TOOL = "email_send"
+
+
+def _find_overlay() -> Path | None:
+    candidates = []
+    home = os.environ.get("HERMES_HOME")
+    if home:
+        candidates.append(Path(home) / "plugins" / "hermes-smd-overlay")
+    candidates.append(Path("/opt/data/plugins/hermes-smd-overlay"))
+    candidates.append(Path.home() / ".hermes" / "plugins" / "hermes-smd-overlay")
+    for c in candidates:
+        if (c / "__init__.py").exists():
+            return c
+    return None
+
+
+class _RecordingCtx:
+    """Records hook registrations; tolerant of any other ctx call."""
+
+    def __init__(self):
+        self.hooks: dict[str, list] = {}
+
+    def register_hook(self, name, fn):
+        self.hooks.setdefault(name, []).append(fn)
+
+    def __getattr__(self, _name):
+        return lambda *a, **k: None
+
+
+def _load_umbrella(overlay_dir: Path):
+    mod_name = "hermes_plugins.hermes_smd_overlay"
+    if "hermes_plugins" not in sys.modules:
+        ns = types.ModuleType("hermes_plugins")
+        ns.__path__ = []  # type: ignore[attr-defined]
+        ns.__package__ = "hermes_plugins"
+        sys.modules["hermes_plugins"] = ns
+    spec = importlib.util.spec_from_file_location(
+        mod_name,
+        overlay_dir / "__init__.py",
+        submodule_search_locations=[str(overlay_dir)],
+    )
+    module = importlib.util.module_from_spec(spec)
+    module.__package__ = mod_name
+    module.__path__ = [str(overlay_dir)]  # type: ignore[attr-defined]
+    sys.modules[mod_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _trust_gates_banned_action(ctx: _RecordingCtx) -> bool:
+    """Invoke every registered pre_tool_call hook with a banned send tool;
+    return True if any returns a block directive (trust enforcing)."""
+    for fn in ctx.hooks.get("pre_tool_call", []):
+        try:
+            res = fn(
+                tool_name=_BANNED_PROBE_TOOL,
+                args={},
+                session_id="invariant-8",
+                tool_call_id="invariant-8",
+                customer_slug=os.environ.get("SMD_CUSTOMER_SLUG", ""),
+            )
+        except Exception:  # noqa: BLE001 — a raising hook is not the gate contract
+            res = None
+        if isinstance(res, dict) and res.get("action") == "block":
+            return True
+    return False
+
+
+def run() -> tuple[bool, str]:
+    overlay = _find_overlay()
+    if overlay is None:
+        return (True, "N/A: overlay not installed in this environment — activation check skipped")
+
+    try:
+        umbrella = _load_umbrella(overlay)
+        ctx = _RecordingCtx()
+        registered = umbrella.load_and_register_subplugins(ctx)
+    except Exception as e:  # noqa: BLE001
+        return (False, f"FAIL: overlay register() raised: {type(e).__name__}: {e}")
+
+    missing = [p for p in _FUNCTIONAL if p not in registered]
+    if missing:
+        return (False, f"FAIL: functional plugins did not register: {missing} (got {registered})")
+
+    hooks_missing = _REQUIRED_HOOKS - set(ctx.hooks)
+    if hooks_missing:
+        return (False, f"FAIL: required hooks not attached: {sorted(hooks_missing)}")
+
+    binding = os.environ.get("SMD_D1_AUDIT_BINDING", "")
+    if binding.startswith("/"):
+        try:
+            conn = sqlite3.connect(f"file:{binding}?mode=ro", uri=True)
+            tables = [r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")]
+            conn.close()
+        except Exception as e:  # noqa: BLE001
+            return (False, f"FAIL: audit db unreadable at {binding}: {type(e).__name__}: {e}")
+        if "audit_log" not in tables:
+            return (False, f"FAIL: audit_log not created at {binding} — ensure_schema did not run")
+
+    if not _trust_gates_banned_action(ctx):
+        return (
+            False,
+            f"FAIL: TRUST NOT ENFORCING — banned tool {_BANNED_PROBE_TOOL!r} was not gated by any "
+            "registered pre_tool_call hook; the operator is ungoverned",
+        )
+
+    return (
+        True,
+        f"PASS: invariant 8 holds — overlay active ({len(registered)} plugins registered, hooks "
+        f"attached, audit schema present, trust gated banned {_BANNED_PROBE_TOOL!r})",
+    )
+
+
+if __name__ == "__main__":
+    ok, msg = run()
+    print(msg)
+    sys.exit(0 if ok else 1)

--- a/operator/templates/Dockerfile
+++ b/operator/templates/Dockerfile
@@ -91,8 +91,15 @@ ARG HERMES_UPSTREAM_SHA=a91a57fa5a13d516c38b07a141a9ce8a3daabeb0
 # register (the Machine's bootstrap never applied the per-customer migrations, so
 # the table was missing). The runtime-read seam now has data to surface
 # (ss-console#1285). Superset of v0.4.9.
+# v0.4.11 (#43) is THE activation fix: the umbrella register() fans out to all
+# sub-plugins. Hermes ignores the plugin.yaml `plugins:` aggregation list, so the
+# umbrella had loaded as a manifest-only plugin with no register() — none of the
+# five functional plugins (audit, trust, voice, webhook-router, memory-mirror)
+# ever registered on a live gateway. No audit, and no trust/ceiling enforcement.
+# The new safety-substrate invariant 8 asserts activation as a HARD boot gate.
+# Superset of v0.4.10.
 ARG OVERLAY_REPO="https://github.com/venturecrane/hermes-smd-overlay.git"
-ARG OVERLAY_REF="v0.4.10"
+ARG OVERLAY_REF="v0.4.11"
 
 ARG CUSTOMER_SLUG=customer-zero
 


### PR DESCRIPTION
**The fix that turns the consoles + runtime-read seam from "a console pointed at an ungoverned agent" into the product.** Closes #1285.

## Two parts

**1. `OVERLAY_REF` → v0.4.11** — pins the Machine to the overlay umbrella `register()` fan-out (hermes-smd-overlay#43). Hermes ignores the `plugin.yaml` `plugins:` aggregation list, so the umbrella had loaded **inert** — none of the five functional plugins (audit, trust, voice, webhook-router, memory-mirror) registered on a live gateway. No audit, and **no trust/ceiling enforcement**.

**2. safety-substrate invariant 8 (overlay activation) — a HARD boot gate** (`run_invariants.py --strict`; `die` on fail → agent won't start). Invariants 1-7 verify the safety *logic* and all passed while the overlay was inert, because they test the library, not activation. Invariant 8 closes that gap: it loads the umbrella, fans out with a recording ctx, and asserts:
- all five functional plugins **registered**,
- their **hooks attached** (incl. the trust `pre_tool_call` ceiling gate),
- **`audit_log` schema present** (ensure_schema ran),
- **TRUST ACTUALLY ENFORCES** — a permanently-banned send tool (`email_send`) is gated.

A future Hermes re-pin that breaks the plugin-load contract now **fails loudly at boot** instead of silently shipping an ungoverned operator — "the overlay is governing" becomes a verified signal, not an assumption. N/A-passes where the overlay isn't installed (CI / bare checkout); "absent entirely" is already caught by the image build + the `hermes-plugins-installed` boot-smoke.

Verified locally against the real overlay checkout: **PASS — 7 registered, hooks attached, audit schema created, banned `email_send` gated**. Also exits 0 in the no-overlay (CI) path.

After merge: redeploy `hermes-smd` → boot gate asserts all five active + trust enforcing → drive one benign Telegram turn → audit row reads back through the live seam. That closes #1285 end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
