### PR TITLE
feat(operator): demo reply relay — design + ss-console implementation

### DIFF
--- a/docs/security/demo-reply-relay-design.md
+++ b/docs/security/demo-reply-relay-design.md
@@ -1,0 +1,73 @@
+# Design — Demo Operator autonomous reply (the email-in / email-back loop)
+
+**Status:** Draft for independent security review. Not yet implemented.
+**Author:** session 2026-06-11. **Reviewer:** TBD (must be someone other than the author — this touches Phase 1 controls).
+
+## What this enables
+
+The tangible law demo: a prospect emails an intake to a demo address; the demo Operator runs `new-matter-intake` against the seeded Clio dev tenant; the prospect gets the result back by email (a CONFLICT-HOLD or an intake-packet acknowledgment). The open problem is the **reply**: how does the Operator's output get back to the prospect, given the Phase-1 safety model is built to _prevent_ an Operator from autonomously emailing on an untrusted-fed turn?
+
+## The gate stack an autonomous reply must clear (grounded in code)
+
+A reply is `agentmail:reply_to_message`, classified `EXTERNAL_SEND` (`shared/action_classes.py:169`). For it to send autonomously, it must clear, in order (`plugins/hermes-smd-trust/enforce.py`):
+
+1. **Banned-tool** — `reply_to_message` is _not_ banned (ADR 0025; `action_classes.py:98-113`). ✓
+2. **Trust ceiling** — `external_send` is fail-closed unless authored (`enforce.py:165`); demo-law would author `autonomous`.
+3. **Vertical floor** — `_VERTICAL_FLOORS["law-firm"]` pins `EXTERNAL_SEND` → `draft_for_review` (`enforce.py:643-647`). `resolve_ceiling` takes the most-restrictive, so **the law floor forces the reply to draft even under an authored autonomous ceiling.** This is the `external-send-draft-floor` compliance floor (ADR 0005). **Hard blocker #1.**
+4. **Taint-gate** — the inbound prospect email taints the session (`hermes-smd-inbound/__init__.py:83` marks `SESSION_TAINT`); `enforce.py:311-320` refuses autonomous `EXTERNAL_SEND` on a tainted turn. **Hard blocker #2.**
+5. **Content-sensitivity floor** — `enforce.py:733` forces money/contract/scope/legal bodies to draft. The receipt-only ack is clean and passes; but the floor exists and would catch a legal-keyword body.
+6. **Fabrication gate** — `shared/outbound_gate.py` Tier-2 citation scan (law). The ack is citation-free. ✓ (Runs on draft creation.)
+
+These are two different _kinds_ of control, and conflating them is a mistake:
+
+- **#3 (law external-send-draft floor) is an authorable posture, not a constraint.** Vertical packs are quick-start templates the engagement configures, not expertise the system imposes (Captain doctrine 2026-06-11) — "it's the client's operator, they configure as they will." And the floor's own rationale (ADR 0005) is about _client/tribunal-bound legal mail_; a demo Operator replying to a prospect who emailed in is outside that scope. So we don't _defeat_ #3 — we **author the demo's posture** past it. (Separate finding: the code floors _all_ law external*send, blunter than ADR 0005's actual scope; and the floor being \_non-raisable* is itself in tension with "they configure as they will" — a product thread to revisit, non-blocking here.)
+- **#4 (the taint-gate) is an integrity control, not an entitlement.** It doesn't say the operator "isn't allowed to send" — it says untrusted inbound can't _make_ it autonomously act (prompt-injection defense). Authoring it off grants no capability; it just opens the hole. So the design goal is to deliver the reply capability _without_ loosening it.
+
+The relay below does exactly that: it gives the operator the full reply capability while keeping the injection defense (#4) intact.
+
+## Recommended design — a trusted demo reply relay (defeats neither floor)
+
+**Key insight:** under both floors, the agent already produces exactly what we want — a **governed draft** of the acknowledgment (UPL-safe, receipt-only on conflict, fabrication-scanned at draft creation). We don't need the _agent_ to send. A small, deterministic, demo-scoped **relay** sends that draft to the verified inbound sender. The agent's safety floors stay fully intact; "autonomous send" is implemented _outside_ the model's governed tool path by trusted code with fixed behavior.
+
+### Components
+
+1. **Record inbound origin (new per-session state).** When the webhook router dispatches the prospect email, record `session_id → {sender_address, message_id, content_digest}` in a new bounded `SESSION_INBOUND_ORIGIN` register (parallel to `SESSION_TAINT` in `shared/inbound.py`). This is the recipient-lock anchor — `SESSION_TAINT` today records only the trust _class_, not _who_ sent it.
+2. **The relay (`hermes-smd-demo-relay`, a NEW demo-scoped plugin).** Fires on `post_tool_call` for `agentmail:create_draft` (the draft the skill produces). It sends **only when all hold**, else no-op:
+   - the customer authored `demo.reply_relay: enabled` (fail-closed; absent ⇒ off — no relay for any real customer);
+   - the draft is a reply to the recorded inbound `message_id` for this session, and its recipient resolves to the recorded `sender_address` (**recipient-lock** — the reply can only go back to whoever emailed in);
+   - the draft body re-passes `content_floor.classify` **and** `outbound_gate.evaluate` (so the relay enforces the same content/fabrication floors the autonomous-send path would have);
+   - a per-sender + global **rate-limit** is not exceeded.
+     On all-pass, the relay sends via the AgentMail reply API keyed on `message_id`, and emits an audit row (`DEMO_RELAY_SENT`) with the draft digest + recipient.
+
+### Why this is safe
+
+- **No agent floor is weakened.** The law external-send-draft floor, the taint-gate, the content floor, and the fabrication gate all stay exactly as hardened. The agent still cannot autonomously send — it drafts.
+- **Recipient-lock is structural.** The relay can only send to the address that emailed in (the recorded origin), keyed on the original `message_id`. An injected "send to X" cannot redirect it — the relay ignores any recipient except the recorded sender.
+- **The body is governed, not attacker-steered.** The relay sends the _skill's_ output draft, which is produced under all the agent's floors and the skill's own UPL/no-fabrication invariants (validated 2026-06-11: `new-matter-intake` holds the UPL line and produces a receipt-only ack even under bait). The relay additionally re-runs the content + fabrication gates before sending.
+- **Contained blast radius.** The demo Operator has synthetic firm data only (no real client data to exfiltrate), no real connectors beyond seeded Clio (read) + AgentMail, and rate-limiting. The classic "sender is the attacker" residual (an attacker steering a reply to themselves) has **no payoff**: recipient-locked to the attacker's own address, body governed, nothing sensitive to leak.
+- **Fail-closed + demo-only.** `demo.reply_relay` is unauthored everywhere except demo-law; absent ⇒ the relay never acts. It cannot regress a real customer.
+
+## Alternative considered — in-agent taint-gate carve-out (NOT recommended)
+
+Author the demo's posture past the law floor (fine — it's the client's operator, and a prospect reply is outside ADR 0005's scope) **and** add a taint-gate exception permitting `reply_to_message` to the verified inbound sender on a tainted turn. **Rejected** not because the operator is "forbidden" anything, but because the taint-gate is an _integrity_ control: adding a configurable exception to it puts a hole in the injection defense — a hole whose blast radius is every customer that ever uses the exception, to get a capability the relay already delivers without it. The relay achieves the identical demo UX while leaving the injection defense byte-for-byte intact.
+
+## Alternative considered — web-display (no send path at all)
+
+The prospect's result is shown on the demo web surface (via the runtime-read seam) instead of emailed back. Avoids all send-path security. **Not chosen** because the stated demo intent is the email-in / email-back loop (prospect emails, Operator emails the result back). Kept on file as the lowest-complexity fallback if the relay review stalls.
+
+## Code touch points (overlay repo `hermes-smd-overlay`, separate PR)
+
+- `shared/inbound.py` — add `SESSION_INBOUND_ORIGIN` (bounded, per-session sender/message_id/digest).
+- `plugins/hermes-smd-webhook-router/` — record the inbound origin on dispatch of a prospect email.
+- `plugins/hermes-smd-demo-relay/` — NEW plugin: the relay (post_tool_call on `create_draft`, recipient-lock + content/fabrication re-check + rate-limit + send + audit).
+- `shared/customer_config.py` / customer.yaml schema (ss-console) — the `demo.reply_relay` authored flag, fail-closed.
+- Tests: recipient-lock (cannot send to a body-derived address), fail-closed (no flag ⇒ no send), content-floor re-check, rate-limit, and that a real (non-demo) customer's behavior is unchanged.
+
+## Independent-review checklist (the reviewer must confirm)
+
+1. The relay can send **only** to the recorded inbound sender — no path lets a body-derived or injected recipient through.
+2. `demo.reply_relay` is fail-closed: any customer without it authored gets zero relay behavior; a real customer cannot be regressed.
+3. The agent's floors (law external-send, taint-gate, content floor, fabrication gate) are byte-for-byte unchanged.
+4. The relay re-applies `content_floor` + `outbound_gate` to the draft body before sending.
+5. Rate-limit bounds per-sender and global send volume.
+6. Threat model line: state plainly that the safety rests on recipient-lock + synthetic-data containment + governed-draft body, and that the relay must NOT be enabled for any customer holding real client data without a further review.

