### PR TITLE
fix(operator): materialize broker credential before privilege drop

### DIFF
--- a/operator/templates/entrypoint.sh
+++ b/operator/templates/entrypoint.sh
@@ -26,6 +26,16 @@ export SMD_WORKSPACE_CREDENTIAL_PATH="${BROKER_DIR}/google.json"
 export SMD_CUSTOMER_YAML="/opt/data/customer.yaml"
 export SMD_GATEWAY_PID="$$"
 
+PYTHONPATH="/opt/workspace-broker" \
+  /opt/workspace-broker/.venv/bin/python -c \
+  'import os; from pathlib import Path; from workspace_broker.google_auth import materialize_credential; materialize_credential(Path(os.environ["SMD_WORKSPACE_CREDENTIAL_PATH"]))'
+[ -f "${SMD_WORKSPACE_CREDENTIAL_PATH}" ] || {
+  log "FATAL: Workspace broker credential was not materialized"
+  exit 1
+}
+chown workspace-broker:workspace-broker "${SMD_WORKSPACE_CREDENTIAL_PATH}"
+chmod 0600 "${SMD_WORKSPACE_CREDENTIAL_PATH}"
+
 setpriv \
   --reuid=workspace-broker \
   --regid=workspace-broker \
@@ -40,8 +50,6 @@ setpriv \
   SMD_WORKSPACE_CREDENTIAL_PATH="${SMD_WORKSPACE_CREDENTIAL_PATH}" \
   SMD_CUSTOMER_YAML="${SMD_CUSTOMER_YAML}" \
   SMD_GATEWAY_PID="${SMD_GATEWAY_PID}" \
-  GOOGLE_SERVICE_ACCOUNT_JSON="${GOOGLE_SERVICE_ACCOUNT_JSON:-}" \
-  GOOGLE_TOKEN_JSON="${GOOGLE_TOKEN_JSON:-}" \
   /opt/workspace-broker/.venv/bin/python \
   -m workspace_broker.server &
 BROKER_PID=$!

--- a/tests/operator-workspace-broker.test.ts
+++ b/tests/operator-workspace-broker.test.ts
@@ -24,6 +24,13 @@ describe('ADR 0045 Workspace capability broker', () => {
     expect(entrypoint).toContain('rm -f "${BROKER_DIR}/google.json"')
     expect(entrypoint).toContain('chmod 0700 "${BROKER_DIR}"')
     expect(entrypoint).toContain('chown workspace-broker:workspace-broker "${BROKER_DIR}"')
+    expect(entrypoint).toContain(
+      'chown workspace-broker:workspace-broker "${SMD_WORKSPACE_CREDENTIAL_PATH}"'
+    )
+    expect(entrypoint).toContain('chmod 0600 "${SMD_WORKSPACE_CREDENTIAL_PATH}"')
+    expect(entrypoint).toContain(
+      'materialize_credential(Path(os.environ["SMD_WORKSPACE_CREDENTIAL_PATH"]))'
+    )
   })
 
   it('strips every Google credential from the gateway environment', () => {
@@ -34,6 +41,12 @@ describe('ADR 0045 Workspace capability broker', () => {
       'unset GOOGLE_IMPERSONATE_SUBJECT GOOGLE_OAUTH_SCOPES GOOGLE_TOKEN_PATH'
     )
     expect(bootstrap).not.toContain('GOOGLE_TOKEN_FILE="/opt/data/oauth/google.json"')
+  })
+
+  it('does not pass Google credentials into the broker child environment', () => {
+    const brokerChild = entrypoint.slice(entrypoint.indexOf('setpriv'))
+    expect(brokerChild).not.toContain('GOOGLE_SERVICE_ACCOUNT_JSON=')
+    expect(brokerChild).not.toContain('GOOGLE_TOKEN_JSON=')
   })
 
   it('does not install Google provider libraries into the Hermes venv', () => {


### PR DESCRIPTION
## Summary
- materialize the Workspace credential in the trusted root launcher
- transfer the resulting file to the broker principal with mode 0600
- omit Google credential values from both broker and gateway child environments
- cover custody and environment behavior with regression tests

## Verification
- npm run verify
- bash -n operator/templates/entrypoint.sh
- npm test -- --run tests/operator-workspace-broker.test.ts tests/operator-dockerfile.test.ts

## Live failure addressed
Release 67 proved the persistent volume credential could not be recreated after dropping to the broker UID. This change makes credential creation and ownership transfer deterministic before privilege drop.