### PR TITLE
fix(operator): preserve broker home boundary

### DIFF
--- a/operator/templates/entrypoint.sh
+++ b/operator/templates/entrypoint.sh
@@ -71,6 +71,7 @@ unset GOOGLE_SERVICE_ACCOUNT_JSON GOOGLE_TOKEN_JSON GOOGLE_CLIENT_SECRET_JSON
 unset GOOGLE_IMPERSONATE_SUBJECT GOOGLE_OAUTH_SCOPES GOOGLE_TOKEN_PATH
 
 export HOME=/opt/data
+export HERMES_HOME_MODE=0750
 log "Workspace broker started as uid $(id -u workspace-broker); dropping gateway to hermes"
 exec setpriv \
   --reuid=hermes \

--- a/tests/operator-workspace-broker.test.ts
+++ b/tests/operator-workspace-broker.test.ts
@@ -41,7 +41,11 @@ describe('ADR 0045 Workspace capability broker', () => {
 
   it('runs the gateway with a writable non-root home', () => {
     expect(entrypoint).toContain('export HOME=/opt/data')
+    expect(entrypoint).toContain('export HERMES_HOME_MODE=0750')
     expect(entrypoint.indexOf('export HOME=/opt/data')).toBeLessThan(
+      entrypoint.lastIndexOf('exec setpriv')
+    )
+    expect(entrypoint.indexOf('export HERMES_HOME_MODE=0750')).toBeLessThan(
       entrypoint.lastIndexOf('exec setpriv')
     )
   })


### PR DESCRIPTION
## Summary
- set Hermes' supported HERMES_HOME_MODE to 0750 before gateway startup
- preserve broker traversal of /opt/data after Hermes secures its home
- add regression coverage for startup ordering

## Verification
- npm run verify
- 3316 repository tests passed
- all worker test suites passed