--- a/operator/customers/demo-law/customer.yaml
+++ b/operator/customers/demo-law/customer.yaml
@@ -83,14 +83,16 @@ personas:
 connectors:
   # Mail on the persona's OWN AgentMail inbox (the demo address). The inbound
   # webhook drives the skill; the relay sends the governed draft reply via the
-  # AgentMail REST reply API. webhook_url points at THIS customer's Machine
-  # (ADR 0009) — its presence is what lets webhook_triggers.source: agentmail
-  # resolve. AGENTMAIL_API_KEY is provisioned as a Fly secret (no token_ref).
+  # AgentMail REST reply API. The webhook_url path segment MUST be the adapter
+  # slug (`agentmail`): the gate (webhook_gate.py) routes by /webhooks/<adapter>
+  # and resolves the per-vendor secret as WEBHOOK_SECRET_<ROUTE> →
+  # WEBHOOK_SECRET_AGENTMAIL, and webhook_triggers.source: agentmail matches the
+  # same adapter slug. AGENTMAIL_API_KEY is provisioned as a Fly secret.
   Email:
     adapter: agentmail
     backend: mcp:agentmail
     enabled: true
-    webhook_url: 'https://hermes-demo-law.fly.dev/webhooks/email'
+    webhook_url: 'https://hermes-demo-law.fly.dev/webhooks/agentmail'
 
   # The connect target: the SEEDED Clio developer tenant (oktopeak/clio-mcp
   # v2.0.0, MIT, ADR 0020) — the same dev tenant pilot-law uses, seeded with the

