### PR TITLE
fix(operator): recover + harden bootstrap overlay refresh (crash-loop)

### DIFF
--- a/operator/templates/bootstrap.sh
+++ b/operator/templates/bootstrap.sh
@@ -464,21 +464,20 @@ log "Verifying Telegram allowlist (fail-closed, ADR 0033)..."
 log "Telegram allowlist guard passed"
 
 # ============================================================================
-# Step 8: safety substrate invariant checks (Phase A.5 gate)
+# Step 8: safety substrate invariant checks — MOVED below the overlay refresh
 # ============================================================================
-# PRESERVED VERBATIM from the prior bootstrap.sh. The five invariants must
-# hold across compaction, restart, tool failure, prompt injection, and
-# ceiling-escalation attempts. Re-runs on every container start so a Hermes
-# SHA bump can't regress the floor. This is the OpenClaw mitigation.
-log "Running safety substrate invariant checks (Phase A.5 gate)..."
-if ! /opt/hermes/.venv/bin/python3 /app/safety-substrate/run_invariants.py \
-       --customer "${CUSTOMER_SLUG}" \
-       --fixtures /app/safety-substrate/tests \
-       --strict ; then
-  die "Safety substrate invariant check FAILED — agent will not start. \
-Inspect /app/safety-substrate/logs/$(date -u +%Y%m%d).log for which invariant failed."
-fi
-log "Safety substrate invariants PASSED"
+# The Phase A.5 gate now runs AFTER the overlay refresh + activation-hook seed
+# (search "Phase A.5 gate — runs AFTER overlay refresh" below), not here.
+#
+# WHY (ss-console#1285 follow-up — crash-loop deadlock). invariant_8 validates
+# that the volume overlay carries the fan-out __init__.py. The refresh that
+# REPAIRS the overlay from the image-pinned pack runs later in this script. With
+# the gate HERE (before the refresh), a volume overlay left partial — e.g. an
+# interrupted refresh where `rm -rf` completed but `cp` did not, which a restart
+# racing a boot can cause — failed invariant_8 and the `die` killed the boot
+# BEFORE the refresh could repair it. Every reboot repeated it: an unbreakable
+# crash-loop. Moving the gate to after the refresh makes each boot repair the
+# overlay first, then validate what will actually launch — self-healing.
 
 # ============================================================================
 # Step 9: pause guard
@@ -652,6 +651,26 @@ fi
 # (Fly restarts) than to serve an operator we cannot prove is governed.
 { [ -f "${ACTIVATION_HOOK_DIR}/HOOK.yaml" ] && [ -f "${ACTIVATION_HOOK_DIR}/handler.py" ]; } \
   || die "overlay activation gate missing (${ACTIVATION_HOOK_DIR}) — refusing to launch a gateway with no live governance self-check (ss-console#1285)"
+
+# ============================================================================
+# Step 8 (moved): safety substrate invariant checks — Phase A.5 gate — runs AFTER overlay refresh
+# ============================================================================
+# Runs here, AFTER the overlay refresh + activation-hook seed above, so
+# invariant_8 validates the freshly-repaired overlay (fan-out __init__.py
+# present) rather than a stale/partial volume copy left by an interrupted prior
+# boot — which previously deadlocked into a crash-loop (see "Step 8" note above).
+# The five invariants must still hold across compaction, restart, tool failure,
+# prompt injection, and ceiling-escalation attempts; re-run every boot so a
+# Hermes SHA bump can't regress the floor (OpenClaw mitigation).
+log "Running safety substrate invariant checks (Phase A.5 gate)..."
+if ! /opt/hermes/.venv/bin/python3 /app/safety-substrate/run_invariants.py \
+       --customer "${CUSTOMER_SLUG}" \
+       --fixtures /app/safety-substrate/tests \
+       --strict ; then
+  die "Safety substrate invariant check FAILED — agent will not start. \
+Inspect /app/safety-substrate/logs/$(date -u +%Y%m%d).log for which invariant failed."
+fi
+log "Safety substrate invariants PASSED"
 
 # Inbound webhook front-door gate (overlay `hermes-smd-webhook-gate`). It binds
 # the public port (8643), verifies the vendor signature (AgentMail), and forwards

--- a/operator/templates/bootstrap.sh
+++ b/operator/templates/bootstrap.sh
@@ -56,6 +56,25 @@ die() {
   exit 1
 }
 
