### PR TITLE
feat(operator): Clio dev-tenant seed tooling for the law demo

### DIFF
--- a/operator/bin/clio-token-and-seed.mjs
+++ b/operator/bin/clio-token-and-seed.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+// Mint a Clio Manage access token from the encrypted token blob, then run the
+// Clio dev seed with that token in the child process env. The token is NEVER
+// printed.
+//
+// Safe for the live pilot-law integration: Clio Manage refresh tokens are
+// reusable and NOT rotated (https://docs.developers.clio.com/faq), so refreshing
+// out-of-band mints a fresh access token and leaves the stored refresh token
+// untouched.
+//
+// Decryption mirrors oktopeak/clio-mcp src/auth/tokenStorage.ts exactly:
+//   aes-256-gcm, key = Buffer.from(ENCRYPTION_KEY,'hex'),
+//   file layout = [iv(16)][authTag(16)][ciphertext], base64 in CLIO_TOKENS_ENC_B64.
+//
+// Run under Infisical so the secrets are in env, never in the transcript:
+//   infisical run --env=prod --path=/ss --silent -- \
+//     node operator/bin/clio-token-and-seed.mjs [--dry-run]
+
+import crypto from 'node:crypto'
+import { spawn } from 'node:child_process'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const TOKEN_URL = process.env.CLIO_TOKEN_URL || 'https://app.clio.com/oauth/token'
+
+function need(name) {
+  const v = process.env[name]
+  if (!v) {
+    console.error(
+      `Missing ${name}. Run under: infisical run --env=prod --path=/ss --silent -- node ...`
+    )
+    process.exit(2)
+  }
+  return v
+}
+
+function decryptRefreshToken() {
+  const combined = Buffer.from(need('CLIO_TOKENS_ENC_B64'), 'base64')
+  const iv = combined.subarray(0, 16)
+  const authTag = combined.subarray(16, 32)
+  const encrypted = combined.subarray(32)
+  const key = Buffer.from(need('CLIO_ENCRYPTION_KEY'), 'hex')
+  const decipher = crypto.createDecipheriv('aes-256-gcm', key, iv)
+  decipher.setAuthTag(authTag)
+  let pt
+  try {
+    pt = Buffer.concat([decipher.update(encrypted), decipher.final()]).toString('utf8')
+  } catch (e) {
+    console.error(
+      `Token blob decryption failed (${e.message}). Wrong ENCRYPTION_KEY or corrupt blob.`
+    )
+    process.exit(2)
+  }
+  const tokens = JSON.parse(pt)
+  const rt = tokens.refresh_token || tokens.refreshToken
+  if (!rt) {
+    console.error(
+      `Decrypted blob has no refresh_token. Keys present: ${Object.keys(tokens).join(', ')}`
+    )
+    process.exit(2)
+  }
+  return rt
+}
+
+async function mintAccessToken(refreshToken) {
+  const body = new URLSearchParams({
+    client_id: need('CLIO_CLIENT_ID'),
+    client_secret: need('CLIO_CLIENT_SECRET'),
+    grant_type: 'refresh_token',
+    refresh_token: refreshToken,
+  })
+  const resp = await fetch(TOKEN_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body,
+  })
+  if (!resp.ok) {
+    const t = await resp.text()
+    console.error(`Token refresh failed: HTTP ${resp.status} ${t.slice(0, 300)}`)
+    process.exit(2)
+  }
+  const json = await resp.json()
+  if (!json.access_token) {
+    console.error('Token refresh response had no access_token')
+    process.exit(2)
+  }
+  return json.access_token
+}
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const seedScript = path.join(here, 'seed-clio-demo.py')
+const passthrough = process.argv.slice(2)
+
+const refreshToken = decryptRefreshToken()
+const accessToken = await mintAccessToken(refreshToken)
+console.log('Minted a fresh Clio access token (refresh token reused, pilot-law untouched).\n')
+
+const child = spawn('python3', [seedScript, ...passthrough], {
+  stdio: 'inherit',
+  env: { ...process.env, CLIO_ACCESS_TOKEN: accessToken },
+})
+child.on('exit', (code) => process.exit(code ?? 0))

