### PR TITLE
fix(operator): pin synchronous voice hooks

### DIFF
--- a/operator/templates/Dockerfile
+++ b/operator/templates/Dockerfile
@@ -103,9 +103,13 @@ ARG HERMES_UPSTREAM_SHA=a91a57fa5a13d516c38b07a141a9ce8a3daabeb0
 # confirms a row lands in audit_log) — the ss-console#1285 Q2 question answered
 # self-provingly at boot. Fail-closed on any check (os._exit). The pre-gateway invariant
 # 8 asserts registration/logic; the live gate asserts the live-turn + audit property.
-# Superset of v0.4.12 (activation gate) / v0.4.11 (fan-out).
+# v0.4.14 makes the voice pre/post LLM hooks synchronous, matching Hermes'
+# synchronous PluginManager dispatcher. Earlier versions returned coroutine objects,
+# so live turns skipped voice-context injection and logged unawaited-coroutine warnings.
+# Superset of v0.4.13 (audit self-check) / v0.4.12 (activation gate) /
+# v0.4.11 (fan-out).
 ARG OVERLAY_REPO="https://github.com/venturecrane/hermes-smd-overlay.git"
-ARG OVERLAY_REF="v0.4.13"
+ARG OVERLAY_REF="v0.4.14"
 
 ARG CUSTOMER_SLUG=customer-zero
 

--- a/tests/operator-dockerfile.test.ts
+++ b/tests/operator-dockerfile.test.ts
@@ -55,6 +55,10 @@ describe('Operator customer Machine Dockerfile', () => {
     ).toBe(true)
   })
 
+  it('pins the synchronous voice-hook release', () => {
+    expect(DOCKERFILE).toContain('ARG OVERLAY_REF="v0.4.14"')
+  })
+
   it('does NOT swallow a failed plugin install (no fail-open `|| echo ... continuing`)', () => {
     // The specific regression: a `|| echo "WARN ...; continuing"` on the plugin
     // install line that let a harness-less image build green.


### PR DESCRIPTION
## Root cause
The profiled gateway now loads the harness, but live logs exposed a second contract bug: Hermes dispatches plugin callbacks synchronously while the overlay voice hooks were `async def`. `pre_llm_call` therefore returned a coroutine object instead of voice context, and `post_llm_call` was never awaited.

## Change
- Pin `hermes-smd-overlay` `v0.4.14`, which makes voice hooks and R2 retrieval synchronous.
- Add an explicit regression assertion for the required release.

## Live evidence before this pin
- Profile-local overlay and activation hook present.
- Gateway logged `[hooks] Loaded hook smd-overlay-activation` and `1 hook(s) loaded`.
- Activation audit row written at `2026-06-10T00:07:21.280Z`.
- Gateway then logged `RuntimeWarning: coroutine on_post_llm_call was never awaited`, proving why voice context was skipped.

## Verification
- Overlay PR venturecrane/hermes-smd-overlay#46 merged, release `v0.4.14`.
- Overlay: 574 tests passed, Ruff lint and format passed.
- Operator targeted test: 15 passed.
- `npm run verify`: passed, 3309 main tests passed plus all worker suites.