### PR TITLE
fix(operator): deploy secrets atomically with the new image (deploy-order outage fix)

### DIFF
--- a/.github/workflows/operator-substrate.yml
+++ b/.github/workflows/operator-substrate.yml
@@ -67,7 +67,8 @@ jobs:
 
       - name: Run pytest suites (adapter + evidence + pytest-style invariants)
         working-directory: operator
-        # bin/tests/test_voice_corpus.py is named explicitly: the rest of bin/tests
-        # needs substrate deps (pyyaml etc.) not installed in this bare-pytest env,
-        # but the voice-corpus tracer lib imports only adapter.voice + stdlib.
-        run: python3 -m pytest adapter/tests adapter/evidence/tests safety-substrate/tests bin/tests/test_voice_corpus.py connectors/google/tests workspace_broker/tests -q
+        # bin/tests/test_voice_corpus.py and test_deploy_ordering.py are named
+        # explicitly: the rest of bin/tests needs substrate deps (pyyaml etc.) not
+        # installed in this bare-pytest env, but these two import only stdlib (and
+        # adapter.voice for the corpus tracer).
+        run: python3 -m pytest adapter/tests adapter/evidence/tests safety-substrate/tests bin/tests/test_voice_corpus.py bin/tests/test_deploy_ordering.py connectors/google/tests workspace_broker/tests -q

--- a/operator/bin/provision-customer.sh
+++ b/operator/bin/provision-customer.sh
@@ -519,17 +519,34 @@ EOF
   && log "Seeded fleet_status (no-op if row already exists or customer_configs is missing)" \
   || log "WARN: fleet_status seed failed — Wave-1 first-heartbeat will create the row on its own"
 
-# Commit staged secrets
-log "Committing staged secrets..."
-fly secrets deploy -a "${APP_NAME}" 2>/dev/null || true
-
-# ---------- Step 7: deploy ----------
-log "Deploying ${APP_NAME}..."
+# ---------- Step 7: deploy (new image + staged secrets, atomically) ----------
+# DEPLOY ORDERING IS LOAD-BEARING — do NOT add a separate `fly secrets deploy`
+# before this. `fly secrets deploy` "redeploys the CURRENT release with the
+# staged secrets" — i.e. it applies staged secret REMOVALS/changes to the OLD,
+# still-running image BEFORE the new image rolls. When a reprovision changes the
+# secret contract (e.g. drops a var the old image marked required), that restarts
+# the old image without it → its own env check fails → crash-loop → max-restart →
+# STOPPED, with no self-heal (the 2026-06-11 ~18-min customer-zero outage).
+# `fly deploy` applies staged secrets as part of the NEW release — even when the
+# image digest is unchanged — so the running code and its secret contract always
+# change together. (Verified against flyctl v0.4.x docs + the staging gate.)
+log "Deploying ${APP_NAME} (new image + staged secrets roll together)..."
 (cd "${REPO_ROOT}" && fly deploy --config "${RENDERED_DIR}/fly.toml" \
   --build-arg HERMES_REF="${HERMES_REF}" \
   --build-arg HERMES_UPSTREAM_TAG="${HERMES_UPSTREAM_TAG}" \
   --build-arg HERMES_UPSTREAM_SHA="${HERMES_UPSTREAM_SHA}" \
   --build-arg CUSTOMER_SLUG="${SLUG}")
+
+# Post-deploy guard: `fly deploy` must have applied EVERY staged secret as part
+# of the new release. If any remain STAGED (the STATUS column in
+# `fly secrets list`), the running image and its secret contract have drifted —
+# fail loudly rather than leave a staged-but-unapplied secret to surprise a
+# later boot/restart. This is the backstop for the "atomic" claim above.
+log "Verifying no secrets remain staged after deploy..."
+if fly secrets list -a "${APP_NAME}" 2>/dev/null | grep -qw Staged; then
+  die "secrets remain STAGED after fly deploy (not applied to the running image). Inspect: fly secrets list -a ${APP_NAME}"
+fi
+log "All staged secrets applied by the deploy."
 
 # ---------- Step 8: boot smoke test ----------
 # The boot-smoke-test.sh script exercises the customer.yaml → profiles → Hermes

