### PR TITLE
fix(operator): refresh overlay on the volume every boot + close invariant-8 hole (#1285)

### DIFF
--- a/operator/safety-substrate/tests/test_invariant_8_overlay_activation.py
+++ b/operator/safety-substrate/tests/test_invariant_8_overlay_activation.py
@@ -62,15 +62,30 @@ _REQUIRED_HOOKS = {
 _BANNED_PROBE_TOOL = "email_send"
 
 
-def _find_overlay() -> Path | None:
-    candidates = []
+def _overlay_dirs() -> list[Path]:
+    dirs = []
     home = os.environ.get("HERMES_HOME")
     if home:
-        candidates.append(Path(home) / "plugins" / "hermes-smd-overlay")
-    candidates.append(Path("/opt/data/plugins/hermes-smd-overlay"))
-    candidates.append(Path.home() / ".hermes" / "plugins" / "hermes-smd-overlay")
-    for c in candidates:
+        dirs.append(Path(home) / "plugins" / "hermes-smd-overlay")
+    dirs.append(Path("/opt/data/plugins/hermes-smd-overlay"))
+    dirs.append(Path.home() / ".hermes" / "plugins" / "hermes-smd-overlay")
+    return dirs
+
+
+def _find_overlay() -> Path | None:
+    """The overlay dir that carries the fan-out register (__init__.py)."""
+    for c in _overlay_dirs():
         if (c / "__init__.py").exists():
+            return c
+    return None
+
+
+def _stale_overlay_dir() -> Path | None:
+    """An overlay dir that EXISTS but lacks the fan-out __init__.py — a
+    pre-fan-out / stale install that would boot ungoverned. Distinguished from
+    'no overlay at all' so the former FAILs the gate and only the latter is N/A."""
+    for c in _overlay_dirs():
+        if c.exists() and not (c / "__init__.py").exists():
             return c
     return None
 
@@ -130,6 +145,13 @@ def _trust_gates_banned_action(ctx: _RecordingCtx) -> bool:
 def run() -> tuple[bool, str]:
     overlay = _find_overlay()
     if overlay is None:
+        stale = _stale_overlay_dir()
+        if stale is not None:
+            return (
+                False,
+                f"FAIL: overlay dir present at {stale} but missing the fan-out register "
+                "__init__.py — stale/pre-fan-out overlay; the operator would boot ungoverned",
+            )
         return (True, "N/A: overlay not installed in this environment — activation check skipped")
 
     try:

--- a/operator/templates/Dockerfile
+++ b/operator/templates/Dockerfile
@@ -224,6 +224,19 @@ RUN npm install -g @oktopeak/clio-mcp@2.0.0
 RUN /opt/hermes/.venv/bin/hermes plugins install \
       venturecrane/hermes-smd-overlay --enable
 
+# Stage a PINNED copy of the overlay at a NON-VOLUME path (/app/overlay-pack) so
+# bootstrap.sh can refresh the per-customer volume's overlay to this exact
+# OVERLAY_REF on EVERY boot. /opt/data is the Fly volume mount and SHADOWS the
+# build-time `hermes plugins install` above, so without this the volume keeps
+# whatever overlay a past provision left behind — an OVERLAY_REF bump never
+# reaches the running gateway (the ss-console#1285 delivery bug: the overlay was
+# inert because the volume's copy was stale and bootstrap only checked presence,
+# never freshness). Cloned at the PINNED ref (unlike the unpinned install above),
+# and hard-gated on the fan-out __init__.py so a mis-pinned ref fails the build.
+RUN git clone --depth 1 --branch "${OVERLAY_REF}" "${OVERLAY_REPO}" /app/overlay-pack \
+      && rm -rf /app/overlay-pack/.git \
+      && test -f /app/overlay-pack/__init__.py
+
 # Deterministic build-time assertion that the pinned `shared` policy core is
 # importable in the venv. This catches a stale/mis-pinned OVERLAY_REF (the exact
 # v0.1.1 `ModuleNotFoundError: shared.outbound_gate`) at BUILD time rather than

--- a/operator/templates/bootstrap.sh
+++ b/operator/templates/bootstrap.sh
@@ -575,13 +575,33 @@ mkdir -p "${HERMES_HOME}/logs" "${HERMES_HOME}/profiles/${ACTIVE_PROFILE}/logs"
 # keeps it across deploys — so the slow `git clone` only runs in the rare reseed
 # case and does not normally delay the public :8643 listener below.
 OVERLAY_PLUGIN_DIR="${HERMES_HOME}/plugins/hermes-smd-overlay"
-if [ -d "${OVERLAY_PLUGIN_DIR}" ]; then
-  log "Overlay plugin present on the volume (${OVERLAY_PLUGIN_DIR})"
+OVERLAY_PACK="/app/overlay-pack"
+# REFRESH the volume's overlay from the image-pinned pack on EVERY boot — do NOT
+# skip when a dir is merely present. The volume (/opt/data) persists across
+# deploys and shadows the build-time install, so a presence-only check kept a
+# STALE overlay forever: every OVERLAY_REF bump rebuilt the image but the running
+# gateway kept loading the old volume copy, and the overlay sat inert — no audit,
+# no trust enforcement (ss-console#1285). Refreshing from the pinned, non-volume
+# pack makes a bump actually take effect, and is idempotent on a steady-state
+# boot (same bytes).
+if [ -d "${OVERLAY_PACK}" ]; then
+  log "Refreshing overlay on the volume from the image-pinned pack (${OVERLAY_PACK})..."
+  mkdir -p "${HERMES_HOME}/plugins"
+  rm -rf "${OVERLAY_PLUGIN_DIR}"
+  # cp (not cp -a): the copies are owned by the running hermes user, not the
+  # root-owned image source — a root-owned volume file would break a later
+  # hermes-user write (the .skills_prompt_snapshot.json FATAL we hit).
+  cp -r "${OVERLAY_PACK}" "${OVERLAY_PLUGIN_DIR}"
+  /opt/hermes/.venv/bin/hermes plugins enable hermes-smd-overlay >/dev/null 2>&1 || true
+  [ -f "${OVERLAY_PLUGIN_DIR}/__init__.py" ] \
+    || die "overlay fan-out __init__.py missing after refresh — refusing to launch an ungoverned gateway"
+  log "Overlay refreshed on the volume (fan-out register present)"
+elif [ -d "${OVERLAY_PLUGIN_DIR}" ]; then
+  # No staged pack (older image) but a volume copy exists — leave it; the
+  # activation invariant is the backstop that halts boot if it is inert.
+  log "Overlay present on the volume; no image pack to refresh from (${OVERLAY_PLUGIN_DIR})"
 else
-  log "Overlay plugin absent (volume shadows build-time install); installing at runtime..."
-  # Clear a stale/empty plugins dir (e.g. a root-owned dir left by a diagnostic).
-  # rm needs only parent write (${HERMES_HOME} is hermes-owned), not target
-  # ownership, so this succeeds even on a root-owned empty dir.
+  log "Overlay absent and no image pack; installing at runtime (unpinned fallback)..."
   rm -rf "${HERMES_HOME}/plugins" 2>/dev/null || true
   /opt/hermes/.venv/bin/hermes plugins install venturecrane/hermes-smd-overlay --enable \
     || die "runtime overlay plugin install failed — refusing to launch a harness-less gateway"


### PR DESCRIPTION
**The delivery bug behind the inert overlay** — why none of #41/#42/#43 ever reached the live gateway.

`/opt/data` is the Fly volume and **shadows** the image's build-time `hermes plugins install`. `bootstrap.sh` checked only **presence** of the overlay dir, so a persisted volume kept a **stale** overlay across every deploy — an `OVERLAY_REF` bump rebuilt the image but the running gateway kept loading the old volume copy. The governance layer (audit + trust) sat inert.

## Fixes
- **Dockerfile** — stage a **pinned** overlay copy at `/app/overlay-pack` (non-volume, cloned at `OVERLAY_REF`, hard-gated on the fan-out `__init__.py`).
- **bootstrap.sh** — **refresh** the volume's overlay from `/app/overlay-pack` on **every boot** (`rm` + `cp` as the hermes user → no root-owned volume files, which is what caused the `.skills_prompt_snapshot.json` boot FATAL), enable, and `die` if the fan-out `__init__.py` is missing after refresh. Idempotent on steady state; an `OVERLAY_REF` bump now actually takes effect.
- **invariant 8** — close the N/A hole: an overlay dir that **exists but lacks** the fan-out `__init__.py` (stale/pre-fan-out) now **FAILS** the boot gate instead of N/A-passing. Only a wholly-absent overlay is N/A (CI / bare checkout).

Verified locally (N/A→0, stale→FAIL, active→PASS) and on the live Machine (volume hand-refreshed): invariant 8 real-passes — *"overlay active (7 plugins registered, hooks attached, audit schema present, trust gated banned 'email_send')"* — and `audit_log` is created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
