### PR TITLE
fix(operator): bump OVERLAY_REF to v0.4.24 (demo-relay origin recovery)

### DIFF
--- a/operator/templates/Dockerfile
+++ b/operator/templates/Dockerfile
@@ -164,8 +164,13 @@ ARG HERMES_UPSTREAM_SHA=a91a57fa5a13d516c38b07a141a9ce8a3daabeb0
 # runtime, so sends defaulted to READ and slipped the trust ceiling + taint-gate
 # (demo-law live test sent a reply autonomously on a tainted turn). P0 security;
 # closes the bypass for ALL customers. Superset of v0.4.22.
+# v0.4.24 (11bcdc5) — #73 recover the demo-relay recipient-lock origin when the
+# dispatch session_id differs from the agent-loop session_id (the router records
+# under an empty dispatch session_id, which record() dropped → relay found no
+# origin → governed draft created but never sent). Address-keyed recovery index,
+# injection-safe. Fixes the demo-law email-back loop. Superset of v0.4.23.
 ARG OVERLAY_REPO="https://github.com/venturecrane/hermes-smd-overlay.git"
-ARG OVERLAY_REF="90dd7f7dddf32436813bc4363499183c5712ad34"
+ARG OVERLAY_REF="11bcdc502cc34512b6a75ffba8e39bdb449f3339"
 
 ARG CUSTOMER_SLUG=customer-zero
 

--- a/tests/operator-dockerfile.test.ts
+++ b/tests/operator-dockerfile.test.ts
@@ -56,15 +56,17 @@ describe('Operator customer Machine Dockerfile', () => {
   })
 
   it('pins the broker-capable overlay revision', () => {
-    // 90dd7f7 is overlay v0.4.23 (v0.4.22 + #72 AgentMail MCP runtime tool-name
-    // classification): P0 security — the prior map keyed the colon spelling
-    // (agentmail:send_message) that never occurs at runtime, so the real
-    // mcp_agentmail_* sends defaulted to READ and slipped the trust ceiling +
-    // taint-gate. v0.4.22 (8706af4) added #71 gate source-stamp + #57 demo reply
-    // relay (fail-closed). Atop v0.4.21 (e0bc503, #69 calendar-read fences) and
-    // the #60–#68 security wave. v0.4.17 must never be re-pinned (fixed-epoch
-    // probe crash-loops the gate).
-    expect(DOCKERFILE).toContain('ARG OVERLAY_REF="90dd7f7dddf32436813bc4363499183c5712ad34"')
+    // 11bcdc5 is overlay v0.4.24 (v0.4.23 + #73 demo-relay origin recovery): the
+    // router records the recipient-lock origin under the empty dispatch
+    // session_id, which record() dropped, so the relay found no origin and the
+    // governed draft was never sent — #73 adds an address-keyed, injection-safe
+    // recovery path. v0.4.23 (90dd7f7, #72) classifies AgentMail MCP runtime
+    // tool names (P0 — mcp_agentmail_* sends had defaulted to READ). v0.4.22
+    // (8706af4) added #71 gate source-stamp + #57 demo reply relay (fail-closed).
+    // Atop v0.4.21 (e0bc503, #69 calendar-read fences) and the #60–#68 security
+    // wave. v0.4.17 must never be re-pinned (fixed-epoch probe crash-loops the
+    // gate).
+    expect(DOCKERFILE).toContain('ARG OVERLAY_REF="11bcdc502cc34512b6a75ffba8e39bdb449f3339"')
   })
 
   it('does NOT swallow a failed plugin install (no fail-open `|| echo ... continuing`)', () => {


### PR DESCRIPTION
## Summary
Bumps `OVERLAY_REF` to overlay v0.4.24 (`11bcdc5`, hermes-smd-overlay#73): the demo reply relay created the governed draft but never sent it back to the prospect. The router records the recipient-lock origin under the empty dispatch session_id, which `record()` dropped, so the relay found no origin and silently no-op'd. #73 adds an address-keyed, injection-safe recovery path. Fixes the demo-law email-back loop.

## Test plan
- [x] `operator-dockerfile.test.ts` pins `11bcdc5` (15 passed)
- [ ] Post-merge: reprovision demo-law on v0.4.24; one test email → relay sends the governed reply back

🤖 Generated with [Claude Code](https://claude.com/claude-code)