### PR TITLE
feat(security): Phase 1 — mirror CODE_EXECUTION + taint-gate into trust core

### DIFF
--- a/operator/adapter/trust_ceiling.py
+++ b/operator/adapter/trust_ceiling.py
@@ -47,6 +47,13 @@ class ActionClass(str, enum.Enum):
     EXTERNAL_SEND = "external_send"  # Email, SMS, Slack-to-external, posts — gated
     COMMITMENT = "commitment"  # Sign, accept terms, agree to dates — never autonomous
     DESTRUCTIVE = "destructive"  # Delete, drop, irreversible — explicit per-call approval
+    CODE_EXECUTION = "code_execution"  # Arbitrary code / shell / subagent — authored-only, fail-closed
+
+
+# Inbound trust class for the taint-gate. Kept as a bare string here (the
+# overlay defines the full vocabulary in shared.inbound); the only distinction
+# this core needs is "internal" (clean) vs anything else (tainted).
+_TRUST_CLASS_INTERNAL = "internal"
 
 
 @dataclass(frozen=True)
@@ -124,6 +131,7 @@ def enforce(
     current_turn_approval: bool = False,
     action_ceilings: Mapping[ActionClass, Ceiling] | None = None,
     vertical_floors: Mapping[ActionClass, Ceiling] | None = None,
+    inbound_trust_class: str = _TRUST_CLASS_INTERNAL,
 ) -> EnforcementDecision:
     """Return whether this tool call is allowed under the configured ceilings.
 
@@ -153,6 +161,44 @@ def enforce(
     # READ always allowed regardless of ceiling
     if action == ActionClass.READ:
         return EnforcementDecision(allowed=True, reason="read action", audit_action="allow")
+
+    # TAINT-GATE — a turn that ingested untrusted inbound content cannot fire an
+    # autonomous sensitive action (the injection-ingress → action-egress tie).
+    # READ and INTERNAL_WRITE (drafts) stay allowed. Mirrors the overlay's live
+    # pre_tool_call gate; here for parity (the two cores must agree).
+    if inbound_trust_class != _TRUST_CLASS_INTERNAL and action in (
+        ActionClass.EXTERNAL_SEND,
+        ActionClass.DESTRUCTIVE,
+        ActionClass.COMMITMENT,
+        ActionClass.CODE_EXECUTION,
+    ):
+        return EnforcementDecision(
+            allowed=False,
+            reason=(
+                f"{action.value} refused: turn ingested untrusted inbound content "
+                f"(trust_class={inbound_trust_class}); sensitive action withheld "
+                f"on a tainted turn — read and draft only"
+            ),
+            audit_action="refuse",
+        )
+
+    # CODE_EXECUTION — arbitrary code / shell / subagent. Governed by its own
+    # authored ceiling, fail-closed when unauthored (ADR 0035). No draft concept;
+    # autonomous → allow, else refuse. Not gated by the skill output scalar (a
+    # mechanism, not an output class).
+    if action == ActionClass.CODE_EXECUTION:
+        eff = resolve_ceiling(action, ceiling, action_ceilings, vertical_floors)
+        if eff == Ceiling.AUTONOMOUS:
+            return EnforcementDecision(
+                allowed=True,
+                reason="code_execution permitted: authored code_execution ceiling is autonomous",
+                audit_action="allow",
+            )
+        return EnforcementDecision(
+            allowed=False,
+            reason="code_execution refused: no authored code_execution ceiling (fail-closed, ADR 0035)",
+            audit_action="refuse",
+        )
 
     # COMMITMENT never autonomous (invariant #3)
     # Draft_for_review skills never originate commitments — escalate to autonomous

--- a/src/lib/admin/governance.ts
+++ b/src/lib/admin/governance.ts
@@ -193,5 +193,7 @@ export function actionClassLabel(actionClass: ActionClass): string {
       return 'Commitment'
     case 'destructive':
       return 'Destructive'
+    case 'code_execution':
+      return 'Code execution'
   }
 }

--- a/src/lib/operator/customer-yaml/types.ts
+++ b/src/lib/operator/customer-yaml/types.ts
@@ -163,6 +163,7 @@ export const ACCEPTED_ACTION_CLASSES = [
   'external_send',
   'commitment',
   'destructive',
+  'code_execution',
 ] as const
 export type ActionClass = (typeof ACCEPTED_ACTION_CLASSES)[number]
 

--- a/src/lib/portal/operator/configure.ts
+++ b/src/lib/portal/operator/configure.ts
@@ -26,6 +26,7 @@ export const ACTION_CLASS_LABEL: Record<ActionClass, string> = {
   external_send: 'External send',
   commitment: 'Commitment',
   destructive: 'Destructive',
+  code_execution: 'Code execution',
 }
 
 export interface GovernanceFloorRow {

--- a/tests/governance.test.ts
+++ b/tests/governance.test.ts
@@ -82,7 +82,7 @@ describe('resolveCell — the ADR-0035 keystone', () => {
     expect(cell.effective).toBe('draft_for_review')
   })
 
-  it('resolveSkillCells covers all five action classes', () => {
+  it('resolveSkillCells covers all six action classes', () => {
     const cells = resolveSkillCells(skill(), null)
     expect(cells.map((c) => c.actionClass)).toEqual([
       'read',
@@ -90,8 +90,10 @@ describe('resolveCell — the ADR-0035 keystone', () => {
       'external_send',
       'commitment',
       'destructive',
+      'code_execution',
     ])
-    // Only internal_write is authored (via scalar); the rest are fail-closed.
+    // Only internal_write is authored (via scalar); the rest (incl. the new
+    // code_execution class) are fail-closed.
     expect(cells.filter((c) => c.status === 'authored').map((c) => c.actionClass)).toEqual([
       'internal_write',
     ])


### PR DESCRIPTION
ss-console side of Operator security hardening **Phase 1**, paired with overlay PR venturecrane/hermes-smd-overlay#53. Closes threat-model findings OP-P0-1/-4/-5, OP-P1-1/-3 on the agent side.

## What
- `operator/adapter/trust_ceiling.py` (the canonical policy core the overlay mirrors, imported by the safety-substrate boot invariants): adds `ActionClass.CODE_EXECUTION`, the `inbound_trust_class` **taint-gate** parameter, and the `CODE_EXECUTION` enforce branch — byte-aligned with the live overlay `enforce.py`. Keeps the two policy cores in lockstep (the threat model flagged drift as a risk).
- `types.ts`: adds `code_execution` to `ACCEPTED_ACTION_CLASSES`; label consumers (`configure.ts`, `governance.ts`) and the governance matrix handle the new member.

## Why
The overlay change governs the agent's back door: `execute_code`/`terminal`/etc. become fail-closed unless an engagement authors a `code_execution` ceiling, and a turn that ingested untrusted content cannot fire an autonomous sensitive action (taint-gate). **Customer-zero authors no `code_execution` ceiling → code execution is fully shut** (the Chrome-install incident becomes impossible).

## Tests
440 adapter/safety-substrate + 197 customer-yaml validator + governance suite pass; typecheck clean; full pre-push verify green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)