### PR TITLE
chore(operator): bump OVERLAY_REF to v0.4.18 (gate crash-loop hotfix + audit health signal)

### DIFF
--- a/operator/templates/Dockerfile
+++ b/operator/templates/Dockerfile
@@ -141,8 +141,14 @@ ARG HERMES_UPSTREAM_SHA=a91a57fa5a13d516c38b07a141a9ce8a3daabeb0
 # fail-open seams: trust-ceiling volume-fault fail-open, Svix replay window,
 # tool-name case bypass), #62 (fence-completeness CI gate, 0700 profile dirs on
 # fresh provision, ceiling-comparison dedup), #63 (README). Superset of #59.
+# DO NOT PIN v0.4.17: its gate boot self-check signs a fixed epoch that the
+# #61 replay window rejects — the gate crash-loops (no ingress/seam).
+# v0.4.18 (1ba04f1) — #66 fixes that self-check (signs a current timestamp,
+# regression-tested via svix_self_check()) and carries #65 (audit-dark health
+# signal: boot sentinel + audit.writer_wired config-seam fact + rate-limited
+# NO-AUDIT-MODE warnings, closes overlay#64). Superset of v0.4.17.
 ARG OVERLAY_REPO="https://github.com/venturecrane/hermes-smd-overlay.git"
-ARG OVERLAY_REF="3b7bb99758a79d0e9578948fd6e6bc30361b39c7"
+ARG OVERLAY_REF="1ba04f11fdaaa8aa4fbe05f98ac1a18e6b229c50"
 
 ARG CUSTOMER_SLUG=customer-zero
 

--- a/tests/operator-dockerfile.test.ts
+++ b/tests/operator-dockerfile.test.ts
@@ -56,12 +56,11 @@ describe('Operator customer Machine Dockerfile', () => {
   })
 
   it('pins the broker-capable overlay revision', () => {
-    // 3b7bb997 is overlay v0.4.17: superset of #59 (cron firing fix) and
-    // v0.4.16 (#55, audit broker), adding the 2026-06-12 code-review security
-    // wave — #60 config seam, #61 three fail-open closures (ceiling
-    // volume-fault, Svix replay, tool-name case), #62 fence gate + 0700
-    // profile dirs.
-    expect(DOCKERFILE).toContain('ARG OVERLAY_REF="3b7bb99758a79d0e9578948fd6e6bc30361b39c7"')
+    // 1ba04f11 is overlay v0.4.18: the v0.4.17 security wave (#60–#63) plus
+    // #66 — the gate boot self-check signs a current timestamp (v0.4.17's
+    // fixed-epoch probe crash-looped under the #61 replay window) — and #65
+    // (audit-dark health signal). v0.4.17 must never be re-pinned.
+    expect(DOCKERFILE).toContain('ARG OVERLAY_REF="1ba04f11fdaaa8aa4fbe05f98ac1a18e6b229c50"')
   })
 
   it('does NOT swallow a failed plugin install (no fail-open `|| echo ... continuing`)', () => {


### PR DESCRIPTION
## Why

The v0.4.17 deploy (#1358) crash-looped the webhook gate on customer-zero: its boot self-check signs a probe with a fixed epoch that the #61 Svix replay window — correctly — rejects. While looping: no webhook ingress, no runtime-read seam, Fly health check red.

## What

- `OVERLAY_REF` 3b7bb99 (v0.4.17) → 1ba04f1 (v0.4.18)
- Carries overlay [#66](https://github.com/venturecrane/hermes-smd-overlay/pull/66) (self-check signs a current timestamp; extracted to `svix_self_check()` with a regression test) and [#65](https://github.com/venturecrane/hermes-smd-overlay/pull/65) (audit-dark health signal, closes overlay#64)
- Dockerfile note marks v0.4.17 as never-re-pin
- Release: https://github.com/venturecrane/hermes-smd-overlay/releases/tag/v0.4.18

## Deploy plan (after merge)

`yes s | operator/bin/reprovision.sh smd` → verify-gate triple + boot-smoke + audit-emit check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)