### PR TITLE
feat(operator): root-side respawn supervisor for the workspace broker (OP-P1-4 follow-up)

### DIFF
--- a/operator/bin/boot-smoke-test.sh
+++ b/operator/bin/boot-smoke-test.sh
@@ -108,4 +108,12 @@ ssh_exec "audit-db-not-agent-writable" "setpriv --reuid=hermes --regid=hermes --
 # the ledger does not break skill capture. The overlay's register() creates it.
 ssh_exec "agent-state-owner-is-hermes" "[ \"\$(stat -c %U /opt/data/agent-state.db)\" = hermes ]"
 
+# ---------- Step 11: the broker is supervised by a ROOT respawner (OP-P1-4 follow-up) ----------
+# The broker must be respawnable on mid-run death, which requires a root parent
+# (only root can re-setpriv to uid workspace-broker). With the supervisor, the
+# broker's parent is the root subshell loop; without it the broker is a direct
+# child of PID 1 (the hermes gateway after the exec-drop). So "broker's parent
+# proc dir is root-owned" is a non-destructive proof the supervisor is in place.
+ssh_exec "broker-respawn-supervised" "pid=\$(pgrep -f workspace_broker.server | head -1); [ -n \"\$pid\" ] && ppid=\$(awk '{print \$4}' /proc/\$pid/stat) && [ \"\$(stat -c %U /proc/\$ppid)\" = root ]"
+
 log "All boot smoke checks passed for ${APP_NAME}"

--- a/operator/bin/boot-smoke-test.sh
+++ b/operator/bin/boot-smoke-test.sh
@@ -114,6 +114,9 @@ ssh_exec "agent-state-owner-is-hermes" "[ \"\$(stat -c %U /opt/data/agent-state.
 # broker's parent is the root subshell loop; without it the broker is a direct
 # child of PID 1 (the hermes gateway after the exec-drop). So "broker's parent
 # proc dir is root-owned" is a non-destructive proof the supervisor is in place.
-ssh_exec "broker-respawn-supervised" "pid=\$(pgrep -f workspace_broker.server | head -1); [ -n \"\$pid\" ] && ppid=\$(awk '{print \$4}' /proc/\$pid/stat) && [ \"\$(stat -c %U /proc/\$ppid)\" = root ]"
+# NB: read PPid from /proc/<pid>/status with grep+tr (NO single quotes) — ssh_exec
+# wraps this whole string in `sh -c '...'`, so a single-quoted `awk '{print $4}'`
+# would collide with the outer quote and mangle the command.
+ssh_exec "broker-respawn-supervised" "pid=\$(pgrep -f workspace_broker.server | head -1); [ -n \"\$pid\" ] && ppid=\$(grep -m1 PPid /proc/\$pid/status | tr -dc 0-9) && [ \"\$(stat -c %U /proc/\$ppid)\" = root ]"
 
 log "All boot smoke checks passed for ${APP_NAME}"

--- a/operator/templates/entrypoint.sh
+++ b/operator/templates/entrypoint.sh
@@ -135,24 +135,54 @@ PYTHONPATH="/opt/workspace-broker" \
 chown workspace-broker:workspace-broker "${SMD_WORKSPACE_CREDENTIAL_PATH}"
 chmod 0600 "${SMD_WORKSPACE_CREDENTIAL_PATH}"
 
