### PR TITLE
fix(operator): bump OVERLAY_REF (router reads event.raw_message — THE demo-law fix)

### DIFF
--- a/operator/templates/Dockerfile
+++ b/operator/templates/Dockerfile
@@ -176,7 +176,7 @@ ARG HERMES_UPSTREAM_SHA=a91a57fa5a13d516c38b07a141a9ce8a3daabeb0
 # masking it). Gate now stamps event_type from Svix `type`; origin extraction
 # reads the Svix `data` envelope. Superset of v0.4.24.
 ARG OVERLAY_REPO="https://github.com/venturecrane/hermes-smd-overlay.git"
-ARG OVERLAY_REF="33ddc0b40444e2c4519eb8183166bbeb5cfdcc44"
+ARG OVERLAY_REF="c7f87ba68adf69012af5ebd187f2b3e34c21df13"
 
 ARG CUSTOMER_SLUG=customer-zero
 

--- a/tests/operator-dockerfile.test.ts
+++ b/tests/operator-dockerfile.test.ts
@@ -67,7 +67,7 @@ describe('Operator customer Machine Dockerfile', () => {
     // gate source-stamp + #57 demo reply relay (fail-closed). Atop v0.4.21
     // (e0bc503, #69 calendar-read fences) and the #60–#68 security wave. v0.4.17
     // must never be re-pinned (fixed-epoch probe crash-loops the gate).
-    expect(DOCKERFILE).toContain('ARG OVERLAY_REF="33ddc0b40444e2c4519eb8183166bbeb5cfdcc44"')
+    expect(DOCKERFILE).toContain('ARG OVERLAY_REF="c7f87ba68adf69012af5ebd187f2b3e34c21df13"')
   })
 
   it('does NOT swallow a failed plugin install (no fail-open `|| echo ... continuing`)', () => {


### PR DESCRIPTION
Overlay hermes-smd-overlay#76 — the demo-law root cause. Hermes fires `pre_gateway_dispatch` with `event=<MessageEvent>` and no `payload` kwarg; the webhook body is on `event.raw_message`. The router read `kwargs["payload"]` (always None) → route never matched → origin never recorded → relay never sent. Now reads `event.raw_message`; verification header-optional (gate + Hermes adapter verify upstream). Includes temp WARNING diagnostics for one confirming run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)