### PR TITLE
fix(auth): let one identity hold admin + client portal at once

### DIFF
--- a/src/components/portal/PortalHeader.astro
+++ b/src/components/portal/PortalHeader.astro
@@ -19,17 +19,33 @@
 import SmdLogo from '../SmdLogo.astro'
 import { SignOutButton } from '@clerk/astro/components'
 import { FIRM_CONTACT } from '../../lib/config/firm-contact'
+import { buildAdminUrl, getAdminBaseUrl } from '../../lib/config/app-url'
+import { env } from 'cloudflare:workers'
 
 interface Props {
   clientName: string
+  /**
+   * Render an "Admin console" cross-surface switch link. Only true for an
+   * admin viewing the portal (SMD dogfooding its own Operator from the
+   * customer seat) — pass `portalData.user.role === 'admin'` from the page.
+   * Defaults false so ordinary clients never see it.
+   */
+  isAdmin?: boolean
 }
 
-const { clientName } = Astro.props
+const { clientName, isAdmin = false } = Astro.props
 
 const phoneDigits = FIRM_CONTACT.phone.replace(/[^+\d]/g, '')
 const smsHref = `sms:${phoneDigits}`
 const telHref = `tel:${phoneDigits}`
 const mailtoHref = `mailto:${FIRM_CONTACT.email}`
+
+// Cross-surface switch back to the admin console. Must be the ABSOLUTE admin
+// origin: a relative '/admin' would be mangled by the portal-subdomain rewrite
+// in src/middleware.ts. Hidden when ADMIN_BASE_URL is unconfigured (local dev)
+// or the viewer is not an admin. The Clerk session is shared across subdomains,
+// so this navigates without re-authentication.
+const adminSwitchHref = isAdmin && getAdminBaseUrl(env) ? buildAdminUrl(env, '/') : null
 
 const iconClasses =
   'inline-flex items-center justify-center w-11 h-11 rounded-[var(--ss-radius-button)] text-[color:var(--ss-color-text-secondary)] hover:text-[color:var(--ss-color-primary)] active:text-[color:var(--ss-color-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2'
@@ -49,6 +65,19 @@ const iconClasses =
       </p>
     </div>
     <div class="flex items-center gap-1">
+      {
+        adminSwitchHref && (
+          <a
+            href={adminSwitchHref}
+            class="hidden sm:inline-flex items-center gap-1.5 min-h-11 px-2 mr-1 font-['Archivo_Narrow'] text-xs font-semibold uppercase tracking-[0.12em] text-[color:var(--ss-color-text-secondary)] hover:text-[color:var(--ss-color-primary)] active:text-[color:var(--ss-color-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2"
+          >
+            <span class="material-symbols-outlined text-base" aria-hidden="true">
+              swap_horiz
+            </span>
+            Admin console
+          </a>
+        )
+      }
       <a href={mailtoHref} aria-label="Email us" class={iconClasses}>
         <span class="material-symbols-outlined" aria-hidden="true">mail</span>
       </a>

--- a/src/layouts/AdminLayout.astro
+++ b/src/layouts/AdminLayout.astro
@@ -3,6 +3,8 @@ import '../styles/global.css'
 import SkipToMain from '../components/SkipToMain.astro'
 import SmdLogo from '../components/SmdLogo.astro'
 import { SignOutButton } from '@clerk/astro/components'
