### PR TITLE
fix(operator): bump OVERLAY_REF → c410c52 (content-floor disclaimer carve-out)

### DIFF
--- a/operator/templates/Dockerfile
+++ b/operator/templates/Dockerfile
@@ -175,8 +175,16 @@ ARG HERMES_UPSTREAM_SHA=a91a57fa5a13d516c38b07a141a9ce8a3daabeb0
 # the recipient-lock origin → relay never sent (agent ran intake autonomously,
 # masking it). Gate now stamps event_type from Svix `type`; origin extraction
 # reads the Svix `data` envelope. Superset of v0.4.24.
+# c410c52 — #78 content-floor disclaimer carve-out: standard UPL boilerplate
+# ("Nothing in this note should be read as legal advice", "no attorney-client
+# relationship is formed") no longer trips the LEGAL category. Removes a false
+# positive, not a real signal — the carve-out is clause-local, so genuinely
+# sensitive content elsewhere in the same message (money/contract/scope/real
+# legal commitment) still forces draft, and the empty-body fail-toward-draft
+# check is unchanged. Fixes demo-law DEMO_RELAY_BLOCKED reason=content_sensitive
+# on a benign disclaimer (2026-06-14 live test). Superset of ed96cebe.
 ARG OVERLAY_REPO="https://github.com/venturecrane/hermes-smd-overlay.git"
-ARG OVERLAY_REF="ed96cebee8a114efde25baf456cfbd3f8ad01cc9"
+ARG OVERLAY_REF="c410c523264fd206badbe8282f171280986ae5e1"
 
 ARG CUSTOMER_SLUG=customer-zero
 

--- a/tests/operator-dockerfile.test.ts
+++ b/tests/operator-dockerfile.test.ts
@@ -67,7 +67,11 @@ describe('Operator customer Machine Dockerfile', () => {
     // gate source-stamp + #57 demo reply relay (fail-closed). Atop v0.4.21
     // (e0bc503, #69 calendar-read fences) and the #60–#68 security wave. v0.4.17
     // must never be re-pinned (fixed-epoch probe crash-loops the gate).
-    expect(DOCKERFILE).toContain('ARG OVERLAY_REF="ed96cebee8a114efde25baf456cfbd3f8ad01cc9"')
+    // c410c52 (#78) carves standard not-legal-advice / attorney-client
+    // disclaimer boilerplate out of the content-floor LEGAL category (clause-
+    // local; genuinely sensitive content elsewhere still forces draft) — fixes
+    // demo-law DEMO_RELAY_BLOCKED on a benign disclaimer. Atop ed96cebe.
+    expect(DOCKERFILE).toContain('ARG OVERLAY_REF="c410c523264fd206badbe8282f171280986ae5e1"')
   })
 
   it('does NOT swallow a failed plugin install (no fail-open `|| echo ... continuing`)', () => {


### PR DESCRIPTION
## Summary
- Picks up [hermes-smd-overlay #78](https://github.com/venturecrane/hermes-smd-overlay/pull/78): the content-floor `LEGAL` category no longer trips on standard UPL boilerplate — *"Nothing in this note should be read as legal advice"*, *"no attorney-client relationship is formed"*.
- On the **demo-law live test (2026-06-14)** a benign not-legal-advice disclaimer fired `DEMO_RELAY_BLOCKED reason=content_sensitive` and held the reply for human review. This was the **only open demo item**.

## Safety
The carve-out **removes a false positive, not a real signal**:
- **Clause-local** — genuinely sensitive content elsewhere in the same message (money / contract / scope / a real legal commitment) still forces draft. e.g. `"This is not legal advice, but please wire $5,000 ..."` still trips on **money**.
- Empty-body **fail-toward-draft** check unchanged.
- *"legal advice"* actually being **given** (no disclaimer negation) still trips.

Verified in overlay #78: 757 tests pass, 14 new regression rows incl. the exact blocked phrasing.

## Test plan
- [x] `tests/operator-dockerfile.test.ts` — OVERLAY_REF pin updated + changelog
- [x] `npm run verify` passes (0 errors)
- [ ] After merge: bump live demo-law via `reprovision.sh smd`/demo-law, re-send the email-2 intake, confirm `DEMO_RELAY_SENT`

🤖 Generated with [Claude Code](https://claude.com/claude-code)