### PR TITLE
fix(agents): add required description to sprint-worker frontmatter

### DIFF
--- a/.claude/agents/sprint-worker.md
+++ b/.claude/agents/sprint-worker.md
@@ -1,5 +1,6 @@
 ---
 name: sprint-worker
+description: Implements a single GitHub issue end-to-end in an isolated git worktree — reads the codebase, makes minimal focused changes, runs verification, commits, pushes, and opens a PR. Used by the fleet sprint orchestrator to parallelize issue work across sibling worktrees.
 model: sonnet
 tools:
   - Bash


### PR DESCRIPTION
## Summary
- `sprint-worker.md` frontmatter was missing the required `description` field, causing a parse error (`/doctor` flagged it) and preventing the fleet orchestrator from loading the agent.
- Adds a one-line description summarizing its single-issue-in-a-worktree role. No behavior change beyond making the agent loadable.

## Test plan
- [x] `npm run verify` passes
- [x] `/doctor` agent parse error clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)