--- a/operator/bin/seed-clio-demo.py
+++ b/operator/bin/seed-clio-demo.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Seed the Clio developer sandbox with the demo law firm's book of business.
+
+This is ONE-TIME setup for the tangible law demo (the email-in Operator that
+runs `new-matter-intake` against a real Clio dev tenant). It is NOT the demo
+Operator and NOT part of the demo loop -- the Clio MCP has no `create_contact`
+tool, so the seed runs against Clio's REST API directly with an OAuth access
+token.
+
+It plants ONE conflict: **Greg Whitfield** as an EXISTING CLIENT of the firm
+(his own open estate matter). When a prospect later emails an intake naming Greg
+as the party they want to act against, `new-matter-intake`'s read-only conflict
+check (`search_contacts(Greg)` + matter cross-check) HITS an existing client and
+produces a CONFLICT-HOLD -- the demo's money shot, on real (sandbox) Clio data.
+
+Idempotent: every record is matched by name first and skipped if present, so the
+script is safe to re-run. Clio assigns its own contact/matter IDs on creation;
+the demo never depends on specific IDs (the conflict check matches by NAME).
+
+Auth: reads CLIO_ACCESS_TOKEN from the environment -- it is NEVER printed. Get a
+token via the refresh flow or a one-time consent; see operator/bin/clio-token.py
+or the demo runbook. Region base is CLIO_API_BASE (default US app.clio.com).
+
+Usage:
+    CLIO_ACCESS_TOKEN=<token> python operator/bin/seed-clio-demo.py
+    CLIO_ACCESS_TOKEN=<token> python operator/bin/seed-clio-demo.py --dry-run
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+API_BASE = os.environ.get("CLIO_API_BASE", "https://app.clio.com/api/v4").rstrip("/")
+DRY_RUN = "--dry-run" in sys.argv[1:]
+
+
+# --- The demo firm: a small estate + immigration practice ------------------
+# Each contact is a Person who is an existing CLIENT of the firm, with one open
+# matter. Greg Whitfield is the PLANTED CONFLICT.
+SEED = [
+    {
+        "first_name": "Greg",
+        "last_name": "Whitfield",
+        "email": "greg.whitfield@example.com",
+        "matter": "Estate Plan - Whitfield Family Trust",
+        "_note": "PLANTED CONFLICT: existing client; a prospect naming Greg as an adverse party must trigger CONFLICT-HOLD",
+    },
+    {
+        "first_name": "Maria",
+        "last_name": "Delgado",
+        "email": "maria.delgado@example.com",
+        "matter": "Naturalization - Delgado",
+    },
+    {
+        "first_name": "Robert",
+        "last_name": "Kline",
+        "email": "robert.kline@example.com",
+        "matter": "Estate Plan - Kline",
+    },
+]
+
+
+class ClioError(RuntimeError):
+    pass
+
+
+def _token() -> str:
+    tok = os.environ.get("CLIO_ACCESS_TOKEN", "").strip()
+    if not tok:
+        raise ClioError(
+            "CLIO_ACCESS_TOKEN is not set. Source it from the secret tooling; "
+            "do not paste a token on the command line in a shared transcript."
+        )
+    return tok
+
+
+def _request(method: str, path: str, body: dict | None = None) -> dict:
+    url = f"{API_BASE}{path}"
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(url, data=data, method=method)
+    req.add_header("Authorization", f"Bearer {_token()}")
+    req.add_header("Accept", "application/json")
+    if data is not None:
+        req.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            raw = resp.read().decode()
+            return json.loads(raw) if raw else {}
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode(errors="replace")[:500]
+        if exc.code in (401, 403):
+            raise ClioError(
+                f"{exc.code} from Clio -- the access token is missing, expired, "
+                f"or lacks scope. Refresh it and retry. ({detail})"
+            ) from exc
+        raise ClioError(f"{method} {path} -> HTTP {exc.code}: {detail}") from exc
+    except urllib.error.URLError as exc:
+        raise ClioError(f"{method} {path} -> network error: {exc.reason}") from exc
+
+
+def find_contact(full_name: str) -> int | None:
+    q = urllib.parse.urlencode({"query": full_name, "fields": "id,name"})
+    res = _request("GET", f"/contacts.json?{q}")
+    for row in res.get("data", []):
+        if (row.get("name") or "").strip().lower() == full_name.strip().lower():
+            return int(row["id"])
+    return None
+
+
+def ensure_contact(first: str, last: str, email: str) -> tuple[int, bool]:
+    full = f"{first} {last}"
+    existing = find_contact(full)
+    if existing is not None:
+        return existing, False
+    if DRY_RUN:
+        return -1, True
+    body = {
+        "data": {
+            "type": "Person",
+            "first_name": first,
+            "last_name": last,
+            "email_addresses": [
+                {"name": "Work", "address": email, "default_email": True}
+            ],
+        }
+    }
+    res = _request("POST", "/contacts.json?fields=id,name", body)
+    return int(res["data"]["id"]), True
+
+
+def find_matter(client_id: int, description: str) -> int | None:
+    q = urllib.parse.urlencode(
+        {"client_id": client_id, "fields": "id,description,status"}
+    )
+    res = _request("GET", f"/matters.json?{q}")
+    for row in res.get("data", []):
+        if (row.get("description") or "").strip().lower() == description.strip().lower():
+            return int(row["id"])
+    return None
+
+
+def ensure_matter(client_id: int, description: str) -> tuple[int, bool]:
+    if client_id != -1:
+        existing = find_matter(client_id, description)
+        if existing is not None:
+            return existing, False
+    if DRY_RUN:
+        return -1, True
+    body = {
+        "data": {
+            "client": {"id": client_id},
+            "description": description,
+            "status": "Open",
+        }
+    }
+    res = _request("POST", "/matters.json?fields=id,description,status", body)
+    return int(res["data"]["id"]), True
+
+
+def main() -> int:
+    mode = "DRY-RUN (no writes)" if DRY_RUN else "LIVE"
+    print(f"Seeding Clio dev tenant at {API_BASE}  [{mode}]\n")
+    # Fail fast on auth before any writes.
+    try:
+        _token()
+        whoami = _request("GET", "/users/who_am_i.json?fields=id,name")
+        who = whoami.get("data", {})
+        print(f"Authenticated as: {who.get('name', '?')} (user {who.get('id', '?')})\n")
+    except ClioError as exc:
+        print(f"ABORT: {exc}", file=sys.stderr)
+        return 2
+
+    created = 0
+    for rec in SEED:
+        full = f"{rec['first_name']} {rec['last_name']}"
+        try:
+            cid, c_new = ensure_contact(rec["first_name"], rec["last_name"], rec["email"])
+            mid, m_new = ensure_matter(cid, rec["matter"])
+        except ClioError as exc:
+            print(f"  ! {full}: {exc}", file=sys.stderr)
+            return 1
+        tag = "PLANTED CONFLICT" if "_note" in rec else "neutral"
+        c_state = "created" if c_new else "exists"
+        m_state = "created" if m_new else "exists"
+        cid_s = "(dry)" if cid == -1 else f"#{cid}"
+        mid_s = "(dry)" if mid == -1 else f"#{mid}"
+        print(f"  - {full:20s} contact {cid_s:>8} [{c_state}]  matter {mid_s:>8} [{m_state}]  <{tag}>")
+        created += int(c_new) + int(m_new)
+
+    print(f"\nDone. {created} record(s) {'would be ' if DRY_RUN else ''}created; rest already present.")
+    if not DRY_RUN:
+        print("Verify the conflict will fire: search_contacts('Greg Whitfield') should return an existing client.")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except ClioError as exc:
+        print(f"ABORT: {exc}", file=sys.stderr)
+        raise SystemExit(2)


