### PR TITLE
fix(stripe): transmit line total (amount × quantity) on invoiceitems

### DIFF
--- a/src/lib/stripe/client.test.ts
+++ b/src/lib/stripe/client.test.ts
@@ -213,15 +213,13 @@ describe('createStripeInvoice', () => {
     expect(second.get('description')).toBe('Phase two')
   })
 
-  it('KNOWN LATENT BUG: line item quantity is never transmitted to Stripe', async () => {
-    // StripeInvoiceLineItem carries `quantity` and createStripeInvoice uses it
-    // when computing the dev-mode total (amount * quantity), but
-    // addStripeLineItems only sends `amount` — so Stripe bills the amount
-    // ONCE regardless of quantity. A line item with quantity 2 would
-    // underbill by half. All current callers pass quantity: 1, so this is
-    // latent, not live. This test documents the current behavior; if the
-    // encoding is fixed to include quantity (or amount * quantity), update
-    // this test alongside the fix.
+  it('transmits the line TOTAL (amount × quantity) on each invoiceitem', async () => {
+    // Fixes the latent underbilling bug (#1354): StripeInvoiceLineItem.amount
+    // is per-unit, but Stripe's invoiceitem `amount` is the line total
+    // (amount = unit_amount × quantity). The encoding multiplies; it does NOT
+    // send `quantity`/`unit_amount`, because unit_amount was removed from
+    // invoiceitems create in API version 2025-03-31.basil and this client
+    // pins no Stripe-Version header.
     queue(
       json({ data: [{ id: 'cus_1' }] }),
       json({ id: 'in_7', hosted_invoice_url: null, status: 'draft' }),
@@ -236,7 +234,7 @@ describe('createStripeInvoice', () => {
     )
 
     const itemBody = bodyParams(calls[2])
-    expect(itemBody.get('amount')).toBe('100000')
+    expect(itemBody.get('amount')).toBe('200000')
     expect(itemBody.get('quantity')).toBeNull()
   })
 

--- a/src/lib/stripe/client.ts
+++ b/src/lib/stripe/client.ts
@@ -88,7 +88,12 @@ async function addStripeLineItems(
     const body = new URLSearchParams()
     body.append('customer', customerId)
     body.append('invoice', invoiceId)
-    body.append('amount', String(item.amount))
+    // `amount` is the LINE TOTAL in Stripe's model (amount = unit_amount ×
+    // quantity). Our StripeInvoiceLineItem.amount is per-unit, so multiply
+    // here. Don't send `quantity`/`unit_amount` instead: unit_amount was
+    // removed from invoiceitems create in API version 2025-03-31.basil and
+    // this client pins no Stripe-Version header.
+    body.append('amount', String(item.amount * item.quantity))
     body.append('currency', item.currency)
     body.append('description', item.description)
     const res = await fetch(`${STRIPE_API_BASE}/invoiceitems`, {


### PR DESCRIPTION
## Why

Closes #1354. `StripeInvoiceLineItem.amount` is per-unit (the dev-mode total computes `amount × quantity`), but `addStripeLineItems` sent the bare per-unit amount — any `quantity > 1` would underbill. Latent only: all current callers pass `quantity: 1`. Pinned by the KNOWN-LATENT-BUG test from #1352, which this PR flips.

## What

- `addStripeLineItems` now sends the line TOTAL (`amount × quantity`) as the invoiceitem `amount`
- Does NOT send `quantity`/`unit_amount`: Stripe removed `unit_amount` from invoiceitems create in API version 2025-03-31.basil ([changelog](https://docs.stripe.com/changelog/basil/2025-03-31/invoice-pricing-configurations)), and this client pins no `Stripe-Version` header — the total-amount form is the only version-proof encoding. Stripe's own attribute contract: `amount = unit_amount × quantity`.
- Test flipped: `transmits the line TOTAL (amount × quantity) on each invoiceitem` asserts `amount=200000` for `{amount: 100000, quantity: 2}` and that `quantity` is not transmitted

🤖 Generated with [Claude Code](https://claude.com/claude-code)