### PR TITLE
fix(operator): wire the overlay live activation gate (#1285, overlay v0.4.12)

### DIFF
--- a/operator/safety-substrate/tests/test_invariant_8_overlay_activation.py
+++ b/operator/safety-substrate/tests/test_invariant_8_overlay_activation.py
@@ -17,6 +17,26 @@ an ungoverned operator must never start. A future Hermes re-pin that breaks the
 plugin-load contract (the original failure mode) fails loudly here instead of
 silently shipping an inert overlay.
 
+PROCESS-BOUNDARY LIMITATION (read this — it is why #1285 hid for so long). This
+invariant runs in the PRE-GATEWAY ``run_invariants`` process. It loads the overlay
+and asserts the registration LOGIC is sound in THAT process's plugin manager. It
+CANNOT assert the property that actually matters at runtime — that the overlay's
+hooks fire through the *gateway* process's live singleton on a real turn — because
+it is a different process. #1285 was exactly this gap: every registration/logic
+invariant stayed green while the gateway's own singleton was cached without the
+overlay and every hook was inert on live turns. So this check is necessary but
+PROVABLY INSUFFICIENT on its own.
+
+The AUTHORITATIVE LIVE GATE is the overlay's ``gateway:startup`` HookRegistry
+handler (``hooks/smd-overlay-activation/handler.py`` in hermes-smd-overlay). It
+runs IN the gateway process: it force-loads the overlay into the live singleton,
+then drives a REAL ``pre_tool_call`` dispatch self-check (trust must block a banned
+send tool) and fails closed (``os._exit``) if the operator is not governed — the
+only place the live-turn property can be asserted. bootstrap.sh fail-closes if that
+handler is not wired onto the volume. This invariant and the live handler are
+COMPLEMENTARY tiers, not redundant: this one catches a broken registration/logic
+contract early and cheaply; the handler catches an inert live singleton.
+
 Environment handling: the activation assertions run whenever the overlay is
 installed (the Machine boot context, and any env where it's present). When the
 overlay is NOT installed (CI / bare checkout), there is nothing to activate, so

--- a/operator/templates/Dockerfile
+++ b/operator/templates/Dockerfile
@@ -96,10 +96,15 @@ ARG HERMES_UPSTREAM_SHA=a91a57fa5a13d516c38b07a141a9ce8a3daabeb0
 # umbrella had loaded as a manifest-only plugin with no register() — none of the
 # five functional plugins (audit, trust, voice, webhook-router, memory-mirror)
 # ever registered on a live gateway. No audit, and no trust/ceiling enforcement.
-# The new safety-substrate invariant 8 asserts activation as a HARD boot gate.
-# Superset of v0.4.10.
+# v0.4.12 adds the gateway:startup ACTIVATION GATE (hooks/smd-overlay-activation):
+# the authoritative LIVE boot check that force-loads the overlay into the gateway's
+# live plugin singleton and drives a real pre_tool_call dispatch self-check, failing
+# closed if the operator is not governed (ss-console#1285). The pre-gateway invariant 8
+# asserts registration/logic; the live gate asserts the live-turn property. Superset of
+# v0.4.11 (fan-out). NOTE: v0.4.11 was the previously-pinned ref but was never tagged —
+# the bump to v0.4.12 also un-dangles that pin.
 ARG OVERLAY_REPO="https://github.com/venturecrane/hermes-smd-overlay.git"
-ARG OVERLAY_REF="v0.4.11"
+ARG OVERLAY_REF="v0.4.12"
 
 ARG CUSTOMER_SLUG=customer-zero
 
@@ -231,11 +236,14 @@ RUN /opt/hermes/.venv/bin/hermes plugins install \
 # whatever overlay a past provision left behind — an OVERLAY_REF bump never
 # reaches the running gateway (the ss-console#1285 delivery bug: the overlay was
 # inert because the volume's copy was stale and bootstrap only checked presence,
-# never freshness). Cloned at the PINNED ref (unlike the unpinned install above),
-# and hard-gated on the fan-out __init__.py so a mis-pinned ref fails the build.
+# never freshness). Cloned at the PINNED ref (unlike the unpinned install above), and
+# hard-gated on BOTH the fan-out __init__.py and the gateway:startup activation gate
+# (the live boot check, ss-console#1285) so a mis-pinned ref lacking either fails the
+# build instead of shipping a Machine with no live governance gate.
 RUN git clone --depth 1 --branch "${OVERLAY_REF}" "${OVERLAY_REPO}" /app/overlay-pack \
       && rm -rf /app/overlay-pack/.git \
-      && test -f /app/overlay-pack/__init__.py
+      && test -f /app/overlay-pack/__init__.py \
+      && test -f /app/overlay-pack/hooks/smd-overlay-activation/handler.py
 
 # Deterministic build-time assertion that the pinned `shared` policy core is
 # importable in the venv. This catches a stale/mis-pinned OVERLAY_REF (the exact

--- a/operator/templates/bootstrap.sh
+++ b/operator/templates/bootstrap.sh
@@ -610,6 +610,49 @@ else
   log "Overlay plugin installed + enabled at runtime"
 fi
 
+# ---------- Seed the gateway-startup ACTIVATION GATE onto the volume ----------
+# The overlay's LIVE governance gate is a HookRegistry handler
+# (hooks/smd-overlay-activation) that fires at gateway:startup IN the gateway
+# process: it force-loads the overlay into the live PluginManager singleton, then
+# drives a REAL pre_tool_call dispatch self-check and fails closed (os._exit) if the
+# operator is not actually governed. This closes ss-console#1285 — registered hooks
+# were inert on the live gateway because its plugin singleton was cached (idempotent
+# discovery) WITHOUT the overlay; the pre-gateway safety-substrate invariant could
+# not catch it (it runs in a different process and asserts its own singleton).
+#
+# Hermes' HookRegistry loads handlers from ${HERMES_HOME}/hooks/ (the volume) — NOT
+# from the plugin dir — so the handler must be seeded THERE, separately from the
+# plugin pack. Source preference: the image-pinned pack (always current with
+# OVERLAY_REF), else the hooks/ shipped inside the overlay plugin dir just placed on
+# the volume. Refresh on every boot (idempotent; same bytes) so an OVERLAY_REF bump
+# takes effect. Uses cp -r (not -a) for the same reason as the plugin refresh: files
+# land hermes-owned, not root-owned (the .skills_prompt_snapshot.json FATAL).
+if [ -d "${OVERLAY_PACK}/hooks" ]; then
+  _HOOKS_SRC="${OVERLAY_PACK}/hooks"
+elif [ -d "${OVERLAY_PLUGIN_DIR}/hooks" ]; then
+  _HOOKS_SRC="${OVERLAY_PLUGIN_DIR}/hooks"
+else
+  _HOOKS_SRC=""
+fi
+ACTIVATION_HOOK_DIR="${HERMES_HOME}/hooks/smd-overlay-activation"
+if [ -n "${_HOOKS_SRC}" ]; then
+  log "Seeding overlay gateway hooks onto the volume from ${_HOOKS_SRC}..."
+  mkdir -p "${HERMES_HOME}/hooks"
+  for _hookdir in "${_HOOKS_SRC}"/*/; do
+    [ -d "${_hookdir}" ] || continue
+    _name="$(basename "${_hookdir}")"
+    rm -rf "${HERMES_HOME}/hooks/${_name}"
+    cp -r "${_hookdir}" "${HERMES_HOME}/hooks/${_name}"
+  done
+  log "Overlay gateway hooks seeded onto the volume"
+fi
+# FAIL-CLOSED: the live activation gate must be wired no matter which overlay branch
+# ran above. Without it the gateway has no in-process check that the overlay governs
+# live turns — the exact unverified state ss-console#1285 shipped. Better to crash-loop
+# (Fly restarts) than to serve an operator we cannot prove is governed.
+{ [ -f "${ACTIVATION_HOOK_DIR}/HOOK.yaml" ] && [ -f "${ACTIVATION_HOOK_DIR}/handler.py" ]; } \
+  || die "overlay activation gate missing (${ACTIVATION_HOOK_DIR}) — refusing to launch a gateway with no live governance self-check (ss-console#1285)"
+
 # Inbound webhook front-door gate (overlay `hermes-smd-webhook-gate`). It binds
 # the public port (8643), verifies the vendor signature (AgentMail), and forwards
 # to the gateway's machine-local :8644 with the Generic header. FAIL-CLOSED: only


### PR DESCRIPTION
## What

Companion to [hermes-smd-overlay#44](https://github.com/venturecrane/hermes-smd-overlay/pull/44). Wires the overlay's new **gateway:startup activation gate** into the Machine and bumps `OVERLAY_REF` to `v0.4.12`.

## Why

The overlay's hooks were **inert on the live gateway** (ss-console#1285, Q2/World 1): Hermes discovers plugins idempotently, and the gateway's plugin singleton was cached *before* the overlay was enabled — so every hook (audit, trust, …) never fired on real turns. Runtime-confirmed: a proven real tool call wrote **zero** `audit_log` rows. The overlay fix is a `gateway:startup` HookRegistry handler that force-loads the overlay into the live singleton and drives a real `pre_tool_call` self-check, failing closed if ungoverned — **overlay-side only, zero Hermes-core edits** (per ADR 0024 / ADR 0015).

## Changes

- **`bootstrap.sh`** — seed `hooks/smd-overlay-activation` onto `$HERMES_HOME/hooks/` (where HookRegistry scans — *not* the plugin dir) on every boot, from the image-pinned pack (volume overlay's `hooks/` as fallback). **FAIL-CLOSED**: `die` if the gate is not on the volume after seeding, regardless of which overlay branch ran.
- **`Dockerfile`** — bump `OVERLAY_REF` `v0.4.11` → `v0.4.12` (v0.4.11 was the previously-pinned ref but **was never tagged** — this un-dangles it; any rebuild on the old pin would have failed at clone). Add a build-time assertion that the pinned ref carries the activation handler.
- **invariant 8 docstring** — make the **process-boundary limitation explicit**: the pre-gateway `run_invariants` process can only assert registration/logic; it *structurally cannot* assert the live-turn property (this is why #1285 hid). The authoritative live gate is the gateway:startup handler. Complementary tiers.

## Verification plan (post-merge)

Redeploy the `hermes-smd` Machine on v0.4.12, then close #1285 Q2 **end-to-end**: confirm a real agent turn writes an `audit_log` row through the live seam (not fabricated, not hand-created). Surfacing the row at the verify gate before declaring Q2 closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)