### PR DESCRIPTION
## What

Reproducible, version-controlled tooling to seed the **Clio developer sandbox** with the demo law firm's book of business, so the real `new-matter-intake` skill can run its conflict check against a live (sandbox) Clio tenant. One-time setup — **not** part of the demo loop, and **not** the demo Operator (the Clio MCP has no `create_contact`, so this hits Clio's REST API directly).

It plants one conflict: **Greg Whitfield** as an existing client (his own open estate matter), plus two neutral clients. A prospect who later emails an intake naming Greg as an adverse party trips `new-matter-intake`'s read-only conflict check → CONFLICT-HOLD.

## Files

- `operator/bin/seed-clio-demo.py` — idempotent Clio REST v4 seeder (contacts + matters). Reads `CLIO_ACCESS_TOKEN` from env, never prints it. Clio assigns IDs; the demo matches the conflict by **name**, not ID. Supports `--dry-run`.
- `operator/bin/clio-token-and-seed.mjs` — mints a fresh access token from the encrypted `tokens.enc` blob (oktopeak `aes-256-gcm` format), then runs the seed with the token in-process. Clio Manage refresh tokens are **reusable / not rotated**, so this leaves pilot-law's stored token untouched.

## Run

```
infisical run --env=prod --path=/ss --silent -- \
  node operator/bin/clio-token-and-seed.mjs [--dry-run]
```

## Verified

Ran live against the Clio dev tenant (user 359163738): Greg Whitfield seeded as contact #2402831283 / matter #1791293643, findable via `search_contacts`. pilot-law's Clio connection unaffected. (Verify ledger `vfy_01KTWAV6SK...`.)

Note: live Clio `search_contacts` has indexing lag — fresh contacts aren't instantly searchable; benign since seeding precedes any demo run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)