+import { buildPortalUrl, getPortalBaseUrl } from '../lib/config/app-url'
+import { env } from 'cloudflare:workers'
 
 interface BreadcrumbItem {
   label: string
@@ -19,6 +21,17 @@ interface Props {
 const { title, breadcrumbs = [], maxWidth = 'max-w-5xl', mainClass = '' } = Astro.props
 const session = Astro.locals.session!
 const pathname = Astro.url.pathname
+
+// Cross-surface switch link to the client portal's Operator view. SMD operates
+// its own dogfooded Operator from the customer seat, so the admin (Scott) needs
+// to jump to the portal without re-authenticating — the Clerk session is shared
+// across subdomains. Must be the ABSOLUTE portal origin: a relative '/portal'
+// would be mangled by the admin-subdomain rewrite in src/middleware.ts. Hidden
+// when PORTAL_BASE_URL is unconfigured (local dev without the var set). An
+// admin who is not yet a provisioned customer is gracefully bounced back here.
+const portalSwitchHref = getPortalBaseUrl(env)
+  ? buildPortalUrl(env, '/portal/products/operator')
+  : null
 
 const navItems = [
   { label: 'Dashboard', href: '/admin', match: (p: string) => p === '/admin' || p === '/admin/' },
@@ -101,6 +114,19 @@ const navItems = [
               })
             }
           </nav>
+          {
+            portalSwitchHref && (
+              <a
+                href={portalSwitchHref}
+                class="inline-flex items-center gap-1.5 min-h-11 px-2 -mx-2 font-['Archivo_Narrow'] text-sm font-semibold uppercase tracking-[0.12em] text-[color:var(--ss-color-text-secondary)] hover:text-[color:var(--ss-color-primary)] active:text-[color:var(--ss-color-primary)] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2"
+              >
+                <span class="material-symbols-outlined text-base" aria-hidden="true">
+                  swap_horiz
+                </span>
+                Operator (client view)
+              </a>
+            )
+          }
           <span class="text-sm text-[color:var(--ss-color-text-muted)]" aria-hidden="true">|</span>
           <span class="text-sm text-[color:var(--ss-color-text-secondary)]">{session.email}</span>
           <SignOutButton asChild redirectUrl="/auth/sign-in?status=signed_out">
@@ -145,6 +171,19 @@ const navItems = [
                 })
               }
             </nav>
+            {
+              portalSwitchHref && (
+                <a
+                  href={portalSwitchHref}
+                  class="flex items-center gap-1.5 px-3 py-2.5 text-sm rounded text-[color:var(--ss-color-text-primary)] hover:bg-[color:var(--ss-color-border-subtle)] active:bg-[color:var(--ss-color-border-subtle)]"
+                >
+                  <span class="material-symbols-outlined text-base" aria-hidden="true">
+                    swap_horiz
+                  </span>
+                  Operator (client view)
+                </a>
+              )
+            }
             <hr class="my-2 border-[color:var(--ss-color-border)]" />
             <p class="px-3 py-1.5 text-xs text-[color:var(--ss-color-text-secondary)] break-all">
               {session.email}

--- a/src/lib/auth/after-sign-in-target.ts
+++ b/src/lib/auth/after-sign-in-target.ts
@@ -1,0 +1,71 @@
+/**
+ * Pure surface-selection logic for the post-sign-in dispatcher
+ * (src/pages/auth/after-sign-in.ts).
+ *
+ * Kept env-free (no `cloudflare:workers` import) so it is unit-testable in a
+ * plain Node/vitest context, mirroring the pattern used by
+ * src/lib/portal/operator-access.ts (pure resolve, side effects in the route).
+ *
+ * Why host-awareness: Clerk is one shared identity across the smd.services
+ * subdomains (production root-domain deployment → session works on every
+ * subdomain automatically). A single human can legitimately be BOTH an admin
+ * and a customer-seat user (SMD operating its own dogfooded Operator). The
+ * old dispatcher checked admin first and always trumped to the admin host,
+ * stranding the portal seat. We instead honor the host the user signed in
+ * from — server-observed, never user-supplied — so a dual-eligible user lands
+ * on the surface they were actually trying to reach. Single-role users are
+ * unaffected: the host-preference only fires when the user qualifies for that
+ * surface, and the admin-first default is preserved otherwise.
+ */
+
+export type SignedInSurface = 'admin' | 'portal' | 'none'
+
+export interface ChooseSignedInSurfaceOptions {
+  /** Hostname of the request that hit the dispatcher (server-observed). */
+  host: string
+  /** Hostname of the configured admin base URL, or null when unset (local dev). */
+  adminHost: string | null
+  /** Hostname of the configured portal base URL, or null when unset (local dev). */
+  portalHost: string | null
+  /** True when the signed-in user resolves to an admin row (role='admin'). */
+  adminEligible: boolean
+  /** True when the signed-in user is bound to a customer entity (portal seat). */
+  portalEligible: boolean
+}
+
+/**
+ * Decide which surface to route a freshly-signed-in user to.
+ *
+ * Order:
+ *   1. Host preference — if the user qualifies for the surface whose host they
+ *      signed in from, send them there (lets a dual-eligible user reach either
+ *      surface by signing in on its subdomain).
+ *   2. Admin-first default — preserves prior single-admin-venture behavior for
+ *      users who are only admin, or who signed in on the apex/an unknown host.
+ *   3. Portal — users bound to a customer but not admin.
+ *   4. 'none' — authenticated but unprovisioned (caller shows no_subscription).
+ */
+export function chooseSignedInSurface(opts: ChooseSignedInSurfaceOptions): SignedInSurface {
+  const { host, adminHost, portalHost, adminEligible, portalEligible } = opts
+
+  if (portalEligible && portalHost !== null && host === portalHost) return 'portal'
+  if (adminEligible && adminHost !== null && host === adminHost) return 'admin'
+
+  if (adminEligible) return 'admin'
+  if (portalEligible) return 'portal'
+  return 'none'
+}
+
+/**
+ * Extract the hostname from a base URL string, or null when the input is
+ * missing/blank/unparseable. Used to compare the request host against the
+ * configured admin/portal origins without throwing on local-dev (unset) config.
+ */
+export function hostnameOf(baseUrl: string | null | undefined): string | null {
+  if (!baseUrl) return null
+  try {
+    return new URL(baseUrl).hostname
+  } catch {
+    return null
+  }
+}

