### PR TITLE
feat(operator): env-consumption contract + fail-closed boot guard (prevention layer)

### DIFF
--- a/.github/workflows/operator-substrate.yml
+++ b/.github/workflows/operator-substrate.yml
@@ -71,4 +71,4 @@ jobs:
         # explicitly: the rest of bin/tests needs substrate deps (pyyaml etc.) not
         # installed in this bare-pytest env, but these two import only stdlib (and
         # adapter.voice for the corpus tracer).
-        run: python3 -m pytest adapter/tests adapter/evidence/tests safety-substrate/tests bin/tests/test_voice_corpus.py bin/tests/test_deploy_ordering.py connectors/google/tests workspace_broker/tests -q
+        run: python3 -m pytest adapter/tests adapter/evidence/tests safety-substrate/tests bin/tests/test_voice_corpus.py bin/tests/test_deploy_ordering.py bin/tests/test_env_contract_conformance.py connectors/google/tests workspace_broker/tests -q

--- a/operator/bin/tests/test_env_contract_conformance.py
+++ b/operator/bin/tests/test_env_contract_conformance.py
@@ -1,0 +1,104 @@
+"""Conformance: the env-consumption contract MATCHES the scripts' reality.
+
+Invariant 9 (operator/safety-substrate) checks the contract is internally
+consistent (no agent-consumed var marked stripped). THIS CI-side check verifies
+the contract is not merely aspirational: bootstrap.sh's REQUIRED_ENV /
+OPTIONAL_ENV arrays and the actual `unset` strip sites must agree with the
+contract. Drift here = red check, caught before deploy.
+
+Run::
+
+    cd operator && python -m pytest bin/tests/test_env_contract_conformance.py -v
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+_OP = Path(__file__).resolve().parents[2]
+_CONTRACT = _OP / "contracts" / "env-consumption.yaml"
+_BOOTSTRAP = _OP / "templates" / "bootstrap.sh"
+_ENTRYPOINT = _OP / "templates" / "entrypoint.sh"
+
+
+def _contract() -> dict:
+    return (yaml.safe_load(_CONTRACT.read_text(encoding="utf-8")) or {}).get("vars", {})
+
+
+def _bash_array(text: str, name: str) -> set[str]:
+    m = re.search(rf"{name}=\((.*?)\)", text, re.DOTALL)
+    assert m, f"{name} array not found in bootstrap.sh"
+    out: set[str] = set()
+    for line in m.group(1).splitlines():
+        line = line.split("#", 1)[0].strip()
+        if line:
+            out.add(line)
+    return out
+
+
+def _unset_vars(text: str) -> set[str]:
+    out: set[str] = set()
+    for m in re.finditer(r"^\s*unset\s+(.+)$", text, re.MULTILINE):
+        for tok in m.group(1).split():
+            if re.fullmatch(r"[A-Z_][A-Z0-9_]*", tok):
+                out.add(tok)
+    return out
+
+
+def test_required_env_is_declared_required() -> None:
+    contract = _contract()
+    for var in _bash_array(_BOOTSTRAP.read_text(encoding="utf-8"), "REQUIRED_ENV"):
+        assert var in contract, f"bootstrap REQUIRED_ENV {var} missing from the contract"
+        assert (
+            contract[var].get("requirement") == "required"
+        ), f"{var} is in REQUIRED_ENV but the contract marks it {contract[var].get('requirement')!r}"
+
+
+def test_optional_env_not_marked_required() -> None:
+    contract = _contract()
+    for var in _bash_array(_BOOTSTRAP.read_text(encoding="utf-8"), "OPTIONAL_ENV"):
+        if var in contract:
+            assert (
+                contract[var].get("requirement") == "optional"
+            ), f"{var} is in OPTIONAL_ENV but the contract marks it required"
+
+
+def test_contract_bootstrap_strips_are_real() -> None:
+    contract = _contract()
+    bootstrap_unset = _unset_vars(_BOOTSTRAP.read_text(encoding="utf-8"))
+    for var, spec in contract.items():
+        if spec.get("agent_env") == "stripped" and str(spec.get("strip_site", "")).endswith(
+            "bootstrap.sh"
+        ):
+            assert (
+                var in bootstrap_unset
+            ), f"contract says {var} is stripped in bootstrap.sh, but there is no `unset {var}` there"
+
+
+def test_contract_entrypoint_strips_are_real() -> None:
+    contract = _contract()
+    entry_unset = _unset_vars(_ENTRYPOINT.read_text(encoding="utf-8"))
+    for var, spec in contract.items():
+        if spec.get("agent_env") == "stripped" and str(spec.get("strip_site", "")).endswith(
+            "entrypoint.sh"
+        ):
+            assert (
+                var in entry_unset
+            ), f"contract says {var} is stripped in entrypoint.sh, but there is no `unset {var}` there"
+
+
+def test_r2_account_wide_strip_is_declared() -> None:
+    """The R2 account-wide strip in bootstrap (the voice-class site) must be
+    declared stripped in the contract, so a future strip can't silently
+    de-credential the agent without updating the contract that invariant 9
+    then guards."""
+    contract = _contract()
+    bootstrap_unset = _unset_vars(_BOOTSTRAP.read_text(encoding="utf-8"))
+    for var in ("R2_ACCESS_KEY_ID", "R2_SECRET_ACCESS_KEY"):
+        assert var in bootstrap_unset, f"expected bootstrap.sh to unset {var}"
+        assert (
+            contract.get(var, {}).get("agent_env") == "stripped"
+        ), f"{var} is unset in bootstrap but not declared stripped in the contract"

--- a/operator/contracts/env-consumption.yaml
+++ b/operator/contracts/env-consumption.yaml
@@ -1,0 +1,161 @@
+# ============================================================================
+# Operator env-consumption contract — the SINGLE SOURCE OF TRUTH for what each
+# environment variable is, where it is consumed, and whether it survives into
+# the long-running agent process.
+# ============================================================================
+#
+# WHY THIS EXISTS. Every Operator deploy used to surprise us because one fact —
+# "what reads this var" — lived in someone's head, separate from the tooling
+# that provisions/strips/requires it, and the two drifted. That is how voice
+# broke: Phase 1 security stripped the account-wide R2 key from the agent env,
+# not knowing the voice plugin read it (OP-P0-2). This file makes that fact
+# explicit and machine-checkable, so the drift becomes a failed check instead of
+# a live incident.
+#
+# ENFORCEMENT (all derived from THIS file):
+#   1. Boot-time, fail-closed (operator/safety-substrate/tests/test_invariant_9_*):
+#      the headline guard — NO var marked `stage: agent` may be `agent_env:
+#      stripped`. You cannot strip a credential the agent needs. Runs in the
+#      image (where this contract is COPY'd) at bootstrap Step 8, before the
+#      gateway starts. This is a STATIC consistency check (no live-env probe, no
+#      grep) so it cannot false-positive and brick a healthy Machine.
+#   2. CI, ss-console (tests/operator-env-contract.test.ts): the contract's
+#      `required`/`optional`/`stripped` facts MATCH bootstrap.sh's REQUIRED_ENV /
+#      OPTIONAL_ENV arrays and the actual `unset`/strip sites. Drift = red check.
+#
+# FIELDS (per var):
+#   stage:       where the value is CONSUMED. One of:
+#                  provisioning-host  - the laptop running provision-customer.sh; never reaches the Machine
+#                  image-build        - a Docker ARG/build-time value
+#                  boot               - read by entrypoint.sh / bootstrap.sh before the agent starts
+#                  agent              - read by the long-running gateway or an overlay plugin
+#                  broker             - read by the uid-split Workspace broker process
+#                  mcp-subprocess     - read by an MCP connector subprocess the agent spawns
+#   requirement: required | optional   (required => boot dies if absent)
+#   agent_env:   held | stripped | n/a
+#                  held     - present in the agent process env
+#                  stripped - explicitly unset before the gateway exec (must NOT be stage:agent)
+#                  n/a      - never on the Machine (provisioning-host / image-build)
+#   strip_site:  (only when agent_env: stripped) the file that unsets it
+#   note:        free text
+#
+# Adding a consumer? Add/update the var here FIRST. If a plugin needs a var at
+# `stage: agent`, it must be `agent_env: held` — the boot invariant enforces it.
+
+vars:
+  # ---- Agent-held credentials/config (the long-running gateway + overlay plugins) ----
+  ANTHROPIC_API_KEY:
+    stage: agent
+    requirement: required
+    agent_env: held
+    note: the gateway's model credential
+  SMD_D1_AUDIT_BINDING:
+    stage: agent
+    requirement: required
+    agent_env: held
+    note: hermes-smd-audit D1 binding (path or var-name indirection)
+  R2_SKILL_BODIES_BUCKET:
+    stage: agent
+    requirement: required
+    agent_env: held
+    note: bucket NAME (not a credential) from fly.toml [env]; skill_capture target
+  R2_ENDPOINT_URL:
+    stage: agent
+    requirement: optional
+    agent_env: held
+    note: endpoint URL (NOT a credential) read by skill_capture + the voice reader path; intentionally kept across the R2 strip
+  SMD_VOICE_VAULT_DIR:
+    stage: agent
+    requirement: optional
+    agent_env: held
+    note: local voice-vault dir set by bootstrap Step 2a; the voice plugin reads samples from here so the agent holds NO R2 credential (OP-P0-2)
+  R2_SKILL_BODIES_ACCESS_KEY_ID:
+    stage: agent
+    requirement: optional
+    agent_env: held
+    note: bucket-SCOPED token for agent-authored skill persistence; OFF by default; NEVER the account-wide pair
+  R2_SKILL_BODIES_SECRET_ACCESS_KEY:
+    stage: agent
+    requirement: optional
+    agent_env: held
+    note: paired with R2_SKILL_BODIES_ACCESS_KEY_ID
+
+  # ---- Boot-stage credentials: read before the agent, then STRIPPED ----
+  R2_ACCESS_KEY_ID:
+    stage: boot
+    requirement: required
+    agent_env: stripped
+    strip_site: operator/templates/bootstrap.sh
+    note: ACCOUNT-WIDE R2 key; read by the customer.yaml fetch (Step 2) + voice-vault sync (Step 2a); unset before gateway exec (OP-P0-2)
+  R2_SECRET_ACCESS_KEY:
+    stage: boot
+    requirement: required
+    agent_env: stripped
+    strip_site: operator/templates/bootstrap.sh
+    note: paired with R2_ACCESS_KEY_ID
+  R2_BUCKET_CONFIG:
+    stage: boot
+    requirement: required
+    agent_env: held
+    note: config-bucket NAME (not a credential); fly.toml [env]; used by the boot fetches and is harmless in the agent env
+
+  # ---- Broker-stage credentials: read by the uid-split broker, unset for the agent ----
+  GOOGLE_SERVICE_ACCOUNT_JSON:
+    stage: broker
+    requirement: optional
+    agent_env: stripped
+    strip_site: operator/templates/entrypoint.sh
+    note: DWD service-account key; only the workspace-broker process decodes it; unset for the gateway
+  GOOGLE_TOKEN_JSON:
+    stage: broker
+    requirement: optional
+    agent_env: stripped
+    strip_site: operator/templates/entrypoint.sh
+    note: legacy user-OAuth token; broker-only
+  GOOGLE_CLIENT_SECRET_JSON:
+    stage: broker
+    requirement: optional
+    agent_env: stripped
+    strip_site: operator/templates/entrypoint.sh
+    note: broker-only OAuth client secret
+
+  # ---- MCP-subprocess credentials (passed only into the connector subprocess env) ----
+  CLIO_CLIENT_ID:
+    stage: mcp-subprocess
+    requirement: optional
+    agent_env: held
+    note: Clio MCP connector; materialized into the mcp_servers subprocess env when the customer binds Clio
+  CLIO_CLIENT_SECRET:
+    stage: mcp-subprocess
+    requirement: optional
+    agent_env: held
+    note: paired with CLIO_CLIENT_ID
+
+  # ---- Optional agent observability / Phase-2 forward-compat ----
+  SMD_D1_OBSERVATIONS_BINDING:
+    stage: agent
+    requirement: optional
+    agent_env: held
+    note: Honcho observations mirror; inert in Phase 1 (ADR 0016 revised)
+  HONCHO_API_KEY:
+    stage: agent
+    requirement: optional
+    agent_env: held
+    note: Honcho inferred-memory; inert in Phase 1
+  AGENTMAIL_API_KEY:
+    stage: agent
+    requirement: optional
+    agent_env: held
+    note: deferred Phase 2; no consumer wired today
+
+  # ---- Provisioning-host only (never reach the Machine) ----
+  OPERATOR_RUNTIME_READ_SECRET:
+    stage: provisioning-host
+    requirement: optional
+    agent_env: n/a
+    note: HMAC seed used at provisioning to derive the per-customer OPERATOR_RUNTIME_READ_KEY; never staged to the Machine
+  CF_API_TOKEN:
+    stage: provisioning-host
+    requirement: optional
+    agent_env: n/a
+    note: Cloudflare token for R2 bucket creation at provisioning; never staged

--- a/operator/safety-substrate/tests/test_invariant_9_env_consumption_contract.py
+++ b/operator/safety-substrate/tests/test_invariant_9_env_consumption_contract.py
@@ -1,0 +1,115 @@
+"""Invariant 9 — env-consumption contract consistency (fail-closed at boot).
+
+The headline guard against the voice-class regression: a variable the AGENT
+consumes can never be marked stripped from the agent env. Phase 1 security
+stripped the account-wide R2 key not knowing the voice plugin read it
+(OP-P0-2); this invariant turns that contradiction into a boot failure at the
+DECLARATION level, caught before the gateway starts.
+
+This is a STATIC consistency check over operator/contracts/env-consumption.yaml
+(no live-env probe, no grep), so it cannot false-positive and brick a healthy
+Machine — only a genuinely inconsistent contract fails it. The complementary
+"does the contract match bootstrap's actual REQUIRED/OPTIONAL/strip behaviour"
+check is CI-side (tests/operator-env-contract conformance).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).resolve()
+
+_VALID_STAGES = {
+    "provisioning-host",
+    "image-build",
+    "boot",
+    "agent",
+    "broker",
+    "mcp-subprocess",
+}
+_VALID_REQUIREMENT = {"required", "optional"}
+_VALID_AGENT_ENV = {"held", "stripped", "n/a"}
+_OFF_MACHINE = {"provisioning-host", "image-build"}
+
+
+def _contract_path() -> Path | None:
+    for cand in (
+        Path("/app/contracts/env-consumption.yaml"),  # image runtime
+        _HERE.parents[2] / "contracts" / "env-consumption.yaml",  # repo/CI
+    ):
+        if cand.is_file():
+            return cand
+    return None
+
+
+def run() -> tuple[bool, str]:
+    path = _contract_path()
+    if path is None:
+        return (
+            False,
+            "FAIL: env-consumption contract not found "
+            "(expected /app/contracts/env-consumption.yaml)",
+        )
+    try:
+        import yaml
+    except ModuleNotFoundError:
+        # Don't brick boot on a missing parser in a stripped venv; CI enforces
+        # the same checks. yaml is present in the Machine venv at boot.
+        return True, "SKIP: yaml unavailable in this interpreter; CI enforces the contract"
+
+    data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    vars_ = data.get("vars")
+    if not isinstance(vars_, dict) or not vars_:
+        return False, "FAIL: env-consumption contract has no `vars` map"
+
+    violations: list[str] = []
+    for name, spec in vars_.items():
+        if not isinstance(spec, dict):
+            violations.append(f"{name}: not a mapping")
+            continue
+        stage = spec.get("stage")
+        requirement = spec.get("requirement")
+        agent_env = spec.get("agent_env")
+        if stage not in _VALID_STAGES:
+            violations.append(f"{name}: invalid stage {stage!r}")
+        if requirement not in _VALID_REQUIREMENT:
+            violations.append(f"{name}: invalid requirement {requirement!r}")
+        if agent_env not in _VALID_AGENT_ENV:
+            violations.append(f"{name}: invalid agent_env {agent_env!r}")
+        # HEADLINE GUARD: an agent-consumed var MUST survive into the agent env.
+        if stage == "agent" and agent_env == "stripped":
+            violations.append(
+                f"{name}: stage:agent but agent_env:stripped — the agent needs this "
+                "var; stripping it is the voice-class regression"
+            )
+        # stripped => must name where it is stripped
+        if agent_env == "stripped" and not spec.get("strip_site"):
+            violations.append(f"{name}: agent_env:stripped but no strip_site named")
+        # off-machine stages never have an agent env
+        if stage in _OFF_MACHINE and agent_env != "n/a":
+            violations.append(
+                f"{name}: stage:{stage} must have agent_env:n/a, got {agent_env!r}"
+            )
+        # on-machine stages must declare held|stripped, not n/a
+        if stage not in _OFF_MACHINE and stage in _VALID_STAGES and agent_env == "n/a":
+            violations.append(
+                f"{name}: on-machine stage:{stage} must be held or stripped, not n/a"
+            )
+
+    if violations:
+        return (
+            False,
+            "FAIL: env-consumption contract inconsistent:\n  - " + "\n  - ".join(violations),
+        )
+    return (
+        True,
+        f"PASS: env-consumption contract consistent ({len(vars_)} vars; "
+        "no agent-needed var is stripped)",
+    )
+
+
+if __name__ == "__main__":
+    ok, msg = run()
+    print(msg)
+    sys.exit(0 if ok else 1)

