### PR TITLE
fix(marketing): cut broken "brings the X to a person" clone from pack §06 openers

### DIFF
--- a/src/pages/packs/home-services.astro
+++ b/src/pages/packs/home-services.astro
@@ -288,10 +288,10 @@ const roleLenses = [
           class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)] mb-12"
         >
           <p>
-            The Operator runs the front office and brings the job calls to a person. What the job
-            needs and what it costs, the diagnosis and the price, those stay with your techs and
-            your owner, who see the work. The Operator books the call and captures the details; it
-            does not quote the job or decide what is wrong.
+            The Operator runs the front office. What the job needs and what it costs, the diagnosis
+            and the price, those stay with your techs and your owner, who see the work. The Operator
+            books the call and captures the details; it does not quote the job or decide what is
+            wrong.
           </p>
           <p>
             Some lines are not settings anyone can move. A call that sounds like a safety emergency,

--- a/src/pages/packs/med-spa.astro
+++ b/src/pages/packs/med-spa.astro
@@ -286,11 +286,11 @@ const roleLenses = [
           class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)] mb-12"
         >
           <p>
-            The Operator runs the front desk and brings the medicine to a person. The good-faith
-            exam, what treatment is appropriate, the dose, those stay with your medical director and
-            your injectors. Not because the software could not book an appointment, but because the
-            license is the point: medical aesthetics takes a licensed clinician who has examined the
-            patient, and a trained but unlicensed coordinator could not make those calls either.
+            The Operator runs the front desk. The good-faith exam, what treatment is appropriate,
+            the dose, those stay with your medical director and your injectors. Not because the
+            software could not book an appointment, but because the license is the point: medical
+            aesthetics takes a licensed clinician who has examined the patient, and a trained but
+            unlicensed coordinator could not make those calls either.
           </p>
           <p>
             Some lines are not settings anyone can move. It does the connective coordination and

--- a/src/pages/packs/mortgage.astro
+++ b/src/pages/packs/mortgage.astro
@@ -286,11 +286,10 @@ const roleLenses = [
           class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)] mb-12"
         >
           <p>
-            The Operator works the file and brings the loan calls and the money to a person. The
-            advice, the rate-lock decision, anything that carries an originator's license, those
-            stay with your MLO. Not because the software could not fill a field, but because the
-            license is the point: the loan advice carries a license and a duty to the borrower, and
-            an unlicensed assistant could not give it either.
+            The Operator works the file. The advice, the rate-lock decision, anything that carries
+            an originator's license, those stay with your MLO. Not because the software could not
+            fill a field, but because the license is the point: the loan advice carries a license
+            and a duty to the borrower, and an unlicensed assistant could not give it either.
           </p>
           <p>
             Some lines are not settings anyone can move. It never advises on products, rates, lock,

--- a/src/pages/packs/property-management.astro
+++ b/src/pages/packs/property-management.astro
@@ -287,11 +287,10 @@ const roleLenses = [
           class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)] mb-12"
         >
           <p>
-            The Operator runs the coordination and brings the calls that carry weight to a person.
-            The legal decisions, an eviction, a fair-housing question, whether a unit is habitable,
-            and the money, those stay with your people. Not because the software could not send a
-            notice, but because those calls carry real liability and belong to a person who is
-            accountable for them.
+            The Operator runs the coordination. The legal decisions, an eviction, a fair-housing
+            question, whether a unit is habitable, and the money, those stay with your people. Not
+            because the software could not send a notice, but because those calls carry real
+            liability and belong to a person who is accountable for them.
           </p>
           <p>
             Some lines are not settings anyone can move. Every prospect and resident message applies

--- a/src/pages/packs/ria.astro
+++ b/src/pages/packs/ria.astro
@@ -286,10 +286,10 @@ const roleLenses = [
           class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)] mb-12"
         >
           <p>
-            The Operator runs client service and brings the advice and the money to you. The advice,
-            the planning, the fiduciary call, those stay with you. Not because the software could
-            not do the math, but because the advice carries your license and your duty to the
-            client, and an unlicensed associate could not give it either.
+            The Operator runs client service. The advice, the planning, the fiduciary call, those
+            stay with you. Not because the software could not do the math, but because the advice
+            carries your license and your duty to the client, and an unlicensed associate could not
+            give it either.
           </p>
           <p>
             Some lines are not settings anyone can move. The Operator does connective work only; it

--- a/src/pages/packs/title.astro
+++ b/src/pages/packs/title.astro
@@ -286,11 +286,10 @@ const roleLenses = [
           class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)] mb-12"
         >
           <p>
-            The Operator moves the file and keeps every party current, and it brings the rest to a
-            person. The money and the legal calls stay with your escrow officer: disbursing funds,
-            the title opinion, the closing figures. Not because the software could not send an
-            email, but because those acts sit under your controls and a licensed, accountable person
-            owns them.
+            The Operator moves the file and keeps every party current. The money and the legal calls
+            stay with your escrow officer: disbursing funds, the title opinion, the closing figures.
+            Not because the software could not send an email, but because those acts sit under your
+            controls and a licensed, accountable person owns them.
           </p>
           <p>
             Some lines are not settings anyone can move. The Operator never transmits, confirms, or

--- a/src/pages/packs/veterinary.astro
+++ b/src/pages/packs/veterinary.astro
@@ -287,11 +287,11 @@ const roleLenses = [
           class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)] mb-12"
         >
           <p>
-            The Operator runs the front of house and brings everything else to a person. The
-            medicine stays with your doctors: the diagnosis, the treatment call, whether a case is
-            urgent, authorizing a refill. Not because the software could not write a careful
-            message, but because medicine on a patient takes a licensed veterinarian who has
-            examined it, and a trained but unlicensed assistant could not make those calls either.
+            The Operator runs the front of house. The medicine stays with your doctors: the
+            diagnosis, the treatment call, whether a case is urgent, authorizing a refill. Not
+            because the software could not write a careful message, but because medicine on a
+            patient takes a licensed veterinarian who has examined it, and a trained but unlicensed
+            assistant could not make those calls either.
           </p>
           <p>
             Some lines are not settings anyone can move. A message that might be an emergency goes


### PR DESCRIPTION
## What
The law-firm exemplar opens "The Line" with "brings the law to a lawyer" — a clean idiom. The fan-out cloned that construction into seven packs where it broke or read oddly:
- med-spa: "brings **the medicine** to a person" (nonsense — caught in spot-check)
- mortgage / ria: "the money"
- title: "the rest" · veterinary: "everything else" · home-services: "the job calls" · property-management: "the calls that carry weight"

Cut the clause on all seven. The next sentence already names who the work belongs to, so the opener now reads naturally, e.g. *"The Operator runs the front desk. The good-faith exam, what treatment is appropriate, the dose, those stay with your medical director and your injectors."*

The sensible uses (law, accounting, dental, marketing-agency, insurance) are unchanged.

## Verification
- 155 marketing guard tests pass (kit-grammar, forbidden-strings, voice, badges).
- Grep confirms no awkward physical-noun "brings" clauses remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)