### PR TITLE
chore(operator): bump OVERLAY_REF -> v0.4.22 (gate source-stamp + demo relay)

### DIFF
--- a/operator/templates/Dockerfile
+++ b/operator/templates/Dockerfile
@@ -155,8 +155,12 @@ ARG HERMES_UPSTREAM_SHA=a91a57fa5a13d516c38b07a141a9ce8a3daabeb0
 # customer-zero). Superset of v0.4.18/v0.4.19.
 # v0.4.21 (e0bc503) — #69 fences workspace_calendar_list/get (external invites
 # carry third-party content; Captain call 2026-06-12). Superset of v0.4.20.
+# v0.4.22 (8706af4) — #71 gate source-stamp (router can route AgentMail
+# webhook_triggers) + #57 demo reply relay (fail-closed off unless demo.reply_relay
+# authored; enables the law demo's email-in/email-back loop). Both additive;
+# safe for all customers (relay no-ops without the flag). Superset of v0.4.21.
 ARG OVERLAY_REPO="https://github.com/venturecrane/hermes-smd-overlay.git"
-ARG OVERLAY_REF="e0bc503981fdb0f4c1cf2588117bcaa1b21e5f05"
+ARG OVERLAY_REF="8706af4df49b6c03d39973f6bcee4de0329d2fc6"
 
 ARG CUSTOMER_SLUG=customer-zero
 

--- a/tests/operator-dockerfile.test.ts
+++ b/tests/operator-dockerfile.test.ts
@@ -56,13 +56,14 @@ describe('Operator customer Machine Dockerfile', () => {
   })
 
   it('pins the broker-capable overlay revision', () => {
-    // e0bc5039 is overlay v0.4.21 (v0.4.20 + #69 calendar-read fences): v0.4.18 (gate self-check hotfix #66 +
-    // audit-dark signal #65, atop the #60–#63 security wave) plus #67
-    // (audit_export/memory_export seam kinds, the Machine-side half of the
-    // #1355 pull-before-destroy decommission fix) and #68 (sentinel
-    // staleness = writer-pid liveness). v0.4.17 must never be re-pinned
-    // (fixed-epoch probe crash-loops the gate).
-    expect(DOCKERFILE).toContain('ARG OVERLAY_REF="e0bc503981fdb0f4c1cf2588117bcaa1b21e5f05"')
+    // 8706af4 is overlay v0.4.22 (v0.4.21 + #71 gate source-stamp + #57 demo
+    // reply relay): both additive — the relay is fail-closed (no-ops unless
+    // demo.reply_relay is authored), the gate source-stamp only adds routing
+    // provenance so the webhook router can route AgentMail webhook_triggers.
+    // Atop v0.4.21 (e0bc503, #69 calendar-read fences) and the #60–#68 security
+    // wave. v0.4.17 must never be re-pinned (fixed-epoch probe crash-loops the
+    // gate).
+    expect(DOCKERFILE).toContain('ARG OVERLAY_REF="8706af4df49b6c03d39973f6bcee4de0329d2fc6"')
   })
 
   it('does NOT swallow a failed plugin install (no fail-open `|| echo ... continuing`)', () => {


### PR DESCRIPTION
## Summary
- Bumps `OVERLAY_REF` (the customer-image overlay pin) `e0bc503` → `8706af4` = v0.4.22, bringing in #71 (gate source-stamp) + #57 (demo reply relay) so demo-law can run the email-in/email-back law demo.
- Both additive: the relay is fail-closed (no-ops unless `demo.reply_relay` is authored); the gate source-stamp only adds routing provenance. Safe for all customers; each picks it up on its next reprovision. `provision-customer.sh` uses the Dockerfile ARG default (no `--build-arg OVERLAY_REF`), so this is the single knob.
- Updates `tests/operator-dockerfile.test.ts` pin to match.

## Test plan
- [x] `operator-dockerfile.test.ts` passes
- [x] full `verify` passed pre-push

🤖 Generated with [Claude Code](https://claude.com/claude-code)