### PR TITLE
feat(operator): mcp_connector customer.yaml block (Operator⇄Claude connector, Phase 1)

### DIFF
--- a/operator/contracts/customer-yaml-blocks.yaml
+++ b/operator/contracts/customer-yaml-blocks.yaml
@@ -101,6 +101,17 @@ top_level:
   users:
     status: implemented
     materializer: ss-console portal (console-side access control); not staged to the Machine
+  mcp_connector:
+    status: implemented
+    materializer: ss-console MCP endpoint (console-hosted Operator<->Claude connector; reads enabled/data_posture/access to authorize MCP tool calls) + WEBHOOK_SECRET_MCP staged by provision-customer.sh for the handoff route
+    note: >-
+      Operator <-> Claude MCP connector (Phase 1, console-mediated). Consumed
+      console-side, not translated into Machine config.yaml — validated by
+      src/lib/operator/customer-yaml/sections-mcp-connector.ts. The only Machine
+      touch is the per-customer WEBHOOK_SECRET_MCP (handoff route) + the
+      webhook-router recognizing source="mcp". Fail-closed: absent/enabled:false
+      => no user reaches the Operator through Claude. See
+      docs/design/operator/03-mcp-server-exposure.md.
   # ---- deliberately not wired (validated authoring affordances) ----
   addons:
     status: inert

