### PR TITLE
refactor(marketing): "A Team, Not A Tool" §07 + from-the-future §03 opener

### DIFF
--- a/src/pages/operator.astro
+++ b/src/pages/operator.astro
@@ -133,9 +133,10 @@ const industries = [
         </h2>
         <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
           <p>
-            Picture a new worker at a desk. A computer, a phone, and access to the systems and
-            processes you already run. You hand it work the way you hand work to anyone on your
-            team. You send the request, it does the job, and it comes back with the result.
+            Picture a remote worker from the future, sitting at a desk in your business today. A
+            computer, a phone, and access to the systems and processes you already run. You hand it
+            work the way you hand work to anyone on your team. You send the request, it does the
+            job, and it comes back with the result.
           </p>
           <p>
             It works from its own office, the way much of your team already does. The bookkeeper you
@@ -266,7 +267,7 @@ const industries = [
       </div>
     </section>
 
-    <!-- § 07 We ride it with you -->
+    <!-- § 07 A team, not a tool -->
     <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
@@ -276,20 +277,22 @@ const industries = [
         <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
         >
-          We Ride It With You.
+          A Team, Not A Tool.
         </h2>
         <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
           <p>
-            This technology is new. No one has ten years of experience with it, because it has not
-            been around for ten years. New enough that no one should hand you a tool and walk away
-            from it.
+            We are the team behind the worker. We build it for your business, and we stay
+            accountable for how it runs. That work is ours, not yours.
           </p>
           <p>
-            So that is not the model. Keeping the Operator useful as the technology changes and as
-            your operation changes is part of the service. We stay close to how it runs for you, and
-            we stay accountable for it. That work is ours, not yours.
+            The technology moves, and we move with it. No one has ten years of experience with this,
+            because it has not been around for ten years. So it is not something you set up once and
+            are left to run on your own.
           </p>
-          <p>This is a service, not a download. You are not on your own with it.</p>
+          <p>
+            This is a service, not a download. We are the team that keeps your business working, and
+            nobody should take on something this new alone.
+          </p>
         </div>
       </div>
     </section>

--- a/src/pages/packs/accounting.astro
+++ b/src/pages/packs/accounting.astro
@@ -116,10 +116,10 @@ const roleLenses = [
         </h2>
         <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
           <p>
-            Picture a new staff accountant at a desk. A computer, a phone, and access to the
-            accounting system, the email, and the document portal you already run. You hand it work
-            the way you hand work to anyone on your team. You send the request, it does the job, and
-            it comes back with the result.
+            Picture a staff accountant from the future, sitting at a desk in your firm today. A
+            computer, a phone, and access to the accounting system, the email, and the document
+            portal you already run. You hand it work the way you hand work to anyone on your team.
+            You send the request, it does the job, and it comes back with the result.
           </p>
           <p>
             It works from its own office, the way much of your team already does. The bookkeeper you
@@ -234,7 +234,7 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 07 We ride it with you -->
+    <!-- § 07 A team, not a tool -->
     <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
@@ -244,18 +244,17 @@ const roleLenses = [
         <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
         >
-          We Ride It With You.
+          A Team, Not A Tool.
         </h2>
         <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
           <p>
-            This technology is new. No one has ten years of experience with it, because it has not
-            been around for ten years. New enough that no one should hand your firm a tool and walk
-            away from it.
+            We are the team behind the worker. We build it for your firm, and we stay accountable
+            for how it runs.
           </p>
           <p>
-            So that is not the model. Keeping the Operator useful as the technology changes and as
-            your firm changes is part of the service, and we stay accountable for it. This is a
-            service, not a download. You are not on your own with it.
+            The technology moves, and we move with it, because no one has a decade of experience
+            with it yet. We are the team that keeps your business working, and nobody should take on
+            something this new alone.
           </p>
         </div>
       </div>

--- a/src/pages/packs/dental.astro
+++ b/src/pages/packs/dental.astro
@@ -117,10 +117,10 @@ const roleLenses = [
         </h2>
         <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
           <p>
-            Picture a new front-office coordinator at a desk. A computer, a phone, and access to the
-            practice-management system, the schedule, and the phones you already run. You hand it
-            work the way you hand work to anyone on your team. You send the request, it does the
-            job, and it comes back with the result.
+            Picture a front-office coordinator from the future, sitting at a desk in your practice
+            today. A computer, a phone, and access to the practice-management system, the schedule,
+            and the phones you already run. You hand it work the way you hand work to anyone on your
+            team. You send the request, it does the job, and it comes back with the result.
           </p>
           <p>
             It works from its own office, the way much of your team already does. The billing
@@ -236,7 +236,7 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 07 We ride it with you -->
+    <!-- § 07 A team, not a tool -->
     <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
@@ -246,18 +246,17 @@ const roleLenses = [
         <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
         >
-          We Ride It With You.
+          A Team, Not A Tool.
         </h2>
         <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
           <p>
-            This technology is new. No one has ten years of experience with it, because it has not
-            been around for ten years. New enough that no one should hand your practice a tool and
-            walk away from it.
+            We are the team behind the worker. We build it for your practice, and we stay
+            accountable for how it runs.
           </p>
           <p>
-            So that is not the model. Keeping the Operator useful as the technology changes and as
-            your practice changes is part of the service, and we stay accountable for it. This is a
-            service, not a download. You are not on your own with it.
+            The technology moves, and we move with it, because no one has a decade of experience
+            with it yet. We are the team that keeps your business working, and nobody should take on
+            something this new alone.
           </p>
         </div>
       </div>

--- a/src/pages/packs/home-services.astro
+++ b/src/pages/packs/home-services.astro
@@ -116,10 +116,10 @@ const roleLenses = [
         </h2>
         <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
           <p>
-            Picture a new dispatcher at a desk. A computer, a phone, and access to the scheduling
-            software, the phones, and the job board you already run. You hand it work the way you
-            hand work to anyone on your team. You send the request, it does the job, and it comes
-            back with the result.
+            Picture a dispatcher from the future, sitting at a desk in your shop today. A computer,
+            a phone, and access to the scheduling software, the phones, and the job board you
+            already run. You hand it work the way you hand work to anyone on your team. You send the
+            request, it does the job, and it comes back with the result.
           </p>
           <p>
             It works from its own office, the way much of your team already does. The office manager
@@ -235,7 +235,7 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 07 We ride it with you -->
+    <!-- § 07 A team, not a tool -->
     <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
@@ -245,18 +245,17 @@ const roleLenses = [
         <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
         >
-          We Ride It With You.
+          A Team, Not A Tool.
         </h2>
         <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
           <p>
-            This technology is new. No one has ten years of experience with it, because it has not
-            been around for ten years. New enough that no one should hand your shop a tool and walk
-            away from it.
+            We are the team behind the worker. We build it for your shop, and we stay accountable
+            for how it runs.
           </p>
           <p>
-            So that is not the model. Keeping the Operator useful as the technology changes and as
-            your shop changes is part of the service, and we stay accountable for it. This is a
-            service, not a download. You are not on your own with it.
+            The technology moves, and we move with it, because no one has a decade of experience
+            with it yet. We are the team that keeps your business working, and nobody should take on
+            something this new alone.
           </p>
         </div>
       </div>

--- a/src/pages/packs/insurance.astro
+++ b/src/pages/packs/insurance.astro
@@ -115,10 +115,10 @@ const roleLenses = [
         </h2>
         <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
           <p>
-            Picture a new account service rep at a desk. A computer, a phone, and access to the
-            agency management system, the email, and the carrier portals you already run. You hand
-            it work the way you hand work to anyone on your team. You send the request, it does the
-            job, and it comes back with the result.
+            Picture an account service rep from the future, sitting at a desk in your agency today.
+            A computer, a phone, and access to the agency management system, the email, and the
+            carrier portals you already run. You hand it work the way you hand work to anyone on
+            your team. You send the request, it does the job, and it comes back with the result.
           </p>
           <p>
             It works from its own office, the way much of your team already does. The account
@@ -238,7 +238,7 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 07 We ride it with you -->
+    <!-- § 07 A team, not a tool -->
     <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
@@ -248,18 +248,17 @@ const roleLenses = [
         <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
         >
-          We Ride It With You.
+          A Team, Not A Tool.
         </h2>
         <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
           <p>
-            This technology is new. No one has ten years of experience with it, because it has not
-            been around for ten years. New enough that no one should hand your agency a tool and
-            walk away from it.
+            We are the team behind the worker. We build it for your agency, and we stay accountable
+            for how it runs.
           </p>
           <p>
-            So that is not the model. Keeping the Operator useful as the technology changes and as
-            your agency changes is part of the service, and we stay accountable for it. This is a
-            service, not a download. You are not on your own with it.
+            The technology moves, and we move with it, because no one has a decade of experience
+            with it yet. We are the team that keeps your business working, and nobody should take on
+            something this new alone.
           </p>
         </div>
       </div>

--- a/src/pages/packs/law-firm.astro
+++ b/src/pages/packs/law-firm.astro
@@ -116,10 +116,10 @@ const roleLenses = [
         </h2>
         <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
           <p>
-            Picture a new legal assistant at a desk. A computer, a phone, and access to the
-            practice-management system, the email, and the calendar you already run. You hand it
-            work the way you hand work to anyone on your team. You send the request, it does the
-            job, and it comes back with the result.
+            Picture a legal assistant from the future, sitting at a desk in your firm today. A
+            computer, a phone, and access to the practice-management system, the email, and the
+            calendar you already run. You hand it work the way you hand work to anyone on your team.
+            You send the request, it does the job, and it comes back with the result.
           </p>
           <p>
             It works from its own office, the way much of your team already does. The contract
@@ -249,7 +249,7 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 07 We ride it with you -->
+    <!-- § 07 A team, not a tool -->
     <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
@@ -259,18 +259,17 @@ const roleLenses = [
         <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
         >
-          We Ride It With You.
+          A Team, Not A Tool.
         </h2>
         <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
           <p>
-            This technology is new. No one has ten years of experience with it, because it has not
-            been around for ten years. New enough that no one should hand your firm a tool and walk
-            away from it.
+            We are the team behind the worker. We build it for your firm, and we stay accountable
+            for how it runs.
           </p>
           <p>
-            So that is not the model. Keeping the Operator useful as the technology changes and as
-            your firm changes is part of the service, and we stay accountable for it. This is a
-            service, not a download. You are not on your own with it.
+            The technology moves, and we move with it, because no one has a decade of experience
+            with it yet. We are the team that keeps your business working, and nobody should take on
+            something this new alone.
           </p>
         </div>
       </div>

--- a/src/pages/packs/marketing-agency.astro
+++ b/src/pages/packs/marketing-agency.astro
@@ -116,10 +116,10 @@ const roleLenses = [
         </h2>
         <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
           <p>
-            Picture a new account coordinator at a desk. A computer, a phone, and access to the
-            project tools, the email, and the client folders you already run. You hand it work the
-            way you hand work to anyone on your team. You send the request, it does the job, and it
-            comes back with the result.
+            Picture an account coordinator from the future, sitting at a desk in your agency today.
+            A computer, a phone, and access to the project tools, the email, and the client folders
+            you already run. You hand it work the way you hand work to anyone on your team. You send
+            the request, it does the job, and it comes back with the result.
           </p>
           <p>
             It works from its own office, the way much of your team already does. The project
@@ -233,7 +233,7 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 07 We ride it with you -->
+    <!-- § 07 A team, not a tool -->
     <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
@@ -243,18 +243,17 @@ const roleLenses = [
         <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
         >
-          We Ride It With You.
+          A Team, Not A Tool.
         </h2>
         <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
           <p>
-            This technology is new. No one has ten years of experience with it, because it has not
-            been around for ten years. New enough that no one should hand your agency a tool and
-            walk away from it.
+            We are the team behind the worker. We build it for your agency, and we stay accountable
+            for how it runs.
           </p>
           <p>
-            So that is not the model. Keeping the Operator useful as the technology changes and as
-            your agency changes is part of the service, and we stay accountable for it. This is a
-            service, not a download. You are not on your own with it.
+            The technology moves, and we move with it, because no one has a decade of experience
+            with it yet. We are the team that keeps your business working, and nobody should take on
+            something this new alone.
           </p>
         </div>
       </div>

--- a/src/pages/packs/med-spa.astro
+++ b/src/pages/packs/med-spa.astro
@@ -115,10 +115,10 @@ const roleLenses = [
         </h2>
         <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
           <p>
-            Picture a new front-desk coordinator at a desk. A computer, a phone, and access to the
-            booking system, the phones, and the membership records you already run. You hand it work
-            the way you hand work to anyone on your team. You send the request, it does the job, and
-            it comes back with the result.
+            Picture a front-desk coordinator from the future, sitting at a desk in your practice
+            today. A computer, a phone, and access to the booking system, the phones, and the
+            membership records you already run. You hand it work the way you hand work to anyone on
+            your team. You send the request, it does the job, and it comes back with the result.
           </p>
           <p>
             It works from its own office, the way much of your team already does. The membership
@@ -235,7 +235,7 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 07 We ride it with you -->
+    <!-- § 07 A team, not a tool -->
     <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
@@ -245,18 +245,17 @@ const roleLenses = [
         <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
         >
-          We Ride It With You.
+          A Team, Not A Tool.
         </h2>
         <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
           <p>
-            This technology is new. No one has ten years of experience with it, because it has not
-            been around for ten years. New enough that no one should hand your practice a tool and
-            walk away from it.
+            We are the team behind the worker. We build it for your practice, and we stay
+            accountable for how it runs.
           </p>
           <p>
-            So that is not the model. Keeping the Operator useful as the technology changes and as
-            your practice changes is part of the service, and we stay accountable for it. This is a
-            service, not a download. You are not on your own with it.
+            The technology moves, and we move with it, because no one has a decade of experience
+            with it yet. We are the team that keeps your business working, and nobody should take on
+            something this new alone.
           </p>
         </div>
       </div>

--- a/src/pages/packs/mortgage.astro
+++ b/src/pages/packs/mortgage.astro
@@ -116,10 +116,10 @@ const roleLenses = [
         </h2>
         <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
           <p>
-            Picture a new loan processor at a desk. A computer, a phone, and access to the
-            loan-origination system, the email, and the document portal you already run. You hand it
-            work the way you hand work to anyone on your team. You send the request, it does the
-            job, and it comes back with the result.
+            Picture a loan processor from the future, sitting at a desk in your shop today. A
+            computer, a phone, and access to the loan-origination system, the email, and the
+            document portal you already run. You hand it work the way you hand work to anyone on
+            your team. You send the request, it does the job, and it comes back with the result.
           </p>
           <p>
             It works from its own office, the way much of your team already does. The processor you
@@ -235,7 +235,7 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 07 We ride it with you -->
+    <!-- § 07 A team, not a tool -->
     <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
@@ -245,18 +245,17 @@ const roleLenses = [
         <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
         >
-          We Ride It With You.
+          A Team, Not A Tool.
         </h2>
         <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
           <p>
-            This technology is new. No one has ten years of experience with it, because it has not
-            been around for ten years. New enough that no one should hand your shop a tool and walk
-            away from it.
+            We are the team behind the worker. We build it for your shop, and we stay accountable
+            for how it runs.
           </p>
           <p>
-            So that is not the model. Keeping the Operator useful as the technology changes and as
-            your shop changes is part of the service, and we stay accountable for it. This is a
-            service, not a download. You are not on your own with it.
+            The technology moves, and we move with it, because no one has a decade of experience
+            with it yet. We are the team that keeps your business working, and nobody should take on
+            something this new alone.
           </p>
         </div>
       </div>

--- a/src/pages/packs/property-management.astro
+++ b/src/pages/packs/property-management.astro
@@ -116,10 +116,10 @@ const roleLenses = [
         </h2>
         <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
           <p>
-            Picture a new property coordinator at a desk. A computer, a phone, and access to the
-            property-management system, the email, and the maintenance queue you already run. You
-            hand it work the way you hand work to anyone on your team. You send the request, it does
-            the job, and it comes back with the result.
+            Picture a property coordinator from the future, sitting at a desk in your company today.
+            A computer, a phone, and access to the property-management system, the email, and the
+            maintenance queue you already run. You hand it work the way you hand work to anyone on
+            your team. You send the request, it does the job, and it comes back with the result.
           </p>
           <p>
             It works from its own office, the way much of your team already does. The regional
@@ -236,7 +236,7 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 07 We ride it with you -->
+    <!-- § 07 A team, not a tool -->
     <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
@@ -246,18 +246,17 @@ const roleLenses = [
         <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
         >
-          We Ride It With You.
+          A Team, Not A Tool.
         </h2>
         <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
           <p>
-            This technology is new. No one has ten years of experience with it, because it has not
-            been around for ten years. New enough that no one should hand your company a tool and
-            walk away from it.
+            We are the team behind the worker. We build it for your company, and we stay accountable
+            for how it runs.
           </p>
           <p>
-            So that is not the model. Keeping the Operator useful as the technology changes and as
-            your company changes is part of the service, and we stay accountable for it. This is a
-            service, not a download. You are not on your own with it.
+            The technology moves, and we move with it, because no one has a decade of experience
+            with it yet. We are the team that keeps your business working, and nobody should take on
+            something this new alone.
           </p>
         </div>
       </div>

--- a/src/pages/packs/ria.astro
+++ b/src/pages/packs/ria.astro
@@ -116,10 +116,10 @@ const roleLenses = [
         </h2>
         <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
           <p>
-            Picture a new client-service associate at a desk. A computer, a phone, and access to the
-            CRM, the custodian portals, and the calendar you already run. You hand it work the way
-            you hand work to anyone on your team. You send the request, it does the job, and it
-            comes back with the result.
+            Picture a client-service associate from the future, sitting at a desk in your firm
+            today. A computer, a phone, and access to the CRM, the custodian portals, and the
+            calendar you already run. You hand it work the way you hand work to anyone on your team.
+            You send the request, it does the job, and it comes back with the result.
           </p>
           <p>
             It works from its own office, the way much of your team already does. The operations
@@ -231,7 +231,7 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 07 We ride it with you -->
+    <!-- § 07 A team, not a tool -->
     <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
@@ -241,18 +241,17 @@ const roleLenses = [
         <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
         >
-          We Ride It With You.
+          A Team, Not A Tool.
         </h2>
         <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
           <p>
-            This technology is new. No one has ten years of experience with it, because it has not
-            been around for ten years. New enough that no one should hand your firm a tool and walk
-            away from it.
+            We are the team behind the worker. We build it for your firm, and we stay accountable
+            for how it runs.
           </p>
           <p>
-            So that is not the model. Keeping the Operator useful as the technology changes and as
-            your firm changes is part of the service, and we stay accountable for it. This is a
-            service, not a download. You are not on your own with it.
+            The technology moves, and we move with it, because no one has a decade of experience
+            with it yet. We are the team that keeps your business working, and nobody should take on
+            something this new alone.
           </p>
         </div>
       </div>

--- a/src/pages/packs/title.astro
+++ b/src/pages/packs/title.astro
@@ -115,10 +115,10 @@ const roleLenses = [
         </h2>
         <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
           <p>
-            Picture a new closing coordinator at a desk. A computer, a phone, and access to the
-            title-production system, the email, and the document portal you already run. You hand it
-            work the way you hand work to anyone on your team. You send the request, it does the
-            job, and it comes back with the result.
+            Picture a closing coordinator from the future, sitting at a desk in your company today.
+            A computer, a phone, and access to the title-production system, the email, and the
+            document portal you already run. You hand it work the way you hand work to anyone on
+            your team. You send the request, it does the job, and it comes back with the result.
           </p>
           <p>
             It works from its own office, the way much of your team already does. The closer you
@@ -235,7 +235,7 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 07 We ride it with you -->
+    <!-- § 07 A team, not a tool -->
     <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
@@ -245,18 +245,17 @@ const roleLenses = [
         <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
         >
-          We Ride It With You.
+          A Team, Not A Tool.
         </h2>
         <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
           <p>
-            This technology is new. No one has ten years of experience with it, because it has not
-            been around for ten years. New enough that no one should hand your company a tool and
-            walk away from it.
+            We are the team behind the worker. We build it for your company, and we stay accountable
+            for how it runs.
           </p>
           <p>
-            So that is not the model. Keeping the Operator useful as the technology changes and as
-            your company changes is part of the service, and we stay accountable for it. This is a
-            service, not a download. You are not on your own with it.
+            The technology moves, and we move with it, because no one has a decade of experience
+            with it yet. We are the team that keeps your business working, and nobody should take on
+            something this new alone.
           </p>
         </div>
       </div>

--- a/src/pages/packs/veterinary.astro
+++ b/src/pages/packs/veterinary.astro
@@ -114,10 +114,10 @@ const roleLenses = [
         </h2>
         <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
           <p>
-            Picture a new front-desk coordinator at a desk. A computer, a phone, and access to the
-            practice-management system, the schedule, and the phones you already run. You hand it
-            work the way you hand work to anyone on your team. You send the request, it does the
-            job, and it comes back with the result.
+            Picture a front-desk coordinator from the future, sitting at a desk in your practice
+            today. A computer, a phone, and access to the practice-management system, the schedule,
+            and the phones you already run. You hand it work the way you hand work to anyone on your
+            team. You send the request, it does the job, and it comes back with the result.
           </p>
           <p>
             It works from its own office, the way much of your team already does. The practice
@@ -236,7 +236,7 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 07 We ride it with you -->
+    <!-- § 07 A team, not a tool -->
     <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
@@ -246,18 +246,17 @@ const roleLenses = [
         <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
         >
-          We Ride It With You.
+          A Team, Not A Tool.
         </h2>
         <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
           <p>
-            This technology is new. No one has ten years of experience with it, because it has not
-            been around for ten years. New enough that no one should hand your practice a tool and
-            walk away from it.
+            We are the team behind the worker. We build it for your practice, and we stay
+            accountable for how it runs.
           </p>
           <p>
-            So that is not the model. Keeping the Operator useful as the technology changes and as
-            your practice changes is part of the service, and we stay accountable for it. This is a
-            service, not a download. You are not on your own with it.
+            The technology moves, and we move with it, because no one has a decade of experience
+            with it yet. We are the team that keeps your business working, and nobody should take on
+            something this new alone.
           </p>
         </div>
       </div>


### PR DESCRIPTION
## What

Two copy refinements to the Operator marketing sections shipped in #1342, across the landing + all 12 packs. No structural/section change.

**§07: "We Ride It With You" → "A Team, Not A Tool."** The old headline was a decode-required metaphor (ride what?). New section says plainly that the *team is us* (SMD), the people behind the worker, and closes on "the team that keeps your business working, and nobody should take on something this new alone." De-conflicted from §06 "We Keep It Running" — §07 now owns the why-a-human-team / newness argument and leads on "the technology moves, and we move with it."

**§03 opener: "Picture a new worker at a desk" → "Picture a remote worker from the future, sitting at a desk in your business today."** Per-vertical role + business noun on packs (articles corrected, e.g. "an account service rep").

## Why

Captain review: "we ride it with you" was a blurt that got promoted to an H2 across 13 pages. The sentiment (the guide who stays, not a merchant who sells and leaves) is right; the words weren't. And the "from the future, here now" framing makes the worker's novelty concrete.

## Safety

Went through `/critique` (Devil's Advocate). Adopted: de-conflicting §07 from §06 + dropping the "keep it current" verb (also broke a tricolon), and fan-out article hygiene ("a" → "an account..."). Held (Captain's explicit calls): the "A Team, Not A Tool" headline (body's first line disambiguates team=us) and "from the future" (his deliberate choice over the hedged "near future"). All §07 copy stays present-tense service-model (no Pattern A); the voice-standard test passes, so "from the future" clears the no-hype guard.

## Verification

- `npm run verify` green: 0 errors, build ✓, all tests.
- `tests/forbidden-strings`, `tests/landing-page` (voice), `tests/operator-section-badges` all pass.
- Sweep of all 13 pages: "A Team, Not A Tool" present, "We Ride It With You" gone, the from-the-future §03 opener present, zero em dashes, badges unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)