### PR TITLE
fix(auth): drop cross-surface switch links — admin and portal are separate products

### DIFF
--- a/src/components/portal/PortalHeader.astro
+++ b/src/components/portal/PortalHeader.astro
@@ -19,33 +19,17 @@
 import SmdLogo from '../SmdLogo.astro'
 import { SignOutButton } from '@clerk/astro/components'
 import { FIRM_CONTACT } from '../../lib/config/firm-contact'
-import { buildAdminUrl, getAdminBaseUrl } from '../../lib/config/app-url'
-import { env } from 'cloudflare:workers'
 
 interface Props {
   clientName: string
-  /**
-   * Render an "Admin console" cross-surface switch link. Only true for an
-   * admin viewing the portal (SMD dogfooding its own Operator from the
-   * customer seat) — pass `portalData.user.role === 'admin'` from the page.
-   * Defaults false so ordinary clients never see it.
-   */
-  isAdmin?: boolean
 }
 
-const { clientName, isAdmin = false } = Astro.props
+const { clientName } = Astro.props
 
 const phoneDigits = FIRM_CONTACT.phone.replace(/[^+\d]/g, '')
 const smsHref = `sms:${phoneDigits}`
 const telHref = `tel:${phoneDigits}`
 const mailtoHref = `mailto:${FIRM_CONTACT.email}`
-
-// Cross-surface switch back to the admin console. Must be the ABSOLUTE admin
-// origin: a relative '/admin' would be mangled by the portal-subdomain rewrite
-// in src/middleware.ts. Hidden when ADMIN_BASE_URL is unconfigured (local dev)
-// or the viewer is not an admin. The Clerk session is shared across subdomains,
-// so this navigates without re-authentication.
-const adminSwitchHref = isAdmin && getAdminBaseUrl(env) ? buildAdminUrl(env, '/') : null
 
 const iconClasses =
   'inline-flex items-center justify-center w-11 h-11 rounded-[var(--ss-radius-button)] text-[color:var(--ss-color-text-secondary)] hover:text-[color:var(--ss-color-primary)] active:text-[color:var(--ss-color-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2'
@@ -65,19 +49,6 @@ const iconClasses =
       </p>
     </div>
     <div class="flex items-center gap-1">
-      {
-        adminSwitchHref && (
-          <a
-            href={adminSwitchHref}
-            class="hidden sm:inline-flex items-center gap-1.5 min-h-11 px-2 mr-1 font-['Archivo_Narrow'] text-xs font-semibold uppercase tracking-[0.12em] text-[color:var(--ss-color-text-secondary)] hover:text-[color:var(--ss-color-primary)] active:text-[color:var(--ss-color-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2"
-          >
-            <span class="material-symbols-outlined text-base" aria-hidden="true">
-              swap_horiz
-            </span>
-            Admin console
-          </a>
-        )
-      }
       <a href={mailtoHref} aria-label="Email us" class={iconClasses}>
         <span class="material-symbols-outlined" aria-hidden="true">mail</span>
       </a>

--- a/src/layouts/AdminLayout.astro
+++ b/src/layouts/AdminLayout.astro
@@ -3,8 +3,6 @@ import '../styles/global.css'
 import SkipToMain from '../components/SkipToMain.astro'
 import SmdLogo from '../components/SmdLogo.astro'
 import { SignOutButton } from '@clerk/astro/components'
-import { buildPortalUrl, getPortalBaseUrl } from '../lib/config/app-url'
-import { env } from 'cloudflare:workers'
 
 interface BreadcrumbItem {
   label: string
@@ -21,17 +19,6 @@ interface Props {
 const { title, breadcrumbs = [], maxWidth = 'max-w-5xl', mainClass = '' } = Astro.props
 const session = Astro.locals.session!
 const pathname = Astro.url.pathname
-
-// Cross-surface switch link to the client portal's Operator view. SMD operates
-// its own dogfooded Operator from the customer seat, so the admin (Scott) needs
-// to jump to the portal without re-authenticating — the Clerk session is shared
-// across subdomains. Must be the ABSOLUTE portal origin: a relative '/portal'
-// would be mangled by the admin-subdomain rewrite in src/middleware.ts. Hidden
-// when PORTAL_BASE_URL is unconfigured (local dev without the var set). An
-// admin who is not yet a provisioned customer is gracefully bounced back here.
-const portalSwitchHref = getPortalBaseUrl(env)
-  ? buildPortalUrl(env, '/portal/products/operator')
-  : null
 
 const navItems = [
   { label: 'Dashboard', href: '/admin', match: (p: string) => p === '/admin' || p === '/admin/' },
@@ -114,19 +101,6 @@ const navItems = [
               })
             }
           </nav>
-          {
-            portalSwitchHref && (
-              <a
-                href={portalSwitchHref}
-                class="inline-flex items-center gap-1.5 min-h-11 px-2 -mx-2 font-['Archivo_Narrow'] text-sm font-semibold uppercase tracking-[0.12em] text-[color:var(--ss-color-text-secondary)] hover:text-[color:var(--ss-color-primary)] active:text-[color:var(--ss-color-primary)] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2"
-              >
-                <span class="material-symbols-outlined text-base" aria-hidden="true">
-                  swap_horiz
-                </span>
-                Operator (client view)
-              </a>
-            )
-          }
           <span class="text-sm text-[color:var(--ss-color-text-muted)]" aria-hidden="true">|</span>
           <span class="text-sm text-[color:var(--ss-color-text-secondary)]">{session.email}</span>
           <SignOutButton asChild redirectUrl="/auth/sign-in?status=signed_out">
@@ -171,19 +145,6 @@ const navItems = [
                 })
               }
             </nav>
