### PR TITLE
fix(marketing): proofread polish on the Operator landing page

### DIFF
--- a/src/pages/operator.astro
+++ b/src/pages/operator.astro
@@ -38,9 +38,9 @@ const roleLenses = [
 const industries = [
   { name: 'Law firms', seat: 'Intake and matter coordination', slug: 'law-firm' },
   { name: 'Insurance agencies', seat: 'The service and renewal desk', slug: 'insurance' },
-  { name: 'Accounting firms', seat: 'The document chase, through busy season', slug: 'accounting' },
+  { name: 'Accounting firms', seat: 'The document chase through busy season', slug: 'accounting' },
   { name: 'Advisory firms', seat: 'Client service and operations', slug: 'ria' },
-  { name: 'Mortgage brokers', seat: 'The pipeline, to clear-to-close', slug: 'mortgage' },
+  { name: 'Mortgage brokers', seat: 'The pipeline through clear-to-close', slug: 'mortgage' },
   { name: 'Veterinary clinics', seat: 'The front desk', slug: 'veterinary' },
   { name: 'Dental practices', seat: 'The front office', slug: 'dental' },
   { name: 'Med spas', seat: 'Booking, membership, and rebooking', slug: 'med-spa' },
@@ -206,8 +206,8 @@ const industries = [
             works with the same Operator, and it gets sharper from everyone's input.
           </p>
           <p>
-            The understanding it builds, your voice, your work patterns, the situations it has
-            learned to handle, is a record you can read and correct. It belongs to the business, not
+            The understanding it builds (your voice, your work patterns, the situations it has
+            learned to handle) is a record you can read and correct. It belongs to the business, not
             to any one person's account or laptop. When someone moves on, what the Operator knows
             about how you run does not go with them. It stays.
           </p>


### PR DESCRIPTION
## What
Closes the one gap from the proofreading pass: the landing page (`operator.astro`) got the same full read-through the 12 packs got. It came back clean on the serious stuff (no P0s, no voice/overclaim violations, tense correct). Three quality fixes:
- §05: a hard-to-parse double-comma appositive → parenthetical.
- §09 industry grid: the two seats that broke the clean noun-phrase pattern the other ten follow — "The document chase, through busy season" and "The pipeline, to clear-to-close" → tightened.

## Verification
`npm run verify` green; voice/badge/forbidden-strings guards pass; 0 em dashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)