+# Replace a volume dir with a fresh copy of ${src}, TOLERANT of stray root-owned
+# files inside the old ${dest}. We `mv` the old dir aside instead of `rm -rf`-ing
+# it: a rename only needs write+exec on the (hermes-owned) PARENT dir, not on the
+# dir's contents — so a root-owned file left inside (e.g. a __pycache__/*.pyc
+# written by a root `ssh console` that imported the overlay) cannot make this fail
+# under `set -e` and crash-loop the boot (the ss-console#1285 self-inflicted
+# outage: bootstrap runs as hermes and `rm -rf` choked on root-owned .pyc). The
+# moved-aside copy is best-effort cleaned; if its root-owned files survive the rm
+# that is harmless — it is out of the plugin/hook search path.
+replace_dir_tolerant() {
+  _rdt_src="$1"; _rdt_dest="$2"
+  if [ -e "${_rdt_dest}" ]; then
+    mv "${_rdt_dest}" "${_rdt_dest}.stale.$$" \
+      || die "could not move aside stale dir ${_rdt_dest} (is its parent hermes-writable?)"
+    rm -rf "${_rdt_dest}.stale.$$" 2>/dev/null || true
+  fi
+  cp -r "${_rdt_src}" "${_rdt_dest}"
+}
+
 # NOTE: the wait_for() bounded-retry helper and supervise() restart wrapper
 # were removed with the Honcho data plane (steps 3-6); Postgres/Redis/Honcho
 # were their only callers. Phase 2 reintroduces supervision when it vendors the
@@ -586,11 +605,12 @@ OVERLAY_PACK="/app/overlay-pack"
 if [ -d "${OVERLAY_PACK}" ]; then
   log "Refreshing overlay on the volume from the image-pinned pack (${OVERLAY_PACK})..."
   mkdir -p "${HERMES_HOME}/plugins"
-  rm -rf "${OVERLAY_PLUGIN_DIR}"
-  # cp (not cp -a): the copies are owned by the running hermes user, not the
-  # root-owned image source — a root-owned volume file would break a later
-  # hermes-user write (the .skills_prompt_snapshot.json FATAL we hit).
-  cp -r "${OVERLAY_PACK}" "${OVERLAY_PLUGIN_DIR}"
+  # replace_dir_tolerant (mv-aside, not rm -rf) so a stray root-owned file in the
+  # old overlay dir can't crash-loop the boot under set -e. cp (not cp -a): the
+  # copies are owned by the running hermes user, not the root-owned image source —
+  # a root-owned volume file would break a later hermes-user write (the
+  # .skills_prompt_snapshot.json FATAL we hit).
+  replace_dir_tolerant "${OVERLAY_PACK}" "${OVERLAY_PLUGIN_DIR}"
   /opt/hermes/.venv/bin/hermes plugins enable hermes-smd-overlay >/dev/null 2>&1 || true
   [ -f "${OVERLAY_PLUGIN_DIR}/__init__.py" ] \
     || die "overlay fan-out __init__.py missing after refresh — refusing to launch an ungoverned gateway"
@@ -640,8 +660,10 @@ if [ -n "${_HOOKS_SRC}" ]; then
   for _hookdir in "${_HOOKS_SRC}"/*/; do
     [ -d "${_hookdir}" ] || continue
     _name="$(basename "${_hookdir}")"
-    rm -rf "${HERMES_HOME}/hooks/${_name}"
-    cp -r "${_hookdir}" "${HERMES_HOME}/hooks/${_name}"
+    # mv-aside (same root-owned-.pyc tolerance as the overlay refresh): a root
+    # `ssh console` that loaded handler.py would leave a root-owned __pycache__
+    # here, which a plain `rm -rf` under set -e would choke on.
+    replace_dir_tolerant "${_hookdir}" "${HERMES_HOME}/hooks/${_name}"
   done
   log "Overlay gateway hooks seeded onto the volume"
 fi


### PR DESCRIPTION
## What

Two-part bootstrap robustness fix that recovers customer-zero (`hermes-smd`) from a crash-loop and permanently hardens the overlay/hook refresh.

## Root cause

A root `ssh console` that imports the overlay (e.g. running `discover_plugins` for diagnostics) writes **root-owned `__pycache__/*.pyc`** into the overlay dir on the Fly volume. Bootstrap runs as the **hermes** user; its `rm -rf` of that dir during refresh hits permission-denied on the root files and, under `set -e`, the boot dies → crash-loop → machine stopped (max restarts). A plain redeploy can't fix it — the broken state persists on the volume.

## Fix

1. **`mv`-aside instead of `rm -rf`** (`replace_dir_tolerant`): a rename only needs write+exec on the hermes-owned *parent* dir, not on the dir's contents, so stray root-owned files can't fail it under `set -e`. Applied to both the overlay-plugin refresh and the activation-hook seed. Recovers on redeploy (renames the polluted dir away, copies a clean overlay) and hardens against recurrence.
2. **Phase A.5 invariant gate moved to after the overlay refresh** — invariant 8 now validates the freshly-repaired overlay instead of a stale/partial volume copy left by an interrupted prior boot (which previously deadlocked: gate failed before the refresh that would fix it could run).

## Verification

`bash -n` clean. Recovery confirmed by redeploy (the working-tree content of this branch) bringing the machine back to a healthy started state with invariant 8 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)