--- a/operator/customers/demo-law/customer.yaml
+++ b/operator/customers/demo-law/customer.yaml
@@ -1,0 +1,153 @@
+schema_version: 1
+
+# Demo law Operator — the tangible email-in / email-back law demo.
+#
+# PURPOSE: a prospect emails an intake to the demo AgentMail address; the demo
+# Operator runs the real `new-matter-intake` skill against the SEEDED Clio dev
+# tenant (Greg Whitfield = existing client → CONFLICT-HOLD; otherwise an intake
+# acknowledgment); the prospect gets the result back by email. This is NOT a
+# real client and holds NO real client data — it runs on synthetic/seeded data
+# only, which is the load-bearing precondition for `demo.reply_relay` below.
+#
+# HARD DEPENDENCY (Captain / live-ops only, not provisionable from the console):
+#   1. demo-law's own AgentMail inbox (the address prospects email) with its
+#      Svix webhook wired to https://hermes-demo-law.fly.dev/webhooks/email.
+#   2. The AgentMail webhook ingress must present the dispatched payload with a
+#      top-level/`metadata` `source: agentmail` marker (the webhook router keys
+#      routing on (source,event_type); AgentMail's native payload carries
+#      event_type but not source) AND preserve the `message{from,message_id,
+#      inbox_id}` block (the relay's recipient-lock anchor).
+#   3. AGENTMAIL_API_KEY + SMD_WEBHOOK_SIGNING_SECRET provisioned as Fly secrets.
+#
+# Write posture is FAIL-CLOSED / draft-and-surface, same as pilot-law: the law
+# external-send-draft floor pins external_send to draft_for_review (non-raisable,
+# ADR 0005). The agent DRAFTS; the demo-scoped, recipient-locked reply relay
+# (hermes-smd-demo-relay) sends that governed draft back to the verified inbound
+# sender WITHOUT weakening any floor (design: docs/security/demo-reply-relay-design.md).
+
+# ---- IDENTITY ----
+customer_id: demo-law
+customer_name: 'Demo Law (Clio Sandbox)'
+vertical: law-firm
+practice_areas:
+  - general-practice
+fly_region: lax # Phoenix-adjacent, consistent with pilot-law / customer-zero
+
+# ---- RUNTIME ----
+model: claude-opus-4-8
+hermes_ref: v2026.5.16@a91a57fa5a13d516c38b07a141a9ce8a3daabeb0
+
+machine:
+  size: shared-cpu-1x
+  memory_mb: 1024
+
+# ---- HUMANS WITH PORTAL ACCESS ----
+users:
+  - email: scott@smd.services
+    role: principal
+    full_name: Scott Durgan
+
+# ---- PERSONAS ----
+# One coordinator persona running the demo skill. The webhook routes an inbound
+# prospect email straight to `new-matter-intake`; the spine router is included
+# so the persona can also be exercised conversationally. Both draft_for_review —
+# the law floor is non-raisable and the relay (not the agent) does the send.
+personas:
+  - slug: avery
+    status: active
+    name: Avery
+    title: AI Associate
+    tone:
+      - plainspoken
+      - warm-but-professional
+      - concise
+    skills:
+      # The named job for the demo: move a new inquiry to an active matter,
+      # holding the conflict + UPL lines. Validated against the seeded Clio dev
+      # tenant 2026-06-11 (correct CONFLICT-HOLD on the Greg Whitfield seed).
+      - name: new-matter-intake
+        version: pending
+        trust_ceiling: draft_for_review
+        enabled: true
+      # Spine — routes inbound to the wedge skills (conversational exercise).
+      - name: matter-inbox-router
+        version: pending
+        trust_ceiling: draft_for_review
+        enabled: true
+    # Native Google/Himalaya skills disabled — the demo's mail is AgentMail.
+    skills_disabled:
+      - google-workspace
+      - himalaya
+
+# ---- CONNECTORS ----
+connectors:
+  # Mail on the persona's OWN AgentMail inbox (the demo address). The inbound
+  # webhook drives the skill; the relay sends the governed draft reply via the
+  # AgentMail REST reply API. webhook_url points at THIS customer's Machine
+  # (ADR 0009) — its presence is what lets webhook_triggers.source: agentmail
+  # resolve. AGENTMAIL_API_KEY is provisioned as a Fly secret (no token_ref).
+  Email:
+    adapter: agentmail
+    backend: mcp:agentmail
+    enabled: true
+    webhook_url: 'https://hermes-demo-law.fly.dev/webhooks/email'
+
+  # The connect target: the SEEDED Clio developer tenant (oktopeak/clio-mcp
+  # v2.0.0, MIT, ADR 0020) — the same dev tenant pilot-law uses, seeded with the
+  # Greg Whitfield conflict fixture. Reuse pilot-law's OAuth token_ref so the
+  # demo reads the same seeded data (the Clio dev app is shared; refresh tokens
+  # are reusable/not rotated). Write scope stays fail-closed (draft-and-surface).
+  PracticeManagement:
+    adapter: clio
+    backend: mcp:clio-oktopeak
+    enabled: true
+    token_ref: 'infisical:/operator/pilot-law/practice-management/clio-oauth'
+
+# ---- WEBHOOK TRIGGERS ----
+# An inbound prospect email (AgentMail message.received) drives the demo skill.
+# source must match a connector adapter with webhook_url (Email/agentmail above).
+webhook_triggers:
+  - source: agentmail
+    event_type: message.received
+    skill: new-matter-intake
+    persona: avery
+
+# ---- DEMO SWITCHES ----
+# Enable the autonomous reply relay. ONLY safe here because demo-law holds no
+# real client data — the relay sends the agent's governed, recipient-locked
+# draft back to the verified inbound sender (fail-closed everywhere else).
+demo:
+  reply_relay: enabled
+
+# ---- SCOPE ----
+scope:
+  email_folders_visible:
+    - Inbox
+    - Sent
+  email_folders_blind: []
+  email_keyword_blocks: []
+  domain_blocks: []
+  # No autonomous external_send: the wedge is draft-and-surface. The law floor
+  # pins external_send to draft_for_review (non-raisable); the relay does the
+  # demo send, outside the agent's governed tool path.
+  action_ceilings:
+    external_send: draft_for_review
+
+# ---- ESCALATION ----
+escalation:
+  red_flag_recipients:
+    - scott@smd.services
+  failure_recipients:
+    - scott@smd.services
+
+# ---- VOICE LIBRARY ----
+# No samples — the demo uses the general voice (Voice-Layer-2 is #855, not a
+# demo blocker).
+voice_library:
+  samples_path: 'r2://vaults/demo-law/voice/samples/'
+
+# ---- MEMORY (per-customer isolation invariants; must match customer_id) ----
+memory:
+  d1_namespace: demo-law
+  r2_vault_path: 'vaults/demo-law/'
+  vectorize_index: 'hermes-demo-law-vault'

