### PR TITLE
fix(operator): migrate persistent volume ownership

### DIFF
--- a/operator/templates/entrypoint.sh
+++ b/operator/templates/entrypoint.sh
@@ -14,9 +14,10 @@ log() {
 
 BROKER_DIR="/opt/data/workspace-broker"
 BROKER_SOCKET="/run/smd-workspace-broker/broker.sock"
+chown -R hermes:hermes /opt/data
 mkdir -p "${BROKER_DIR}" "$(dirname "${BROKER_SOCKET}")"
 rm -f "${BROKER_DIR}/google.json"
-chown workspace-broker:workspace-broker "${BROKER_DIR}"
+chown -R workspace-broker:workspace-broker "${BROKER_DIR}"
 chmod 0700 "${BROKER_DIR}"
 chown workspace-broker:workspace-connectors "$(dirname "${BROKER_SOCKET}")"
 chmod 2750 "$(dirname "${BROKER_SOCKET}")"

--- a/tests/operator-workspace-broker.test.ts
+++ b/tests/operator-workspace-broker.test.ts
@@ -21,15 +21,19 @@ describe('ADR 0045 Workspace capability broker', () => {
 
   it('keeps broker code root-owned and credentials broker-only', () => {
     expect(dockerfile).toContain('chown -R root:root /opt/workspace-broker')
+    expect(entrypoint).toContain('chown -R hermes:hermes /opt/data')
     expect(entrypoint).toContain('rm -f "${BROKER_DIR}/google.json"')
     expect(entrypoint).toContain('chmod 0700 "${BROKER_DIR}"')
-    expect(entrypoint).toContain('chown workspace-broker:workspace-broker "${BROKER_DIR}"')
+    expect(entrypoint).toContain('chown -R workspace-broker:workspace-broker "${BROKER_DIR}"')
     expect(entrypoint).toContain(
       'chown workspace-broker:workspace-broker "${SMD_WORKSPACE_CREDENTIAL_PATH}"'
     )
     expect(entrypoint).toContain('chmod 0600 "${SMD_WORKSPACE_CREDENTIAL_PATH}"')
     expect(entrypoint).toContain(
       'materialize_credential(Path(os.environ["SMD_WORKSPACE_CREDENTIAL_PATH"]))'
+    )
+    expect(entrypoint.indexOf('chown -R hermes:hermes /opt/data')).toBeLessThan(
+      entrypoint.indexOf('chown -R workspace-broker:workspace-broker "${BROKER_DIR}"')
     )
   })
 


### PR DESCRIPTION
## Summary
- migrate the persistent operator volume to the non-root gateway UID at boot
- recursively restore the Workspace broker subtree to the broker UID
- preserve broker-only credential custody after the migration

## Verification
- npm run verify
- bash -n operator/templates/entrypoint.sh
- npm test -- --run tests/operator-workspace-broker.test.ts tests/operator-dockerfile.test.ts

## Live failure addressed
Release 68 proved the broker starts and Google secrets are absent from the gateway, but the non-root gateway could not refresh customer.yaml because the existing Fly volume remained root-owned.