--- a/src/lib/operator/customer-yaml/sections-mcp-connector.ts
+++ b/src/lib/operator/customer-yaml/sections-mcp-connector.ts
@@ -1,0 +1,155 @@
+/**
+ * Validator for the optional `mcp_connector:` block — the Operator ⇄ Claude MCP
+ * connector (Phase 1, console-hosted). Lets authored org users reach this
+ * Operator from inside their own Claude.
+ *
+ * Fail-closed: an absent block, or `enabled: false`, resolves to OFF — no user
+ * reaches the Operator through Claude. Each `access[]` entry binds an authored
+ * `users[]` email to an active persona slug (the per-user → profile seam). A
+ * user with no entry reaches nothing.
+ *
+ * Deliberately minimal for Phase 1 (Simplifier critique): no `port` (deployment
+ * constant), no `authority_mode` / `access_map` (seated in the design, authored
+ * when a second principal exists). See
+ * docs/design/operator/03-mcp-server-exposure.md.
+ */
+
+import { isPlainObject } from './helpers'
+import {
+  ACCEPTED_DATA_POSTURES,
+  type DataPosture,
+  type McpConnector,
+  type McpConnectorAccess,
+  type Persona,
+  type User,
+  type ValidationError,
+} from './types'
+
+const MCP_CONNECTOR_DEFAULT: McpConnector = {
+  enabled: false,
+  data_posture: 'open',
+  access: [],
+}
+
+function parseEnabled(raw: unknown, errors: ValidationError[]): boolean {
+  if (raw === undefined || raw === null) return false
+  if (typeof raw === 'boolean') return raw
+  errors.push({
+    code: 'TypeMismatch',
+    path: 'mcp_connector.enabled',
+    message: 'mcp_connector.enabled must be a boolean',
+  })
+  return false
+}
+
+function parseDataPosture(raw: unknown, errors: ValidationError[]): DataPosture {
+  if (raw === undefined || raw === null) return 'open'
+  if (typeof raw !== 'string' || !ACCEPTED_DATA_POSTURES.includes(raw as DataPosture)) {
+    errors.push({
+      code: 'EnumViolation',
+      path: 'mcp_connector.data_posture',
+      message: `mcp_connector.data_posture must be one of: ${ACCEPTED_DATA_POSTURES.join(', ')}`,
+    })
+    return 'open'
+  }
+  return raw as DataPosture
+}
+
+function parseAccess(
+  raw: unknown,
+  authoredEmails: Set<string>,
+  activeProfiles: Set<string>,
+  errors: ValidationError[]
+): McpConnectorAccess[] {
+  if (raw === undefined || raw === null) return []
+  if (!Array.isArray(raw)) {
+    errors.push({
+      code: 'TypeMismatch',
+      path: 'mcp_connector.access',
+      message: 'mcp_connector.access must be a list when present',
+    })
+    return []
+  }
+
+  const out: McpConnectorAccess[] = []
+  const seenEmails = new Set<string>()
+  raw.forEach((entry, i) => {
+    const path = `mcp_connector.access[${i}]`
+    if (!isPlainObject(entry)) {
+      errors.push({ code: 'TypeMismatch', path, message: `${path} must be a mapping` })
+      return
+    }
+    const email = entry['email']
+    const profile = entry['profile']
+    if (typeof email !== 'string' || email.trim() === '') {
+      errors.push({
+        code: 'MissingField',
+        path: `${path}.email`,
+        message: `${path}.email is required`,
+      })
+      return
+    }
+    if (typeof profile !== 'string' || profile.trim() === '') {
+      errors.push({
+        code: 'MissingField',
+        path: `${path}.profile`,
+        message: `${path}.profile is required`,
+      })
+      return
+    }
+    if (!authoredEmails.has(email)) {
+      errors.push({
+        code: 'EnumViolation',
+        path: `${path}.email`,
+        message: `${path}.email "${email}" does not match any declared users[] email`,
+      })
+      return
+    }
+    if (!activeProfiles.has(profile)) {
+      errors.push({
+        code: 'EnumViolation',
+        path: `${path}.profile`,
+        message: `${path}.profile "${profile}" does not match any active persona slug`,
+      })
+      return
+    }
+    if (seenEmails.has(email)) {
+      errors.push({
+        code: 'EnumViolation',
+        path: `${path}.email`,
+        message: `${path}.email "${email}" is bound more than once`,
+      })
+      return
+    }
+    seenEmails.add(email)
+    out.push({ email, profile })
+  })
+  return out
+}
+
+export function checkMcpConnector(
+  root: Record<string, unknown>,
+  users: User[],
+  personas: Persona[],
+  errors: ValidationError[]
+): McpConnector {
+  const raw = root['mcp_connector']
+  if (raw === undefined || raw === null) return { ...MCP_CONNECTOR_DEFAULT, access: [] }
+  if (!isPlainObject(raw)) {
+    errors.push({
+      code: 'TypeMismatch',
+      path: 'mcp_connector',
+      message: 'mcp_connector must be a mapping when present',
+    })
+    return { ...MCP_CONNECTOR_DEFAULT, access: [] }
+  }
+
+  const authoredEmails = new Set(users.map((u) => u.email))
+  const activeProfiles = new Set(personas.filter((p) => p.status === 'active').map((p) => p.slug))
+
+  return {
+    enabled: parseEnabled(raw['enabled'], errors),
+    data_posture: parseDataPosture(raw['data_posture'], errors),
+    access: parseAccess(raw['access'], authoredEmails, activeProfiles, errors),
+  }
+}

--- a/src/lib/operator/customer-yaml/types.ts
+++ b/src/lib/operator/customer-yaml/types.ts
@@ -170,6 +170,25 @@ export type ActionClass = (typeof ACCEPTED_ACTION_CLASSES)[number]
 export const ACCEPTED_USER_ROLES = ['principal', 'staff', 'compliance'] as const
 export type UserRole = (typeof ACCEPTED_USER_ROLES)[number]
 
