### PR TITLE
chore(operator): bump OVERLAY_REF to v0.4.21 (calendar-read fences)

### DIFF
--- a/operator/templates/Dockerfile
+++ b/operator/templates/Dockerfile
@@ -153,8 +153,10 @@ ARG HERMES_UPSTREAM_SHA=a91a57fa5a13d516c38b07a141a9ce8a3daabeb0
 # BEFORE fly apps destroy) + #68 (audit sentinel staleness = writer-pid
 # liveness; kills the spurious pid-mismatch degradation live-verified on
 # customer-zero). Superset of v0.4.18/v0.4.19.
+# v0.4.21 (e0bc503) — #69 fences workspace_calendar_list/get (external invites
+# carry third-party content; Captain call 2026-06-12). Superset of v0.4.20.
 ARG OVERLAY_REPO="https://github.com/venturecrane/hermes-smd-overlay.git"
-ARG OVERLAY_REF="83cc1bdd907830aa4b002994e7072f4cfc968585"
+ARG OVERLAY_REF="e0bc503981fdb0f4c1cf2588117bcaa1b21e5f05"
 
 ARG CUSTOMER_SLUG=customer-zero
 

--- a/tests/operator-dockerfile.test.ts
+++ b/tests/operator-dockerfile.test.ts
@@ -56,13 +56,13 @@ describe('Operator customer Machine Dockerfile', () => {
   })
 
   it('pins the broker-capable overlay revision', () => {
-    // 83cc1bdd is overlay v0.4.20: v0.4.18 (gate self-check hotfix #66 +
+    // e0bc5039 is overlay v0.4.21 (v0.4.20 + #69 calendar-read fences): v0.4.18 (gate self-check hotfix #66 +
     // audit-dark signal #65, atop the #60–#63 security wave) plus #67
     // (audit_export/memory_export seam kinds, the Machine-side half of the
     // #1355 pull-before-destroy decommission fix) and #68 (sentinel
     // staleness = writer-pid liveness). v0.4.17 must never be re-pinned
     // (fixed-epoch probe crash-loops the gate).
-    expect(DOCKERFILE).toContain('ARG OVERLAY_REF="83cc1bdd907830aa4b002994e7072f4cfc968585"')
+    expect(DOCKERFILE).toContain('ARG OVERLAY_REF="e0bc503981fdb0f4c1cf2588117bcaa1b21e5f05"')
   })
 
   it('does NOT swallow a failed plugin install (no fail-open `|| echo ... continuing`)', () => {


### PR DESCRIPTION
Pins overlay [v0.4.21](https://github.com/venturecrane/hermes-smd-overlay/releases/tag/v0.4.21) (e0bc503) — #69: `workspace_calendar_list/get` join `_FENCED_READ_TOOLS` (nonce fence + session taint; external invites carry third-party content; Captain call 2026-06-12). Superset of v0.4.20. Final pin of today's wave — deploy follows merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)