### PR TITLE
fix(security): close code-review issues #833 #834 #835 — parse-don't-cast on KV, LLM, and webhook inputs

### DIFF
--- a/src/lib/auth/admin-session-shim.ts
+++ b/src/lib/auth/admin-session-shim.ts
@@ -33,6 +33,32 @@ interface AdminUserRow {
 }
 
 /**
+ * Parse a KV-cached admin session into SessionData, or null when corrupt
+ * (unparseable or wrong shape). The shim only ever caches role 'admin';
+ * anything else in the cache is treated as corrupt.
+ */
+function parseCachedAdminSession(cached: string): SessionData | null {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(cached)
+  } catch {
+    return null
+  }
+  if (parsed === null || typeof parsed !== 'object') return null
+  const candidate = parsed as Record<string, unknown>
+  if (
+    typeof candidate.userId !== 'string' ||
+    typeof candidate.orgId !== 'string' ||
+    typeof candidate.email !== 'string' ||
+    typeof candidate.expiresAt !== 'string' ||
+    candidate.role !== 'admin'
+  ) {
+    return null
+  }
+  return candidate as unknown as SessionData
+}
+
+/**
  * Resolve a Clerk user_id to the legacy SessionData shape, gated to
  * `role === 'admin'`. Reads from KV first; falls back to D1; repopulates KV.
  */
