### PR TITLE
feat(operator): repeatable customer.yaml → customer_configs projection (#1308)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ operator/safety-substrate/logs/
 **/*.egg-info/
 __pycache__/
 *.py[cod]
+
+# Generated projection SQL (scripts/project-customer-config.ts)
+scripts/.generated/

--- a/scripts/project-customer-config.ts
+++ b/scripts/project-customer-config.ts
@@ -1,0 +1,167 @@
+#!/usr/bin/env tsx
+/**
+ * Project a customer.yaml into the portal `customer_configs` D1 row (ADR 0012).
+ *
+ * This is the repeatable, git-sourced projection the portal read replica is
+ * built from — NOT a hand-seed (hand-edited customer_configs rows are forbidden
+ * by ADR 0012). It reuses the canonical mapper at
+ * src/lib/portal/customer-config-projection.ts (the future CI pipeline must
+ * import the same mapper), validates with the canonical schema validator, and
+ * emits an idempotent .sql file applied via `wrangler d1 execute --file`.
+ *
+ * Usage:
+ *   npx tsx scripts/project-customer-config.ts <slug> <entity_id> \
+ *     [--org-id=<org>] [--actor=<email>] [--out=<path>] [--apply-local]
+ *
+ * It NEVER writes to remote D1. For the gated prod apply, run by hand after a
+ * local dry-run:
+ *   npx wrangler d1 execute ss-console-db --remote --file=<out>
+ *
+ * Exit codes:
+ *   0 — SQL emitted (and applied to local D1 when --apply-local)
+ *   1 — schema validation errors
+ *   2 — file not readable / not parseable YAML
+ *   3 — git provenance guard failed (dirty tree or file never committed)
+ */
+
+import { execFileSync } from 'node:child_process'
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { parse as parseYaml } from 'yaml'
+
+import { validate } from '../src/lib/operator/customer-yaml'
+import {
+  buildProjectionSql,
+  projectCustomerYamlToConfigRow,
+} from '../src/lib/portal/customer-config-projection'
+import { ORG_ID } from '../src/lib/constants'
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+
+function fail(code: number, message: string): never {
+  process.stderr.write(`${message}\n`)
+  process.exit(code)
+}
+
+interface Args {
+  slug: string
+  entityId: string
+  orgId: string
+  actor: string
+  out: string
+  applyLocal: boolean
+}
+
+function parseArgs(argv: string[]): Args {
+  const positional: string[] = []
+  const flags = new Map<string, string>()
+  let applyLocal = false
+  for (const arg of argv) {
+    if (arg === '--apply-local') applyLocal = true
+    else if (arg.startsWith('--')) {
+      const [k, v] = arg.slice(2).split('=')
+      flags.set(k, v ?? '')
+    } else positional.push(arg)
+  }
+  const [slug, entityId] = positional
+  if (!slug || !entityId) {
+    fail(
+      2,
+      'Usage: project-customer-config.ts <slug> <entity_id> [--org-id=] [--actor=] [--out=] [--apply-local]'
+    )
+  }
+  return {
+    slug,
+    entityId,
+    orgId: flags.get('org-id') || ORG_ID,
+    actor: flags.get('actor') || 'scott@smd.services',
+    out: flags.get('out') || join(REPO_ROOT, 'scripts/.generated', `project-${slug}.sql`),
+    applyLocal,
+  }
+}
+
+/**
+ * ADR 0012 provenance guard: the row's git_sha must faithfully name the
+ * committed bytes that were projected. A dirty worktree (uncommitted edits to
+ * the yaml) or an uncommitted file would record a SHA whose content differs
+ * from what we projected — silent provenance corruption. Hard-fail instead.
+ */
+function resolveGitSha(relPath: string): string {
+  const dirty = execFileSync('git', ['status', '--porcelain', '--', relPath], {
+    cwd: REPO_ROOT,
+    encoding: 'utf-8',
+  }).trim()
+  if (dirty) {
+    fail(
+      3,
+      `Refusing to project: ${relPath} has uncommitted changes. Commit it first so git_sha names the projected bytes.`
+    )
+  }
+  const sha = execFileSync('git', ['log', '-1', '--format=%H', '--', relPath], {
+    cwd: REPO_ROOT,
+    encoding: 'utf-8',
+  }).trim()
+  if (!sha) fail(3, `Refusing to project: ${relPath} has no commit history.`)
+  return sha
+}
+
+function main(): void {
+  const args = parseArgs(process.argv.slice(2))
+  const relPath = `operator/customers/${args.slug}/customer.yaml`
+  const absPath = join(REPO_ROOT, relPath)
+  if (!existsSync(absPath)) fail(2, `Not found: ${relPath}`)
+
+  const gitSha = resolveGitSha(relPath)
+
+  let parsed: unknown
+  try {
+    parsed = parseYaml(readFileSync(absPath, 'utf-8'))
+  } catch (err) {
+    fail(2, `Could not parse YAML: ${err instanceof Error ? err.message : String(err)}`)
+  }
+
+  const result = validate(parsed)
+  if (!result.ok) {
+    const lines = result.errors.map((e) => `  [${e.code}] ${e.path}: ${e.message}`).join('\n')
+    fail(1, `customer.yaml failed validation:\n${lines}`)
+  }
+
+  const row = projectCustomerYamlToConfigRow(result.value, {
+    entityId: args.entityId,
+    orgId: args.orgId,
+    gitSha,
+    syncedAt: new Date().toISOString(),
+  })
+
+  const sql = buildProjectionSql(row, args.actor)
+  mkdirSync(dirname(args.out), { recursive: true })
+  writeFileSync(args.out, sql, 'utf-8')
+
+  process.stdout.write(`Wrote projection SQL → ${args.out}\n`)
+  process.stdout.write(
+    `  customer_slug=${row.customer_slug} entity_id=${row.entity_id} git_sha=${gitSha}\n\n`
+  )
+
+  if (args.applyLocal) {
+    process.stdout.write('Applying to LOCAL D1 (dry-run)...\n')
+    execFileSync(
+      'npx',
+      ['wrangler', 'd1', 'execute', 'ss-console-db', '--local', `--file=${args.out}`],
+      {
+        cwd: REPO_ROOT,
+        stdio: 'inherit',
+      }
+    )
+  } else {
+    process.stdout.write('Next:\n')
+    process.stdout.write(
+      `  Dry-run (local):  npx wrangler d1 execute ss-console-db --local  --file=${args.out}\n`
+    )
+    process.stdout.write(
+      `  Apply (PROD):     npx wrangler d1 execute ss-console-db --remote --file=${args.out}\n`
+    )
+  }
+}
+
+main()

--- a/src/lib/portal/customer-config-projection.ts
+++ b/src/lib/portal/customer-config-projection.ts
@@ -1,0 +1,183 @@
+/**
+ * Forward projection: validated `customer.yaml` → the `customer_configs` D1 row.
+ *
+ * This is the **canonical mapper** for the ADR 0012 projection (git source of
+ * truth → portal D1 read replica). The future CI sync pipeline (out of scope
+ * here; tracked on #1308) MUST import this function rather than author a second
+ * mapping — the read side (`projectRow` in ./customer-config.ts) and this write
+ * side must stay exact inverses.
+ *
+ * Kept pure and env-free (no `cloudflare:workers`) so it is unit-testable and
+ * importable from both a Node script (scripts/project-customer-config.ts) and a
+ * future Worker/CI context.
+ *
+ * Critical correctness invariant (see the #1308 critique): the portal reads
+ * `personas_json` with `parseJsonRequired`, which THROWS on a shape mismatch —
+ * a subtly-wrong row turns a safe "being configured" empty state into a 500 on
+ * the live client portal. Two defenses live here:
+ *   1. `personas_json` is narrowed to the exact read-side `PersonaConfig` shape
+ *      (skills reduced to `{name, trust_ceiling}`).
+ *   2. Every nullable field is normalized to `null` (never left `undefined`),
+ *      so `JSON.stringify` cannot silently DROP a key the reader expects.
+ */
+
+import type { CustomerYaml, Persona } from '../operator/customer-yaml/types'
+import type { CustomerConfigDbRow, PersonaConfig } from './customer-config'
+
+export interface ProjectionContext {
+  /** The local entities.id this customer maps to (customer_configs PK). */
+  entityId: string
+  /** Owning organizations.id. */
+  orgId: string
+  /** Commit SHA of the customer.yaml the projection was built from (ADR 0012). */
+  gitSha: string
+  /** ISO-8601 timestamp the projection ran. */
+  syncedAt: string
+}
+
+/**
+ * Narrow a full schema `Persona` to the read-side `PersonaConfig`. Drops the
+ * fields the portal projection does not surface (version, action_ceilings,
+ * enabled, cost_estimate, scope, bundles, cron, avatar, pronouns, overrides)
+ * and reduces each skill to `{name, trust_ceiling}`. Nullable scalars are
+ * coerced to `null` so the serialized JSON always carries the key.
+ */
+function toPersonaConfig(p: Persona): PersonaConfig {
+  return {
+    slug: p.slug,
+    status: p.status,
+    name: p.name,
+    title: p.title ?? null,
+    signature_html: p.signature_html ?? null,
+    tone: p.tone ?? [],
+    send_as: p.send_as ?? null,
+    skills: (p.skills ?? []).map((s) => ({ name: s.name, trust_ceiling: s.trust_ceiling })),
+    channel_bindings: (p.channel_bindings ?? []).map((c) => ({
+      integration: c.integration,
+      channels: c.channels ?? [],
+    })),
+  }
+}
+
+/**
+ * Project a validated `CustomerYaml` into the `customer_configs` DB row shape
+ * (`CustomerConfigDbRow`) — JSON columns serialized, `compliance_enabled` as
+ * 0/1, nullable columns as `null` when the source field is absent.
+ *
+ * The output is exactly what `projectRow` consumes on read, so a round-trip
+ * `projectRow(projectCustomerYamlToConfigRow(yaml, ctx))` must never throw.
+ */
+export function projectCustomerYamlToConfigRow(
+  yaml: CustomerYaml,
+  ctx: ProjectionContext
+): CustomerConfigDbRow {
+  const personas: PersonaConfig[] = yaml.personas.map(toPersonaConfig)
+
+  return {
+    entity_id: ctx.entityId,
+    org_id: ctx.orgId,
+    customer_slug: yaml.customer_id,
+    schema_version: String(yaml.schema_version),
+    // Required, throwing column — narrowed to the exact read-side shape.
+    personas_json: JSON.stringify(personas),
+    // Nullable opaque columns: serialize when present, else explicit null.
+    voice_library_json: yaml.voice_library ? JSON.stringify(yaml.voice_library) : null,
+    escalation_json: yaml.escalation ? JSON.stringify(yaml.escalation) : null,
+    business_hours_json: yaml.business_hours ? JSON.stringify(yaml.business_hours) : null,
+    connectors_json: yaml.connectors ? JSON.stringify(yaml.connectors) : null,
+    scope_json: yaml.scope ? JSON.stringify(yaml.scope) : null,
+    // Absent compliance_enabled MUST become 0, never NaN.
+    compliance_enabled: yaml.compliance_enabled === true ? 1 : 0,
+    vertical: yaml.vertical ?? null,
+    // authority is always non-null on a validated CustomerYaml; guard anyway.
+    authority_json: yaml.authority ? JSON.stringify(yaml.authority) : null,
+    credential_custody_default: yaml.credential_custody_default ?? null,
+    git_sha: ctx.gitSha,
+    synced_at: ctx.syncedAt,
+  }
+}
+
+/**
+ * Escape a string into a SQLite single-quoted literal (doubling embedded
+ * single-quotes), or `NULL`. The projected JSON columns carry arbitrary
+ * authored content (HTML in `signature_html`, apostrophes in names, free-form
+ * tone strings), so values MUST be applied via `wrangler d1 execute --file`
+ * with literals escaped this way — never interpolated into a `--command`
+ * string, where a stray quote corrupts the row or the statement.
+ */
+export function escapeSqlLiteral(v: string | null): string {
+  if (v === null) return 'NULL'
+  return `'${v.replace(/'/g, "''")}'`
+}
+
+const CONFIG_COLUMNS = [
+  'entity_id',
+  'org_id',
+  'customer_slug',
+  'schema_version',
+  'personas_json',
+  'voice_library_json',
+  'escalation_json',
+  'business_hours_json',
+  'connectors_json',
+  'scope_json',
+  'compliance_enabled',
+  'vertical',
+  'authority_json',
+  'credential_custody_default',
+  'git_sha',
+  'synced_at',
+] as const
+
+/**
+ * Build the idempotent `.sql` text for a projected row: an UPSERT into
+ * `customer_configs` (re-projection overwrites every column but the PK) plus a
+ * `customer_config_history` event that mirrors `recordCustomerConfigSync` —
+ * `prev_git_sha` = the slug's latest recorded sha, and the insert is skipped
+ * when this exact sha is already recorded (the no-op guard). `synced_by` is
+ * `'manual'` because a human runs this under Captain approval.
+ */
+export function buildProjectionSql(row: CustomerConfigDbRow, actor: string): string {
+  const e = escapeSqlLiteral
+  const values: string[] = [
+    e(row.entity_id),
+    e(row.org_id),
+    e(row.customer_slug),
+    e(row.schema_version),
+    e(row.personas_json),
+    e(row.voice_library_json),
+    e(row.escalation_json),
+    e(row.business_hours_json),
+    e(row.connectors_json),
+    e(row.scope_json),
+    String(row.compliance_enabled),
+    e(row.vertical),
+    e(row.authority_json),
+    e(row.credential_custody_default),
+    e(row.git_sha),
+    e(row.synced_at),
+  ]
+  const updates = CONFIG_COLUMNS.filter((c) => c !== 'entity_id')
+    .map((c) => `  ${c} = excluded.${c}`)
+    .join(',\n')
+  const slug = e(row.customer_slug)
+  const sha = e(row.git_sha)
+
+  return `-- Generated by scripts/project-customer-config.ts — do not hand-edit.
+-- customer.yaml projection for customer_slug=${row.customer_slug} (git_sha ${row.git_sha}).
+
+INSERT INTO customer_configs (${CONFIG_COLUMNS.join(', ')})
+VALUES (${values.join(', ')})
+ON CONFLICT(entity_id) DO UPDATE SET
+${updates};
+
+INSERT INTO customer_config_history
+  (customer_slug, git_sha, synced_at, synced_by, actor, prev_git_sha, r2_shadow_key)
+SELECT ${slug}, ${sha}, ${e(row.synced_at)}, 'manual', ${e(actor)},
+  (SELECT git_sha FROM customer_config_history WHERE customer_slug = ${slug} ORDER BY id DESC LIMIT 1),
+  NULL
+WHERE NOT EXISTS (
+  SELECT 1 FROM customer_config_history WHERE customer_slug = ${slug} AND git_sha = ${sha}
+);
+`
+}

--- a/src/lib/portal/customer-config.ts
+++ b/src/lib/portal/customer-config.ts
@@ -103,7 +103,7 @@ export interface CustomerConfigRow {
   synced_at: string
 }
 
-interface CustomerConfigDbRow {
+export interface CustomerConfigDbRow {
   entity_id: string
   org_id: string
   customer_slug: string
@@ -153,7 +153,7 @@ function parseJsonRequired<T>(value: string, column: string, entityId: string): 
   }
 }
 
-function projectRow(row: CustomerConfigDbRow): CustomerConfigRow {
+export function projectRow(row: CustomerConfigDbRow): CustomerConfigRow {
   return {
     entity_id: row.entity_id,
     org_id: row.org_id,

--- a/tests/customer-config-projection.test.ts
+++ b/tests/customer-config-projection.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { parse as parseYaml } from 'yaml'
+
+import { validate } from '../src/lib/operator/customer-yaml'
+import type { CustomerYaml } from '../src/lib/operator/customer-yaml/types'
+import {
+  projectCustomerYamlToConfigRow,
+  buildProjectionSql,
+  escapeSqlLiteral,
+} from '../src/lib/portal/customer-config-projection'
+import { projectRow, type PersonaConfig } from '../src/lib/portal/customer-config'
+
+const CTX = {
+  entityId: 'entity-123',
+  orgId: 'org-123',
+  gitSha: 'abc123def456',
+  syncedAt: '2026-06-10T18:00:00.000Z',
+}
+
+/** Load + validate the live smd customer.yaml as a realistic base fixture. */
+function smdYaml(): CustomerYaml {
+  const parsed = parseYaml(readFileSync(resolve('operator/customers/smd/customer.yaml'), 'utf-8'))
+  const result = validate(parsed)
+  if (!result.ok) {
+    throw new Error('smd customer.yaml failed validation: ' + JSON.stringify(result.errors))
+  }
+  return result.value
+}
+
+/** Simulate SQLite's single-quote unescaping of a literal produced by escapeSqlLiteral. */
+function unescapeSqlLiteral(literal: string): string | null {
+  if (literal === 'NULL') return null
+  return literal.slice(1, -1).replace(/''/g, "'")
+}
+
+describe('customer-config projection: real smd yaml', () => {
+  it('round-trips through the read-side projectRow without throwing', () => {
+    const row = projectCustomerYamlToConfigRow(smdYaml(), CTX)
+    expect(() => projectRow(row)).not.toThrow()
+    const config = projectRow(row)
+    expect(config.customer_slug).toBe('smd')
+    expect(config.vertical).toBe('mixed')
+    expect(config.entity_id).toBe('entity-123')
+  })
+
+  it('absent compliance_enabled projects to 0 (never NaN)', () => {
+    const row = projectCustomerYamlToConfigRow(smdYaml(), CTX)
+    expect(row.compliance_enabled).toBe(0)
+  })
+
+  it('narrows personas to the read-side PersonaConfig shape (skills = {name, trust_ceiling})', () => {
+    const row = projectCustomerYamlToConfigRow(smdYaml(), CTX)
+    const personas = JSON.parse(row.personas_json) as PersonaConfig[]
+    const crane = personas.find((p) => p.slug === 'crane')
+    expect(crane).toBeDefined()
+    expect(crane!.name).toBe('Crane')
+    expect(crane!.skills.length).toBeGreaterThan(0)
+    for (const skill of crane!.skills) {
+      // Exactly the two read-side keys — no version/enabled/action_ceilings leak.
+      expect(Object.keys(skill).sort()).toEqual(['name', 'trust_ceiling'])
+    }
+  })
+
+  it('authority + credential custody survive the read-side resolvers', () => {
+    const config = projectRow(projectCustomerYamlToConfigRow(smdYaml(), CTX))
+    expect(config.authority).toBeDefined()
+    expect(config.credential_custody_default).toBeTruthy()
+  })
+})
+
+describe('customer-config projection: null normalization', () => {
+  it('serializes absent nullable persona fields as JSON null (key present, not dropped)', () => {
+    const yaml = smdYaml()
+    // Force the nullable fields undefined to prove they normalize to null.
+    yaml.personas[0] = {
+      ...yaml.personas[0],
+      title: undefined as unknown as string | null,
+      signature_html: undefined as unknown as string | null,
+      send_as: undefined as unknown as null,
+    }
+    const row = projectCustomerYamlToConfigRow(yaml, CTX)
+    // The raw JSON text must contain explicit nulls, not omit the keys.
+    expect(row.personas_json).toContain('"title":null')
+    expect(row.personas_json).toContain('"signature_html":null')
+    expect(row.personas_json).toContain('"send_as":null')
+    const personas = JSON.parse(row.personas_json) as PersonaConfig[]
+    expect(personas[0]).toHaveProperty('title', null)
+    expect(personas[0]).toHaveProperty('signature_html', null)
+    expect(personas[0]).toHaveProperty('send_as', null)
+    expect(() => projectRow(row)).not.toThrow()
+  })
+
+  it('compliance_enabled true projects to 1', () => {
+    const yaml = smdYaml()
+    yaml.compliance_enabled = true
+    expect(projectCustomerYamlToConfigRow(yaml, CTX).compliance_enabled).toBe(1)
+  })
+})
+
+describe('customer-config projection: SQL escaping (adversarial characters)', () => {
+  const ADVERSARIAL = `O'Brien said "hi"; <script>alert(1)</script>\nline2 -- not a comment`
+
+  it('escapeSqlLiteral is lossless through a simulated SQLite unescape', () => {
+    for (const v of [ADVERSARIAL, "''", "a'b'c", 'plain', '']) {
+      expect(unescapeSqlLiteral(escapeSqlLiteral(v))).toBe(v)
+    }
+    expect(escapeSqlLiteral(null)).toBe('NULL')
+    expect(unescapeSqlLiteral('NULL')).toBeNull()
+  })
+
+  it('adversarial signature_html survives projection + escape + unescape + parse', () => {
+    const yaml = smdYaml()
+    yaml.personas[0] = {
+      ...yaml.personas[0],
+      signature_html: ADVERSARIAL,
+      tone: ["it's", 'a "quote"', 'semi;colon'],
+    }
+    const row = projectCustomerYamlToConfigRow(yaml, CTX)
+    // Round-trip the escaped JSON literal back to the JSON, then parse it.
+    const recovered = unescapeSqlLiteral(escapeSqlLiteral(row.personas_json))
+    expect(recovered).toBe(row.personas_json)
+    const personas = JSON.parse(recovered!) as PersonaConfig[]
+    expect(personas[0].signature_html).toBe(ADVERSARIAL)
+    expect(personas[0].tone).toEqual(["it's", 'a "quote"', 'semi;colon'])
+  })
+})
+
+describe('customer-config projection: SQL document', () => {
+  it('builds an idempotent UPSERT + a guarded manual history event', () => {
+    const sql = buildProjectionSql(
+      projectCustomerYamlToConfigRow(smdYaml(), CTX),
+      'scott@smd.services'
+    )
+    expect(sql).toContain('INSERT INTO customer_configs')
+    expect(sql).toContain('ON CONFLICT(entity_id) DO UPDATE SET')
+    expect(sql).toContain('INSERT INTO customer_config_history')
+    expect(sql).toContain("'manual'")
+    // No-op guard + prev_git_sha lineage.
+    expect(sql).toContain('WHERE NOT EXISTS')
+    expect(sql).toContain('ORDER BY id DESC LIMIT 1')
+  })
+})


### PR DESCRIPTION
## Why

Client-portal Operator surfaces read `customer_configs` (the ADR 0012 projection of `customer.yaml`). No row existed for `smd` and the projection pipeline was never built, so those surfaces render a "being configured" empty state. This ships the canonical, **repeatable** projection — not a hand-seed (ADR 0012 forbids hand-edited rows).

Closes the code half of #1308. Running it for `smd` (gated prod write) and CI automation are tracked follow-ups.

## What

- **`src/lib/portal/customer-config-projection.ts`** — pure, env-free mapper `projectCustomerYamlToConfigRow(yaml, ctx)`, the exact inverse of the read-side `projectRow`. `personas_json` narrowed to the read-side `PersonaConfig` shape (`skills` → `{name, trust_ceiling}`); **every nullable field normalized to `null`** so `JSON.stringify` never drops a key the reader's `parseJsonRequired` would throw on. Plus `escapeSqlLiteral` + `buildProjectionSql` (UPSERT + a history event mirroring `recordCustomerConfigSync` — no-op guard + `prev_git_sha` lineage, `synced_by='manual'`). **The future CI pipeline must import this mapper — no second mapping implementation.**
- **`scripts/project-customer-config.ts`** — reads `operator/customers/<slug>/customer.yaml`, **hard-fails on a dirty/uncommitted tree** (the `git_sha` must name the projected bytes — ADR 0012 provenance), validates via the canonical validator, emits an **idempotent `.sql` file** applied with `wrangler d1 execute --file` (never `--command`, which would corrupt HTML/quoted content). **Never writes remote D1.**
- Exported `projectRow` + `CustomerConfigDbRow` for reuse.

## Why it's safe

Today's empty state is *safe*; a subtly-wrong projection would make `parseJsonRequired(personas_json)` **throw at render → 500 on the live client portal**. Guards:
- Mapper narrows personas to the exact read shape and normalizes `undefined`→`null`.
- Test feeds the projection of the **real `smd` yaml** back through `projectRow` and asserts no throw — plus null-normalization, adversarial-character SQL-escape round-trips (`'`, `"`, `;`, newline, `</script>`), and `compliance_enabled` 0/1.
- The script's dirty-tree guard prevents recording a `git_sha` whose committed bytes differ from what was projected.

## Verification
- `npm run verify` green (build + lint 0 errors + new projection suite).
- `npx tsx scripts/project-customer-config.ts smd <entity_id>` fails on a dirty tree; on a clean tree emits faithful SQL (personas narrowed, connectors defaulted, authority/credential resolved, no-op history guard).
- Part B (separate, gated): local-D1 dry-run exercising the read path → prod apply with Captain approval → portal renders authored config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)