### PR TITLE
feat(marketing): rebuild Operator vertical pages as concrete, customizable head-starts

### DIFF
--- a/src/lib/operator-packs/shared.ts
+++ b/src/lib/operator-packs/shared.ts
@@ -1,0 +1,30 @@
+// Shared frame copy for the Operator vertical pack pages.
+//
+// These strings are identical-by-design across all 12 packs. Keeping them here
+// (rather than re-typing them in each page) prevents drift and keeps the one
+// place a reviewer has to check for the shared scaffolding. Per-vertical content
+// (the starting templates, the day-one narrative, the line) lives in each pack
+// file and is sourced from operator/verticals/<vertical>/vertical.yaml.
+//
+// This module is scanned by tests/landing-page.test.ts for voice violations, so
+// it must stay in firm "we"/"you" voice with no em dashes.
+
+// A direct lander (arriving from search, not from /operator) may not have seen
+// the concept yet. This link points them to the full explanation without the
+// pack page having to re-run the landing's argument.
+export const coldLanderLink = {
+  text: 'New to the Operator? See how it works',
+  href: '/operator',
+}
+
+// The three customization zones of every pack, shown in the "Yours To Shape"
+// section. Titles are shared; the body under each is per-vertical.
+export const shapeZoneTitles = {
+  prebuilt: 'Pre-built',
+  connected: 'Connected to your stack',
+  yours: 'Yours to shape',
+}
+
+// The pricing line shown in every pack's closing section.
+export const ctaPricingLine =
+  'Pricing is a flat monthly subscription, scoped to the seat we build together, and we walk through it before any setup begins.'

--- a/src/pages/packs/accounting.astro
+++ b/src/pages/packs/accounting.astro
@@ -5,13 +5,14 @@ import Base from '../../layouts/Base.astro'
 import Nav from '../../components/Nav.astro'
 import Footer from '../../components/Footer.astro'
 import CtaButton from '../../components/CtaButton.astro'