@@ -45,7 +71,11 @@ export async function resolveAdminSessionFromClerk(
 
   const cached = await kv.get(cacheKey)
   if (cached) {
-    return JSON.parse(cached) as SessionData
+    // Issue #834: a corrupt KV entry must fall through to the D1 path
+    // (which repopulates the cache), never 500 an authenticated request.
+    const parsed = parseCachedAdminSession(cached)
+    if (parsed) return parsed
+    await kv.delete(cacheKey)
   }
 
   const row = await db

--- a/src/lib/auth/session.ts
+++ b/src/lib/auth/session.ts
@@ -113,10 +113,38 @@ export async function createSession(
 }
 
 /**
+ * Parse a KV-cached session value into SessionData, or null when the entry
+ * is corrupt (unparseable JSON or wrong shape). Issue #834: a corrupt KV
+ * value used to throw out of validateSession and 500 an otherwise-valid
+ * request; corrupt entries now fall through to the authoritative D1 path.
+ */
+function parseCachedSession(cached: string): SessionData | null {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(cached)
+  } catch {
+    return null
+  }
+  if (parsed === null || typeof parsed !== 'object') return null
+  const candidate = parsed as Record<string, unknown>
+  if (
+    typeof candidate.userId !== 'string' ||
+    typeof candidate.orgId !== 'string' ||
+    typeof candidate.email !== 'string' ||
+    typeof candidate.expiresAt !== 'string' ||
+    (candidate.role !== 'admin' && candidate.role !== 'client')
+  ) {
+    return null
+  }
+  return candidate as unknown as SessionData
+}
+
+/**
  * Validate a session token. Returns session data if valid, null otherwise.
  *
  * Fast path: check KV cache first.
- * Fallback: check D1 if KV miss (repopulates KV on success).
+ * Fallback: check D1 if KV miss OR corrupt cache entry (repopulates KV on
+ * success).
  */
 export async function validateSession(
   db: D1Database,
@@ -126,13 +154,17 @@ export async function validateSession(
   // Fast path: KV lookup
   const cached = await kv.get(`session:${token}`)
   if (cached) {
-    const data: SessionData = JSON.parse(cached)
-    if (new Date(data.expiresAt) > new Date()) {
+    const data = parseCachedSession(cached)
+    if (data === null) {
+      // Corrupt cache entry — drop it and fall through to D1 (#834).
+      await kv.delete(`session:${token}`)
+    } else if (new Date(data.expiresAt) > new Date()) {
       return data
+    } else {
+      // Expired in cache — clean up
+      await kv.delete(`session:${token}`)
+      return null
     }
-    // Expired in cache — clean up
-    await kv.delete(`session:${token}`)
-    return null
   }
 
   // Fallback: D1 lookup

--- a/src/lib/enrichment/review-analysis.ts
+++ b/src/lib/enrichment/review-analysis.ts
@@ -24,6 +24,36 @@ export interface ReviewAnalysis {
   evidence_summary: string
 }
 
+/**
+ * Parse + coerce the LLM's JSON into a ReviewAnalysis, or null when
+ * malformed (issue #835: LLM output is external input — a response that
+ * fails to parse must skip the module, not throw into the Workflow
+ * step's retry loop).
+ */
+function parseAnalysisJson(jsonText: string): ReviewAnalysis | null {
+  let parsed: Record<string, unknown>
+  try {
+    const raw: unknown = JSON.parse(jsonText)
+    if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) {
+      console.warn('[review-analysis] LLM returned non-object JSON; skipping')
+      return null
+    }
+    parsed = raw as Record<string, unknown>
+  } catch {
+    console.warn('[review-analysis] LLM returned unparseable JSON; skipping')
+    return null
+  }
+  return {
+    response_pattern:
+      typeof parsed.response_pattern === 'string' ? parsed.response_pattern : 'unknown',
+    engagement_level:
+      typeof parsed.engagement_level === 'string' ? parsed.engagement_level : 'unknown',
+    owner_accessible:
+      typeof parsed.owner_accessible === 'boolean' ? parsed.owner_accessible : false,
+    evidence_summary: typeof parsed.evidence_summary === 'string' ? parsed.evidence_summary : '',
+  }
+}
+
 export async function analyzeReviewPatterns(
   signalContent: string,
   anthropicKey: string
@@ -61,11 +91,5 @@ export async function analyzeReviewPatterns(
     jsonText = jsonText.replace(/^```(?:json)?\n?/, '').replace(/\n?```$/, '')
   }
 
-  const parsed = JSON.parse(jsonText)
-  return {
-    response_pattern: parsed.response_pattern ?? 'unknown',
-    engagement_level: parsed.engagement_level ?? 'unknown',
-    owner_accessible: parsed.owner_accessible ?? false,
-    evidence_summary: parsed.evidence_summary ?? '',
-  }
+  return parseAnalysisJson(jsonText)
 }

--- a/src/lib/enrichment/review-synthesis.ts
+++ b/src/lib/enrichment/review-synthesis.ts
@@ -64,5 +64,58 @@ export async function synthesizeReviews(
   if (!text) return null
   if (text.startsWith('```')) text = text.replace(/^```(?:json)?\n?/, '').replace(/\n?```$/, '')
 
-  return JSON.parse(text)
+  return parseSynthesisJson(text)
+}
+
+/**
+ * Parse + validate the LLM's JSON into a ReviewSynthesis, or null when
+ * malformed. Issue #835: `return JSON.parse(text)` was an implicit
+ * any→ReviewSynthesis cast that threw on malformed output, burning
+ * Workflow retries; a response that fails validation skips the module.
+ */
+function parseSynthesisJson(text: string): ReviewSynthesis | null {
+  let raw: unknown
+  try {
+    raw = JSON.parse(text)
+  } catch {
+    console.warn('[review-synthesis] LLM returned unparseable JSON; skipping')
+    return null
+  }
+  if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) {
+    console.warn('[review-synthesis] LLM returned non-object JSON; skipping')
+    return null
+  }
+  const candidate = raw as Record<string, unknown>
+  return {
+    unified_rating: typeof candidate.unified_rating === 'number' ? candidate.unified_rating : null,
+    total_reviews_across_platforms:
+      typeof candidate.total_reviews_across_platforms === 'number'
+        ? candidate.total_reviews_across_platforms
+        : 0,
+    sentiment_trend: coerceSentimentTrend(candidate.sentiment_trend),
+    top_themes: Array.isArray(candidate.top_themes)
+      ? candidate.top_themes.filter((t): t is string => typeof t === 'string')
+      : [],
+    operational_problems: coerceOperationalProblems(candidate.operational_problems),
+    customer_sentiment:
+      typeof candidate.customer_sentiment === 'string' ? candidate.customer_sentiment : '',
+  }
+}
+
+function coerceSentimentTrend(value: unknown): ReviewSynthesis['sentiment_trend'] {
+  if (value === 'improving' || value === 'stable' || value === 'declining') return value
+  return 'insufficient_data'
+}
+
+function coerceOperationalProblems(value: unknown): ReviewSynthesis['operational_problems'] {
+  if (!Array.isArray(value)) return []
+  return value.filter((p): p is { problem: string; confidence: string; evidence: string } => {
+    if (p === null || typeof p !== 'object') return false
+    const record = p as Record<string, unknown>
+    return (
+      typeof record.problem === 'string' &&
+      typeof record.confidence === 'string' &&
+      typeof record.evidence === 'string'
+    )
+  })
 }

--- a/src/lib/enrichment/website-analyzer.ts
+++ b/src/lib/enrichment/website-analyzer.ts
@@ -156,7 +156,29 @@ async function extractWithHaiku(
     jsonText = jsonText.replace(/^```(?:json)?\n?/, '').replace(/\n?```$/, '')
   }
 
-  const parsed = JSON.parse(jsonText)
+  return parseExtractionJson(jsonText)
+}
+
+/**
+ * Parse + coerce the LLM's JSON into the extraction shape, or null when
+ * malformed. Issue #835: malformed LLM JSON skips the module (null)
+ * instead of throwing into the Workflow step's retry loop.
+ */
+function parseExtractionJson(
+  jsonText: string
+): Omit<WebsiteEnrichment, 'tech_stack' | 'pages_analyzed'> | null {
+  let parsedRaw: unknown
+  try {
+    parsedRaw = JSON.parse(jsonText)
+  } catch {
+    console.warn('[website-analyzer] LLM returned unparseable JSON; skipping')
+    return null
+  }
+  if (parsedRaw === null || typeof parsedRaw !== 'object' || Array.isArray(parsedRaw)) {
+    console.warn('[website-analyzer] LLM returned non-object JSON; skipping')
+    return null
+  }
+  const parsed = parsedRaw as Record<string, unknown>
   return {
     owner_name: typeof parsed.owner_name === 'string' ? parsed.owner_name : null,
     team_size: typeof parsed.team_size === 'number' ? parsed.team_size : null,

--- a/src/pages/api/webhooks/signwell.ts
+++ b/src/pages/api/webhooks/signwell.ts
@@ -28,14 +28,37 @@ import { env } from 'cloudflare:workers'
 /** Maximum age (in seconds) for a webhook timestamp to be considered fresh. */
 const MAX_WEBHOOK_AGE_SECONDS = 300
 
+/**
+ * Issue #833: the pre-verify path extracts only the three verification
+ * fields; everything past HMAC verification was trusted via the
+ * TypeScript-only `as SignWellWebhookPayload` cast. Runtime-narrow the one
+ * structure the completion handler actually keys on (data.object.id) before
+ * dispatch — an HMAC-valid payload with a mangled document object gets a
+ * 400, not a handler exception.
+ */
+function hasProcessableDocument(payload: SignWellWebhookPayload): boolean {
+  const documentObject = payload.data?.object
+  return (
+    documentObject !== null &&
+    typeof documentObject === 'object' &&
+    typeof documentObject.id === 'string' &&
+    documentObject.id.length > 0
+  )
+}
+
+/** JSON error response shorthand used by every reject branch below. */
+function jsonError(status: number, error: string): Response {
+  return new Response(JSON.stringify({ error }), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
 export const POST: APIRoute = async ({ request }) => {
   const webhookSecret = env.SIGNWELL_WEBHOOK_SECRET
   if (!webhookSecret) {
     console.error('[webhook/signwell] SIGNWELL_WEBHOOK_SECRET not configured')
-    return new Response(JSON.stringify({ error: 'Server misconfigured' }), {
-      status: 500,
-      headers: { 'Content-Type': 'application/json' },
-    })
+    return jsonError(500, 'Server misconfigured')
   }
 
   // --- Parse body (required — SignWell puts the hash inside the JSON) ---
@@ -44,10 +67,7 @@ export const POST: APIRoute = async ({ request }) => {
     const rawBody = await request.text()
     payload = JSON.parse(rawBody) as SignWellWebhookPayload
   } catch {
-    return new Response(JSON.stringify({ error: 'Invalid JSON' }), {
-      status: 400,
-      headers: { 'Content-Type': 'application/json' },
-    })
+    return jsonError(400, 'Invalid JSON')
   }
 
   // --- Extract verification fields only (no logging/dispatch yet) ---
@@ -56,41 +76,34 @@ export const POST: APIRoute = async ({ request }) => {
   const eventHash = payload.event?.hash
 
   if (!eventType || eventTime == null || !eventHash) {
-    return new Response(JSON.stringify({ error: 'Missing event fields' }), {
-      status: 400,
-      headers: { 'Content-Type': 'application/json' },
-    })
+    return jsonError(400, 'Missing event fields')
   }
 
   // --- HMAC-SHA256 verification ---
   const isValid = await verifyEventHash(eventType, eventTime, eventHash, webhookSecret)
   if (!isValid) {
     console.error('[webhook/signwell] Invalid event hash')
-    return new Response(JSON.stringify({ error: 'Invalid signature' }), {
-      status: 401,
-      headers: { 'Content-Type': 'application/json' },
-    })
+    return jsonError(401, 'Invalid signature')
   }
 
   // --- Timestamp freshness check (replay protection) ---
   const nowSeconds = Math.floor(Date.now() / 1000)
   if (nowSeconds - eventTime > MAX_WEBHOOK_AGE_SECONDS) {
     console.error(`[webhook/signwell] Stale webhook: event.time ${eventTime}, now ${nowSeconds}`)
-    return new Response(JSON.stringify({ error: 'Stale webhook' }), {
-      status: 401,
-      headers: { 'Content-Type': 'application/json' },
-    })
+    return jsonError(401, 'Stale webhook')
   }
 
   // --- Dispatch by event type ---
   if (payload.event.type === 'document_completed') {
+    if (!hasProcessableDocument(payload)) {
+      console.error('[webhook/signwell] document_completed payload missing data.object.id')
+      return jsonError(400, 'Malformed document payload')
+    }
+
     const apiKey = env.SIGNWELL_API_KEY
     if (!apiKey) {
       console.error('[webhook/signwell] SIGNWELL_API_KEY not configured')
-      return new Response(JSON.stringify({ error: 'Server misconfigured' }), {
-        status: 500,
-        headers: { 'Content-Type': 'application/json' },
-      })
+      return jsonError(500, 'Server misconfigured')
     }
 
     return handleDocumentCompleted(

--- a/tests/signwell.test.ts
+++ b/tests/signwell.test.ts
@@ -298,8 +298,9 @@ describe('signwell: webhook route', () => {
 
   it('returns 401 for invalid signatures', () => {
     const code = source()
-    expect(code).toContain('Invalid signature')
-    expect(code).toContain('status: 401')
+    // Reject branches go through the jsonError(status, message) helper
+    // since the #833 hardening pass; assert on the helper call shape.
+    expect(code).toContain("jsonError(401, 'Invalid signature')")
   })
 
   it('checks for SIGNWELL_WEBHOOK_SECRET configuration', () => {


### PR DESCRIPTION
## What

Closes the three open `source:code-review` security issues the 2026-06-12 review re-verified as still accurate.

- **#834 — session KV cache**: `validateSession` + admin-session shim shape-validate cached JSON; corrupt entries are deleted and fall through to the authoritative D1 path instead of 500ing an authenticated request.
- **#835 — enrichment LLM JSON**: all three enrichment modules (review-analysis, review-synthesis, website-analyzer) parse+structurally-validate LLM output in extracted helpers; malformed output skips the module (null) instead of throwing into the Workflow retry loop. review-synthesis loses its implicit `any→ReviewSynthesis` cast entirely.
- **#833 — SignWell post-verify cast**: `document_completed` dispatch runtime-narrows `data.object.id` after HMAC passes — a valid-signature payload with a mangled document object gets a 400, not a handler exception. Reject branches extracted to a `jsonError` helper.

Closes #833. Closes #834. Closes #835.

## Verification

`npm run verify` fully green (typecheck, lint 0 errors, all 8 suites, format). One source-mirror assertion in tests/signwell.test.ts updated (it pinned the literal `status: 401` text the helper extraction moved).

Note: may overlap textually with #1352's signwell.test.ts pruning — whichever lands second gets a branch update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)