### PR TITLE
feat(operator): staging gate + fix fresh-provision customer.yaml seed (#1304 regression)

### DIFF
--- a/operator/bin/gen-staging-google-cred.py
+++ b/operator/bin/gen-staging-google-cred.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Generate an ISOLATED, throwaway Google service-account JSON for the staging
+Operator (hermes-smd-staging).
+
+It is a structurally-valid service account with a freshly generated RSA keypair,
+so the Workspace broker boots IDENTICALLY to production (entrypoint.sh's
+`materialize_credential` decodes + writes it; `from_service_account_info` can
+construct a Credentials object from it). But it is wired to a fictitious
+project/account with no domain-wide delegation to anything real, so it can
+authenticate against NO Google resource. boot-smoke and the voice gate never
+make a live Google call, so the staging broker never needs this to actually
+work against Google — only to be a well-formed credential.
+
+This is NEVER a real credential and is NEVER committed. The staging reprovision
+wrapper base64-encodes stdout into the GOOGLE_SERVICE_ACCOUNT_JSON Fly secret on
+the staging Machine only. A fresh key is generated on every provision, which is
+fine — staging holds no persistent Google state.
+
+Run via uv so cryptography is available without a repo dependency:
+    uv run --quiet --with cryptography python3 operator/bin/gen-staging-google-cred.py
+"""
+
+from __future__ import annotations
+
+import json
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+
+def main() -> None:
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    pem = key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.TraditionalOpenSSL,
+        serialization.NoEncryption(),
+    ).decode("ascii")
+    cred = {
+        "type": "service_account",
+        "project_id": "smd-staging-isolated",
+        "private_key_id": "0000000000000000000000000000000000000000",
+        "private_key": pem,
+        "client_email": "crane-staging@smd-staging-isolated.iam.gserviceaccount.com",
+        "client_id": "000000000000000000000",
+        "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+        "token_uri": "https://oauth2.googleapis.com/token",
+        "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+        "client_x509_cert_url": (
+            "https://www.googleapis.com/robot/v1/metadata/x509/"
+            "crane-staging%40smd-staging-isolated.iam.gserviceaccount.com"
+        ),
+    }
+    print(json.dumps(cred))
+
+
+if __name__ == "__main__":
+    main()

--- a/operator/bin/reprovision-staging.sh
+++ b/operator/bin/reprovision-staging.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# reprovision-staging.sh — (re)provision the STAGING Operator: the permanent,
+# faithful pre-production gate for Operator lifecycle work.
+#
+# WHY THIS EXISTS: a world-class deploy process never tests changes to the
+# deploy/boot/voice/env machinery on the one live customer. This stands up
+# hermes-smd-staging from the EXACT same tooling as production, so every cut is
+# proven here before it touches a real customer.
+#
+# ISOLATION (the load-bearing part): the normal reprovision injects every
+# Infisical /ss key as an env var, and provision-customer.sh stages the
+# per-customer ones (GOOGLE_SERVICE_ACCOUNT_JSON, CLIO_*) onto the Machine.
+# Those are the REAL customer credentials. This wrapper:
+#   - replaces GOOGLE_SERVICE_ACCOUNT_JSON with a freshly generated ISOLATED
+#     service account (gen-staging-google-cred.py) — boots the broker
+#     identically to prod, wired to nothing real; and
+#   - BLANKS CLIO_* so the real Clio credentials never reach the staging box.
+# Result: staging borrows none of the live business's access.
+#
+# The slug is HARDCODED to smd-staging. This wrapper must never touch a real
+# customer.
+#
+# Usage:  operator/bin/reprovision-staging.sh
+set -euo pipefail
+
+SLUG="smd-staging"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+exec infisical run --env=prod --path=/ss --silent -- bash -c '
+  set -euo pipefail
+  HERE="$1"; SLUG="$2"
+  # Generated isolated Google credential (throwaway RSA key, fictitious project).
+  # Value flows env -> fly secrets import; never printed.
+  GEN_JSON="$(uv run --quiet --with cryptography python3 "${HERE}/gen-staging-google-cred.py")"
+  export GOOGLE_SERVICE_ACCOUNT_JSON="$(printf "%s" "${GEN_JSON}" | base64 | tr -d "\n")"
+  unset GEN_JSON
+  # Blank real per-customer secrets so they never leak onto the staging Machine.
+  # The values are empty strings (blanking), not secrets — gitleaks false positive.
+  export CLIO_CLIENT_ID="" CLIO_CLIENT_SECRET="" CLIO_ENCRYPTION_KEY="" CLIO_TOKENS_ENC_B64="" # gitleaks:allow
+  # Non-interactive: Machine secrets persist; nothing to paste.
+  yes s | "${HERE}/provision-customer.sh" "${SLUG}"
+' _ "${HERE}" "${SLUG}"

--- a/operator/customers/smd-staging/customer.yaml
+++ b/operator/customers/smd-staging/customer.yaml
@@ -1,0 +1,134 @@
+schema_version: 1
+
+# ============================================================================
+# STAGING Operator — faithful pre-production mirror of customer-zero (smd).
+# ============================================================================
+# This is NOT a real customer. It exists so that every change to the Operator
+# deploy/boot/voice/env machinery is proven on a Machine provisioned by the
+# EXACT same tooling as production, before it ever touches the live business.
+# It is a permanent, reusable pre-prod gate for Operator lifecycle work.
+#
+# Faithful where it matters (same boot sequence: unconditional Workspace
+# broker + uid-split, same skill/connector materialization, same voice vault
+# path shape, same env contract) but INERT and ISOLATED:
+#   - Google credential is a GENERATED, isolated service account (real RSA key,
+#     wired to nothing real). It boots the broker identically to prod; it is
+#     never used for a live Google call by boot-smoke or the voice gate.
+#     Staged at provision time, NEVER committed.
+#   - No managed_mailboxes  -> touches no real inbox.
+#   - No Telegram, no cron  -> no inbound, no autonomous action. The agent
+#     boots and idles, which is exactly what a deploy/boot test target needs.
+#   - Own R2 prefix (vaults/smd-staging/), own D1 namespace, own skill-bodies
+#     bucket. Shares no mutable state with smd.
+#
+# Provision with (overriding the real per-customer secrets in /ss so none leak):
+#   see operator/customers/smd-staging/PROVISION.md
+
+# ---- IDENTITY ----
+customer_id: smd-staging
+customer_name: 'SMD Staging (pre-prod, not a real customer)'
+vertical: mixed
+fly_region: lax
+
+# ---- RUNTIME ----
+model: claude-opus-4-8
+hermes_ref: v2026.5.16@a91a57fa5a13d516c38b07a141a9ce8a3daabeb0
+
+machine:
+  size: shared-cpu-1x
+  memory_mb: 1024
+
+# ---- GOOGLE WORKSPACE AUTHORITY ----
+# Mirrors smd's DWD shape so the broker boots identically. The credential
+# (GOOGLE_SERVICE_ACCOUNT_JSON Fly secret) is a generated isolated key, not the
+# real customer credential. Subject is an unresolvable staging address — no
+# managed mailboxes, so the broker's authored surface is the subject alone and
+# nothing real is reachable.
+google_auth:
+  mode: dwd
+  subject: crane@smd-staging.invalid
+  scopes:
+    - https://www.googleapis.com/auth/gmail.modify
+    - https://www.googleapis.com/auth/calendar.events
+    - https://www.googleapis.com/auth/drive
+
+# ---- HUMANS WITH PORTAL ACCESS ----
+users:
+  - email: staging@smd-staging.invalid
+    role: principal
+    full_name: Staging Principal
+    voice_profile_id: scott
+
+# ---- PERSONAS ----
+# Same persona/skill shape as smd so skill + connector materialization is
+# exercised. No cron block: the agent does not self-trigger on staging.
+personas:
+  - slug: crane
+    status: active
+    name: Crane
+    title: Chief of Staff
+    tone:
+      - plainspoken
+      - direct
+      - executive-summary
+      - concise
+    skills:
+      - name: inbox-triage
+        version: pending
+        trust_ceiling: draft_for_review
+        enabled: true
+      - name: workspace
+        version: pending
+        trust_ceiling: draft_for_review
+        enabled: true
+    skills_disabled:
+      - google-workspace
+      - himalaya
+
+# ---- CONNECTORS ----
+connectors:
+  Email:
+    adapter: google-gmail
+    backend: build:google-gmail
+    enabled: true
+  Calendar:
+    adapter: google-calendar
+    backend: build:google-calendar
+    enabled: true
+  DocumentStorage:
+    adapter: google-drive
+    backend: build:google-drive
+    enabled: true
+
+# ---- SCOPE ----
+scope:
+  email_folders_visible:
+    - Inbox
+  email_folders_blind: []
+  email_keyword_blocks: []
+  domain_blocks: []
+  trusted_sender_domains:
+    - smd-staging.invalid
+  # Inert: drafts only, and there is no inbound to act on anyway.
+  action_ceilings:
+    external_send: draft_for_review
+
+# ---- ESCALATION ----
+escalation:
+  red_flag_recipients:
+    - staging@smd-staging.invalid
+  failure_recipients:
+    - staging@smd-staging.invalid
+
+# ---- VOICE LIBRARY ----
+# Same path shape as smd. A copy of smd's content-free structural-diff samples
+# is staged under vaults/smd-staging/voice/ at setup so the POPULATED voice path
+# is exercised end-to-end on staging.
+voice_library:
+  samples_path: 'r2://vaults/smd-staging/voice/samples/'
+
+# ---- MEMORY (per-customer isolation; must match customer_id) ----
+memory:
+  d1_namespace: smd-staging
+  r2_vault_path: 'vaults/smd-staging/'
+  vectorize_index: 'hermes-smd-staging-vault'

--- a/operator/templates/entrypoint.sh
+++ b/operator/templates/entrypoint.sh
@@ -15,6 +15,33 @@ log() {
 BROKER_DIR="/var/lib/smd-workspace-broker"
 BROKER_SOCKET="/run/smd-workspace-broker/broker.sock"
 BROKER_CUSTOMER_PATH="${BROKER_DIR}/customer.yaml"
+
+# Fresh-volume seed (load-bearing). The Workspace broker starts as root BELOW,
+# before the privilege drop to the hermes user and BEFORE bootstrap.sh runs its
+# own R2 fetch (bootstrap.sh Step 2). On a brand-new volume
+# /opt/data/customer.yaml does not exist yet, so the broker `cp` further down
+# fails and the boot crash-loops to max-restarts. Seed it here from R2 (the
+# source of truth) with the boot-time creds, so a FRESH provision boots with no
+# manual volume seed. Idempotent: on a persisted volume the file already exists
+# (skip), and bootstrap still re-fetches the latest on every boot. This is a
+# regression from #1304 (broker-home isolation introduced the root-side cp);
+# the staging gate caught it on first use.
+if [ ! -f /opt/data/customer.yaml ]; then
+  log "customer.yaml absent on fresh volume — seeding from R2 before broker start"
+  : "${R2_BUCKET_CONFIG:?R2_BUCKET_CONFIG required to seed customer.yaml}"
+  : "${CUSTOMER_SLUG:?CUSTOMER_SLUG required to seed customer.yaml}"
+  _seed_endpoint="${R2_ENDPOINT_URL:-https://${R2_ACCOUNT_ID:-}.r2.cloudflarestorage.com}"
+  if ! AWS_ACCESS_KEY_ID="${R2_ACCESS_KEY_ID:?}" \
+       AWS_SECRET_ACCESS_KEY="${R2_SECRET_ACCESS_KEY:?}" \
+         aws s3 cp \
+           --endpoint-url "${_seed_endpoint}" \
+           --only-show-errors \
+           "s3://${R2_BUCKET_CONFIG}/vaults/${CUSTOMER_SLUG}/customer.yaml" \
+           /opt/data/customer.yaml; then
+    log "FATAL: failed to seed customer.yaml from R2 on fresh boot"
+    exit 1
+  fi
+fi
 chown -R hermes:hermes /opt/data
 rm -rf /opt/data/workspace-broker
 rm -f /opt/data/oauth/google.json


### PR DESCRIPTION
## Summary

Stands up a **permanent, faithful pre-production gate** for the Operator (`hermes-smd-staging`), provisioned by the exact same tooling as prod — and fixes a **fresh-provision regression the gate caught on its very first boot**.

This is the foundation for the Operator-lifecycle work: every change to the deploy/boot/voice/configuration machinery is now provable on staging before it touches a live customer.

### Two commits

1. **`fix(operator): self-seed customer.yaml on fresh-volume boot`** — a production fix.
   The broker-home isolation work (#1304) added a root-side `cp /opt/data/customer.yaml` to `entrypoint.sh` that runs *before* bootstrap's R2 fetch. On a brand-new volume the file isn't there yet, so the broker copy fails and the boot crash-loops to max-restart. **Fresh provisioning of any new customer is currently broken**; existing machines (smd, pilot-law) survive only because their volumes were seeded under the older flow. Entrypoint now self-seeds `customer.yaml` from R2 on a fresh volume (no-op on a persisted one).

2. **`feat(operator): permanent faithful staging gate`** — the gate itself.
   - `gen-staging-google-cred.py` — an **isolated** generated service account (real RSA key, fictitious project) so the Workspace broker boots identically to prod, wired to nothing real.
   - `reprovision-staging.sh` — blanks the real per-customer secrets in `/ss` (`GOOGLE_SERVICE_ACCOUNT_JSON`, `CLIO_*`) so none leak onto the staging box; slug hardcoded to `smd-staging`.
   - `customers/smd-staging/customer.yaml` — faithful boot path (broker + uid-split, skill/connector materialization, voice vault) but inert (no managed mailbox, no Telegram, no cron) and isolated (own R2 prefix / D1 namespace).

## Verification (on the live staging Machine)

- Full boot smoke test passes: machine started, **customer.yaml present** (the fix), profiles dir, plugins installed, curator disabled.
- All **9 safety-substrate invariants pass** (incl. overlay activation — 8 plugins registered).
- Hermes gateway starts; agent idles.
- Isolation confirmed in the provision log: the isolated Google credential staged; `CLIO_*` skipped (blanked); your real credentials untouched.
- The gate also faithfully **reproduces the known voice-inactive bug** (`R2 voice vault env missing`), which the next cut fixes.

## Test plan

- [x] `npm run verify` passes (0 errors)
- [x] `operator/bin/boot-smoke-test.sh smd-staging` all checks pass
- [x] gitleaks clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
