### PR TITLE
fix(operator): rematerialize broker credential

### DIFF
--- a/operator/templates/entrypoint.sh
+++ b/operator/templates/entrypoint.sh
@@ -15,6 +15,7 @@ log() {
 BROKER_DIR="/opt/data/workspace-broker"
 BROKER_SOCKET="/run/smd-workspace-broker/broker.sock"
 mkdir -p "${BROKER_DIR}" "$(dirname "${BROKER_SOCKET}")"
+rm -f "${BROKER_DIR}/google.json"
 chown workspace-broker:workspace-broker "${BROKER_DIR}"
 chmod 0700 "${BROKER_DIR}"
 chown workspace-broker:workspace-connectors "$(dirname "${BROKER_SOCKET}")"

--- a/tests/operator-workspace-broker.test.ts
+++ b/tests/operator-workspace-broker.test.ts
@@ -21,6 +21,7 @@ describe('ADR 0045 Workspace capability broker', () => {
 
   it('keeps broker code root-owned and credentials broker-only', () => {
     expect(dockerfile).toContain('chown -R root:root /opt/workspace-broker')
+    expect(entrypoint).toContain('rm -f "${BROKER_DIR}/google.json"')
     expect(entrypoint).toContain('chmod 0700 "${BROKER_DIR}"')
     expect(entrypoint).toContain('chown workspace-broker:workspace-broker "${BROKER_DIR}"')
   })


### PR DESCRIPTION
## Summary
- remove the ephemeral broker credential copy before dropping privileges
- rematerialize it from the Fly secret under the broker UID
- preserve the broker receipt journal across restarts
- assert the persistent-volume migration behavior

## Root cause
The persistent broker directory could contain `google.json` owned by a prior principal. The new broker UID could resolve its package but could not truncate that stale file. Startup now removes only the credential copy as root before the broker recreates it with broker-only ownership.

## Verification
- `bash -n operator/templates/entrypoint.sh`
- focused broker and Dockerfile tests: 20 passed
- full pre-push verification: 3,314 console tests plus all worker suites