### PR TITLE
feat(operator): boot-sync voice vault to volume — restore voice with no agent R2 credential

### DIFF
--- a/operator/bin/voice-ingest-corpus.py
+++ b/operator/bin/voice-ingest-corpus.py
@@ -100,6 +100,17 @@ def main(argv: list[str] | None = None) -> int:
 
     target = f"R2 bucket {os.environ.get('R2_BUCKET_CONFIG', '?')}" if args.r2 else args.out_dir
     print(f"ingested {written} content-free samples -> {target} (slug={args.slug} cohort={args.cohort})")
+    if args.r2 and written:
+        # The Machine syncs the voice vault to its volume only at BOOT (bootstrap
+        # Step 2a). A freshly-ingested corpus is therefore INVISIBLE to the
+        # running agent until a restart — make that explicit, not a silent lag.
+        print(
+            "\nNOTE: the running agent only re-reads the voice vault at boot. "
+            "Restart the Machine to activate this corpus:\n"
+            f"  fly machine restart -a hermes-{args.slug}\n"
+            "(or reprovision). Until then the agent uses the previously-synced samples.",
+            file=sys.stderr,
+        )
     return 0
 
 

--- a/operator/templates/Dockerfile
+++ b/operator/templates/Dockerfile
@@ -121,7 +121,7 @@ ARG HERMES_UPSTREAM_SHA=a91a57fa5a13d516c38b07a141a9ce8a3daabeb0
 # external-send identity brand) and #53 (security Phase 1: govern code execution,
 # fence the managed-mailbox read, taint-gate autonomy, destructive Gmail ops).
 ARG OVERLAY_REPO="https://github.com/venturecrane/hermes-smd-overlay.git"
-ARG OVERLAY_REF="50d80f7feea95afc4ce40ed91cd14a11cc55d010"
+ARG OVERLAY_REF="d1990d51ebcca99dc6e9a6a6f163abc5c105b5f2"
 
 ARG CUSTOMER_SLUG=customer-zero
 

--- a/operator/templates/bootstrap.sh
+++ b/operator/templates/bootstrap.sh
@@ -188,6 +188,42 @@ chmod 0644 "${CUSTOMER_YAML}" \
   || die "customer.yaml must be readable by the separate Workspace broker principal"
 
 # ============================================================================
+# Step 2a: sync the voice vault to the volume (agent holds NO R2 credential)
+# ============================================================================
+# The voice plugin reads the customer's content-free voice samples from R2
+# (vaults/<slug>/voice/). We fetch them HERE at boot — with the same boot-time
+# creds used for the customer.yaml fetch above, which are STRIPPED before the
+# gateway exec (OP-P0-2) — and point the plugin at the local mirror via
+# SMD_VOICE_VAULT_DIR. Net: the agent process holds no R2 credential for voice,
+# yet voice works. Samples change only when an operator re-ingests a corpus (a
+# deliberate out-of-band action), so a boot snapshot is sufficient. This runs as
+# the hermes user (entrypoint already dropped privilege), so synced files are
+# hermes-owned — no extra chown, no race with entrypoint's blanket chown.
+export SMD_VOICE_VAULT_DIR="${HERMES_HOME:-/opt/data}/voice"
+R2_VOICE_PREFIX="s3://${R2_BUCKET_CONFIG}/vaults/${CUSTOMER_SLUG}/voice/"
+# Empty/absent vault is the COMMON case (no corpus ingested yet) and MUST NOT
+# fail the boot under `set -e`: probe first, sync only when non-empty, and never
+# `die`. When empty we leave SMD_VOICE_VAULT_DIR's dir absent so reader_from_env
+# falls through and the plugin reports INACTIVE (accurate), rather than ACTIVE
+# with zero samples.
+if AWS_ACCESS_KEY_ID="${R2_ACCESS_KEY_ID}" \
+   AWS_SECRET_ACCESS_KEY="${R2_SECRET_ACCESS_KEY}" \
+     aws s3 ls --endpoint-url "${R2_ENDPOINT_URL}" "${R2_VOICE_PREFIX}" 2>/dev/null | grep -q .; then
+  mkdir -p "${SMD_VOICE_VAULT_DIR}"
+  if AWS_ACCESS_KEY_ID="${R2_ACCESS_KEY_ID}" \
+     AWS_SECRET_ACCESS_KEY="${R2_SECRET_ACCESS_KEY}" \
+       aws s3 cp --recursive --only-show-errors \
+         --endpoint-url "${R2_ENDPOINT_URL}" \
+         "${R2_VOICE_PREFIX}" "${SMD_VOICE_VAULT_DIR}/"; then
+    log "voice vault synced to ${SMD_VOICE_VAULT_DIR} (agent holds no R2 credential for voice)"
+  else
+    log "WARN: voice vault sync failed; voice INACTIVE this boot (non-fatal)"
+  fi
+else
+  log "no voice vault at ${R2_VOICE_PREFIX} (no corpus ingested) — voice stays inactive"
+fi
+
+# ============================================================================
 # Step 2b: verify mediated Workspace broker readiness
 # ============================================================================
 # entrypoint.sh started the broker as a separate uid and removed every Google