--- a/operator/bin/tests/test_deploy_ordering.py
+++ b/operator/bin/tests/test_deploy_ordering.py
@@ -1,0 +1,85 @@
+"""Guard the Operator deploy ORDERING in provision-customer.sh.
+
+The 2026-06-11 ~18-min customer-zero outage was caused by `fly secrets deploy`
+committing staged secret REMOVALS to the OLD, still-running image BEFORE the new
+image rolled — the old image crash-looped on its now-missing required var, hit
+max-restart, and STOPPED with no self-heal. The fix relies on `fly deploy`
+applying staged secrets atomically with the new release, and on NEVER committing
+secrets to the live machine first.
+
+These tests encode that as a permanent invariant (failure -> permanent guard) so
+the class cannot regress:
+
+  1. No `fly secrets deploy` runs before the `fly deploy` image roll.
+  2. A post-deploy guard fails loudly if any secret remains STAGED (the
+     staged-but-unapplied path the atomic claim depends on).
+
+Run::
+
+    cd operator && python -m pytest bin/tests/test_deploy_ordering.py -v
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "bin" / "provision-customer.sh"
+
+
+def _code_lines() -> list[str]:
+    """Script lines with comment-only lines blanked (so prose can't match)."""
+    out = []
+    for line in _SCRIPT.read_text(encoding="utf-8").splitlines():
+        out.append("" if line.lstrip().startswith("#") else line)
+    return out
+
+
+def _first_index(lines: list[str], pattern: str) -> int:
+    rx = re.compile(pattern)
+    for i, line in enumerate(lines):
+        if rx.search(line):
+            return i
+    return -1
+
+
+def test_no_secrets_deploy_before_image_roll() -> None:
+    """`fly secrets deploy` must never run before the `fly deploy` image roll.
+
+    `fly secrets deploy` redeploys the CURRENT (old) image with the staged
+    secrets; running it before the new image rolls is exactly the outage.
+    """
+    lines = _code_lines()
+    deploy_idx = _first_index(lines, r"\bfly\s+deploy\s+--config\b")
+    assert deploy_idx != -1, "could not find the `fly deploy --config` image roll"
+
+    early = [
+        i + 1
+        for i, line in enumerate(lines)
+        if i < deploy_idx and re.search(r"\bfly\s+secrets\s+deploy\b", line)
+    ]
+    assert not early, (
+        f"`fly secrets deploy` appears before the image roll at line(s) {early} — "
+        "this commits staged secrets to the OLD running image and caused the "
+        "2026-06-11 outage. Let `fly deploy` apply staged secrets atomically."
+    )
+
+
+def test_post_deploy_no_staged_secrets_guard_exists() -> None:
+    """After the deploy, the script must fail if any secret is left STAGED."""
+    lines = _code_lines()
+    deploy_idx = _first_index(lines, r"\bfly\s+deploy\s+--config\b")
+    guard_idx = _first_index(lines, r"fly\s+secrets\s+list\b.*\|\s*grep\s+-qw\s+Staged")
+    assert guard_idx != -1, (
+        "missing the post-deploy staged-secret guard "
+        "(`fly secrets list ... | grep -qw Staged`)"
+    )
+    assert guard_idx > deploy_idx, (
+        "the staged-secret guard must run AFTER the `fly deploy` image roll, "
+        f"not before (guard line {guard_idx + 1}, deploy line {deploy_idx + 1})"
+    )
+    # The guard must terminate provisioning (die) when staged secrets remain.
+    window = "\n".join(lines[guard_idx : guard_idx + 4])
+    assert "die " in window, (
+        "the staged-secret guard must `die` when secrets remain staged"
+    )


### PR DESCRIPTION
## Summary

Fixes the deploy-ordering bug behind the **2026-06-11 ~18-min customer-zero outage**, and adds a permanent guard so the class can't regress.

`provision-customer.sh` ran `fly secrets deploy` **before** `fly deploy`. Per flyctl docs, `fly secrets deploy` *"redeploys the CURRENT release with the staged secrets"* — i.e. it applies staged secret **removals** to the **old, still-running image**. When a reprovision drops a var the old image marked required, the old image restarts without it → fails its env check → crash-loops → max-restart → STOPPED, no self-heal. `fly deploy` instead applies staged secrets as part of the **new** release (even on an unchanged image), so code and its secret contract always change together.

### Changes
- **Remove the premature `fly secrets deploy`** — let `fly deploy` roll the new image and its secrets atomically.
- **Post-deploy guard**: after the deploy, fail loudly (`die`) if any secret remains `STAGED` — closes the staged-but-unapplied path.
- **`operator/bin/tests/test_deploy_ordering.py`** (wired into `operator-substrate` CI): asserts (1) no `fly secrets deploy` before the image roll, (2) the post-deploy staged-secret guard exists, runs after the deploy, and dies. Confirmed it fails against the old ordering (teeth).

## Verification (staging gate)

Reprovisioned `hermes-smd-staging` with the fix — full clean path:
- `0` premature "Committing staged secrets"
- "new image + staged secrets roll together"
- post-deploy guard ran: **"All staged secrets applied by the deploy"**
- all 5 boot smoke checks pass; "Provisioning complete"

smd exercises the same path on its next reprovision (it passes its `:8643` health check, so the full path runs there too).

## Test plan
- [x] `npm run verify` (exit 0)
- [x] `cd operator && python -m pytest bin/tests/test_deploy_ordering.py` (2 passed; fails on old ordering)
- [x] staging reprovision clean end-to-end
- [x] gitleaks clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
