### PR TITLE
feat(admin): price the operator, real MRR, operator as a commercial spine citizen (ADR 0046)

### DIFF
--- a/migrations/0068_service_spine_ddl.sql
+++ b/migrations/0068_service_spine_ddl.sql
@@ -24,7 +24,8 @@
 -- status is a COARSE COMMERCIAL ROLLUP, deliberately separate from the rich
 -- delivery lifecycle. engagements.status / subscriptions.status remain the
 -- AUTHORITATIVE lifecycle; services.status is a projection (see
--- src/lib/db/services.ts projectServiceStatus, used by both backfill + runtime).
+-- src/lib/db/services.ts projectConsultingStatus/projectOperatorStatus, used by
+-- both backfill + runtime).
 --   proposed  — quoted, not yet accepted. Unreachable in Stage 1 (services are
 --               created only at acceptance); reachable from Stage 2.
 --   active    — committed/live revenue line (signed or being stood up → in delivery).

--- a/migrations/0069_service_spine_backfill_consulting.sql
+++ b/migrations/0069_service_spine_backfill_consulting.sql
@@ -12,7 +12,7 @@
 -- service_id IS NULL but an existing 'svc_'||id services row is a CORRUPTION
 -- state requiring manual reconciliation — not auto-re-runnable.
 --
--- Status projection (must match src/lib/db/services.ts projectServiceStatus):
+-- Status projection (must match src/lib/db/services.ts projectConsultingStatus):
 --   completed → completed ; cancelled → churned ;
 --   scheduled/active/handoff/safety_net → active (committed/live revenue line).
 -- ============================================================================

--- a/migrations/0070_service_spine_backfill_operator.sql
+++ b/migrations/0070_service_spine_backfill_operator.sql
@@ -6,7 +6,7 @@
 -- don't exist until Stage 2) and recurring_price is NULL (authored per-quote in
 -- Stage 2 — never fabricated).
 --
--- Status projection (must match src/lib/db/services.ts projectServiceStatus):
+-- Status projection (must match src/lib/db/services.ts projectOperatorStatus):
 --   cancelled → churned ; provisioning/active/paused → active.
 -- A provisioning operator is a COMMITTED revenue line being stood up, so it
 -- maps to `active` (not `proposed`). `proposed` means "quoted, not yet

--- a/src/lib/admin/billing-view.ts
+++ b/src/lib/admin/billing-view.ts
@@ -36,6 +36,36 @@ export interface OneTimeTotals {
   overdueAmount: number
 }
 
+export interface OperatorRecurring {
+  /** Real MRR: sum of authored recurring prices across the active operator roster. */
+  mrr: number
+  /** Authoritative count of active operators (from the roster, never the spine). */
+  activeCount: number
+  /** Active operators with no price authored yet — surfaced, never summed as 0. */
+  unpricedCount: number
+}
+
+/**
+ * Recurring revenue, computed the safe way (ADR 0046): iterate the AUTHORITATIVE
+ * operator roster (every live operator), and price each from the spine via
+ * `priceByEntity` (entity_id → `services.recurring_price` for active operator
+ * services). A roster operator with no priced service is counted `unpriced` —
+ * never dropped, never silently summed as 0. MRR sums only real authored prices.
+ */
+export function operatorRecurring(
+  rosterEntityIds: string[],
+  priceByEntity: Map<string, number | null>
+): OperatorRecurring {
+  let mrr = 0
+  let unpricedCount = 0
+  for (const id of rosterEntityIds) {
+    const price = priceByEntity.get(id) ?? null
+    if (price == null) unpricedCount += 1
+    else mrr += price
+  }
+  return { mrr, activeCount: rosterEntityIds.length, unpricedCount }
+}
+
 export function oneTimeTotals(invoices: Invoice[]): OneTimeTotals {
   const base = computeBillingRollup(invoices)
   let overdueCount = 0

--- a/src/lib/admin/cost-query.ts
+++ b/src/lib/admin/cost-query.ts
@@ -5,8 +5,10 @@
  * Two data surfaces are involved:
  *
  *   1. Central D1 (`env.DB`) — holds `customer_configs` (the customer
- *      enumeration) and `subscriptions` (the recurring-revenue figure
- *      used by the COGS/MRR ratio).
+ *      enumeration), `subscriptions` (the delivery-status display), and the
+ *      `services` spine (the authoritative recurring-revenue figure,
+ *      `recurring_price`, used by the COGS/MRR ratio — ADR 0046, single
+ *      source of truth, no longer `subscriptions.settings_json`).
  *
  *   2. Per-customer D1 (one per customer, addressed via the Cloudflare
  *      D1 HTTP API) — holds the `cost_telemetry` table per ADR 0009.