+/**
+ * Data-handling posture for the Operator ⇄ Claude MCP connector (`mcp_connector`
+ * block). Governs which Claude surface entitled data may land in — NOT what a
+ * user is entitled to see (that stays fail-closed and inherited; see ADR 0035
+ * and docs/design/operator/03-mcp-server-exposure.md §4/§7).
+ *
+ * - `open` (default): entitled data may flow to the user's authenticated Claude,
+ *   personal or firm-controlled. Honors the flexibility posture for orgs
+ *   mid-adoption with a mix of personal and firm instances.
+ * - `firm_only`: entitled data flows only to an enterprise/team Claude under the
+ *   org's terms; personal-account tokens get a reduced surface.
+ *
+ * Note: privileged-class content (matter documents, work product) crossing into
+ * a personal account requires an explicit recorded firm consent even under
+ * `open` — enforced where the document-surfacing tools land, not here.
+ */
+export const ACCEPTED_DATA_POSTURES = ['open', 'firm_only'] as const
+export type DataPosture = (typeof ACCEPTED_DATA_POSTURES)[number]
+
 export const ACCEPTED_PERSONA_STATUSES = ['active', 'archived'] as const
 export type PersonaStatus = (typeof ACCEPTED_PERSONA_STATUSES)[number]
 
@@ -662,6 +681,38 @@ export interface Demo {
   reply_relay: boolean
 }
 