--- a/operator/templates/Dockerfile
+++ b/operator/templates/Dockerfile
@@ -304,6 +304,11 @@ COPY operator/connectors/ /app/connectors/
 # Safety-substrate tests — bootstrap.sh runs these on container start
 COPY operator/safety-substrate/ /app/safety-substrate/
 
+# Env-consumption contract — the single source of truth the boot-time invariant
+# (safety-substrate/tests/test_invariant_9) reads to enforce that no var the
+# agent consumes is stripped from its env (the voice-class regression guard).
+COPY operator/contracts/ /app/contracts/
+
 # Bootstrap entrypoint
 COPY operator/templates/bootstrap.sh /app/bootstrap.sh
 COPY operator/templates/entrypoint.sh /app/entrypoint.sh


### PR DESCRIPTION
## Summary

The **structural prevention layer** behind the two live-wound fixes (Cuts 1–2). Makes the "a deploy silently breaks a feature" class — the disease behind the voice regression — impossible to repeat: a variable the **agent** consumes can never be silently stripped from its env.

The disease was one fact ("what reads this var") living apart from the tooling that provisions/strips/requires it, so the two drifted. This adds **one declaration** and enforces it on both ends.

- **`operator/contracts/env-consumption.yaml`** — the single source of truth for every env var: `stage` (where consumed), `requirement`, `agent_env` (`held`/`stripped`/`n/a`), `strip_site`. COPY'd into the image at `/app/contracts`.
- **Fail-closed boot invariant** (`safety-substrate/tests/test_invariant_9_…`) — at bootstrap Step 8, before the gateway: a **static** consistency check that no `stage: agent` var is `agent_env: stripped`. No live-env probe, no grep → it **cannot false-positive and brick a healthy Machine**; only a genuinely inconsistent contract fails it. (The boot gate must fail on *liveness*, never on *conformance* — that distinction is the whole de-risk.)
- **CI conformance** (`operator/bin/tests/test_env_contract_conformance.py`, wired into `operator-substrate`) — the contract MATCHES `bootstrap.sh`'s `REQUIRED_ENV`/`OPTIONAL_ENV` and the real `unset` strip sites; the R2 account-wide strip (the voice site) must be declared stripped.

## Verification (staging gate)

Reprovisioned `hermes-smd-staging`:
- `PASS test_invariant_9_env_consumption_contract.py` at boot; substrate **10 pass, 0 fail** (was 9)
- machine boots clean — the new fail-closed check does **not** brick a healthy Machine
- voice stays synced/active (no Cut 2 regression)

## Deferred (named, Phase B)
- overlay `contracts/consumes.yaml` + grep-completeness (warn-at-boot, never fail)
- `bootstrap.sh` deriving `REQUIRED_ENV`/`OPTIONAL_ENV` from the contract
- the standing self-improving drift-audit (declared desired-state vs the running Machine)

## Test plan
- [x] `npm run verify` (exit 0, incl. Dockerfile integrity test with the new COPY)
- [x] `pytest bin/tests/test_env_contract_conformance.py` — 5 passed
- [x] invariant 9 PASS locally and at boot on staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)