+import { coldLanderLink, shapeZoneTitles, ctaPricingLine } from '../../lib/operator-packs/shared'
 
 const productSchema = {
   '@context': 'https://schema.org',
   '@type': 'Product',
   name: 'Operator for Accounting Firms',
   description:
-    'A dedicated Operator that runs the client chase: it sends the PBC list, chases the missing documents, routes the return for review, runs the deadline and extension cadence, and keeps your practice-management system current. The return is signed by your CPAs; you set the line.',
+    'The Operator is a worker you hire, not software you buy. The accounting pack is its head start: a starting point shaped around the client chase and deadline cadence, which we configure with you and you customize to your firm. The return is signed by your CPAs; you set the line.',
   brand: { '@type': 'Brand', name: 'SMD Services' },
   offers: {
     '@type': 'Offer',
@@ -19,6 +20,46 @@ const productSchema = {
     seller: { '@type': 'Organization', name: 'SMD Services' },
   },
 }
+
+// Section 03: the starting templates in the pack, grouped in plain language. Sourced
+// from operator/verticals/accounting/vertical.yaml (the onboarding, documents-and-
+// deadlines, status-and-renewal, and digest skill families). These are templates we
+// configure, not a finished, running product.
+const packTemplates = [
+  {
+    title: 'Onboarding',
+    body: "A new client welcomed with the firm's authored engagement terms, the engagement letter chased toward signature, the prior-year records requested.",
+  },
+  {
+    title: 'Documents and deadlines',
+    body: 'The organizer distributed, the PBC request list chased, the appointment booked, the firm-authored dates surfaced, the e-file authorization chased toward signature.',
+  },
+  {
+    title: 'Status, billing, and renewal',
+    body: 'The routine status question answered, the extension status tracked, the invoice followed up on, the authored renewal terms relayed.',
+  },
+  {
+    title: 'The internal digest',
+    body: 'Inbound mail routed to the right template, the internal client and deadline digest assembled, your practice-management system kept in sync.',
+  },
+]
+
+// Section 05: the three customization zones. Titles are shared (shapeZoneTitles); the
+// body under each is accounting-specific.
+const zones = [
+  {
+    title: shapeZoneTitles.prebuilt,
+    body: 'The starting templates above, shaped around a client-chase desk and ready to configure. You are not building from a blank page.',
+  },
+  {
+    title: shapeZoneTitles.connected,
+    body: 'Wired into your own accounts: your practice-management system, your email and calendar, your documents. It works inside the tools you already run.',
+  },
+  {
+    title: shapeZoneTitles.yours,
+    body: 'Your voice, your clients and your cadence, and where the line sits. You decide what runs on its own and what waits for a person. You are the expert in your firm; you shape it from there.',
+  },
+]
 
 const roleLenses = [
   {
@@ -38,7 +79,7 @@ const roleLenses = [
 
 <Base
   title="Operator for Accounting Firms | SMD Services"
-  description="A dedicated Operator that runs the client chase: the PBC list, the missing documents, routing the return for review, the deadline and extension cadence, and keeping your practice-management system current. The return is signed by your CPAs. You set the line."
+  description="The accounting pack is the Operator's head start: a starting point shaped around the client chase and deadline cadence, which we configure with you and you customize to your firm. The return is signed by your CPAs. You set the line."
 >
   <Nav />
   <main id="main" role="main">
@@ -59,17 +100,22 @@ const roleLenses = [
           Busy Season, Fully Staffed.
         </h1>
         <p
-          class="mx-auto mb-12 max-w-2xl text-xl leading-relaxed text-[color:var(--ss-color-text-secondary)]"
+          class="mx-auto mb-8 max-w-2xl text-xl leading-relaxed text-[color:var(--ss-color-text-secondary)]"
         >
-          A dedicated worker for your firm, in its own office and plugged into the tools you already
-          run. It runs the client chase, the way a sharp firm administrator would: it works the PBC
-          list, chases the missing documents, routes the return for review, and keeps the deadline
-          and extension cadence on schedule. You add capacity through busy season without adding to
-          payroll.
+          The Operator is a worker you hire, not software you buy. This is its accounting head
+          start: a starting point already shaped around the client chase and deadline cadence, so
+          you are not building from a blank page. You make it yours from there.
         </p>
         <CtaButton href="/book?interest=accounting" data-ev="accounting-hero-cta"
           >Start the conversation</CtaButton
         >
+        <p class="mt-8">
+          <a
+            href={coldLanderLink.href}
+            class="font-['Archivo_Narrow'] text-sm font-semibold uppercase tracking-[0.12em] text-[color:var(--ss-color-text-secondary)] underline underline-offset-4 hover:text-[color:var(--ss-color-primary)]"
+            >{coldLanderLink.text} &rarr;</a
+          >
+        </p>
       </div>
     </section>
 
@@ -102,7 +148,7 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 03 A worker, in another office -->
+    <!-- § 03 What the pack starts you with -->
     <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
@@ -110,32 +156,49 @@ const roleLenses = [
           >§ 03</span
         >
         <h2
-          class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
+          class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
         >
-          A Worker, In Another Office.
+          What The Pack Starts You With.
         </h2>
-        <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
-          <p>
-            Picture a staff accountant from the future, sitting at a desk in your firm today. A
-            computer, a phone, and access to the accounting system, the email, and the document
-            portal you already run. You hand it work the way you hand work to anyone on your team.
-            You send the request, it does the job, and it comes back with the result.
-          </p>
-          <p>
-            It works from its own office, the way much of your team already does. The bookkeeper you
-            have never met in person. The client contact you email and chase documents from. This is
-            one more of those.
-          </p>
-          <p>
-            What it takes on is the work you would want that seat doing, inside the limits you set.
-            The client document that is three weeks late in the middle of March. The return waiting
-            on one missing form. We get to the limits below.
-          </p>
+        <p
+          class="mb-12 max-w-2xl text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]"
+        >
+          You do not start from a blank page. The accounting pack comes shaped around the work a
+          client-chase desk runs, as starting templates we configure with you:
+        </p>
+
+        <div
+          class="grid grid-cols-1 md:grid-cols-2 gap-0 border-t-[3px] border-[color:var(--ss-color-text-primary)]"
+        >
+          {
+            packTemplates.map((t, i) => (
+              <div
+                class:list={[
+                  'flex flex-col gap-3 p-8 min-h-[12rem] border-b-[3px] border-[color:var(--ss-color-text-primary)]',
+                  i % 2 !== 1 && 'md:border-r-[3px] md:border-[color:var(--ss-color-text-primary)]',
+                ]}
+              >
+                <p class="font-['Archivo_Narrow'] text-xs font-semibold uppercase tracking-[0.12em] text-[color:var(--ss-color-primary)]">
+                  {t.title}
+                </p>
+                <p class="font-['Archivo'] text-base leading-relaxed text-[color:var(--ss-color-text-secondary)]">
+                  {t.body}
+                </p>
+              </div>
+            ))
+          }
         </div>
+
+        <p
+          class="mt-12 max-w-2xl text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]"
+        >
+          These plug into your practice-management system and your email and calendar. The templates
+          are the head start. How they run is yours to shape.
+        </p>
       </div>
     </section>
 
-    <!-- § 04 What it does -->
+    <!-- § 04 From the start -->
     <section class="bg-white px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
@@ -145,30 +208,27 @@ const roleLenses = [
         <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
         >
-          What It Does.
+          From The Start.
         </h2>
         <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
           <p>
-            We build the Operator for your firm and connect it to the tools you already run: your
-            practice-management system, your email, your document storage.
+            Before it starts, we sit down with you and the people who run the client chase, and we
+            shape the templates around how your firm actually operates, so it begins ready, not
+            green.
           </p>
           <p>
-            Before it starts, we sit down with you and the people who run the work, and we build it
-            around how you operate, so it shows up ready, not green. From there it keeps getting
-            sharper, learning from your team's corrections.
-          </p>
-          <p>
-            The engagement opens. It sends the PBC list, chases the missing items, and follows up on
-            the client who has gone quiet, as many times as it takes, in your voice. It routes the
-            return to a reviewer when the file is ready, answers the routine status question, and
-            keeps the deadline and extension cadence on schedule. Every piece of it is logged in
-            your practice-management system as it happens.
+            From there the work moves the way it always did. The engagement opens, the PBC list goes
+            out, the missing items get chased, the client who has gone quiet gets a follow-up, as
+            many times as it takes, in your voice. The return gets routed to a reviewer when the
+            file is ready, the routine status question gets answered, and the deadline and extension
+            cadence stays on schedule. It is all logged in your practice-management system as it
+            happens, and it keeps getting sharper from your team's corrections.
           </p>
         </div>
       </div>
     </section>
 
-    <!-- § 05 You set the line -->
+    <!-- § 05 Yours to shape -->
     <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
@@ -176,9 +236,52 @@ const roleLenses = [
           >§ 05</span
         >
         <h2
+          class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
+        >
+          Yours To Shape.
+        </h2>
+        <p
+          class="mb-12 max-w-2xl text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]"
+        >
+          We are not the experts in how your firm runs. You are. So the pack is a starting point in
+          three parts, and the third is the biggest.
+        </p>
+
+        <div
+          class="grid grid-cols-1 md:grid-cols-3 gap-0 border-t-[3px] border-[color:var(--ss-color-text-primary)]"
+        >
+          {
+            zones.map((z, i) => (
+              <div
+                class:list={[
+                  'flex flex-col gap-3 p-8 min-h-[14rem] border-b-[3px] border-[color:var(--ss-color-text-primary)]',
+                  i % 3 !== 2 && 'md:border-r-[3px] md:border-[color:var(--ss-color-text-primary)]',
+                ]}
+              >
+                <p class="font-['Archivo_Narrow'] text-xs font-semibold uppercase tracking-[0.12em] text-[color:var(--ss-color-primary)]">
+                  {z.title}
+                </p>
+                <p class="font-['Archivo'] text-base leading-relaxed text-[color:var(--ss-color-text-secondary)]">
+                  {z.body}
+                </p>
+              </div>
+            ))
+          }
+        </div>
+      </div>
+    </section>
+
+    <!-- § 06 The line -->
+    <section class="bg-white px-6 py-24">
+      <div class="mx-auto max-w-5xl">
+        <span
+          class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
+          >§ 06</span
+        >
+        <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
         >
-          You Set The Line.
+          The Line.
         </h2>
         <div
           class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)] mb-12"
@@ -191,11 +294,20 @@ const roleLenses = [
             and an unlicensed staff preparer could not sign it either.
           </p>
           <p>
-            You govern where that line sits. Out of the box, the return waits for a preparer and a
-            reviewer, and every outbound message goes through a person on your team who sends it
-            under their own name. You widen what the Operator runs on its own as you learn what it
-            is good at. It never grants itself more authority, and every action it takes is logged
-            where you can see it.
+            Some lines are not settings anyone can move. It does the connective work and never
+            offers a tax position or a financial interpretation. It tracks the firm-authored dates
+            and never computes a filing requirement or a due date itself. Taxpayer information is
+            not disclosed or used beyond the engagement, and client financial records stay inside
+            your firm's systems. Anything that leaves the firm goes to a reviewer on your team until
+            you decide otherwise. Every action it takes is logged where you can see it.
+          </p>
+          <p>
+            Beyond those floors, you govern where the line sits, and you can move it as you learn
+            what the Operator is good at. Your client files stay private, including from us. The
+            Operator works in your firm's own walled-off environment, on your own accounts. We can
+            see that it is running and the record of what it did, but the contents of your
+            engagements and messages stay yours, and so do the configuration, the logs, and the off
+            switch.
           </p>
         </div>
         <div class="text-center">
@@ -208,64 +320,12 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 06 One coordinator, your whole firm -->
-    <section class="bg-white px-6 py-24">
-      <div class="mx-auto max-w-5xl">
-        <span
-          class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
-          >§ 06</span
-        >
-        <h2
-          class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
-        >
-          One Coordinator. Your Whole Firm.
-        </h2>
-        <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
-          <p>
-            One Operator for the whole firm, not a separate tool for each preparer. Everyone works
-            with the same one, and it gets sharper from everyone's corrections.
-          </p>
-          <p>
-            What it learns, your clients, your workpapers, your cadence, your voice, is a record you
-            can read and correct. It belongs to the firm, not to a person's login. When someone
-            moves on, what the Operator knows about how you run does not leave with them.
-          </p>
-        </div>
-      </div>
-    </section>
-
-    <!-- § 07 A team, not a tool -->
+    <!-- § 07 Where it fits -->
     <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
           class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
           >§ 07</span
-        >
-        <h2
-          class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
-        >
-          A Team, Not A Tool.
-        </h2>
-        <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
-          <p>
-            We are the team behind the worker. We build it for your firm, and we stay accountable
-            for how it runs.
-          </p>
-          <p>
-            The technology moves, and we move with it, because no one has a decade of experience
-            with it yet. We are the team that keeps your business working, and nobody should take on
-            something this new alone.
-          </p>
-        </div>
-      </div>
-    </section>
-
-    <!-- § 08 Where it fits -->
-    <section class="bg-white px-6 py-24">
-      <div class="mx-auto max-w-5xl">
-        <span
-          class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
-          >§ 08</span
         >
         <h2
           class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
@@ -303,12 +363,12 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 09 Start the conversation -->
+    <!-- § 08 Start the conversation -->
     <section class="bg-[color:var(--ss-color-surface-inverse)] px-6 py-24">
       <div class="mx-auto max-w-5xl text-center">
         <span
           class="inline-block bg-[color:var(--ss-color-background)] text-[color:var(--ss-color-text-primary)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-8"
-          >§ 09</span
+          >§ 08</span
         >
         <h2
           class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-white"
@@ -317,12 +377,11 @@ const roleLenses = [
         </h2>
         <p class="mx-auto mb-6 max-w-2xl text-lg text-[color:var(--ss-color-text-muted)]">
           It starts with a conversation. We learn how your firm runs, find the client chase and the
-          coordination that is eating your team's time, and figure out where a dedicated Operator
-          fits. If it is not a fit, we will tell you.
+          coordination that is eating your team's time, and start from the pack, customizing it to
+          your firm. If it is not a fit, we will tell you.
         </p>
         <p class="mx-auto mb-10 max-w-2xl text-lg text-[color:var(--ss-color-text-muted)]">
-          Pricing is a flat monthly subscription, scoped to the seat we build together, and we walk
-          through it before any setup begins.
+          {ctaPricingLine}
         </p>
         <CtaButton
           variant="outline-white"

--- a/src/pages/packs/dental.astro
+++ b/src/pages/packs/dental.astro
@@ -5,13 +5,14 @@ import Base from '../../layouts/Base.astro'
 import Nav from '../../components/Nav.astro'
 import Footer from '../../components/Footer.astro'
 import CtaButton from '../../components/CtaButton.astro'
+import { coldLanderLink, shapeZoneTitles, ctaPricingLine } from '../../lib/operator-packs/shared'
 
 const productSchema = {
   '@context': 'https://schema.org',
   '@type': 'Product',
   name: 'Operator for Dental Practices',
   description:
-    'A dedicated Operator that runs the front office: it confirms the schedule, works the recall list, fills the openings a cancellation leaves, handles insurance-verification logistics, and rebooks the no-show. The clinical decisions stay with your dentists; a possible emergency routes to a person.',
+    'The Operator is a worker you hire, not software you buy. The dental pack is its head start: a starting point shaped around the front office, which we configure with you and you customize to your practice. The clinical decisions stay with your dentists; a possible emergency routes to a person.',
   brand: { '@type': 'Brand', name: 'SMD Services' },
   offers: {
     '@type': 'Offer',
@@ -19,6 +20,46 @@ const productSchema = {
     seller: { '@type': 'Organization', name: 'SMD Services' },
   },
 }
+
+// Section 03: the starting templates in the pack, grouped in plain language. Sourced
+// from operator/verticals/dental/vertical.yaml (the scheduling, recall, benefits, and
+// records skill families). These are templates we configure, not a finished, running
+// product.
+const packTemplates = [
+  {
+    title: 'New patient and scheduling',
+    body: 'A new-patient inquiry captured and a possible emergency routed to a person, the schedule confirmed and reminded, the short-call list worked, the no-show rebooked.',
+  },
+  {
+    title: 'The recall engine',
+    body: 'The recall and recare list surfaced from the interval the practice marks due, and the lapsed patient reactivated, so a gap on the calendar does not become lost production.',
+  },
+  {
+    title: 'Benefits, treatment, and money',
+    body: 'The payer-returned benefits relayed, the unscheduled treatment plan followed up on logistics, the claim status chased, the patient balance reminded.',
+  },
+  {
+    title: 'Records and proactive',
+    body: 'The forms and records collected, a possible emergency routed straight to the team, inbound routed to the right desk, the internal digest assembled.',
+  },
+]
+
+// Section 05: the three customization zones. Titles are shared (shapeZoneTitles); the
+// body under each is dental-specific.
+const zones = [
+  {
+    title: shapeZoneTitles.prebuilt,
+    body: 'The starting templates above, shaped around a front-office and treatment-coordinator desk and ready to configure. You are not building from a blank page.',
+  },
+  {
+    title: shapeZoneTitles.connected,
+    body: 'Wired into your own accounts: your practice-management system, your email and calendar, your documents. It works inside the tools you already run.',
+  },
+  {
+    title: shapeZoneTitles.yours,
+    body: 'Your voice, your recall protocol and verification steps, the way you run a schedule, and where the line sits. You decide what runs on its own and what waits for a person. You are the expert in your practice; you shape it from there.',
+  },
+]
 
 const roleLenses = [
   {
@@ -38,13 +79,13 @@ const roleLenses = [
 
 <Base
   title="Operator for Dental Practices | SMD Services"
-  description="A dedicated Operator that runs the front office: confirming the schedule, working the recall list, filling the openings a cancellation leaves, handling insurance-verification logistics, and rebooking the no-show. The clinical decisions stay with your dentists."
+  description="The dental pack is the Operator's head start: a starting point shaped around the front office, which we configure with you and you customize to your practice. The clinical decisions stay with your dentists. You set the line."
 >
   <Nav />
   <main id="main" role="main">
     <script is:inline type="application/ld+json" set:html={JSON.stringify(productSchema)} />
 
-    <!-- § 01 Hero -->
+    <!-- Section 01: Hero -->
     <section
       class="relative overflow-hidden bg-[color:var(--ss-color-background)] px-6 pt-24 pb-32"
     >
@@ -59,21 +100,26 @@ const roleLenses = [
           The Front Office, Fully Staffed.
         </h1>
         <p
-          class="mx-auto mb-12 max-w-2xl text-xl leading-relaxed text-[color:var(--ss-color-text-secondary)]"
+          class="mx-auto mb-8 max-w-2xl text-xl leading-relaxed text-[color:var(--ss-color-text-secondary)]"
         >
-          A dedicated worker for your practice, in its own office and plugged into the tools you
-          already run. It runs the front office the way a sharp scheduling coordinator would: it
-          confirms the schedule, works the recall list, fills the openings a cancellation leaves,
-          handles the insurance-verification logistics, and rebooks the no-show. You add capacity to
-          the busiest seat in the practice without adding to payroll.
+          The Operator is a worker you hire, not software you buy. This is its dental head start: a
+          starting point already shaped around the front office, so you are not building from a
+          blank page. You make it yours from there.
         </p>
         <CtaButton href="/book?interest=dental" data-ev="dental-hero-cta"
           >Start the conversation</CtaButton
         >
+        <p class="mt-8">
+          <a
+            href={coldLanderLink.href}
+            class="font-['Archivo_Narrow'] text-sm font-semibold uppercase tracking-[0.12em] text-[color:var(--ss-color-text-secondary)] underline underline-offset-4 hover:text-[color:var(--ss-color-primary)]"
+            >{coldLanderLink.text} &rarr;</a
+          >
+        </p>
       </div>
     </section>
 
-    <!-- § 02 The seat the market won't fill -->
+    <!-- Section 02: The seat the market won't fill -->
     <section class="bg-white px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
@@ -103,7 +149,7 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 03 A worker, in another office -->
+    <!-- Section 03: What the pack starts you with -->
     <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
@@ -111,32 +157,49 @@ const roleLenses = [
           >§ 03</span
         >
         <h2
-          class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
+          class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
         >
-          A Worker, In Another Office.
+          What The Pack Starts You With.
         </h2>
-        <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
-          <p>
-            Picture a front-office coordinator from the future, sitting at a desk in your practice
-            today. A computer, a phone, and access to the practice-management system, the schedule,
-            and the phones you already run. You hand it work the way you hand work to anyone on your
-            team. You send the request, it does the job, and it comes back with the result.
-          </p>
-          <p>
-            It works from its own office, the way much of your team already does. The billing
-            coordinator you have never met in person. The lab you call and trade cases with every
-            week. This is one more of those.
-          </p>
-          <p>
-            What it takes on is the work you would want that seat doing, inside the limits you set.
-            The patient who needs to reschedule and falls off the calendar. The insurance
-            verification that has to happen before the appointment. We get to the limits below.
-          </p>
+        <p
+          class="mb-12 max-w-2xl text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]"
+        >
+          You do not start from a blank page. The dental pack comes shaped around the work a
+          front-office coordinator runs, as starting templates we configure with you:
+        </p>
+
+        <div
+          class="grid grid-cols-1 md:grid-cols-2 gap-0 border-t-[3px] border-[color:var(--ss-color-text-primary)]"
+        >
+          {
+            packTemplates.map((t, i) => (
+              <div
+                class:list={[
+                  'flex flex-col gap-3 p-8 min-h-[12rem] border-b-[3px] border-[color:var(--ss-color-text-primary)]',
+                  i % 2 !== 1 && 'md:border-r-[3px] md:border-[color:var(--ss-color-text-primary)]',
+                ]}
+              >
+                <p class="font-['Archivo_Narrow'] text-xs font-semibold uppercase tracking-[0.12em] text-[color:var(--ss-color-primary)]">
+                  {t.title}
+                </p>
+                <p class="font-['Archivo'] text-base leading-relaxed text-[color:var(--ss-color-text-secondary)]">
+                  {t.body}
+                </p>
+              </div>
+            ))
+          }
         </div>
+
+        <p
+          class="mt-12 max-w-2xl text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]"
+        >
+          These plug into your practice-management system and your email and calendar. The templates
+          are the head start. How they run is yours to shape.
+        </p>
       </div>
     </section>
 
-    <!-- § 04 What it does -->
+    <!-- Section 04: From the start -->
     <section class="bg-white px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
@@ -146,30 +209,27 @@ const roleLenses = [
         <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
         >
-          What It Does.
+          From The Start.
         </h2>
         <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
           <p>
-            We build the Operator for your practice and connect it to the tools you already run:
-            your practice-management system, your email and calendar.
+            Before it starts, we sit down with you and the people who run the front office, and we
+            shape the templates around how your practice actually operates, so it begins ready, not
+            green.
           </p>
           <p>
-            Before it starts, we sit down with you and the people who run the work, and we build it
-            around how you operate, so it shows up ready, not green. From there it keeps getting
-            sharper, learning from your team's corrections.
-          </p>
-          <p>
-            It confirms the schedule and rebooks the no-show, works the recall and recare list so
-            patients do not get lost, handles the insurance-verification and claim-status logistics,
-            and fills the openings a cancellation leaves. A message that might be an emergency it
-            hands to a person right away. Every piece of it is logged in your practice-management
-            system as it happens.
+            From there the work moves the way it always did. It confirms the schedule and rebooks
+            the no-show, works the recall and recare list so patients do not get lost, handles the
+            insurance-verification and claim-status logistics, and fills the openings a cancellation
+            leaves. A message that might be an emergency it hands to a person right away. It is all
+            logged in your practice-management system as it happens, and it keeps getting sharper
+            from your team's corrections.
           </p>
         </div>
       </div>
     </section>
 
-    <!-- § 05 You set the line -->
+    <!-- Section 05: Yours to shape -->
     <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
@@ -177,9 +237,52 @@ const roleLenses = [
           >§ 05</span
         >
         <h2
+          class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
+        >
+          Yours To Shape.
+        </h2>
+        <p
+          class="mb-12 max-w-2xl text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]"
+        >
+          We are not the experts in how your practice runs. You are. So the pack is a starting point
+          in three parts, and the third is the biggest.
+        </p>
+
+        <div
+          class="grid grid-cols-1 md:grid-cols-3 gap-0 border-t-[3px] border-[color:var(--ss-color-text-primary)]"
+        >
+          {
+            zones.map((z, i) => (
+              <div
+                class:list={[
+                  'flex flex-col gap-3 p-8 min-h-[14rem] border-b-[3px] border-[color:var(--ss-color-text-primary)]',
+                  i % 3 !== 2 && 'md:border-r-[3px] md:border-[color:var(--ss-color-text-primary)]',
+                ]}
+              >
+                <p class="font-['Archivo_Narrow'] text-xs font-semibold uppercase tracking-[0.12em] text-[color:var(--ss-color-primary)]">
+                  {z.title}
+                </p>
+                <p class="font-['Archivo'] text-base leading-relaxed text-[color:var(--ss-color-text-secondary)]">
+                  {z.body}
+                </p>
+              </div>
+            ))
+          }
+        </div>
+      </div>
+    </section>
+
+    <!-- Section 06: The line -->
+    <section class="bg-white px-6 py-24">
+      <div class="mx-auto max-w-5xl">
+        <span
+          class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
+          >§ 06</span
+        >
+        <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
         >
-          You Set The Line.
+          The Line.
         </h2>
         <div
           class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)] mb-12"
@@ -192,12 +295,20 @@ const roleLenses = [
             trained but unlicensed front-office person could not make those calls either.
           </p>
           <p>
-            One line is not a setting anyone can move: a message that might be a dental emergency
-            goes straight to a person at your practice, right then, never handled later and never
-            answered with clinical content. Everywhere else, you govern what the Operator runs on
-            its own. Out of the box the clinical calls wait for a clinician, and every outbound
-            message goes through a reviewer on your team who sends it under their own name. It never
-            grants itself more authority, and every action it takes is logged where you can see it.
+            Some lines are not settings anyone can move. The Operator does connective work only; it
+            never offers a diagnosis, a treatment recommendation, or a judgment about urgency. A
+            message that might be a dental emergency goes straight to a person at your practice,
+            right then, never handled later. Benefits are relayed as the payer returns them, never a
+            guarantee of coverage or out-of-pocket. Patient health information stays inside your
+            practice surfaces. Every action it takes is logged where you can see it.
+          </p>
+          <p>
+            Beyond those floors, you govern where the line sits, and you can move it as you learn
+            what the Operator is good at. Your patient files stay private, including from us. The
+            Operator works in your practice's own walled-off environment, on your own accounts. We
+            can see that it is running and the record of what it did, but the contents of your
+            patient records and messages stay yours, and so do the configuration, the logs, and the
+            off switch.
           </p>
         </div>
         <div class="text-center">
@@ -208,66 +319,12 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 06 One coordinator, your whole practice -->
-    <section class="bg-white px-6 py-24">
-      <div class="mx-auto max-w-5xl">
-        <span
-          class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
-          >§ 06</span
-        >
-        <h2
-          class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
-        >
-          One Coordinator. Your Whole Practice.
-        </h2>
-        <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
-          <p>
-            One Operator for the whole practice, not a separate tool for each chair or each
-            location. Everyone works with the same one, and it gets sharper from everyone's
-            corrections.
-          </p>
-          <p>
-            What it learns, your schedule, your recall protocol, your verification steps, your
-            voice, is a record you can read and correct. It belongs to the practice, not to a
-            person's login. When someone moves on, what the Operator knows about how you run does
-            not leave with them.
-          </p>
-        </div>
-      </div>
-    </section>
-
-    <!-- § 07 A team, not a tool -->
+    <!-- Section 07: Where it fits -->
     <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
           class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
           >§ 07</span
-        >
-        <h2
-          class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
-        >
-          A Team, Not A Tool.
-        </h2>
-        <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
-          <p>
-            We are the team behind the worker. We build it for your practice, and we stay
-            accountable for how it runs.
-          </p>
-          <p>
-            The technology moves, and we move with it, because no one has a decade of experience
-            with it yet. We are the team that keeps your business working, and nobody should take on
-            something this new alone.
-          </p>
-        </div>
-      </div>
-    </section>
-
-    <!-- § 08 Where it fits -->
-    <section class="bg-white px-6 py-24">
-      <div class="mx-auto max-w-5xl">
-        <span
-          class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
-          >§ 08</span
         >
         <h2
           class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
@@ -305,12 +362,12 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 09 Start the conversation -->
+    <!-- Section 08: Start the conversation -->
     <section class="bg-[color:var(--ss-color-surface-inverse)] px-6 py-24">
       <div class="mx-auto max-w-5xl text-center">
         <span
           class="inline-block bg-[color:var(--ss-color-background)] text-[color:var(--ss-color-text-primary)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-8"
-          >§ 09</span
+          >§ 08</span
         >
         <h2
           class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-white"
@@ -319,12 +376,11 @@ const roleLenses = [
         </h2>
         <p class="mx-auto mb-6 max-w-2xl text-lg text-[color:var(--ss-color-text-muted)]">
           It starts with a conversation. We learn how your practice runs, find the front-office work
-          that is eating your team's day, and figure out where a dedicated Operator fits. If it is
-          not a fit, we will tell you.
+          that is eating your team's day, and start from the pack, customizing it to your practice.
+          If it is not a fit, we will tell you.
         </p>
         <p class="mx-auto mb-10 max-w-2xl text-lg text-[color:var(--ss-color-text-muted)]">
-          Pricing is a flat monthly subscription, scoped to the seat we build together, and we walk
-          through it before any setup begins.
+          {ctaPricingLine}
         </p>
         <CtaButton variant="outline-white" href="/book?interest=dental" data-ev="dental-final-cta"
           >Start the conversation</CtaButton

--- a/src/pages/packs/home-services.astro
+++ b/src/pages/packs/home-services.astro
@@ -5,13 +5,14 @@ import Base from '../../layouts/Base.astro'
 import Nav from '../../components/Nav.astro'
 import Footer from '../../components/Footer.astro'
 import CtaButton from '../../components/CtaButton.astro'
+import { coldLanderLink, shapeZoneTitles, ctaPricingLine } from '../../lib/operator-packs/shared'
 
 const productSchema = {
   '@context': 'https://schema.org',
   '@type': 'Product',
   name: 'Operator for Home Services',
   description:
-    'A dedicated Operator that runs the front office: it answers the call, books the job, confirms the appointment, follows up on the estimate, and keeps your field-service system current, including after-hours. A safety emergency routes to your on-call person; the price and the diagnosis stay with your techs.',
+    'The Operator is a worker you hire, not software you buy. The home-services pack is its head start: a starting point shaped around front-office call handling and job coordination, which we configure with you and you customize to your shop. The diagnosis and the price stay with your techs; a safety emergency goes straight to a person.',
   brand: { '@type': 'Brand', name: 'SMD Services' },
   offers: {
     '@type': 'Offer',
@@ -19,6 +20,46 @@ const productSchema = {
     seller: { '@type': 'Organization', name: 'SMD Services' },
   },
 }
+
+// Section 03: the starting templates in the pack, grouped in plain language. Sourced
+// from operator/verticals/home-services/vertical.yaml (the intake-and-scheduling,
+// money-and-retention, proactive, and safety skill families). These are templates we
+// configure, not a finished, running product.
+const packTemplates = [
+  {
+    title: 'Intake and scheduling',
+    body: 'A service request captured and routed wherever it lands, the appointment booked, the arrival window confirmed, the board status relayed back to the customer.',
+  },
+  {
+    title: 'Money and retention',
+    body: 'The estimate chased toward a yes, the invoice followed up, the membership plan terms relayed, the maintenance due date surfaced, the part you are waiting on tracked.',
+  },
+  {
+    title: 'Proactive touches',
+    body: 'The review request sent after the job, the lapsed customer reached for a win-back, your field-service software kept in sync.',
+  },
+  {
+    title: 'The safety gate',
+    body: 'A call that sounds like a gas leak, a fire, water coming in, no heat in a freeze, or a live electrical hazard, recognized and routed straight to a person, never queued behind a routine booking.',
+  },
+]
+
+// Section 05: the three customization zones. Titles are shared (shapeZoneTitles); the
+// body under each is home-services-specific.
+const zones = [
+  {
+    title: shapeZoneTitles.prebuilt,
+    body: 'The starting templates above, shaped around a front-office call-and-coordination desk and ready to configure. You are not building from a blank page.',
+  },
+  {
+    title: shapeZoneTitles.connected,
+    body: 'Wired into your own accounts: your field-service software, your email and calendar, your documents. It works inside the tools you already run.',
+  },
+  {
+    title: shapeZoneTitles.yours,
+    body: 'Your voice, your services and pricing rules, your booking rules, and where the line sits. You decide what runs on its own and what waits for a person. You are the expert in your shop; you shape it from there.',
+  },
+]
 
 const roleLenses = [
   {
@@ -38,7 +79,7 @@ const roleLenses = [
 
 <Base
   title="Operator for Home Services | SMD Services"
-  description="A dedicated Operator that runs the front office: answering the call, booking the job, confirming the appointment, following up on the estimate, and keeping your field-service system current, including after-hours. A safety emergency routes to your on-call person."
+  description="The home-services pack is the Operator's head start: a starting point shaped around front-office call handling and job coordination, which we configure with you and you customize to your shop. The diagnosis and the price stay with your techs. You set the line."
 >
   <Nav />
   <main id="main" role="main">
@@ -59,17 +100,23 @@ const roleLenses = [
           Every Call, Answered.
         </h1>
         <p
-          class="mx-auto mb-12 max-w-2xl text-xl leading-relaxed text-[color:var(--ss-color-text-secondary)]"
+          class="mx-auto mb-8 max-w-2xl text-xl leading-relaxed text-[color:var(--ss-color-text-secondary)]"
         >
-          A dedicated worker for your shop, in its own office and plugged into the tools you already
-          run. It runs the front office the way a sharp CSR would: it answers the call, books the
-          job, confirms the appointment, follows up on the estimate, and keeps your field-service
-          system current, including the calls that come in after hours. You stop sending leads to
-          voicemail, and you do not add a seat to hire and train.
+          The Operator is a worker you hire, not software you buy. This is its home-services head
+          start: a starting point already shaped around answering the call, booking the job, and
+          chasing the follow-up, so you are not building from a blank page. You make it yours from
+          there.
         </p>
         <CtaButton href="/book?interest=home-services" data-ev="home-services-hero-cta"
           >Start the conversation</CtaButton
         >
+        <p class="mt-8">
+          <a
+            href={coldLanderLink.href}
+            class="font-['Archivo_Narrow'] text-sm font-semibold uppercase tracking-[0.12em] text-[color:var(--ss-color-text-secondary)] underline underline-offset-4 hover:text-[color:var(--ss-color-primary)]"
+            >{coldLanderLink.text} &rarr;</a
+          >
+        </p>
       </div>
     </section>
 
@@ -102,7 +149,7 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 03 A worker, in another office -->
+    <!-- § 03 What the pack starts you with -->
     <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
@@ -110,32 +157,49 @@ const roleLenses = [
           >§ 03</span
         >
         <h2
-          class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
+          class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
         >
-          A Worker, In Another Office.
+          What The Pack Starts You With.
         </h2>
-        <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
-          <p>
-            Picture a dispatcher from the future, sitting at a desk in your shop today. A computer,
-            a phone, and access to the scheduling software, the phones, and the job board you
-            already run. You hand it work the way you hand work to anyone on your team. You send the
-            request, it does the job, and it comes back with the result.
-          </p>
-          <p>
-            It works from its own office, the way much of your team already does. The office manager
-            you have never met in person. The supplier you call and order parts from. This is one
-            more of those.
-          </p>
-          <p>
-            What it takes on is the work you would want that seat doing, inside the limits you set.
-            The call that comes in after hours and goes to voicemail. The quote that never got a
-            follow-up before the customer called someone else. We get to the limits below.
-          </p>
+        <p
+          class="mb-12 max-w-2xl text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]"
+        >
+          You do not start from a blank page. The home-services pack comes shaped around the work a
+          front-office call-and-coordination desk runs, as starting templates we configure with you:
+        </p>
+
+        <div
+          class="grid grid-cols-1 md:grid-cols-2 gap-0 border-t-[3px] border-[color:var(--ss-color-text-primary)]"
+        >
+          {
+            packTemplates.map((t, i) => (
+              <div
+                class:list={[
+                  'flex flex-col gap-3 p-8 min-h-[12rem] border-b-[3px] border-[color:var(--ss-color-text-primary)]',
+                  i % 2 !== 1 && 'md:border-r-[3px] md:border-[color:var(--ss-color-text-primary)]',
+                ]}
+              >
+                <p class="font-['Archivo_Narrow'] text-xs font-semibold uppercase tracking-[0.12em] text-[color:var(--ss-color-primary)]">
+                  {t.title}
+                </p>
+                <p class="font-['Archivo'] text-base leading-relaxed text-[color:var(--ss-color-text-secondary)]">
+                  {t.body}
+                </p>
+              </div>
+            ))
+          }
         </div>
+
+        <p
+          class="mt-12 max-w-2xl text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]"
+        >
+          These plug into your field-service software and your email and calendar. The templates are
+          the head start. How they run is yours to shape.
+        </p>
       </div>
     </section>
 
-    <!-- § 04 What it does -->
+    <!-- § 04 From the start -->
     <section class="bg-white px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
@@ -145,31 +209,27 @@ const roleLenses = [
         <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
         >
-          What It Does.
+          From The Start.
         </h2>
         <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
           <p>
-            We build the Operator for your shop and connect it to the tools you already run: your
-            field-service system, your email and calendar.
+            Before it starts, we sit down with you and the people who run the front office, and we
+            shape the templates around how your shop actually operates, so it begins ready, not
+            green.
           </p>
           <p>
-            Before it starts, we sit down with you and the people who run the work, and we build it
-            around how you operate, so it shows up ready, not green. From there it keeps getting
-            sharper, learning from your team's corrections.
-          </p>
-          <p>
-            The phone rings, after hours or in the middle of peak season, and it answers, captures
-            the job, and books the appointment instead of letting it roll to voicemail. It confirms
-            appointments, follows up on the estimate, chases the callback, and keeps the
-            field-service system current. Anything that sounds like a safety emergency it routes to
-            your on-call person right away. Every piece of it is logged in your field-service system
-            as it happens.
+            From there the work moves the way it always did. The phone rings, after hours or in the
+            middle of peak season, and it answers, captures the job, and books the appointment
+            instead of letting it roll to voicemail. It confirms appointments, follows up on the
+            estimate, chases the callback. Anything that sounds like a safety emergency goes
+            straight to your on-call person right away. It is all logged in your field-service
+            software as it happens, and it kept getting sharper from your team's corrections.
           </p>
         </div>
       </div>
     </section>
 
-    <!-- § 05 You set the line -->
+    <!-- § 05 Yours to shape -->
     <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
@@ -177,9 +237,52 @@ const roleLenses = [
           >§ 05</span
         >
         <h2
+          class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
+        >
+          Yours To Shape.
+        </h2>
+        <p
+          class="mb-12 max-w-2xl text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]"
+        >
+          We are not the experts in how your shop runs. You are. So the pack is a starting point in
+          three parts, and the third is the biggest.
+        </p>
+
+        <div
+          class="grid grid-cols-1 md:grid-cols-3 gap-0 border-t-[3px] border-[color:var(--ss-color-text-primary)]"
+        >
+          {
+            zones.map((z, i) => (
+              <div
+                class:list={[
+                  'flex flex-col gap-3 p-8 min-h-[14rem] border-b-[3px] border-[color:var(--ss-color-text-primary)]',
+                  i % 3 !== 2 && 'md:border-r-[3px] md:border-[color:var(--ss-color-text-primary)]',
+                ]}
+              >
+                <p class="font-['Archivo_Narrow'] text-xs font-semibold uppercase tracking-[0.12em] text-[color:var(--ss-color-primary)]">
+                  {z.title}
+                </p>
+                <p class="font-['Archivo'] text-base leading-relaxed text-[color:var(--ss-color-text-secondary)]">
+                  {z.body}
+                </p>
+              </div>
+            ))
+          }
+        </div>
+      </div>
+    </section>
+
+    <!-- § 06 The line -->
+    <section class="bg-white px-6 py-24">
+      <div class="mx-auto max-w-5xl">
+        <span
+          class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
+          >§ 06</span
+        >
+        <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
         >
-          You Set The Line.
+          The Line.
         </h2>
         <div
           class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)] mb-12"
@@ -191,12 +294,20 @@ const roleLenses = [
             does not quote the job or decide what is wrong.
           </p>
           <p>
-            One line is not a setting anyone can move: a call that sounds like a safety emergency, a
-            gas leak, no heat in a hard freeze, a live electrical hazard, water coming in, goes
-            straight to your on-call person, right then, never queued behind a routine booking.
-            Everywhere else you govern what the Operator runs on its own, every outbound message
-            goes through a reviewer who sends it under their own name, and every action it takes is
-            logged where you can see it.
+            Some lines are not settings anyone can move. A call that sounds like a safety emergency,
+            a gas leak, a fire, water coming in, no heat in a hard freeze, or a live electrical
+            hazard, goes straight to a person right then, and anything that sounds like a threat to
+            life goes to 911, never queued behind a routine booking. It never commits a diagnosis or
+            a price; that stays with your techs. It follows up on invoices, but it never processes a
+            payment. Anything that leaves the shop goes to a reviewer on your team until you decide
+            otherwise. Every action it takes is logged where you can see it.
+          </p>
+          <p>
+            Beyond those floors, you govern where the line sits, and you can move it as you learn
+            what the Operator is good at. Your customer files stay private, including from us. The
+            Operator works in your shop's own walled-off environment, on your own accounts. We can
+            see that it is running and the record of what it did, but the contents of your jobs and
+            messages stay yours, and so do the configuration, the logs, and the off switch.
           </p>
         </div>
         <div class="text-center">
@@ -209,64 +320,12 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 06 One coordinator, your whole shop -->
-    <section class="bg-white px-6 py-24">
-      <div class="mx-auto max-w-5xl">
-        <span
-          class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
-          >§ 06</span
-        >
-        <h2
-          class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
-        >
-          One Coordinator. Your Whole Shop.
-        </h2>
-        <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
-          <p>
-            One Operator for the whole shop, not a separate tool for each CSR or each tech. Everyone
-            works with the same one, and it gets sharper from everyone's corrections.
-          </p>
-          <p>
-            What it learns, your services, your pricing rules, your booking rules, your voice, is a
-            record you can read and correct. It belongs to the shop, not to a person's login. When
-            someone moves on, what the Operator knows about how you run does not leave with them.
-          </p>
-        </div>
-      </div>
-    </section>
-
-    <!-- § 07 A team, not a tool -->
+    <!-- § 07 Where it fits -->
     <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
           class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
           >§ 07</span
-        >
-        <h2
-          class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
-        >
-          A Team, Not A Tool.
-        </h2>
-        <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
-          <p>
-            We are the team behind the worker. We build it for your shop, and we stay accountable
-            for how it runs.
-          </p>
-          <p>
-            The technology moves, and we move with it, because no one has a decade of experience
-            with it yet. We are the team that keeps your business working, and nobody should take on
-            something this new alone.
-          </p>
-        </div>
-      </div>
-    </section>
-
-    <!-- § 08 Where it fits -->
-    <section class="bg-white px-6 py-24">
-      <div class="mx-auto max-w-5xl">
-        <span
-          class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
-          >§ 08</span
         >
         <h2
           class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
@@ -304,12 +363,12 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 09 Start the conversation -->
+    <!-- § 08 Start the conversation -->
     <section class="bg-[color:var(--ss-color-surface-inverse)] px-6 py-24">
       <div class="mx-auto max-w-5xl text-center">
         <span
           class="inline-block bg-[color:var(--ss-color-background)] text-[color:var(--ss-color-text-primary)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-8"
-          >§ 09</span
+          >§ 08</span
         >
         <h2
           class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-white"
@@ -318,12 +377,11 @@ const roleLenses = [
         </h2>
         <p class="mx-auto mb-6 max-w-2xl text-lg text-[color:var(--ss-color-text-muted)]">
           It starts with a conversation. We learn how your shop runs, find the call-handling and
-          coordination work that is eating your team's time, and figure out where a dedicated
-          Operator fits. If it is not a fit, we will tell you.
+          coordination work that is eating your team's time, and start from the pack, customizing it
+          to your shop. If it is not a fit, we will tell you.
         </p>
         <p class="mx-auto mb-10 max-w-2xl text-lg text-[color:var(--ss-color-text-muted)]">
-          Pricing is a flat monthly subscription, scoped to the seat we build together, and we walk
-          through it before any setup begins.
+          {ctaPricingLine}
         </p>
         <CtaButton
           variant="outline-white"

--- a/src/pages/packs/insurance.astro
+++ b/src/pages/packs/insurance.astro
@@ -5,13 +5,14 @@ import Base from '../../layouts/Base.astro'
 import Nav from '../../components/Nav.astro'
 import Footer from '../../components/Footer.astro'
 import CtaButton from '../../components/CtaButton.astro'
+import { coldLanderLink, shapeZoneTitles, ctaPricingLine } from '../../lib/operator-packs/shared'
 
 const productSchema = {
   '@context': 'https://schema.org',
   '@type': 'Product',
   name: 'Operator for Insurance Agencies',
   description:
-    'A dedicated Operator that services your book: it works new-quote intake and routes it to a producer, runs the renewal cadence, turns around certificates and endorsements, fields billing questions, and routes first notice of loss. The licensed acts stay with your licensed people; you set the line.',
+    'The Operator is a worker you hire, not software you buy. The insurance pack is its head start: a starting point shaped around new-business intake, the renewal cadence, and the service desk, which we configure with you and you customize to your agency. The licensed acts stay with your licensed people; you set the line.',
   brand: { '@type': 'Brand', name: 'SMD Services' },
   offers: {
     '@type': 'Offer',
@@ -19,6 +20,46 @@ const productSchema = {
     seller: { '@type': 'Organization', name: 'SMD Services' },
   },
 }
+
+// Section 03: the starting templates in the pack, grouped in plain language. Sourced
+// from operator/verticals/insurance/vertical.yaml (the intake, renewal, service-desk,
+// and retention skill families). These are templates we configure, not a finished,
+// running product.
+const packTemplates = [
+  {
+    title: 'New-business intake',
+    body: 'A quote request captured wherever it lands, the exposure facts gathered, the acknowledgment drafted in your voice, the whole package routed to a producer.',
+  },
+  {
+    title: 'The renewal desk',
+    body: 'The renewal cadence surfaced so nothing lapses, the outreach drafted to confirm changes, the carrier chased for the remarket answer.',
+  },
+  {
+    title: 'The service desk',
+    body: 'The certificate built from what is on the policy, the endorsement relayed to the carrier, the policy-document question answered, the billing status reply, the first notice of loss captured and routed.',
+  },
+  {
+    title: 'Retention and proactive',
+    body: 'The cancellation notice chased toward the cure, the account-rounding gap surfaced for the producer, inbound routed to the right desk, the internal digest assembled.',
+  },
+]
+
+// Section 05: the three customization zones. Titles are shared (shapeZoneTitles); the
+// body under each is insurance-specific.
+const zones = [
+  {
+    title: shapeZoneTitles.prebuilt,
+    body: 'The starting templates above, shaped around a service and renewal desk and ready to configure. You are not building from a blank page.',
+  },
+  {
+    title: shapeZoneTitles.connected,
+    body: 'Wired into your own accounts: your agency management system, your email and calendar, your documents. It works inside the tools you already run.',
+  },
+  {
+    title: shapeZoneTitles.yours,
+    body: 'Your voice, your carriers and appetite, the way you run a renewal, and where the line sits. You decide what runs on its own and what waits for a person. You are the expert in your agency; you shape it from there.',
+  },
+]
 
 const roleLenses = [
   {
@@ -38,13 +79,13 @@ const roleLenses = [
 
 <Base
   title="Operator for Insurance Agencies | SMD Services"
-  description="A dedicated Operator that services your book: new-quote intake routed to a producer, the renewal cadence, certificates and endorsements, billing questions, and first notice of loss. The licensed acts stay with your licensed people. You set the line."
+  description="The insurance pack is the Operator's head start: a starting point shaped around new-business intake, the renewal cadence, and the service desk, which we configure with you and you customize to your agency. The licensed acts stay with your licensed people. You set the line."
 >
   <Nav />
   <main id="main" role="main">
     <script is:inline type="application/ld+json" set:html={JSON.stringify(productSchema)} />
 
-    <!-- § 01 Hero -->
+    <!-- Section 01: Hero -->
     <section
       class="relative overflow-hidden bg-[color:var(--ss-color-background)] px-6 pt-24 pb-32"
     >
@@ -59,21 +100,26 @@ const roleLenses = [
           The Service Desk, Fully Staffed.
         </h1>
         <p
-          class="mx-auto mb-12 max-w-2xl text-xl leading-relaxed text-[color:var(--ss-color-text-secondary)]"
+          class="mx-auto mb-8 max-w-2xl text-xl leading-relaxed text-[color:var(--ss-color-text-secondary)]"
         >
-          A dedicated worker for your agency, in its own office and plugged into the tools you
-          already run. It services your book the way a sharp account manager would: it works
-          new-quote intake, runs the renewal cadence, turns around COIs and endorsements, fields the
-          billing questions, and routes first notice of loss. You add capacity to the desk without
-          adding to payroll.
+          The Operator is a worker you hire, not software you buy. This is its insurance head start:
+          a starting point already shaped around new-business intake, the renewal cadence, and the
+          service desk, so you are not building from a blank page. You make it yours from there.
         </p>
         <CtaButton href="/book?interest=insurance" data-ev="insurance-hero-cta"
           >Start the conversation</CtaButton
         >
+        <p class="mt-8">
+          <a
+            href={coldLanderLink.href}
+            class="font-['Archivo_Narrow'] text-sm font-semibold uppercase tracking-[0.12em] text-[color:var(--ss-color-text-secondary)] underline underline-offset-4 hover:text-[color:var(--ss-color-primary)]"
+            >{coldLanderLink.text} &rarr;</a
+          >
+        </p>
       </div>
     </section>
 
-    <!-- § 02 The seat the market won't fill -->
+    <!-- Section 02: The seat the market won't fill -->
     <section class="bg-white px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
@@ -101,7 +147,7 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 03 A worker, in another office -->
+    <!-- Section 03: What the pack starts you with -->
     <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
@@ -109,32 +155,49 @@ const roleLenses = [
           >§ 03</span
         >
         <h2
-          class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
+          class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
         >
-          A Worker, In Another Office.
+          What The Pack Starts You With.
         </h2>
-        <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
-          <p>
-            Picture an account service rep from the future, sitting at a desk in your agency today.
-            A computer, a phone, and access to the agency management system, the email, and the
-            carrier portals you already run. You hand it work the way you hand work to anyone on
-            your team. You send the request, it does the job, and it comes back with the result.
-          </p>
-          <p>
-            It works from its own office, the way much of your team already does. The account
-            manager you have never met in person. The wholesaler you email and trade submissions
-            with every week. This is one more of those.
-          </p>
-          <p>
-            What it takes on is the work you would want that seat doing, inside the limits you set.
-            The renewal that is sixty days out and still needs a review. The certificate a client
-            needs before they can start a job. We get to the limits below.
-          </p>
+        <p
+          class="mb-12 max-w-2xl text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]"
+        >
+          You do not start from a blank page. The insurance pack comes shaped around the work a
+          service and renewal desk runs, as starting templates we configure with you:
+        </p>
+
+        <div
+          class="grid grid-cols-1 md:grid-cols-2 gap-0 border-t-[3px] border-[color:var(--ss-color-text-primary)]"
+        >
+          {
+            packTemplates.map((t, i) => (
+              <div
+                class:list={[
+                  'flex flex-col gap-3 p-8 min-h-[12rem] border-b-[3px] border-[color:var(--ss-color-text-primary)]',
+                  i % 2 !== 1 && 'md:border-r-[3px] md:border-[color:var(--ss-color-text-primary)]',
+                ]}
+              >
+                <p class="font-['Archivo_Narrow'] text-xs font-semibold uppercase tracking-[0.12em] text-[color:var(--ss-color-primary)]">
+                  {t.title}
+                </p>
+                <p class="font-['Archivo'] text-base leading-relaxed text-[color:var(--ss-color-text-secondary)]">
+                  {t.body}
+                </p>
+              </div>
+            ))
+          }
         </div>
+
+        <p
+          class="mt-12 max-w-2xl text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]"
+        >
+          These plug into your agency management system and your email and calendar. The templates
+          are the head start. How they run is yours to shape.
+        </p>
       </div>
     </section>
 
-    <!-- § 04 What it does -->
+    <!-- Section 04: From the start -->
     <section class="bg-white px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
@@ -144,33 +207,28 @@ const roleLenses = [
         <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
         >
-          What It Does.
+          From The Start.
         </h2>
         <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
           <p>
-            We build the Operator for your agency and connect it to the systems you already run:
-            your management system, your email and calendar, your document storage. It reads carrier
-            downloads as they land, so renewals, billing status, and cancellation notices are in
-            front of it, not buried.
+            Before it starts, we sit down with you and the people who run the service desk, and we
+            shape the templates around how your agency actually operates, so it begins ready, not
+            green.
           </p>
           <p>
-            Before it starts, we sit down with you and the people who run the work, and we build it
-            around how you operate, so it shows up ready, not green. From there it keeps getting
-            sharper, learning from your team's corrections.
-          </p>
-          <p>
-            A quote request comes in. It captures the exposure, drafts the acknowledgment in your
-            voice, and routes it to a producer. It runs the renewal cadence so nothing lapses,
-            builds the certificate from what is on the policy, relays the endorsement to the carrier
-            and confirms it back, answers the routine billing question, and chases a cancellation
-            notice to the cure before coverage drops. Every piece of it is logged in your management
-            system as it happens.
+            From there the work moves the way it always did. A quote request comes in and gets its
+            exposure captured, an acknowledgment in your voice, and a clean hand-off to a producer.
+            The renewal cadence runs so nothing lapses. The certificate gets built from what is on
+            the policy, the endorsement gets relayed to the carrier and confirmed back, the routine
+            billing question gets answered, the cancellation notice gets chased to the cure. It is
+            all logged in your management system as it happens, and it keeps getting sharper from
+            your team's corrections.
           </p>
         </div>
       </div>
     </section>
 
-    <!-- § 05 You set the line -->
+    <!-- Section 05: Yours to shape -->
     <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
@@ -178,9 +236,52 @@ const roleLenses = [
           >§ 05</span
         >
         <h2
+          class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
+        >
+          Yours To Shape.
+        </h2>
+        <p
+          class="mb-12 max-w-2xl text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]"
+        >
+          We are not the experts in how your agency runs. You are. So the pack is a starting point
+          in three parts, and the third is the biggest.
+        </p>
+
+        <div
+          class="grid grid-cols-1 md:grid-cols-3 gap-0 border-t-[3px] border-[color:var(--ss-color-text-primary)]"
+        >
+          {
+            zones.map((z, i) => (
+              <div
+                class:list={[
+                  'flex flex-col gap-3 p-8 min-h-[14rem] border-b-[3px] border-[color:var(--ss-color-text-primary)]',
+                  i % 3 !== 2 && 'md:border-r-[3px] md:border-[color:var(--ss-color-text-primary)]',
+                ]}
+              >
+                <p class="font-['Archivo_Narrow'] text-xs font-semibold uppercase tracking-[0.12em] text-[color:var(--ss-color-primary)]">
+                  {z.title}
+                </p>
+                <p class="font-['Archivo'] text-base leading-relaxed text-[color:var(--ss-color-text-secondary)]">
+                  {z.body}
+                </p>
+              </div>
+            ))
+          }
+        </div>
+      </div>
+    </section>
+
+    <!-- Section 06: The line -->
+    <section class="bg-white px-6 py-24">
+      <div class="mx-auto max-w-5xl">
+        <span
+          class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
+          >§ 06</span
+        >
+        <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
         >
-          You Set The Line.
+          The Line.
         </h2>
         <div
           class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)] mb-12"
@@ -194,11 +295,19 @@ const roleLenses = [
             unlicensed assistant could not make them either.
           </p>
           <p>
-            You govern where that line sits. Out of the box, anything that carries the license waits
-            for a person, and every outbound message goes through a reviewer on your team who sends
-            it under their own name. You widen what the Operator runs on its own as you learn what
-            it is good at. It never grants itself more authority. Every action it takes is logged
-            where you can see it: what it did, when, and why.
+            Some lines are not settings anyone can move. The Operator gives connective service only;
+            it never offers coverage advice or substance. It never binds, changes, cancels, or
+            reinstates coverage. A certificate reflects only the coverage on record, and a
+            certificate always clears a person before it goes out. Quotes, binding, and any coverage
+            or claims-coverage question route to a licensed producer. Non-public information stays
+            inside your agency surfaces. Every action it takes is logged where you can see it.
+          </p>
+          <p>
+            Beyond those floors, you govern where the line sits, and you can move it as you learn
+            what the Operator is good at. Your client files stay private, including from us. The
+            Operator works in your agency's own walled-off environment, on your own accounts. We can
+            see that it is running and the record of what it did, but the contents of your accounts
+            and messages stay yours, and so do the configuration, the logs, and the off switch.
           </p>
         </div>
         <div class="text-center">
@@ -211,65 +320,12 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 06 One coordinator, your whole agency -->
-    <section class="bg-white px-6 py-24">
-      <div class="mx-auto max-w-5xl">
-        <span
-          class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
-          >§ 06</span
-        >
-        <h2
-          class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
-        >
-          One Coordinator. Your Whole Agency.
-        </h2>
-        <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
-          <p>
-            One Operator for the whole agency, not a separate tool for each producer. Everyone works
-            with the same one, and it gets sharper from everyone's corrections.
-          </p>
-          <p>
-            What it learns, your carriers, your appetite, your voice, the way you run a renewal, is
-            a record you can read and correct. It belongs to the agency, not to a person's login.
-            When someone moves on, what the Operator knows about how you run does not leave with
-            them.
-          </p>
-        </div>
-      </div>
-    </section>
-
-    <!-- § 07 A team, not a tool -->
+    <!-- Section 07: Where it fits -->
     <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
           class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
           >§ 07</span
-        >
-        <h2
-          class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
-        >
-          A Team, Not A Tool.
-        </h2>
-        <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
-          <p>
-            We are the team behind the worker. We build it for your agency, and we stay accountable
-            for how it runs.
-          </p>
-          <p>
-            The technology moves, and we move with it, because no one has a decade of experience
-            with it yet. We are the team that keeps your business working, and nobody should take on
-            something this new alone.
-          </p>
-        </div>
-      </div>
-    </section>
-
-    <!-- § 08 Where it fits -->
-    <section class="bg-white px-6 py-24">
-      <div class="mx-auto max-w-5xl">
-        <span
-          class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
-          >§ 08</span
         >
         <h2
           class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
@@ -307,12 +363,12 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 09 Start the conversation -->
+    <!-- Section 08: Start the conversation -->
     <section class="bg-[color:var(--ss-color-surface-inverse)] px-6 py-24">
       <div class="mx-auto max-w-5xl text-center">
         <span
           class="inline-block bg-[color:var(--ss-color-background)] text-[color:var(--ss-color-text-primary)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-8"
-          >§ 09</span
+          >§ 08</span
         >
         <h2
           class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-white"
@@ -321,12 +377,11 @@ const roleLenses = [
         </h2>
         <p class="mx-auto mb-6 max-w-2xl text-lg text-[color:var(--ss-color-text-muted)]">
           It starts with a conversation. We learn how your agency runs, find the service and renewal
-          work that is eating your team's time, and figure out where a dedicated Operator fits. If
-          it is not a fit, we will tell you.
+          work that is eating your team's time, and start from the pack, customizing it to your
+          agency. If it is not a fit, we will tell you.
         </p>
         <p class="mx-auto mb-10 max-w-2xl text-lg text-[color:var(--ss-color-text-muted)]">
-          Pricing is a flat monthly subscription, scoped to the seat we build together, and we walk
-          through it before any setup begins.
+          {ctaPricingLine}
         </p>
         <CtaButton
           variant="outline-white"

--- a/src/pages/packs/law-firm.astro
+++ b/src/pages/packs/law-firm.astro
@@ -5,13 +5,14 @@ import Base from '../../layouts/Base.astro'
 import Nav from '../../components/Nav.astro'
 import Footer from '../../components/Footer.astro'
 import CtaButton from '../../components/CtaButton.astro'
+import { coldLanderLink, shapeZoneTitles, ctaPricingLine } from '../../lib/operator-packs/shared'
 
 const productSchema = {
   '@context': 'https://schema.org',
   '@type': 'Product',
   name: 'Operator for Law Firms',
   description:
-    'A dedicated Operator that runs intake and keeps your matters moving: it answers the new inquiry, books the consult, chases the engagement letter to signature, keeps your practice-management system current, and nudges the matter that has gone quiet. The law stays with your lawyers; you set the line.',
+    'The Operator is a worker you hire, not software you buy. The law-firm pack is its head start: a starting point shaped around intake and matter coordination, which we configure with you and you customize to your firm. The law stays with your lawyers; you set the line.',
   brand: { '@type': 'Brand', name: 'SMD Services' },
   offers: {
     '@type': 'Offer',
@@ -19,6 +20,46 @@ const productSchema = {
     seller: { '@type': 'Organization', name: 'SMD Services' },
   },
 }
+
+// Section 03: the starting templates in the pack, grouped in plain language. Sourced
+// from operator/verticals/law-firm/vertical.yaml (the intake, matter-motion,
+// routine, and proactive skill families). These are templates we configure, not
+// a finished, running product.
+const packTemplates = [
+  {
+    title: 'Intake and conflicts',
+    body: 'A new inquiry captured and routed wherever it lands, the matter details gathered, the conflict check captured and sent to a person to clear, the consult booked.',
+  },
+  {
+    title: 'Keeping matters moving',
+    body: 'The engagement letter chased toward signature, status updates drafted, documents logged as they arrive, the quiet matter nudged, the dates you have authored tracked.',
+  },
+  {
+    title: 'The routine back-and-forth',
+    body: 'The status question that gets the same answer every time, the receipt of a document, the scheduling. Drafts go to a reviewer until you trust a kind of message on its own.',
+  },
+  {
+    title: 'Proactive touches',
+    body: 'The internal matter digest assembled, referral sources thanked, your practice-management system kept in sync.',
+  },
+]
+
+// Section 05: the three customization zones. Titles are shared (shapeZoneTitles); the
+// body under each is law-specific.
+const zones = [
+  {
+    title: shapeZoneTitles.prebuilt,
+    body: 'The starting templates above, shaped around an intake and matter desk and ready to configure. You are not building from a blank page.',
+  },
+  {
+    title: shapeZoneTitles.connected,
+    body: 'Wired into your own accounts: Clio, your email and calendar, your documents. It works inside the tools you already run.',
+  },
+  {
+    title: shapeZoneTitles.yours,
+    body: 'Your voice, your intake questions, the way you run a matter, and where the line sits. You decide what runs on its own and what waits for a person. You are the expert in your firm; you shape it from there.',
+  },
+]
 
 const roleLenses = [
   {
@@ -38,7 +79,7 @@ const roleLenses = [
 
 <Base
   title="Operator for Law Firms | SMD Services"
-  description="A dedicated Operator that runs intake and keeps your matters moving: it answers the inquiry, books the consult, chases the signed engagement letter, keeps your practice-management system current, and nudges the stalled matter. The law stays with your lawyers. You set the line."
+  description="The law-firm pack is the Operator's head start: a starting point shaped around intake and matter coordination, which we configure with you and you customize to your firm. The law stays with your lawyers. You set the line."
 >
   <Nav />
   <main id="main" role="main">
@@ -59,17 +100,22 @@ const roleLenses = [
           The Intake Desk, Fully Staffed.
         </h1>
         <p
-          class="mx-auto mb-12 max-w-2xl text-xl leading-relaxed text-[color:var(--ss-color-text-secondary)]"
+          class="mx-auto mb-8 max-w-2xl text-xl leading-relaxed text-[color:var(--ss-color-text-secondary)]"
         >
-          A dedicated worker for your firm, in its own office and plugged into the tools you already
-          run. It handles intake and keeps your matters moving the way a sharp legal assistant
-          would: it answers the new inquiry, books the consult, chases the engagement letter to
-          signature, and keeps your practice-management system current. You add capacity at the
-          front of the firm without adding to payroll.
+          The Operator is a worker you hire, not software you buy. This is its law-firm head start:
+          a starting point already shaped around intake and matter coordination, so you are not
+          building from a blank page. You make it yours from there.
         </p>
         <CtaButton href="/book?interest=law-firm" data-ev="law-firm-hero-cta"
           >Start the conversation</CtaButton
         >
+        <p class="mt-8">
+          <a
+            href={coldLanderLink.href}
+            class="font-['Archivo_Narrow'] text-sm font-semibold uppercase tracking-[0.12em] text-[color:var(--ss-color-text-secondary)] underline underline-offset-4 hover:text-[color:var(--ss-color-primary)]"
+            >{coldLanderLink.text} &rarr;</a
+          >
+        </p>
       </div>
     </section>
 
@@ -94,15 +140,15 @@ const roleLenses = [
             get chased are the matter itself, gone.
           </p>
           <p>
-            An Operator fills that seat now. It runs intake at full speed, all the time, and what it
-            learns about how your firm runs, your practice areas, your intake questions, your voice,
-            stays with the firm instead of leaving with the person who had it.
+            An Operator fills that seat. It works at full speed, all the time, and what it learns
+            about how your firm runs, your practice areas, your intake questions, your voice, stays
+            with the firm instead of leaving with the person who had it.
           </p>
         </div>
       </div>
     </section>
 
-    <!-- § 03 A worker, in another office -->
+    <!-- § 03 What the pack starts you with -->
     <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
@@ -110,33 +156,49 @@ const roleLenses = [
           >§ 03</span
         >
         <h2
-          class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
+          class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
         >
-          A Worker, In Another Office.
+          What The Pack Starts You With.
         </h2>
-        <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
-          <p>
-            Picture a legal assistant from the future, sitting at a desk in your firm today. A
-            computer, a phone, and access to the practice-management system, the email, and the
-            calendar you already run. You hand it work the way you hand work to anyone on your team.
-            You send the request, it does the job, and it comes back with the result.
-          </p>
-          <p>
-            It works from its own office, the way much of your team already does. The contract
-            paralegal you have never met in person. The process server you email and trade work with
-            every week. This is one more of those.
-          </p>
-          <p>
-            What it takes on is the work you would want that seat doing, inside the limits you set.
-            The new-client inquiry that lands at seven in the evening and needs an answer before a
-            competing firm sends one. The engagement letter that has sat unsigned for a week. We get
-            to the limits below.
-          </p>
+        <p
+          class="mb-12 max-w-2xl text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]"
+        >
+          You do not start from a blank page. The law-firm pack comes shaped around the work an
+          intake and matter desk runs, as starting templates we configure with you:
+        </p>
+
+        <div
+          class="grid grid-cols-1 md:grid-cols-2 gap-0 border-t-[3px] border-[color:var(--ss-color-text-primary)]"
+        >
+          {
+            packTemplates.map((t, i) => (
+              <div
+                class:list={[
+                  'flex flex-col gap-3 p-8 min-h-[12rem] border-b-[3px] border-[color:var(--ss-color-text-primary)]',
+                  i % 2 !== 1 && 'md:border-r-[3px] md:border-[color:var(--ss-color-text-primary)]',
+                ]}
+              >
+                <p class="font-['Archivo_Narrow'] text-xs font-semibold uppercase tracking-[0.12em] text-[color:var(--ss-color-primary)]">
+                  {t.title}
+                </p>
+                <p class="font-['Archivo'] text-base leading-relaxed text-[color:var(--ss-color-text-secondary)]">
+                  {t.body}
+                </p>
+              </div>
+            ))
+          }
         </div>
+
+        <p
+          class="mt-12 max-w-2xl text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]"
+        >
+          These plug into Clio and your email and calendar. The templates are the head start. How
+          they run is yours to shape.
+        </p>
       </div>
     </section>
 
-    <!-- § 04 What it does -->
+    <!-- § 04 From the start -->
     <section class="bg-white px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
@@ -146,30 +208,25 @@ const roleLenses = [
         <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
         >
-          What It Does.
+          From The Start.
         </h2>
         <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
           <p>
-            We build the Operator for your firm and connect it to the tools you already run: your
-            practice-management system, your email and calendar, your documents.
+            Before it starts, we sit down with you and the people who run intake, and we shape the
+            templates around how your firm actually operates, so it begins ready, not green.
           </p>
           <p>
-            Before it starts, we sit down with you and the people who run intake, and we build it
-            around how your firm operates, so it shows up ready, not green. From there it keeps
-            getting sharper, learning from your team's corrections.
-          </p>
-          <p>
-            A new inquiry lands, wherever it comes from. It captures the details that matter, drafts
-            the first reply in your voice, and offers times for the consult. It chases the
-            engagement letter to signature, answers the routine status questions, logs the documents
-            that arrive, and nudges the matter that has gone quiet. The coordination moves the way
-            it always did, logged in your practice-management system as it happens.
+            From there the work moves the way it always did. A new inquiry comes in and gets a first
+            reply in your voice with times for the consult. The engagement letter gets chased toward
+            signature. The routine status question gets answered, the document that arrives gets
+            logged, the matter that has gone quiet gets a nudge. It is all logged in Clio as it
+            happens, and it keeps getting sharper from your team's corrections.
           </p>
         </div>
       </div>
     </section>
 
-    <!-- § 05 You set the line -->
+    <!-- § 05 Yours to shape -->
     <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
@@ -177,9 +234,52 @@ const roleLenses = [
           >§ 05</span
         >
         <h2
+          class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
+        >
+          Yours To Shape.
+        </h2>
+        <p
+          class="mb-12 max-w-2xl text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]"
+        >
+          We are not the experts in how your firm runs. You are. So the pack is a starting point in
+          three parts, and the third is the biggest.
+        </p>
+
+        <div
+          class="grid grid-cols-1 md:grid-cols-3 gap-0 border-t-[3px] border-[color:var(--ss-color-text-primary)]"
+        >
+          {
+            zones.map((z, i) => (
+              <div
+                class:list={[
+                  'flex flex-col gap-3 p-8 min-h-[14rem] border-b-[3px] border-[color:var(--ss-color-text-primary)]',
+                  i % 3 !== 2 && 'md:border-r-[3px] md:border-[color:var(--ss-color-text-primary)]',
+                ]}
+              >
+                <p class="font-['Archivo_Narrow'] text-xs font-semibold uppercase tracking-[0.12em] text-[color:var(--ss-color-primary)]">
+                  {z.title}
+                </p>
+                <p class="font-['Archivo'] text-base leading-relaxed text-[color:var(--ss-color-text-secondary)]">
+                  {z.body}
+                </p>
+              </div>
+            ))
+          }
+        </div>
+      </div>
+    </section>
+
+    <!-- § 06 The line -->
+    <section class="bg-white px-6 py-24">
+      <div class="mx-auto max-w-5xl">
+        <span
+          class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
+          >§ 06</span
+        >
+        <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
         >
-          You Set The Line.
+          The Line.
         </h2>
         <div
           class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)] mb-12"
@@ -192,18 +292,18 @@ const roleLenses = [
             unlicensed paralegal could not give that advice either.
           </p>
           <p>
-            You govern where that line sits. You decide what the Operator handles on its own and
-            what waits for a person on your team to approve, and you can move that line as you learn
-            what it is good at. A common place to start is conservative: it drafts, and someone on
-            your team approves and sends, until you are ready to let it carry a kind of message
-            itself. It never grants itself more authority, and every action it takes is logged where
+            Some lines are not settings anyone can move. A conflict check is captured and routed to
+            a person to clear; the Operator never clears it itself. Trust balances are read-only: it
+            can report them, and it never moves money. Anything that leaves the firm goes to a
+            reviewer on your team until you decide otherwise. Every action it takes is logged where
             you can see it.
           </p>
           <p>
-            Your client files stay private, including from us. The Operator works in your firm's own
-            walled-off environment, on your own accounts. We watch that it is running and we can see
-            the record of what it did, but the contents of your matters and messages stay yours, and
-            so do the controls: the configuration, the logs, and the off switch.
+            Beyond those floors, you govern where the line sits, and you can move it as you learn
+            what the Operator is good at. Your client files stay private, including from us. The
+            Operator works in your firm's own walled-off environment, on your own accounts. We can
+            see that it is running and the record of what it did, but the contents of your matters
+            and messages stay yours, and so do the configuration, the logs, and the off switch.
           </p>
         </div>
         <div class="text-center">
@@ -216,71 +316,12 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 06 One coordinator, your whole firm -->
-    <section class="bg-white px-6 py-24">
-      <div class="mx-auto max-w-5xl">
-        <span
-          class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
-          >§ 06</span
-        >
-        <h2
-          class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
-        >
-          One Coordinator. Your Whole Firm.
-        </h2>
-        <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
-          <p>
-            One Operator for the whole firm, not a separate assistant for each attorney. Everyone
-            works with the same one, and it gets sharper from everyone's corrections.
-          </p>
-          <p>
-            We are not the experts in how your firm runs. You are. So the Operator runs on your
-            firm's expertise, not ours: your practice areas, your intake questions, the way you run
-            a matter, your voice. We build it ready from what we learn working with you, so it shows
-            up ready, not green, and it keeps getting sharper, learning from your team's corrections
-            and remembering them.
-          </p>
-          <p>
-            What it learns is a record you can read and correct, and it belongs to the firm, not to
-            a person's login. When someone moves on, what the Operator knows about how you run does
-            not leave with them.
-          </p>
-        </div>
-      </div>
-    </section>
-
-    <!-- § 07 A team, not a tool -->
+    <!-- § 07 Where it fits -->
     <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
           class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
           >§ 07</span
-        >
-        <h2
-          class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
-        >
-          A Team, Not A Tool.
-        </h2>
-        <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
-          <p>
-            We are the team behind the worker. We build it for your firm, and we stay accountable
-            for how it runs.
-          </p>
-          <p>
-            The technology moves, and we move with it, because no one has a decade of experience
-            with it yet. We are the team that keeps your business working, and nobody should take on
-            something this new alone.
-          </p>
-        </div>
-      </div>
-    </section>
-
-    <!-- § 08 Where it fits -->
-    <section class="bg-white px-6 py-24">
-      <div class="mx-auto max-w-5xl">
-        <span
-          class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
-          >§ 08</span
         >
         <h2
           class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
@@ -318,12 +359,12 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 09 Start the conversation -->
+    <!-- § 08 Start the conversation -->
     <section class="bg-[color:var(--ss-color-surface-inverse)] px-6 py-24">
       <div class="mx-auto max-w-5xl text-center">
         <span
           class="inline-block bg-[color:var(--ss-color-background)] text-[color:var(--ss-color-text-primary)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-8"
-          >§ 09</span
+          >§ 08</span
         >
         <h2
           class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-white"
@@ -332,12 +373,11 @@ const roleLenses = [
         </h2>
         <p class="mx-auto mb-6 max-w-2xl text-lg text-[color:var(--ss-color-text-muted)]">
           It starts with a conversation. We learn how your firm runs, find the intake and
-          coordination work that is eating your team's time, and figure out where a dedicated
-          Operator fits. If it is not a fit, we will tell you.
+          coordination work that is eating your team's time, and start from the pack, customizing it
+          to your firm. If it is not a fit, we will tell you.
         </p>
         <p class="mx-auto mb-10 max-w-2xl text-lg text-[color:var(--ss-color-text-muted)]">
-          Pricing is a flat monthly subscription, scoped to the seat we build together, and we walk
-          through it before any setup begins.
+          {ctaPricingLine}
         </p>
         <CtaButton
           variant="outline-white"

--- a/src/pages/packs/marketing-agency.astro
+++ b/src/pages/packs/marketing-agency.astro
@@ -5,13 +5,14 @@ import Base from '../../layouts/Base.astro'
 import Nav from '../../components/Nav.astro'
 import Footer from '../../components/Footer.astro'
 import CtaButton from '../../components/CtaButton.astro'
+import { coldLanderLink, shapeZoneTitles, ctaPricingLine } from '../../lib/operator-packs/shared'
 
 const productSchema = {
   '@context': 'https://schema.org',
   '@type': 'Product',
   name: 'Operator for Marketing Agencies',
   description:
-    'A dedicated Operator that keeps the account moving: it chases approvals and assets, sends status, keeps the project on track, and handles the routine client back-and-forth. The creative direction and the client relationship stay with your people; it never speaks for the account or signs off.',
+    'The Operator is a worker you hire, not software you buy. The marketing-agency pack is its head start: a starting point shaped around account coordination, which we configure with you and you customize to your agency. The creative direction and the client relationship stay with your people; you set the line.',
   brand: { '@type': 'Brand', name: 'SMD Services' },
   offers: {
     '@type': 'Offer',
@@ -19,6 +20,46 @@ const productSchema = {
     seller: { '@type': 'Organization', name: 'SMD Services' },
   },
 }
+
+// Section 03: the starting templates in the pack, grouped in plain language. Sourced
+// from operator/verticals/marketing-agency/vertical.yaml (the onboarding-and-status,
+// asset-and-approval, timeline-and-money, and reporting skill families). These are
+// templates we configure, not a finished, running product.
+const packTemplates = [
+  {
+    title: 'Onboarding and status',
+    body: 'The authored onboarding relayed to a new client, the project status kept current, the recurring status update the client expects.',
+  },
+  {
+    title: 'The asset and approval chase',
+    body: 'The approval a deliverable is stuck behind, the asset the client owes, the feedback round that has gone quiet, the authored deliverable routed to the right reviewer.',
+  },
+  {
+    title: 'Timelines and money',
+    body: 'The meeting booked, the milestone date surfaced, the authored timeline change relayed, the invoice followed up on.',
+  },
+  {
+    title: 'Reporting and renewals',
+    body: 'The authored metrics delivered as a report, the authored renewal terms relayed, the internal account digest assembled.',
+  },
+]
+
+// Section 05: the three customization zones. Titles are shared (shapeZoneTitles); the
+// body under each is agency-specific.
+const zones = [
+  {
+    title: shapeZoneTitles.prebuilt,
+    body: 'The starting templates above, shaped around an account desk and ready to configure. You are not building from a blank page.',
+  },
+  {
+    title: shapeZoneTitles.connected,
+    body: 'Wired into your own accounts: your project and client tools, your email and calendar, your documents. It works inside the tools you already run.',
+  },
+  {
+    title: shapeZoneTitles.yours,
+    body: 'Your voice, your clients and your process, and where the line sits. You decide what runs on its own and what waits for a person. You are the expert in your agency; you shape it from there.',
+  },
+]
 
 const roleLenses = [
   {
@@ -38,7 +79,7 @@ const roleLenses = [
 
 <Base
   title="Operator for Marketing Agencies | SMD Services"
-  description="A dedicated Operator that keeps the account moving: chasing approvals and assets, sending status, keeping the project on track, and handling the routine client back-and-forth. The creative direction and the client relationship stay with your people."
+  description="The marketing-agency pack is the Operator's head start: a starting point shaped around account coordination, which we configure with you and you customize to your agency. The creative direction and the client relationship stay with your people. You set the line."
 >
   <Nav />
   <main id="main" role="main">
@@ -59,17 +100,22 @@ const roleLenses = [
           The Account Desk, Fully Staffed.
         </h1>
         <p
-          class="mx-auto mb-12 max-w-2xl text-xl leading-relaxed text-[color:var(--ss-color-text-secondary)]"
+          class="mx-auto mb-8 max-w-2xl text-xl leading-relaxed text-[color:var(--ss-color-text-secondary)]"
         >
-          A dedicated worker for your agency, in its own office and plugged into the tools you
-          already run. It keeps the account moving, the way a sharp account manager would: it chases
-          approvals and assets, sends status, keeps the project on track, and handles the routine
-          client back-and-forth. You add capacity, and your account managers get back the hours they
-          lose to work about work.
+          The Operator is a worker you hire, not software you buy. This is its agency head start: a
+          starting point already shaped around account coordination, so you are not building from a
+          blank page. You make it yours from there.
         </p>
         <CtaButton href="/book?interest=marketing-agency" data-ev="marketing-agency-hero-cta"
           >Start the conversation</CtaButton
         >
+        <p class="mt-8">
+          <a
+            href={coldLanderLink.href}
+            class="font-['Archivo_Narrow'] text-sm font-semibold uppercase tracking-[0.12em] text-[color:var(--ss-color-text-secondary)] underline underline-offset-4 hover:text-[color:var(--ss-color-primary)]"
+            >{coldLanderLink.text} &rarr;</a
+          >
+        </p>
       </div>
     </section>
 
@@ -102,7 +148,7 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 03 A worker, in another office -->
+    <!-- § 03 What the pack starts you with -->
     <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
@@ -110,32 +156,49 @@ const roleLenses = [
           >§ 03</span
         >
         <h2
-          class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
+          class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
         >
-          A Worker, In Another Office.
+          What The Pack Starts You With.
         </h2>
-        <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
-          <p>
-            Picture an account coordinator from the future, sitting at a desk in your agency today.
-            A computer, a phone, and access to the project tools, the email, and the client folders
-            you already run. You hand it work the way you hand work to anyone on your team. You send
-            the request, it does the job, and it comes back with the result.
-          </p>
-          <p>
-            It works from its own office, the way much of your team already does. The project
-            manager you have never met in person. The freelancer you email and hand work to every
-            week. This is one more of those.
-          </p>
-          <p>
-            What it takes on is the work you would want that seat doing, inside the limits you set.
-            The client status update that is a day late. The asset waiting on approval before it can
-            ship. We get to the limits below.
-          </p>
+        <p
+          class="mb-12 max-w-2xl text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]"
+        >
+          You do not start from a blank page. The marketing-agency pack comes shaped around the work
+          an account desk runs, as starting templates we configure with you:
+        </p>
+
+        <div
+          class="grid grid-cols-1 md:grid-cols-2 gap-0 border-t-[3px] border-[color:var(--ss-color-text-primary)]"
+        >
+          {
+            packTemplates.map((t, i) => (
+              <div
+                class:list={[
+                  'flex flex-col gap-3 p-8 min-h-[12rem] border-b-[3px] border-[color:var(--ss-color-text-primary)]',
+                  i % 2 !== 1 && 'md:border-r-[3px] md:border-[color:var(--ss-color-text-primary)]',
+                ]}
+              >
+                <p class="font-['Archivo_Narrow'] text-xs font-semibold uppercase tracking-[0.12em] text-[color:var(--ss-color-primary)]">
+                  {t.title}
+                </p>
+                <p class="font-['Archivo'] text-base leading-relaxed text-[color:var(--ss-color-text-secondary)]">
+                  {t.body}
+                </p>
+              </div>
+            ))
+          }
         </div>
+
+        <p
+          class="mt-12 max-w-2xl text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]"
+        >
+          These plug into your project and client tools and your email and calendar. The templates
+          are the head start. How they run is yours to shape.
+        </p>
       </div>
     </section>
 
-    <!-- § 04 What it does -->
+    <!-- § 04 From the start -->
     <section class="bg-white px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
@@ -145,29 +208,26 @@ const roleLenses = [
         <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
         >
-          What It Does.
+          From The Start.
         </h2>
         <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
           <p>
-            We build the Operator for your agency and connect it to the tools you already run: your
-            project-management system, your email and calendar, your file storage.
+            Before it starts, we sit down with you and the people who run the accounts, and we shape
+            the templates around how your agency actually operates, so it begins ready, not green.
           </p>
           <p>
-            Before it starts, we sit down with you and the people who run the work, and we build it
-            around how you operate, so it shows up ready, not green. From there it keeps getting
-            sharper, learning from your team's corrections.
-          </p>
-          <p>
-            It chases the approvals and assets a deliverable is waiting on, sends the status updates
-            clients expect, keeps the project current, and handles the routine back-and-forth that
-            fills an account manager's day. The work about work moves off your people. Every piece
-            of it is logged in your project-management system as it happens.
+            From there the work moves the way it always did. A deliverable gets chased toward the
+            approval it is stuck behind, the asset a client owes gets a nudge, the status update
+            clients expect goes out in your voice. The routine question gets answered, the milestone
+            date gets surfaced, the invoice that is due gets a follow-up. It is all logged in your
+            project and client tools as it happens, and it keeps getting sharper from your team's
+            corrections.
           </p>
         </div>
       </div>
     </section>
 
-    <!-- § 05 You set the line -->
+    <!-- § 05 Yours to shape -->
     <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
@@ -175,9 +235,52 @@ const roleLenses = [
           >§ 05</span
         >
         <h2
+          class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
+        >
+          Yours To Shape.
+        </h2>
+        <p
+          class="mb-12 max-w-2xl text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]"
+        >
+          We are not the experts in how your agency runs. You are. So the pack is a starting point
+          in three parts, and the third is the biggest.
+        </p>
+
+        <div
+          class="grid grid-cols-1 md:grid-cols-3 gap-0 border-t-[3px] border-[color:var(--ss-color-text-primary)]"
+        >
+          {
+            zones.map((z, i) => (
+              <div
+                class:list={[
+                  'flex flex-col gap-3 p-8 min-h-[14rem] border-b-[3px] border-[color:var(--ss-color-text-primary)]',
+                  i % 3 !== 2 && 'md:border-r-[3px] md:border-[color:var(--ss-color-text-primary)]',
+                ]}
+              >
+                <p class="font-['Archivo_Narrow'] text-xs font-semibold uppercase tracking-[0.12em] text-[color:var(--ss-color-primary)]">
+                  {z.title}
+                </p>
+                <p class="font-['Archivo'] text-base leading-relaxed text-[color:var(--ss-color-text-secondary)]">
+                  {z.body}
+                </p>
+              </div>
+            ))
+          }
+        </div>
+      </div>
+    </section>
+
+    <!-- § 06 The line -->
+    <section class="bg-white px-6 py-24">
+      <div class="mx-auto max-w-5xl">
+        <span
+          class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
+          >§ 06</span
+        >
+        <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
         >
-          You Set The Line.
+          The Line.
         </h2>
         <div
           class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)] mb-12"
@@ -186,15 +289,24 @@ const roleLenses = [
             The Operator keeps the account moving and brings the judgment calls to a person. The
             creative direction, the strategy, the client relationship, anything that speaks for the
             account, those stay with your people. It chases an approval; it does not give one. It
-            drafts the update; it does not decide what the agency commits to. The Operator never
-            speaks for the account or signs off in your name, and it never invents a result or a
-            claim. Those are yours.
+            drafts the update; it does not decide what the agency commits to. There is no license
+            here, but there is a sign-off, and the sign-off is the point: the call about what the
+            agency promises and what it puts its name on belongs to your people.
           </p>
           <p>
-            You govern what it runs on its own. Out of the box, anything that goes to a client goes
-            through a reviewer on your team who sends it under their own name, and you widen what
-            the Operator handles as you learn what it is good at. It never grants itself more
-            authority, and every action it takes is logged where you can see it.
+            Some lines are not settings anyone can move. It delivers only authored deliverables,
+            metrics, and status, and never invents a number, a result, or a claim. No client's
+            information or assets cross into another client's work. It relays the scope, terms, and
+            dates you have authored, and never commits the agency on its own. Anything that leaves
+            the agency goes to a reviewer on your team until you decide otherwise. Every action it
+            takes is logged where you can see it.
+          </p>
+          <p>
+            Beyond those floors, you govern where the line sits, and you can move it as you learn
+            what the Operator is good at. Your client files stay private, including from us. The
+            Operator works in your agency's own walled-off environment, on your own accounts. We can
+            see that it is running and the record of what it did, but the contents of your accounts
+            and messages stay yours, and so do the configuration, the logs, and the off switch.
           </p>
         </div>
         <div class="text-center">
@@ -207,64 +319,12 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 06 One coordinator, your whole agency -->
-    <section class="bg-white px-6 py-24">
-      <div class="mx-auto max-w-5xl">
-        <span
-          class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
-          >§ 06</span
-        >
-        <h2
-          class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
-        >
-          One Coordinator. Your Whole Agency.
-        </h2>
-        <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
-          <p>
-            One Operator for the whole agency, not a separate tool for each account manager.
-            Everyone works with the same one, and it gets sharper from everyone's corrections.
-          </p>
-          <p>
-            What it learns, your clients, your process, your templates, your voice, is a record you
-            can read and correct. It belongs to the agency, not to a person's login. When someone
-            moves on, what the Operator knows about how you run does not leave with them.
-          </p>
-        </div>
-      </div>
-    </section>
-
-    <!-- § 07 A team, not a tool -->
+    <!-- § 07 Where it fits -->
     <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
           class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
           >§ 07</span
-        >
-        <h2
-          class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
-        >
-          A Team, Not A Tool.
-        </h2>
-        <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
-          <p>
-            We are the team behind the worker. We build it for your agency, and we stay accountable
-            for how it runs.
-          </p>
-          <p>
-            The technology moves, and we move with it, because no one has a decade of experience
-            with it yet. We are the team that keeps your business working, and nobody should take on
-            something this new alone.
-          </p>
-        </div>
-      </div>
-    </section>
-
-    <!-- § 08 Where it fits -->
-    <section class="bg-white px-6 py-24">
-      <div class="mx-auto max-w-5xl">
-        <span
-          class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
-          >§ 08</span
         >
         <h2
           class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
@@ -302,12 +362,12 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 09 Start the conversation -->
+    <!-- § 08 Start the conversation -->
     <section class="bg-[color:var(--ss-color-surface-inverse)] px-6 py-24">
       <div class="mx-auto max-w-5xl text-center">
         <span
           class="inline-block bg-[color:var(--ss-color-background)] text-[color:var(--ss-color-text-primary)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-8"
-          >§ 09</span
+          >§ 08</span
         >
         <h2
           class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-white"
@@ -316,12 +376,11 @@ const roleLenses = [
         </h2>
         <p class="mx-auto mb-6 max-w-2xl text-lg text-[color:var(--ss-color-text-muted)]">
           It starts with a conversation. We learn how your agency runs, find the
-          account-coordination work that is eating your team's time, and figure out where a
-          dedicated Operator fits. If it is not a fit, we will tell you.
+          account-coordination work that is eating your team's time, and start from the pack,
+          customizing it to your agency. If it is not a fit, we will tell you.
         </p>
         <p class="mx-auto mb-10 max-w-2xl text-lg text-[color:var(--ss-color-text-muted)]">
-          Pricing is a flat monthly subscription, scoped to the seat we build together, and we walk
-          through it before any setup begins.
+          {ctaPricingLine}
         </p>
         <CtaButton
           variant="outline-white"

--- a/src/pages/packs/med-spa.astro
+++ b/src/pages/packs/med-spa.astro
@@ -5,13 +5,14 @@ import Base from '../../layouts/Base.astro'
 import Nav from '../../components/Nav.astro'
 import Footer from '../../components/Footer.astro'
 import CtaButton from '../../components/CtaButton.astro'
+import { coldLanderLink, shapeZoneTitles, ctaPricingLine } from '../../lib/operator-packs/shared'
 
 const productSchema = {
   '@context': 'https://schema.org',
   '@type': 'Product',
   name: 'Operator for Med Spas',
   description:
-    'A dedicated Operator that runs the front desk: it books and confirms consults and treatments, runs the membership and rebooking cadence, chases the no-show, and handles the routine client back-and-forth. The good-faith exam and the medicine stay with your clinicians; a possible complication routes to a person.',
+    'The Operator is a worker you hire, not software you buy. The med-spa pack is its head start: a starting point shaped around the front desk and booking cadence, which we configure with you and you customize to your practice. The good-faith exam and the medicine stay with your clinicians; you set the line.',
   brand: { '@type': 'Brand', name: 'SMD Services' },
   offers: {
     '@type': 'Offer',
@@ -19,6 +20,46 @@ const productSchema = {
     seller: { '@type': 'Organization', name: 'SMD Services' },
   },
 }
+
+// Section 03: the starting templates in the pack, grouped in plain language. Sourced
+// from operator/verticals/med-spa/vertical.yaml (the leads-and-scheduling, good-faith-
+// exam, membership-care-money, and proactive-and-safety skill families). These are
+// templates we configure, not a finished, running product.
+const packTemplates = [
+  {
+    title: 'Leads and scheduling',
+    body: 'A new lead captured and acknowledged, the consult booked, the appointment reminder and confirmation with the deposit and cancellation policy, the no-show rebooked.',
+  },
+  {
+    title: 'The good-faith exam',
+    body: 'The required exam scheduled before treatment, kept as a gate a person clears, never substituted or cleared by the Operator.',
+  },
+  {
+    title: 'Memberships, care, and money',
+    body: "The membership balance and renewal logistics, the provider's authored pre-care and post-care instructions, the treatment check-in, the financing application logistics.",
+  },
+  {
+    title: 'Proactive and safety',
+    body: 'The review and referral request, the reactivation and win-back outreach, and any possible adverse reaction routed straight to a provider.',
+  },
+]
+
+// Section 05: the three customization zones. Titles are shared (shapeZoneTitles); the
+// body under each is med-spa-specific.
+const zones = [
+  {
+    title: shapeZoneTitles.prebuilt,
+    body: 'The starting templates above, shaped around a front desk and ready to configure. You are not building from a blank page.',
+  },
+  {
+    title: shapeZoneTitles.connected,
+    body: 'Wired into your own accounts: your booking and records system, your email and calendar, your documents. It works inside the tools you already run.',
+  },
+  {
+    title: shapeZoneTitles.yours,
+    body: 'Your voice, your services and your membership, and where the line sits. You decide what runs on its own and what waits for a person. You are the expert in your practice; you shape it from there.',
+  },
+]
 
 const roleLenses = [
   {
@@ -38,7 +79,7 @@ const roleLenses = [
 
 <Base
   title="Operator for Med Spas | SMD Services"
-  description="A dedicated Operator that runs the front desk: booking and confirming consults and treatments, running the membership and rebooking cadence, chasing the no-show, and handling the routine client back-and-forth. The good-faith exam and the medicine stay with your clinicians."
+  description="The med-spa pack is the Operator's head start: a starting point shaped around the front desk and booking cadence, which we configure with you and you customize to your practice. The good-faith exam and the medicine stay with your clinicians. You set the line."
 >
   <Nav />
   <main id="main" role="main">
@@ -59,17 +100,22 @@ const roleLenses = [
           The Front Desk, Fully Staffed.
         </h1>
         <p
-          class="mx-auto mb-12 max-w-2xl text-xl leading-relaxed text-[color:var(--ss-color-text-secondary)]"
+          class="mx-auto mb-8 max-w-2xl text-xl leading-relaxed text-[color:var(--ss-color-text-secondary)]"
         >
-          A dedicated worker for your practice, in its own office and plugged into the tools you
-          already run. It runs the front desk, the way a sharp patient care coordinator would: it
-          books and confirms consults and treatments, runs the membership and rebooking cadence,
-          chases the no-show, and handles the routine client back-and-forth. You add capacity to a
-          seat that turns over hard, without adding to payroll.
+          The Operator is a worker you hire, not software you buy. This is its med-spa head start: a
+          starting point already shaped around the front desk and booking cadence, so you are not
+          building from a blank page. You make it yours from there.
         </p>
         <CtaButton href="/book?interest=med-spa" data-ev="med-spa-hero-cta"
           >Start the conversation</CtaButton
         >
+        <p class="mt-8">
+          <a
+            href={coldLanderLink.href}
+            class="font-['Archivo_Narrow'] text-sm font-semibold uppercase tracking-[0.12em] text-[color:var(--ss-color-text-secondary)] underline underline-offset-4 hover:text-[color:var(--ss-color-primary)]"
+            >{coldLanderLink.text} &rarr;</a
+          >
+        </p>
       </div>
     </section>
 
@@ -101,7 +147,7 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 03 A worker, in another office -->
+    <!-- § 03 What the pack starts you with -->
     <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
@@ -109,32 +155,49 @@ const roleLenses = [
           >§ 03</span
         >
         <h2
-          class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
+          class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
         >
-          A Worker, In Another Office.
+          What The Pack Starts You With.
         </h2>
-        <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
-          <p>
-            Picture a front-desk coordinator from the future, sitting at a desk in your practice
-            today. A computer, a phone, and access to the booking system, the phones, and the
-            membership records you already run. You hand it work the way you hand work to anyone on
-            your team. You send the request, it does the job, and it comes back with the result.
-          </p>
-          <p>
-            It works from its own office, the way much of your team already does. The membership
-            coordinator you have never met in person. The rep you email about product and supplies.
-            This is one more of those.
-          </p>
-          <p>
-            What it takes on is the work you would want that seat doing, inside the limits you set.
-            The consult that needs rebooking. The membership renewal coming due that no one has
-            flagged. We get to the limits below.
-          </p>
+        <p
+          class="mb-12 max-w-2xl text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]"
+        >
+          You do not start from a blank page. The med-spa pack comes shaped around the work a front
+          desk runs, as starting templates we configure with you:
+        </p>
+
+        <div
+          class="grid grid-cols-1 md:grid-cols-2 gap-0 border-t-[3px] border-[color:var(--ss-color-text-primary)]"
+        >
+          {
+            packTemplates.map((t, i) => (
+              <div
+                class:list={[
+                  'flex flex-col gap-3 p-8 min-h-[12rem] border-b-[3px] border-[color:var(--ss-color-text-primary)]',
+                  i % 2 !== 1 && 'md:border-r-[3px] md:border-[color:var(--ss-color-text-primary)]',
+                ]}
+              >
+                <p class="font-['Archivo_Narrow'] text-xs font-semibold uppercase tracking-[0.12em] text-[color:var(--ss-color-primary)]">
+                  {t.title}
+                </p>
+                <p class="font-['Archivo'] text-base leading-relaxed text-[color:var(--ss-color-text-secondary)]">
+                  {t.body}
+                </p>
+              </div>
+            ))
+          }
         </div>
+
+        <p
+          class="mt-12 max-w-2xl text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]"
+        >
+          These plug into your booking and records system and your email and calendar. The templates
+          are the head start. How they run is yours to shape.
+        </p>
       </div>
     </section>
 
-    <!-- § 04 What it does -->
+    <!-- § 04 From the start -->
     <section class="bg-white px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
@@ -144,30 +207,27 @@ const roleLenses = [
         <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
         >
-          What It Does.
+          From The Start.
         </h2>
         <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
           <p>
-            We build the Operator for your practice and connect it to the tools you already run:
-            your practice-management system, your email and calendar.
+            Before it starts, we sit down with you and the people who run the front desk, and we
+            shape the templates around how your practice actually operates, so it begins ready, not
+            green.
           </p>
           <p>
-            Before it starts, we sit down with you and the people who run the work, and we build it
-            around how you operate, so it shows up ready, not green. From there it keeps getting
-            sharper, learning from your team's corrections.
-          </p>
-          <p>
-            It books and confirms consults and treatments, runs the membership and rebooking
-            cadence, chases every no-show, and answers the routine client question in your voice,
-            including the calls that come in after you close. A message that might be a medical
-            concern it hands to a person right away. Every piece of it is logged in your
-            practice-management system as it happens.
+            From there the work moves the way it always did. A consult gets booked and confirmed,
+            the membership and rebooking cadence runs, every no-show gets chased, and the routine
+            client question gets answered in your voice, including the calls that come in after you
+            close. The required exam stays a gate a person clears, and a message that might be a
+            medical concern goes to a person right away. It is all logged in your booking and
+            records system as it happens, and it keeps getting sharper from your team's corrections.
           </p>
         </div>
       </div>
     </section>
 
-    <!-- § 05 You set the line -->
+    <!-- § 05 Yours to shape -->
     <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
@@ -175,9 +235,52 @@ const roleLenses = [
           >§ 05</span
         >
         <h2
+          class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
+        >
+          Yours To Shape.
+        </h2>
+        <p
+          class="mb-12 max-w-2xl text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]"
+        >
+          We are not the experts in how your practice runs. You are. So the pack is a starting point
+          in three parts, and the third is the biggest.
+        </p>
+
+        <div
+          class="grid grid-cols-1 md:grid-cols-3 gap-0 border-t-[3px] border-[color:var(--ss-color-text-primary)]"
+        >
+          {
+            zones.map((z, i) => (
+              <div
+                class:list={[
+                  'flex flex-col gap-3 p-8 min-h-[14rem] border-b-[3px] border-[color:var(--ss-color-text-primary)]',
+                  i % 3 !== 2 && 'md:border-r-[3px] md:border-[color:var(--ss-color-text-primary)]',
+                ]}
+              >
+                <p class="font-['Archivo_Narrow'] text-xs font-semibold uppercase tracking-[0.12em] text-[color:var(--ss-color-primary)]">
+                  {z.title}
+                </p>
+                <p class="font-['Archivo'] text-base leading-relaxed text-[color:var(--ss-color-text-secondary)]">
+                  {z.body}
+                </p>
+              </div>
+            ))
+          }
+        </div>
+      </div>
+    </section>
+
+    <!-- § 06 The line -->
+    <section class="bg-white px-6 py-24">
+      <div class="mx-auto max-w-5xl">
+        <span
+          class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
+          >§ 06</span
+        >
+        <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
         >
-          You Set The Line.
+          The Line.
         </h2>
         <div
           class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)] mb-12"
@@ -185,18 +288,27 @@ const roleLenses = [
           <p>
             The Operator runs the front desk and brings the medicine to a person. The good-faith
             exam, what treatment is appropriate, the dose, those stay with your medical director and
-            your injectors. Not because the software could not book an appointment, but because
-            medical aesthetics takes a licensed clinician who has examined the patient, and a
-            trained but unlicensed coordinator could not make those calls either.
+            your injectors. Not because the software could not book an appointment, but because the
+            license is the point: medical aesthetics takes a licensed clinician who has examined the
+            patient, and a trained but unlicensed coordinator could not make those calls either.
           </p>
           <p>
-            One line is not a setting anyone can move: a message that might be a complication or an
-            adverse reaction goes straight to a person at your practice, right then, never handled
-            later and never answered with clinical content. Everywhere else, you govern what the
-            Operator runs on its own. Out of the box the clinical calls wait for a clinician, and
-            every outbound message goes through a reviewer on your team who sends it under their own
-            name. It never grants itself more authority, and every action it takes is logged where
-            you can see it.
+            Some lines are not settings anyone can move. It does the connective coordination and
+            never offers a recommendation or a clinical opinion. It schedules the required
+            good-faith exam and never substitutes or clears a client for treatment. Pre-care and
+            post-care convey only the provider's authored instructions. A message that might be an
+            adverse reaction goes to a provider immediately, never handled later and never answered
+            with clinical content. Protected health information stays inside your practice's
+            surfaces, and anything that leaves the practice goes to a reviewer on your team until
+            you decide otherwise. Every action it takes is logged where you can see it.
+          </p>
+          <p>
+            Beyond those floors, you govern where the line sits, and you can move it as you learn
+            what the Operator is good at. Your client records stay private, including from us. The
+            Operator works in your practice's own walled-off environment, on your own accounts. We
+            can see that it is running and the record of what it did, but the contents of your
+            records and messages stay yours, and so do the configuration, the logs, and the off
+            switch.
           </p>
         </div>
         <div class="text-center">
@@ -207,66 +319,12 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 06 One coordinator, your whole practice -->
-    <section class="bg-white px-6 py-24">
-      <div class="mx-auto max-w-5xl">
-        <span
-          class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
-          >§ 06</span
-        >
-        <h2
-          class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
-        >
-          One Coordinator. Your Whole Practice.
-        </h2>
-        <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
-          <p>
-            One Operator for the whole practice, not a separate tool for each provider or each
-            location. Everyone works with the same one, and it gets sharper from everyone's
-            corrections.
-          </p>
-          <p>
-            What it learns, your services, your membership, your booking rules, your voice, is a
-            record you can read and correct. It belongs to the practice, not to a person's login.
-            When someone moves on, what the Operator knows about how you run does not leave with
-            them.
-          </p>
-        </div>
-      </div>
-    </section>
-
-    <!-- § 07 A team, not a tool -->
+    <!-- § 07 Where it fits -->
     <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
           class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
           >§ 07</span
-        >
-        <h2
-          class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
-        >
-          A Team, Not A Tool.
-        </h2>
-        <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
-          <p>
-            We are the team behind the worker. We build it for your practice, and we stay
-            accountable for how it runs.
-          </p>
-          <p>
-            The technology moves, and we move with it, because no one has a decade of experience
-            with it yet. We are the team that keeps your business working, and nobody should take on
-            something this new alone.
-          </p>
-        </div>
-      </div>
-    </section>
-
-    <!-- § 08 Where it fits -->
-    <section class="bg-white px-6 py-24">
-      <div class="mx-auto max-w-5xl">
-        <span
-          class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
-          >§ 08</span
         >
         <h2
           class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
@@ -304,12 +362,12 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 09 Start the conversation -->
+    <!-- § 08 Start the conversation -->
     <section class="bg-[color:var(--ss-color-surface-inverse)] px-6 py-24">
       <div class="mx-auto max-w-5xl text-center">
         <span
           class="inline-block bg-[color:var(--ss-color-background)] text-[color:var(--ss-color-text-primary)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-8"
-          >§ 09</span
+          >§ 08</span
         >
         <h2
           class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-white"
@@ -318,12 +376,11 @@ const roleLenses = [
         </h2>
         <p class="mx-auto mb-6 max-w-2xl text-lg text-[color:var(--ss-color-text-muted)]">
           It starts with a conversation. We learn how your practice runs, find the front-desk work
-          that is eating your team's day, and figure out where a dedicated Operator fits. If it is
-          not a fit, we will tell you.
+          that is eating your team's day, and start from the pack, customizing it to your practice.
+          If it is not a fit, we will tell you.
         </p>
         <p class="mx-auto mb-10 max-w-2xl text-lg text-[color:var(--ss-color-text-muted)]">
-          Pricing is a flat monthly subscription, scoped to the seat we build together, and we walk
-          through it before any setup begins.
+          {ctaPricingLine}
         </p>
         <CtaButton variant="outline-white" href="/book?interest=med-spa" data-ev="med-spa-final-cta"
           >Start the conversation</CtaButton

--- a/src/pages/packs/mortgage.astro
+++ b/src/pages/packs/mortgage.astro
@@ -5,13 +5,14 @@ import Base from '../../layouts/Base.astro'
 import Nav from '../../components/Nav.astro'
 import Footer from '../../components/Footer.astro'
 import CtaButton from '../../components/CtaButton.astro'
+import { coldLanderLink, shapeZoneTitles, ctaPricingLine } from '../../lib/operator-packs/shared'
 
 const productSchema = {
   '@context': 'https://schema.org',
   '@type': 'Product',
   name: 'Operator for Mortgage Brokers',
   description:
-    'A dedicated Operator that keeps the pipeline moving: it collects the borrower conditions, keeps every party current, works the condition chain toward clear-to-close, and keeps the loan-origination system current. The loan calls and the money stay with your MLO; one money-and-wire line never moves.',
+    'The Operator is a worker you hire, not software you buy. The mortgage pack is its head start: a starting point shaped around processing and condition coordination, which we configure with you and you customize to your shop. The loan calls and the money stay with your MLO; you set the line.',
   brand: { '@type': 'Brand', name: 'SMD Services' },
   offers: {
     '@type': 'Offer',
@@ -19,6 +20,46 @@ const productSchema = {
     seller: { '@type': 'Organization', name: 'SMD Services' },
   },
 }
+
+// Section 03: the starting templates in the pack, grouped in plain language. Sourced
+// from operator/verticals/mortgage/vertical.yaml (the application-and-conditions,
+// services-and-verifications, status-and-closing, and wire-safety skill families).
+// These are templates we configure, not a finished, running product.
+const packTemplates = [
+  {
+    title: 'Application and conditions',
+    body: 'A new application routed to a licensed loan officer, the underwriting conditions chased, the borrower documents collected and tracked as they arrive.',
+  },
+  {
+    title: 'Services and verifications',
+    body: 'The appraisal order tracked, the title order coordinated, the verifications of employment and deposit requested and logged.',
+  },
+  {
+    title: 'Status, dates, and closing',
+    body: 'The borrower kept current, the agent and loan officer kept current, the file dates surfaced, the closing logistics coordinated, the post-closing follow-up sent.',
+  },
+  {
+    title: 'Wire safety and the pipeline',
+    body: 'Any wire or banking message routed to a verified person, the internal pipeline digest assembled, your loan-origination system kept in sync.',
+  },
+]
+
+// Section 05: the three customization zones. Titles are shared (shapeZoneTitles); the
+// body under each is mortgage-specific.
+const zones = [
+  {
+    title: shapeZoneTitles.prebuilt,
+    body: 'The starting templates above, shaped around a processing desk and ready to configure. You are not building from a blank page.',
+  },
+  {
+    title: shapeZoneTitles.connected,
+    body: 'Wired into your own accounts: your loan-origination system, your email and calendar, your documents. It works inside the tools you already run.',
+  },
+  {
+    title: shapeZoneTitles.yours,
+    body: 'Your voice, your investors and your conditions, and where the line sits. You decide what runs on its own and what waits for a person. You are the expert in your shop; you shape it from there.',
+  },
+]
 
 const roleLenses = [
   {
@@ -38,7 +79,7 @@ const roleLenses = [
 
 <Base
   title="Operator for Mortgage Brokers | SMD Services"
-  description="A dedicated Operator that keeps the pipeline moving: collecting borrower conditions, keeping every party current, working the condition chain toward clear-to-close, and keeping the loan-origination system current. The loan calls and the money stay with your MLO."
+  description="The mortgage pack is the Operator's head start: a starting point shaped around processing and condition coordination, which we configure with you and you customize to your shop. The loan calls and the money stay with your MLO. You set the line."
 >
   <Nav />
   <main id="main" role="main">
@@ -59,17 +100,22 @@ const roleLenses = [
           The Processing Desk, Fully Staffed.
         </h1>
         <p
-          class="mx-auto mb-12 max-w-2xl text-xl leading-relaxed text-[color:var(--ss-color-text-secondary)]"
+          class="mx-auto mb-8 max-w-2xl text-xl leading-relaxed text-[color:var(--ss-color-text-secondary)]"
         >
-          A dedicated worker for your shop, in its own office and plugged into the tools you already
-          run. It keeps the pipeline moving, the way a sharp loan-officer assistant would: it
-          collects the borrower conditions, keeps every party current, works the condition chain
-          toward clear-to-close, and keeps your loan-origination system current. You add capacity
-          without the hire-fast, fire-fast cycle.
+          The Operator is a worker you hire, not software you buy. This is its mortgage head start:
+          a starting point already shaped around processing and condition coordination, so you are
+          not building from a blank page. You make it yours from there.
         </p>
         <CtaButton href="/book?interest=mortgage" data-ev="mortgage-hero-cta"
           >Start the conversation</CtaButton
         >
+        <p class="mt-8">
+          <a
+            href={coldLanderLink.href}
+            class="font-['Archivo_Narrow'] text-sm font-semibold uppercase tracking-[0.12em] text-[color:var(--ss-color-text-secondary)] underline underline-offset-4 hover:text-[color:var(--ss-color-primary)]"
+            >{coldLanderLink.text} &rarr;</a
+          >
+        </p>
       </div>
     </section>
 
@@ -102,7 +148,7 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 03 A worker, in another office -->
+    <!-- § 03 What the pack starts you with -->
     <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
@@ -110,32 +156,49 @@ const roleLenses = [
           >§ 03</span
         >
         <h2
-          class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
+          class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
         >
-          A Worker, In Another Office.
+          What The Pack Starts You With.
         </h2>
-        <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
-          <p>
-            Picture a loan processor from the future, sitting at a desk in your shop today. A
-            computer, a phone, and access to the loan-origination system, the email, and the
-            document portal you already run. You hand it work the way you hand work to anyone on
-            your team. You send the request, it does the job, and it comes back with the result.
-          </p>
-          <p>
-            It works from its own office, the way much of your team already does. The processor you
-            have never met in person. The title rep you email and trade files with. This is one more
-            of those.
-          </p>
-          <p>
-            What it takes on is the work you would want that seat doing, inside the limits you set.
-            The condition that is holding up the file. The borrower document that has not come back
-            before the rate lock expires. We get to the limits below.
-          </p>
+        <p
+          class="mb-12 max-w-2xl text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]"
+        >
+          You do not start from a blank page. The mortgage pack comes shaped around the work a
+          processing desk runs, as starting templates we configure with you:
+        </p>
+
+        <div
+          class="grid grid-cols-1 md:grid-cols-2 gap-0 border-t-[3px] border-[color:var(--ss-color-text-primary)]"
+        >
+          {
+            packTemplates.map((t, i) => (
+              <div
+                class:list={[
+                  'flex flex-col gap-3 p-8 min-h-[12rem] border-b-[3px] border-[color:var(--ss-color-text-primary)]',
+                  i % 2 !== 1 && 'md:border-r-[3px] md:border-[color:var(--ss-color-text-primary)]',
+                ]}
+              >
+                <p class="font-['Archivo_Narrow'] text-xs font-semibold uppercase tracking-[0.12em] text-[color:var(--ss-color-primary)]">
+                  {t.title}
+                </p>
+                <p class="font-['Archivo'] text-base leading-relaxed text-[color:var(--ss-color-text-secondary)]">
+                  {t.body}
+                </p>
+              </div>
+            ))
+          }
         </div>
+
+        <p
+          class="mt-12 max-w-2xl text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]"
+        >
+          These plug into your loan-origination system and your email and calendar. The templates
+          are the head start. How they run is yours to shape.
+        </p>
       </div>
     </section>
 
-    <!-- § 04 What it does -->
+    <!-- § 04 From the start -->
     <section class="bg-white px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
@@ -145,30 +208,26 @@ const roleLenses = [
         <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
         >
-          What It Does.
+          From The Start.
         </h2>
         <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
           <p>
-            We build the Operator for your shop and connect it to the tools you already run: your
-            loan-origination system, your email, your document storage.
+            Before it starts, we sit down with you and the people who run the files, and we shape
+            the templates around how your shop actually operates, so it begins ready, not green.
           </p>
           <p>
-            Before it starts, we sit down with you and the people who run the work, and we build it
-            around how you operate, so it shows up ready, not green. From there it keeps getting
-            sharper, learning from your team's corrections.
-          </p>
-          <p>
-            A file comes in. It collects the borrower conditions, chases the documents the file
-            needs, and works the condition chain so the file keeps moving toward clear-to-close. It
-            keeps the borrower, the agent, and title current at every step, and keeps the
-            loan-origination system current as it goes. Every piece of it is logged there as it
-            happens.
+            From there the work moves the way it always did. A file comes in and gets routed to a
+            licensed loan officer. The conditions get chased, the borrower documents get collected,
+            the appraisal and title orders get tracked. The borrower, the agent, and title get kept
+            current at every step, the file dates get surfaced, and any message that touches a wire
+            goes to a verified person. It is all logged in your loan-origination system as it
+            happens, and it keeps getting sharper from your team's corrections.
           </p>
         </div>
       </div>
     </section>
 
-    <!-- § 05 You set the line -->
+    <!-- § 05 Yours to shape -->
     <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
@@ -176,9 +235,52 @@ const roleLenses = [
           >§ 05</span
         >
         <h2
+          class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
+        >
+          Yours To Shape.
+        </h2>
+        <p
+          class="mb-12 max-w-2xl text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]"
+        >
+          We are not the experts in how your shop runs. You are. So the pack is a starting point in
+          three parts, and the third is the biggest.
+        </p>
+
+        <div
+          class="grid grid-cols-1 md:grid-cols-3 gap-0 border-t-[3px] border-[color:var(--ss-color-text-primary)]"
+        >
+          {
+            zones.map((z, i) => (
+              <div
+                class:list={[
+                  'flex flex-col gap-3 p-8 min-h-[14rem] border-b-[3px] border-[color:var(--ss-color-text-primary)]',
+                  i % 3 !== 2 && 'md:border-r-[3px] md:border-[color:var(--ss-color-text-primary)]',
+                ]}
+              >
+                <p class="font-['Archivo_Narrow'] text-xs font-semibold uppercase tracking-[0.12em] text-[color:var(--ss-color-primary)]">
+                  {z.title}
+                </p>
+                <p class="font-['Archivo'] text-base leading-relaxed text-[color:var(--ss-color-text-secondary)]">
+                  {z.body}
+                </p>
+              </div>
+            ))
+          }
+        </div>
+      </div>
+    </section>
+
+    <!-- § 06 The line -->
+    <section class="bg-white px-6 py-24">
+      <div class="mx-auto max-w-5xl">
+        <span
+          class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
+          >§ 06</span
+        >
+        <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
         >
-          You Set The Line.
+          The Line.
         </h2>
         <div
           class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)] mb-12"
@@ -187,16 +289,23 @@ const roleLenses = [
             The Operator works the file and brings the loan calls and the money to a person. The
             advice, the rate-lock decision, anything that carries an originator's license, those
             stay with your MLO. Not because the software could not fill a field, but because the
-            loan advice carries a license and a duty to the borrower, and an unlicensed assistant
-            could not give it either.
+            license is the point: the loan advice carries a license and a duty to the borrower, and
+            an unlicensed assistant could not give it either.
           </p>
           <p>
-            One line is not a setting anyone can move: the Operator never moves money and never
-            transmits or changes wiring or closing-fund instructions. Any message that touches funds
-            or wire details goes to a verified person through your process. Everywhere else you
-            govern what the Operator runs on its own, every outbound message goes through a reviewer
-            who sends it under their own name, and every action it takes is logged where you can see
-            it.
+            Some lines are not settings anyone can move. It never advises on products, rates, lock,
+            or eligibility, and it never approves, denies, or conditions a loan. It never transmits,
+            confirms, or changes wire instructions; any message that touches funds or wire details
+            goes to a verified person through your process. Non-public borrower information stays
+            inside your shop's surfaces. Anything that leaves the shop goes to a reviewer on your
+            team until you decide otherwise. Every action it takes is logged where you can see it.
+          </p>
+          <p>
+            Beyond those floors, you govern where the line sits, and you can move it as you learn
+            what the Operator is good at. Your borrower files stay private, including from us. The
+            Operator works in your shop's own walled-off environment, on your own accounts. We can
+            see that it is running and the record of what it did, but the contents of your files and
+            messages stay yours, and so do the configuration, the logs, and the off switch.
           </p>
         </div>
         <div class="text-center">
@@ -209,64 +318,12 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 06 One coordinator, your whole shop -->
-    <section class="bg-white px-6 py-24">
-      <div class="mx-auto max-w-5xl">
-        <span
-          class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
-          >§ 06</span
-        >
-        <h2
-          class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
-        >
-          One Coordinator. Your Whole Shop.
-        </h2>
-        <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
-          <p>
-            One Operator for the whole shop, not a separate tool for each loan officer. Everyone
-            works with the same one, and it gets sharper from everyone's corrections.
-          </p>
-          <p>
-            What it learns, your investors, your conditions, the way you run a file, your voice, is
-            a record you can read and correct. It belongs to the shop, not to a person's login. When
-            someone moves on, what the Operator knows about how you run does not leave with them.
-          </p>
-        </div>
-      </div>
-    </section>
-
-    <!-- § 07 A team, not a tool -->
+    <!-- § 07 Where it fits -->
     <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
           class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
           >§ 07</span
-        >
-        <h2
-          class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
-        >
-          A Team, Not A Tool.
-        </h2>
-        <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
-          <p>
-            We are the team behind the worker. We build it for your shop, and we stay accountable
-            for how it runs.
-          </p>
-          <p>
-            The technology moves, and we move with it, because no one has a decade of experience
-            with it yet. We are the team that keeps your business working, and nobody should take on
-            something this new alone.
-          </p>
-        </div>
-      </div>
-    </section>
-
-    <!-- § 08 Where it fits -->
-    <section class="bg-white px-6 py-24">
-      <div class="mx-auto max-w-5xl">
-        <span
-          class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
-          >§ 08</span
         >
         <h2
           class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
@@ -304,12 +361,12 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 09 Start the conversation -->
+    <!-- § 08 Start the conversation -->
     <section class="bg-[color:var(--ss-color-surface-inverse)] px-6 py-24">
       <div class="mx-auto max-w-5xl text-center">
         <span
           class="inline-block bg-[color:var(--ss-color-background)] text-[color:var(--ss-color-text-primary)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-8"
-          >§ 09</span
+          >§ 08</span
         >
         <h2
           class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-white"
@@ -318,12 +375,11 @@ const roleLenses = [
         </h2>
         <p class="mx-auto mb-6 max-w-2xl text-lg text-[color:var(--ss-color-text-muted)]">
           It starts with a conversation. We learn how your shop runs, find the processing and
-          coordination work that is eating your team's time, and figure out where a dedicated
-          Operator fits. If it is not a fit, we will tell you.
+          coordination work that is eating your team's time, and start from the pack, customizing it
+          to your shop. If it is not a fit, we will tell you.
         </p>
         <p class="mx-auto mb-10 max-w-2xl text-lg text-[color:var(--ss-color-text-muted)]">
-          Pricing is a flat monthly subscription, scoped to the seat we build together, and we walk
-          through it before any setup begins.
+          {ctaPricingLine}
         </p>
         <CtaButton
           variant="outline-white"

--- a/src/pages/packs/property-management.astro
+++ b/src/pages/packs/property-management.astro
@@ -5,13 +5,14 @@ import Base from '../../layouts/Base.astro'
 import Nav from '../../components/Nav.astro'
 import Footer from '../../components/Footer.astro'
 import CtaButton from '../../components/CtaButton.astro'
+import { coldLanderLink, shapeZoneTitles, ctaPricingLine } from '../../lib/operator-packs/shared'
 
 const productSchema = {
   '@context': 'https://schema.org',
   '@type': 'Product',
   name: 'Operator for Property Managers',
   description:
-    'A dedicated Operator that runs resident and owner coordination: it intakes the work order, coordinates the maintenance, runs the lease-renewal cadence, fields routine resident and owner questions, and keeps your management system current. The legal and money calls stay with your people; a real emergency routes to a person.',
+    'The Operator is a worker you hire, not software you buy. The property-management pack is its head start: a starting point shaped around resident and owner coordination, which we configure with you and you customize to your company. The legal and money calls stay with your people; a real emergency routes to a person.',
   brand: { '@type': 'Brand', name: 'SMD Services' },
   offers: {
     '@type': 'Offer',
@@ -19,6 +20,46 @@ const productSchema = {
     seller: { '@type': 'Organization', name: 'SMD Services' },
   },
 }
+
+// Section 03: the starting templates in the pack, grouped in plain language. Sourced
+// from operator/verticals/property-management/vertical.yaml (the leasing, maintenance,
+// residency, and owner skill families). These are templates we configure, not a
+// finished, running product.
+const packTemplates = [
+  {
+    title: 'Leasing',
+    body: 'A leasing inquiry captured under the same criteria for everyone, the tour scheduled, the application status routed to screening for the decision.',
+  },
+  {
+    title: 'Maintenance',
+    body: 'A work order intake, a routine fix dispatched to a vendor, and a habitability emergency routed straight to a person, never handled later.',
+  },
+  {
+    title: 'Residency and owners',
+    body: 'The rent reminder under your authored delinquency process, the lease-renewal outreach with authored terms, the move logistics, the owner report delivery, the resident status reply.',
+  },
+  {
+    title: 'Proactive',
+    body: 'A vendor coordinated for the work, inbound routed to the right desk, the internal digest assembled.',
+  },
+]
+
+// Section 05: the three customization zones. Titles are shared (shapeZoneTitles); the
+// body under each is property-management-specific.
+const zones = [
+  {
+    title: shapeZoneTitles.prebuilt,
+    body: 'The starting templates above, shaped around a leasing and tenant-coordination desk and ready to configure. You are not building from a blank page.',
+  },
+  {
+    title: shapeZoneTitles.connected,
+    body: 'Wired into your own accounts: your property-management system, your email and calendar, your documents. It works inside the tools you already run.',
+  },
+  {
+    title: shapeZoneTitles.yours,
+    body: 'Your voice, your properties and owners, the way you run a renewal, and where the line sits. You decide what runs on its own and what waits for a person. You are the expert in your company; you shape it from there.',
+  },
+]
 
 const roleLenses = [
   {
@@ -38,13 +79,13 @@ const roleLenses = [
 
 <Base
   title="Operator for Property Managers | SMD Services"
-  description="A dedicated Operator that runs resident and owner coordination: intaking the work order, coordinating maintenance, running the lease-renewal cadence, fielding routine resident and owner questions, and keeping your management system current. The legal and money calls stay with your people."
+  description="The property-management pack is the Operator's head start: a starting point shaped around resident and owner coordination, which we configure with you and you customize to your company. The legal and money calls stay with your people. You set the line."
 >
   <Nav />
   <main id="main" role="main">
     <script is:inline type="application/ld+json" set:html={JSON.stringify(productSchema)} />
 
-    <!-- § 01 Hero -->
+    <!-- Section 01: Hero -->
     <section
       class="relative overflow-hidden bg-[color:var(--ss-color-background)] px-6 pt-24 pb-32"
     >
@@ -59,21 +100,26 @@ const roleLenses = [
           The Coordination Desk, Fully Staffed.
         </h1>
         <p
-          class="mx-auto mb-12 max-w-2xl text-xl leading-relaxed text-[color:var(--ss-color-text-secondary)]"
+          class="mx-auto mb-8 max-w-2xl text-xl leading-relaxed text-[color:var(--ss-color-text-secondary)]"
         >
-          A dedicated worker for your company, in its own office and plugged into the tools you
-          already run. It runs resident and owner coordination the way a sharp property manager
-          would: it intakes the work order, coordinates the maintenance, runs the lease-renewal
-          cadence, fields the routine resident and owner questions, and keeps your management system
-          current. You take on more doors without staffing up for every one.
+          The Operator is a worker you hire, not software you buy. This is its property-management
+          head start: a starting point already shaped around resident and owner coordination, so you
+          are not building from a blank page. You make it yours from there.
         </p>
         <CtaButton href="/book?interest=property-management" data-ev="property-management-hero-cta"
           >Start the conversation</CtaButton
         >
+        <p class="mt-8">
+          <a
+            href={coldLanderLink.href}
+            class="font-['Archivo_Narrow'] text-sm font-semibold uppercase tracking-[0.12em] text-[color:var(--ss-color-text-secondary)] underline underline-offset-4 hover:text-[color:var(--ss-color-primary)]"
+            >{coldLanderLink.text} &rarr;</a
+          >
+        </p>
       </div>
     </section>
 
-    <!-- § 02 The seat the market won't fill -->
+    <!-- Section 02: The seat the market won't fill -->
     <section class="bg-white px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
@@ -102,7 +148,7 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 03 A worker, in another office -->
+    <!-- Section 03: What the pack starts you with -->
     <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
@@ -110,32 +156,49 @@ const roleLenses = [
           >§ 03</span
         >
         <h2
-          class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
+          class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
         >
-          A Worker, In Another Office.
+          What The Pack Starts You With.
         </h2>
-        <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
-          <p>
-            Picture a property coordinator from the future, sitting at a desk in your company today.
-            A computer, a phone, and access to the property-management system, the email, and the
-            maintenance queue you already run. You hand it work the way you hand work to anyone on
-            your team. You send the request, it does the job, and it comes back with the result.
-          </p>
-          <p>
-            It works from its own office, the way much of your team already does. The regional
-            coordinator you have never met in person. The vendor you email and dispatch work to.
-            This is one more of those.
-          </p>
-          <p>
-            What it takes on is the work you would want that seat doing, inside the limits you set.
-            The maintenance request that sits unrouted overnight. The lease renewal coming up in
-            forty-five days. We get to the limits below.
-          </p>
+        <p
+          class="mb-12 max-w-2xl text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]"
+        >
+          You do not start from a blank page. The property-management pack comes shaped around the
+          work a leasing and tenant coordinator runs, as starting templates we configure with you:
+        </p>
+
+        <div
+          class="grid grid-cols-1 md:grid-cols-2 gap-0 border-t-[3px] border-[color:var(--ss-color-text-primary)]"
+        >
+          {
+            packTemplates.map((t, i) => (
+              <div
+                class:list={[
+                  'flex flex-col gap-3 p-8 min-h-[12rem] border-b-[3px] border-[color:var(--ss-color-text-primary)]',
+                  i % 2 !== 1 && 'md:border-r-[3px] md:border-[color:var(--ss-color-text-primary)]',
+                ]}
+              >
+                <p class="font-['Archivo_Narrow'] text-xs font-semibold uppercase tracking-[0.12em] text-[color:var(--ss-color-primary)]">
+                  {t.title}
+                </p>
+                <p class="font-['Archivo'] text-base leading-relaxed text-[color:var(--ss-color-text-secondary)]">
+                  {t.body}
+                </p>
+              </div>
+            ))
+          }
         </div>
+
+        <p
+          class="mt-12 max-w-2xl text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]"
+        >
+          These plug into your property-management system and your email and calendar. The templates
+          are the head start. How they run is yours to shape.
+        </p>
       </div>
     </section>
 
-    <!-- § 04 What it does -->
+    <!-- Section 04: From the start -->
     <section class="bg-white px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
@@ -145,30 +208,27 @@ const roleLenses = [
         <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
         >
-          What It Does.
+          From The Start.
         </h2>
         <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
           <p>
-            We build the Operator for your company and connect it to the tools you already run: your
-            property-management system, your email and calendar.
+            Before it starts, we sit down with you and the people who run the coordination, and we
+            shape the templates around how your company actually operates, so it begins ready, not
+            green.
           </p>
           <p>
-            Before it starts, we sit down with you and the people who run the work, and we build it
-            around how you operate, so it shows up ready, not green. From there it keeps getting
-            sharper, learning from your team's corrections.
-          </p>
-          <p>
-            It intakes the work order and coordinates the routine maintenance, runs the
-            lease-renewal cadence, answers the routine resident and owner question in your voice,
-            and keeps the management system current. The after-hours back-and-forth it handles, and
-            anything that sounds like an emergency it routes to a person right away. Every piece of
-            it is logged in your property-management system as it happens.
+            From there the work moves the way it always did. It intakes the work order and
+            coordinates the routine maintenance, runs the lease-renewal cadence, answers the routine
+            resident and owner question in your voice, and keeps the management system current. The
+            after-hours back-and-forth it handles, and anything that sounds like an emergency it
+            routes to a person right away. It is all logged in your property-management system as it
+            happens, and it keeps getting sharper from your team's corrections.
           </p>
         </div>
       </div>
     </section>
 
-    <!-- § 05 You set the line -->
+    <!-- Section 05: Yours to shape -->
     <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
@@ -176,9 +236,52 @@ const roleLenses = [
           >§ 05</span
         >
         <h2
+          class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
+        >
+          Yours To Shape.
+        </h2>
+        <p
+          class="mb-12 max-w-2xl text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]"
+        >
+          We are not the experts in how your company runs. You are. So the pack is a starting point
+          in three parts, and the third is the biggest.
+        </p>
+
+        <div
+          class="grid grid-cols-1 md:grid-cols-3 gap-0 border-t-[3px] border-[color:var(--ss-color-text-primary)]"
+        >
+          {
+            zones.map((z, i) => (
+              <div
+                class:list={[
+                  'flex flex-col gap-3 p-8 min-h-[14rem] border-b-[3px] border-[color:var(--ss-color-text-primary)]',
+                  i % 3 !== 2 && 'md:border-r-[3px] md:border-[color:var(--ss-color-text-primary)]',
+                ]}
+              >
+                <p class="font-['Archivo_Narrow'] text-xs font-semibold uppercase tracking-[0.12em] text-[color:var(--ss-color-primary)]">
+                  {z.title}
+                </p>
+                <p class="font-['Archivo'] text-base leading-relaxed text-[color:var(--ss-color-text-secondary)]">
+                  {z.body}
+                </p>
+              </div>
+            ))
+          }
+        </div>
+      </div>
+    </section>
+
+    <!-- Section 06: The line -->
+    <section class="bg-white px-6 py-24">
+      <div class="mx-auto max-w-5xl">
+        <span
+          class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
+          >§ 06</span
+        >
+        <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
         >
-          You Set The Line.
+          The Line.
         </h2>
         <div
           class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)] mb-12"
@@ -191,12 +294,21 @@ const roleLenses = [
             accountable for them.
           </p>
           <p>
-            One line is not a setting anyone can move: a call that sounds like a real emergency, no
-            heat in winter, a gas smell, a flood, a burst pipe, goes straight to a person, right
-            then, never queued behind the routine. The routine work orders, the renewal cadence, and
-            the owner questions do not wait on one. Everywhere else you govern what the Operator
-            runs on its own, every outbound message goes through a reviewer who sends it under their
-            own name, and every action it takes is logged where you can see it.
+            Some lines are not settings anyone can move. Every prospect and resident message applies
+            the same criteria for everyone, with no protected-class inference and no steering. The
+            Operator coordinates and routes the application to screening; it never makes or
+            communicates the screening decision. A call that sounds like a habitability emergency,
+            no heat in winter, a gas smell, a flood, goes straight to a person, right then, never
+            queued behind the routine. It follows your authored delinquency process, gives no
+            eviction advice, and never processes rent or deposits. Every action it takes is logged
+            where you can see it.
+          </p>
+          <p>
+            Beyond those floors, you govern where the line sits, and you can move it as you learn
+            what the Operator is good at. Your records stay private, including from us. The Operator
+            works in your company's own walled-off environment, on your own accounts. We can see
+            that it is running and the record of what it did, but the contents of your properties
+            and messages stay yours, and so do the configuration, the logs, and the off switch.
           </p>
         </div>
         <div class="text-center">
@@ -209,65 +321,12 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 06 One coordinator, your whole company -->
-    <section class="bg-white px-6 py-24">
-      <div class="mx-auto max-w-5xl">
-        <span
-          class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
-          >§ 06</span
-        >
-        <h2
-          class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
-        >
-          One Coordinator. Your Whole Company.
-        </h2>
-        <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
-          <p>
-            One Operator for the whole company, not a separate tool for each manager or each
-            property. Everyone works with the same one, and it gets sharper from everyone's
-            corrections.
-          </p>
-          <p>
-            What it learns, your properties, your owners, your routines, your voice, is a record you
-            can read and correct. It belongs to the company, not to a person's login. When someone
-            moves on, what the Operator knows about how you run does not leave with them.
-          </p>
-        </div>
-      </div>
-    </section>
-
-    <!-- § 07 A team, not a tool -->
+    <!-- Section 07: Where it fits -->
     <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
           class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
           >§ 07</span
-        >
-        <h2
-          class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
-        >
-          A Team, Not A Tool.
-        </h2>
-        <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
-          <p>
-            We are the team behind the worker. We build it for your company, and we stay accountable
-            for how it runs.
-          </p>
-          <p>
-            The technology moves, and we move with it, because no one has a decade of experience
-            with it yet. We are the team that keeps your business working, and nobody should take on
-            something this new alone.
-          </p>
-        </div>
-      </div>
-    </section>
-
-    <!-- § 08 Where it fits -->
-    <section class="bg-white px-6 py-24">
-      <div class="mx-auto max-w-5xl">
-        <span
-          class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
-          >§ 08</span
         >
         <h2
           class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
@@ -305,12 +364,12 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 09 Start the conversation -->
+    <!-- Section 08: Start the conversation -->
     <section class="bg-[color:var(--ss-color-surface-inverse)] px-6 py-24">
       <div class="mx-auto max-w-5xl text-center">
         <span
           class="inline-block bg-[color:var(--ss-color-background)] text-[color:var(--ss-color-text-primary)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-8"
-          >§ 09</span
+          >§ 08</span
         >
         <h2
           class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-white"
@@ -319,12 +378,11 @@ const roleLenses = [
         </h2>
         <p class="mx-auto mb-6 max-w-2xl text-lg text-[color:var(--ss-color-text-muted)]">
           It starts with a conversation. We learn how your company runs, find the coordination work
-          that is eating your team's time, and figure out where a dedicated Operator fits. If it is
-          not a fit, we will tell you.
+          that is eating your team's time, and start from the pack, customizing it to your company.
+          If it is not a fit, we will tell you.
         </p>
         <p class="mx-auto mb-10 max-w-2xl text-lg text-[color:var(--ss-color-text-muted)]">
-          Pricing is a flat monthly subscription, scoped to the seat we build together, and we walk
-          through it before any setup begins.
+          {ctaPricingLine}
         </p>
         <CtaButton
           variant="outline-white"

--- a/src/pages/packs/ria.astro
+++ b/src/pages/packs/ria.astro
@@ -5,13 +5,14 @@ import Base from '../../layouts/Base.astro'
 import Nav from '../../components/Nav.astro'
 import Footer from '../../components/Footer.astro'
 import CtaButton from '../../components/CtaButton.astro'
+import { coldLanderLink, shapeZoneTitles, ctaPricingLine } from '../../lib/operator-packs/shared'
 
 const productSchema = {
   '@context': 'https://schema.org',
   '@type': 'Product',
   name: 'Operator for Advisory Firms',
   description:
-    'A dedicated Operator that runs client service and operations at an RIA: it schedules the review, preps the meeting, chases the paperwork, runs the RMD and review cadence, and keeps the CRM current. The advice and the money stay with you; one money-movement line never moves.',
+    'The Operator is a worker you hire, not software you buy. The advisory pack is its head start: a starting point shaped around client service and operations, which we configure with you and you customize to your firm. The advice and the money stay with you; one money-movement line never moves.',
   brand: { '@type': 'Brand', name: 'SMD Services' },
   offers: {
     '@type': 'Offer',
@@ -19,6 +20,46 @@ const productSchema = {
     seller: { '@type': 'Organization', name: 'SMD Services' },
   },
 }
+
+// Section 03: the starting templates in the pack, grouped in plain language. Sourced
+// from operator/verticals/ria/vertical.yaml (the onboarding, money-line, review, and
+// status skill families). These are templates we configure, not a finished, running
+// product.
+const packTemplates = [
+  {
+    title: 'Onboarding and accounts',
+    body: 'The new-client paperwork relayed, the not-in-good-order item chased, the account-maintenance paperwork routed for the change a household needs.',
+  },
+  {
+    title: 'The money line',
+    body: 'A money-movement request gathered and routed to a verified person, and any banking or transfer instruction caught and held for that person to act on.',
+  },
+  {
+    title: 'Reviews and reminders',
+    body: 'The annual review scheduled, the meeting prep assembled from authored materials, the firm-tracked action surfaced, the documents a household owes chased.',
+  },
+  {
+    title: 'Status and proactive',
+    body: 'The routine client status question answered, the billing-fee follow-up drafted, inbound routed to the right desk, the internal digest assembled.',
+  },
+]
+
+// Section 05: the three customization zones. Titles are shared (shapeZoneTitles); the
+// body under each is RIA-specific.
+const zones = [
+  {
+    title: shapeZoneTitles.prebuilt,
+    body: 'The starting templates above, shaped around a client-service and operations desk and ready to configure. You are not building from a blank page.',
+  },
+  {
+    title: shapeZoneTitles.connected,
+    body: 'Wired into your own accounts: your CRM, your email and calendar, your documents. It works inside the tools you already run.',
+  },
+  {
+    title: shapeZoneTitles.yours,
+    body: 'Your voice, your households and cadence, the way you run a review, and where the line sits. You decide what runs on its own and what waits for a person. You are the expert in your firm; you shape it from there.',
+  },
+]
 
 const roleLenses = [
   {
@@ -38,13 +79,13 @@ const roleLenses = [
 
 <Base
   title="Operator for Advisory Firms | SMD Services"
-  description="A dedicated Operator that runs client service and operations at an RIA: scheduling the review, prepping the meeting, chasing paperwork, running the RMD and review cadence, and keeping the CRM current. The advice and the money stay with you."
+  description="The advisory pack is the Operator's head start: a starting point shaped around client service and operations, which we configure with you and you customize to your firm. The advice and the money stay with you. You set the line."
 >
   <Nav />
   <main id="main" role="main">
     <script is:inline type="application/ld+json" set:html={JSON.stringify(productSchema)} />
 
-    <!-- § 01 Hero -->
+    <!-- Section 01: Hero -->
     <section
       class="relative overflow-hidden bg-[color:var(--ss-color-background)] px-6 pt-24 pb-32"
     >
@@ -59,21 +100,26 @@ const roleLenses = [
           The Back Office, Fully Staffed.
         </h1>
         <p
-          class="mx-auto mb-12 max-w-2xl text-xl leading-relaxed text-[color:var(--ss-color-text-secondary)]"
+          class="mx-auto mb-8 max-w-2xl text-xl leading-relaxed text-[color:var(--ss-color-text-secondary)]"
         >
-          A dedicated worker for your firm, in its own office and plugged into the tools you already
-          run. It runs client service and operations the way a sharp client service associate would:
-          it schedules the review, preps the meeting, chases the paperwork, runs the RMD and review
-          cadence, and keeps the CRM current. You add capacity without adding the paraplanner your
-          margins cannot carry yet.
+          The Operator is a worker you hire, not software you buy. This is its advisory head start:
+          a starting point already shaped around client service and operations, so you are not
+          building from a blank page. You make it yours from there.
         </p>
         <CtaButton href="/book?interest=ria" data-ev="ria-hero-cta"
           >Start the conversation</CtaButton
         >
+        <p class="mt-8">
+          <a
+            href={coldLanderLink.href}
+            class="font-['Archivo_Narrow'] text-sm font-semibold uppercase tracking-[0.12em] text-[color:var(--ss-color-text-secondary)] underline underline-offset-4 hover:text-[color:var(--ss-color-primary)]"
+            >{coldLanderLink.text} &rarr;</a
+          >
+        </p>
       </div>
     </section>
 
-    <!-- § 02 The seat the market won't fill -->
+    <!-- Section 02: The seat the market won't fill -->
     <section class="bg-white px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
@@ -102,7 +148,7 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 03 A worker, in another office -->
+    <!-- Section 03: What the pack starts you with -->
     <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
@@ -110,32 +156,49 @@ const roleLenses = [
           >§ 03</span
         >
         <h2
-          class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
+          class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
         >
-          A Worker, In Another Office.
+          What The Pack Starts You With.
         </h2>
-        <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
-          <p>
-            Picture a client-service associate from the future, sitting at a desk in your firm
-            today. A computer, a phone, and access to the CRM, the custodian portals, and the
-            calendar you already run. You hand it work the way you hand work to anyone on your team.
-            You send the request, it does the job, and it comes back with the result.
-          </p>
-          <p>
-            It works from its own office, the way much of your team already does. The operations
-            associate you have never met in person. The custodian rep you email and trade paperwork
-            with. This is one more of those.
-          </p>
-          <p>
-            What it takes on is the work you would want that seat doing, inside the limits you set.
-            The new-account paperwork waiting on a signature. The client email that came in this
-            morning and needs a same-day reply. We get to the limits below.
-          </p>
+        <p
+          class="mb-12 max-w-2xl text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]"
+        >
+          You do not start from a blank page. The advisory pack comes shaped around the work a
+          client-service associate runs, as starting templates we configure with you:
+        </p>
+
+        <div
+          class="grid grid-cols-1 md:grid-cols-2 gap-0 border-t-[3px] border-[color:var(--ss-color-text-primary)]"
+        >
+          {
+            packTemplates.map((t, i) => (
+              <div
+                class:list={[
+                  'flex flex-col gap-3 p-8 min-h-[12rem] border-b-[3px] border-[color:var(--ss-color-text-primary)]',
+                  i % 2 !== 1 && 'md:border-r-[3px] md:border-[color:var(--ss-color-text-primary)]',
+                ]}
+              >
+                <p class="font-['Archivo_Narrow'] text-xs font-semibold uppercase tracking-[0.12em] text-[color:var(--ss-color-primary)]">
+                  {t.title}
+                </p>
+                <p class="font-['Archivo'] text-base leading-relaxed text-[color:var(--ss-color-text-secondary)]">
+                  {t.body}
+                </p>
+              </div>
+            ))
+          }
         </div>
+
+        <p
+          class="mt-12 max-w-2xl text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]"
+        >
+          These plug into your CRM and your email and calendar. The templates are the head start.
+          How they run is yours to shape.
+        </p>
       </div>
     </section>
 
-    <!-- § 04 What it does -->
+    <!-- Section 04: From the start -->
     <section class="bg-white px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
@@ -145,29 +208,26 @@ const roleLenses = [
         <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
         >
-          What It Does.
+          From The Start.
         </h2>
         <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
           <p>
-            We build the Operator for your firm and connect it to the tools you already run: your
-            CRM, your email and calendar, your document storage.
+            Before it starts, we sit down with you and the people who run client service, and we
+            shape the templates around how your firm actually operates, so it begins ready, not
+            green.
           </p>
           <p>
-            Before it starts, we sit down with you and the people who run the work, and we build it
-            around how you operate, so it shows up ready, not green. From there it keeps getting
-            sharper, learning from your team's corrections.
-          </p>
-          <p>
-            It schedules the client review and preps the meeting, chases the paperwork a household
-            owes, runs the RMD and annual-review cadence so nothing is late, and keeps the CRM
-            current instead of living on sticky notes. The routine client back-and-forth it handles
-            in your voice. Every piece of it is logged in your CRM as it happens.
+            From there the work moves the way it always did. It schedules the client review and
+            preps the meeting, chases the paperwork a household owes, runs the RMD and annual-review
+            cadence so nothing is late, and keeps the CRM current instead of living on sticky notes.
+            The routine client back-and-forth it handles in your voice. It is all logged in your CRM
+            as it happens, and it keeps getting sharper from your team's corrections.
           </p>
         </div>
       </div>
     </section>
 
-    <!-- § 05 You set the line -->
+    <!-- Section 05: Yours to shape -->
     <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
@@ -175,9 +235,52 @@ const roleLenses = [
           >§ 05</span
         >
         <h2
+          class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
+        >
+          Yours To Shape.
+        </h2>
+        <p
+          class="mb-12 max-w-2xl text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]"
+        >
+          We are not the experts in how your firm runs. You are. So the pack is a starting point in
+          three parts, and the third is the biggest.
+        </p>
+
+        <div
+          class="grid grid-cols-1 md:grid-cols-3 gap-0 border-t-[3px] border-[color:var(--ss-color-text-primary)]"
+        >
+          {
+            zones.map((z, i) => (
+              <div
+                class:list={[
+                  'flex flex-col gap-3 p-8 min-h-[14rem] border-b-[3px] border-[color:var(--ss-color-text-primary)]',
+                  i % 3 !== 2 && 'md:border-r-[3px] md:border-[color:var(--ss-color-text-primary)]',
+                ]}
+              >
+                <p class="font-['Archivo_Narrow'] text-xs font-semibold uppercase tracking-[0.12em] text-[color:var(--ss-color-primary)]">
+                  {z.title}
+                </p>
+                <p class="font-['Archivo'] text-base leading-relaxed text-[color:var(--ss-color-text-secondary)]">
+                  {z.body}
+                </p>
+              </div>
+            ))
+          }
+        </div>
+      </div>
+    </section>
+
+    <!-- Section 06: The line -->
+    <section class="bg-white px-6 py-24">
+      <div class="mx-auto max-w-5xl">
+        <span
+          class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
+          >§ 06</span
+        >
+        <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
         >
-          You Set The Line.
+          The Line.
         </h2>
         <div
           class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)] mb-12"
@@ -189,12 +292,21 @@ const roleLenses = [
             client, and an unlicensed associate could not give it either.
           </p>
           <p>
-            One line is not a setting anyone can move: the Operator never moves money. It places no
-            trades, initiates no transfers, and changes no account. Any request that touches money
-            or an account change goes to a verified person through your process. Everywhere else you
-            govern what the Operator runs on its own, every outbound message goes through a reviewer
-            who sends it under their own name, and every action it takes is logged where you can see
-            it.
+            Some lines are not settings anyone can move. The Operator does connective work only; it
+            never makes a recommendation or gives an opinion on a holding, an allocation, or a
+            product. It never moves money: it gathers a money-movement request and routes it to a
+            verified person, and any banking or transfer instruction is caught and held for that
+            person to act on. Client non-public information stays inside your firm surfaces, every
+            communication is retained where it can be archived, and review and testimonial asks
+            follow the marketing rule. Every action it takes is logged where you can see it.
+          </p>
+          <p>
+            Beyond those floors, you govern where the line sits, and you can move it as you learn
+            what the Operator is good at. Your client files stay private, including from us. The
+            Operator works in your firm's own walled-off environment, on your own accounts. We can
+            see that it is running and the record of what it did, but the contents of your
+            households and messages stay yours, and so do the configuration, the logs, and the off
+            switch.
           </p>
         </div>
         <div class="text-center">
@@ -205,64 +317,12 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 06 One coordinator, your whole firm -->
-    <section class="bg-white px-6 py-24">
-      <div class="mx-auto max-w-5xl">
-        <span
-          class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
-          >§ 06</span
-        >
-        <h2
-          class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
-        >
-          One Coordinator. Your Whole Firm.
-        </h2>
-        <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
-          <p>
-            One Operator for the whole firm, not a separate tool for each advisor. Everyone works
-            with the same one, and it gets sharper from everyone's corrections.
-          </p>
-          <p>
-            What it learns, your households, your cadence, the way you run a review, your voice, is
-            a record you can read and correct. It belongs to the firm, not to a person's login. When
-            someone moves on, what the Operator knows about how you run does not leave with them.
-          </p>
-        </div>
-      </div>
-    </section>
-
-    <!-- § 07 A team, not a tool -->
+    <!-- Section 07: Where it fits -->
     <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
           class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
           >§ 07</span
-        >
-        <h2
-          class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
-        >
-          A Team, Not A Tool.
-        </h2>
-        <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
-          <p>
-            We are the team behind the worker. We build it for your firm, and we stay accountable
-            for how it runs.
-          </p>
-          <p>
-            The technology moves, and we move with it, because no one has a decade of experience
-            with it yet. We are the team that keeps your business working, and nobody should take on
-            something this new alone.
-          </p>
-        </div>
-      </div>
-    </section>
-
-    <!-- § 08 Where it fits -->
-    <section class="bg-white px-6 py-24">
-      <div class="mx-auto max-w-5xl">
-        <span
-          class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
-          >§ 08</span
         >
         <h2
           class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
@@ -300,12 +360,12 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 09 Start the conversation -->
+    <!-- Section 08: Start the conversation -->
     <section class="bg-[color:var(--ss-color-surface-inverse)] px-6 py-24">
       <div class="mx-auto max-w-5xl text-center">
         <span
           class="inline-block bg-[color:var(--ss-color-background)] text-[color:var(--ss-color-text-primary)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-8"
-          >§ 09</span
+          >§ 08</span
         >
         <h2
           class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-white"
@@ -314,12 +374,11 @@ const roleLenses = [
         </h2>
         <p class="mx-auto mb-6 max-w-2xl text-lg text-[color:var(--ss-color-text-muted)]">
           It starts with a conversation. We learn how your firm runs, find the client-service and
-          operations work that is eating your team's time, and figure out where a dedicated Operator
-          fits. If it is not a fit, we will tell you.
+          operations work that is eating your team's time, and start from the pack, customizing it
+          to your firm. If it is not a fit, we will tell you.
         </p>
         <p class="mx-auto mb-10 max-w-2xl text-lg text-[color:var(--ss-color-text-muted)]">
-          Pricing is a flat monthly subscription, scoped to the seat we build together, and we walk
-          through it before any setup begins.
+          {ctaPricingLine}
         </p>
         <CtaButton variant="outline-white" href="/book?interest=ria" data-ev="ria-final-cta"
           >Start the conversation</CtaButton

--- a/src/pages/packs/title.astro
+++ b/src/pages/packs/title.astro
@@ -5,13 +5,14 @@ import Base from '../../layouts/Base.astro'
 import Nav from '../../components/Nav.astro'
 import Footer from '../../components/Footer.astro'
 import CtaButton from '../../components/CtaButton.astro'
+import { coldLanderLink, shapeZoneTitles, ctaPricingLine } from '../../lib/operator-packs/shared'
 
 const productSchema = {
   '@context': 'https://schema.org',
   '@type': 'Product',
   name: 'Operator for Title & Escrow',
   description:
-    'A dedicated Operator that runs the file from open to recorded: it opens the order, chases payoffs and HOA and survey, keeps every party current at each milestone, coordinates the clear-to-close, and confirms the signing. It never touches funds or wire instructions.',
+    'The Operator is a worker you hire, not software you buy. The title pack is its head start: a starting point shaped around running the file from open to recorded, which we configure with you and you customize to your company. It never touches funds or wire instructions; the legal calls stay with your people.',
   brand: { '@type': 'Brand', name: 'SMD Services' },
   offers: {
     '@type': 'Offer',
@@ -19,6 +20,46 @@ const productSchema = {
     seller: { '@type': 'Organization', name: 'SMD Services' },
   },
 }
+
+// Section 03: the starting templates in the pack, grouped in plain language. Sourced
+// from operator/verticals/title/vertical.yaml (the opening-and-documents, party-loop,
+// closing-and-after, and wire-safety skill families). These are templates we configure,
+// not a finished, running product.
+const packTemplates = [
+  {
+    title: 'Opening and documents',
+    body: "The order captured from the contract, the acknowledgment to the opening party drafted, the file's open items chased: payoffs, HOA estoppel, survey, tax certificates, lender instructions.",
+  },
+  {
+    title: 'The party loop',
+    body: 'Every party kept current at each milestone, the issued commitment delivered with a cover note, the clear-to-close handoff coordinated with the lender, the realtors and the lender looped in.',
+  },
+  {
+    title: 'Closing and after',
+    body: 'The signing scheduled and confirmed with your authored bring-list, the earnest-money receipt logged as the file records it, recording and final-policy issuance tracked and the parties notified.',
+  },
+  {
+    title: 'The wire-safety gate',
+    body: 'Any message that touches wire or banking details recognized and routed to your verified process, with the party told that wire details are confirmed only through your secure channel.',
+  },
+]
+
+// Section 05: the three customization zones. Titles are shared (shapeZoneTitles); the
+// body under each is title-specific.
+const zones = [
+  {
+    title: shapeZoneTitles.prebuilt,
+    body: 'The starting templates above, shaped around a closing-coordination desk and ready to configure. You are not building from a blank page.',
+  },
+  {
+    title: shapeZoneTitles.connected,
+    body: 'Wired into your own accounts: your title-production system, your email and calendar, your documents. It works inside the tools you already run.',
+  },
+  {
+    title: shapeZoneTitles.yours,
+    body: 'Your voice, your parties and workflow and milestones, and where the line sits. You decide what runs on its own and what waits for a person. You are the expert in your company; you shape it from there.',
+  },
+]
 
 const roleLenses = [
   {
@@ -38,7 +79,7 @@ const roleLenses = [
 
 <Base
   title="Operator for Title & Escrow | SMD Services"
-  description="A dedicated Operator that runs the file from open to recorded: opening the order, chasing payoffs and HOA and survey, keeping every party current, coordinating the clear-to-close, and confirming the signing. It never touches funds or wire instructions."
+  description="The title pack is the Operator's head start: a starting point shaped around running the file from open to recorded, which we configure with you and you customize to your company. It never touches funds or wire instructions. You set the line."
 >
   <Nav />
   <main id="main" role="main">
@@ -59,18 +100,23 @@ const roleLenses = [
           The Closing Desk, Fully Staffed.
         </h1>
         <p
-          class="mx-auto mb-12 max-w-2xl text-xl leading-relaxed text-[color:var(--ss-color-text-secondary)]"
+          class="mx-auto mb-8 max-w-2xl text-xl leading-relaxed text-[color:var(--ss-color-text-secondary)]"
         >
-          A dedicated worker for your company, in its own office and plugged into the tools you
-          already run. It runs the file the way a sharp closing coordinator would: it opens the
-          order, chases the payoffs and the HOA and the survey, keeps every party current at each
-          milestone, coordinates the clear-to-close, and confirms the signing. It never touches
-          funds or wire instructions. You add capacity to the closing desk without adding to
-          payroll.
+          The Operator is a worker you hire, not software you buy. This is its title head start: a
+          starting point already shaped around opening the order, chasing the documents, and keeping
+          every party current to close, so you are not building from a blank page. You make it yours
+          from there.
         </p>
         <CtaButton href="/book?interest=title" data-ev="title-hero-cta"
           >Start the conversation</CtaButton
         >
+        <p class="mt-8">
+          <a
+            href={coldLanderLink.href}
+            class="font-['Archivo_Narrow'] text-sm font-semibold uppercase tracking-[0.12em] text-[color:var(--ss-color-text-secondary)] underline underline-offset-4 hover:text-[color:var(--ss-color-primary)]"
+            >{coldLanderLink.text} &rarr;</a
+          >
+        </p>
       </div>
     </section>
 
@@ -101,7 +147,7 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 03 A worker, in another office -->
+    <!-- § 03 What the pack starts you with -->
     <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
@@ -109,32 +155,49 @@ const roleLenses = [
           >§ 03</span
         >
         <h2
-          class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
+          class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
         >
-          A Worker, In Another Office.
+          What The Pack Starts You With.
         </h2>
-        <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
-          <p>
-            Picture a closing coordinator from the future, sitting at a desk in your company today.
-            A computer, a phone, and access to the title-production system, the email, and the
-            document portal you already run. You hand it work the way you hand work to anyone on
-            your team. You send the request, it does the job, and it comes back with the result.
-          </p>
-          <p>
-            It works from its own office, the way much of your team already does. The closer you
-            have never met in person. The lender contact you email and trade files with. This is one
-            more of those.
-          </p>
-          <p>
-            What it takes on is the work you would want that seat doing, inside the limits you set.
-            The commitment that is waiting on a cleared exception. The closing package that needs
-            assembling before the signing. We get to the limits below.
-          </p>
+        <p
+          class="mb-12 max-w-2xl text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]"
+        >
+          You do not start from a blank page. The title pack comes shaped around the work a
+          closing-coordination desk runs, as starting templates we configure with you:
+        </p>
+
+        <div
+          class="grid grid-cols-1 md:grid-cols-2 gap-0 border-t-[3px] border-[color:var(--ss-color-text-primary)]"
+        >
+          {
+            packTemplates.map((t, i) => (
+              <div
+                class:list={[
+                  'flex flex-col gap-3 p-8 min-h-[12rem] border-b-[3px] border-[color:var(--ss-color-text-primary)]',
+                  i % 2 !== 1 && 'md:border-r-[3px] md:border-[color:var(--ss-color-text-primary)]',
+                ]}
+              >
+                <p class="font-['Archivo_Narrow'] text-xs font-semibold uppercase tracking-[0.12em] text-[color:var(--ss-color-primary)]">
+                  {t.title}
+                </p>
+                <p class="font-['Archivo'] text-base leading-relaxed text-[color:var(--ss-color-text-secondary)]">
+                  {t.body}
+                </p>
+              </div>
+            ))
+          }
         </div>
+
+        <p
+          class="mt-12 max-w-2xl text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]"
+        >
+          These plug into your title-production system and your email and calendar. The templates
+          are the head start. How they run is yours to shape.
+        </p>
       </div>
     </section>
 
-    <!-- § 04 What it does -->
+    <!-- § 04 From the start -->
     <section class="bg-white px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
@@ -144,31 +207,27 @@ const roleLenses = [
         <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
         >
-          What It Does.
+          From The Start.
         </h2>
         <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
           <p>
-            We build the Operator for your company and connect it to the systems you already run:
-            your title production system, your email and calendar, your document storage. No escrow
-            or banking system is connected, by design: the Operator never touches funds.
+            Before it starts, we sit down with you and the people who run the file, and we shape the
+            templates around how your company actually operates, so it begins ready, not green.
           </p>
           <p>
-            Before it starts, we sit down with you and the people who run the work, and we build it
-            around how you operate, so it shows up ready, not green. From there it keeps getting
-            sharper, learning from your team's corrections.
-          </p>
-          <p>
-            An order comes in from an agent or a lender. It opens the file, chases the documents the
-            file needs, payoffs, HOA estoppel, survey, tax certificates, lender instructions, and
-            keeps every party current at each milestone. It coordinates the clear-to-close with the
-            lender, schedules and confirms the signing, and tracks recording and the final policy
-            after close. Every piece of it is logged in your title production system as it happens.
+            From there the work moves the way it always did. An order comes in from an agent or a
+            lender. It opens the file, chases the documents the file needs, payoffs, HOA estoppel,
+            survey, tax certificates, lender instructions, and keeps every party current at each
+            milestone. It coordinates the clear-to-close with the lender, schedules and confirms the
+            signing, and tracks recording and the final policy after close. It is all logged in your
+            title-production system as it happens, and it kept getting sharper from your team's
+            corrections.
           </p>
         </div>
       </div>
     </section>
 
-    <!-- § 05 You set the line -->
+    <!-- § 05 Yours to shape -->
     <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
@@ -176,9 +235,52 @@ const roleLenses = [
           >§ 05</span
         >
         <h2
+          class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
+        >
+          Yours To Shape.
+        </h2>
+        <p
+          class="mb-12 max-w-2xl text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]"
+        >
+          We are not the experts in how your company runs. You are. So the pack is a starting point
+          in three parts, and the third is the biggest.
+        </p>
+
+        <div
+          class="grid grid-cols-1 md:grid-cols-3 gap-0 border-t-[3px] border-[color:var(--ss-color-text-primary)]"
+        >
+          {
+            zones.map((z, i) => (
+              <div
+                class:list={[
+                  'flex flex-col gap-3 p-8 min-h-[14rem] border-b-[3px] border-[color:var(--ss-color-text-primary)]',
+                  i % 3 !== 2 && 'md:border-r-[3px] md:border-[color:var(--ss-color-text-primary)]',
+                ]}
+              >
+                <p class="font-['Archivo_Narrow'] text-xs font-semibold uppercase tracking-[0.12em] text-[color:var(--ss-color-primary)]">
+                  {z.title}
+                </p>
+                <p class="font-['Archivo'] text-base leading-relaxed text-[color:var(--ss-color-text-secondary)]">
+                  {z.body}
+                </p>
+              </div>
+            ))
+          }
+        </div>
+      </div>
+    </section>
+
+    <!-- § 06 The line -->
+    <section class="bg-white px-6 py-24">
+      <div class="mx-auto max-w-5xl">
+        <span
+          class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
+          >§ 06</span
+        >
+        <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
         >
-          You Set The Line.
+          The Line.
         </h2>
         <div
           class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)] mb-12"
@@ -191,14 +293,21 @@ const roleLenses = [
             owns them.
           </p>
           <p>
-            One line is not a setting anyone can move: the Operator never transmits, confirms, or
-            changes a wire instruction, ever. Any message that touches wire or banking details goes
+            Some lines are not settings anyone can move. The Operator never transmits, confirms, or
+            changes a wire instruction, ever; any message that touches wire or banking details goes
             straight to your verified process, and the party is told that wire details are confirmed
-            only through your secure channel. Seller impersonation and wire fraud are where the
-            money is lost, and a coordinator that provably never touches funds is safer there than a
-            person working under a deadline. Everywhere else you govern what the Operator runs on
-            its own, every outbound message goes through a reviewer who sends it under their own
-            name, and every action it takes is logged where you can see it.
+            only through your secure channel. It never moves, directs, or confirms disbursement of
+            escrow funds. It gives no opinion on title or the contract. Nonpublic personal
+            information stays inside your company's surfaces, per GLBA and ALTA Best Practices.
+            Anything that leaves the company goes to a reviewer on your team until you decide
+            otherwise. Every action it takes is logged where you can see it.
+          </p>
+          <p>
+            Beyond those floors, you govern where the line sits, and you can move it as you learn
+            what the Operator is good at. Your files stay private, including from us. The Operator
+            works in your company's own walled-off environment, on your own accounts. We can see
+            that it is running and the record of what it did, but the contents of your files and
+            messages stay yours, and so do the configuration, the logs, and the off switch.
           </p>
         </div>
         <div class="text-center">
@@ -209,64 +318,12 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 06 One coordinator, your whole company -->
-    <section class="bg-white px-6 py-24">
-      <div class="mx-auto max-w-5xl">
-        <span
-          class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
-          >§ 06</span
-        >
-        <h2
-          class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
-        >
-          One Coordinator. Your Whole Company.
-        </h2>
-        <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
-          <p>
-            One Operator for the whole company, not a separate tool for each closer. Everyone works
-            with the same one, and it gets sharper from everyone's corrections.
-          </p>
-          <p>
-            What it learns, your parties, your workflow, your milestones, your voice, is a record
-            you can read and correct. It belongs to the company, not to a person's login. When
-            someone moves on, what the Operator knows about how you close does not leave with them.
-          </p>
-        </div>
-      </div>
-    </section>
-
-    <!-- § 07 A team, not a tool -->
+    <!-- § 07 Where it fits -->
     <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
           class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
           >§ 07</span
-        >
-        <h2
-          class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
-        >
-          A Team, Not A Tool.
-        </h2>
-        <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
-          <p>
-            We are the team behind the worker. We build it for your company, and we stay accountable
-            for how it runs.
-          </p>
-          <p>
-            The technology moves, and we move with it, because no one has a decade of experience
-            with it yet. We are the team that keeps your business working, and nobody should take on
-            something this new alone.
-          </p>
-        </div>
-      </div>
-    </section>
-
-    <!-- § 08 Where it fits -->
-    <section class="bg-white px-6 py-24">
-      <div class="mx-auto max-w-5xl">
-        <span
-          class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
-          >§ 08</span
         >
         <h2
           class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
@@ -304,12 +361,12 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 09 Start the conversation -->
+    <!-- § 08 Start the conversation -->
     <section class="bg-[color:var(--ss-color-surface-inverse)] px-6 py-24">
       <div class="mx-auto max-w-5xl text-center">
         <span
           class="inline-block bg-[color:var(--ss-color-background)] text-[color:var(--ss-color-text-primary)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-8"
-          >§ 09</span
+          >§ 08</span
         >
         <h2
           class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-white"
@@ -318,12 +375,11 @@ const roleLenses = [
         </h2>
         <p class="mx-auto mb-6 max-w-2xl text-lg text-[color:var(--ss-color-text-muted)]">
           It starts with a conversation. We learn how your company closes, find the coordination
-          work that is eating your desk's time, and figure out where a dedicated Operator fits. If
-          it is not a fit, we will tell you.
+          work that is eating your desk's time, and start from the pack, customizing it to your
+          company. If it is not a fit, we will tell you.
         </p>
         <p class="mx-auto mb-10 max-w-2xl text-lg text-[color:var(--ss-color-text-muted)]">
-          Pricing is a flat monthly subscription, scoped to the seat we build together, and we walk
-          through it before any setup begins.
+          {ctaPricingLine}
         </p>
         <CtaButton variant="outline-white" href="/book?interest=title" data-ev="title-final-cta"
           >Start the conversation</CtaButton

--- a/src/pages/packs/veterinary.astro
+++ b/src/pages/packs/veterinary.astro
@@ -5,13 +5,14 @@ import Base from '../../layouts/Base.astro'
 import Nav from '../../components/Nav.astro'
 import Footer from '../../components/Footer.astro'
 import CtaButton from '../../components/CtaButton.astro'
+import { coldLanderLink, shapeZoneTitles, ctaPricingLine } from '../../lib/operator-packs/shared'
 
 const productSchema = {
   '@context': 'https://schema.org',
   '@type': 'Product',
   name: 'Operator for Veterinary Clinics',
   description:
-    'A dedicated Operator that runs the front of house: it books and confirms appointments, works the recall list, relays refill requests to the doctor, gets released results to clients, and routes a possible emergency straight to a person. The medicine stays with your doctors; one emergency line never moves.',
+    'The Operator is a worker you hire, not software you buy. The veterinary pack is its head start: a starting point shaped around front-of-house scheduling, recall, and the service desk, which we configure with you and you customize to your practice. The medicine stays with your doctors; one emergency line never moves.',
   brand: { '@type': 'Brand', name: 'SMD Services' },
   offers: {
     '@type': 'Offer',
@@ -19,6 +20,46 @@ const productSchema = {
     seller: { '@type': 'Organization', name: 'SMD Services' },
   },
 }
+
+// Section 03: the starting templates in the pack, grouped in plain language. Sourced
+// from operator/verticals/veterinary/vertical.yaml (the scheduling, recall, service-desk,
+// and safety skill families). These are templates we configure, not a finished, running
+// product.
+const packTemplates = [
+  {
+    title: 'New client and scheduling',
+    body: 'A new client and patient captured, the appointment booked, the reminder and confirmation sent, the no-show rebooked.',
+  },
+  {
+    title: 'The recall engine',
+    body: 'The patients your clinic protocol marks due for wellness care or vaccines surfaced, the recall drafted in your voice, the client who has not been seen in a while reconnected.',
+  },
+  {
+    title: 'The service desk',
+    body: "The refill request routed to the doctor, the doctor's released result conveyed exactly as written, the estimate followed up, boarding booked against recorded vaccine status, the post-visit follow-up carried.",
+  },
+  {
+    title: 'The safety gate',
+    body: 'A message that might be an emergency recognized and routed straight to a person at the clinic, never handled later and never answered with medical content.',
+  },
+]
+
+// Section 05: the three customization zones. Titles are shared (shapeZoneTitles); the
+// body under each is veterinary-specific.
+const zones = [
+  {
+    title: shapeZoneTitles.prebuilt,
+    body: 'The starting templates above, shaped around a front-of-house coordination desk and ready to configure. You are not building from a blank page.',
+  },
+  {
+    title: shapeZoneTitles.connected,
+    body: 'Wired into your own accounts: your practice-management system, your email and calendar, your documents. It works inside the tools you already run.',
+  },
+  {
+    title: shapeZoneTitles.yours,
+    body: 'Your voice, your protocols and schedule, your services, and where the line sits. You decide what runs on its own and what waits for a person. You are the expert in your practice; you shape it from there.',
+  },
+]
 
 const roleLenses = [
   {
@@ -38,7 +79,7 @@ const roleLenses = [
 
 <Base
   title="Operator for Veterinary Clinics | SMD Services"
-  description="A dedicated Operator that runs your front of house: appointments, the recall list, refill requests relayed to the doctor, released results, and a possible emergency routed straight to a person. The medicine stays with your doctors."
+  description="The veterinary pack is the Operator's head start: a starting point shaped around front-of-house scheduling, recall, and the service desk, which we configure with you and you customize to your practice. The medicine stays with your doctors. You set the line."
 >
   <Nav />
   <main id="main" role="main">
@@ -59,17 +100,23 @@ const roleLenses = [
           The Front Desk, Fully Staffed.
         </h1>
         <p
-          class="mx-auto mb-12 max-w-2xl text-xl leading-relaxed text-[color:var(--ss-color-text-secondary)]"
+          class="mx-auto mb-8 max-w-2xl text-xl leading-relaxed text-[color:var(--ss-color-text-secondary)]"
         >
-          A dedicated worker for your practice, in its own office and plugged into the tools you
-          already run. It runs your front of house the way your best CSR would: it books and
-          confirms appointments, works your recall list, relays refill requests to the doctor, gets
-          released results to clients, and routes a possible emergency straight to a person. You add
-          capacity to the front desk without adding to payroll.
+          The Operator is a worker you hire, not software you buy. This is its veterinary head
+          start: a starting point already shaped around booking the appointment, working the recall
+          list, and relaying the service desk, so you are not building from a blank page. You make
+          it yours from there.
         </p>
         <CtaButton href="/book?interest=veterinary" data-ev="veterinary-hero-cta"
           >Start the conversation</CtaButton
         >
+        <p class="mt-8">
+          <a
+            href={coldLanderLink.href}
+            class="font-['Archivo_Narrow'] text-sm font-semibold uppercase tracking-[0.12em] text-[color:var(--ss-color-text-secondary)] underline underline-offset-4 hover:text-[color:var(--ss-color-primary)]"
+            >{coldLanderLink.text} &rarr;</a
+          >
+        </p>
       </div>
     </section>
 
@@ -100,7 +147,7 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 03 A worker, in another office -->
+    <!-- § 03 What the pack starts you with -->
     <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
@@ -108,32 +155,49 @@ const roleLenses = [
           >§ 03</span
         >
         <h2
-          class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
+          class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
         >
-          A Worker, In Another Office.
+          What The Pack Starts You With.
         </h2>
-        <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
-          <p>
-            Picture a front-desk coordinator from the future, sitting at a desk in your practice
-            today. A computer, a phone, and access to the practice-management system, the schedule,
-            and the phones you already run. You hand it work the way you hand work to anyone on your
-            team. You send the request, it does the job, and it comes back with the result.
-          </p>
-          <p>
-            It works from its own office, the way much of your team already does. The practice
-            coordinator you have never met in person. The lab or pharmacy you email every week. This
-            is one more of those.
-          </p>
-          <p>
-            What it takes on is the work you would want that seat doing, inside the limits you set.
-            The client who needs to reschedule a surgery. The vaccine reminder that never goes out.
-            We get to the limits below.
-          </p>
+        <p
+          class="mb-12 max-w-2xl text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]"
+        >
+          You do not start from a blank page. The veterinary pack comes shaped around the work a
+          front-of-house coordination desk runs, as starting templates we configure with you:
+        </p>
+
+        <div
+          class="grid grid-cols-1 md:grid-cols-2 gap-0 border-t-[3px] border-[color:var(--ss-color-text-primary)]"
+        >
+          {
+            packTemplates.map((t, i) => (
+              <div
+                class:list={[
+                  'flex flex-col gap-3 p-8 min-h-[12rem] border-b-[3px] border-[color:var(--ss-color-text-primary)]',
+                  i % 2 !== 1 && 'md:border-r-[3px] md:border-[color:var(--ss-color-text-primary)]',
+                ]}
+              >
+                <p class="font-['Archivo_Narrow'] text-xs font-semibold uppercase tracking-[0.12em] text-[color:var(--ss-color-primary)]">
+                  {t.title}
+                </p>
+                <p class="font-['Archivo'] text-base leading-relaxed text-[color:var(--ss-color-text-secondary)]">
+                  {t.body}
+                </p>
+              </div>
+            ))
+          }
         </div>
+
+        <p
+          class="mt-12 max-w-2xl text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]"
+        >
+          These plug into your practice-management system and your email and calendar. The templates
+          are the head start. How they run is yours to shape.
+        </p>
       </div>
     </section>
 
-    <!-- § 04 What it does -->
+    <!-- § 04 From the start -->
     <section class="bg-white px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
@@ -143,33 +207,28 @@ const roleLenses = [
         <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
         >
-          What It Does.
+          From The Start.
         </h2>
         <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
           <p>
-            We build the Operator for your clinic and connect it to the systems you already run:
-            your practice-management system, your email and calendar, your document storage. It
-            reads the record as results, reminders, and due dates land, so the front desk is working
-            from what is actually in the file.
+            Before it starts, we sit down with you and the people who run the front of house, and we
+            shape the templates around how your practice actually operates, so it begins ready, not
+            green.
           </p>
           <p>
-            Before it starts, we sit down with you and the people who run the work, and we build it
-            around how you operate, so it shows up ready, not green. From there it keeps getting
-            sharper, learning from your team's corrections.
-          </p>
-          <p>
-            A new client reaches out. It captures the client and patient, drafts the reply in your
-            voice, and offers a time. It confirms and rebooks appointments, works your recall list
-            so wellness care does not slip, relays refill requests to the doctor, gets the doctor's
-            released result to the client exactly as written, follows the estimate, and books
-            boarding. A message that might be an emergency it hands to a person immediately. Every
-            piece of it is logged in your practice-management system as it happens.
+            From there the work moves the way it always did. A new client reaches out. It captures
+            the client and patient, drafts the reply in your voice, and offers a time. It confirms
+            and rebooks appointments, works your recall list so wellness care does not slip, relays
+            refill requests to the doctor, gets the doctor's released result to the client exactly
+            as written, follows the estimate, and books boarding. A message that might be an
+            emergency it hands to a person immediately. It is all logged in your practice-management
+            system as it happens, and it kept getting sharper from your team's corrections.
           </p>
         </div>
       </div>
     </section>
 
-    <!-- § 05 You set the line -->
+    <!-- § 05 Yours to shape -->
     <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
@@ -177,9 +236,52 @@ const roleLenses = [
           >§ 05</span
         >
         <h2
+          class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
+        >
+          Yours To Shape.
+        </h2>
+        <p
+          class="mb-12 max-w-2xl text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]"
+        >
+          We are not the experts in how your practice runs. You are. So the pack is a starting point
+          in three parts, and the third is the biggest.
+        </p>
+
+        <div
+          class="grid grid-cols-1 md:grid-cols-3 gap-0 border-t-[3px] border-[color:var(--ss-color-text-primary)]"
+        >
+          {
+            zones.map((z, i) => (
+              <div
+                class:list={[
+                  'flex flex-col gap-3 p-8 min-h-[14rem] border-b-[3px] border-[color:var(--ss-color-text-primary)]',
+                  i % 3 !== 2 && 'md:border-r-[3px] md:border-[color:var(--ss-color-text-primary)]',
+                ]}
+              >
+                <p class="font-['Archivo_Narrow'] text-xs font-semibold uppercase tracking-[0.12em] text-[color:var(--ss-color-primary)]">
+                  {z.title}
+                </p>
+                <p class="font-['Archivo'] text-base leading-relaxed text-[color:var(--ss-color-text-secondary)]">
+                  {z.body}
+                </p>
+              </div>
+            ))
+          }
+        </div>
+      </div>
+    </section>
+
+    <!-- § 06 The line -->
+    <section class="bg-white px-6 py-24">
+      <div class="mx-auto max-w-5xl">
+        <span
+          class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
+          >§ 06</span
+        >
+        <h2
           class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
         >
-          You Set The Line.
+          The Line.
         </h2>
         <div
           class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)] mb-12"
@@ -192,12 +294,21 @@ const roleLenses = [
             examined it, and a trained but unlicensed assistant could not make those calls either.
           </p>
           <p>
-            One line is not a setting anyone can move: a message that might be an emergency goes
-            straight to a person at your clinic, right then, never handled later and never answered
-            with medical content. Everywhere else, you govern what the Operator runs on its own. Out
-            of the box the clinical calls wait for a doctor, and every outbound message goes through
-            a reviewer on your team who sends it under their own name. It never grants itself more
-            authority, and every action it takes is logged where you can see it.
+            Some lines are not settings anyone can move. A message that might be an emergency goes
+            straight to a person at your clinic right then, never handled later and never answered
+            with medical content. It gives no medical advice, no diagnosis, no triage, no
+            interpretation of a result. A refill routes to the doctor; it never authorizes or
+            advises on dosing. Client and patient records stay inside your clinic's own surfaces.
+            Anything that leaves the clinic goes to a reviewer on your team until you decide
+            otherwise. Every action it takes is logged where you can see it.
+          </p>
+          <p>
+            Beyond those floors, you govern where the line sits, and you can move it as you learn
+            what the Operator is good at. Your client and patient files stay private, including from
+            us. The Operator works in your clinic's own walled-off environment, on your own
+            accounts. We can see that it is running and the record of what it did, but the contents
+            of your records and messages stay yours, and so do the configuration, the logs, and the
+            off switch.
           </p>
         </div>
         <div class="text-center">
@@ -210,64 +321,12 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 06 One coordinator, your whole clinic -->
-    <section class="bg-white px-6 py-24">
-      <div class="mx-auto max-w-5xl">
-        <span
-          class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
-          >§ 06</span
-        >
-        <h2
-          class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
-        >
-          One Coordinator. Your Whole Clinic.
-        </h2>
-        <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
-          <p>
-            One Operator for the whole clinic, not a separate tool for each doctor or each station.
-            Everyone works with the same one, and it gets sharper from everyone's corrections.
-          </p>
-          <p>
-            What it learns, your protocols, your schedule, your services, your voice, is a record
-            you can read and correct. It belongs to the clinic, not to a person's login. When
-            someone moves on, what the Operator knows about how you run does not leave with them.
-          </p>
-        </div>
-      </div>
-    </section>
-
-    <!-- § 07 A team, not a tool -->
+    <!-- § 07 Where it fits -->
     <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <span
           class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
           >§ 07</span
-        >
-        <h2
-          class="mb-10 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
-        >
-          A Team, Not A Tool.
-        </h2>
-        <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
-          <p>
-            We are the team behind the worker. We build it for your practice, and we stay
-            accountable for how it runs.
-          </p>
-          <p>
-            The technology moves, and we move with it, because no one has a decade of experience
-            with it yet. We are the team that keeps your business working, and nobody should take on
-            something this new alone.
-          </p>
-        </div>
-      </div>
-    </section>
-
-    <!-- § 08 Where it fits -->
-    <section class="bg-white px-6 py-24">
-      <div class="mx-auto max-w-5xl">
-        <span
-          class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
-          >§ 08</span
         >
         <h2
           class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
@@ -305,12 +364,12 @@ const roleLenses = [
       </div>
     </section>
 
-    <!-- § 09 Start the conversation -->
+    <!-- § 08 Start the conversation -->
     <section class="bg-[color:var(--ss-color-surface-inverse)] px-6 py-24">
       <div class="mx-auto max-w-5xl text-center">
         <span
           class="inline-block bg-[color:var(--ss-color-background)] text-[color:var(--ss-color-text-primary)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-8"
-          >§ 09</span
+          >§ 08</span
         >
         <h2
           class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-white"
@@ -319,12 +378,11 @@ const roleLenses = [
         </h2>
         <p class="mx-auto mb-6 max-w-2xl text-lg text-[color:var(--ss-color-text-muted)]">
           It starts with a conversation. We learn how your clinic runs, find the front-desk work
-          that is eating your team's day, and figure out where a dedicated Operator fits. If it is
-          not a fit, we will tell you.
+          that is eating your team's day, and start from the pack, customizing it to your practice.
+          If it is not a fit, we will tell you.
         </p>
         <p class="mx-auto mb-10 max-w-2xl text-lg text-[color:var(--ss-color-text-muted)]">
-          Pricing is a flat monthly subscription, scoped to the seat we build together, and we walk
-          through it before any setup begins.
+          {ctaPricingLine}
         </p>
         <CtaButton
           variant="outline-white"

--- a/tests/operator-pack-kit-grammar.test.ts
+++ b/tests/operator-pack-kit-grammar.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync, readdirSync } from 'fs'
+import { resolve, join } from 'path'
+
+// The vertical pack pages each have a "What The Pack Starts You With" section
+// driven by a `packTemplates` array. Those entries describe the STARTING
+// TEMPLATES the pack ships with — work the Operator is configured to start
+// from, NOT a finished, running product. The distinction is a truthfulness P0:
+// the pack config is largely aspirational (only Clio is runtime-live, and there
+// are no customers yet), so the kit must read as "templates we configure," never
+// as a delivered capability. This guard enforces that grammar mechanically.
+//
+// Scope: ONLY the `packTemplates` array literal. The role-lens narratives and
+// the day-one section legitimately use the established selling voice
+// ("captures / drafts / chases"); this guard does not touch those.
+
+const packsDir = resolve('src/pages/packs')
+
+// Verbs that assert a finished, running capability. Banned inside packTemplates,
+// where they would turn "a starting template for X" into "it does X today."
+// ("does" is intentionally excluded: it matches benign "does not ..." phrasing.)
+const CAPABILITY_VERBS = /\b(handles|manages|automates)\b/i
+
+function packFiles(): string[] {
+  return readdirSync(packsDir)
+    .filter((n) => n.endsWith('.astro'))
+    .map((n) => join(packsDir, n))
+}
+
+function packTemplatesLiteral(src: string): string | null {
+  const m = src.match(/const packTemplates = \[([\s\S]*?)\n\]/)
+  return m ? m[1] : null
+}
+
+describe('Operator pack kit grammar (truthfulness)', () => {
+  for (const file of packFiles()) {
+    const rel = file.slice(file.indexOf('src/'))
+    const src = readFileSync(file, 'utf-8')
+
+    it(`${rel} frames the kit as starting templates, not a capability`, () => {
+      // The truthful framing must be present on every pack page.
+      expect(src).toContain('starting templates we configure with you')
+    })
+
+    it(`${rel} packTemplates use no finished-capability verbs`, () => {
+      const literal = packTemplatesLiteral(src)
+      expect(literal, 'packTemplates array not found').not.toBeNull()
+      expect(
+        CAPABILITY_VERBS.test(literal as string),
+        `packTemplates binds a finished-capability verb (handles/manages/automates/does) to a template in ${rel}`
+      ).toBe(false)
+    })
+  }
+})


### PR DESCRIPTION
## What

The 12 Operator vertical pages were ~67% verbatim restatement of the `/operator` landing (the page the visitor just clicked from) plus noun-swapped clones of each other — they read as templated, which undercuts the whole "you get a real head start" promise. Rebuilt each into a distinct page that **proves the pre-built starting point for that industry** instead of re-pitching the Operator.

**New 8-section IA:** Hero / The Seat The Market Won't Fill / **What The Pack Starts You With** (NEW) / From The Start / **Yours To Shape** (NEW — three zones: pre-built / connects to your stack / yours) / The Line / Where It Fits / Start The Conversation.

**Removed the two landing-restatement sections** ("A Worker, In Another Office", "A Team, Not A Tool") — they stay on the landing only. A "New to the Operator? See how it works →" link covers direct/SEO landers.

## Why it's genuinely differentiated (not reworded)

Each page's kit (§03) and boundary (§06) are sourced from the real `operator/verticals/<v>/vertical.yaml` — the actual skills and compliance floors:
- law: conflict check routed to a person (never auto-cleared), trust funds read-only
- home-services: gas/fire/flood/no-heat go straight to a person, life-safety to 911
- insurance: never binds/changes/cancels coverage; a certificate always clears a person
- title: never transmits/confirms/changes a wire instruction
- ria: never moves money; a transfer instruction is caught and held

## Truthfulness (P0)

Pack config is largely aspirational (only Clio is runtime-live; zero customers). So the kit is framed as **"starting templates we configure with you,"** never a finished/running product. **No vendor system is named except Clio** (law, the one live integration); all others use generic system-of-record terms. New `tests/operator-pack-kit-grammar.test.ts` enforces the templates-grammar mechanically.

## Process

Plan → `/critique` (caught the Pattern B fabrication risk and an over-engineering call) → law-firm authored by hand as the canonical exemplar → 11 fanned out from real yaml with cited sources → single-threaded P0 read-through. Architecture deliberately minimal: content rebuilt in the existing 12 files (no route refactor), shared frame copy in `src/lib/operator-packs/shared.ts`.

## Verification
- `npm run verify` green: 0 errors, build ✓, all tests.
- Guards: forbidden-strings, landing-page (voice), badge sequence, and the new kit-grammar test all pass.
- Sweep: all 12 packs §01–08 sequential, zero em-dashes, no aspirational vendor names, the re-pitch sections gone (still on the landing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)