### PR TITLE
fix(operator): establish non-root runtime home

### DIFF
--- a/operator/templates/entrypoint.sh
+++ b/operator/templates/entrypoint.sh
@@ -15,6 +15,8 @@ log() {
 BROKER_DIR="/opt/data/workspace-broker"
 BROKER_SOCKET="/run/smd-workspace-broker/broker.sock"
 chown -R hermes:hermes /opt/data
+chown hermes:workspace-connectors /opt/data
+chmod 0750 /opt/data
 mkdir -p "${BROKER_DIR}" "$(dirname "${BROKER_SOCKET}")"
 rm -f "${BROKER_DIR}/google.json"
 chown -R workspace-broker:workspace-broker "${BROKER_DIR}"
@@ -68,6 +70,7 @@ done
 unset GOOGLE_SERVICE_ACCOUNT_JSON GOOGLE_TOKEN_JSON GOOGLE_CLIENT_SECRET_JSON
 unset GOOGLE_IMPERSONATE_SUBJECT GOOGLE_OAUTH_SCOPES GOOGLE_TOKEN_PATH
 
+export HOME=/opt/data
 log "Workspace broker started as uid $(id -u workspace-broker); dropping gateway to hermes"
 exec setpriv \
   --reuid=hermes \

--- a/tests/operator-workspace-broker.test.ts
+++ b/tests/operator-workspace-broker.test.ts
@@ -22,6 +22,8 @@ describe('ADR 0045 Workspace capability broker', () => {
   it('keeps broker code root-owned and credentials broker-only', () => {
     expect(dockerfile).toContain('chown -R root:root /opt/workspace-broker')
     expect(entrypoint).toContain('chown -R hermes:hermes /opt/data')
+    expect(entrypoint).toContain('chown hermes:workspace-connectors /opt/data')
+    expect(entrypoint).toContain('chmod 0750 /opt/data')
     expect(entrypoint).toContain('rm -f "${BROKER_DIR}/google.json"')
     expect(entrypoint).toContain('chmod 0700 "${BROKER_DIR}"')
     expect(entrypoint).toContain('chown -R workspace-broker:workspace-broker "${BROKER_DIR}"')
@@ -34,6 +36,13 @@ describe('ADR 0045 Workspace capability broker', () => {
     )
     expect(entrypoint.indexOf('chown -R hermes:hermes /opt/data')).toBeLessThan(
       entrypoint.indexOf('chown -R workspace-broker:workspace-broker "${BROKER_DIR}"')
+    )
+  })
+
+  it('runs the gateway with a writable non-root home', () => {
+    expect(entrypoint).toContain('export HOME=/opt/data')
+    expect(entrypoint.indexOf('export HOME=/opt/data')).toBeLessThan(
+      entrypoint.lastIndexOf('exec setpriv')
     )
   })
 


### PR DESCRIPTION
## Summary
- persist the proven 0750 group boundary on /opt/data so both gateway and broker can traverse required state
- set HOME=/opt/data before launching the non-root gateway
- prevent Hermes lock and state paths from resolving under /root

## Verification
- npm run verify
- bash -n operator/templates/entrypoint.sh
- npm test -- --run tests/operator-workspace-broker.test.ts tests/operator-dockerfile.test.ts

## Live proof
On release 69, applying hermes:workspace-connectors mode 0750 to /opt/data made broker readiness pass, all nine substrate invariants pass, and the gateway launch. The remaining Telegram failure was a lock path under inherited HOME=/root.