@@ -682,15 +718,18 @@ fi
 
 # Strip the account-wide R2 credential before handing off to the agent (OP-P0-2,
 # docs/security/operator-threat-model.md). R2_ACCESS_KEY_ID / R2_SECRET_ACCESS_KEY
-# are an ACCOUNT-WIDE R2 key (R/W on every bucket in the account); their only
-# in-Machine consumer is the customer.yaml fetch in Step 2 above. The agent's own
-# skill-body writer (skill_capture.py) uses the bucket-SCOPED R2_SKILL_BODIES_*
-# pair plus R2_ENDPOINT_URL — NOT these — so the account-wide key must not remain
-# in the gateway env where an injection could exfiltrate it cross-tenant.
-# ORDERING IS LOAD-BEARING: this unset MUST stay AFTER the R2 fetch (Step 2) and
-# BEFORE the gateway exec; moving it earlier breaks the fetch (R2_ACCESS_KEY_ID is
-# read at the `aws s3 cp` above). R2_ENDPOINT_URL is intentionally KEPT — the
-# scoped skill-body writer reads it, and it is an endpoint URL, not a credential.
+# are an ACCOUNT-WIDE R2 key (R/W on every bucket in the account); their
+# in-Machine consumers are the customer.yaml fetch (Step 2) and the voice-vault
+# sync (Step 2a) above — both BOOT-time and both BEFORE this strip. The agent's
+# own skill-body writer (skill_capture.py) uses the bucket-SCOPED
+# R2_SKILL_BODIES_* pair plus R2_ENDPOINT_URL — NOT these — and voice reads its
+# vault from the local SMD_VOICE_VAULT_DIR mirror, so the account-wide key must
+# not remain in the gateway env where an injection could exfiltrate it
+# cross-tenant. ORDERING IS LOAD-BEARING: this unset MUST stay AFTER the R2 fetch
+# + voice sync (Step 2/2a) and BEFORE the gateway exec; moving it earlier breaks
+# them (R2_ACCESS_KEY_ID is read by the `aws s3 cp`s above). R2_ENDPOINT_URL is
+# intentionally KEPT — the scoped skill-body writer reads it, and it is an
+# endpoint URL, not a credential.
 unset R2_ACCESS_KEY_ID R2_SECRET_ACCESS_KEY
 
 log "Launching Hermes gateway for profile '${ACTIVE_PROFILE}' (overlay plugins enabled)..."

--- a/tests/operator-dockerfile.test.ts
+++ b/tests/operator-dockerfile.test.ts
@@ -56,7 +56,7 @@ describe('Operator customer Machine Dockerfile', () => {
   })
 
   it('pins the broker-capable overlay revision', () => {
-    expect(DOCKERFILE).toContain('ARG OVERLAY_REF="50d80f7feea95afc4ce40ed91cd14a11cc55d010"')
+    expect(DOCKERFILE).toContain('ARG OVERLAY_REF="d1990d51ebcca99dc6e9a6a6f163abc5c105b5f2"')
   })
 
   it('does NOT swallow a failed plugin install (no fail-open `|| echo ... continuing`)', () => {


### PR DESCRIPTION
## Summary

The ss-console half of the voice fix (pairs with **hermes-smd-overlay#54**, already merged). Together they restore voice after the Phase 1 security strip with **zero R2 credential in the agent**.

- **`bootstrap.sh` Step 2a** — boot-syncs the customer's voice vault (`vaults/<slug>/voice/`) to the volume with the boot-time R2 creds (the same ones used for the customer.yaml fetch, stripped before the gateway exec), and exports `SMD_VOICE_VAULT_DIR`. The overlay's `LocalVaultSampleReader` reads from disk → the agent holds **no R2 credential** for voice.
  - Empty/absent vault (the common no-corpus case) is probed first and never fails the boot under `set -e`.
  - Runs as the hermes user → synced files are hermes-owned (no chown race).
- **Strip comment** updated to name the voice sync as a boot-time R2 consumer.
- **`voice-ingest-corpus.py`** prints the exact `fly machine restart` to activate a freshly-ingested corpus (boot snapshot → restart required; made explicit, not a silent lag).
- **`OVERLAY_REF`** bumped to the merged overlay (`d1990d5`); the Dockerfile integrity-pin test updated to match.

## Verification (staging gate, on the live agent)

Reprovisioned `hermes-smd-staging`; on the running gateway process:
- `R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY`: **ABSENT** (OP-P0-2 stays closed)
- `R2_ENDPOINT_URL` / `SMD_VOICE_VAULT_DIR`: present
- **29 voice samples** synced to `/opt/data/voice/`
- `[bootstrap] voice vault synced to /opt/data/voice (agent holds no R2 credential for voice)`; boot smoke passes

## Test plan
- [x] `npm run verify` (exit 0, incl. updated Dockerfile integrity-pin test)
- [x] staging: agent holds no R2 credential; 29 voice samples on disk
- [x] overlay#54 merged with 11 passing voice tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
