### PR TITLE
fix(operator): expose broker package path

### DIFF
--- a/operator/templates/entrypoint.sh
+++ b/operator/templates/entrypoint.sh
@@ -32,6 +32,7 @@ setpriv \
   --no-new-privs \
   /usr/bin/env -i \
   PATH="/opt/workspace-broker/.venv/bin:/usr/bin:/bin" \
+  PYTHONPATH="/opt/workspace-broker" \
   PYTHONUNBUFFERED=1 \
   CUSTOMER_SLUG="${CUSTOMER_SLUG}" \
   SMD_WORKSPACE_BROKER_SOCKET="${SMD_WORKSPACE_BROKER_SOCKET}" \

--- a/tests/operator-workspace-broker.test.ts
+++ b/tests/operator-workspace-broker.test.ts
@@ -15,6 +15,7 @@ describe('ADR 0045 Workspace capability broker', () => {
     expect(entrypoint).toContain('--reuid=hermes')
     expect(entrypoint).toContain('--no-new-privs')
     expect(entrypoint).toContain('/usr/bin/env -i')
+    expect(entrypoint).toContain('PYTHONPATH="/opt/workspace-broker"')
     expect(dockerfile).not.toMatch(/\bsudo\b/)
   })
 


### PR DESCRIPTION
## Summary
- add the broker package root to the sanitized broker-only Python environment
- assert the runtime module path in the ADR 0045 regression test

## Root cause
The image copied `workspace_broker` under `/opt/workspace-broker`, but the broker starts from `/app` under `env -i`. Python therefore could not resolve `workspace_broker.server`, and the fail-closed socket gate correctly stopped boot.

## Verification
- `bash -n operator/templates/entrypoint.sh`
- focused broker and Dockerfile tests: 20 passed
- full pre-push verification: 3,314 console tests plus all worker suites