@@ -50,7 +52,11 @@ interface CustomerConfigRow {
 interface SubscriptionRow {
   entity_id: string
   status: string
-  settings_json: string | null
+}
+
+interface OperatorServiceRow {
+  entity_id: string
+  recurring_price: number | null
 }
 
 interface EntityRow {
@@ -83,16 +89,33 @@ export async function listCostCustomers(db: D1Database): Promise<CustomerListRow
 
   const subsResult = await db
     .prepare(
-      `SELECT entity_id, status, settings_json
+      `SELECT entity_id, status
          FROM subscriptions
          WHERE product_slug = 'operator'
            AND entity_id IN (${placeholders})`
     )
     .bind(...entityIds)
     .all<SubscriptionRow>()
-  const subsByEntity = new Map<string, SubscriptionRow>()
+  const subStatusByEntity = new Map<string, string>()
   for (const row of subsResult.results ?? []) {
-    subsByEntity.set(row.entity_id, row)
+    subStatusByEntity.set(row.entity_id, row.status)
+  }
+
+  // ADR 0046: recurring revenue is the spine's authoritative figure
+  // (`services.recurring_price`, dollars), not `subscriptions.settings_json`.
+  // One source of truth — the same number that feeds the Billing MRR band.
+  const svcResult = await db
+    .prepare(
+      `SELECT entity_id, recurring_price
+         FROM services
+         WHERE type = 'operator' AND status = 'active'
+           AND entity_id IN (${placeholders})`
+    )
+    .bind(...entityIds)
+    .all<OperatorServiceRow>()
+  const priceByEntity = new Map<string, number | null>()
+  for (const row of svcResult.results ?? []) {
+    priceByEntity.set(row.entity_id, row.recurring_price)
   }
 
   const entitiesResult = await db
@@ -106,14 +129,15 @@ export async function listCostCustomers(db: D1Database): Promise<CustomerListRow
 
   return configs.map((c) => {
     const { perCustomerDbId } = parseConnectors(c.connectors_json)
-    const sub = subsByEntity.get(c.entity_id) ?? null
+    const price = priceByEntity.get(c.entity_id) ?? null
     return {
       customer_slug: c.customer_slug,
       entity_id: c.entity_id,
       entity_name: namesByEntity.get(c.entity_id) ?? null,
       per_customer_d1_database_id: perCustomerDbId,
-      subscription_status: sub?.status ?? null,
-      monthly_revenue_cents: parseMonthlyRevenueCents(sub?.settings_json ?? null),
+      subscription_status: subStatusByEntity.get(c.entity_id) ?? null,
+      // Authoritative recurring revenue from the spine, in cents for the ratio math.
+      monthly_revenue_cents: price == null ? null : Math.round(price * 100),
     }
   })
 }
@@ -136,30 +160,6 @@ function parseConnectors(connectorsJson: string | null): {
   return {
     perCustomerDbId: typeof dbId === 'string' && dbId.length > 0 ? dbId : null,
   }
-}
-
-/**
- * Recurring revenue (MRR) for the customer in integer cents. Read from
- * `subscriptions.settings_json.monthly_price_cents`, the documented
- * per-product configuration field (cost-telemetry-events.md "COGS/MRR
- * ratio computation" — "customer's flat-monthly SKU price in cents").
- *
- * Returns null when the field is absent or unparseable. The caller
- * treats null as "unpriced" and renders the COGS/MRR indicator as
- * "—" rather than fabricating a default.
- */
-function parseMonthlyRevenueCents(settingsJson: string | null): number | null {
-  if (!settingsJson) return null
-  let parsed: unknown
-  try {
-    parsed = JSON.parse(settingsJson)
-  } catch {
-    return null
-  }
-  if (!parsed || typeof parsed !== 'object') return null
-  const value = (parsed as Record<string, unknown>)['monthly_price_cents']
-  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) return null
-  return Math.round(value)
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib/admin/services-list.ts
+++ b/src/lib/admin/services-list.ts
@@ -58,6 +58,12 @@ export interface OperatorInput {
   /** From the runtime summary; null when no runtime row has been pushed. */
   openAlerts: number | null
   hasRuntime: boolean
+  /**
+   * Monthly price from the spine (`services.recurring_price`), joined by
+   * entity_id. Null when no operator service exists yet or its price is
+   * unauthored — rendered as "unpriced", never fabricated. (ADR 0046.)
+   */
+  recurringPrice: number | null
 }
 
 export interface BuildServiceListInput {
@@ -165,7 +171,8 @@ function operatorRow(op: OperatorInput): ServiceListRow {
     title: 'Operator',
     statusLabel: s.statusLabel,
     tone: s.tone,
-    value: null, // Operator recurring price has no schema home yet — never fabricated.
+    // Monthly price from the spine; null renders as "—" (unpriced), never fabricated.
+    value: op.recurringPrice == null ? null : `${formatMoney(op.recurringPrice)}/mo`,
     risk: s.risk,
     riskTone: s.riskTone,
     riskRank: s.riskRank,

--- a/src/lib/db/services.ts
+++ b/src/lib/db/services.ts
@@ -14,21 +14,22 @@
  * it must stay inside one atomic `db.batch([...])`. Do NOT "DRY" the two
  * together; that would break the atomic engagement+invoice+service creation.
  *
- * READ-MIGRATION STATUS (ADR 0046, as of Stage 1b):
+ * READ-MIGRATION STATUS (ADR 0046):
  * - Consulting services have a real forward writer (SOW finalize + the manual
- *   `createEngagement` path), so the consulting spine is authoritative. Stage 1b
- *   makes it READ + self-validating via `findConsultingSpineDrift` below; the
- *   full render-migration of the admin surfaces (client hub, services list) is
- *   deferred to Stage 3 so it lands once for BOTH delivery types together.
- * - Operator services currently have NO forward writer — the Stage 1 backfill
- *   (migration 0070) sourced them from the legacy `subscriptions` table (no
- *   `INSERT` in src; pre-Hermes-realignment), while the live operator registry
- *   is `customer_configs` (src/lib/portal/customer-config-projection.ts). So the
- *   operator UI still reads `customer_configs`/the fleet roster, NOT this spine.
- *   Operator-service creation on provisioning is Stage 3 (bounded by ADR 0012);
- *   only then does the operator UI migrate to the spine. Do not iterate the
- *   operator spine for display before that — it would silently drop any operator
- *   provisioned after the backfill.
+ *   `createEngagement` path), so the consulting spine is authoritative and
+ *   self-validating via `findSpineDrift` below.
+ * - Operator: `setOperatorPrice` is the forward writer for the COMMERCIAL record
+ *   (the service + its `recurring_price`) — NOT the provisioning record
+ *   (`subscriptions`, which gates portal access and is owned by provisioning).
+ *   The authoritative operator REGISTRY is still `customer_configs` (the live CI
+ *   projection): provisioning writes a config, not a service. So the admin
+ *   surfaces ITERATE the roster / `customer_configs` for the operator list and
+ *   only ENRICH each row with spine data (price, commercial status) by entity_id
+ *   — they must NOT iterate the operator spine as the list source, or any
+ *   operator provisioned without a commercial record would silently vanish.
+ *   `findSpineDrift` surfaces exactly that gap (a live config with no service).
+ *   Making provisioning write the spine (so the list can iterate it) is the
+ *   remaining step, on a different axis (CI/projection, ADR 0012).
  */
 
 export interface Service {
@@ -240,6 +241,65 @@ export async function updateServiceStatus(
 }
 
 // ===========================================================================
+// Operator commercial record (ADR 0046, operator arc)
+// ===========================================================================
+
+/**
+ * The single operator service for an entity, or null. The partial unique index
+ * `idx_services_one_operator` guarantees at most one operator service per entity.
+ */
+export async function getOperatorServiceForEntity(
+  db: D1Database,
+  orgId: string,
+  entityId: string
+): Promise<Service | null> {
+  return (
+    (await db
+      .prepare(`SELECT * FROM services WHERE org_id = ? AND entity_id = ? AND type = 'operator'`)
+      .bind(orgId, entityId)
+      .first<Service>()) ?? null
+  )
+}
+
+/**
+ * Author the operator's monthly recurring price (ADR 0046). This is the operator's
+ * forward writer for the COMMERCIAL record (the service) — deliberately NOT the
+ * delivery/provisioning record (`subscriptions`), which gates portal access and is
+ * owned by the provisioning path. Upserts `recurring_price` on the entity's single
+ * operator service: updates it if present, creates an `active` operator service if
+ * not. Pass `price = null` to clear the price (back to unpriced). Idempotent.
+ */
+export async function setOperatorPrice(
+  db: D1Database,
+  orgId: string,
+  entityId: string,
+  price: number | null
+): Promise<Service> {
+  const existing = await getOperatorServiceForEntity(db, orgId, entityId)
+  if (existing) {
+    await db
+      .prepare(
+        `UPDATE services SET recurring_price = ?, updated_at = ? WHERE id = ? AND org_id = ?`
+      )
+      .bind(price, new Date().toISOString(), existing.id, orgId)
+      .run()
+    const updated = await getService(db, orgId, existing.id)
+    if (!updated) throw new Error(`Failed to update operator service ${existing.id}`)
+    return updated
+  }
+  // No operator service yet — create the commercial record, born active (we are
+  // pricing a real operator). started_at stamps the revenue line's start.
+  return createService(db, orgId, {
+    entity_id: entityId,
+    type: 'operator',
+    cadence: 'recurring',
+    status: 'active',
+    recurring_price: price,
+    started_at: new Date().toISOString(),
+  })
+}
+
+// ===========================================================================
 // Spine reconciliation (ADR 0046, Stage 1b)
 // ===========================================================================
 
@@ -257,37 +317,55 @@ export interface ChildlessService {
   status: string
 }
 
+/** An active operator service whose entity has no live `customer_configs` row. */
+export interface OperatorServiceWithoutConfig {
+  id: string
+  entity_id: string
+  status: string
+}
+
+/** A live operator (`customer_configs` row) with no operator service (no commercial record). */
+export interface ConfigWithoutService {
+  entity_id: string
+  customer_slug: string
+}
+
 /**
- * The two ways the consulting spine ↔ child invariant can break. Both lists
- * empty is the healthy state (the normal case).
+ * Every way the spine ↔ child / registry invariant can break, across BOTH
+ * delivery types. All lists empty is the healthy state (the normal case).
  */
-export interface ConsultingSpineDrift {
-  /** In-flight engagements whose `service_id` is NULL or points at no service. */
+export interface SpineDrift {
+  /** In-flight consulting engagements whose `service_id` is NULL or dangles. */
   orphanEngagements: OrphanEngagement[]
-  /** Active consulting services with no engagement pointing back at them. */
+  /** Active consulting services with no engagement pointing back. */
   childlessServices: ChildlessService[]
+  /** Active operator services whose entity has no `customer_configs` row. */
+  operatorServicesWithoutConfig: OperatorServiceWithoutConfig[]
+  /** Live operators (`customer_configs`) with no operator service — uncommercialized. */
+  configsWithoutService: ConfigWithoutService[]
 }
 
 /** In-flight consulting engagement statuses — those expected to have a live parent. */
 const IN_FLIGHT_ENGAGEMENT_STATUSES = ['scheduled', 'active', 'handoff', 'safety_net']
 
 /**
- * Reconcile the consulting spine against its engagement children (ADR 0046,
- * Stage 1b). This is the READ that makes the otherwise write-only spine
- * load-bearing: the services list calls it on every load and surfaces drift,
- * so any future code path that creates an engagement without a service (or a
- * service without an engagement) fails loud instead of rotting silently.
+ * Reconcile the spine against its registries for BOTH delivery types (ADR 0046).
+ * This is the READ that keeps the spine load-bearing: the services list calls it
+ * on every load and surfaces drift, so a path that creates a child without a
+ * service (or a live operator without a commercial record) fails loud instead of
+ * rotting silently.
  *
- * Scoped to consulting only — operator services have no forward writer yet
- * (see the file header), so reconciling them would flag false positives.
+ * Consulting: engagement ↔ service must be 1:1 (the spine is authoritative — every
+ * engagement has a service and vice versa). Operator: the authoritative registry is
+ * `customer_configs`, NOT the spine, so we reconcile the two directions against the
+ * registry — never assume the spine enumerates operators (it does not until
+ * provisioning writes it). A `configWithoutService` is the expected, useful signal
+ * that a live operator has not been given a commercial record yet.
  */
-export async function findConsultingSpineDrift(
-  db: D1Database,
-  orgId: string
-): Promise<ConsultingSpineDrift> {
+export async function findSpineDrift(db: D1Database, orgId: string): Promise<SpineDrift> {
   const placeholders = IN_FLIGHT_ENGAGEMENT_STATUSES.map(() => '?').join(', ')
 
-  const [orphans, childless] = await Promise.all([
+  const [orphans, childless, opNoConfig, configNoService] = await Promise.all([
     db
       .prepare(
         `SELECT e.id, e.status, e.service_id
@@ -315,15 +393,46 @@ export async function findConsultingSpineDrift(
       )
       .bind(orgId, orgId)
       .all<ChildlessService>(),
+    db
+      .prepare(
+        `SELECT s.id, s.entity_id, s.status
+           FROM services s
+          WHERE s.org_id = ?
+            AND s.type = 'operator'
+            AND s.status = 'active'
+            AND s.entity_id NOT IN (
+              SELECT c.entity_id FROM customer_configs c WHERE c.org_id = ?
+            )`
+      )
+      .bind(orgId, orgId)
+      .all<OperatorServiceWithoutConfig>(),
+    db
+      .prepare(
+        `SELECT c.entity_id, c.customer_slug
+           FROM customer_configs c
+          WHERE c.org_id = ?
+            AND c.entity_id NOT IN (
+              SELECT s.entity_id FROM services s WHERE s.org_id = ? AND s.type = 'operator'
+            )`
+      )
+      .bind(orgId, orgId)
+      .all<ConfigWithoutService>(),
   ])
 
   return {
     orphanEngagements: orphans.results,
     childlessServices: childless.results,
+    operatorServicesWithoutConfig: opNoConfig.results,
+    configsWithoutService: configNoService.results,
   }
 }
 
