### PR TITLE
fix(operator): isolate broker state from Hermes home

### DIFF
--- a/operator/templates/entrypoint.sh
+++ b/operator/templates/entrypoint.sh
@@ -12,13 +12,15 @@ log() {
   exit 1
 }
 
-BROKER_DIR="/opt/data/workspace-broker"
+BROKER_DIR="/var/lib/smd-workspace-broker"
 BROKER_SOCKET="/run/smd-workspace-broker/broker.sock"
+BROKER_CUSTOMER_PATH="${BROKER_DIR}/customer.yaml"
 chown -R hermes:hermes /opt/data
-chown hermes:workspace-connectors /opt/data
-chmod 0750 /opt/data
+rm -rf /opt/data/workspace-broker
+rm -f /opt/data/oauth/google.json
 mkdir -p "${BROKER_DIR}" "$(dirname "${BROKER_SOCKET}")"
 rm -f "${BROKER_DIR}/google.json"
+cp /opt/data/customer.yaml "${BROKER_CUSTOMER_PATH}"
 chown -R workspace-broker:workspace-broker "${BROKER_DIR}"
 chmod 0700 "${BROKER_DIR}"
 chown workspace-broker:workspace-connectors "$(dirname "${BROKER_SOCKET}")"
@@ -26,7 +28,7 @@ chmod 2750 "$(dirname "${BROKER_SOCKET}")"
 
 export SMD_WORKSPACE_BROKER_SOCKET="${BROKER_SOCKET}"
 export SMD_WORKSPACE_CREDENTIAL_PATH="${BROKER_DIR}/google.json"
-export SMD_CUSTOMER_YAML="/opt/data/customer.yaml"
+export SMD_CUSTOMER_YAML="${BROKER_CUSTOMER_PATH}"
 export SMD_GATEWAY_PID="$$"
 
 PYTHONPATH="/opt/workspace-broker" \
@@ -71,7 +73,6 @@ unset GOOGLE_SERVICE_ACCOUNT_JSON GOOGLE_TOKEN_JSON GOOGLE_CLIENT_SECRET_JSON
 unset GOOGLE_IMPERSONATE_SUBJECT GOOGLE_OAUTH_SCOPES GOOGLE_TOKEN_PATH
 
 export HOME=/opt/data
-export HERMES_HOME_MODE=0750
 log "Workspace broker started as uid $(id -u workspace-broker); dropping gateway to hermes"
 exec setpriv \
   --reuid=hermes \

--- a/tests/operator-workspace-broker.test.ts
+++ b/tests/operator-workspace-broker.test.ts
@@ -22,9 +22,12 @@ describe('ADR 0045 Workspace capability broker', () => {
   it('keeps broker code root-owned and credentials broker-only', () => {
     expect(dockerfile).toContain('chown -R root:root /opt/workspace-broker')
     expect(entrypoint).toContain('chown -R hermes:hermes /opt/data')
-    expect(entrypoint).toContain('chown hermes:workspace-connectors /opt/data')
-    expect(entrypoint).toContain('chmod 0750 /opt/data')
+    expect(entrypoint).toContain('BROKER_DIR="/var/lib/smd-workspace-broker"')
+    expect(entrypoint).not.toContain('BROKER_DIR="/opt/data/workspace-broker"')
+    expect(entrypoint).toContain('rm -rf /opt/data/workspace-broker')
+    expect(entrypoint).toContain('rm -f /opt/data/oauth/google.json')
     expect(entrypoint).toContain('rm -f "${BROKER_DIR}/google.json"')
+    expect(entrypoint).toContain('cp /opt/data/customer.yaml "${BROKER_CUSTOMER_PATH}"')
     expect(entrypoint).toContain('chmod 0700 "${BROKER_DIR}"')
     expect(entrypoint).toContain('chown -R workspace-broker:workspace-broker "${BROKER_DIR}"')
     expect(entrypoint).toContain(
@@ -41,13 +44,10 @@ describe('ADR 0045 Workspace capability broker', () => {
 
   it('runs the gateway with a writable non-root home', () => {
     expect(entrypoint).toContain('export HOME=/opt/data')
-    expect(entrypoint).toContain('export HERMES_HOME_MODE=0750')
     expect(entrypoint.indexOf('export HOME=/opt/data')).toBeLessThan(
       entrypoint.lastIndexOf('exec setpriv')
     )
-    expect(entrypoint.indexOf('export HERMES_HOME_MODE=0750')).toBeLessThan(
-      entrypoint.lastIndexOf('exec setpriv')
-    )
+    expect(entrypoint).not.toContain('HERMES_HOME_MODE')
   })
 
   it('strips every Google credential from the gateway environment', () => {


### PR DESCRIPTION
## Summary
- move broker credential, config snapshot, and receipt journal outside the Hermes-controlled home
- remove legacy raw Google credential locations before gateway privilege drop
- allow Hermes to retain its intended owner-only home permissions
- add regression coverage for custody boundaries

## Root cause
Hermes auth persistence correctly secures its home at 0700. Broker state under /opt/data therefore depended on a directory owned and mutated by the gateway security domain. A stale /opt/data/oauth/google.json also remained gateway-readable.

## Verification
- bash -n operator/templates/entrypoint.sh
- npm run verify
- 3316 repository tests passed
- all worker test suites passed