### PR TITLE
feat(marketing): worker-in-another-office imagery + guide journey across Operator pages

### DIFF
--- a/src/pages/operator.astro
+++ b/src/pages/operator.astro
@@ -80,9 +80,8 @@ const industries = [
         <p
           class="mx-auto mb-12 max-w-2xl text-xl leading-relaxed text-[color:var(--ss-color-text-secondary)]"
         >
-          A dedicated Operator, built for your business and given a real role. The technology
-          underneath keeps improving. The Operator, and everything it learns about how you run,
-          stays yours.
+          A dedicated worker for your business, in its own office and plugged into your systems. It
+          takes on the recurring work, learns how you run, and everything it learns stays yours.
         </p>
         <CtaButton href="/book?interest=operator" data-ev="operator-hero-cta"
           >Start the conversation</CtaButton
@@ -120,12 +119,43 @@ const industries = [
       </div>
     </section>
 
-    <!-- § 03 What you actually get -->
+    <!-- § 03 A worker, in another office -->
     <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
           class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
           >§ 03</span
+        >
+        <h2
+          class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
+        >
+          A Worker, In Another Office.
+        </h2>
+        <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
+          <p>
+            Picture a new worker at a desk. A computer, a phone, and access to the systems and
+            processes you already run. You hand it work the way you hand work to anyone on your
+            team. You send the request, it does the job, and it comes back with the result.
+          </p>
+          <p>
+            It works from its own office, the way much of your team already does. The bookkeeper you
+            have never met in person. The vendor you email and trade work with every day. This is
+            one more of those.
+          </p>
+          <p>
+            What it takes on is the work you would want that role doing, inside the limits you set.
+            We get to those limits below.
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <!-- § 04 What you actually get -->
+    <section class="bg-white px-6 py-24">
+      <div class="mx-auto max-w-5xl">
+        <span
+          class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
+          >§ 04</span
         >
         <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
@@ -136,6 +166,11 @@ const industries = [
           <p>
             You get an Operator, not a tool. We build one for your business, give it a role, and set
             it up in the tools your team already uses.
+          </p>
+          <p>
+            Before it starts, we sit down with you and the people who run the work, and we build it
+            around how you operate, so it shows up ready, not green. From there it keeps getting
+            sharper, learning from your team's corrections.
           </p>
           <p>
             Say you give it intake. It reads a new inquiry, pulls the details that matter, drafts
@@ -150,12 +185,12 @@ const industries = [
       </div>
     </section>
 
-    <!-- § 04 One Operator, one memory, all yours -->
-    <section class="bg-white px-6 py-24">
+    <!-- § 05 One Operator, one memory, all yours -->
+    <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
           class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
-          >§ 04</span
+          >§ 05</span
         >
         <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
@@ -191,12 +226,12 @@ const industries = [
       </div>
     </section>
 
-    <!-- § 05 You set the limits, we keep it running -->
-    <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
+    <!-- § 06 You set the limits, we keep it running -->
+    <section class="bg-white px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
           class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
-          >§ 05</span
+          >§ 06</span
         >
         <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
@@ -231,12 +266,40 @@ const industries = [
       </div>
     </section>
 
-    <!-- § 06 Where it fits -->
+    <!-- § 07 We ride it with you -->
+    <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
+      <div class="mx-auto max-w-5xl">
+        <span
+          class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
+          >§ 07</span
+        >
+        <h2
+          class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
+        >
+          We Ride It With You.
+        </h2>
+        <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
+          <p>
+            This technology is new. No one has ten years of experience with it, because it has not
+            been around for ten years. New enough that no one should hand you a tool and walk away
+            from it.
+          </p>
+          <p>
+            So that is not the model. Keeping the Operator useful as the technology changes and as
+            your operation changes is part of the service. We stay close to how it runs for you, and
+            we stay accountable for it. That work is ours, not yours.
+          </p>
+          <p>This is a service, not a download. You are not on your own with it.</p>
+        </div>
+      </div>
+    </section>
+
+    <!-- § 08 Where it fits -->
     <section class="bg-white px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
           class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
-          >§ 06</span
+          >§ 08</span
         >
         <h2
           class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
@@ -274,12 +337,12 @@ const industries = [
       </div>
     </section>
 
-    <!-- § 07 Built for your industry -->
+    <!-- § 09 Built for your industry -->
     <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
           class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
-          >§ 07</span
+          >§ 09</span
         >
         <h2
           class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
@@ -319,12 +382,12 @@ const industries = [
       </div>
     </section>
 
-    <!-- § 08 Start the conversation -->
+    <!-- § 10 Start the conversation -->
     <section class="bg-[color:var(--ss-color-surface-inverse)] px-6 py-24">
       <div class="mx-auto max-w-5xl text-center">
         <span
           class="inline-block bg-[color:var(--ss-color-background)] text-[color:var(--ss-color-text-primary)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-8"
-          >§ 08</span
+          >§ 10</span
         >
         <h2
           class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-white"

--- a/src/pages/packs/accounting.astro
+++ b/src/pages/packs/accounting.astro
@@ -61,10 +61,11 @@ const roleLenses = [
         <p
           class="mx-auto mb-12 max-w-2xl text-xl leading-relaxed text-[color:var(--ss-color-text-secondary)]"
         >
-          A dedicated Operator that runs the client chase, the way a sharp firm administrator would:
-          it works the PBC list, chases the missing documents, routes the return for review, and
-          keeps the deadline and extension cadence on schedule. You add capacity through busy season
-          without adding to payroll.
+          A dedicated worker for your firm, in its own office and plugged into the tools you already
+          run. It runs the client chase, the way a sharp firm administrator would: it works the PBC
+          list, chases the missing documents, routes the return for review, and keeps the deadline
+          and extension cadence on schedule. You add capacity through busy season without adding to
+          payroll.
         </p>
         <CtaButton href="/book?interest=accounting" data-ev="accounting-hero-cta"
           >Start the conversation</CtaButton
@@ -101,12 +102,45 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 03 What it does -->
+    <!-- § 03 A worker, in another office -->
     <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
           class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
           >§ 03</span
+        >
+        <h2
+          class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
+        >
+          A Worker, In Another Office.
+        </h2>
+        <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
+          <p>
+            Picture a new staff accountant at a desk. A computer, a phone, and access to the
+            accounting system, the email, and the document portal you already run. You hand it work
+            the way you hand work to anyone on your team. You send the request, it does the job, and
+            it comes back with the result.
+          </p>
+          <p>
+            It works from its own office, the way much of your team already does. The bookkeeper you
+            have never met in person. The client contact you email and chase documents from. This is
+            one more of those.
+          </p>
+          <p>
+            What it takes on is the work you would want that seat doing, inside the limits you set.
+            The client document that is three weeks late in the middle of March. The return waiting
+            on one missing form. We get to the limits below.
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <!-- § 04 What it does -->
+    <section class="bg-white px-6 py-24">
+      <div class="mx-auto max-w-5xl">
+        <span
+          class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
+          >§ 04</span
         >
         <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
@@ -119,6 +153,11 @@ const roleLenses = [
             practice-management system, your email, your document storage.
           </p>
           <p>
+            Before it starts, we sit down with you and the people who run the work, and we build it
+            around how you operate, so it shows up ready, not green. From there it keeps getting
+            sharper, learning from your team's corrections.
+          </p>
+          <p>
             The engagement opens. It sends the PBC list, chases the missing items, and follows up on
             the client who has gone quiet, as many times as it takes, in your voice. It routes the
             return to a reviewer when the file is ready, answers the routine status question, and
@@ -129,12 +168,12 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 04 You set the line -->
-    <section class="bg-white px-6 py-24">
+    <!-- § 05 You set the line -->
+    <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
           class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
-          >§ 04</span
+          >§ 05</span
         >
         <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
@@ -169,12 +208,12 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 05 One coordinator, your whole firm -->
-    <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
+    <!-- § 06 One coordinator, your whole firm -->
+    <section class="bg-white px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
           class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
-          >§ 05</span
+          >§ 06</span
         >
         <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
@@ -195,12 +234,39 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 06 Where it fits -->
+    <!-- § 07 We ride it with you -->
+    <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
+      <div class="mx-auto max-w-5xl">
+        <span
+          class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
+          >§ 07</span
+        >
+        <h2
+          class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
+        >
+          We Ride It With You.
+        </h2>
+        <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
+          <p>
+            This technology is new. No one has ten years of experience with it, because it has not
+            been around for ten years. New enough that no one should hand your firm a tool and walk
+            away from it.
+          </p>
+          <p>
+            So that is not the model. Keeping the Operator useful as the technology changes and as
+            your firm changes is part of the service, and we stay accountable for it. This is a
+            service, not a download. You are not on your own with it.
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <!-- § 08 Where it fits -->
     <section class="bg-white px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
           class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
-          >§ 06</span
+          >§ 08</span
         >
         <h2
           class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
@@ -238,12 +304,12 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 07 Start the conversation -->
+    <!-- § 09 Start the conversation -->
     <section class="bg-[color:var(--ss-color-surface-inverse)] px-6 py-24">
       <div class="mx-auto max-w-5xl text-center">
         <span
           class="inline-block bg-[color:var(--ss-color-background)] text-[color:var(--ss-color-text-primary)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-8"
-          >§ 07</span
+          >§ 09</span
         >
         <h2
           class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-white"

--- a/src/pages/packs/dental.astro
+++ b/src/pages/packs/dental.astro
@@ -61,10 +61,11 @@ const roleLenses = [
         <p
           class="mx-auto mb-12 max-w-2xl text-xl leading-relaxed text-[color:var(--ss-color-text-secondary)]"
         >
-          A dedicated Operator that runs the front office, the way a sharp scheduling coordinator
-          would: it confirms the schedule, works the recall list, fills the openings a cancellation
-          leaves, handles the insurance-verification logistics, and rebooks the no-show. You add
-          capacity to the busiest seat in the practice without adding to payroll.
+          A dedicated worker for your practice, in its own office and plugged into the tools you
+          already run. It runs the front office the way a sharp scheduling coordinator would: it
+          confirms the schedule, works the recall list, fills the openings a cancellation leaves,
+          handles the insurance-verification logistics, and rebooks the no-show. You add capacity to
+          the busiest seat in the practice without adding to payroll.
         </p>
         <CtaButton href="/book?interest=dental" data-ev="dental-hero-cta"
           >Start the conversation</CtaButton
@@ -102,12 +103,45 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 03 What it does -->
+    <!-- § 03 A worker, in another office -->
     <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
           class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
           >§ 03</span
+        >
+        <h2
+          class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
+        >
+          A Worker, In Another Office.
+        </h2>
+        <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
+          <p>
+            Picture a new front-office coordinator at a desk. A computer, a phone, and access to the
+            practice-management system, the schedule, and the phones you already run. You hand it
+            work the way you hand work to anyone on your team. You send the request, it does the
+            job, and it comes back with the result.
+          </p>
+          <p>
+            It works from its own office, the way much of your team already does. The billing
+            coordinator you have never met in person. The lab you call and trade cases with every
+            week. This is one more of those.
+          </p>
+          <p>
+            What it takes on is the work you would want that seat doing, inside the limits you set.
+            The patient who needs to reschedule and falls off the calendar. The insurance
+            verification that has to happen before the appointment. We get to the limits below.
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <!-- § 04 What it does -->
+    <section class="bg-white px-6 py-24">
+      <div class="mx-auto max-w-5xl">
+        <span
+          class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
+          >§ 04</span
         >
         <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
@@ -120,6 +154,11 @@ const roleLenses = [
             your practice-management system, your email and calendar.
           </p>
           <p>
+            Before it starts, we sit down with you and the people who run the work, and we build it
+            around how you operate, so it shows up ready, not green. From there it keeps getting
+            sharper, learning from your team's corrections.
+          </p>
+          <p>
             It confirms the schedule and rebooks the no-show, works the recall and recare list so
             patients do not get lost, handles the insurance-verification and claim-status logistics,
             and fills the openings a cancellation leaves. A message that might be an emergency it
@@ -130,12 +169,12 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 04 You set the line -->
-    <section class="bg-white px-6 py-24">
+    <!-- § 05 You set the line -->
+    <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
           class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
-          >§ 04</span
+          >§ 05</span
         >
         <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
@@ -169,12 +208,12 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 05 One coordinator, your whole practice -->
-    <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
+    <!-- § 06 One coordinator, your whole practice -->
+    <section class="bg-white px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
           class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
-          >§ 05</span
+          >§ 06</span
         >
         <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
@@ -197,12 +236,39 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 06 Where it fits -->
+    <!-- § 07 We ride it with you -->
+    <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
+      <div class="mx-auto max-w-5xl">
+        <span
+          class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
+          >§ 07</span
+        >
+        <h2
+          class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
+        >
+          We Ride It With You.
+        </h2>
+        <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
+          <p>
+            This technology is new. No one has ten years of experience with it, because it has not
+            been around for ten years. New enough that no one should hand your practice a tool and
+            walk away from it.
+          </p>
+          <p>
+            So that is not the model. Keeping the Operator useful as the technology changes and as
+            your practice changes is part of the service, and we stay accountable for it. This is a
+            service, not a download. You are not on your own with it.
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <!-- § 08 Where it fits -->
     <section class="bg-white px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
           class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
-          >§ 06</span
+          >§ 08</span
         >
         <h2
           class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
@@ -240,12 +306,12 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 07 Start the conversation -->
+    <!-- § 09 Start the conversation -->
     <section class="bg-[color:var(--ss-color-surface-inverse)] px-6 py-24">
       <div class="mx-auto max-w-5xl text-center">
         <span
           class="inline-block bg-[color:var(--ss-color-background)] text-[color:var(--ss-color-text-primary)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-8"
-          >§ 07</span
+          >§ 09</span
         >
         <h2
           class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-white"

--- a/src/pages/packs/home-services.astro
+++ b/src/pages/packs/home-services.astro
@@ -61,10 +61,11 @@ const roleLenses = [
         <p
           class="mx-auto mb-12 max-w-2xl text-xl leading-relaxed text-[color:var(--ss-color-text-secondary)]"
         >
-          A dedicated Operator that runs the front office, the way a sharp CSR would: it answers the
-          call, books the job, confirms the appointment, follows up on the estimate, and keeps your
-          field-service system current, including the calls that come in after hours. You stop
-          sending leads to voicemail, and you do not add a seat to hire and train.
+          A dedicated worker for your shop, in its own office and plugged into the tools you already
+          run. It runs the front office the way a sharp CSR would: it answers the call, books the
+          job, confirms the appointment, follows up on the estimate, and keeps your field-service
+          system current, including the calls that come in after hours. You stop sending leads to
+          voicemail, and you do not add a seat to hire and train.
         </p>
         <CtaButton href="/book?interest=home-services" data-ev="home-services-hero-cta"
           >Start the conversation</CtaButton
@@ -101,12 +102,45 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 03 What it does -->
+    <!-- § 03 A worker, in another office -->
     <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
           class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
           >§ 03</span
+        >
+        <h2
+          class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
+        >
+          A Worker, In Another Office.
+        </h2>
+        <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
+          <p>
+            Picture a new dispatcher at a desk. A computer, a phone, and access to the scheduling
+            software, the phones, and the job board you already run. You hand it work the way you
+            hand work to anyone on your team. You send the request, it does the job, and it comes
+            back with the result.
+          </p>
+          <p>
+            It works from its own office, the way much of your team already does. The office manager
+            you have never met in person. The supplier you call and order parts from. This is one
+            more of those.
+          </p>
+          <p>
+            What it takes on is the work you would want that seat doing, inside the limits you set.
+            The call that comes in after hours and goes to voicemail. The quote that never got a
+            follow-up before the customer called someone else. We get to the limits below.
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <!-- § 04 What it does -->
+    <section class="bg-white px-6 py-24">
+      <div class="mx-auto max-w-5xl">
+        <span
+          class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
+          >§ 04</span
         >
         <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
@@ -117,6 +151,11 @@ const roleLenses = [
           <p>
             We build the Operator for your shop and connect it to the tools you already run: your
             field-service system, your email and calendar.
+          </p>
+          <p>
+            Before it starts, we sit down with you and the people who run the work, and we build it
+            around how you operate, so it shows up ready, not green. From there it keeps getting
+            sharper, learning from your team's corrections.
           </p>
           <p>
             The phone rings, after hours or in the middle of peak season, and it answers, captures
@@ -130,12 +169,12 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 04 You set the line -->
-    <section class="bg-white px-6 py-24">
+    <!-- § 05 You set the line -->
+    <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
           class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
-          >§ 04</span
+          >§ 05</span
         >
         <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
@@ -170,12 +209,12 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 05 One coordinator, your whole shop -->
-    <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
+    <!-- § 06 One coordinator, your whole shop -->
+    <section class="bg-white px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
           class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
-          >§ 05</span
+          >§ 06</span
         >
         <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
@@ -196,12 +235,39 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 06 Where it fits -->
+    <!-- § 07 We ride it with you -->
+    <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
+      <div class="mx-auto max-w-5xl">
+        <span
+          class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
+          >§ 07</span
+        >
+        <h2
+          class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
+        >
+          We Ride It With You.
+        </h2>
+        <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
+          <p>
+            This technology is new. No one has ten years of experience with it, because it has not
+            been around for ten years. New enough that no one should hand your shop a tool and walk
+            away from it.
+          </p>
+          <p>
+            So that is not the model. Keeping the Operator useful as the technology changes and as
+            your shop changes is part of the service, and we stay accountable for it. This is a
+            service, not a download. You are not on your own with it.
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <!-- § 08 Where it fits -->
     <section class="bg-white px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
           class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
-          >§ 06</span
+          >§ 08</span
         >
         <h2
           class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
@@ -239,12 +305,12 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 07 Start the conversation -->
+    <!-- § 09 Start the conversation -->
     <section class="bg-[color:var(--ss-color-surface-inverse)] px-6 py-24">
       <div class="mx-auto max-w-5xl text-center">
         <span
           class="inline-block bg-[color:var(--ss-color-background)] text-[color:var(--ss-color-text-primary)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-8"
-          >§ 07</span
+          >§ 09</span
         >
         <h2
           class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-white"

--- a/src/pages/packs/insurance.astro
+++ b/src/pages/packs/insurance.astro
@@ -61,10 +61,11 @@ const roleLenses = [
         <p
           class="mx-auto mb-12 max-w-2xl text-xl leading-relaxed text-[color:var(--ss-color-text-secondary)]"
         >
-          A dedicated Operator that services your book the way a sharp account manager would: it
-          works new-quote intake, runs the renewal cadence, turns around COIs and endorsements,
-          fields the billing questions, and routes first notice of loss. You add capacity to the
-          desk without adding to payroll.
+          A dedicated worker for your agency, in its own office and plugged into the tools you
+          already run. It services your book the way a sharp account manager would: it works
+          new-quote intake, runs the renewal cadence, turns around COIs and endorsements, fields the
+          billing questions, and routes first notice of loss. You add capacity to the desk without
+          adding to payroll.
         </p>
         <CtaButton href="/book?interest=insurance" data-ev="insurance-hero-cta"
           >Start the conversation</CtaButton
@@ -100,12 +101,45 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 03 What it does -->
+    <!-- § 03 A worker, in another office -->
     <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
           class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
           >§ 03</span
+        >
+        <h2
+          class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
+        >
+          A Worker, In Another Office.
+        </h2>
+        <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
+          <p>
+            Picture a new account service rep at a desk. A computer, a phone, and access to the
+            agency management system, the email, and the carrier portals you already run. You hand
+            it work the way you hand work to anyone on your team. You send the request, it does the
+            job, and it comes back with the result.
+          </p>
+          <p>
+            It works from its own office, the way much of your team already does. The account
+            manager you have never met in person. The wholesaler you email and trade submissions
+            with every week. This is one more of those.
+          </p>
+          <p>
+            What it takes on is the work you would want that seat doing, inside the limits you set.
+            The renewal that is sixty days out and still needs a review. The certificate a client
+            needs before they can start a job. We get to the limits below.
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <!-- § 04 What it does -->
+    <section class="bg-white px-6 py-24">
+      <div class="mx-auto max-w-5xl">
+        <span
+          class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
+          >§ 04</span
         >
         <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
@@ -120,6 +154,11 @@ const roleLenses = [
             front of it, not buried.
           </p>
           <p>
+            Before it starts, we sit down with you and the people who run the work, and we build it
+            around how you operate, so it shows up ready, not green. From there it keeps getting
+            sharper, learning from your team's corrections.
+          </p>
+          <p>
             A quote request comes in. It captures the exposure, drafts the acknowledgment in your
             voice, and routes it to a producer. It runs the renewal cadence so nothing lapses,
             builds the certificate from what is on the policy, relays the endorsement to the carrier
@@ -131,12 +170,12 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 04 You set the line -->
-    <section class="bg-white px-6 py-24">
+    <!-- § 05 You set the line -->
+    <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
           class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
-          >§ 04</span
+          >§ 05</span
         >
         <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
@@ -172,12 +211,12 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 05 One coordinator, your whole agency -->
-    <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
+    <!-- § 06 One coordinator, your whole agency -->
+    <section class="bg-white px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
           class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
-          >§ 05</span
+          >§ 06</span
         >
         <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
@@ -199,12 +238,39 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 06 Where it fits -->
+    <!-- § 07 We ride it with you -->
+    <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
+      <div class="mx-auto max-w-5xl">
+        <span
+          class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
+          >§ 07</span
+        >
+        <h2
+          class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
+        >
+          We Ride It With You.
+        </h2>
+        <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
+          <p>
+            This technology is new. No one has ten years of experience with it, because it has not
+            been around for ten years. New enough that no one should hand your agency a tool and
+            walk away from it.
+          </p>
+          <p>
+            So that is not the model. Keeping the Operator useful as the technology changes and as
+            your agency changes is part of the service, and we stay accountable for it. This is a
+            service, not a download. You are not on your own with it.
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <!-- § 08 Where it fits -->
     <section class="bg-white px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
           class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
-          >§ 06</span
+          >§ 08</span
         >
         <h2
           class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
@@ -242,12 +308,12 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 07 Start the conversation -->
+    <!-- § 09 Start the conversation -->
     <section class="bg-[color:var(--ss-color-surface-inverse)] px-6 py-24">
       <div class="mx-auto max-w-5xl text-center">
         <span
           class="inline-block bg-[color:var(--ss-color-background)] text-[color:var(--ss-color-text-primary)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-8"
-          >§ 07</span
+          >§ 09</span
         >
         <h2
           class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-white"

--- a/src/pages/packs/law-firm.astro
+++ b/src/pages/packs/law-firm.astro
@@ -61,10 +61,11 @@ const roleLenses = [
         <p
           class="mx-auto mb-12 max-w-2xl text-xl leading-relaxed text-[color:var(--ss-color-text-secondary)]"
         >
-          A dedicated Operator that runs intake and keeps your matters moving, the way a sharp legal
-          assistant would: it answers the new inquiry, books the consult, chases the engagement
-          letter to signature, and keeps your practice-management system current. You add capacity
-          to the front of the firm without adding to payroll.
+          A dedicated worker for your firm, in its own office and plugged into the tools you already
+          run. It handles intake and keeps your matters moving the way a sharp legal assistant
+          would: it answers the new inquiry, books the consult, chases the engagement letter to
+          signature, and keeps your practice-management system current. You add capacity at the
+          front of the firm without adding to payroll.
         </p>
         <CtaButton href="/book?interest=law-firm" data-ev="law-firm-hero-cta"
           >Start the conversation</CtaButton
@@ -101,12 +102,46 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 03 What it does -->
+    <!-- § 03 A worker, in another office -->
     <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
           class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
           >§ 03</span
+        >
+        <h2
+          class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
+        >
+          A Worker, In Another Office.
+        </h2>
+        <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
+          <p>
+            Picture a new legal assistant at a desk. A computer, a phone, and access to the
+            practice-management system, the email, and the calendar you already run. You hand it
+            work the way you hand work to anyone on your team. You send the request, it does the
+            job, and it comes back with the result.
+          </p>
+          <p>
+            It works from its own office, the way much of your team already does. The contract
+            paralegal you have never met in person. The process server you email and trade work with
+            every week. This is one more of those.
+          </p>
+          <p>
+            What it takes on is the work you would want that seat doing, inside the limits you set.
+            The new-client inquiry that lands at seven in the evening and needs an answer before a
+            competing firm sends one. The engagement letter that has sat unsigned for a week. We get
+            to the limits below.
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <!-- § 04 What it does -->
+    <section class="bg-white px-6 py-24">
+      <div class="mx-auto max-w-5xl">
+        <span
+          class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
+          >§ 04</span
         >
         <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
@@ -119,6 +154,11 @@ const roleLenses = [
             practice-management system, your email and calendar, your documents.
           </p>
           <p>
+            Before it starts, we sit down with you and the people who run intake, and we build it
+            around how your firm operates, so it shows up ready, not green. From there it keeps
+            getting sharper, learning from your team's corrections.
+          </p>
+          <p>
             A new inquiry lands, wherever it comes from. It captures the details that matter, drafts
             the first reply in your voice, and offers times for the consult. It chases the
             engagement letter to signature, answers the routine status questions, logs the documents
@@ -129,12 +169,12 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 04 You set the line -->
-    <section class="bg-white px-6 py-24">
+    <!-- § 05 You set the line -->
+    <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
           class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
-          >§ 04</span
+          >§ 05</span
         >
         <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
@@ -176,12 +216,12 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 05 One coordinator, your whole firm -->
-    <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
+    <!-- § 06 One coordinator, your whole firm -->
+    <section class="bg-white px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
           class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
-          >§ 05</span
+          >§ 06</span
         >
         <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
@@ -196,9 +236,9 @@ const roleLenses = [
           <p>
             We are not the experts in how your firm runs. You are. So the Operator runs on your
             firm's expertise, not ours: your practice areas, your intake questions, the way you run
-            a matter, your voice. You teach it the way you would train a new hire, and it gets
-            better at your firm every week, because it learns from your corrections and remembers
-            them.
+            a matter, your voice. We build it ready from what we learn working with you, so it shows
+            up ready, not green, and it keeps getting sharper, learning from your team's corrections
+            and remembering them.
           </p>
           <p>
             What it learns is a record you can read and correct, and it belongs to the firm, not to
@@ -209,12 +249,39 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 06 Where it fits -->
+    <!-- § 07 We ride it with you -->
+    <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
+      <div class="mx-auto max-w-5xl">
+        <span
+          class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
+          >§ 07</span
+        >
+        <h2
+          class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
+        >
+          We Ride It With You.
+        </h2>
+        <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
+          <p>
+            This technology is new. No one has ten years of experience with it, because it has not
+            been around for ten years. New enough that no one should hand your firm a tool and walk
+            away from it.
+          </p>
+          <p>
+            So that is not the model. Keeping the Operator useful as the technology changes and as
+            your firm changes is part of the service, and we stay accountable for it. This is a
+            service, not a download. You are not on your own with it.
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <!-- § 08 Where it fits -->
     <section class="bg-white px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
           class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
-          >§ 06</span
+          >§ 08</span
         >
         <h2
           class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
@@ -252,12 +319,12 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 07 Start the conversation -->
+    <!-- § 09 Start the conversation -->
     <section class="bg-[color:var(--ss-color-surface-inverse)] px-6 py-24">
       <div class="mx-auto max-w-5xl text-center">
         <span
           class="inline-block bg-[color:var(--ss-color-background)] text-[color:var(--ss-color-text-primary)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-8"
-          >§ 07</span
+          >§ 09</span
         >
         <h2
           class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-white"

--- a/src/pages/packs/marketing-agency.astro
+++ b/src/pages/packs/marketing-agency.astro
@@ -61,10 +61,11 @@ const roleLenses = [
         <p
           class="mx-auto mb-12 max-w-2xl text-xl leading-relaxed text-[color:var(--ss-color-text-secondary)]"
         >
-          A dedicated Operator that keeps the account moving, the way a sharp account manager would:
-          it chases approvals and assets, sends status, keeps the project on track, and handles the
-          routine client back-and-forth. You add capacity, and your account managers get back the
-          hours they lose to work about work.
+          A dedicated worker for your agency, in its own office and plugged into the tools you
+          already run. It keeps the account moving, the way a sharp account manager would: it chases
+          approvals and assets, sends status, keeps the project on track, and handles the routine
+          client back-and-forth. You add capacity, and your account managers get back the hours they
+          lose to work about work.
         </p>
         <CtaButton href="/book?interest=marketing-agency" data-ev="marketing-agency-hero-cta"
           >Start the conversation</CtaButton
@@ -101,12 +102,45 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 03 What it does -->
+    <!-- § 03 A worker, in another office -->
     <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
           class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
           >§ 03</span
+        >
+        <h2
+          class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
+        >
+          A Worker, In Another Office.
+        </h2>
+        <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
+          <p>
+            Picture a new account coordinator at a desk. A computer, a phone, and access to the
+            project tools, the email, and the client folders you already run. You hand it work the
+            way you hand work to anyone on your team. You send the request, it does the job, and it
+            comes back with the result.
+          </p>
+          <p>
+            It works from its own office, the way much of your team already does. The project
+            manager you have never met in person. The freelancer you email and hand work to every
+            week. This is one more of those.
+          </p>
+          <p>
+            What it takes on is the work you would want that seat doing, inside the limits you set.
+            The client status update that is a day late. The asset waiting on approval before it can
+            ship. We get to the limits below.
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <!-- § 04 What it does -->
+    <section class="bg-white px-6 py-24">
+      <div class="mx-auto max-w-5xl">
+        <span
+          class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
+          >§ 04</span
         >
         <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
@@ -119,6 +153,11 @@ const roleLenses = [
             project-management system, your email and calendar, your file storage.
           </p>
           <p>
+            Before it starts, we sit down with you and the people who run the work, and we build it
+            around how you operate, so it shows up ready, not green. From there it keeps getting
+            sharper, learning from your team's corrections.
+          </p>
+          <p>
             It chases the approvals and assets a deliverable is waiting on, sends the status updates
             clients expect, keeps the project current, and handles the routine back-and-forth that
             fills an account manager's day. The work about work moves off your people. Every piece
@@ -128,12 +167,12 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 04 You set the line -->
-    <section class="bg-white px-6 py-24">
+    <!-- § 05 You set the line -->
+    <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
           class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
-          >§ 04</span
+          >§ 05</span
         >
         <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
@@ -168,12 +207,12 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 05 One coordinator, your whole agency -->
-    <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
+    <!-- § 06 One coordinator, your whole agency -->
+    <section class="bg-white px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
           class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
-          >§ 05</span
+          >§ 06</span
         >
         <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
@@ -194,12 +233,39 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 06 Where it fits -->
+    <!-- § 07 We ride it with you -->
+    <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
+      <div class="mx-auto max-w-5xl">
+        <span
+          class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
+          >§ 07</span
+        >
+        <h2
+          class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
+        >
+          We Ride It With You.
+        </h2>
+        <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
+          <p>
+            This technology is new. No one has ten years of experience with it, because it has not
+            been around for ten years. New enough that no one should hand your agency a tool and
+            walk away from it.
+          </p>
+          <p>
+            So that is not the model. Keeping the Operator useful as the technology changes and as
+            your agency changes is part of the service, and we stay accountable for it. This is a
+            service, not a download. You are not on your own with it.
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <!-- § 08 Where it fits -->
     <section class="bg-white px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
           class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
-          >§ 06</span
+          >§ 08</span
         >
         <h2
           class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
@@ -237,12 +303,12 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 07 Start the conversation -->
+    <!-- § 09 Start the conversation -->
     <section class="bg-[color:var(--ss-color-surface-inverse)] px-6 py-24">
       <div class="mx-auto max-w-5xl text-center">
         <span
           class="inline-block bg-[color:var(--ss-color-background)] text-[color:var(--ss-color-text-primary)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-8"
-          >§ 07</span
+          >§ 09</span
         >
         <h2
           class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-white"

--- a/src/pages/packs/med-spa.astro
+++ b/src/pages/packs/med-spa.astro
@@ -61,10 +61,11 @@ const roleLenses = [
         <p
           class="mx-auto mb-12 max-w-2xl text-xl leading-relaxed text-[color:var(--ss-color-text-secondary)]"
         >
-          A dedicated Operator that runs the front desk, the way a sharp patient care coordinator
-          would: it books and confirms consults and treatments, runs the membership and rebooking
-          cadence, chases the no-show, and handles the routine client back-and-forth. You add
-          capacity to a seat that turns over hard, without adding to payroll.
+          A dedicated worker for your practice, in its own office and plugged into the tools you
+          already run. It runs the front desk, the way a sharp patient care coordinator would: it
+          books and confirms consults and treatments, runs the membership and rebooking cadence,
+          chases the no-show, and handles the routine client back-and-forth. You add capacity to a
+          seat that turns over hard, without adding to payroll.
         </p>
         <CtaButton href="/book?interest=med-spa" data-ev="med-spa-hero-cta"
           >Start the conversation</CtaButton
@@ -100,12 +101,45 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 03 What it does -->
+    <!-- § 03 A worker, in another office -->
     <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
           class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
           >§ 03</span
+        >
+        <h2
+          class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
+        >
+          A Worker, In Another Office.
+        </h2>
+        <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
+          <p>
+            Picture a new front-desk coordinator at a desk. A computer, a phone, and access to the
+            booking system, the phones, and the membership records you already run. You hand it work
+            the way you hand work to anyone on your team. You send the request, it does the job, and
+            it comes back with the result.
+          </p>
+          <p>
+            It works from its own office, the way much of your team already does. The membership
+            coordinator you have never met in person. The rep you email about product and supplies.
+            This is one more of those.
+          </p>
+          <p>
+            What it takes on is the work you would want that seat doing, inside the limits you set.
+            The consult that needs rebooking. The membership renewal coming due that no one has
+            flagged. We get to the limits below.
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <!-- § 04 What it does -->
+    <section class="bg-white px-6 py-24">
+      <div class="mx-auto max-w-5xl">
+        <span
+          class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
+          >§ 04</span
         >
         <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
@@ -118,6 +152,11 @@ const roleLenses = [
             your practice-management system, your email and calendar.
           </p>
           <p>
+            Before it starts, we sit down with you and the people who run the work, and we build it
+            around how you operate, so it shows up ready, not green. From there it keeps getting
+            sharper, learning from your team's corrections.
+          </p>
+          <p>
             It books and confirms consults and treatments, runs the membership and rebooking
             cadence, chases every no-show, and answers the routine client question in your voice,
             including the calls that come in after you close. A message that might be a medical
@@ -128,12 +167,12 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 04 You set the line -->
-    <section class="bg-white px-6 py-24">
+    <!-- § 05 You set the line -->
+    <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
           class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
-          >§ 04</span
+          >§ 05</span
         >
         <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
@@ -168,12 +207,12 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 05 One coordinator, your whole practice -->
-    <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
+    <!-- § 06 One coordinator, your whole practice -->
+    <section class="bg-white px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
           class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
-          >§ 05</span
+          >§ 06</span
         >
         <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
@@ -196,12 +235,39 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 06 Where it fits -->
+    <!-- § 07 We ride it with you -->
+    <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
+      <div class="mx-auto max-w-5xl">
+        <span
+          class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
+          >§ 07</span
+        >
+        <h2
+          class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
+        >
+          We Ride It With You.
+        </h2>
+        <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
+          <p>
+            This technology is new. No one has ten years of experience with it, because it has not
+            been around for ten years. New enough that no one should hand your practice a tool and
+            walk away from it.
+          </p>
+          <p>
+            So that is not the model. Keeping the Operator useful as the technology changes and as
+            your practice changes is part of the service, and we stay accountable for it. This is a
+            service, not a download. You are not on your own with it.
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <!-- § 08 Where it fits -->
     <section class="bg-white px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
           class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
-          >§ 06</span
+          >§ 08</span
         >
         <h2
           class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
@@ -239,12 +305,12 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 07 Start the conversation -->
+    <!-- § 09 Start the conversation -->
     <section class="bg-[color:var(--ss-color-surface-inverse)] px-6 py-24">
       <div class="mx-auto max-w-5xl text-center">
         <span
           class="inline-block bg-[color:var(--ss-color-background)] text-[color:var(--ss-color-text-primary)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-8"
-          >§ 07</span
+          >§ 09</span
         >
         <h2
           class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-white"

--- a/src/pages/packs/mortgage.astro
+++ b/src/pages/packs/mortgage.astro
@@ -61,10 +61,11 @@ const roleLenses = [
         <p
           class="mx-auto mb-12 max-w-2xl text-xl leading-relaxed text-[color:var(--ss-color-text-secondary)]"
         >
-          A dedicated Operator that keeps the pipeline moving, the way a sharp loan-officer
-          assistant would: it collects the borrower conditions, keeps every party current, works the
-          condition chain toward clear-to-close, and keeps your loan-origination system current. You
-          add capacity without the hire-fast, fire-fast cycle.
+          A dedicated worker for your shop, in its own office and plugged into the tools you already
+          run. It keeps the pipeline moving, the way a sharp loan-officer assistant would: it
+          collects the borrower conditions, keeps every party current, works the condition chain
+          toward clear-to-close, and keeps your loan-origination system current. You add capacity
+          without the hire-fast, fire-fast cycle.
         </p>
         <CtaButton href="/book?interest=mortgage" data-ev="mortgage-hero-cta"
           >Start the conversation</CtaButton
@@ -101,12 +102,45 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 03 What it does -->
+    <!-- § 03 A worker, in another office -->
     <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
           class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
           >§ 03</span
+        >
+        <h2
+          class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
+        >
+          A Worker, In Another Office.
+        </h2>
+        <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
+          <p>
+            Picture a new loan processor at a desk. A computer, a phone, and access to the
+            loan-origination system, the email, and the document portal you already run. You hand it
+            work the way you hand work to anyone on your team. You send the request, it does the
+            job, and it comes back with the result.
+          </p>
+          <p>
+            It works from its own office, the way much of your team already does. The processor you
+            have never met in person. The title rep you email and trade files with. This is one more
+            of those.
+          </p>
+          <p>
+            What it takes on is the work you would want that seat doing, inside the limits you set.
+            The condition that is holding up the file. The borrower document that has not come back
+            before the rate lock expires. We get to the limits below.
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <!-- § 04 What it does -->
+    <section class="bg-white px-6 py-24">
+      <div class="mx-auto max-w-5xl">
+        <span
+          class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
+          >§ 04</span
         >
         <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
@@ -119,6 +153,11 @@ const roleLenses = [
             loan-origination system, your email, your document storage.
           </p>
           <p>
+            Before it starts, we sit down with you and the people who run the work, and we build it
+            around how you operate, so it shows up ready, not green. From there it keeps getting
+            sharper, learning from your team's corrections.
+          </p>
+          <p>
             A file comes in. It collects the borrower conditions, chases the documents the file
             needs, and works the condition chain so the file keeps moving toward clear-to-close. It
             keeps the borrower, the agent, and title current at every step, and keeps the
@@ -129,12 +168,12 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 04 You set the line -->
-    <section class="bg-white px-6 py-24">
+    <!-- § 05 You set the line -->
+    <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
           class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
-          >§ 04</span
+          >§ 05</span
         >
         <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
@@ -170,12 +209,12 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 05 One coordinator, your whole shop -->
-    <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
+    <!-- § 06 One coordinator, your whole shop -->
+    <section class="bg-white px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
           class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
-          >§ 05</span
+          >§ 06</span
         >
         <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
@@ -196,12 +235,39 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 06 Where it fits -->
+    <!-- § 07 We ride it with you -->
+    <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
+      <div class="mx-auto max-w-5xl">
+        <span
+          class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
+          >§ 07</span
+        >
+        <h2
+          class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
+        >
+          We Ride It With You.
+        </h2>
+        <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
+          <p>
+            This technology is new. No one has ten years of experience with it, because it has not
+            been around for ten years. New enough that no one should hand your shop a tool and walk
+            away from it.
+          </p>
+          <p>
+            So that is not the model. Keeping the Operator useful as the technology changes and as
+            your shop changes is part of the service, and we stay accountable for it. This is a
+            service, not a download. You are not on your own with it.
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <!-- § 08 Where it fits -->
     <section class="bg-white px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
           class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
-          >§ 06</span
+          >§ 08</span
         >
         <h2
           class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
@@ -239,12 +305,12 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 07 Start the conversation -->
+    <!-- § 09 Start the conversation -->
     <section class="bg-[color:var(--ss-color-surface-inverse)] px-6 py-24">
       <div class="mx-auto max-w-5xl text-center">
         <span
           class="inline-block bg-[color:var(--ss-color-background)] text-[color:var(--ss-color-text-primary)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-8"
-          >§ 07</span
+          >§ 09</span
         >
         <h2
           class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-white"

--- a/src/pages/packs/property-management.astro
+++ b/src/pages/packs/property-management.astro
@@ -61,10 +61,11 @@ const roleLenses = [
         <p
           class="mx-auto mb-12 max-w-2xl text-xl leading-relaxed text-[color:var(--ss-color-text-secondary)]"
         >
-          A dedicated Operator that runs resident and owner coordination, the way a sharp property
-          manager would: it intakes the work order, coordinates the maintenance, runs the
-          lease-renewal cadence, fields the routine resident and owner questions, and keeps your
-          management system current. You take on more doors without staffing up for every one.
+          A dedicated worker for your company, in its own office and plugged into the tools you
+          already run. It runs resident and owner coordination the way a sharp property manager
+          would: it intakes the work order, coordinates the maintenance, runs the lease-renewal
+          cadence, fields the routine resident and owner questions, and keeps your management system
+          current. You take on more doors without staffing up for every one.
         </p>
         <CtaButton href="/book?interest=property-management" data-ev="property-management-hero-cta"
           >Start the conversation</CtaButton
@@ -101,12 +102,45 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 03 What it does -->
+    <!-- § 03 A worker, in another office -->
     <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
           class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
           >§ 03</span
+        >
+        <h2
+          class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
+        >
+          A Worker, In Another Office.
+        </h2>
+        <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
+          <p>
+            Picture a new property coordinator at a desk. A computer, a phone, and access to the
+            property-management system, the email, and the maintenance queue you already run. You
+            hand it work the way you hand work to anyone on your team. You send the request, it does
+            the job, and it comes back with the result.
+          </p>
+          <p>
+            It works from its own office, the way much of your team already does. The regional
+            coordinator you have never met in person. The vendor you email and dispatch work to.
+            This is one more of those.
+          </p>
+          <p>
+            What it takes on is the work you would want that seat doing, inside the limits you set.
+            The maintenance request that sits unrouted overnight. The lease renewal coming up in
+            forty-five days. We get to the limits below.
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <!-- § 04 What it does -->
+    <section class="bg-white px-6 py-24">
+      <div class="mx-auto max-w-5xl">
+        <span
+          class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
+          >§ 04</span
         >
         <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
@@ -119,6 +153,11 @@ const roleLenses = [
             property-management system, your email and calendar.
           </p>
           <p>
+            Before it starts, we sit down with you and the people who run the work, and we build it
+            around how you operate, so it shows up ready, not green. From there it keeps getting
+            sharper, learning from your team's corrections.
+          </p>
+          <p>
             It intakes the work order and coordinates the routine maintenance, runs the
             lease-renewal cadence, answers the routine resident and owner question in your voice,
             and keeps the management system current. The after-hours back-and-forth it handles, and
@@ -129,12 +168,12 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 04 You set the line -->
-    <section class="bg-white px-6 py-24">
+    <!-- § 05 You set the line -->
+    <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
           class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
-          >§ 04</span
+          >§ 05</span
         >
         <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
@@ -170,12 +209,12 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 05 One coordinator, your whole company -->
-    <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
+    <!-- § 06 One coordinator, your whole company -->
+    <section class="bg-white px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
           class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
-          >§ 05</span
+          >§ 06</span
         >
         <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
@@ -197,12 +236,39 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 06 Where it fits -->
+    <!-- § 07 We ride it with you -->
+    <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
+      <div class="mx-auto max-w-5xl">
+        <span
+          class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
+          >§ 07</span
+        >
+        <h2
+          class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
+        >
+          We Ride It With You.
+        </h2>
+        <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
+          <p>
+            This technology is new. No one has ten years of experience with it, because it has not
+            been around for ten years. New enough that no one should hand your company a tool and
+            walk away from it.
+          </p>
+          <p>
+            So that is not the model. Keeping the Operator useful as the technology changes and as
+            your company changes is part of the service, and we stay accountable for it. This is a
+            service, not a download. You are not on your own with it.
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <!-- § 08 Where it fits -->
     <section class="bg-white px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
           class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
-          >§ 06</span
+          >§ 08</span
         >
         <h2
           class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
@@ -240,12 +306,12 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 07 Start the conversation -->
+    <!-- § 09 Start the conversation -->
     <section class="bg-[color:var(--ss-color-surface-inverse)] px-6 py-24">
       <div class="mx-auto max-w-5xl text-center">
         <span
           class="inline-block bg-[color:var(--ss-color-background)] text-[color:var(--ss-color-text-primary)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-8"
-          >§ 07</span
+          >§ 09</span
         >
         <h2
           class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-white"

--- a/src/pages/packs/ria.astro
+++ b/src/pages/packs/ria.astro
@@ -61,10 +61,11 @@ const roleLenses = [
         <p
           class="mx-auto mb-12 max-w-2xl text-xl leading-relaxed text-[color:var(--ss-color-text-secondary)]"
         >
-          A dedicated Operator that runs client service and operations, the way a sharp client
-          service associate would: it schedules the review, preps the meeting, chases the paperwork,
-          runs the RMD and review cadence, and keeps the CRM current. You add capacity without
-          adding the paraplanner your margins cannot carry yet.
+          A dedicated worker for your firm, in its own office and plugged into the tools you already
+          run. It runs client service and operations the way a sharp client service associate would:
+          it schedules the review, preps the meeting, chases the paperwork, runs the RMD and review
+          cadence, and keeps the CRM current. You add capacity without adding the paraplanner your
+          margins cannot carry yet.
         </p>
         <CtaButton href="/book?interest=ria" data-ev="ria-hero-cta"
           >Start the conversation</CtaButton
@@ -101,12 +102,45 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 03 What it does -->
+    <!-- § 03 A worker, in another office -->
     <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
           class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
           >§ 03</span
+        >
+        <h2
+          class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
+        >
+          A Worker, In Another Office.
+        </h2>
+        <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
+          <p>
+            Picture a new client-service associate at a desk. A computer, a phone, and access to the
+            CRM, the custodian portals, and the calendar you already run. You hand it work the way
+            you hand work to anyone on your team. You send the request, it does the job, and it
+            comes back with the result.
+          </p>
+          <p>
+            It works from its own office, the way much of your team already does. The operations
+            associate you have never met in person. The custodian rep you email and trade paperwork
+            with. This is one more of those.
+          </p>
+          <p>
+            What it takes on is the work you would want that seat doing, inside the limits you set.
+            The new-account paperwork waiting on a signature. The client email that came in this
+            morning and needs a same-day reply. We get to the limits below.
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <!-- § 04 What it does -->
+    <section class="bg-white px-6 py-24">
+      <div class="mx-auto max-w-5xl">
+        <span
+          class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
+          >§ 04</span
         >
         <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
@@ -119,6 +153,11 @@ const roleLenses = [
             CRM, your email and calendar, your document storage.
           </p>
           <p>
+            Before it starts, we sit down with you and the people who run the work, and we build it
+            around how you operate, so it shows up ready, not green. From there it keeps getting
+            sharper, learning from your team's corrections.
+          </p>
+          <p>
             It schedules the client review and preps the meeting, chases the paperwork a household
             owes, runs the RMD and annual-review cadence so nothing is late, and keeps the CRM
             current instead of living on sticky notes. The routine client back-and-forth it handles
@@ -128,12 +167,12 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 04 You set the line -->
-    <section class="bg-white px-6 py-24">
+    <!-- § 05 You set the line -->
+    <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
           class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
-          >§ 04</span
+          >§ 05</span
         >
         <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
@@ -166,12 +205,12 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 05 One coordinator, your whole firm -->
-    <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
+    <!-- § 06 One coordinator, your whole firm -->
+    <section class="bg-white px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
           class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
-          >§ 05</span
+          >§ 06</span
         >
         <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
@@ -192,12 +231,39 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 06 Where it fits -->
+    <!-- § 07 We ride it with you -->
+    <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
+      <div class="mx-auto max-w-5xl">
+        <span
+          class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
+          >§ 07</span
+        >
+        <h2
+          class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
+        >
+          We Ride It With You.
+        </h2>
+        <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
+          <p>
+            This technology is new. No one has ten years of experience with it, because it has not
+            been around for ten years. New enough that no one should hand your firm a tool and walk
+            away from it.
+          </p>
+          <p>
+            So that is not the model. Keeping the Operator useful as the technology changes and as
+            your firm changes is part of the service, and we stay accountable for it. This is a
+            service, not a download. You are not on your own with it.
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <!-- § 08 Where it fits -->
     <section class="bg-white px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
           class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
-          >§ 06</span
+          >§ 08</span
         >
         <h2
           class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
@@ -235,12 +301,12 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 07 Start the conversation -->
+    <!-- § 09 Start the conversation -->
     <section class="bg-[color:var(--ss-color-surface-inverse)] px-6 py-24">
       <div class="mx-auto max-w-5xl text-center">
         <span
           class="inline-block bg-[color:var(--ss-color-background)] text-[color:var(--ss-color-text-primary)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-8"
-          >§ 07</span
+          >§ 09</span
         >
         <h2
           class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-white"

--- a/src/pages/packs/title.astro
+++ b/src/pages/packs/title.astro
@@ -61,10 +61,11 @@ const roleLenses = [
         <p
           class="mx-auto mb-12 max-w-2xl text-xl leading-relaxed text-[color:var(--ss-color-text-secondary)]"
         >
-          A dedicated Operator that runs the file the way a sharp closing coordinator would: it
-          opens the order, chases the payoffs and the HOA and the survey, keeps every party current
-          at each milestone, coordinates the clear-to-close, and confirms the signing. It never
-          touches funds or wire instructions. You add capacity to the closing desk without adding to
+          A dedicated worker for your company, in its own office and plugged into the tools you
+          already run. It runs the file the way a sharp closing coordinator would: it opens the
+          order, chases the payoffs and the HOA and the survey, keeps every party current at each
+          milestone, coordinates the clear-to-close, and confirms the signing. It never touches
+          funds or wire instructions. You add capacity to the closing desk without adding to
           payroll.
         </p>
         <CtaButton href="/book?interest=title" data-ev="title-hero-cta"
@@ -100,12 +101,45 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 03 What it does -->
+    <!-- § 03 A worker, in another office -->
     <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
           class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
           >§ 03</span
+        >
+        <h2
+          class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
+        >
+          A Worker, In Another Office.
+        </h2>
+        <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
+          <p>
+            Picture a new closing coordinator at a desk. A computer, a phone, and access to the
+            title-production system, the email, and the document portal you already run. You hand it
+            work the way you hand work to anyone on your team. You send the request, it does the
+            job, and it comes back with the result.
+          </p>
+          <p>
+            It works from its own office, the way much of your team already does. The closer you
+            have never met in person. The lender contact you email and trade files with. This is one
+            more of those.
+          </p>
+          <p>
+            What it takes on is the work you would want that seat doing, inside the limits you set.
+            The commitment that is waiting on a cleared exception. The closing package that needs
+            assembling before the signing. We get to the limits below.
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <!-- § 04 What it does -->
+    <section class="bg-white px-6 py-24">
+      <div class="mx-auto max-w-5xl">
+        <span
+          class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
+          >§ 04</span
         >
         <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
@@ -119,6 +153,11 @@ const roleLenses = [
             or banking system is connected, by design: the Operator never touches funds.
           </p>
           <p>
+            Before it starts, we sit down with you and the people who run the work, and we build it
+            around how you operate, so it shows up ready, not green. From there it keeps getting
+            sharper, learning from your team's corrections.
+          </p>
+          <p>
             An order comes in from an agent or a lender. It opens the file, chases the documents the
             file needs, payoffs, HOA estoppel, survey, tax certificates, lender instructions, and
             keeps every party current at each milestone. It coordinates the clear-to-close with the
@@ -129,12 +168,12 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 04 You set the line -->
-    <section class="bg-white px-6 py-24">
+    <!-- § 05 You set the line -->
+    <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
           class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
-          >§ 04</span
+          >§ 05</span
         >
         <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
@@ -170,12 +209,12 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 05 One coordinator, your whole company -->
-    <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
+    <!-- § 06 One coordinator, your whole company -->
+    <section class="bg-white px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
           class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
-          >§ 05</span
+          >§ 06</span
         >
         <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
@@ -196,12 +235,39 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 06 Where it fits -->
+    <!-- § 07 We ride it with you -->
+    <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
+      <div class="mx-auto max-w-5xl">
+        <span
+          class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
+          >§ 07</span
+        >
+        <h2
+          class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
+        >
+          We Ride It With You.
+        </h2>
+        <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
+          <p>
+            This technology is new. No one has ten years of experience with it, because it has not
+            been around for ten years. New enough that no one should hand your company a tool and
+            walk away from it.
+          </p>
+          <p>
+            So that is not the model. Keeping the Operator useful as the technology changes and as
+            your company changes is part of the service, and we stay accountable for it. This is a
+            service, not a download. You are not on your own with it.
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <!-- § 08 Where it fits -->
     <section class="bg-white px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
           class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
-          >§ 06</span
+          >§ 08</span
         >
         <h2
           class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
@@ -239,12 +305,12 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 07 Start the conversation -->
+    <!-- § 09 Start the conversation -->
     <section class="bg-[color:var(--ss-color-surface-inverse)] px-6 py-24">
       <div class="mx-auto max-w-5xl text-center">
         <span
           class="inline-block bg-[color:var(--ss-color-background)] text-[color:var(--ss-color-text-primary)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-8"
-          >§ 07</span
+          >§ 09</span
         >
         <h2
           class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-white"

--- a/src/pages/packs/veterinary.astro
+++ b/src/pages/packs/veterinary.astro
@@ -61,10 +61,11 @@ const roleLenses = [
         <p
           class="mx-auto mb-12 max-w-2xl text-xl leading-relaxed text-[color:var(--ss-color-text-secondary)]"
         >
-          A dedicated Operator that runs your front of house the way your best CSR would: it books
-          and confirms appointments, works your recall list, relays refill requests to the doctor,
-          gets released results to clients, and routes a possible emergency straight to a person.
-          You add capacity to the front desk without adding to payroll.
+          A dedicated worker for your practice, in its own office and plugged into the tools you
+          already run. It runs your front of house the way your best CSR would: it books and
+          confirms appointments, works your recall list, relays refill requests to the doctor, gets
+          released results to clients, and routes a possible emergency straight to a person. You add
+          capacity to the front desk without adding to payroll.
         </p>
         <CtaButton href="/book?interest=veterinary" data-ev="veterinary-hero-cta"
           >Start the conversation</CtaButton
@@ -99,12 +100,45 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 03 What it does -->
+    <!-- § 03 A worker, in another office -->
     <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
           class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
           >§ 03</span
+        >
+        <h2
+          class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
+        >
+          A Worker, In Another Office.
+        </h2>
+        <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
+          <p>
+            Picture a new front-desk coordinator at a desk. A computer, a phone, and access to the
+            practice-management system, the schedule, and the phones you already run. You hand it
+            work the way you hand work to anyone on your team. You send the request, it does the
+            job, and it comes back with the result.
+          </p>
+          <p>
+            It works from its own office, the way much of your team already does. The practice
+            coordinator you have never met in person. The lab or pharmacy you email every week. This
+            is one more of those.
+          </p>
+          <p>
+            What it takes on is the work you would want that seat doing, inside the limits you set.
+            The client who needs to reschedule a surgery. The vaccine reminder that never goes out.
+            We get to the limits below.
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <!-- § 04 What it does -->
+    <section class="bg-white px-6 py-24">
+      <div class="mx-auto max-w-5xl">
+        <span
+          class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
+          >§ 04</span
         >
         <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
@@ -119,6 +153,11 @@ const roleLenses = [
             from what is actually in the file.
           </p>
           <p>
+            Before it starts, we sit down with you and the people who run the work, and we build it
+            around how you operate, so it shows up ready, not green. From there it keeps getting
+            sharper, learning from your team's corrections.
+          </p>
+          <p>
             A new client reaches out. It captures the client and patient, drafts the reply in your
             voice, and offers a time. It confirms and rebooks appointments, works your recall list
             so wellness care does not slip, relays refill requests to the doctor, gets the doctor's
@@ -130,12 +169,12 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 04 You set the line -->
-    <section class="bg-white px-6 py-24">
+    <!-- § 05 You set the line -->
+    <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
           class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
-          >§ 04</span
+          >§ 05</span
         >
         <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
@@ -171,12 +210,12 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 05 One coordinator, your whole clinic -->
-    <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
+    <!-- § 06 One coordinator, your whole clinic -->
+    <section class="bg-white px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
           class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
-          >§ 05</span
+          >§ 06</span
         >
         <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
@@ -197,12 +236,39 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 06 Where it fits -->
+    <!-- § 07 We ride it with you -->
+    <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
+      <div class="mx-auto max-w-5xl">
+        <span
+          class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
+          >§ 07</span
+        >
+        <h2
+          class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
+        >
+          We Ride It With You.
+        </h2>
+        <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
+          <p>
+            This technology is new. No one has ten years of experience with it, because it has not
+            been around for ten years. New enough that no one should hand your practice a tool and
+            walk away from it.
+          </p>
+          <p>
+            So that is not the model. Keeping the Operator useful as the technology changes and as
+            your practice changes is part of the service, and we stay accountable for it. This is a
+            service, not a download. You are not on your own with it.
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <!-- § 08 Where it fits -->
     <section class="bg-white px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
           class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
-          >§ 06</span
+          >§ 08</span
         >
         <h2
           class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
@@ -240,12 +306,12 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 07 Start the conversation -->
+    <!-- § 09 Start the conversation -->
     <section class="bg-[color:var(--ss-color-surface-inverse)] px-6 py-24">
       <div class="mx-auto max-w-5xl text-center">
         <span
           class="inline-block bg-[color:var(--ss-color-background)] text-[color:var(--ss-color-text-primary)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-8"
-          >§ 07</span
+          >§ 09</span
         >
         <h2
           class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-white"

--- a/tests/operator-section-badges.test.ts
+++ b/tests/operator-section-badges.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync, readdirSync } from 'fs'
+import { resolve, join } from 'path'
+
+// The Operator landing and every vertical pack use an editorial "§ NN" section
+// rhythm rendered as mono badge spans. Inserting or removing a section means
+// hand-renumbering every badge below it, which is the most likely mechanical
+// defect on these pages (a duplicate or skipped § reads as a quality miss on the
+// surface meant to project operational discipline). This guard asserts the
+// rendered badges run sequentially from 01 with no gaps or duplicates. It does
+// NOT enforce a fixed count — sections can be added or removed freely, they just
+// have to stay numbered in order.
+
+const operatorPage = resolve('src/pages/operator.astro')
+const packsDir = resolve('src/pages/packs')
+
+function badgeNumbers(file: string): number[] {
+  const src = readFileSync(file, 'utf-8')
+  // Matches the rendered span content, e.g. `>§ 03</span`
+  return [...src.matchAll(/>§\s*(\d+)<\/span/g)].map((m) => Number(m[1]))
+}
+
+function pages(): string[] {
+  const packs = readdirSync(packsDir)
+    .filter((n) => n.endsWith('.astro'))
+    .map((n) => join(packsDir, n))
+  return [operatorPage, ...packs]
+}
+
+describe('Operator marketing § section badges', () => {
+  for (const page of pages()) {
+    const rel = page.slice(page.indexOf('src/'))
+    it(`${rel} has sequential § badges from 01`, () => {
+      const nums = badgeNumbers(page)
+      expect(nums.length).toBeGreaterThan(0)
+      const expected = Array.from({ length: nums.length }, (_, i) => i + 1)
+      expect(nums).toEqual(expected)
+    })
+  }
+})


### PR DESCRIPTION
## What

Brings the Operator pitch we shaped and pressure-tested live this session into the marketing site. Two new sections on the Operator landing **and all 12 vertical packs** (13 pages), in the existing firm "we" voice and flat Sign Shop system — copy + sections only, no new components or tokens.

**§03 — A Worker, In Another Office.** Turns the abstract ("we connect your systems," "a role," "a seat") into a person the buyer can picture: a worker at a desk with a computer and a phone, in its own office the way the remote colleagues they already trust work, who you hand work to and it comes back done. Scoped honestly by *the work you'd want that role doing, inside the limits you set.*

**§07 — We Ride It With You.** The partnership-through-a-new-technology beat a SaaS competitor structurally can't make: this is new, nobody has a decade of doing it, so you don't want a tool handed to you and abandoned. Framed as the **service model in present tense**, not an open-ended future promise.

Also:
- Weaves the corrected **delivery model** (we build it ready from the assessment; it shows up ready, not green; it sharpens on the job) into each "What it does" section.
- Fixes the stale **"you teach it the way you would train a new hire"** line in `law-firm.astro` (the pre-correction model — the client does not train it from scratch).
- Strengthens each §01 hero subhead to plant the worker-in-its-own-office image while preserving every pack's existing vertical specifics.

## Why

A live pitch session established that prospects can't believe what they can't picture, and that the guide-by-your-side promise is the strongest differentiator. The marketing copy didn't carry either beat. Now every page does.

## Safety / governance

This copy went through `/critique` (Devil's Advocate) before writing. Specifically de-risked:
- **No Pattern A fabricated promises.** Reframed away from "that's ours to fix" / "someone in it with you" (contracted future behavior, a venture P0) to present-tense service-model statements grounded in language already shipped in `operator.astro` §05.
- **No pre-knowledge claims** (collaborator voice — "the work you would want that role doing," never "what your business needs").
- **No em dashes, no AI tricolons, no fixed engagement timeframes.**
- New **`tests/operator-section-badges.test.ts`** guards against the most likely mechanical defect: it asserts the renumbered `§ NN` badges stay sequential per page (inserting two sections renumbered ~117 badges across 13 files).

## Verification

- `npm run verify` green: **0 errors, build ✓, 3398 tests passed** (2 skipped, pre-existing).
- `tests/forbidden-strings.test.ts`, `tests/landing-page.test.ts` (voice standard), and the new badge test all pass.
- Independent sweep: all 13 pages have sequential badges, zero em-dashes, both new sections present.
- Note: local `npm run dev` render is blocked in this worktree by Clerk keyless-mode (no local keys) 500-ing every SSR route — environmental, unrelated to the copy; the production build compiles all 13 pages cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)