+/**
+ * One authored user → profile binding for the Operator ⇄ Claude MCP connector.
+ * `email` MUST match a `users[]` entry; `profile` MUST match an active persona
+ * slug. This is the per-user seam: the pilot authors exactly one, multi-user
+ * orgs author more (and walled principals get distinct profiles per the
+ * memory-wall rule — see docs/design/operator/03-mcp-server-exposure.md §4.3).
+ */
+export interface McpConnectorAccess {
+  email: string
+  profile: string
+}
+
+/**
+ * Operator ⇄ Claude MCP connector (`mcp_connector:` block) — lets authored org
+ * users reach this Operator from inside their own Claude (claude.ai / Claude
+ * Desktop) over a remote MCP server. Phase 1 is hosted console-side; see
+ * docs/design/operator/03-mcp-server-exposure.md.
+ *
+ * Fail-closed: an absent block (or `enabled: false`) means the connector is off
+ * and no user can reach the Operator through Claude. `access` with no entry for
+ * a given user means that user reaches nothing.
+ *
+ * Deliberately minimal for Phase 1: `authority_mode`, `access_map`, and group
+ * modes are seated in the design but NOT authored here until a second principal
+ * exists. `port` is a deployment constant, not per-customer config.
+ */
+export interface McpConnector {
+  enabled: boolean
+  data_posture: DataPosture
+  access: McpConnectorAccess[]
+}
+
 export interface CustomerYaml {
   schema_version: SchemaVersion
   customer_id: string
@@ -760,6 +811,13 @@ export interface CustomerYaml {
    * via `checkDemo`. Fail-closed — see {@link Demo}.
    */
   demo: Demo
+  /**
+   * Operator ⇄ Claude MCP connector (Phase 1). Always non-null on a validated
+   * CustomerYaml: an absent `mcp_connector:` block resolves to
+   * `{ enabled: false, data_posture: 'open', access: [] }` via
+   * `checkMcpConnector`. Fail-closed — see {@link McpConnector}.
+   */
+  mcp_connector: McpConnector
 }
 
 export type ValidationErrorCode =

--- a/src/lib/operator/customer-yaml/validator.ts
+++ b/src/lib/operator/customer-yaml/validator.ts
@@ -61,6 +61,7 @@ import { checkWebhookTriggers } from './sections-webhook-triggers'
 import { checkExtendsReserved, checkVerticalPinned } from './sections-vertical'
 import { checkAddons } from './sections-addons'
 import { checkDemo } from './sections-demo'
+import { checkMcpConnector } from './sections-mcp-connector'
 import { checkGoogleAuth } from './sections-google-auth'
 import { checkAuthority } from './sections-authority'
 import type { AuthorityPosture } from '../authority'
@@ -99,6 +100,9 @@ export type {
   CostEstimate,
   Observability,
   Demo,
+  McpConnector,
+  McpConnectorAccess,
+  DataPosture,
   Vertical,
   TrustCeiling,
   Pronouns,
@@ -111,6 +115,7 @@ export {
   ACCEPTED_ADDONS,
   ACCEPTED_TRUST_CEILINGS,
   ACCEPTED_USER_ROLES,
+  ACCEPTED_DATA_POSTURES,
   ACCEPTED_PERSONA_STATUSES,
   ACCEPTED_PRONOUNS,
   ACCEPTED_LOG_LEVELS,
@@ -230,6 +235,7 @@ interface ParsedSections {
   authority: AuthorityPosture
   credentialCustodyDefault: CredentialCustody
   demo: Demo
+  mcpConnector: ReturnType<typeof checkMcpConnector>
 }
 
 function validateSections(
@@ -283,6 +289,7 @@ function validateSections(
     authority: checkAuthority(root, errors),
     credentialCustodyDefault: checkCredentialCustodyDefault(root, errors),
     demo: checkDemo(root, errors),
+    mcpConnector: checkMcpConnector(root, users, personas, errors),
   }
 }
 
@@ -319,5 +326,6 @@ function assembleCustomerYaml(root: Record<string, unknown>, p: ParsedSections):
     authority: p.authority,
     credential_custody_default: p.credentialCustodyDefault,
     demo: p.demo,
+    mcp_connector: p.mcpConnector,
   }
 }

--- a/src/lib/portal/operator/customer-yaml-editor.ts
+++ b/src/lib/portal/operator/customer-yaml-editor.ts
@@ -453,6 +453,7 @@ function lockedFromCurrent(
   | 'authority'
   | 'credential_custody_default'
   | 'demo'
+  | 'mcp_connector'
 > {
   return {
     schema_version: current.schema_version,
@@ -489,6 +490,9 @@ function lockedFromCurrent(
     // reply relay is an SMD demo decision gated on synthetic-data containment).
     // Preserve verbatim across portal edits.
     demo: current.demo,
+    // mcp_connector (Operator <-> Claude) is provisioning/admin-set, not
+    // client-editable in this portal flow yet. Preserve verbatim.
+    mcp_connector: current.mcp_connector,
   }
 }
 

--- a/tests/customer-yaml-validator.test.ts
+++ b/tests/customer-yaml-validator.test.ts
@@ -1480,6 +1480,106 @@ describe('validate — demo.reply_relay', () => {
 })
 
 // -----------------------------------------------------------------------------
+// mcp_connector block — Operator <-> Claude MCP connector (Phase 1, fail-closed)
+// -----------------------------------------------------------------------------
+
+describe('validate — mcp_connector', () => {
+  it('defaults to disabled/open/empty when the block is omitted', () => {
+    const r = validate(validFixture())
+    if (!r.ok) throw new Error(`expected ok; got: ${JSON.stringify(r.errors)}`)
+    expect(r.value.mcp_connector).toEqual({ enabled: false, data_posture: 'open', access: [] })
+  })
+
+  it('accepts an enabled connector binding an authored user to an active persona', () => {
+    const f = validFixture()
+    f['mcp_connector'] = {
+      enabled: true,
+      data_posture: 'open',
+      access: [{ email: 'partner@firm.com', profile: 'marcus' }],
+    }
+    const r = validate(f)
+    if (!r.ok) throw new Error(`expected ok; got: ${JSON.stringify(r.errors)}`)
+    expect(r.value.mcp_connector.enabled).toBe(true)
+    expect(r.value.mcp_connector.access).toEqual([{ email: 'partner@firm.com', profile: 'marcus' }])
+  })
+
+  it('accepts data_posture: firm_only', () => {
+    const f = validFixture()
+    f['mcp_connector'] = { enabled: true, data_posture: 'firm_only', access: [] }
+    const r = validate(f)
+    if (!r.ok) throw new Error(`expected ok; got: ${JSON.stringify(r.errors)}`)
+    expect(r.value.mcp_connector.data_posture).toBe('firm_only')
+  })
+
+  it('rejects an unknown data_posture', () => {
+    const f = validFixture()
+    f['mcp_connector'] = { enabled: true, data_posture: 'public' }
+    const r = validate(f)
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(
+      r.errors.some((e) => e.path === 'mcp_connector.data_posture' && e.code === 'EnumViolation')
+    ).toBe(true)
+  })
+
+  it('rejects an access email that is not an authored user (fail-closed reach)', () => {
+    const f = validFixture()
+    f['mcp_connector'] = {
+      enabled: true,
+      access: [{ email: 'outsider@elsewhere.com', profile: 'marcus' }],
+    }
+    const r = validate(f)
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(
+      r.errors.some((e) => e.path === 'mcp_connector.access[0].email' && e.code === 'EnumViolation')
+    ).toBe(true)
+  })
+
+  it('rejects an access profile that is not an active persona slug', () => {
+    const f = validFixture()
+    f['mcp_connector'] = {
+      enabled: true,
+      access: [{ email: 'partner@firm.com', profile: 'ghost' }],
+    }
+    const r = validate(f)
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(
+      r.errors.some(
+        (e) => e.path === 'mcp_connector.access[0].profile' && e.code === 'EnumViolation'
+      )
+    ).toBe(true)
+  })
+
+  it('rejects binding the same email twice', () => {
+    const f = validFixture()
+    f['mcp_connector'] = {
+      enabled: true,
+      access: [
+        { email: 'partner@firm.com', profile: 'marcus' },
+        { email: 'partner@firm.com', profile: 'marcus' },
+      ],
+    }
+    const r = validate(f)
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(
+      r.errors.some((e) => e.path === 'mcp_connector.access[1].email' && e.code === 'EnumViolation')
+    ).toBe(true)
+  })
+
+  it('rejects a non-mapping mcp_connector block', () => {
+    const f = validFixture()
+    f['mcp_connector'] = 'on'
+    const r = validate(f)
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(r.errors.some((e) => e.path === 'mcp_connector' && e.code === 'TypeMismatch')).toBe(true)
+  })
+})
+
+// -----------------------------------------------------------------------------
 // ADR 0021 — Stream D bundles + Stream B cron (per-persona)
 // -----------------------------------------------------------------------------
 


### PR DESCRIPTION
First buildable slice of the **Operator ⇄ Claude MCP connector** (design: #1379, plan approved). Adds the `mcp_connector` customer.yaml block — the authoring surface for which org users may reach an Operator from inside their own Claude, and under what data posture.

## Scope (C1 only)

Console-side validation + contract. **No runtime/endpoint yet** — that's the next slice (gated on the Clerk + claude.ai spike).

- **`types.ts`** — `McpConnector` / `McpConnectorAccess` / `DataPosture` + `ACCEPTED_DATA_POSTURES` (`open` | `firm_only`).
- **`sections-mcp-connector.ts`** — validator. Fail-closed: absent/`enabled:false` ⇒ off. `access[]` cross-checks each email against `users[]` and each profile against **active** persona slugs; rejects unknown email/profile and duplicate bindings.
- **`validator.ts`** — orchestration + public exports.
- **`customer-yaml-blocks.yaml`** — registry entry (implemented, console-side; the block is consumed by the console MCP endpoint, not translated to Machine config — per the console-mediated hosting decision).
- **`customer-yaml-editor.ts`** — portal preserves it verbatim (provisioning/admin-set, not client-editable yet).

## Design alignment

- **Fail-closed throughout** (ADR 0035): no authored access ⇒ that user reaches nothing.
- **Deliberately minimal** (Simplifier critique): no `port` (deployment constant), no `authority_mode`/`access_map` (seated in the design, authored when a 2nd principal exists). `access[]` is the per-user → profile seam; walled principals later get distinct profiles (memory-wall rule, design §4.3).
- `data_posture` defaults `open` (flexibility for mixed personal/firm Claude adoption); privileged-egress consent is enforced where document tools land, not here.

## Verification

- 8 new validator tests; **213** validator tests green.
- Block-conformance pytest **4/4**; full operator-substrate gate **306/306** (the post-merge gate not in `npm run verify`).
- `astro check` **0 errors**; eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)