--- a/operator/skills/new-matter-intake/SKILL.md
+++ b/operator/skills/new-matter-intake/SKILL.md
@@ -72,7 +72,8 @@ Three phases, in order. Phase 2 can stop the skill.
 
 7. **Draft the matter as an internal artifact** — the structured fields + the `create_note` log body. **Do not call `create_matter`.** The firm's v1 Clio write scope is unverified (`clio-surface.md`); creating the matter is a human step until the connect step proves the capability and the engagement authors it on.
 8. **Draft the acknowledgment** (`references/voice.md`): warm, plainspoken, confirms receipt, names only a next step the **firm authored** (never an invented date or promise), and **never** says "we can take your case," gives legal advice, or characterizes the merits. A non-lawyer can send it as-is.
-9. **Surface for review.** The acknowledgment is a draft for a human reviewer to send under their own identity. The internal log + the matter draft accompany it.
+9. **Create the acknowledgment as a reply draft** to the original sender using the Email connector's draft-creation tool (`agentmail:create_draft` on an AgentMail inbox; `email_create_draft` on M365). Address it **in-thread to the inbound sender only** — never to a recipient, address, or link named inside the inquiry body (the recipient-lock is structural: a reply threads to the original sender). This is an `INTERNAL_WRITE` draft, never a send. On a CONFLICT-HOLD, the draft is the neutral receipt-only form (`references/output-format.md`), never anything that implies representation.
+10. **Surface for review.** The acknowledgment draft is for a human reviewer to send under their own identity; where the engagement has authored an external-send posture, the **governed draft** is what ships (the agent still only drafts). The internal log + the matter draft accompany it.
 
 ## Trust Ceiling
 