-setpriv \
-  --reuid=workspace-broker \
-  --regid=workspace-broker \
-  --init-groups \
-  --no-new-privs \
-  /usr/bin/env -i \
-  PATH="/opt/workspace-broker/.venv/bin:/usr/bin:/bin" \
-  PYTHONPATH="/opt/workspace-broker" \
-  PYTHONUNBUFFERED=1 \
-  CUSTOMER_SLUG="${CUSTOMER_SLUG}" \
-  SMD_WORKSPACE_BROKER_SOCKET="${SMD_WORKSPACE_BROKER_SOCKET}" \
-  SMD_WORKSPACE_CREDENTIAL_PATH="${SMD_WORKSPACE_CREDENTIAL_PATH}" \
-  SMD_CUSTOMER_YAML="${SMD_CUSTOMER_YAML}" \
-  SMD_GATEWAY_PID="${SMD_GATEWAY_PID}" \
-  SMD_AUDIT_DB_PATH="${AUDIT_BIND_DB}" \
-  /opt/workspace-broker/.venv/bin/python \
-  -m workspace_broker.server &
-BROKER_PID=$!
+# The broker is the SECOND principal that BOTH the Google capability path AND the
+# OP-P1-4 audit_append path depend on. Define its launch ONCE; the supervisor
+# below uses it for the first start and every respawn. env -i with a fixed
+# allowlist — the broker reads its Google credential from the materialized file
+# (SMD_WORKSPACE_CREDENTIAL_PATH), never from env, so a respawn needs nothing the
+# parent later unsets.
+launch_broker() {
+  setpriv \
+    --reuid=workspace-broker \
+    --regid=workspace-broker \
+    --init-groups \
+    --no-new-privs \
+    /usr/bin/env -i \
+    PATH="/opt/workspace-broker/.venv/bin:/usr/bin:/bin" \
+    PYTHONPATH="/opt/workspace-broker" \
+    PYTHONUNBUFFERED=1 \
+    CUSTOMER_SLUG="${CUSTOMER_SLUG}" \
+    SMD_WORKSPACE_BROKER_SOCKET="${SMD_WORKSPACE_BROKER_SOCKET}" \
+    SMD_WORKSPACE_CREDENTIAL_PATH="${SMD_WORKSPACE_CREDENTIAL_PATH}" \
+    SMD_CUSTOMER_YAML="${SMD_CUSTOMER_YAML}" \
+    SMD_GATEWAY_PID="${SMD_GATEWAY_PID}" \
+    SMD_AUDIT_DB_PATH="${AUDIT_BIND_DB}" \
+    /opt/workspace-broker/.venv/bin/python \
+    -m workspace_broker.server
+}
+
+# Root-side respawn supervisor (OP-P1-4 follow-up). WITHOUT it, a broker that dies
+# mid-run is never restarted: audit_append then fails OPEN (rows silently dropped,
+# the exact gap OP-P1-4 closes) and Google capability stops, with no signal. We
+# fork the supervisor while STILL ROOT — before the exec-drop to hermes at the
+# bottom — so each respawn can re-setpriv a fresh broker to uid workspace-broker
+# (a hermes process could not re-acquire that uid). The server unlinks its stale
+# socket on bind (server.py), so respawns rebind cleanly. SMD_GATEWAY_PID is the
+# entrypoint PID, preserved across the exec, so the SO_PEERCRED gate still admits
+# the gateway after a respawn. A broker that is broken from the FIRST boot is NOT
+# masked: the parent's socket-wait below still FATALs the whole Machine (Fly
+# restarts it); the supervisor only covers death AFTER a healthy first start. The
+# `if` guard keeps the inherited `set -e` from killing the loop on a non-zero
+# broker exit. (Fail-open-with-respawn is intentional for this PR; the stronger
+# fail-closed ack-before-dispatch is deferred to the autonomous-send workstream.)
+(
+  while true; do
+    if launch_broker; then _brk_rc=0; else _brk_rc=$?; fi
+    log "Workspace broker exited (rc=${_brk_rc}); respawning in 2s"
+    sleep 2
+  done
+) &
+SUPERVISOR_PID=$!
 
 for _ in 1 2 3 4 5; do
   [ -S "${BROKER_SOCKET}" ] && break
@@ -160,7 +190,7 @@ for _ in 1 2 3 4 5; do
 done
 [ -S "${BROKER_SOCKET}" ] || {
   log "FATAL: Workspace broker socket was not created"
-  kill "${BROKER_PID}" 2>/dev/null || true
+  kill "${SUPERVISOR_PID}" 2>/dev/null || true
   exit 1
 }
 