-            {
-              portalSwitchHref && (
-                <a
-                  href={portalSwitchHref}
-                  class="flex items-center gap-1.5 px-3 py-2.5 text-sm rounded text-[color:var(--ss-color-text-primary)] hover:bg-[color:var(--ss-color-border-subtle)] active:bg-[color:var(--ss-color-border-subtle)]"
-                >
-                  <span class="material-symbols-outlined text-base" aria-hidden="true">
-                    swap_horiz
-                  </span>
-                  Operator (client view)
-                </a>
-              )
-            }
             <hr class="my-2 border-[color:var(--ss-color-border)]" />
             <p class="px-3 py-1.5 text-xs text-[color:var(--ss-color-text-secondary)] break-all">
               {session.email}

--- a/src/pages/portal/index.astro
+++ b/src/pages/portal/index.astro
@@ -297,7 +297,7 @@ const touchpointText: string | null = (() => {
   </head>
   <body class="min-h-screen bg-[color:var(--ss-color-background)]">
     <SkipToMain />
-    <PortalHeader clientName={client.name} isAdmin={portalData.user.role === 'admin'} />
+    <PortalHeader clientName={client.name} />
 
     <PortalTabs pathname={Astro.url.pathname} operatorActive={operatorActive} />
 

--- a/src/pages/portal/products/operator/index.astro
+++ b/src/pages/portal/products/operator/index.astro
@@ -249,7 +249,7 @@ const crTone = crStatus === 'filed' ? 'complete' : 'error'
   </head>
   <body class="min-h-screen bg-[color:var(--ss-color-background)]">
     <SkipToMain />
-    <PortalHeader clientName={client.name} isAdmin={portalData.user.role === 'admin'} />
+    <PortalHeader clientName={client.name} />
 
     <PortalTabs pathname={Astro.url.pathname} operatorActive={subscription !== null} />
 

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -279,31 +279,22 @@ describe('auth: after-sign-in surface selection (host-aware dual-role dispatch)'
   })
 })
 
-describe('auth: cross-surface switch links', () => {
-  it('admin layout links to the portal Operator view via the absolute portal origin', () => {
+describe('auth: portal products stay decoupled (no cross-surface links)', () => {
+  // The admin console and the client portal are two separate products that
+  // happen to share a login credential. Neither should link into the other
+  // (Captain decision 2026-06-10 — "Amazon doesn't put a Costco button in its
+  // header"). Each is navigated to and operated independently; the host-aware
+  // dispatcher routes each product's own sign-in to that product.
+  it('admin layout does not link into the client portal', () => {
     const source = readFileSync(resolve('src/layouts/AdminLayout.astro'), 'utf-8')
-    expect(source).toContain('buildPortalUrl')
-    expect(source).toContain('/portal/products/operator')
-    expect(source).toContain('Operator (client view)')
+    expect(source).not.toContain('buildPortalUrl')
+    expect(source).not.toContain('Operator (client view)')
   })
 
-  it('portal header gates the admin-console link behind an isAdmin prop and absolute admin origin', () => {
+  it('portal header does not link into the admin console', () => {
     const source = readFileSync(resolve('src/components/portal/PortalHeader.astro'), 'utf-8')
-    expect(source).toContain('isAdmin')
-    expect(source).toContain('buildAdminUrl')
-    expect(source).toContain('Admin console')
-    // Default false so ordinary clients never see the link.
-    expect(source).toContain('isAdmin = false')
-  })
-
-  it('portal entry pages pass the viewer admin status into the header', () => {
-    for (const page of [
-      'src/pages/portal/index.astro',
-      'src/pages/portal/products/operator/index.astro',
-    ]) {
-      const source = readFileSync(resolve(page), 'utf-8')
-      expect(source).toContain("isAdmin={portalData.user.role === 'admin'}")
-    }
+    expect(source).not.toContain('buildAdminUrl')
+    expect(source).not.toContain('Admin console')
   })
 })
 


### PR DESCRIPTION
## Why

Follow-up to #1307. The admin console (`admin.smd.services`) and the client portal (`portal.smd.services`) are **two distinct products** that happen to share a login credential — like signing into Amazon and Costco with the same email. Neither should link into the other.

#1307 added "Operator (client view)" / "Admin console" switch links, which coupled the two and implied a single dual-hat surface. That's the wrong model (and the same shape as the earlier mistake of treating customer-zero specially instead of like a real client).

## What this does

- Removes both switch links + the `isAdmin` prop plumbing on `PortalHeader` and the now-unused `app-url`/`env` imports in `AdminLayout` and `PortalHeader`.
- **Keeps** the host-aware `after-sign-in` dispatcher — this is what makes signing in *on the client portal* land you *in the client portal* (instead of being trumped to admin), so each product owns its own sign-in landing.
- **Keeps** the SMD client provisioning (you are a real `principal` on the SMD Services entity).

## Resulting behavior

Navigate to each portal independently; both can be open and operated at the same time. One sign-in covers both (shared Clerk session across subdomains), and each surface uses its own authority — admin role on admin, client `principal` on the portal. No cross-links, no coupling.

## Verification
`npm run verify` green (build + lint 0 errors + tests). New guard tests assert neither chrome links into the other surface; the dispatcher tests from #1307 are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)