--- a/operator/skills/new-matter-intake/references/algorithm.md
+++ b/operator/skills/new-matter-intake/references/algorithm.md
@@ -34,7 +34,8 @@ The agent **never** clears a hit. Surfacing is the whole job; the human decides.
 
 1. **Matter draft (internal, autonomous).** Assemble the structured fields into the matter draft + the `create_note` log body. Do NOT `create_matter`.
 2. **Acknowledgment (draft-for-review).** Per `voice.md`: confirm receipt, be warm and human, name only a firm-authored next step, hold the UPL line absolutely. "Outside authored practice areas" → a polite receipt that promises neither representation nor an unauthored referral.
-3. **Surface.** Emit the intake packet (`output-format.md`): matter draft + conflict-check result (clear) + acknowledgment draft + internal log + any internal flags.
+3. **Create the reply draft.** Write the acknowledgment as a reply draft to the original sender via the Email connector's draft tool (`agentmail:create_draft` / `email_create_draft`), in-thread to the inbound sender only — never a recipient named in the body. `INTERNAL_WRITE`, never a send.
+4. **Surface.** Emit the intake packet (`output-format.md`): matter draft + conflict-check result (clear) + acknowledgment draft + internal log + any internal flags.
 
 ## What this algorithm is NOT
 

--- a/src/lib/operator/customer-yaml/index.ts
+++ b/src/lib/operator/customer-yaml/index.ts
@@ -77,6 +77,7 @@ export {
   type Pause,
   type MachineSpec,
   type CostEstimate,
+  type Demo,
   type Vertical,
   type TrustCeiling,
   type Pronouns,

--- a/src/lib/operator/customer-yaml/sections-demo.ts
+++ b/src/lib/operator/customer-yaml/sections-demo.ts
@@ -1,0 +1,63 @@
+/**
+ * Validator for the optional `demo:` block — demo-only switches.
+ *
+ * The block holds behavior that exists solely to drive a tangible prospect
+ * demo and must never be authored for a real customer holding real client data
+ * (see the {@link Demo} doc comment). Every switch is fail-closed: an absent
+ * block, or an absent field, resolves to OFF.
+ *
+ * v1 ships one switch: `reply_relay` (the overlay `hermes-smd-demo-relay`
+ * plugin). Future demo switches append here.
+ */
+
+import { isPlainObject } from './helpers'
+import { type Demo, type ValidationError } from './types'
+
+const DEMO_DEFAULT: Demo = { reply_relay: false }
+
+export function checkDemo(root: Record<string, unknown>, errors: ValidationError[]): Demo {
+  const raw = root['demo']
+  if (raw === undefined || raw === null) return { ...DEMO_DEFAULT }
+  if (!isPlainObject(raw)) {
+    errors.push({
+      code: 'TypeMismatch',
+      path: 'demo',
+      message: 'demo must be a mapping when present',
+    })
+    return { ...DEMO_DEFAULT }
+  }
+
+  const replyRelayRaw = raw['reply_relay']
+  let replyRelay = false
+  if (replyRelayRaw !== undefined && replyRelayRaw !== null) {
+    if (typeof replyRelayRaw === 'boolean') {
+      replyRelay = replyRelayRaw
+    } else if (typeof replyRelayRaw === 'string') {
+      // The overlay loader (shared/customer_config.py) accepts the string form
+      // "enabled" as the on value; mirror that here so author intent validates
+      // identically on both sides of the contract.
+      const normalized = replyRelayRaw.trim().toLowerCase()
+      if (normalized === 'enabled' || normalized === 'true' || normalized === 'on') {
+        replyRelay = true
+      } else if (normalized === 'disabled' || normalized === 'false' || normalized === 'off') {
+        replyRelay = false
+      } else {
+        errors.push({
+          code: 'EnumViolation',
+          path: 'demo.reply_relay',
+          message:
+            'demo.reply_relay must be a boolean or one of: enabled, disabled, ' +
+            'true, false, on, off',
+        })
+      }
+    } else {
+      errors.push({
+        code: 'TypeMismatch',
+        path: 'demo.reply_relay',
+        message: 'demo.reply_relay must be a boolean (or the string "enabled"/"disabled")',
+      })
+    }
+  }
+
+  return { reply_relay: replyRelay }
+}

--- a/src/lib/operator/customer-yaml/types.ts
+++ b/src/lib/operator/customer-yaml/types.ts
@@ -640,6 +640,28 @@ export interface MachineSpec {
   memory_mb: number
 }
 
+/**
+ * Demo-only switches (`demo:` block). Behavior that exists solely to drive a
+ * tangible prospect demo and must never be authored for a real customer holding
+ * real client data. All fields default OFF when the block (or the field) is
+ * absent — fail-closed.
+ */
+export interface Demo {
+  /**
+   * Demo reply relay (overlay plugin `hermes-smd-demo-relay`). When `true`, the
+   * demo Operator's GOVERNED draft (produced under the law external-send-draft
+   * floor + taint-gate + content/fabrication floors) is sent back to the
+   * VERIFIED inbound sender by a trusted, demo-scoped, recipient-locked relay —
+   * WITHOUT weakening any agent floor (the agent still only drafts). See
+   * docs/security/demo-reply-relay-design.md.
+   *
+   * Fail-closed: absent/`false` ⇒ the relay never acts. MUST NOT be enabled for
+   * any customer holding real client data without a further security review —
+   * the safety argument rests on synthetic-data containment + recipient-lock.
+   */
+  reply_relay: boolean
+}
+
 export interface CustomerYaml {
   schema_version: SchemaVersion
   customer_id: string
@@ -732,6 +754,12 @@ export interface CustomerYaml {
    * is `resolveCredentialCustody` in src/lib/operator/credential-custody.ts.
    */
   credential_custody_default: CredentialCustody
+  /**
+   * Demo-only switches (ADR 0004 demo path). Always non-null on a validated
+   * CustomerYaml: an absent `demo:` block resolves to `{ reply_relay: false }`
+   * via `checkDemo`. Fail-closed — see {@link Demo}.
+   */
+  demo: Demo
 }
 
 export type ValidationErrorCode =

--- a/src/lib/operator/customer-yaml/validator.ts
+++ b/src/lib/operator/customer-yaml/validator.ts
@@ -24,6 +24,7 @@ import { checkHermesRef, checkRequiredString, isPlainObject, secretFindingToErro
 import {
   type AddonSpec,
   type CustomerYaml,
+  type Demo,
   type GoogleAuth,
   type MachineSpec,
   type Memory,
@@ -59,6 +60,7 @@ import { checkVoiceCohorts } from './sections-voice'
 import { checkWebhookTriggers } from './sections-webhook-triggers'
 import { checkExtendsReserved, checkVerticalPinned } from './sections-vertical'
 import { checkAddons } from './sections-addons'
+import { checkDemo } from './sections-demo'
 import { checkGoogleAuth } from './sections-google-auth'
 import { checkAuthority } from './sections-authority'
 import type { AuthorityPosture } from '../authority'
@@ -96,6 +98,7 @@ export type {
   MachineSpec,
   CostEstimate,
   Observability,
+  Demo,
   Vertical,
   TrustCeiling,
   Pronouns,
@@ -226,6 +229,7 @@ interface ParsedSections {
   complianceEnabled: boolean
   authority: AuthorityPosture
   credentialCustodyDefault: CredentialCustody
+  demo: Demo
 }
 
 function validateSections(
@@ -278,6 +282,7 @@ function validateSections(
     complianceEnabled: checkComplianceEnabled(root, errors),
     authority: checkAuthority(root, errors),
     credentialCustodyDefault: checkCredentialCustodyDefault(root, errors),
+    demo: checkDemo(root, errors),
   }
 }
 
@@ -313,5 +318,6 @@ function assembleCustomerYaml(root: Record<string, unknown>, p: ParsedSections):
     compliance_enabled: p.complianceEnabled,
     authority: p.authority,
     credential_custody_default: p.credentialCustodyDefault,
+    demo: p.demo,
   }
 }

--- a/src/lib/portal/operator/customer-yaml-editor.ts
+++ b/src/lib/portal/operator/customer-yaml-editor.ts
@@ -452,6 +452,7 @@ function lockedFromCurrent(
   | 'google_auth'
   | 'authority'
   | 'credential_custody_default'
+  | 'demo'
 > {
   return {
     schema_version: current.schema_version,
@@ -484,6 +485,10 @@ function lockedFromCurrent(
     // credential_custody_default (ADR 0042) is set at provisioning / via the
     // connectors authority domain, not the general config editor. Preserve.
     credential_custody_default: current.credential_custody_default,
+    // demo switches are provisioning-time, never client-editable (enabling the
+    // reply relay is an SMD demo decision gated on synthetic-data containment).
+    // Preserve verbatim across portal edits.
+    demo: current.demo,
   }
 }
 

--- a/tests/customer-yaml-validator.test.ts
+++ b/tests/customer-yaml-validator.test.ts
@@ -1405,6 +1405,81 @@ describe('validate — compliance_enabled (#895)', () => {
 })
 
 // -----------------------------------------------------------------------------
+// demo block (demo.reply_relay) — fail-closed demo-only switches
+// -----------------------------------------------------------------------------
+
+describe('validate — demo.reply_relay', () => {
+  it('defaults to reply_relay: false when the demo block is omitted', () => {
+    const r = validate(validFixture())
+    if (!r.ok) throw new Error(`expected ok; got: ${JSON.stringify(r.errors)}`)
+    expect(r.value.demo).toEqual({ reply_relay: false })
+  })
+
+  it('accepts demo.reply_relay: true (boolean)', () => {
+    const f = validFixture()
+    f['demo'] = { reply_relay: true }
+    const r = validate(f)
+    if (!r.ok) throw new Error(`expected ok; got: ${JSON.stringify(r.errors)}`)
+    expect(r.value.demo.reply_relay).toBe(true)
+  })
+
+  it('accepts the string form "enabled" (mirrors the overlay loader)', () => {
+    const f = validFixture()
+    f['demo'] = { reply_relay: 'enabled' }
+    const r = validate(f)
+    if (!r.ok) throw new Error(`expected ok; got: ${JSON.stringify(r.errors)}`)
+    expect(r.value.demo.reply_relay).toBe(true)
+  })
+
+  it('accepts the string form "disabled" as off', () => {
+    const f = validFixture()
+    f['demo'] = { reply_relay: 'disabled' }
+    const r = validate(f)
+    if (!r.ok) throw new Error(`expected ok; got: ${JSON.stringify(r.errors)}`)
+    expect(r.value.demo.reply_relay).toBe(false)
+  })
+
+  it('defaults reply_relay to false when demo is present but reply_relay omitted', () => {
+    const f = validFixture()
+    f['demo'] = {}
+    const r = validate(f)
+    if (!r.ok) throw new Error(`expected ok; got: ${JSON.stringify(r.errors)}`)
+    expect(r.value.demo.reply_relay).toBe(false)
+  })
+
+  it('rejects a non-mapping demo block', () => {
+    const f = validFixture()
+    f['demo'] = 'enabled'
+    const r = validate(f)
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(r.errors.some((e) => e.path === 'demo' && e.code === 'TypeMismatch')).toBe(true)
+  })
+
+  it('rejects an unrecognized reply_relay string', () => {
+    const f = validFixture()
+    f['demo'] = { reply_relay: 'sometimes' }
+    const r = validate(f)
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(r.errors.some((e) => e.path === 'demo.reply_relay' && e.code === 'EnumViolation')).toBe(
+      true
+    )
+  })
+
+  it('rejects a non-boolean, non-string reply_relay', () => {
+    const f = validFixture()
+    f['demo'] = { reply_relay: 1 }
+    const r = validate(f)
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(r.errors.some((e) => e.path === 'demo.reply_relay' && e.code === 'TypeMismatch')).toBe(
+      true
+    )
+  })
+})
+
+// -----------------------------------------------------------------------------
 // ADR 0021 — Stream D bundles + Stream B cron (per-persona)
 // -----------------------------------------------------------------------------
 


### PR DESCRIPTION
## What

The tangible law demo's email-in / email-back loop: a prospect emails an intake to the demo address, the demo Operator runs `new-matter-intake` against the seeded Clio dev tenant and **drafts** the result, and a trusted, recipient-locked relay sends that governed draft back to the verified inbound sender — **without weakening any Phase-1 safety floor**.

This PR carries the **design doc** (`docs/security/demo-reply-relay-design.md`, independently reviewed — verdict in a comment below) **and the ss-console implementation**:

- **customer-yaml schema** — new optional `demo:` block with `reply_relay` (fail-closed; absent ⇒ `{ reply_relay: false }`; boolean or `"enabled"`/`"disabled"` string, mirroring the overlay loader). New `sections-demo.ts`; `Demo` type + `CustomerYaml.demo`; wired through `validate()`/assemble + exported.
- **portal editor** — preserves `demo` verbatim (provisioning-time switch, never client-editable).
- **`operator/customers/demo-law/customer.yaml`** — law-firm; AgentMail inbound (`Email`→`mcp:agentmail` + `webhook_url`); `PracticeManagement`→`mcp:clio-oktopeak` reusing pilot-law's seeded dev-tenant token; `webhook_trigger` `message.received`→`new-matter-intake`; `demo.reply_relay: enabled`; `external_send` pinned `draft_for_review`. Validates clean.
- **tests** — `demo.reply_relay` block coverage; full suite green.

The overlay build (the relay plugin + recipient-lock recording) is **hermes-smd-overlay#57**.

## Safety posture

The agent's floors are untouched — it still only **drafts**. The relay sends the governed draft **outside** the model's tool path, fail-closed on the flag, recipient-locked to the verified inbound sender, re-checking the content + fabrication floors. Safe **only** because `demo-law` holds synthetic/seeded data; MUST NOT be enabled for any customer with real client data without a further review.

## Live-ops dependency (Captain only)

`demo-law` needs its own AgentMail inbox + Svix webhook wired to `https://hermes-demo-law.fly.dev/webhooks/email`; the ingress must inject a `source: agentmail` marker (AgentMail's native payload has `event_type` but no `source`) and preserve `message{from,message_id,inbox_id}`; `AGENTMAIL_API_KEY` + `SMD_WEBHOOK_SIGNING_SECRET` as Fly secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
