### PR TITLE
feat(admin): service spine load-bearing — write-gap + reconciliation (ADR 0046 Stage 1b)

### DIFF
--- a/src/lib/db/engagements.ts
+++ b/src/lib/db/engagements.ts
@@ -14,6 +14,13 @@ export interface Engagement {
   org_id: string
   entity_id: string
   quote_id: string
+  /**
+   * Parent `service` spine row (ADR 0046). Added by migration 0068 and set by
+   * every creation path (SOW finalize + `createEngagement`). Nullable only for
+   * historical safety — a NULL here on an in-flight engagement is a spine-drift
+   * corruption surfaced by `findConsultingSpineDrift` in `db/services.ts`.
+   */
+  service_id: string | null
   scope_summary: string | null
   start_date: string | null
   estimated_end: string | null
@@ -204,6 +211,15 @@ export async function getEngagement(
 
 /**
  * Create a new engagement. Returns the created engagement record.
+ *
+ * ADR 0046: every engagement is a delivery child of a `service` spine row.
+ * This path creates both in one atomic `db.batch([...])` — the consulting
+ * service parent (born `active`, since `projectConsultingStatus('scheduled')`
+ * is `active`) and the engagement carrying `service_id`. The service INSERT is
+ * inlined (not via the `createService` DAL, which does its own INSERT+SELECT)
+ * so it stays inside the same atomic batch, exactly like the SOW finalize hook
+ * (`src/lib/sow/service-finalize.ts` `buildCoreStmts`). Signal resolution is an
+ * independent read and stays outside the batch.
  */
 export async function createEngagement(
   db: D1Database,
@@ -211,6 +227,9 @@ export async function createEngagement(
   data: CreateEngagementData
 ): Promise<Engagement> {
   const id = crypto.randomUUID()
+  // 'svc_' prefix is the shared invariant with the backfill (migrations
+  // 0069/0070) and the SOW hook — every service id carries it.
+  const serviceId = `svc_${crypto.randomUUID()}`
   const now = new Date().toISOString()
 
   // Resolve originating-signal attribution (#589). `undefined` means "use
@@ -222,25 +241,33 @@ export async function createEngagement(
       ? await getDefaultOriginatingSignalId(db, orgId, data.entity_id)
       : data.originating_signal_id
 
-  await db
-    .prepare(
-      `INSERT INTO engagements (id, org_id, entity_id, quote_id, scope_summary, start_date, estimated_end, status, estimated_hours, originating_signal_id, created_at, updated_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, 'scheduled', ?, ?, ?, ?)`
-    )
-    .bind(
-      id,
-      orgId,
-      data.entity_id,
-      data.quote_id,
-      data.scope_summary ?? null,
-      data.start_date ?? null,
-      data.estimated_end ?? null,
-      data.estimated_hours ?? null,
-      originatingSignalId,
-      now,
-      now
-    )
-    .run()
+  await db.batch([
+    db
+      .prepare(
+        `INSERT INTO services (id, org_id, entity_id, quote_id, type, cadence, status, started_at, created_at, updated_at)
+         VALUES (?, ?, ?, ?, 'consulting', 'one_time', 'active', ?, ?, ?)`
+      )
+      .bind(serviceId, orgId, data.entity_id, data.quote_id, now, now, now),
+    db
+      .prepare(
+        `INSERT INTO engagements (id, org_id, entity_id, quote_id, service_id, scope_summary, start_date, estimated_end, status, estimated_hours, originating_signal_id, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'scheduled', ?, ?, ?, ?)`
+      )
+      .bind(
+        id,
+        orgId,
+        data.entity_id,
+        data.quote_id,
+        serviceId,
+        data.scope_summary ?? null,
+        data.start_date ?? null,
+        data.estimated_end ?? null,
+        data.estimated_hours ?? null,
+        originatingSignalId,
+        now,
+        now
+      ),
+  ])
 
   const engagement = await getEngagement(db, orgId, id)
   if (!engagement) {

--- a/src/lib/db/services.ts
+++ b/src/lib/db/services.ts
@@ -13,6 +13,22 @@
  * INLINES its own `INSERT INTO services` rather than calling `createService` —
  * it must stay inside one atomic `db.batch([...])`. Do NOT "DRY" the two
  * together; that would break the atomic engagement+invoice+service creation.
+ *
+ * READ-MIGRATION STATUS (ADR 0046, as of Stage 1b):
+ * - Consulting services have a real forward writer (SOW finalize + the manual
+ *   `createEngagement` path), so the consulting spine is authoritative. Stage 1b
+ *   makes it READ + self-validating via `findConsultingSpineDrift` below; the
+ *   full render-migration of the admin surfaces (client hub, services list) is
+ *   deferred to Stage 3 so it lands once for BOTH delivery types together.
+ * - Operator services currently have NO forward writer — the Stage 1 backfill
+ *   (migration 0070) sourced them from the legacy `subscriptions` table (no
+ *   `INSERT` in src; pre-Hermes-realignment), while the live operator registry
+ *   is `customer_configs` (src/lib/portal/customer-config-projection.ts). So the
+ *   operator UI still reads `customer_configs`/the fleet roster, NOT this spine.
+ *   Operator-service creation on provisioning is Stage 3 (bounded by ADR 0012);
+ *   only then does the operator UI migrate to the spine. Do not iterate the
+ *   operator spine for display before that — it would silently drop any operator
+ *   provisioned after the backfill.
  */
 
 export interface Service {
@@ -221,4 +237,93 @@ export async function updateServiceStatus(
     .run()
 
   return getService(db, orgId, serviceId)
+}
+
+// ===========================================================================
+// Spine reconciliation (ADR 0046, Stage 1b)
+// ===========================================================================
+
+/** A consulting engagement that has no valid parent service row. */
+export interface OrphanEngagement {
+  id: string
+  status: string
+  /** NULL (never linked) or a dangling id pointing at no service row. */
+  service_id: string | null
+}
+
+/** An active consulting service that has no delivery child. */
+export interface ChildlessService {
+  id: string
+  status: string
+}
+
+/**
+ * The two ways the consulting spine ↔ child invariant can break. Both lists
+ * empty is the healthy state (the normal case).
+ */
+export interface ConsultingSpineDrift {
+  /** In-flight engagements whose `service_id` is NULL or points at no service. */
+  orphanEngagements: OrphanEngagement[]
+  /** Active consulting services with no engagement pointing back at them. */
+  childlessServices: ChildlessService[]
+}
+
+/** In-flight consulting engagement statuses — those expected to have a live parent. */
+const IN_FLIGHT_ENGAGEMENT_STATUSES = ['scheduled', 'active', 'handoff', 'safety_net']
+
+/**
+ * Reconcile the consulting spine against its engagement children (ADR 0046,
+ * Stage 1b). This is the READ that makes the otherwise write-only spine
+ * load-bearing: the services list calls it on every load and surfaces drift,
+ * so any future code path that creates an engagement without a service (or a
+ * service without an engagement) fails loud instead of rotting silently.
+ *
+ * Scoped to consulting only — operator services have no forward writer yet
+ * (see the file header), so reconciling them would flag false positives.
+ */
+export async function findConsultingSpineDrift(
+  db: D1Database,
+  orgId: string
+): Promise<ConsultingSpineDrift> {
+  const placeholders = IN_FLIGHT_ENGAGEMENT_STATUSES.map(() => '?').join(', ')
+
+  const [orphans, childless] = await Promise.all([
+    db
+      .prepare(
+        `SELECT e.id, e.status, e.service_id
+           FROM engagements e
+          WHERE e.org_id = ?
+            AND e.status IN (${placeholders})
+            AND (
+              e.service_id IS NULL
+              OR e.service_id NOT IN (SELECT s.id FROM services s WHERE s.org_id = ?)
+            )`
+      )
+      .bind(orgId, ...IN_FLIGHT_ENGAGEMENT_STATUSES, orgId)
+      .all<OrphanEngagement>(),
+    db
+      .prepare(
+        `SELECT s.id, s.status
+           FROM services s
+          WHERE s.org_id = ?
+            AND s.type = 'consulting'
+            AND s.status = 'active'
+            AND s.id NOT IN (
+              SELECT e.service_id FROM engagements e
+               WHERE e.org_id = ? AND e.service_id IS NOT NULL
+            )`
+      )
+      .bind(orgId, orgId)
+      .all<ChildlessService>(),
+  ])
+
+  return {
+    orphanEngagements: orphans.results,
+    childlessServices: childless.results,
+  }
+}
+
+/** True when either drift class is non-empty. */
+export function hasSpineDrift(drift: ConsultingSpineDrift): boolean {
+  return drift.orphanEngagements.length > 0 || drift.childlessServices.length > 0
 }

--- a/src/pages/admin/services/index.astro
+++ b/src/pages/admin/services/index.astro
@@ -3,9 +3,12 @@
  * Services — the global, cross-client delivery list (ADR 0046).
  *
  * Every in-flight service across all clients, both kinds, risk-sorted.
- * Composed view-side from engagements + operators (the `service` spine is
- * deferred). Consulting rows drill to the client hub; operator rows to the
- * cockpit.
+ * The render is still composed view-side from engagements + operators; the
+ * full render-migration onto the `service` spine is Stage 3 (done once for
+ * both delivery types). Stage 1b adds one spine READ — `findConsultingSpineDrift`
+ * — that validates the consulting spine ↔ engagement invariant on every load
+ * and surfaces a warning strip on drift, so the spine is no longer write-only.
+ * Consulting rows drill to the client hub; operator rows to the cockpit.
  */
 import AdminLayout from '../../../layouts/AdminLayout.astro'
 import { listEngagements } from '../../../lib/db/engagements'
@@ -20,17 +23,22 @@ import {
   type OperatorInput,
 } from '../../../lib/admin/services-list'
 import { serviceToneDotClass } from '../../../lib/admin/client-hub'
+import { findConsultingSpineDrift, hasSpineDrift } from '../../../lib/db/services'
 import { env } from 'cloudflare:workers'
 
 const session = Astro.locals.session!
 
-const [engagements, entities, quotes, roster, runtime] = await Promise.all([
+const [engagements, entities, quotes, roster, runtime, spineDrift] = await Promise.all([
   listEngagements(env.DB, session.orgId),
   listEntities(env.DB, session.orgId),
   listQuotes(env.DB, session.orgId),
   listFleetRoster(env.DB),
   listRuntimeSummary(env.DB),
+  // ADR 0046 Stage 1b: the read that makes the consulting spine self-validating.
+  // Renders nothing when clean (the normal case); flags drift loudly otherwise.
+  findConsultingSpineDrift(env.DB, session.orgId),
 ])
+const showSpineDrift = hasSpineDrift(spineDrift)
 
 const nameById = new Map(entities.map((e) => [e.id, e.name]))
 const quotesById = new Map<string, Quote>(quotes.map((q) => [q.id, q]))
@@ -67,6 +75,33 @@ const COL = 'grid grid-cols-[1.4fr_1.9fr_0.9fr_1.1fr_0.9fr_1.6fr] gap-4 items-ce
   maxWidth="max-w-6xl"
 >
   <h1 class="mb-5 text-2xl font-bold text-[color:var(--ss-color-text-primary)]">Services</h1>
+
+  {
+    showSpineDrift && (
+      <div class="mb-6 border border-[color:var(--ss-color-error)] border-l-[3px] bg-[rgba(160,42,42,0.04)] px-[18px] py-3.5">
+        <div class="mb-1 font-['Archivo_Narrow'] text-[11px] font-bold uppercase tracking-[0.12em] text-[color:var(--ss-color-error)]">
+          Service spine drift
+        </div>
+        <p class="text-sm text-[color:var(--ss-color-text-secondary)]">
+          The commercial spine is out of sync with delivery records — these need manual
+          reconciliation (ADR 0046).
+        </p>
+        <ul class="mt-2 list-none space-y-1 font-['JetBrains_Mono'] text-xs text-[color:var(--ss-color-text-primary)]">
+          {spineDrift.orphanEngagements.map((e) => (
+            <li>
+              engagement {e.id} ({e.status}) →{' '}
+              {e.service_id ? `dangling service ${e.service_id}` : 'no service_id'}
+            </li>
+          ))}
+          {spineDrift.childlessServices.map((s) => (
+            <li>
+              service {s.id} ({s.status}) → no engagement
+            </li>
+          ))}
+        </ul>
+      </div>
+    )
+  }
 
   <!-- stat band -->
   <div class="mb-6 flex border border-[color:var(--ss-color-text-primary)]">

--- a/tests/services.test.ts
+++ b/tests/services.test.ts
@@ -14,8 +14,12 @@ import {
   updateServiceStatus,
   projectConsultingStatus,
   projectOperatorStatus,
+  findConsultingSpineDrift,
+  hasSpineDrift,
   SERVICE_VALID_TRANSITIONS,
 } from '../src/lib/db/services'
+import { createEngagement } from '../src/lib/db/engagements'
+import { createQuote } from '../src/lib/db/quotes'
 
 const migrationsDir = path.resolve(__dirname, '../migrations')
 const ORG = 'org-test'
@@ -35,6 +39,24 @@ async function seed(db: D1Database) {
       .bind(e, ORG, e, e)
       .run()
   }
+}
+
+/** Real assessment+quote so an engagement can satisfy its FK to quotes(id). */
+async function seedQuote(db: D1Database, entityId: string): Promise<string> {
+  const assessmentId = `mtg-${entityId}`
+  await db
+    .prepare(
+      `INSERT INTO assessments (id, org_id, entity_id, scheduled_at, status, created_at) VALUES (?, ?, ?, ?, 'scheduled', datetime('now'))`
+    )
+    .bind(assessmentId, ORG, entityId, null)
+    .run()
+  const quote = await createQuote(db, ORG, {
+    entityId,
+    assessmentId,
+    lineItems: [],
+    rate: 175,
+  })
+  return quote.id
 }
 
 describe('services DAL', () => {
@@ -171,5 +193,94 @@ describe('status projection (must match the backfill SQL CASE in 0069/0070)', ()
   it('transition graph terminals are empty', () => {
     expect(SERVICE_VALID_TRANSITIONS.completed).toEqual([])
     expect(SERVICE_VALID_TRANSITIONS.churned).toEqual([])
+  })
+})
+
+describe('createEngagement spawns a linked service (ADR 0046 Stage 1b)', () => {
+  let db: D1Database
+  beforeEach(async () => {
+    db = createTestD1()
+    await runMigrations(db, { files: discoverNumericMigrations(migrationsDir) })
+    await seed(db)
+  })
+
+  it('creates a consulting service parent and links the engagement 1:1', async () => {
+    const quoteId = await seedQuote(db, 'ent-1')
+    const eng = await createEngagement(db, ORG, { entity_id: 'ent-1', quote_id: quoteId })
+
+    expect(eng.service_id).toBeTruthy()
+    expect(eng.service_id?.startsWith('svc_')).toBe(true)
+
+    const services = await getServicesForEntity(db, ORG, 'ent-1')
+    expect(services).toHaveLength(1)
+    expect(services[0].id).toBe(eng.service_id)
+    expect(services[0].type).toBe('consulting')
+    expect(services[0].cadence).toBe('one_time')
+    // born active — projectConsultingStatus('scheduled') === 'active'
+    expect(services[0].status).toBe('active')
+    expect(services[0].quote_id).toBe(quoteId)
+  })
+})
+
+describe('findConsultingSpineDrift (ADR 0046 Stage 1b)', () => {
+  let db: D1Database
+  beforeEach(async () => {
+    db = createTestD1()
+    await runMigrations(db, { files: discoverNumericMigrations(migrationsDir) })
+    await seed(db)
+  })
+
+  it('returns empty when every engagement has its service parent', async () => {
+    const quoteId = await seedQuote(db, 'ent-1')
+    await createEngagement(db, ORG, { entity_id: 'ent-1', quote_id: quoteId })
+
+    const drift = await findConsultingSpineDrift(db, ORG)
+    expect(hasSpineDrift(drift)).toBe(false)
+    expect(drift.orphanEngagements).toHaveLength(0)
+    expect(drift.childlessServices).toHaveLength(0)
+  })
+
+  it('flags an in-flight engagement with no service parent and a childless service', async () => {
+    const quoteId = await seedQuote(db, 'ent-1')
+    // orphan engagement: in-flight, service_id NULL (the pre-fix corruption shape)
+    await db
+      .prepare(
+        `INSERT INTO engagements (id, org_id, entity_id, quote_id, status, created_at, updated_at) VALUES ('eng-orphan', ?, 'ent-1', ?, 'active', datetime('now'), datetime('now'))`
+      )
+      .bind(ORG, quoteId)
+      .run()
+    // childless service: active consulting with no engagement pointing back
+    const childless = await createService(db, ORG, {
+      entity_id: 'ent-2',
+      type: 'consulting',
+      cadence: 'one_time',
+      status: 'active',
+    })
+
+    const drift = await findConsultingSpineDrift(db, ORG)
+    expect(hasSpineDrift(drift)).toBe(true)
+    expect(drift.orphanEngagements.map((e) => e.id)).toContain('eng-orphan')
+    expect(drift.childlessServices.map((s) => s.id)).toContain(childless.id)
+  })
+
+  it('does not flag a completed engagement or a completed service', async () => {
+    const quoteId = await seedQuote(db, 'ent-1')
+    // completed engagement with no service_id — terminal, not in-flight, so ignored
+    await db
+      .prepare(
+        `INSERT INTO engagements (id, org_id, entity_id, quote_id, status, created_at, updated_at) VALUES ('eng-done', ?, 'ent-1', ?, 'completed', datetime('now'), datetime('now'))`
+      )
+      .bind(ORG, quoteId)
+      .run()
+    // completed consulting service with no child — only 'active' counts as childless drift
+    await createService(db, ORG, {
+      entity_id: 'ent-2',
+      type: 'consulting',
+      cadence: 'one_time',
+      status: 'completed',
+    })
+
+    const drift = await findConsultingSpineDrift(db, ORG)
+    expect(hasSpineDrift(drift)).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary
Stage 1 (#1314) shipped a `services` spine that **nothing read** and left one write path (`createEngagement`) that bypassed it. Stage 1b closes both — and, per `/critique`, does so *without* the render-rewire the first plan draft proposed (which would have been churn-for-purity plus a new silent-drop risk).

- **Type the link** — `service_id` added to the `Engagement` interface (column exists since migration 0068).
- **Close the write-gap** — `createEngagement` now creates the consulting service parent + the engagement in one atomic `db.batch`, mirroring the SOW finalize hook. No more orphan children.
- **Spine read + self-validating** — `findConsultingSpineDrift(db, orgId)` reconciles the consulting spine against its engagement children (orphan engagements / childless services). The services page renders a quiet warning strip **only on drift** (invisible when clean — honest empty state, admin-only surface).
- **Operator deferral documented** — operator services have no forward writer yet (Stage 1 backfilled them from the vestigial `subscriptions` table; the live registry is `customer_configs`). The operator UI keeps reading `customer_configs`; the unified render-migration onto the spine is **Stage 3**.

The render data path is untouched, so no row can vanish from a join miss.

## Test plan
- [x] `npm run verify` passes (3370 main tests, 0 failures)
- [x] `tests/services.test.ts`: `createEngagement` spawns a linked consulting service (1:1, born `active`); `findConsultingSpineDrift` returns empty when clean, flags an orphan engagement + a childless service, and ignores terminal-status rows
- [x] No migration in this stage (column already exists) — code-only deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)