--- a/src/pages/auth/after-sign-in.ts
+++ b/src/pages/auth/after-sign-in.ts
@@ -8,74 +8,104 @@ import {
   getAdminBaseUrl,
   getPortalBaseUrl,
 } from '../../lib/config/app-url'
+import { chooseSignedInSurface, hostnameOf } from '../../lib/auth/after-sign-in-target'
 
 /**
- * Post-sign-in role dispatcher.
+ * Post-sign-in dispatcher.
  *
- * Clerk's <SignIn /> redirects here after authentication completes. We
- * look up the authenticated user's role in the local users table and
- * forward them to the appropriate surface:
+ * Clerk's <SignIn /> redirects here (relative forceRedirectUrl, so we land on
+ * whichever subdomain the user signed in from) after authentication completes.
+ * We resolve the authenticated user's eligibility for each surface and forward
+ * them appropriately:
  *
- *   - role=admin → https://admin.smd.services/
- *   - role=client with an entity binding → https://portal.smd.services/
- *   - role=client without a binding → /auth/sign-in?status=no_subscription
+ *   - admin-eligible (users.role='admin')                 → admin host
+ *   - portal-eligible (bound to a customer entity)         → portal host
+ *   - both                                                 → host they signed
+ *                                                            in from (then
+ *                                                            admin-first default)
+ *   - neither                                              → /auth/sign-in?status=no_subscription
  *
- * We route through ensureLocalUser so a pre-Clerk users row (created by
- * an admin invite or via legacy magic-link auth) gets auto-bound to the
- * Clerk identity on its first sign-in. A lookup-by-clerk_user_id-only
- * path would miss those rows and falsely surface no_subscription.
+ * The dual-eligible case is real: SMD operates its own dogfooded Operator, so
+ * the founder is both the admin AND a customer-seat principal. We honor the
+ * sign-in host (server-observed, never a user-supplied redirect URL — Clerk's
+ * forceRedirectUrl ignores redirect_url params anyway) so being one does not
+ * trump reaching the other. See src/lib/auth/after-sign-in-target.ts.
  *
- * When the host base URLs are not configured (e.g., local dev without
- * ADMIN_BASE_URL/PORTAL_BASE_URL set), fall back to relative paths so the
- * subdomain rewrite in src/middleware.ts handles routing on a single
- * host.
+ * We route eligibility through ensureLocalUser FIRST so a pre-Clerk users row
+ * (admin seed or legacy magic-link invite) gets auto-linked to the Clerk
+ * identity by email on first sign-in — before the admin shim reads it — which
+ * also makes admin eligibility resolve correctly on that first login.
+ *
+ * When host base URLs are not configured (local dev without
+ * ADMIN_BASE_URL/PORTAL_BASE_URL), fall back to relative paths so the
+ * subdomain rewrite in src/middleware.ts handles routing on a single host.
  */
 