-/** True when either drift class is non-empty. */
-export function hasSpineDrift(drift: ConsultingSpineDrift): boolean {
-  return drift.orphanEngagements.length > 0 || drift.childlessServices.length > 0
+/** True when any drift class is non-empty. */
+export function hasSpineDrift(drift: SpineDrift): boolean {
+  return (
+    drift.orphanEngagements.length > 0 ||
+    drift.childlessServices.length > 0 ||
+    drift.operatorServicesWithoutConfig.length > 0 ||
+    drift.configsWithoutService.length > 0
+  )
 }

--- a/src/pages/admin/billing/index.astro
+++ b/src/pages/admin/billing/index.astro
@@ -2,9 +2,10 @@
 /**
  * Billing — the global, bi-modal money surface (ADR 0046).
  *
- * One-time totals are derived from invoices. The recurring side is honest
- * about the schema gap (no recurring-price column yet): it shows a real
- * count of active operator subscriptions and never a fabricated MRR.
+ * One-time totals are derived from invoices. The recurring side shows REAL
+ * MRR (ADR 0046 operator arc): the active operator roster priced from the
+ * spine (`services.recurring_price`), with any unpriced operator surfaced
+ * explicitly rather than silently summed as zero.
  * Tabs: Quotes (money-in-waiting) · Invoices (one-time) · Recurring.
  */
 import AdminLayout from '../../../layouts/AdminLayout.astro'
@@ -13,7 +14,12 @@ import { listQuotes } from '../../../lib/db/quotes'
 import { listEntities } from '../../../lib/db/entities'
 import { listFleetRoster } from '../../../lib/admin/fleet-roster'
 import { listRuntimeSummary } from '../../../lib/admin/runtime-summary'
-import { oneTimeTotals, sortInvoicesForBilling } from '../../../lib/admin/billing-view'
+import { listServices } from '../../../lib/db/services'
+import {
+  oneTimeTotals,
+  sortInvoicesForBilling,
+  operatorRecurring,
+} from '../../../lib/admin/billing-view'
 import { formatMoney } from '../../../lib/admin/client-hub'
 import { formatDate } from '../../../lib/admin/entity-detail-page'
 import { statusBadgeClass } from '../../../lib/ui/status-badge'
@@ -21,18 +27,31 @@ import { env } from 'cloudflare:workers'
 
 const session = Astro.locals.session!
 
-const [invoices, quotes, entities, roster, runtime] = await Promise.all([
+const [invoices, quotes, entities, roster, runtime, operatorServices] = await Promise.all([
   listInvoices(env.DB, session.orgId),
   listQuotes(env.DB, session.orgId),
   listEntities(env.DB, session.orgId),
   listFleetRoster(env.DB),
   listRuntimeSummary(env.DB),
+  listServices(env.DB, session.orgId, { type: 'operator', status: 'active' }),
 ])
 
 const nameById = new Map(entities.map((e) => [e.id, e.name]))
 const runtimeEntities = new Set(runtime.map((r) => r.entity_id))
 const totals = oneTimeTotals(invoices)
 const sortedInvoices = sortInvoicesForBilling(invoices)
+
+// Recurring revenue: iterate the authoritative roster, price each from the spine.
+const priceByEntity = new Map<string, number | null>(
+  operatorServices.map((s) => [s.entity_id, s.recurring_price])
+)
+const recurring = operatorRecurring(
+  roster.map((r) => r.entity_id),
+  priceByEntity
+)
+function operatorPrice(entityId: string): number | null {
+  return priceByEntity.get(entityId) ?? null
+}
 
 function clientName(entityId: string): string {
   return nameById.get(entityId) ?? '—'
@@ -103,13 +122,19 @@ const REC_COLS = 'grid-cols-[1.6fr_1.6fr_0.9fr_1fr]'
       <div class="flex gap-8">
         <div>
           <span class={`${LAB} mb-1 block`}>Active operators</span>
-          <span class="font-['JetBrains_Mono'] text-xl font-bold">{roster.length}</span>
+          <span class="font-['JetBrains_Mono'] text-xl font-bold">{recurring.activeCount}</span>
         </div>
         <div>
           <span class={`${LAB} mb-1 block`}>MRR</span>
-          <span class="font-['JetBrains_Mono'] text-base text-[color:var(--ss-color-text-muted)]"
-            >pending pricing</span
+          <span class="font-['JetBrains_Mono'] text-xl font-bold">{formatMoney(recurring.mrr)}</span
           >
+          {
+            recurring.unpricedCount > 0 && (
+              <div class="mt-1 text-[11px] text-[color:var(--ss-color-primary)]">
+                {recurring.unpricedCount} unpriced
+              </div>
+            )
+          }
         </div>
       </div>
     </div>
@@ -249,9 +274,15 @@ const REC_COLS = 'grid-cols-[1.6fr_1.6fr_0.9fr_1fr]'
               <span class="font-['Archivo_Narrow'] text-[11px] font-bold uppercase tracking-[0.08em] text-[color:var(--ss-color-text-secondary)]">
                 {runtimeEntities.has(r.entity_id) ? 'Active' : 'Provisioning'}
               </span>
-              <span class="text-right font-['JetBrains_Mono'] text-[color:var(--ss-color-text-muted)]">
-                —
-              </span>
+              {operatorPrice(r.entity_id) == null ? (
+                <span class="text-right font-['JetBrains_Mono'] text-[13px] text-[color:var(--ss-color-primary)]">
+                  unpriced
+                </span>
+              ) : (
+                <span class="text-right font-['JetBrains_Mono'] text-[13px] font-medium">
+                  {formatMoney(operatorPrice(r.entity_id) ?? 0)}/mo
+                </span>
+              )}
             </a>
           ))}
         </div>

--- a/src/pages/admin/clients/[id].astro
+++ b/src/pages/admin/clients/[id].astro
@@ -19,6 +19,7 @@ import {
   serviceToneDotClass,
 } from '../../../lib/admin/client-hub'
 import { ENTITY_VERTICALS, ENTITY_STAGES } from '../../../lib/db/entities'
+import { getOperatorServiceForEntity } from '../../../lib/db/services'
 import { statusBadgeClass } from '../../../lib/ui/status-badge'
 import { env } from 'cloudflare:workers'
 
@@ -37,6 +38,11 @@ const { entity, engagements, quotes, invoices, contacts, deduplicatedTimeline } 
 
 const roster = await listFleetRoster(env.DB)
 const operator = roster.find((r) => r.entity_id === entityId) ?? null
+// Operator commercial record from the spine (ADR 0046) — its monthly price.
+const operatorService = operator
+  ? await getOperatorServiceForEntity(env.DB, session.orgId, entityId)
+  : null
+const operatorPrice = operatorService?.recurring_price ?? null
 
 const rollup = computeBillingRollup(invoices)
 const serviceRows = engagements.map((eng) => engagementToServiceRow(eng, quotes))
@@ -150,6 +156,46 @@ const LINK_ACT =
                 {personaSummary(operator.personas)}
                 {operator.config_error && ' · config needs attention'}
               </div>
+              <div class="mt-3 flex items-baseline justify-between border-t border-[color:var(--ss-color-border-subtle)] pt-3">
+                <span class="font-['Archivo_Narrow'] text-[11px] font-bold uppercase tracking-[0.1em] text-[color:var(--ss-color-text-secondary)]">
+                  Monthly price
+                </span>
+                <span
+                  class:list={[
+                    "font-['JetBrains_Mono'] text-base font-bold",
+                    operatorPrice == null && 'text-[color:var(--ss-color-text-muted)]',
+                  ]}
+                >
+                  {operatorPrice == null ? 'Not set' : `${formatMoney(operatorPrice)}/mo`}
+                </span>
+              </div>
+              <form
+                method="POST"
+                action={`/api/admin/clients/${entityId}/operator-price`}
+                class="mt-2.5 flex items-center gap-2"
+              >
+                <span class="font-['JetBrains_Mono'] text-sm text-[color:var(--ss-color-text-secondary)]">
+                  $
+                </span>
+                <input
+                  type="number"
+                  name="monthly_price"
+                  min="0"
+                  step="1"
+                  value={operatorPrice ?? ''}
+                  placeholder="0"
+                  class="w-28 border border-[color:var(--ss-color-border)] px-2 py-1 font-['JetBrains_Mono'] text-sm"
+                />
+                <span class="font-['Archivo_Narrow'] text-[11px] text-[color:var(--ss-color-text-muted)]">
+                  / mo
+                </span>
+                <button
+                  type="submit"
+                  class="border border-[color:var(--ss-color-primary)] px-3 py-1 font-['Archivo_Narrow'] text-[11px] font-bold uppercase tracking-[0.1em] text-[color:var(--ss-color-primary)]"
+                >
+                  Save
+                </button>
+              </form>
               <div class="mt-3 flex items-center justify-end border-t border-[color:var(--ss-color-border-subtle)] pt-3">
                 <a href="/admin/operator" class={LINK_ACT}>
                   Open cockpit →

--- a/src/pages/admin/index.astro
+++ b/src/pages/admin/index.astro
@@ -19,12 +19,13 @@ import { listQuotes } from '../../lib/db/quotes'
 import type { Quote } from '../../lib/db/quotes'
 import { listFleetRoster } from '../../lib/admin/fleet-roster'
 import { listRuntimeSummary } from '../../lib/admin/runtime-summary'
+import { listServices } from '../../lib/db/services'
 import {
   buildServiceList,
   serviceListStats,
   type OperatorInput,
 } from '../../lib/admin/services-list'
-import { oneTimeTotals } from '../../lib/admin/billing-view'
+import { oneTimeTotals, operatorRecurring } from '../../lib/admin/billing-view'
 import { buildActionQueue } from '../../lib/admin/home-actions'
 import { formatMoney } from '../../lib/admin/client-hub'
 import { env } from 'cloudflare:workers'
@@ -41,6 +42,7 @@ const [
   entities,
   roster,
   runtime,
+  operatorServices,
 ] = await Promise.all([
   listFollowUps(env.DB, session.orgId, { overdue: true }),
   listFollowUps(env.DB, session.orgId, { upcoming: true }),
@@ -50,11 +52,21 @@ const [
   listEntities(env.DB, session.orgId),
   listFleetRoster(env.DB),
   listRuntimeSummary(env.DB),
+  listServices(env.DB, session.orgId, { type: 'operator', status: 'active' }),
 ])
 
 const nameById = new Map(entities.map((e) => [e.id, e.name]))
 const quotesById = new Map<string, Quote>(quotes.map((q) => [q.id, q]))
 const runtimeByEntity = new Map(runtime.map((r) => [r.entity_id, r]))
+
+// Real MRR: authoritative roster priced from the spine (ADR 0046 operator arc).
+const operatorPriceByEntity = new Map<string, number | null>(
+  operatorServices.map((s) => [s.entity_id, s.recurring_price])
+)
+const recurring = operatorRecurring(
+  roster.map((r) => r.entity_id),
+  operatorPriceByEntity
+)
 
 const operators: OperatorInput[] = roster.map((r) => ({
   entityId: r.entity_id,
@@ -62,6 +74,7 @@ const operators: OperatorInput[] = roster.map((r) => ({
   configError: r.config_error,
   openAlerts: runtimeByEntity.get(r.entity_id)?.open_alerts ?? null,
   hasRuntime: runtimeByEntity.has(r.entity_id),
+  recurringPrice: operatorPriceByEntity.get(r.entity_id) ?? null,
 }))
 
 const services = buildServiceList({
@@ -233,13 +246,19 @@ const motion: MotionCard[] = [
       <div class="flex gap-8">
         <div>
           <span class={`${LAB} mb-1 block`}>Active operators</span>
-          <span class="font-['JetBrains_Mono'] text-xl font-bold">{roster.length}</span>
+          <span class="font-['JetBrains_Mono'] text-xl font-bold">{recurring.activeCount}</span>
         </div>
         <div>
           <span class={`${LAB} mb-1 block`}>MRR</span>
-          <span class="font-['JetBrains_Mono'] text-base text-[color:var(--ss-color-text-muted)]"
-            >pending pricing</span
+          <span class="font-['JetBrains_Mono'] text-xl font-bold">{formatMoney(recurring.mrr)}</span
           >
+          {
+            recurring.unpricedCount > 0 && (
+              <div class="mt-1 text-[11px] text-[color:var(--ss-color-primary)]">
+                {recurring.unpricedCount} unpriced
+              </div>
+            )
+          }
         </div>
       </div>
     </div>

--- a/src/pages/admin/services/index.astro
+++ b/src/pages/admin/services/index.astro
@@ -23,26 +23,31 @@ import {
   type OperatorInput,
 } from '../../../lib/admin/services-list'
 import { serviceToneDotClass } from '../../../lib/admin/client-hub'
-import { findConsultingSpineDrift, hasSpineDrift } from '../../../lib/db/services'
+import { findSpineDrift, hasSpineDrift, listServices } from '../../../lib/db/services'
 import { env } from 'cloudflare:workers'
 
 const session = Astro.locals.session!
 
-const [engagements, entities, quotes, roster, runtime, spineDrift] = await Promise.all([
-  listEngagements(env.DB, session.orgId),
-  listEntities(env.DB, session.orgId),
-  listQuotes(env.DB, session.orgId),
-  listFleetRoster(env.DB),
-  listRuntimeSummary(env.DB),
-  // ADR 0046 Stage 1b: the read that makes the consulting spine self-validating.
-  // Renders nothing when clean (the normal case); flags drift loudly otherwise.
-  findConsultingSpineDrift(env.DB, session.orgId),
-])
+const [engagements, entities, quotes, roster, runtime, operatorServices, spineDrift] =
+  await Promise.all([
+    listEngagements(env.DB, session.orgId),
+    listEntities(env.DB, session.orgId),
+    listQuotes(env.DB, session.orgId),
+    listFleetRoster(env.DB),
+    listRuntimeSummary(env.DB),
+    listServices(env.DB, session.orgId, { type: 'operator', status: 'active' }),
+    // ADR 0046: the read that keeps the spine self-validating across both types.
+    // Renders nothing when clean (the normal case); flags drift loudly otherwise.
+    findSpineDrift(env.DB, session.orgId),
+  ])
 const showSpineDrift = hasSpineDrift(spineDrift)
 
 const nameById = new Map(entities.map((e) => [e.id, e.name]))
 const quotesById = new Map<string, Quote>(quotes.map((q) => [q.id, q]))
 const runtimeByEntity = new Map(runtime.map((r) => [r.entity_id, r]))
+const priceByEntity = new Map<string, number | null>(
+  operatorServices.map((s) => [s.entity_id, s.recurring_price])
+)
 
 const operators: OperatorInput[] = roster.map((r) => ({
   entityId: r.entity_id,
@@ -50,6 +55,7 @@ const operators: OperatorInput[] = roster.map((r) => ({
   configError: r.config_error,
   openAlerts: runtimeByEntity.get(r.entity_id)?.open_alerts ?? null,
   hasRuntime: runtimeByEntity.has(r.entity_id),
+  recurringPrice: priceByEntity.get(r.entity_id) ?? null,
 }))
 
 const rows = buildServiceList({
@@ -97,6 +103,14 @@ const COL = 'grid grid-cols-[1.4fr_1.9fr_0.9fr_1.1fr_0.9fr_1.6fr] gap-4 items-ce
             <li>
               service {s.id} ({s.status}) → no engagement
             </li>
+          ))}
+          {spineDrift.operatorServicesWithoutConfig.map((s) => (
+            <li>
+              operator service {s.id} ({s.status}) → no customer config
+            </li>
+          ))}
+          {spineDrift.configsWithoutService.map((c) => (
+            <li>operator {c.customer_slug} → no commercial service (unpriced/uncommercialized)</li>
           ))}
         </ul>
       </div>

--- a/src/pages/api/admin/clients/[id]/operator-price.ts
+++ b/src/pages/api/admin/clients/[id]/operator-price.ts
@@ -1,0 +1,51 @@
+import type { APIContext, APIRoute } from 'astro'
+import { setOperatorPrice } from '../../../../../lib/db/services'
+import { env } from 'cloudflare:workers'
+
+/**
+ * POST /api/admin/clients/[id]/operator-price
+ *
+ * Authors the operator's monthly recurring price on the commercial spine
+ * (ADR 0046). The form field `monthly_price` is the dollar amount; an empty
+ * value clears it (back to unpriced). Writes ONLY the `services` commercial
+ * record — never `subscriptions` (that is provisioning's, and gates portal
+ * access). Admin-gated. Redirects back to the client hub.
+ */
+
+/** Parse the submitted price: '' → null (clear); otherwise a finite, non-negative number. */
+function parsePrice(
+  raw: FormDataEntryValue | null
+): { ok: true; value: number | null } | { ok: false } {
+  if (typeof raw !== 'string' || raw.trim() === '') return { ok: true, value: null }
+  const n = Number(raw.trim().replace(/[$,]/g, ''))
+  if (!Number.isFinite(n) || n < 0) return { ok: false }
+  return { ok: true, value: n }
+}
+
+async function handlePost({ request, locals, params, redirect }: APIContext): Promise<Response> {
+  const session = locals.session
+  if (!session || session.role !== 'admin') {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const entityId = params.id
+  if (!entityId) return redirect('/admin/clients?error=missing', 302)
+
+  try {
+    const formData = await request.formData()
+    const parsed = parsePrice(formData.get('monthly_price'))
+    if (!parsed.ok) {
+      return redirect(`/admin/clients/${entityId}?error=bad_price`, 302)
+    }
+    await setOperatorPrice(env.DB, session.orgId, entityId, parsed.value)
+    return redirect(`/admin/clients/${entityId}?priced=1`, 302)
+  } catch (err) {
+    console.error('[api/admin/clients/operator-price] error:', err)
+    return redirect(`/admin/clients/${entityId}?error=server`, 302)
+  }
+}
+
+export const POST: APIRoute = (ctx) => handlePost(ctx)

--- a/tests/billing-view.test.ts
+++ b/tests/billing-view.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest'
-import { sortInvoicesForBilling, oneTimeTotals } from '../src/lib/admin/billing-view'
+import {
+  sortInvoicesForBilling,
+  oneTimeTotals,
+  operatorRecurring,
+} from '../src/lib/admin/billing-view'
 import type { Invoice } from '../src/lib/db/invoices'
 
 function inv(
@@ -63,5 +67,24 @@ describe('oneTimeTotals', () => {
     expect(t.outstanding).toBe(4600) // sent + overdue
     expect(t.overdueCount).toBe(2)
     expect(t.overdueAmount).toBe(1600)
+  })
+})
+
+describe('operatorRecurring', () => {
+  it('sums priced operators and counts the unpriced (null and missing), never dropping any', () => {
+    const price = new Map<string, number | null>([
+      ['a', 1000],
+      ['b', 2000],
+      ['c', null], // priced row exists but no price authored
+    ])
+    // 'd' is in the authoritative roster but has no spine entry at all.
+    const r = operatorRecurring(['a', 'b', 'c', 'd'], price)
+    expect(r.mrr).toBe(3000) // only real authored prices
+    expect(r.activeCount).toBe(4) // every roster operator counted
+    expect(r.unpricedCount).toBe(2) // c (null) + d (missing)
+  })
+
+  it('an empty roster yields zeros', () => {
+    expect(operatorRecurring([], new Map())).toEqual({ mrr: 0, activeCount: 0, unpricedCount: 0 })
   })
 })

--- a/tests/services-list.test.ts
+++ b/tests/services-list.test.ts
@@ -41,8 +41,22 @@ describe('buildServiceList', () => {
 
   it('sorts by risk: alerting operator, then overdue handoff, then safety-net soon', () => {
     const operators: OperatorInput[] = [
-      { entityId: 'op1', clientName: 'Alpha', configError: null, openAlerts: 2, hasRuntime: true },
-      { entityId: 'op2', clientName: 'Bravo', configError: null, openAlerts: 0, hasRuntime: true },
+      {
+        entityId: 'op1',
+        clientName: 'Alpha',
+        configError: null,
+        openAlerts: 2,
+        hasRuntime: true,
+        recurringPrice: null,
+      },
+      {
+        entityId: 'op2',
+        clientName: 'Bravo',
+        configError: null,
+        openAlerts: 0,
+        hasRuntime: true,
+        recurringPrice: null,
+      },
     ]
     const rows = buildServiceList({
       engagements: [
@@ -73,21 +87,48 @@ describe('buildServiceList', () => {
     expect(rows[rows.length - 1].statusLabel).toBe('Healthy')
   })
 
-  it('draws consulting value from the quote; never fabricates operator price', () => {
+  it('draws consulting value from the quote; operator value from the spine price', () => {
     const quote = { id: 'q1', total_price: 8400 } as unknown as Quote
     const rows = buildServiceList({
       engagements: [eng({ id: 'e1', entity_id: 'c1', status: 'active', quote_id: 'q1' })],
       entityName: () => 'Client',
       quotesById: new Map([['q1', quote]]),
       operators: [
-        { entityId: 'op1', clientName: 'Op', configError: null, openAlerts: 0, hasRuntime: true },
+        {
+          entityId: 'op1',
+          clientName: 'Op',
+          configError: null,
+          openAlerts: 0,
+          hasRuntime: true,
+          recurringPrice: 1200,
+        },
       ],
       now: NOW,
     })
     const consulting = rows.find((r) => r.kind === 'consulting')!
     const operator = rows.find((r) => r.kind === 'operator')!
     expect(consulting.value).toBe('$8,400')
-    expect(operator.value).toBeNull()
+    expect(operator.value).toBe('$1,200/mo')
+  })
+
+  it('renders an unpriced operator value as null, never fabricated', () => {
+    const rows = buildServiceList({
+      engagements: [],
+      entityName: () => 'Client',
+      quotesById: new Map(),
+      operators: [
+        {
+          entityId: 'op1',
+          clientName: 'Op',
+          configError: null,
+          openAlerts: 0,
+          hasRuntime: true,
+          recurringPrice: null,
+        },
+      ],
+      now: NOW,
+    })
+    expect(rows.find((r) => r.kind === 'operator')!.value).toBeNull()
   })
 })
 
@@ -101,7 +142,14 @@ describe('serviceListStats', () => {
       entityName: () => 'C',
       quotesById: new Map(),
       operators: [
-        { entityId: 'op1', clientName: 'Op', configError: null, openAlerts: 1, hasRuntime: true },
+        {
+          entityId: 'op1',
+          clientName: 'Op',
+          configError: null,
+          openAlerts: 1,
+          hasRuntime: true,
+          recurringPrice: null,
+        },
       ],
       now: NOW,
     })

--- a/tests/services.test.ts
+++ b/tests/services.test.ts
@@ -14,8 +14,10 @@ import {
   updateServiceStatus,
   projectConsultingStatus,
   projectOperatorStatus,
-  findConsultingSpineDrift,
+  findSpineDrift,
   hasSpineDrift,
+  setOperatorPrice,
+  getOperatorServiceForEntity,
   SERVICE_VALID_TRANSITIONS,
 } from '../src/lib/db/services'
 import { createEngagement } from '../src/lib/db/engagements'
@@ -222,7 +224,7 @@ describe('createEngagement spawns a linked service (ADR 0046 Stage 1b)', () => {
   })
 })
 
-describe('findConsultingSpineDrift (ADR 0046 Stage 1b)', () => {
+describe('findSpineDrift — consulting classes (ADR 0046)', () => {
   let db: D1Database
   beforeEach(async () => {
     db = createTestD1()
@@ -234,7 +236,7 @@ describe('findConsultingSpineDrift (ADR 0046 Stage 1b)', () => {
     const quoteId = await seedQuote(db, 'ent-1')
     await createEngagement(db, ORG, { entity_id: 'ent-1', quote_id: quoteId })
 
-    const drift = await findConsultingSpineDrift(db, ORG)
+    const drift = await findSpineDrift(db, ORG)
     expect(hasSpineDrift(drift)).toBe(false)
     expect(drift.orphanEngagements).toHaveLength(0)
     expect(drift.childlessServices).toHaveLength(0)
@@ -257,7 +259,7 @@ describe('findConsultingSpineDrift (ADR 0046 Stage 1b)', () => {
       status: 'active',
     })
 
-    const drift = await findConsultingSpineDrift(db, ORG)
+    const drift = await findSpineDrift(db, ORG)
     expect(hasSpineDrift(drift)).toBe(true)
     expect(drift.orphanEngagements.map((e) => e.id)).toContain('eng-orphan')
     expect(drift.childlessServices.map((s) => s.id)).toContain(childless.id)
@@ -280,7 +282,85 @@ describe('findConsultingSpineDrift (ADR 0046 Stage 1b)', () => {
       status: 'completed',
     })
 
-    const drift = await findConsultingSpineDrift(db, ORG)
+    const drift = await findSpineDrift(db, ORG)
     expect(hasSpineDrift(drift)).toBe(false)
+  })
+})
+
+/** Seed a live operator (`customer_configs` row) for an entity. */
+async function seedConfig(db: D1Database, entityId: string, slug: string) {
+  await db
+    .prepare(
+      `INSERT INTO customer_configs (entity_id, org_id, customer_slug, schema_version, personas_json, git_sha, synced_at)
+       VALUES (?, ?, ?, '1', '[]', 'abc', datetime('now'))`
+    )
+    .bind(entityId, ORG, slug)
+    .run()
+}
+
+describe('setOperatorPrice (ADR 0046 operator arc)', () => {
+  let db: D1Database
+  beforeEach(async () => {
+    db = createTestD1()
+    await runMigrations(db, { files: discoverNumericMigrations(migrationsDir) })
+    await seed(db)
+  })
+
+  it('creates an active operator service when none exists', async () => {
+    const svc = await setOperatorPrice(db, ORG, 'ent-1', 1200)
+    expect(svc.type).toBe('operator')
+    expect(svc.cadence).toBe('recurring')
+    expect(svc.status).toBe('active')
+    expect(svc.recurring_price).toBe(1200)
+    expect(svc.id.startsWith('svc_')).toBe(true)
+
+    const fetched = await getOperatorServiceForEntity(db, ORG, 'ent-1')
+    expect(fetched?.id).toBe(svc.id)
+  })
+
+  it('updates the price on an existing operator service (no second row)', async () => {
+    const first = await setOperatorPrice(db, ORG, 'ent-1', 1000)
+    const second = await setOperatorPrice(db, ORG, 'ent-1', 1500)
+    expect(second.id).toBe(first.id) // same row, no duplicate
+    expect(second.recurring_price).toBe(1500)
+    const all = await getServicesForEntity(db, ORG, 'ent-1')
+    expect(all.filter((s) => s.type === 'operator')).toHaveLength(1)
+  })
+
+  it('clears the price to null (unpriced) without deleting the service', async () => {
+    await setOperatorPrice(db, ORG, 'ent-1', 900)
+    const cleared = await setOperatorPrice(db, ORG, 'ent-1', null)
+    expect(cleared.recurring_price).toBeNull()
+    expect(cleared.status).toBe('active')
+  })
+})
+
+describe('findSpineDrift — operator classes (ADR 0046)', () => {
+  let db: D1Database
+  beforeEach(async () => {
+    db = createTestD1()
+    await runMigrations(db, { files: discoverNumericMigrations(migrationsDir) })
+    await seed(db)
+  })
+
+  it('is clean when a live operator has a commercial service', async () => {
+    await seedConfig(db, 'ent-1', 'ent-1')
+    await setOperatorPrice(db, ORG, 'ent-1', 1200)
+    const drift = await findSpineDrift(db, ORG)
+    expect(hasSpineDrift(drift)).toBe(false)
+  })
+
+  it('flags a live operator (config) with no commercial service', async () => {
+    await seedConfig(db, 'ent-1', 'acme')
+    const drift = await findSpineDrift(db, ORG)
+    expect(hasSpineDrift(drift)).toBe(true)
+    expect(drift.configsWithoutService.map((c) => c.customer_slug)).toContain('acme')
+  })
+
+  it('flags an active operator service whose entity has no config', async () => {
+    const svc = await setOperatorPrice(db, ORG, 'ent-1', 1200) // creates service, no config seeded
+    const drift = await findSpineDrift(db, ORG)
+    expect(hasSpineDrift(drift)).toBe(true)
+    expect(drift.operatorServicesWithoutConfig.map((s) => s.id)).toContain(svc.id)
   })
 })


### PR DESCRIPTION
## Summary
Finishes the mission's operator items on the `service` spine — pricing, real MRR, and the operator as a commercial spine citizen — done the way `/critique` steered (no silent-drop, no disconnected `subscriptions` writer).

- **`setOperatorPrice` (DAL) + admin route** — the operator's forward writer for the **commercial** record (the service + `recurring_price`). Upserts the entity's one operator service; `null` clears to unpriced. Deliberately does **not** write `subscriptions` (portal-access-coupled, owned by provisioning).
- **Real MRR** — `operatorRecurring()` sums the **authoritative roster** priced from the spine; active-but-unpriced operators are surfaced explicitly, never summed as 0. Replaces both `"pending pricing"` literals (billing + home). `cost-query` now reads `services.recurring_price` — single source of truth, no `settings_json` drift.
- **Unified reads, the safe direction** — operator rows still iterate the roster and only **enrich** with spine price/status (no iterate-from-spine, so no operator can vanish). Services list, billing recurring tab, and the client-hub operator card all show the price.
- **`findConsultingSpineDrift` → `findSpineDrift`** — adds operator drift classes (a live `customer_config` with no service / an active service with no config).
- **Client-hub authoring UI** — a control to set the operator's monthly price; honest "Not set" empty state.
- Fixed stale migration `0068`–`0070` header refs (`projectConsultingStatus`/`projectOperatorStatus`).

**No migration** — `recurring_price` has existed since `0068`; this is a code-only deploy.

## Test plan
- [x] `npm run verify` (3379 tests, 0 failures)
- [x] `setOperatorPrice` create / update-no-dup / clear-to-null
- [x] `operatorRecurring` sums priced, counts unpriced (null + missing), drops none
- [x] `findSpineDrift` operator classes; operator row carries the spine price

## Not in this arc (with reason)
- `subscriptions`-on-accept / client-facing signing — `subscriptions` gates portal access and is owned by provisioning; the commercial record is the service.
- Making the spine the *iteration* source for the operator list — needs provisioning (`customer.yaml → CI → customer_configs`) to also write a service; a CI-axis change (ADR 0012). The enrich-join delivers the intent safely meanwhile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)