--- a/tests/operator-entrypoint.test.ts
+++ b/tests/operator-entrypoint.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Regression guard: the customer-Machine entrypoint must launch the Workspace
+ * broker under a ROOT respawn supervisor (OP-P1-4 follow-up).
+ *
+ * The broker is the second principal that BOTH the Google capability path AND the
+ * append-only audit_append path depend on. If it dies mid-run with no supervisor,
+ * audit silently fails OPEN and Google capability stops — with no signal. Only a
+ * root process can re-`setpriv` a fresh broker to uid workspace-broker, so the
+ * supervisor MUST be forked while the entrypoint is still root, before it
+ * exec-drops to the hermes gateway.
+ *
+ * These assertions lock that shape so a future edit can't quietly regress the
+ * broker back to an un-supervised one-shot background launch.
+ *
+ * @see operator/templates/entrypoint.sh
+ * @see docs/security/operator-threat-model.md  (§9 — WS5 / OP-P1-4)
+ */
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+
+const ENTRYPOINT = readFileSync(resolve('operator/templates/entrypoint.sh'), 'utf8')
+
+// Strip `#`-comment lines so assertions match executable content only — the
+// supervisor's rationale comments deliberately NAME the failure mode.
+const ENTRYPOINT_CODE = ENTRYPOINT.split('\n')
+  .filter((l) => !/^\s*#/.test(l))
+  .join('\n')
+
+describe('Operator customer Machine entrypoint — broker respawn supervisor', () => {
+  it('defines the broker launch once, as a reusable function', () => {
+    expect(ENTRYPOINT_CODE).toMatch(/launch_broker\(\)\s*\{/)
+    // The broker module is referenced exactly once (inside the function), so the
+    // supervisor is the sole launch site — no parallel un-supervised copy.
+    const hits = ENTRYPOINT_CODE.match(/-m\s+workspace_broker\.server/g) ?? []
+    expect(hits.length, 'broker should be launched from exactly one site').toBe(1)
+  })
+
+  it('runs the broker under a backgrounded while-true respawn loop', () => {
+    // A subshell loop that re-invokes launch_broker forever, backgrounded so the
+    // parent can proceed to the socket-wait and the exec-drop.
+    expect(ENTRYPOINT_CODE).toMatch(/while\s+true;?\s*do[\s\S]*?launch_broker[\s\S]*?done\s*\)\s*&/)
+    expect(ENTRYPOINT_CODE).toMatch(/SUPERVISOR_PID=\$!/)
+  })
+
+  it('never launches the broker as an un-supervised one-shot background job', () => {
+    // The exact regression this guards: `... workspace_broker.server &` outside
+    // the supervised loop, which can't be respawned after death.
+    expect(
+      /workspace_broker\.server\s*&/.test(ENTRYPOINT_CODE),
+      'broker must not be backgrounded directly; only the supervisor subshell is backgrounded'
+    ).toBe(false)
+  })
+
+  it('forks the supervisor while still root, BEFORE dropping to the hermes gateway', () => {
+    const supervisorIdx = ENTRYPOINT_CODE.indexOf('SUPERVISOR_PID=$!')
+    const hermesExec = ENTRYPOINT_CODE.search(/exec\s+setpriv[\s\S]*?--reuid=hermes/)
+    expect(supervisorIdx, 'supervisor must be present').toBeGreaterThan(-1)
+    expect(hermesExec, 'hermes exec-drop must be present').toBeGreaterThan(-1)
+    expect(
+      supervisorIdx < hermesExec,
+      'the supervisor must be forked before the exec-drop to hermes (else it would not be root)'
+    ).toBe(true)
+  })
+
+  it('preserves the gateway PID into each respawn (SO_PEERCRED gate survives)', () => {
+    // The broker admits only the gateway PID; respawns must carry the same
+    // SMD_GATEWAY_PID (the entrypoint PID, preserved across the exec).
+    expect(ENTRYPOINT_CODE).toMatch(/SMD_GATEWAY_PID=["']?\$\{SMD_GATEWAY_PID\}/)
+  })
+
+  it('tears down the supervisor (not a stale broker PID) if the socket never appears', () => {
+    expect(ENTRYPOINT_CODE).toMatch(/kill\s+"\$\{SUPERVISOR_PID\}"/)
+    // The old BROKER_PID variable is gone — the supervised loop owns the lifecycle.
+    expect(/BROKER_PID=/.test(ENTRYPOINT_CODE)).toBe(false)
+  })
+})


### PR DESCRIPTION
The third and final WS5 / OP-P1-4 follow-up. Closes the broker-death **fail-open** gap.

## The gap
The Workspace broker (uid 10001) is the second principal that **both** the Google capability path **and** the OP-P1-4 append-only `audit_append` path depend on. `entrypoint.sh` launched it as a one-shot background job, then exec-dropped to the hermes gateway. After that exec there is no root left, so a broker that dies mid-run is **never restarted** — `audit_append` then fails OPEN (rows silently dropped, the exact gap OP-P1-4 closes) and Google capability stops, with no signal. (Pre-existing trait, shared with the Google broker; surfaced as a residual in the OP-P1-4 ship.)

## The fix
Fork a **root-side supervisor** *before* the exec-drop: a `while true` subshell that re-`setpriv`s a fresh broker to uid `workspace-broker` on every exit (a hermes process could not re-acquire that uid). The launch is factored into a `launch_broker()` function so first-start and respawn share one definition.

- The server already `unlink`s its stale socket on bind (`server.py:213`), so respawns rebind cleanly.
- `SMD_GATEWAY_PID` is the entrypoint PID, preserved across the exec → the `SO_PEERCRED` gate still admits the gateway after a respawn.
- A broker broken from **first boot** is NOT masked: the parent's socket-wait still FATALs the Machine (Fly restarts it). The supervisor only covers death **after** a healthy first start.
- Fail-open-with-respawn is intentional for this PR; the stronger fail-closed **ack-before-dispatch** is deferred to the autonomous-send workstream.

## Guards
- **`tests/operator-entrypoint.test.ts`** (new, 6 assertions) — static regression for the supervisor shape: single launch site, backgrounded `while true` loop calling `launch_broker`, forked before the hermes exec, no un-supervised `server &`, `SMD_GATEWAY_PID` carried into respawns, socket-FATAL tears down the supervisor.
- **boot-smoke Step 11** (`broker-respawn-supervised`) — non-destructive runtime proof: the broker's parent proc dir is **root**-owned (supervised), not PID 1 / hermes (un-supervised).

## Verification
- `bash -n` + shellcheck clean on `entrypoint.sh` and `boot-smoke-test.sh`.
- Shell logic proven locally with a fake broker: `set -e` survives non-zero broker exits (the `if launch_broker` guard), the respawn loop fires, killing the supervisor stops it.
- `operator-entrypoint` + `operator-dockerfile` tests green (21).

## Not yet done (gating customer-zero)
- [ ] **smd-staging kill-9 respawn proof** — deploy this entrypoint to staging, run boot-smoke (incl. Step 11), `kill -9` the live broker, confirm it respawns and the socket returns.
- [ ] Customer-zero redeploy — **only** after staging proof + explicit go (live founder business; no root-SSH on the live box).

🤖 Generated with [Claude Code](https://claude.com/claude-code)