### PR TITLE
chore(operator): bump OVERLAY_REF to v0.4.17 (security wave #60–#63)

### DIFF
--- a/operator/templates/Dockerfile
+++ b/operator/templates/Dockerfile
@@ -136,8 +136,13 @@ ARG HERMES_UPSTREAM_SHA=a91a57fa5a13d516c38b07a141a9ce8a3daabeb0
 # bare data home. This SHA is on overlay main ABOVE v0.4.16 (#55), so it carries
 # the audit broker AND the cron fix. Verified live on staging — a scheduled turn
 # actually fired (last_status=ok) and the broker boots clean on a fresh Machine.
+# v0.4.17 (3b7bb99) — code-review 2026-06-12 security wave. Carries #60 (runtime
+# config seam: operator.runtime.config/v1 facts snapshot), #61 (closes three
+# fail-open seams: trust-ceiling volume-fault fail-open, Svix replay window,
+# tool-name case bypass), #62 (fence-completeness CI gate, 0700 profile dirs on
+# fresh provision, ceiling-comparison dedup), #63 (README). Superset of #59.
 ARG OVERLAY_REPO="https://github.com/venturecrane/hermes-smd-overlay.git"
-ARG OVERLAY_REF="2e310674e0ec0200f87030a33dd0ca10abffabc7"
+ARG OVERLAY_REF="3b7bb99758a79d0e9578948fd6e6bc30361b39c7"
 
 ARG CUSTOMER_SLUG=customer-zero
 

--- a/tests/operator-dockerfile.test.ts
+++ b/tests/operator-dockerfile.test.ts
@@ -56,11 +56,12 @@ describe('Operator customer Machine Dockerfile', () => {
   })
 
   it('pins the broker-capable overlay revision', () => {
-    // 2e310674 is overlay main ABOVE v0.4.16 (#55, audit broker): it carries the
-    // OP-P1-4 audit broker AND the Phase B Cut C1 cron firing fix (#59). Verified
-    // live on staging — a scheduled turn fired (last_status=ok) and the broker
-    // boots clean on a fresh Machine.
-    expect(DOCKERFILE).toContain('ARG OVERLAY_REF="2e310674e0ec0200f87030a33dd0ca10abffabc7"')
+    // 3b7bb997 is overlay v0.4.17: superset of #59 (cron firing fix) and
+    // v0.4.16 (#55, audit broker), adding the 2026-06-12 code-review security
+    // wave — #60 config seam, #61 three fail-open closures (ceiling
+    // volume-fault, Svix replay, tool-name case), #62 fence gate + 0700
+    // profile dirs.
+    expect(DOCKERFILE).toContain('ARG OVERLAY_REF="3b7bb99758a79d0e9578948fd6e6bc30361b39c7"')
   })
 
   it('does NOT swallow a failed plugin install (no fail-open `|| echo ... continuing`)', () => {


### PR DESCRIPTION
## Why

Customer-zero runs the pre-#61 overlay. The 2026-06-12 code-review security fixes (overlay #61: trust-ceiling volume-fault fail-open, Svix replay window, tool-name case bypass; #62: fence-completeness gate, 0700 profile dirs, ceiling dedup) are merged in hermes-smd-overlay but not live until this ref bump + reprovision.

## What

- `OVERLAY_REF` 2e31067 (#59) → 3b7bb99 (v0.4.17, carries #60–#63, superset of #59)
- Pin test in `tests/operator-dockerfile.test.ts` updated to the new SHA
- Release: https://github.com/venturecrane/hermes-smd-overlay/releases/tag/v0.4.17

## Deploy plan (after merge)

`yes s | operator/bin/reprovision.sh smd` → verify-gate triple (good 200 / wrong-key 401 / wrong-slug 401) → boot-smoke → audit-emit live check. The #62 0700-profile-dirs change applies to fresh-created leaf dirs on this provision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)