-export const GET: APIRoute = async ({ locals, redirect }) => {
-  const auth = locals.auth()
-  if (!auth.userId) {
-    return redirect('/auth/sign-in', 302)
-  }
+type ClerkUser = NonNullable<Awaited<ReturnType<App.Locals['currentUser']>>>
 
-  // Admin path first — single-admin venture posture, fast path.
-  const adminSession = await resolveAdminSessionFromClerk(auth.userId, env.DB, env.SESSIONS)
-  if (adminSession) {
-    const target = getAdminBaseUrl(env) ? buildAdminUrl(env, '/') : '/admin'
-    return redirect(target, 302)
-  }
-
-  // Client path. Fetch Clerk profile so ensureLocalUser can auto-link
-  // an existing users row by email (UNIQUE(org_id, email) blocks insert
-  // of a duplicate) or JIT-create a new row.
-  const clerkUser = await locals.currentUser()
-  if (!clerkUser) {
-    return redirect('/auth/sign-in', 302)
-  }
-
+/** Extract the email + display name we persist locally from a Clerk user. */
+function clerkProfile(clerkUser: ClerkUser): { email: string; name: string } {
   const email =
     clerkUser.primaryEmailAddress?.emailAddress ?? clerkUser.emailAddresses[0]?.emailAddress ?? ''
   const name =
     [clerkUser.firstName, clerkUser.lastName].filter(Boolean).join(' ').trim() ||
     clerkUser.username ||
     email
+  return { email, name }
+}
 
-  const userRow = await ensureLocalUser(env.DB, auth.userId, { email, name })
-
-  if (userRow.role !== 'client') {
-    // Defense in depth: any unexpected role lands at sign-in. The admin
-    // path already returned above; this branch only catches future role
-    // additions or data drift.
-    return redirect('/auth/sign-in?status=no_subscription', 302)
+export const GET: APIRoute = async ({ locals, redirect, url }) => {
+  const auth = locals.auth()
+  if (!auth.userId) {
+    return redirect('/auth/sign-in', 302)
   }
 
-  // Bound clients land in the portal regardless of which binding path
-  // (users.entity_id or entities.clerk_org_id via auth.orgId) resolves
-  // their entity. resolveClerkPortalContext figures that out per-route;
-  // we just route to portal home and let it render the right state.
-  if (userRow.entity_id || auth.orgId) {
-    const target = getPortalBaseUrl(env) ? buildPortalUrl(env, '/portal') : '/portal'
-    return redirect(target, 302)
+  // Fetch the Clerk profile so ensureLocalUser can auto-link an existing
+  // users row by email (UNIQUE(org_id, email) blocks a duplicate insert) or
+  // JIT-create one. Required for both eligibility checks below.
+  const clerkUser = await locals.currentUser()
+  if (!clerkUser) {
+    return redirect('/auth/sign-in', 302)
   }
 
+  // Link/JIT the local row first; the admin shim then sees the linked row.
+  const userRow = await ensureLocalUser(env.DB, auth.userId, clerkProfile(clerkUser))
+  const adminSession = await resolveAdminSessionFromClerk(auth.userId, env.DB, env.SESSIONS)
+
+  const adminEligible = adminSession !== null
+  // Portal eligibility is binding-based, NOT role-gated: an admin who is also
+  // bound to a customer entity is a legitimate portal (Operator) user. Per
+  // operator-access.ts, in-product authorization keys off product_roles, not
+  // users.role — so we must not exclude an admin from the portal seat here.
+  const portalEligible = Boolean(userRow.entity_id || auth.orgId)
+
+  // Host-aware selection. Fail-safe: any throw falls back to chooseSignedInSurface
+  // with unknown hosts, which yields the admin-first default — so a dispatcher
+  // bug can never strand the sole admin.
+  let surface: 'admin' | 'portal' | 'none'
+  try {
+    surface = chooseSignedInSurface({
+      host: url.hostname,
+      adminHost: hostnameOf(getAdminBaseUrl(env)),
+      portalHost: hostnameOf(getPortalBaseUrl(env)),
+      adminEligible,
+      portalEligible,
+    })
+  } catch {
+    surface = chooseSignedInSurface({
+      host: '',
+      adminHost: null,
+      portalHost: null,
+      adminEligible,
+      portalEligible,
+    })
+  }
+
+  if (surface === 'admin') {
+    return redirect(getAdminBaseUrl(env) ? buildAdminUrl(env, '/') : '/admin', 302)
+  }
+  if (surface === 'portal') {
+    return redirect(getPortalBaseUrl(env) ? buildPortalUrl(env, '/portal') : '/portal', 302)
+  }
   return redirect('/auth/sign-in?status=no_subscription', 302)
 }

--- a/src/pages/portal/index.astro
+++ b/src/pages/portal/index.astro
@@ -297,7 +297,7 @@ const touchpointText: string | null = (() => {
   </head>
   <body class="min-h-screen bg-[color:var(--ss-color-background)]">
     <SkipToMain />
-    <PortalHeader clientName={client.name} />
+    <PortalHeader clientName={client.name} isAdmin={portalData.user.role === 'admin'} />
 
     <PortalTabs pathname={Astro.url.pathname} operatorActive={operatorActive} />
 

--- a/src/pages/portal/products/operator/index.astro
+++ b/src/pages/portal/products/operator/index.astro
@@ -249,7 +249,7 @@ const crTone = crStatus === 'filed' ? 'complete' : 'error'
   </head>
   <body class="min-h-screen bg-[color:var(--ss-color-background)]">
     <SkipToMain />
-    <PortalHeader clientName={client.name} />
+    <PortalHeader clientName={client.name} isAdmin={portalData.user.role === 'admin'} />
 
     <PortalTabs pathname={Astro.url.pathname} operatorActive={subscription !== null} />
 

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -180,6 +180,133 @@ describe('auth: unified sign-in pages', () => {
   })
 })
 
+describe('auth: after-sign-in surface selection (host-aware dual-role dispatch)', () => {
+  const ADMIN = 'admin.smd.services'
+  const PORTAL = 'portal.smd.services'
+
+  it('routes a dual-eligible user to the host they signed in from', async () => {
+    const { chooseSignedInSurface } = await import('../src/lib/auth/after-sign-in-target')
+    const base = { adminHost: ADMIN, portalHost: PORTAL, adminEligible: true, portalEligible: true }
+    expect(chooseSignedInSurface({ ...base, host: PORTAL })).toBe('portal')
+    expect(chooseSignedInSurface({ ...base, host: ADMIN })).toBe('admin')
+  })
+
+  it('falls back to admin-first for a dual-eligible user on the apex/unknown host', async () => {
+    const { chooseSignedInSurface } = await import('../src/lib/auth/after-sign-in-target')
+    expect(
+      chooseSignedInSurface({
+        host: 'smd.services',
+        adminHost: ADMIN,
+        portalHost: PORTAL,
+        adminEligible: true,
+        portalEligible: true,
+      })
+    ).toBe('admin')
+  })
+
+  it('keeps single-role behavior: admin-only → admin even on the portal host', async () => {
+    const { chooseSignedInSurface } = await import('../src/lib/auth/after-sign-in-target')
+    expect(
+      chooseSignedInSurface({
+        host: PORTAL,
+        adminHost: ADMIN,
+        portalHost: PORTAL,
+        adminEligible: true,
+        portalEligible: false,
+      })
+    ).toBe('admin')
+  })
+
+  it('keeps single-role behavior: client-only → portal even on the admin host', async () => {
+    const { chooseSignedInSurface } = await import('../src/lib/auth/after-sign-in-target')
+    expect(
+      chooseSignedInSurface({
+        host: ADMIN,
+        adminHost: ADMIN,
+        portalHost: PORTAL,
+        adminEligible: false,
+        portalEligible: true,
+      })
+    ).toBe('portal')
+  })
+
+  it('returns none when the user qualifies for neither surface', async () => {
+    const { chooseSignedInSurface } = await import('../src/lib/auth/after-sign-in-target')
+    expect(
+      chooseSignedInSurface({
+        host: PORTAL,
+        adminHost: ADMIN,
+        portalHost: PORTAL,
+        adminEligible: false,
+        portalEligible: false,
+      })
+    ).toBe('none')
+  })
+
+  it('ignores host preference when base URLs are unconfigured (local dev)', async () => {
+    const { chooseSignedInSurface } = await import('../src/lib/auth/after-sign-in-target')
+    // No admin/portal host known → host can never match → admin-first default.
+    expect(
+      chooseSignedInSurface({
+        host: 'localhost',
+        adminHost: null,
+        portalHost: null,
+        adminEligible: true,
+        portalEligible: true,
+      })
+    ).toBe('admin')
+  })
+
+  it('hostnameOf parses base URLs and tolerates missing/garbage input', async () => {
+    const { hostnameOf } = await import('../src/lib/auth/after-sign-in-target')
+    expect(hostnameOf('https://admin.smd.services')).toBe('admin.smd.services')
+    expect(hostnameOf('https://portal.smd.services/portal')).toBe('portal.smd.services')
+    expect(hostnameOf(null)).toBeNull()
+    expect(hostnameOf(undefined)).toBeNull()
+    expect(hostnameOf('')).toBeNull()
+    expect(hostnameOf('not a url')).toBeNull()
+  })
+
+  it('dispatcher uses host-aware selection and fails safe to the admin-first default', () => {
+    const source = readFileSync(resolve('src/pages/auth/after-sign-in.ts'), 'utf-8')
+    expect(source).toContain('chooseSignedInSurface')
+    // Fail-safe: the sole admin must never be stranded by a dispatcher throw.
+    expect(source).toContain('try {')
+    expect(source).toContain('catch')
+    // Portal eligibility must be binding-based, not gated on users.role —
+    // an admin bound to a customer entity is a legitimate portal seat.
+    expect(source).toContain('userRow.entity_id || auth.orgId')
+  })
+})
+
+describe('auth: cross-surface switch links', () => {
+  it('admin layout links to the portal Operator view via the absolute portal origin', () => {
+    const source = readFileSync(resolve('src/layouts/AdminLayout.astro'), 'utf-8')
+    expect(source).toContain('buildPortalUrl')
+    expect(source).toContain('/portal/products/operator')
+    expect(source).toContain('Operator (client view)')
+  })
+
+  it('portal header gates the admin-console link behind an isAdmin prop and absolute admin origin', () => {
+    const source = readFileSync(resolve('src/components/portal/PortalHeader.astro'), 'utf-8')
+    expect(source).toContain('isAdmin')
+    expect(source).toContain('buildAdminUrl')
+    expect(source).toContain('Admin console')
+    // Default false so ordinary clients never see the link.
+    expect(source).toContain('isAdmin = false')
+  })
+
+  it('portal entry pages pass the viewer admin status into the header', () => {
+    for (const page of [
+      'src/pages/portal/index.astro',
+      'src/pages/portal/products/operator/index.astro',
+    ]) {
+      const source = readFileSync(resolve(page), 'utf-8')
+      expect(source).toContain("isAdmin={portalData.user.role === 'admin'}")
+    }
+  })
+})
+
 describe('auth: admin dashboard', () => {
   it('admin index page exists', () => {
     expect(existsSync(resolve('src/pages/admin/index.astro'))).toBe(true)


### PR DESCRIPTION
## Problem

Being signed into one surface (`admin.smd.services` or `portal.smd.services`) bounces you to the other. Root cause: the post-sign-in dispatcher (`src/pages/auth/after-sign-in.ts`) checks admin **first** and force-redirects to the admin host, and `<SignIn forceRedirectUrl="/auth/after-sign-in">` fires it on every sign-in visit. A single Clerk identity that is **both** an admin and a customer-seat user — which is exactly SMD operating its own dogfooded Operator from the client seat — can therefore never reach the portal.

## Why the fix is small

The middleware **already** allows a signed-in user on either host (`enforcePortalAuth` allows any `auth.userId`; `enforceAdminAuth` allows `role='admin'`). And Clerk shares the session across root-domain subdomains automatically (verified against Clerk docs — production root-domain deployments share auth across all subdomains; `forceRedirectUrl` ignores `redirect_url`). So once you're on a host you stay authed — the only trap was the sign-in dispatcher.

## Changes

- **Host-aware dispatcher.** `after-sign-in.ts` now honors the subdomain the user signed in from (server-observed; `forceRedirectUrl` is already relative so the dispatcher lands on that host). Decision logic extracted to a pure, env-free, unit-tested module `src/lib/auth/after-sign-in-target.ts`. Portal eligibility is **binding-based, not role-gated** (matches `operator-access.ts`, where in-product authz keys off `product_roles`, not `users.role`), so an admin bound to a customer entity is a legitimate portal seat. **Fail-safe:** any throw falls back to the admin-first default — the sole admin can never be stranded. Single-role users are unaffected.
- **Cross-surface switch links.** "Operator (client view)" in the admin chrome (`AdminLayout.astro`); "Admin console" in the portal header (`PortalHeader.astro`), gated behind an `isAdmin` prop (default `false`) wired at the portal home + Operator landing. Both use the **absolute** cross-host origin (a relative `/admin`÷`/portal` would be mangled by the subdomain rewrite) and hide when the base URL is unconfigured (local dev).

## Not in this PR

- **No middleware / auth-enforcement change.**
- **Provisioning** SMD as its own Operator customer (binding the user to the `smd` entity + an `operator` subscription + a `product_role`) is a separate, prod-data PR (PR2) gated on a live-DB read. Until then, an unprovisioned admin who clicks "Operator (client view)" is gracefully bounced back to admin — no loop.

## Verification

- `npm run verify` green (build + lint 0 errors + 3327 tests).
- Unit tests cover the dual-role host preference, single-role preservation, the `none`/no-subscription case, unconfigured-base-URL (local dev), and `hostnameOf` parsing/garbage handling. Source-level guards assert the dispatcher uses host-aware selection + fail-safe and that the switch links use absolute origins.
- Manual (post-merge / local subdomain dev): signed in, jump admin↔portal via the links with no re-login; sign-in on the portal host lands a dual-eligible user on the portal, admin host lands admin, apex defaults admin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)