### PR TITLE
feat(operator): console-hosted MCP endpoint scaffold + Clerk auth (A0 spike)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,4 @@ __pycache__/
 
 # Generated projection SQL (scripts/project-customer-config.ts)
 scripts/.generated/
+node_modules

--- a/docs/design/operator/mcp-clerk-setup.md
+++ b/docs/design/operator/mcp-clerk-setup.md
@@ -1,0 +1,222 @@
+# Clerk setup for the Operator ⇄ Claude MCP connector (Captain runbook)
+
+**Status:** A0 spike. This guide is what unblocks the live spike — it walks the
+Captain through creating a per-customer Clerk OAuth application and copying the
+values the console needs to validate tokens. Everything in `src/lib/operator/mcp/`
+typechecks and is unit-tested, but cannot be exercised end-to-end (real
+`claude.ai` connector add → OAuth → authed `tools/call`) until a real Clerk app
+exists and its issuer is wired into the customer descriptor.
+
+Audience: the Captain (Scott). Mechanical, click-by-click. Where a value must be
+copied into config, the field name is in **bold** and the destination is named.
+
+---
+
+## 0. Background: what Clerk is doing here
+
+The console is an **OAuth 2.1 Resource Server**. Clerk is the **Authorization
+Server (AS)**. The flow:
+
+1. A client org's Claude (claude.ai custom connector / Claude Desktop) is pointed
+   at our MCP endpoint: `https://smd.services/api/mcp`.
+2. Claude fetches `https://smd.services/.well-known/oauth-protected-resource/api/mcp`
+   (RFC 9728). That document names the customer's Clerk instance as the AS.
+3. Claude runs OAuth 2.1 + PKCE against Clerk. The user signs in with their Clerk
+   identity. Clerk issues an **OAuth access token** (a signed RS256 JWT).
+4. Claude calls `POST /api/mcp` with `Authorization: Bearer <token>`.
+5. The console verifies the token (signature via Clerk's JWKS, `iss`, `aud`/`azp`)
+   and maps the identity (`email`) to the customer's authored
+   `mcp_connector.access[]` block. No authored entry ⇒ 401 (fail-closed).
+
+**One Clerk OAuth application per customer** is the isolation mechanism for the
+pilot (see §6, the audience open question). Customer B's token is issued by a
+different Clerk app / issuer and will not validate against customer A.
+
+---
+
+## 1. Pick the Clerk instance
+
+SMD already runs a Clerk application **"SMD Services"** (see `astro.config.mjs`).
+The pilot customer (customer-zero, `smd`) uses **that same Clerk instance** — the
+pilot user already has an identity there.
+
+- For a real external client later, the decision is: a **separate Clerk
+  application** under SMD's Clerk account per client org (recommended — clean
+  issuer isolation), vs. one shared instance with per-app OAuth clients. For the
+  pilot, reuse the existing SMD Services instance.
+
+Dashboard home: **https://dashboard.clerk.com**
+
+---
+
+## 2. Create the OAuth application
+
+1. In the Clerk Dashboard, open the OAuth applications page directly:
+   **https://dashboard.clerk.com/~/oauth-applications**
+   (Or: left sidebar → **Configure** → **OAuth applications**.)
+2. Click **Add OAuth application**. A modal opens.
+3. **Name:** `SMD Operator MCP — <customer slug>` (e.g. `SMD Operator MCP — smd`).
+   The name is only for your own identification.
+4. **Scopes:** enable exactly these three:
+   - `openid`
+   - `profile`
+   - `email` ← **required.** The console maps the token's `email` claim to
+     `mcp_connector.access[]`. Without the `email` scope the token carries no
+     email, the identity mapping fails, and every call 401s. (See the SEAM NOTE
+     in `token-validation.ts` for the Backend-API `sub`→email fallback — not
+     wired in the spike, so `email` scope is mandatory for now.)
+5. Click **Add**.
+
+---
+
+## 3. Copy the credentials (and where each goes)
+
+After you click **Add**, Clerk shows the **Client Secret once** and then the
+app's settings page.
+
+| Clerk dashboard field | Where it lives                           | Notes                                                                                                                                                                                                             |
+| --------------------- | ---------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Client Secret**     | Worker secret (later slice)              | Shown once. Copy it now into Infisical `/ss` as `MCP_CLERK_CLIENT_SECRET_<slug>` (or hold it). Confidential clients only; if you register Claude via DCR (public client) you may not need it.                     |
+| **Client ID**         | `ClerkCustomerBinding.authorizedParties` | Settings page → **Application credentials** → **Client ID**. This is the `azp` value the console pins.                                                                                                            |
+| **Discovery URL**     | derive the **issuer** from it            | Settings page → **Application configuration URLs** → **Discovery URL**. It looks like `https://<issuer>/.well-known/openid-configuration`. The **issuer** is that URL with the `/.well-known/...` suffix removed. |
+
+### The issuer + JWKS
+
+- **Issuer** (`iss`): the origin of the Discovery URL. For an SMD production
+  instance this is typically `https://clerk.smd.services`; for a dev instance it
+  is `https://<slug>.clerk.accounts.dev`. The console pins `iss` to this exact
+  string (`ClerkCustomerBinding.issuer`).
+- **JWKS:** the console does **not** need the JWKS URL hand-copied —
+  `@clerk/backend`'s `verifyToken` discovers and caches the JWKS from the token's
+  issuer automatically. (The JWKS is at `<issuer>/.well-known/jwks.json` if you
+  ever want to inspect it.)
+
+---
+
+## 4. Redirect URIs
+
+The redirect URI is where Clerk sends the user back after they authenticate.
+**The MCP client supplies this**, not the console.
+
+- **claude.ai custom connector:** when you add the connector in the claude.ai UI,
+  claude.ai tells you the redirect URI to register. Paste it into the Clerk app's
+  **Redirect URIs** field (Settings page). It will be a `https://claude.ai/...`
+  callback URL.
+- **Claude Desktop:** Desktop uses a localhost loopback redirect
+  (`http://localhost:<port>/...` or a custom scheme). Register whatever Desktop
+  shows you. (Localhost redirects are standard for native OAuth clients.)
+- If you enable **Dynamic Client Registration** (§5), the client registers its own
+  redirect URI automatically and you do not hand-enter it.
+
+> Add the redirect URI **before** completing the connector add in Claude, or the
+> first OAuth round-trip fails with `redirect_uri_mismatch`.
+
+---
+
+## 5. Dynamic Client Registration (DCR) vs. pre-registered
+
+Clerk supports **Dynamic Client Registration** (RFC 7591) — a toggle on the
+OAuth applications page (**Dynamic client registration**).
+
+- **For the pilot: leave DCR OFF and pre-register the client** (one OAuth app,
+  redirect URI hand-entered per §4). Simpler, fewer moving parts, and the pilot is
+  a single known client. This matches the build plan's "Out of scope (Phase 1):
+  DCR-based multi-client onboarding."
+- **DCR ON** is the path for onboarding many client orgs without hand-creating an
+  app each time (claude.ai registers itself). Revisit when the connector graduates
+  past the single pilot.
+
+---
+
+## 6. OPEN QUESTION for the Captain — does Clerk bind a per-resource `aud`? (RFC 8707)
+
+This is the one thing the spike cannot answer from docs and needs you to confirm
+against a **real minted token**. It decides the cross-tenant isolation story.
+
+**Why it matters.** The MCP authorization spec (2025-11-25 / 2026-03-15) mandates
+RFC 8707 **resource indicators**: the client sends a `resource` parameter naming
+our endpoint, and a compliant AS binds the token's `aud` claim to that resource.
+The resource server (us) MUST then reject any token whose `aud` is not our
+resource. This is what stops a token minted for one resource being replayed at
+another ("confused-deputy" / token mis-redemption).
+
+**What to check.** After you complete one OAuth handshake (the A0 spike), decode
+the issued access token (paste it into https://jwt.io or inspect it in the
+console logs) and look at the `aud` claim:
+
+- **If `aud` equals `https://smd.services/api/mcp`** (our resource URL): Clerk
+  binds a per-resource audience. Set `ClerkCustomerBinding.audience` to that exact
+  string in the customer descriptor. The console then enforces it via
+  `verifyToken({ audience })` — best-in-class isolation, spec-compliant.
+- **If `aud` is absent, or is a generic value** (e.g. the instance or client id,
+  not our resource URL): Clerk does **not** resource-bind `aud` for this token
+  type. Leave `ClerkCustomerBinding.audience = null` and rely on the **fallback
+  isolation**: one Clerk OAuth app per customer + the per-customer **issuer pin**
+  (`iss` must equal this customer's instance) + the **`azp`/Client ID pin**
+  (`authorizedParties`). The console already enforces all three. A customer-B
+  token then fails customer A because its `iss` (and `azp`) are a different app.
+
+**Record the answer** in this file (edit the line below) once confirmed, so the
+next person provisioning a customer knows which isolation mode is in force:
+
+> **Audience binding status:** _TBD — Captain to confirm against a real token._
+
+Either way the console is safe: the fallback (issuer + azp pin, one app per
+customer) is enforced unconditionally, and the audience check layers on top when
+available.
+
+---
+
+## 7. Wire the values into the console (where the spike stub is)
+
+The spike ships a single hard-coded descriptor in
+`src/lib/operator/mcp/customer-resolution.ts` (`PILOT_STUB`). To light up the live
+path for the pilot:
+
+1. Set `PILOT_STUB.clerk.issuer` to the issuer from §3 (e.g.
+   `https://clerk.smd.services`).
+2. Set `PILOT_STUB.clerk.authorizedParties` to `[<Client ID>]` from §3.
+3. Set `PILOT_STUB.clerk.audience` per the §6 finding (the resource URL, or null).
+4. Set `PILOT_STUB.connector` from the pilot's real `mcp_connector` block — most
+   importantly `enabled: true` and the `access: [{ email, profile }]` entry for
+   the pilot user. (Live slice: read this from the materialized `customer.yaml`
+   instead of hard-coding — that is the documented next slice, not the spike.)
+
+Until step 4 authors a real `access[]`, the endpoint **fail-closes**: a Clerk-valid
+token still 401s because its email is not authored. That is the correct posture —
+the spike cannot grant access to anyone until a real config is wired in.
+
+---
+
+## 8. What the Captain runs to finish A0 (the part the agent cannot do)
+
+The agent built and unit-tested everything that does not need a live Clerk app.
+The signature-verification path and the real OAuth round-trip need a live app +
+a real client. The Captain's A0 steps:
+
+1. Create the Clerk OAuth app (§2–§3).
+2. Wire `PILOT_STUB` (§7) and deploy the console (or run it against a dev Clerk
+   instance).
+3. Add the connector in claude.ai pointed at `https://smd.services/api/mcp`
+   (register the redirect URI it gives you, §4).
+4. Complete the OAuth sign-in. Confirm one authed `tools/list` + one
+   `operator_status` `tools/call` returns the stub payload.
+5. Decode the token and **answer the §6 audience question**; set `audience`
+   accordingly.
+6. Negative test (build-plan A1): a token minted for a different Clerk app/issuer
+   must 401. Once a second customer exists, this becomes the cross-tenant test
+   added to the operator-substrate suite.
+
+---
+
+## Reference
+
+- Clerk OAuth applications: https://dashboard.clerk.com/~/oauth-applications
+- Clerk — how Clerk implements OAuth (DCR, scopes):
+  https://clerk.com/docs/guides/configure/auth-strategies/oauth/how-clerk-implements-oauth
+- Clerk — verifying OAuth access tokens:
+  https://clerk.com/docs/guides/configure/auth-strategies/oauth/verify-oauth-tokens
+- RFC 9728 (Protected Resource Metadata): https://datatracker.ietf.org/doc/html/rfc9728
+- RFC 8707 (Resource Indicators): https://www.rfc-editor.org/rfc/rfc8707.html
+- MCP authorization spec:
+  https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization

--- a/docs/design/operator/mcp-clerk-setup.md
+++ b/docs/design/operator/mcp-clerk-setup.md
@@ -24,9 +24,13 @@ Server (AS)**. The flow:
 3. Claude runs OAuth 2.1 + PKCE against Clerk. The user signs in with their Clerk
    identity. Clerk issues an **OAuth access token** (a signed RS256 JWT).
 4. Claude calls `POST /api/mcp` with `Authorization: Bearer <token>`.
-5. The console verifies the token (signature via Clerk's JWKS, `iss`, `aud`/`azp`)
-   and maps the identity (`email`) to the customer's authored
-   `mcp_connector.access[]` block. No authored entry ⇒ 401 (fail-closed).
+5. The console validates the token, security-ordered: verify signature (Clerk's
+   JWKS) → **derive which customer the token is for from its verified `aud`**
+   (else the per-customer `iss`) → enforce that customer's binding (`iss`/`azp`) →
+   map the identity (`email`) to the customer's authored `mcp_connector.access[]`.
+   The customer is taken from the **token**, never from the URL or body; a token
+   whose `aud` matches no customer 401s before any data access. No authored
+   access entry ⇒ 401 (fail-closed).
 
 **One Clerk OAuth application per customer** is the isolation mechanism for the
 pilot (see §6, the audience open question). Customer B's token is issued by a

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@astrojs/cloudflare": "^13.1.10",
         "@astrojs/sitemap": "^3.7.2",
         "@clerk/astro": "^3.2.6",
+        "@clerk/backend": "^3.4.11",
         "@elevenlabs/client": "^1.9.0",
         "@formepdf/core": "^0.8.2",
         "@formepdf/react": "^0.8.2",
@@ -2585,6 +2586,70 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.2.2",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@astrojs/cloudflare": "^13.1.10",
     "@astrojs/sitemap": "^3.7.2",
     "@clerk/astro": "^3.2.6",
+    "@clerk/backend": "^3.4.11",
     "@elevenlabs/client": "^1.9.0",
     "@formepdf/core": "^0.8.2",
     "@formepdf/react": "^0.8.2",

--- a/src/lib/operator/mcp/customer-resolution.ts
+++ b/src/lib/operator/mcp/customer-resolution.ts
@@ -1,0 +1,110 @@
+/**
+ * SPIKE SCAFFOLD (A0) — customer-resolution seam for the Operator ⇄ Claude MCP
+ * connector. See docs/design/operator/03-mcp-server-exposure.md and the build
+ * plan (Workstream A). This is the one seam the spike deliberately stubs: it
+ * answers "which customer does this MCP request serve, and what is that
+ * customer's authored `mcp_connector` block + Clerk binding?"
+ *
+ * Why a seam (and not the real customer.yaml read yet): the live path needs to
+ * (a) load the customer's materialized `customer.yaml` (the same source the
+ * portal projection reads) to get `mcp_connector.access[]`, and (b) load the
+ * per-customer Clerk app binding (issuer + audience + JWKS) that the Captain
+ * provisions per the Clerk setup guide. Both land in later slices (C1's block is
+ * authored; C2 provisions the Clerk app). For the spike, a single hard-coded
+ * pilot descriptor lets the endpoint typecheck and exercise discovery + JWT
+ * validation end-to-end against a real Clerk app once the Captain creates one.
+ *
+ * Fail-closed: an unknown resource id resolves to `null` → the endpoint refuses
+ * (no customer ⇒ no Operator). This mirrors `resolveCustomerFlyApp` in
+ * fly-app-registry.ts, which the live implementation will extend rather than
+ * duplicate.
+ */
+
+import type { McpConnector } from '../customer-yaml/types'
+
+/**
+ * The per-customer Clerk OAuth binding the token validator needs. One Clerk
+ * OAuth application per customer is the spike's isolation mechanism (see the
+ * `aud`-binding open question in the Clerk setup guide): even if Clerk does not
+ * bind a per-resource `aud`, pinning the issuer + authorized client per customer
+ * keeps customer B's token from validating against customer A.
+ */
+export interface ClerkCustomerBinding {
+  /**
+   * The customer's Clerk instance issuer, e.g.
+   * `https://clerk.smd.services` (prod) or `https://<slug>.clerk.accounts.dev`
+   * (dev). Copied from the Clerk dashboard per the setup guide. The token's
+   * `iss` claim MUST equal this exactly.
+   */
+  issuer: string
+  /**
+   * Expected audience for tokens minted for this customer's MCP resource, when
+   * Clerk binds a per-resource `aud` (RFC 8707). `null` when the instance does
+   * not emit a resource-bound `aud` — in that case isolation rests on the
+   * per-customer issuer + authorized-party pin instead. See the setup guide.
+   */
+  audience: string | null
+  /**
+   * Authorized-party (`azp`) / client id values permitted for this customer's
+   * OAuth app. Used as the `authorizedParties` check in `verifyToken`. Empty
+   * array ⇒ the azp check is skipped (acceptable only when `audience` is set).
+   */
+  authorizedParties: string[]
+}
+
+/**
+ * Everything the MCP endpoint needs to serve one authenticated request for one
+ * customer: the customer id (→ Fly app via the registry), the authored
+ * connector block (enabled flag + `access[]` email→profile bindings + posture),
+ * and the Clerk binding for token validation.
+ */
+export interface ResolvedMcpCustomer {
+  customerId: string
+  connector: McpConnector
+  clerk: ClerkCustomerBinding
+}
+
+/**
+ * SPIKE STUB. The pilot customer descriptor. Replaced in the live slice by a
+ * read of the materialized `customer.yaml` (the `mcp_connector` block authored
+ * in C1) keyed by the resource path, plus the provisioned Clerk binding.
+ *
+ * The `access` list here is intentionally empty: with no authored access entry,
+ * EVERY email fails the authored-user check and the endpoint fail-closes. That
+ * is the correct spike posture — the endpoint cannot grant access to anyone
+ * until a real `customer.yaml` with a real `access[]` is wired in. The Captain
+ * populates `issuer` from the Clerk dashboard (setup guide) to exercise the
+ * discovery + OAuth handshake; identity mapping then 401s until `access[]` is
+ * sourced from the real config, which is the documented next slice.
+ */
+const PILOT_STUB: ResolvedMcpCustomer = {
+  customerId: 'smd',
+  connector: {
+    enabled: false,
+    data_posture: 'open',
+    access: [],
+  },
+  clerk: {
+    // Captain fills this from the Clerk dashboard per mcp-clerk-setup.md.
+    // Empty string ⇒ token validation fail-closes (no issuer to match).
+    issuer: '',
+    audience: null,
+    authorizedParties: [],
+  },
+}
+
+/**
+ * Resolve the customer this MCP resource serves. SPIKE: a single resource path
+ * maps to the pilot stub; anything else fail-closes to `null`.
+ *
+ * Live implementation: map the resource path → customer id (the MCP endpoint is
+ * per-customer; the path or host carries the customer slug), then load the
+ * materialized config + Clerk binding. Keep this signature so the route code
+ * does not change when the stub is replaced.
+ */
+export function resolveMcpCustomer(resourcePath: string): ResolvedMcpCustomer | null {
+  // SPIKE: the pilot is served at the single canonical MCP path. The live path
+  // will carry the customer slug (e.g. `/api/mcp/<slug>`) and look it up.
+  if (resourcePath === '/api/mcp' || resourcePath === '/api/mcp/') return PILOT_STUB
+  return null
+}

--- a/src/lib/operator/mcp/customer-resolution.ts
+++ b/src/lib/operator/mcp/customer-resolution.ts
@@ -5,43 +5,53 @@
  * answers "which customer does this MCP request serve, and what is that
  * customer's authored `mcp_connector` block + Clerk binding?"
  *
- * Why a seam (and not the real customer.yaml read yet): the live path needs to
- * (a) load the customer's materialized `customer.yaml` (the same source the
- * portal projection reads) to get `mcp_connector.access[]`, and (b) load the
- * per-customer Clerk app binding (issuer + audience + JWKS) that the Captain
- * provisions per the Clerk setup guide. Both land in later slices (C1's block is
- * authored; C2 provisions the Clerk app). For the spike, a single hard-coded
- * pilot descriptor lets the endpoint typecheck and exercise discovery + JWT
- * validation end-to-end against a real Clerk app once the Captain creates one.
+ * SECURITY CONTRACT (from the console-hosting security review — these are app-code
+ * authz invariants because one console validates tokens for ALL customers):
  *
- * Fail-closed: an unknown resource id resolves to `null` → the endpoint refuses
- * (no customer ⇒ no Operator). This mirrors `resolveCustomerFlyApp` in
- * fly-app-registry.ts, which the live implementation will extend rather than
- * duplicate.
+ *   1. The customer is DERIVED FROM THE VERIFIED TOKEN — its `aud` when Clerk
+ *      binds a per-resource audience (RFC 8707), else the per-customer `iss`
+ *      (one Clerk app per customer ⇒ unique issuer). It is NEVER read from a URL
+ *      path segment or request body. A path/body slug, if present, is UNTRUSTED
+ *      and may only be used to CHECK-MATCH the token-derived customer, never to
+ *      select it. A `/mcp/<customer>` routing shape would be a confused-deputy
+ *      bug one layer up — so the endpoint serves ONE fixed path and the customer
+ *      falls out of the token. See `resolveCustomerFromClaims`.
+ *
+ *   2. Cross-customer isolation rests entirely on `aud` (or the `iss` fallback)
+ *      enforcement. `resolveCustomerFromClaims` returning the wrong/none customer
+ *      for a token IS the cross-tenant wall; the validator gates on it before any
+ *      per-user authorization or data access.
+ *
+ * Fail-closed: claims that match no registered customer resolve to `null` → the
+ * endpoint refuses. This mirrors `resolveCustomerFlyApp` in fly-app-registry.ts,
+ * which the live implementation will extend rather than duplicate.
  */
 
 import type { McpConnector } from '../customer-yaml/types'
 
 /**
  * The per-customer Clerk OAuth binding the token validator needs. One Clerk
- * OAuth application per customer is the spike's isolation mechanism (see the
- * `aud`-binding open question in the Clerk setup guide): even if Clerk does not
- * bind a per-resource `aud`, pinning the issuer + authorized client per customer
- * keeps customer B's token from validating against customer A.
+ * OAuth application per customer is the isolation mechanism (see the `aud`-binding
+ * open question in the Clerk setup guide): even if Clerk does not bind a
+ * per-resource `aud`, the per-customer issuer + authorized client keep customer
+ * B's token from resolving to — or validating against — customer A.
  */
 export interface ClerkCustomerBinding {
   /**
    * The customer's Clerk instance issuer, e.g.
    * `https://clerk.smd.services` (prod) or `https://<slug>.clerk.accounts.dev`
    * (dev). Copied from the Clerk dashboard per the setup guide. The token's
-   * `iss` claim MUST equal this exactly.
+   * `iss` claim MUST equal this exactly. When `audience` is null this `iss` is
+   * ALSO the customer-identity key (the token-derived customer is whichever
+   * registered binding owns this issuer).
    */
   issuer: string
   /**
    * Expected audience for tokens minted for this customer's MCP resource, when
    * Clerk binds a per-resource `aud` (RFC 8707). `null` when the instance does
-   * not emit a resource-bound `aud` — in that case isolation rests on the
-   * per-customer issuer + authorized-party pin instead. See the setup guide.
+   * not emit a resource-bound `aud` — in that case the customer is keyed off
+   * `issuer` instead. When set, `aud` is BOTH the customer-identity key and the
+   * mis-redemption gate. See the setup guide §6.
    */
   audience: string | null
   /**
@@ -64,18 +74,26 @@ export interface ResolvedMcpCustomer {
   clerk: ClerkCustomerBinding
 }
 
+/** The subset of verified token claims used to derive the customer identity. */
+export interface CustomerIdentityClaims {
+  /** Verified `aud` claim (string or string[]); the primary customer key. */
+  aud?: string | string[]
+  /** Verified `iss` claim; the fallback customer key when `aud` is unbound. */
+  iss?: string
+}
+
 /**
  * SPIKE STUB. The pilot customer descriptor. Replaced in the live slice by a
  * read of the materialized `customer.yaml` (the `mcp_connector` block authored
- * in C1) keyed by the resource path, plus the provisioned Clerk binding.
+ * in C1) plus the provisioned Clerk binding, indexed for claim-based lookup.
  *
  * The `access` list here is intentionally empty: with no authored access entry,
- * EVERY email fails the authored-user check and the endpoint fail-closes. That
- * is the correct spike posture — the endpoint cannot grant access to anyone
- * until a real `customer.yaml` with a real `access[]` is wired in. The Captain
- * populates `issuer` from the Clerk dashboard (setup guide) to exercise the
- * discovery + OAuth handshake; identity mapping then 401s until `access[]` is
- * sourced from the real config, which is the documented next slice.
+ * EVERY email fails the per-user check and the endpoint fail-closes. That is the
+ * correct spike posture — the endpoint cannot grant access to anyone until a real
+ * `customer.yaml` with a real `access[]` is wired in. The Captain populates
+ * `issuer` (and, per the §6 finding, `audience`) from the Clerk dashboard to
+ * exercise discovery + OAuth; identity mapping then 401s until `access[]` is
+ * sourced from the real config (the documented next slice).
  */
 const PILOT_STUB: ResolvedMcpCustomer = {
   customerId: 'smd',
@@ -85,26 +103,87 @@ const PILOT_STUB: ResolvedMcpCustomer = {
     access: [],
   },
   clerk: {
-    // Captain fills this from the Clerk dashboard per mcp-clerk-setup.md.
-    // Empty string ⇒ token validation fail-closes (no issuer to match).
+    // Captain fills these from the Clerk dashboard per mcp-clerk-setup.md.
+    // Empty issuer ⇒ no token can resolve to this customer (fail-closed).
     issuer: '',
     audience: null,
     authorizedParties: [],
   },
 }
 
+/** The registry of all customers this console serves. SPIKE: just the pilot. */
+const CUSTOMERS: readonly ResolvedMcpCustomer[] = [PILOT_STUB]
+
+/** Does the token's `aud` (string or array) include the customer's bound audience? */
+function audMatches(aud: string | string[] | undefined, expected: string): boolean {
+  if (aud === undefined) return false
+  return Array.isArray(aud) ? aud.includes(expected) : aud === expected
+}
+
 /**
- * Resolve the customer this MCP resource serves. SPIKE: a single resource path
- * maps to the pilot stub; anything else fail-closes to `null`.
+ * SECURITY-CRITICAL (invariant 1 + 2): derive the customer from VERIFIED token
+ * claims — never from a path or body. Call this ONLY with claims that came out of
+ * a successful signature verification; passing unverified claims would let a
+ * forged `aud`/`iss` select a customer.
  *
- * Live implementation: map the resource path → customer id (the MCP endpoint is
- * per-customer; the path or host carries the customer slug), then load the
- * materialized config + Clerk binding. Keep this signature so the route code
- * does not change when the stub is replaced.
+ * Resolution order, per the §6 audience finding:
+ *   - If a registered customer binds an `audience` and the token's `aud` matches
+ *     it → that customer. This is the RFC 8707 mis-redemption gate: a token whose
+ *     `aud` is another resource matches no customer here and the validator 401s
+ *     BEFORE any data access.
+ *   - Else (no audience-bound match) fall back to the per-customer `iss`: the
+ *     token's issuer uniquely identifies the customer's Clerk app (one app per
+ *     customer). A customer whose binding has `audience: null` is matched by
+ *     issuer; a customer WITH an audience is matched ONLY by audience (so an
+ *     issuer-only match never bypasses a resource-bound customer).
+ *
+ * Returns the single matching customer, or `null` when none matches (fail-closed)
+ * or when more than one matches (ambiguous ⇒ refuse rather than guess).
  */
-export function resolveMcpCustomer(resourcePath: string): ResolvedMcpCustomer | null {
-  // SPIKE: the pilot is served at the single canonical MCP path. The live path
-  // will carry the customer slug (e.g. `/api/mcp/<slug>`) and look it up.
-  if (resourcePath === '/api/mcp' || resourcePath === '/api/mcp/') return PILOT_STUB
-  return null
+export function resolveCustomerFromClaims(
+  claims: CustomerIdentityClaims
+): ResolvedMcpCustomer | null {
+  // Pass 1: audience-bound customers (the strong, spec-compliant key).
+  const audMatched = CUSTOMERS.filter(
+    (c) => c.clerk.audience !== null && audMatches(claims.aud, c.clerk.audience)
+  )
+  if (audMatched.length === 1) return audMatched[0]
+  if (audMatched.length > 1) return null // ambiguous → refuse
+
+  // Pass 2: issuer-keyed customers (fallback when Clerk does not bind `aud`).
+  // Only customers WITHOUT an audience binding are eligible here, so a token that
+  // failed the audience match above cannot sidestep into an issuer match against a
+  // resource-bound customer.
+  if (typeof claims.iss !== 'string' || claims.iss.length === 0) return null
+  const issMatched = CUSTOMERS.filter(
+    (c) => c.clerk.audience === null && c.clerk.issuer.length > 0 && c.clerk.issuer === claims.iss
+  )
+  return issMatched.length === 1 ? issMatched[0] : null
+}
+
+/**
+ * UNTRUSTED path check (invariant 1). The MCP endpoint serves ONE fixed resource
+ * path; this only confirms a request hit that path. It does NOT and MUST NOT
+ * select the customer — that comes from the verified token via
+ * `resolveCustomerFromClaims`. If a future routing shape carries a slug in the
+ * path/body, compare it against the token-derived `customerId` here and reject a
+ * mismatch; never trust it to choose the customer.
+ */
+export const MCP_RESOURCE_PATH = '/api/mcp'
+
+export function isMcpResourcePath(resourcePath: string): boolean {
+  return resourcePath === MCP_RESOURCE_PATH || resourcePath === `${MCP_RESOURCE_PATH}/`
+}
+
+/**
+ * Authorization-server issuers to advertise in the PUBLIC RFC 9728 discovery doc
+ * for the MCP resource. This is discovery only — it tells a client WHERE to
+ * authenticate and carries no customer-selecting power (isolation is enforced at
+ * token validation via {@link resolveCustomerFromClaims}). Returns the distinct
+ * non-empty issuers of every registered customer; empty when none provisioned
+ * (honest "no AS configured", never fabricated).
+ */
+export function discoveryAuthorizationServers(): string[] {
+  const issuers = CUSTOMERS.map((c) => c.clerk.issuer).filter((i) => i.length > 0)
+  return [...new Set(issuers)]
 }

--- a/src/lib/operator/mcp/mcp-handler.ts
+++ b/src/lib/operator/mcp/mcp-handler.ts
@@ -1,0 +1,150 @@
+/**
+ * SPIKE SCAFFOLD (A0) — minimal MCP Streamable HTTP handler.
+ *
+ * Build-vs-adapt finding: the MCP TypeScript SDK's `StreamableHTTPServerTransport`
+ * assumes a Node request/response object model and pulls Node-only deps — it is
+ * not a clean fit for Astro-on-CF-Workers (web-standard Request/Response, no
+ * Node APIs). The Streamable HTTP spec, however, permits a server to answer a
+ * POST with a SINGLE `application/json` JSON-RPC response (SSE is optional). For
+ * a stateless read/handoff surface we never need server-initiated streaming, so
+ * we BUILD a tiny JSON-RPC dispatcher (~one method switch) instead of adapting
+ * the SDK transport. This keeps the Worker free of Node shims.
+ *
+ * Scope: `initialize`, `notifications/initialized` (ack), `tools/list`,
+ * `tools/call`, `ping`. Anything else → JSON-RPC method-not-found. Stateless:
+ * we do not persist a session; each POST is self-contained (the optional
+ * `Mcp-Session-Id` header is accepted but not required, which the spec allows
+ * for stateless servers).
+ */
+
+import { getTool, listToolDescriptors, type McpToolContext, type McpToolResult } from './tools'
+
+/** Protocol version we advertise. Mirrors the negotiated value back to clients. */
+const SERVER_PROTOCOL_VERSION = '2025-06-18'
+
+const SERVER_INFO = {
+  name: 'smd-operator-connector',
+  title: 'SMD Operator',
+  version: '0.1.0-spike',
+} as const
+
+/** JSON-RPC 2.0 request shape (params optional). */
+interface JsonRpcRequest {
+  jsonrpc: '2.0'
+  id?: string | number | null
+  method: string
+  params?: unknown
+}
+
+/** Standard JSON-RPC error codes we use. */
+const JSON_RPC = {
+  PARSE_ERROR: -32700,
+  INVALID_REQUEST: -32600,
+  METHOD_NOT_FOUND: -32601,
+  INVALID_PARAMS: -32602,
+  INTERNAL_ERROR: -32603,
+} as const
+
+function rpcResult(id: JsonRpcRequest['id'], result: unknown): Response {
+  return jsonResponse({ jsonrpc: '2.0', id: id ?? null, result }, 200)
+}
+
+function rpcError(id: JsonRpcRequest['id'], code: number, message: string): Response {
+  return jsonResponse({ jsonrpc: '2.0', id: id ?? null, error: { code, message } }, 200)
+}
+
+function jsonResponse(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+function isJsonRpcRequest(v: unknown): v is JsonRpcRequest {
+  if (v === null || typeof v !== 'object') return false
+  const o = v as Record<string, unknown>
+  return o.jsonrpc === '2.0' && typeof o.method === 'string'
+}
+
+/**
+ * Dispatch one already-authenticated JSON-RPC request. The route layer
+ * (src/pages/api/mcp.ts) owns auth + audit and only calls this once the caller
+ * is a validated, authored identity.
+ */
+export async function dispatchMcpRequest(
+  req: JsonRpcRequest,
+  ctx: McpToolContext
+): Promise<Response> {
+  switch (req.method) {
+    case 'initialize':
+      return rpcResult(req.id, {
+        protocolVersion: SERVER_PROTOCOL_VERSION,
+        capabilities: { tools: { listChanged: false } },
+        serverInfo: SERVER_INFO,
+      })
+
+    // Client lifecycle ack — a notification (no id). Nothing to return; per
+    // JSON-RPC a notification gets no response body, but a 202 keeps clients
+    // happy over HTTP.
+    case 'notifications/initialized':
+      return new Response(null, { status: 202 })
+
+    case 'ping':
+      return rpcResult(req.id, {})
+
+    case 'tools/list':
+      return rpcResult(req.id, { tools: listToolDescriptors() })
+
+    case 'tools/call':
+      return handleToolsCall(req, ctx)
+
+    default:
+      return rpcError(req.id, JSON_RPC.METHOD_NOT_FOUND, `method not found: ${req.method}`)
+  }
+}
+
+async function handleToolsCall(req: JsonRpcRequest, ctx: McpToolContext): Promise<Response> {
+  const params = req.params
+  if (params === null || typeof params !== 'object') {
+    return rpcError(req.id, JSON_RPC.INVALID_PARAMS, 'tools/call requires params')
+  }
+  const { name, arguments: rawArgs } = params as { name?: unknown; arguments?: unknown }
+  if (typeof name !== 'string') {
+    return rpcError(req.id, JSON_RPC.INVALID_PARAMS, 'tools/call requires a string name')
+  }
+  const tool = getTool(name)
+  if (!tool) {
+    return rpcError(req.id, JSON_RPC.METHOD_NOT_FOUND, `unknown tool: ${name}`)
+  }
+  const args: Record<string, unknown> =
+    rawArgs !== null && typeof rawArgs === 'object' ? (rawArgs as Record<string, unknown>) : {}
+
+  let result: McpToolResult
+  try {
+    result = await tool.handle(args, ctx)
+  } catch (err) {
+    return rpcError(
+      req.id,
+      JSON_RPC.INTERNAL_ERROR,
+      err instanceof Error ? err.message : 'tool handler threw'
+    )
+  }
+  return rpcResult(req.id, result)
+}
+
+/**
+ * Parse a raw POST body into a JSON-RPC request, or a Response describing the
+ * parse/shape error. Returned as a union so the route can short-circuit.
+ */
+export function parseMcpBody(raw: string): { req: JsonRpcRequest } | { error: Response } {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return { error: rpcError(null, JSON_RPC.PARSE_ERROR, 'invalid JSON') }
+  }
+  if (!isJsonRpcRequest(parsed)) {
+    return { error: rpcError(null, JSON_RPC.INVALID_REQUEST, 'not a JSON-RPC 2.0 request') }
+  }
+  return { req: parsed }
+}

--- a/src/lib/operator/mcp/oauth-metadata.ts
+++ b/src/lib/operator/mcp/oauth-metadata.ts
@@ -1,0 +1,63 @@
+/**
+ * SPIKE SCAFFOLD (A0) — RFC 9728 OAuth Protected Resource Metadata.
+ *
+ * The MCP client (claude.ai / Claude Desktop) discovers where to authenticate by
+ * fetching `/.well-known/oauth-protected-resource[/<resource-path>]` on the
+ * resource server (this console). The document points at the customer's Clerk
+ * Authorization Server (`authorization_servers`) and declares the resource id +
+ * supported scopes. The client then runs the OAuth 2.1 + PKCE handshake against
+ * Clerk and returns with a bearer token we validate in token-validation.ts.
+ *
+ * We BUILD this small document rather than adapt Clerk's
+ * `protectedResourceHandlerClerk` (Next.js/Express-only). The shape is a stable
+ * RFC, so the build cost is trivial and keeps us off the Node-bound helpers.
+ *
+ * Per-customer: `authorization_servers` is the customer's Clerk issuer. With one
+ * Clerk OAuth app per customer (the spike's isolation mechanism), each customer’s
+ * resource advertises its own AS — so a token minted by customer B’s AS is
+ * issued by a different `iss` and fails customer A’s issuer pin.
+ */
+
+import type { ResolvedMcpCustomer } from './customer-resolution'
+
+/** RFC 9728 §2 protected-resource-metadata document (subset we emit). */
+export interface ProtectedResourceMetadata {
+  /** The resource identifier — the canonical URL of THIS MCP endpoint. */
+  resource: string
+  /** Authorization servers that can issue tokens for this resource. */
+  authorization_servers: string[]
+  /** OAuth scopes this resource understands. */
+  scopes_supported: string[]
+  /** How the bearer token is presented (header only). */
+  bearer_methods_supported: string[]
+}
+
+/**
+ * Build the protected-resource metadata for a resolved customer.
+ * `resourceUrl` is the absolute URL of the MCP endpoint (e.g.
+ * `https://smd.services/api/mcp`) — it MUST match the `resource` the client used
+ * for discovery and the `aud` Clerk binds (when it does).
+ */
+export function buildProtectedResourceMetadata(
+  resourceUrl: string,
+  customer: ResolvedMcpCustomer
+): ProtectedResourceMetadata {
+  return {
+    resource: resourceUrl,
+    // When the issuer is not yet provisioned (spike stub), advertise an empty
+    // list — an honest "no AS configured" rather than a fabricated one.
+    authorization_servers: customer.clerk.issuer ? [customer.clerk.issuer] : [],
+    scopes_supported: ['openid', 'profile', 'email'],
+    bearer_methods_supported: ['header'],
+  }
+}
+
+/**
+ * The RFC 9728 §5.1 `WWW-Authenticate` challenge value a 401 from the MCP
+ * endpoint must carry, pointing the client at the metadata document so it can
+ * (re)discover the AS. `resourceMetadataUrl` is the absolute
+ * `/.well-known/oauth-protected-resource/...` URL for this resource.
+ */
+export function buildWwwAuthenticate(resourceMetadataUrl: string): string {
+  return `Bearer resource_metadata="${resourceMetadataUrl}"`
+}

--- a/src/lib/operator/mcp/oauth-metadata.ts
+++ b/src/lib/operator/mcp/oauth-metadata.ts
@@ -12,13 +12,14 @@
  * `protectedResourceHandlerClerk` (Next.js/Express-only). The shape is a stable
  * RFC, so the build cost is trivial and keeps us off the Node-bound helpers.
  *
- * Per-customer: `authorization_servers` is the customer's Clerk issuer. With one
- * Clerk OAuth app per customer (the spike's isolation mechanism), each customer’s
- * resource advertises its own AS — so a token minted by customer B’s AS is
- * issued by a different `iss` and fails customer A’s issuer pin.
+ * Per-customer: `authorization_servers` lists the Clerk issuer(s) registered for
+ * this resource. With one Clerk OAuth app per customer (the isolation mechanism),
+ * a token minted by customer B's AS is issued by a different `iss` and is
+ * rejected when validating against customer A — the discovery doc only tells a
+ * client WHERE to authenticate; isolation is enforced at token validation, not
+ * here. This document is PUBLIC and unauthenticated, so it carries no
+ * customer-selecting power.
  */
-
-import type { ResolvedMcpCustomer } from './customer-resolution'
 
 /** RFC 9728 §2 protected-resource-metadata document (subset we emit). */
 export interface ProtectedResourceMetadata {
@@ -33,20 +34,20 @@ export interface ProtectedResourceMetadata {
 }
 
 /**
- * Build the protected-resource metadata for a resolved customer.
- * `resourceUrl` is the absolute URL of the MCP endpoint (e.g.
- * `https://smd.services/api/mcp`) — it MUST match the `resource` the client used
- * for discovery and the `aud` Clerk binds (when it does).
+ * Build the protected-resource metadata for the MCP resource. `resourceUrl` is
+ * the absolute URL of the MCP endpoint (e.g. `https://smd.services/api/mcp`) — it
+ * MUST match the `resource` the client used for discovery and the `aud` Clerk
+ * binds (when it does). `authorizationServers` is the list of issuer URLs
+ * registered for this resource (empty when none provisioned — an honest "no AS
+ * configured" rather than a fabricated one).
  */
 export function buildProtectedResourceMetadata(
   resourceUrl: string,
-  customer: ResolvedMcpCustomer
+  authorizationServers: readonly string[]
 ): ProtectedResourceMetadata {
   return {
     resource: resourceUrl,
-    // When the issuer is not yet provisioned (spike stub), advertise an empty
-    // list — an honest "no AS configured" rather than a fabricated one.
-    authorization_servers: customer.clerk.issuer ? [customer.clerk.issuer] : [],
+    authorization_servers: [...authorizationServers],
     scopes_supported: ['openid', 'profile', 'email'],
     bearer_methods_supported: ['header'],
   }

--- a/src/lib/operator/mcp/token-validation.ts
+++ b/src/lib/operator/mcp/token-validation.ts
@@ -1,0 +1,217 @@
+/**
+ * SPIKE SCAFFOLD (A0/A1) — fail-closed Clerk OAuth-token validation for the
+ * Operator ⇄ Claude MCP connector.
+ *
+ * Build-vs-adapt finding (the spike's key result): Clerk's MCP helpers
+ * (`@clerk/mcp-tools`) ship only Next.js/Express handlers and cannot be used
+ * from Astro-on-Cloudflare-Workers. BUT the underlying verification primitive,
+ * `verifyToken` from `@clerk/backend`, is runtime-agnostic (web-crypto, no Node
+ * APIs — it is the same primitive `@clerk/astro` uses) and runs natively on CF
+ * Workers. It fetches + caches the instance JWKS, checks the RS256 signature,
+ * and validates `iss` / `aud` / `azp` for us. So we ADAPT (`verifyToken`) for
+ * the JWT layer rather than hand-rolling JWKS + web-crypto.
+ *
+ * What this module adds on top of `verifyToken`:
+ *   1. Per-customer issuer pin (`iss` MUST equal the customer's Clerk issuer).
+ *   2. Per-customer audience/authorized-party binding (cross-tenant isolation:
+ *      customer B's token must NOT validate against customer A — build-plan A1
+ *      negative test).
+ *   3. Identity → `access[]` mapping (the authored email → profile seam from
+ *      C1). A Clerk-valid token whose identity is not an authored access entry
+ *      is REJECTED (fail-closed).
+ *
+ * Fail-closed everywhere: any throw, any missing claim, any unmatched identity
+ * resolves to a typed failure, never a silent pass.
+ */
+
+import { verifyToken } from '@clerk/backend'
+import type { McpConnectorAccess } from '../customer-yaml/types'
+import type { ResolvedMcpCustomer } from './customer-resolution'
+
+/**
+ * Outcome of validating one bearer token against one customer. A discriminated
+ * union so callers cannot accidentally treat a failure as a success.
+ */
+export type McpAuthResult =
+  | {
+      ok: true
+      /** Clerk user id (`sub`) — the stable subject for audit rows. */
+      subject: string
+      /** Authored email this token mapped to (from `access[]`). */
+      email: string
+      /** Persona/profile slug the email is bound to (the per-user seam). */
+      profile: string
+    }
+  | {
+      ok: false
+      /** Machine-readable reason; surfaced as `MCP_AUTH` audit decision. */
+      reason:
+        | 'missing_token'
+        | 'customer_not_configured'
+        | 'connector_disabled'
+        | 'signature_or_claims_invalid'
+        | 'identity_not_authored'
+      /** Human-readable detail for logs (never returned to the client verbatim). */
+      detail: string
+    }
+
+/**
+ * Extract the bearer token from an Authorization header. Returns null when
+ * absent or malformed — the caller emits the RFC 9728 `WWW-Authenticate`
+ * challenge in that case.
+ */
+export function extractBearerToken(authorizationHeader: string | null): string | null {
+  if (!authorizationHeader) return null
+  const m = /^Bearer\s+(.+)$/i.exec(authorizationHeader.trim())
+  if (!m) return null
+  const token = m[1].trim()
+  return token.length > 0 ? token : null
+}
+
+/**
+ * The subset of the verified Clerk JWT payload we read. Kept local + permissive
+ * because the OAuth access-token claim set depends on granted scopes; we read
+ * `sub` (always present) and `email` (present when the `email` scope is granted,
+ * which the setup guide requires).
+ */
+interface VerifiedClaims {
+  sub?: unknown
+  email?: unknown
+  iss?: unknown
+}
+
+/**
+ * Map a verified subject/email to an authored `access[]` entry. Email is the
+ * authored key (C1). We match on email when the token carries it; this is why
+ * the Clerk OAuth app MUST grant the `email` scope (setup guide). The `sub` is
+ * retained for audit even when the match is by email.
+ *
+ * SEAM NOTE: if a deployment cannot guarantee `email` in the token, the live
+ * slice resolves `sub` → email via the Clerk Backend API (one cached lookup)
+ * before this match. That lookup is deliberately NOT in the spike — it needs a
+ * live Clerk app + secret key — and its absence is fail-closed (no email ⇒ no
+ * match ⇒ reject).
+ */
+function matchAuthoredAccess(
+  email: string | null,
+  access: readonly McpConnectorAccess[]
+): McpConnectorAccess | null {
+  if (!email) return null
+  const normalized = email.trim().toLowerCase()
+  for (const entry of access) {
+    if (entry.email.trim().toLowerCase() === normalized) return entry
+  }
+  return null
+}
+
+/**
+ * The pre-flight gates that don't require the token signature: token present,
+ * customer configured + enabled, issuer provisioned. Returns a failure result
+ * to short-circuit, or `null` to proceed to signature verification.
+ */
+function preflightFailure(
+  token: string | null,
+  customer: ResolvedMcpCustomer | null
+): Extract<McpAuthResult, { ok: false }> | null {
+  if (!token) return { ok: false, reason: 'missing_token', detail: 'no bearer token' }
+  if (!customer) {
+    return { ok: false, reason: 'customer_not_configured', detail: 'unknown resource' }
+  }
+  if (!customer.connector.enabled) {
+    return { ok: false, reason: 'connector_disabled', detail: 'mcp_connector disabled' }
+  }
+  if (!customer.clerk.issuer) {
+    // Spike stub ships with an empty issuer until the Captain provisions the
+    // Clerk app. No issuer ⇒ we cannot pin `iss` ⇒ refuse rather than trust.
+    return { ok: false, reason: 'customer_not_configured', detail: 'clerk issuer not provisioned' }
+  }
+  return null
+}
+
+/**
+ * Verify the token signature + claims against the customer's Clerk binding.
+ * `verifyToken` fetches + caches the JWKS from the issuer, verifies the RS256
+ * signature, and enforces audience / authorizedParties when supplied. Returns
+ * the verified claims, or a failure result.
+ */
+async function verifyClaims(
+  token: string,
+  customer: ResolvedMcpCustomer
+): Promise<VerifiedClaims | Extract<McpAuthResult, { ok: false }>> {
+  try {
+    // No `secretKey`: signature verification is JWKS-based (public-key), which is
+    // all an OAuth resource server needs. The JWKS is discovered from the token
+    // issuer. (The live slice may pass the per-customer `secretKey` if a
+    // Backend-API `sub`→email lookup is wired; not needed for the spike.)
+    return await verifyToken(token, {
+      authorizedParties:
+        customer.clerk.authorizedParties.length > 0 ? customer.clerk.authorizedParties : undefined,
+      audience: customer.clerk.audience ?? undefined,
+    })
+  } catch (err) {
+    return {
+      ok: false,
+      reason: 'signature_or_claims_invalid',
+      detail: err instanceof Error ? err.message : 'verifyToken threw',
+    }
+  }
+}
+
+/**
+ * Validate one bearer token against one resolved customer. Fail-closed.
+ *
+ * Order of checks (each fails closed):
+ *   1. token present
+ *   2. customer configured + connector enabled
+ *   3. Clerk issuer pinned (no issuer ⇒ refuse; the spike stub ships empty)
+ *   4. signature + `aud`/`azp` via `verifyToken`, then `iss` pinned per-customer
+ *   5. identity (email) matches an authored `access[]` entry
+ */
+export async function validateMcpToken(
+  token: string | null,
+  customer: ResolvedMcpCustomer | null
+): Promise<McpAuthResult> {
+  const preflight = preflightFailure(token, customer)
+  if (preflight) return preflight
+  // Both non-null after preflight.
+  const safeCustomer = customer as ResolvedMcpCustomer
+  const safeToken = token as string
+
+  const claimsOrFail = await verifyClaims(safeToken, safeCustomer)
+  if ('ok' in claimsOrFail) return claimsOrFail
+  const claims = claimsOrFail
+
+  // Pin the issuer per-customer (cross-tenant isolation). `verifyToken` checks
+  // the signature against the discovered JWKS; we additionally require the
+  // issuer to be exactly this customer's.
+  const iss = typeof claims.iss === 'string' ? claims.iss : null
+  if (!iss || iss !== safeCustomer.clerk.issuer) {
+    return {
+      ok: false,
+      reason: 'signature_or_claims_invalid',
+      detail: `iss mismatch (got ${iss ?? 'none'})`,
+    }
+  }
+
+  const subject = typeof claims.sub === 'string' ? claims.sub : null
+  if (!subject) {
+    return { ok: false, reason: 'signature_or_claims_invalid', detail: 'no sub claim' }
+  }
+  const email = typeof claims.email === 'string' ? claims.email : null
+
+  const authored = matchAuthoredAccess(email, safeCustomer.connector.access)
+  if (!authored) {
+    // Clerk-valid but not an authored user (or no email in token). Fail-closed:
+    // a valid token is necessary but NOT sufficient — the email must be authored
+    // in `access[]`. This is also where customer B's valid token (wrong customer
+    // entirely) lands if it somehow reached customer A's resource: its email is
+    // not in A's `access[]`.
+    return {
+      ok: false,
+      reason: 'identity_not_authored',
+      detail: email ? `email ${email} not in access[]` : 'no email claim to map',
+    }
+  }
+
+  return { ok: true, subject, email: authored.email, profile: authored.profile }
+}

--- a/src/lib/operator/mcp/token-validation.ts
+++ b/src/lib/operator/mcp/token-validation.ts
@@ -7,34 +7,48 @@
  * from Astro-on-Cloudflare-Workers. BUT the underlying verification primitive,
  * `verifyToken` from `@clerk/backend`, is runtime-agnostic (web-crypto, no Node
  * APIs — it is the same primitive `@clerk/astro` uses) and runs natively on CF
- * Workers. It fetches + caches the instance JWKS, checks the RS256 signature,
- * and validates `iss` / `aud` / `azp` for us. So we ADAPT (`verifyToken`) for
- * the JWT layer rather than hand-rolling JWKS + web-crypto.
+ * Workers. It fetches + caches the JWKS from the token issuer and checks the
+ * RS256 signature for us. So we ADAPT (`verifyToken`) for the JWT layer rather
+ * than hand-rolling JWKS + web-crypto.
  *
- * What this module adds on top of `verifyToken`:
- *   1. Per-customer issuer pin (`iss` MUST equal the customer's Clerk issuer).
- *   2. Per-customer audience/authorized-party binding (cross-tenant isolation:
- *      customer B's token must NOT validate against customer A — build-plan A1
- *      negative test).
- *   3. Identity → `access[]` mapping (the authored email → profile seam from
- *      C1). A Clerk-valid token whose identity is not an authored access entry
- *      is REJECTED (fail-closed).
+ * SECURITY ORDERING (from the console-hosting review — one console validates
+ * tokens for ALL customers, so cross-tenant isolation is enforced HERE):
  *
- * Fail-closed everywhere: any throw, any missing claim, any unmatched identity
- * resolves to a typed failure, never a silent pass.
+ *   1. Verify the SIGNATURE first (against the token's own issuer JWKS). This
+ *      yields trusted claims; nothing downstream trusts an unverified field.
+ *   2. DERIVE THE CUSTOMER FROM THE VERIFIED `aud` (RFC 8707), else the
+ *      per-customer `iss`. A valid-but-wrong-`aud` token matches NO customer and
+ *      401s HERE — before any per-user authorization or data access. The customer
+ *      is NEVER taken from a URL path or request body (invariant 1); the caller
+ *      passes only the verified claims, and resolution happens off them. This is
+ *      the single highest-leverage gate: cross-customer isolation rests on it.
+ *   3. Enforce the customer's binding on the verified claims: `iss` pin, `azp`
+ *      (authorized-party) pin, connector enabled.
+ *   4. Map the identity (`email`) → the customer's authored `access[]` (the
+ *      per-user authorization WITHIN the resolved customer). Unauthored ⇒ reject.
+ *
+ * Fail-closed everywhere: any throw, any missing claim, any unmatched customer or
+ * identity resolves to a typed failure, never a silent pass.
  */
 
 import { verifyToken } from '@clerk/backend'
 import type { McpConnectorAccess } from '../customer-yaml/types'
-import type { ResolvedMcpCustomer } from './customer-resolution'
+import {
+  resolveCustomerFromClaims,
+  type CustomerIdentityClaims,
+  type ResolvedMcpCustomer,
+} from './customer-resolution'
 
 /**
- * Outcome of validating one bearer token against one customer. A discriminated
- * union so callers cannot accidentally treat a failure as a success.
+ * Outcome of validating one bearer token. A discriminated union so callers
+ * cannot accidentally treat a failure as a success. On success it carries the
+ * token-DERIVED customer (never path-derived) so the caller never re-resolves.
  */
 export type McpAuthResult =
   | {
       ok: true
+      /** The customer this token was issued for, derived from verified claims. */
+      customer: ResolvedMcpCustomer
       /** Clerk user id (`sub`) — the stable subject for audit rows. */
       subject: string
       /** Authored email this token mapped to (from `access[]`). */
@@ -47,9 +61,10 @@ export type McpAuthResult =
       /** Machine-readable reason; surfaced as `MCP_AUTH` audit decision. */
       reason:
         | 'missing_token'
-        | 'customer_not_configured'
+        | 'signature_invalid'
+        | 'wrong_audience'
+        | 'binding_mismatch'
         | 'connector_disabled'
-        | 'signature_or_claims_invalid'
         | 'identity_not_authored'
       /** Human-readable detail for logs (never returned to the client verbatim). */
       detail: string
@@ -71,13 +86,27 @@ export function extractBearerToken(authorizationHeader: string | null): string |
 /**
  * The subset of the verified Clerk JWT payload we read. Kept local + permissive
  * because the OAuth access-token claim set depends on granted scopes; we read
- * `sub` (always present) and `email` (present when the `email` scope is granted,
- * which the setup guide requires).
+ * `sub` (always present), `email` (present when the `email` scope is granted —
+ * the setup guide requires it), and the identity claims `aud`/`iss`/`azp`.
  */
 interface VerifiedClaims {
   sub?: unknown
   email?: unknown
   iss?: unknown
+  aud?: unknown
+  azp?: unknown
+}
+
+/** Narrow the permissive verified payload to the customer-identity claim shape. */
+function toIdentityClaims(claims: VerifiedClaims): CustomerIdentityClaims {
+  const aud =
+    typeof claims.aud === 'string'
+      ? claims.aud
+      : Array.isArray(claims.aud) && claims.aud.every((a) => typeof a === 'string')
+        ? claims.aud
+        : undefined
+  const iss = typeof claims.iss === 'string' ? claims.iss : undefined
+  return { aud, iss }
 }
 
 /**
@@ -105,107 +134,106 @@ function matchAuthoredAccess(
 }
 
 /**
- * The pre-flight gates that don't require the token signature: token present,
- * customer configured + enabled, issuer provisioned. Returns a failure result
- * to short-circuit, or `null` to proceed to signature verification.
+ * Verify ONLY the token signature (and standard exp/nbf) against the token's own
+ * issuer JWKS. We do NOT pass `audience`/`authorizedParties` here: the customer —
+ * and therefore the expected aud/azp — is not known until AFTER we have trusted
+ * claims to derive it from. The per-customer aud/iss/azp checks run explicitly in
+ * `validateMcpToken` once the customer is resolved. Returns verified claims or a
+ * failure.
  */
-function preflightFailure(
-  token: string | null,
-  customer: ResolvedMcpCustomer | null
-): Extract<McpAuthResult, { ok: false }> | null {
-  if (!token) return { ok: false, reason: 'missing_token', detail: 'no bearer token' }
-  if (!customer) {
-    return { ok: false, reason: 'customer_not_configured', detail: 'unknown resource' }
-  }
-  if (!customer.connector.enabled) {
-    return { ok: false, reason: 'connector_disabled', detail: 'mcp_connector disabled' }
-  }
-  if (!customer.clerk.issuer) {
-    // Spike stub ships with an empty issuer until the Captain provisions the
-    // Clerk app. No issuer ⇒ we cannot pin `iss` ⇒ refuse rather than trust.
-    return { ok: false, reason: 'customer_not_configured', detail: 'clerk issuer not provisioned' }
-  }
-  return null
-}
-
-/**
- * Verify the token signature + claims against the customer's Clerk binding.
- * `verifyToken` fetches + caches the JWKS from the issuer, verifies the RS256
- * signature, and enforces audience / authorizedParties when supplied. Returns
- * the verified claims, or a failure result.
- */
-async function verifyClaims(
-  token: string,
-  customer: ResolvedMcpCustomer
+async function verifySignature(
+  token: string
 ): Promise<VerifiedClaims | Extract<McpAuthResult, { ok: false }>> {
   try {
-    // No `secretKey`: signature verification is JWKS-based (public-key), which is
-    // all an OAuth resource server needs. The JWKS is discovered from the token
-    // issuer. (The live slice may pass the per-customer `secretKey` if a
-    // Backend-API `sub`→email lookup is wired; not needed for the spike.)
-    return await verifyToken(token, {
-      authorizedParties:
-        customer.clerk.authorizedParties.length > 0 ? customer.clerk.authorizedParties : undefined,
-      audience: customer.clerk.audience ?? undefined,
-    })
+    // No `secretKey`: JWKS (public-key) verification is all an OAuth resource
+    // server needs; the JWKS is discovered + cached from the token's `iss`.
+    return await verifyToken(token, {})
   } catch (err) {
     return {
       ok: false,
-      reason: 'signature_or_claims_invalid',
+      reason: 'signature_invalid',
       detail: err instanceof Error ? err.message : 'verifyToken threw',
     }
   }
 }
 
 /**
- * Validate one bearer token against one resolved customer. Fail-closed.
- *
- * Order of checks (each fails closed):
- *   1. token present
- *   2. customer configured + connector enabled
- *   3. Clerk issuer pinned (no issuer ⇒ refuse; the spike stub ships empty)
- *   4. signature + `aud`/`azp` via `verifyToken`, then `iss` pinned per-customer
- *   5. identity (email) matches an authored `access[]` entry
+ * Enforce the resolved customer's Clerk binding on the verified claims:
+ *   - `iss` MUST equal the customer's issuer (defense in depth — the customer was
+ *     already derived from a verified claim, but we re-pin so a future multi-issuer
+ *     registry cannot drift).
+ *   - `azp` (authorized party) MUST be in the customer's allowlist when one is set.
+ *   - the connector MUST be enabled.
+ * Returns a failure, or null to proceed.
  */
-export async function validateMcpToken(
-  token: string | null,
-  customer: ResolvedMcpCustomer | null
-): Promise<McpAuthResult> {
-  const preflight = preflightFailure(token, customer)
-  if (preflight) return preflight
-  // Both non-null after preflight.
-  const safeCustomer = customer as ResolvedMcpCustomer
-  const safeToken = token as string
-
-  const claimsOrFail = await verifyClaims(safeToken, safeCustomer)
-  if ('ok' in claimsOrFail) return claimsOrFail
-  const claims = claimsOrFail
-
-  // Pin the issuer per-customer (cross-tenant isolation). `verifyToken` checks
-  // the signature against the discovered JWKS; we additionally require the
-  // issuer to be exactly this customer's.
+function enforceBinding(
+  claims: VerifiedClaims,
+  customer: ResolvedMcpCustomer
+): Extract<McpAuthResult, { ok: false }> | null {
   const iss = typeof claims.iss === 'string' ? claims.iss : null
-  if (!iss || iss !== safeCustomer.clerk.issuer) {
+  if (!iss || iss !== customer.clerk.issuer) {
+    return { ok: false, reason: 'binding_mismatch', detail: `iss mismatch (got ${iss ?? 'none'})` }
+  }
+  const allowed = customer.clerk.authorizedParties
+  if (allowed.length > 0) {
+    const azp = typeof claims.azp === 'string' ? claims.azp : null
+    if (!azp || !allowed.includes(azp)) {
+      return {
+        ok: false,
+        reason: 'binding_mismatch',
+        detail: `azp not authorized (got ${azp ?? 'none'})`,
+      }
+    }
+  }
+  if (!customer.connector.enabled) {
+    return { ok: false, reason: 'connector_disabled', detail: 'mcp_connector disabled' }
+  }
+  return null
+}
+
+/**
+ * Validate one bearer token. Fail-closed, security-ordered (see module header):
+ * signature → customer-from-`aud` → binding pin → per-user `access[]`.
+ *
+ * The customer is the RESULT of validation, not an input — it is derived from the
+ * verified token, never from the request path/body (invariant 1). A token whose
+ * `aud` matches no customer here is rejected (`wrong_audience`) before any data
+ * access (invariant 2).
+ */
+export async function validateMcpToken(token: string | null): Promise<McpAuthResult> {
+  if (!token) return { ok: false, reason: 'missing_token', detail: 'no bearer token' }
+
+  // 1. Signature first — establishes trusted claims.
+  const verified = await verifySignature(token)
+  if ('ok' in verified) return verified
+  const claims = verified
+
+  // 2. Derive the customer FROM the verified claims (aud-first; iss fallback).
+  //    This is the cross-tenant gate: a valid-but-wrong-aud token matches no
+  //    customer and is rejected here, before any per-user authz or data access.
+  const customer = resolveCustomerFromClaims(toIdentityClaims(claims))
+  if (!customer) {
     return {
       ok: false,
-      reason: 'signature_or_claims_invalid',
-      detail: `iss mismatch (got ${iss ?? 'none'})`,
+      reason: 'wrong_audience',
+      detail: 'token aud/iss matches no configured customer',
     }
   }
 
+  // 3. Enforce the resolved customer's binding on the verified claims.
+  const bindingFailure = enforceBinding(claims, customer)
+  if (bindingFailure) return bindingFailure
+
+  // 4. Per-user authorization WITHIN the resolved customer.
   const subject = typeof claims.sub === 'string' ? claims.sub : null
   if (!subject) {
-    return { ok: false, reason: 'signature_or_claims_invalid', detail: 'no sub claim' }
+    return { ok: false, reason: 'signature_invalid', detail: 'no sub claim' }
   }
   const email = typeof claims.email === 'string' ? claims.email : null
-
-  const authored = matchAuthoredAccess(email, safeCustomer.connector.access)
+  const authored = matchAuthoredAccess(email, customer.connector.access)
   if (!authored) {
-    // Clerk-valid but not an authored user (or no email in token). Fail-closed:
-    // a valid token is necessary but NOT sufficient — the email must be authored
-    // in `access[]`. This is also where customer B's valid token (wrong customer
-    // entirely) lands if it somehow reached customer A's resource: its email is
-    // not in A's `access[]`.
+    // Clerk-valid, right customer, but not an authored user (or no email claim).
+    // Fail-closed: a valid token is necessary but NOT sufficient.
     return {
       ok: false,
       reason: 'identity_not_authored',
@@ -213,5 +241,5 @@ export async function validateMcpToken(
     }
   }
 
-  return { ok: true, subject, email: authored.email, profile: authored.profile }
+  return { ok: true, customer, subject, email: authored.email, profile: authored.profile }
 }

--- a/src/lib/operator/mcp/tools.ts
+++ b/src/lib/operator/mcp/tools.ts
@@ -1,0 +1,96 @@
+/**
+ * SPIKE SCAFFOLD (A0) — MCP tool registry for the Operator ⇄ Claude connector.
+ *
+ * Phase 1 ships exactly one STUB read tool, `operator_status`, returning a
+ * placeholder payload. Real data wiring (the runtime-read seam in
+ * runtime-read-transport.ts → the Machine's `GET /runtime/<kind>`) is a later
+ * slice per the build plan (Workstream B). The read/handoff tool surface
+ * (`operator_search_memory`, `operator_get_context`, `operator_handoff_task`)
+ * is intentionally NOT built here — B0 decides the final surface from observed
+ * bytes against the running Machine.
+ *
+ * Each tool is a pure descriptor + handler so the JSON-RPC layer (mcp-handler.ts)
+ * stays transport-only. Handlers receive the authenticated identity so a real
+ * tool can scope its read to the entitled user; the stub ignores it beyond echo.
+ */
+
+/** JSON-Schema-ish shape for a tool's input. Kept minimal for the spike. */
+export interface McpToolInputSchema {
+  type: 'object'
+  properties: Record<string, unknown>
+  required?: string[]
+}
+
+/** MCP `tools/list` entry shape (subset of the spec we emit). */
+export interface McpToolDescriptor {
+  name: string
+  description: string
+  inputSchema: McpToolInputSchema
+}
+
+/** The authenticated caller context handed to a tool handler. */
+export interface McpToolContext {
+  customerId: string
+  subject: string
+  email: string
+  profile: string
+}
+
+/** MCP `tools/call` result content block (text only for the spike). */
+export interface McpToolResultContent {
+  type: 'text'
+  text: string
+}
+
+export interface McpToolResult {
+  content: McpToolResultContent[]
+  isError?: boolean
+}
+
+export interface McpTool {
+  descriptor: McpToolDescriptor
+  handle: (args: Record<string, unknown>, ctx: McpToolContext) => Promise<McpToolResult>
+}
+
+/**
+ * STUB tool: `operator_status`. Real version surfaces Operator liveness + this
+ * user's handoff queue via the runtime-read seam (build plan B1). The spike
+ * returns a clearly-labeled placeholder so a `claude.ai` connector add can make
+ * one real authed `tools/call` round-trip end to end.
+ */
+const operatorStatus: McpTool = {
+  descriptor: {
+    name: 'operator_status',
+    description:
+      'Report this Operator’s current status and the calling user’s handoff queue. ' +
+      'SPIKE STUB: returns a placeholder; live data wiring is a later slice.',
+    inputSchema: { type: 'object', properties: {} },
+  },
+  // Not `async`: the stub does no I/O. The live version (runtime-read seam) will
+  // be async; the interface already returns a Promise, so swapping in real I/O
+  // is a body change, not a signature change.
+  handle: (_args, ctx) => {
+    const payload = {
+      stub: true,
+      note: 'SPIKE placeholder — not live Operator data.',
+      customer_id: ctx.customerId,
+      authenticated_as: { profile: ctx.profile, email: ctx.email },
+      operator: { status: 'unknown', handoff_queue_depth: null },
+    }
+    return Promise.resolve({ content: [{ type: 'text', text: JSON.stringify(payload, null, 2) }] })
+  },
+}
+
+const REGISTRY: ReadonlyMap<string, McpTool> = new Map([
+  [operatorStatus.descriptor.name, operatorStatus],
+])
+
+/** All tool descriptors for `tools/list`. */
+export function listToolDescriptors(): McpToolDescriptor[] {
+  return [...REGISTRY.values()].map((t) => t.descriptor)
+}
+
+/** Look up a tool by name for `tools/call`; null when unknown. */
+export function getTool(name: string): McpTool | null {
+  return REGISTRY.get(name) ?? null
+}

--- a/src/pages/.well-known/oauth-protected-resource/[...resource].ts
+++ b/src/pages/.well-known/oauth-protected-resource/[...resource].ts
@@ -1,0 +1,58 @@
+/**
+ * SPIKE SCAFFOLD (A0) — RFC 9728 OAuth Protected Resource Metadata endpoint.
+ *
+ * `GET /.well-known/oauth-protected-resource/<resource-path>` — the discovery
+ * document an MCP client fetches to learn which Authorization Server (the
+ * customer's Clerk instance) issues tokens for our MCP resource. Per RFC 9728
+ * §3.1, the resource path is appended to the well-known prefix; for our endpoint
+ * at `/api/mcp` the client requests `/.well-known/oauth-protected-resource/api/mcp`.
+ *
+ * Public + unauthenticated (the middleware leaves `/.well-known/*` ungated). The
+ * `Access-Control-Allow-Origin: *` + OPTIONS preflight are required so
+ * browser-based MCP clients (claude.ai) can read it cross-origin.
+ *
+ * Fail-closed: an unknown resource path → 404 (no customer ⇒ no metadata).
+ */
+
+import type { APIRoute } from 'astro'
+import { resolveMcpCustomer } from '../../../lib/operator/mcp/customer-resolution'
+import { buildProtectedResourceMetadata } from '../../../lib/operator/mcp/oauth-metadata'
+
+const CORS_HEADERS: Record<string, string> = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET, OPTIONS',
+  'Access-Control-Allow-Headers': 'Authorization, Content-Type',
+}
+
+function json(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json', ...CORS_HEADERS },
+  })
+}
+
+/**
+ * Reconstruct the resource path the metadata describes from the rest param.
+ * Astro gives `resource` as the captured tail (e.g. `api/mcp`); we re-prefix a
+ * leading slash to match the canonical endpoint path used by `resolveMcpCustomer`.
+ */
+function resourcePathFromParam(resource: string | undefined): string {
+  const tail = (resource ?? '').replace(/^\/+/, '')
+  return `/${tail}`
+}
+
+export const GET: APIRoute = ({ params, url }) => {
+  const resourcePath = resourcePathFromParam(params.resource)
+  const customer = resolveMcpCustomer(resourcePath)
+  if (!customer) {
+    return json({ error: 'unknown_resource' }, 404)
+  }
+
+  // The canonical resource URL is this origin + the resource path. Must match
+  // what the client used for discovery and (when bound) Clerk's `aud`.
+  const resourceUrl = new URL(resourcePath, url.origin).toString()
+  const metadata = buildProtectedResourceMetadata(resourceUrl, customer)
+  return json(metadata, 200)
+}
+
+export const OPTIONS: APIRoute = () => new Response(null, { status: 204, headers: CORS_HEADERS })

--- a/src/pages/.well-known/oauth-protected-resource/[...resource].ts
+++ b/src/pages/.well-known/oauth-protected-resource/[...resource].ts
@@ -15,7 +15,10 @@
  */
 
 import type { APIRoute } from 'astro'
-import { resolveMcpCustomer } from '../../../lib/operator/mcp/customer-resolution'
+import {
+  discoveryAuthorizationServers,
+  isMcpResourcePath,
+} from '../../../lib/operator/mcp/customer-resolution'
 import { buildProtectedResourceMetadata } from '../../../lib/operator/mcp/oauth-metadata'
 
 const CORS_HEADERS: Record<string, string> = {
@@ -34,7 +37,7 @@ function json(body: unknown, status: number): Response {
 /**
  * Reconstruct the resource path the metadata describes from the rest param.
  * Astro gives `resource` as the captured tail (e.g. `api/mcp`); we re-prefix a
- * leading slash to match the canonical endpoint path used by `resolveMcpCustomer`.
+ * leading slash to match the canonical MCP resource path.
  */
 function resourcePathFromParam(resource: string | undefined): string {
   const tail = (resource ?? '').replace(/^\/+/, '')
@@ -43,15 +46,17 @@ function resourcePathFromParam(resource: string | undefined): string {
 
 export const GET: APIRoute = ({ params, url }) => {
   const resourcePath = resourcePathFromParam(params.resource)
-  const customer = resolveMcpCustomer(resourcePath)
-  if (!customer) {
+  // Public discovery: only confirm the path is the MCP resource. This does NOT
+  // select a customer (that happens at token validation from the verified aud);
+  // the doc just advertises where to authenticate.
+  if (!isMcpResourcePath(resourcePath)) {
     return json({ error: 'unknown_resource' }, 404)
   }
 
   // The canonical resource URL is this origin + the resource path. Must match
   // what the client used for discovery and (when bound) Clerk's `aud`.
   const resourceUrl = new URL(resourcePath, url.origin).toString()
-  const metadata = buildProtectedResourceMetadata(resourceUrl, customer)
+  const metadata = buildProtectedResourceMetadata(resourceUrl, discoveryAuthorizationServers())
   return json(metadata, 200)
 }
 

--- a/src/pages/api/mcp.ts
+++ b/src/pages/api/mcp.ts
@@ -7,9 +7,12 @@
  *   1. Client discovers the AS via `/.well-known/oauth-protected-resource/api/mcp`.
  *   2. Client runs OAuth 2.1 + PKCE against the customer's Clerk app, returns
  *      with a bearer token.
- *   3. Every POST here carries `Authorization: Bearer <token>`. We validate it
- *      fail-closed (signature + iss + aud/azp via @clerk/backend, then map the
- *      identity to the customer's authored `mcp_connector.access[]`).
+ *   3. Every POST carries `Authorization: Bearer <token>`. validateMcpToken is
+ *      fail-closed and SECURITY-ORDERED: verify signature → DERIVE the customer
+ *      from the verified `aud` (else per-customer `iss`) → enforce the customer's
+ *      binding → map identity to that customer's `mcp_connector.access[]`. The
+ *      customer is NEVER read from the URL path or body; a wrong-`aud` token 401s
+ *      before any data access. (Console-hosting security invariants 1 & 2.)
  *   4. Authenticated → dispatch the JSON-RPC method (initialize/tools.list/
  *      tools.call) and answer with a single application/json response.
  *

--- a/src/pages/api/mcp.ts
+++ b/src/pages/api/mcp.ts
@@ -31,7 +31,7 @@
  */
 
 import type { APIRoute } from 'astro'
-import { resolveMcpCustomer } from '../../lib/operator/mcp/customer-resolution'
+import { isMcpResourcePath, MCP_RESOURCE_PATH } from '../../lib/operator/mcp/customer-resolution'
 import { buildWwwAuthenticate } from '../../lib/operator/mcp/oauth-metadata'
 import {
   extractBearerToken,
@@ -41,7 +41,7 @@ import {
 import { dispatchMcpRequest, parseMcpBody } from '../../lib/operator/mcp/mcp-handler'
 import type { McpToolContext } from '../../lib/operator/mcp/tools'
 
-const RESOURCE_PATH = '/api/mcp'
+const RESOURCE_PATH = MCP_RESOURCE_PATH
 
 const CORS_HEADERS: Record<string, string> = {
   'Access-Control-Allow-Origin': '*',
@@ -81,17 +81,26 @@ function denyFor(originUrl: URL, auth: Extract<McpAuthResult, { ok: false }>): R
 }
 
 export const POST: APIRoute = async ({ request, url }) => {
-  const customer = resolveMcpCustomer(RESOURCE_PATH)
+  // The endpoint serves ONE fixed resource path. This is an UNTRUSTED existence
+  // check only — it does NOT select the customer (invariant 1). The customer is
+  // derived from the verified token inside validateMcpToken. If a future routing
+  // shape carries a slug, compare it to `auth.customer.customerId` and reject a
+  // mismatch; never let the path choose the customer.
+  if (!isMcpResourcePath(url.pathname)) {
+    return jsonWithCors({ error: 'not_found' }, 404)
+  }
 
-  // --- Auth (fail-closed) ---
+  // --- Auth (fail-closed, security-ordered) ---
+  // validateMcpToken: verify signature → derive customer from verified aud/iss →
+  // enforce binding → per-user access[]. A wrong-aud token 401s before any data
+  // access (invariant 2). The customer comes OUT of validation, not in.
   const token = extractBearerToken(request.headers.get('authorization'))
-  const auth = await validateMcpToken(token, customer)
+  const auth = await validateMcpToken(token)
   if (!auth.ok) {
     return denyFor(url, auth)
   }
-  // `customer` is non-null here: a null customer fails validation above.
   const ctx: McpToolContext = {
-    customerId: customer!.customerId,
+    customerId: auth.customer.customerId,
     subject: auth.subject,
     email: auth.email,
     profile: auth.profile,

--- a/src/pages/api/mcp.ts
+++ b/src/pages/api/mcp.ts
@@ -1,0 +1,133 @@
+/**
+ * SPIKE SCAFFOLD (A0) — Operator ⇄ Claude MCP endpoint (Streamable HTTP).
+ *
+ * `POST /api/mcp` — the single MCP endpoint a client org's Claude connects to.
+ * Auth = Clerk OAuth (the console is the OAuth Resource Server; Clerk is the
+ * Authorization Server). Flow:
+ *   1. Client discovers the AS via `/.well-known/oauth-protected-resource/api/mcp`.
+ *   2. Client runs OAuth 2.1 + PKCE against the customer's Clerk app, returns
+ *      with a bearer token.
+ *   3. Every POST here carries `Authorization: Bearer <token>`. We validate it
+ *      fail-closed (signature + iss + aud/azp via @clerk/backend, then map the
+ *      identity to the customer's authored `mcp_connector.access[]`).
+ *   4. Authenticated → dispatch the JSON-RPC method (initialize/tools.list/
+ *      tools.call) and answer with a single application/json response.
+ *
+ * Hosting decision (lower-friction path, justified): a path under `src/pages/api`
+ * rather than a dedicated `mcp.smd.services` host. The apex/any host already
+ * serves `/api/*` unauthenticated through the existing middleware (only /admin
+ * and /portal are gated), so no `src/middleware.ts` change, no new DNS record,
+ * no new TLS cert, no new Worker route are needed. The dedicated-host option
+ * stays open (the design's durable on-Machine sidecar is the other axis) but is
+ * unnecessary cost for the Phase-1 pilot.
+ *
+ * Audit (build plan C3): every call SHOULD write an `MCP_AUTH` / `MCP_TOOL_CALL`
+ * row (console-side, digest-only). The spike marks the exact emission point with
+ * a TODO + a clearly-named seam; wiring it needs the `MCP_*` action types added
+ * to the console audit allowlist, which is a C3 slice, not A0.
+ *
+ * NOTE: prerender is implicitly false (astro.config `output: 'server'`); this is
+ * a server route. The body is read once via `request.text()`.
+ */
+
+import type { APIRoute } from 'astro'
+import { resolveMcpCustomer } from '../../lib/operator/mcp/customer-resolution'
+import { buildWwwAuthenticate } from '../../lib/operator/mcp/oauth-metadata'
+import {
+  extractBearerToken,
+  validateMcpToken,
+  type McpAuthResult,
+} from '../../lib/operator/mcp/token-validation'
+import { dispatchMcpRequest, parseMcpBody } from '../../lib/operator/mcp/mcp-handler'
+import type { McpToolContext } from '../../lib/operator/mcp/tools'
+
+const RESOURCE_PATH = '/api/mcp'
+
+const CORS_HEADERS: Record<string, string> = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+  'Access-Control-Allow-Headers':
+    'Authorization, Content-Type, Mcp-Session-Id, MCP-Protocol-Version',
+  'Access-Control-Expose-Headers': 'WWW-Authenticate, Mcp-Session-Id',
+}
+
+function jsonWithCors(body: unknown, status: number, extra?: Record<string, string>): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json', ...CORS_HEADERS, ...(extra ?? {}) },
+  })
+}
+
+/**
+ * Build the RFC 9728 `WWW-Authenticate` challenge a 401 must carry, pointing the
+ * client back at the discovery document for this resource.
+ */
+function unauthorized(originUrl: URL, reasonDetail: string): Response {
+  const metadataUrl = new URL(
+    `/.well-known/oauth-protected-resource${RESOURCE_PATH}`,
+    originUrl.origin
+  ).toString()
+  // SPIKE-AUDIT-SEAM: emit MCP_AUTH(decision=deny, reason=reasonDetail) here once
+  // the MCP_* action types are added to the console audit allowlist (build plan
+  // C3). Digest-only — never log the raw token.
+  return jsonWithCors({ error: 'unauthorized', detail: reasonDetail }, 401, {
+    'WWW-Authenticate': buildWwwAuthenticate(metadataUrl),
+  })
+}
+
+/** Map a failed auth result to a 401 with the right challenge. */
+function denyFor(originUrl: URL, auth: Extract<McpAuthResult, { ok: false }>): Response {
+  return unauthorized(originUrl, auth.reason)
+}
+
+export const POST: APIRoute = async ({ request, url }) => {
+  const customer = resolveMcpCustomer(RESOURCE_PATH)
+
+  // --- Auth (fail-closed) ---
+  const token = extractBearerToken(request.headers.get('authorization'))
+  const auth = await validateMcpToken(token, customer)
+  if (!auth.ok) {
+    return denyFor(url, auth)
+  }
+  // `customer` is non-null here: a null customer fails validation above.
+  const ctx: McpToolContext = {
+    customerId: customer!.customerId,
+    subject: auth.subject,
+    email: auth.email,
+    profile: auth.profile,
+  }
+
+  // --- Parse JSON-RPC body ---
+  const raw = await request.text()
+  const parsed = parseMcpBody(raw)
+  if ('error' in parsed) return withCorsHeaders(parsed.error)
+
+  // SPIKE-AUDIT-SEAM: emit MCP_TOOL_CALL(actor=auth.subject, customer, method)
+  // here for tools/call methods once MCP_* audit types land (build plan C3).
+  const response = await dispatchMcpRequest(parsed.req, ctx)
+  return withCorsHeaders(response)
+}
+
+/**
+ * Per the Streamable HTTP spec a server MAY support GET for a server→client SSE
+ * stream. The spike is a stateless request/response surface with no
+ * server-initiated messages, so we decline GET with 405 + Allow. (Not an error
+ * the client can't handle — clients fall back to POST-only operation.)
+ */
+export const GET: APIRoute = () =>
+  jsonWithCors(
+    { error: 'method_not_allowed', detail: 'MCP GET/SSE not supported (stateless)' },
+    405,
+    {
+      Allow: 'POST, OPTIONS',
+    }
+  )
+
+export const OPTIONS: APIRoute = () => new Response(null, { status: 204, headers: CORS_HEADERS })
+
+/** Re-attach CORS headers to a Response produced by the transport layer. */
+function withCorsHeaders(resp: Response): Response {
+  const headers = new Headers(resp.headers)
+  for (const [k, v] of Object.entries(CORS_HEADERS)) headers.set(k, v)
+  return new Response(resp.body, { status: resp.status, headers })
+}

--- a/tests/operator-mcp-endpoint.test.ts
+++ b/tests/operator-mcp-endpoint.test.ts
@@ -1,0 +1,162 @@
+/**
+ * SPIKE SCAFFOLD (A0) tests for the Operator ⇄ Claude MCP endpoint.
+ *
+ * These cover the parts that do NOT need a live Clerk app: the fail-closed auth
+ * gates that run BEFORE signature verification, the identity → access[] mapping,
+ * and the stateless JSON-RPC dispatcher (initialize / tools.list / tools.call /
+ * method-not-found). The signature-verification path (`@clerk/backend`
+ * verifyToken against a real JWKS) is exercised end-to-end by the Captain's A0
+ * step with a real `claude.ai` connector add — it cannot be unit-tested without
+ * a live Clerk instance, which is called out in the deliverable notes.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { extractBearerToken, validateMcpToken } from '../src/lib/operator/mcp/token-validation'
+import type { ResolvedMcpCustomer } from '../src/lib/operator/mcp/customer-resolution'
+import { dispatchMcpRequest, parseMcpBody } from '../src/lib/operator/mcp/mcp-handler'
+import type { McpToolContext } from '../src/lib/operator/mcp/tools'
+
+const CTX: McpToolContext = {
+  customerId: 'smd',
+  subject: 'user_123',
+  email: 'pilot@example.com',
+  profile: 'marcus',
+}
+
+function customer(overrides: Partial<ResolvedMcpCustomer> = {}): ResolvedMcpCustomer {
+  return {
+    customerId: 'smd',
+    connector: { enabled: true, data_posture: 'open', access: [] },
+    clerk: { issuer: 'https://clerk.example.com', audience: null, authorizedParties: [] },
+    ...overrides,
+  }
+}
+
+describe('extractBearerToken', () => {
+  it('returns the token for a well-formed header', () => {
+    expect(extractBearerToken('Bearer abc.def.ghi')).toBe('abc.def.ghi')
+  })
+  it('is case-insensitive on the scheme', () => {
+    expect(extractBearerToken('bearer xyz')).toBe('xyz')
+  })
+  it('returns null for missing/malformed headers', () => {
+    expect(extractBearerToken(null)).toBeNull()
+    expect(extractBearerToken('')).toBeNull()
+    expect(extractBearerToken('Basic abc')).toBeNull()
+    expect(extractBearerToken('Bearer ')).toBeNull()
+  })
+})
+
+describe('validateMcpToken — fail-closed pre-signature gates', () => {
+  it('rejects when no token is present', async () => {
+    const r = await validateMcpToken(null, customer())
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.reason).toBe('missing_token')
+  })
+
+  it('rejects when the customer is unknown', async () => {
+    const r = await validateMcpToken('tok', null)
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.reason).toBe('customer_not_configured')
+  })
+
+  it('rejects when the connector is disabled (fail-closed default)', async () => {
+    const r = await validateMcpToken(
+      'tok',
+      customer({ connector: { enabled: false, data_posture: 'open', access: [] } })
+    )
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.reason).toBe('connector_disabled')
+  })
+
+  it('rejects when the Clerk issuer is not provisioned (spike stub posture)', async () => {
+    const r = await validateMcpToken(
+      'tok',
+      customer({ clerk: { issuer: '', audience: null, authorizedParties: [] } })
+    )
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.reason).toBe('customer_not_configured')
+  })
+
+  it('rejects an invalid token signature once the issuer is set', async () => {
+    // A garbage token cannot pass @clerk/backend verifyToken (no real JWKS) —
+    // exercises the signature_or_claims_invalid fail-closed branch end to end.
+    const r = await validateMcpToken('not.a.real.jwt', customer())
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.reason).toBe('signature_or_claims_invalid')
+  })
+})
+
+describe('JSON-RPC dispatcher', () => {
+  it('initialize returns protocolVersion + serverInfo', async () => {
+    const resp = await dispatchMcpRequest({ jsonrpc: '2.0', id: 1, method: 'initialize' }, CTX)
+    expect(resp.status).toBe(200)
+    const body: { result: { protocolVersion: string; serverInfo: { name: string } } } =
+      await resp.json()
+    expect(body.result.protocolVersion).toBeTruthy()
+    expect(body.result.serverInfo.name).toBe('smd-operator-connector')
+  })
+
+  it('tools/list returns the operator_status stub', async () => {
+    const resp = await dispatchMcpRequest({ jsonrpc: '2.0', id: 2, method: 'tools/list' }, CTX)
+    const body: { result: { tools: { name: string }[] } } = await resp.json()
+    const names = body.result.tools.map((t) => t.name)
+    expect(names).toContain('operator_status')
+  })
+
+  it('tools/call operator_status echoes the authenticated identity', async () => {
+    const resp = await dispatchMcpRequest(
+      {
+        jsonrpc: '2.0',
+        id: 3,
+        method: 'tools/call',
+        params: { name: 'operator_status', arguments: {} },
+      },
+      CTX
+    )
+    const body: { result: { content: { text: string }[] } } = await resp.json()
+    const payload: { stub: boolean; authenticated_as: { email: string } } = JSON.parse(
+      body.result.content[0].text
+    )
+    expect(payload.stub).toBe(true)
+    expect(payload.authenticated_as.email).toBe('pilot@example.com')
+  })
+
+  it('tools/call on an unknown tool is method-not-found', async () => {
+    const resp = await dispatchMcpRequest(
+      { jsonrpc: '2.0', id: 4, method: 'tools/call', params: { name: 'nope', arguments: {} } },
+      CTX
+    )
+    const body: { error?: { code: number } } = await resp.json()
+    expect(body.error?.code).toBe(-32601)
+  })
+
+  it('an unknown method is method-not-found', async () => {
+    const resp = await dispatchMcpRequest({ jsonrpc: '2.0', id: 5, method: 'frobnicate' }, CTX)
+    const body: { error?: { code: number } } = await resp.json()
+    expect(body.error?.code).toBe(-32601)
+  })
+})
+
+describe('parseMcpBody', () => {
+  it('parses a valid JSON-RPC request', () => {
+    const out = parseMcpBody('{"jsonrpc":"2.0","id":1,"method":"ping"}')
+    expect('req' in out).toBe(true)
+  })
+  it('rejects invalid JSON with a parse error', async () => {
+    const out = parseMcpBody('{not json')
+    expect('error' in out).toBe(true)
+    if ('error' in out) {
+      const body: { error: { code: number } } = await out.error.json()
+      expect(body.error.code).toBe(-32700)
+    }
+  })
+  it('rejects a non-JSON-RPC object', async () => {
+    const out = parseMcpBody('{"foo":"bar"}')
+    expect('error' in out).toBe(true)
+    if ('error' in out) {
+      const body: { error: { code: number } } = await out.error.json()
+      expect(body.error.code).toBe(-32600)
+    }
+  })
+})

--- a/tests/operator-mcp-endpoint.test.ts
+++ b/tests/operator-mcp-endpoint.test.ts
@@ -12,7 +12,7 @@
 
 import { describe, it, expect } from 'vitest'
 import { extractBearerToken, validateMcpToken } from '../src/lib/operator/mcp/token-validation'
-import type { ResolvedMcpCustomer } from '../src/lib/operator/mcp/customer-resolution'
+import { resolveCustomerFromClaims } from '../src/lib/operator/mcp/customer-resolution'
 import { dispatchMcpRequest, parseMcpBody } from '../src/lib/operator/mcp/mcp-handler'
 import type { McpToolContext } from '../src/lib/operator/mcp/tools'
 
@@ -21,15 +21,6 @@ const CTX: McpToolContext = {
   subject: 'user_123',
   email: 'pilot@example.com',
   profile: 'marcus',
-}
-
-function customer(overrides: Partial<ResolvedMcpCustomer> = {}): ResolvedMcpCustomer {
-  return {
-    customerId: 'smd',
-    connector: { enabled: true, data_posture: 'open', access: [] },
-    clerk: { issuer: 'https://clerk.example.com', audience: null, authorizedParties: [] },
-    ...overrides,
-  }
 }
 
 describe('extractBearerToken', () => {
@@ -47,43 +38,53 @@ describe('extractBearerToken', () => {
   })
 })
 
-describe('validateMcpToken — fail-closed pre-signature gates', () => {
+describe('validateMcpToken — token gates (no live Clerk app)', () => {
   it('rejects when no token is present', async () => {
-    const r = await validateMcpToken(null, customer())
+    const r = await validateMcpToken(null)
     expect(r.ok).toBe(false)
     if (!r.ok) expect(r.reason).toBe('missing_token')
   })
 
-  it('rejects when the customer is unknown', async () => {
-    const r = await validateMcpToken('tok', null)
+  it('rejects an unverifiable token at the signature gate (FIRST gate)', async () => {
+    // A garbage token cannot pass @clerk/backend verifyToken (no real JWKS).
+    // Signature is verified BEFORE any customer resolution or data access, so a
+    // forged token never reaches the aud/customer logic. Exercises the
+    // security-ordered fail-closed branch end to end.
+    const r = await validateMcpToken('not.a.real.jwt')
     expect(r.ok).toBe(false)
-    if (!r.ok) expect(r.reason).toBe('customer_not_configured')
+    if (!r.ok) expect(r.reason).toBe('signature_invalid')
+  })
+})
+
+/**
+ * SECURITY INVARIANTS (console-hosting review). The customer is DERIVED from the
+ * verified token's aud/iss — never a path/body. resolveCustomerFromClaims is the
+ * cross-tenant gate; these test it directly with already-"verified" claim shapes
+ * (the function is only ever called post-signature-verification in production).
+ */
+describe('resolveCustomerFromClaims — customer derives from verified claims', () => {
+  it('returns null when claims match no registered customer (wrong-aud rejection)', () => {
+    // The spike pilot ships with empty issuer/audience, so NOTHING resolves —
+    // the fail-closed posture until the Captain provisions the Clerk binding.
+    expect(resolveCustomerFromClaims({ aud: 'https://evil.example/api/mcp' })).toBeNull()
+    expect(resolveCustomerFromClaims({ iss: 'https://attacker.clerk.dev' })).toBeNull()
+    expect(resolveCustomerFromClaims({})).toBeNull()
   })
 
-  it('rejects when the connector is disabled (fail-closed default)', async () => {
-    const r = await validateMcpToken(
-      'tok',
-      customer({ connector: { enabled: false, data_posture: 'open', access: [] } })
-    )
-    expect(r.ok).toBe(false)
-    if (!r.ok) expect(r.reason).toBe('connector_disabled')
+  it('does not resolve a customer from an empty/unprovisioned issuer', () => {
+    // Guards against an empty-string issuer matching an empty claim.
+    expect(resolveCustomerFromClaims({ iss: '' })).toBeNull()
   })
+})
 
-  it('rejects when the Clerk issuer is not provisioned (spike stub posture)', async () => {
-    const r = await validateMcpToken(
-      'tok',
-      customer({ clerk: { issuer: '', audience: null, authorizedParties: [] } })
-    )
+describe('validateMcpToken — wrong-aud rejection ordering', () => {
+  it('a syntactically-valid but unverifiable token never selects a customer', async () => {
+    // Even if an attacker crafts a token whose aud names our resource, it fails
+    // at the signature gate first (no valid JWKS signature). The customer is only
+    // derived AFTER verification, so a wrong/forged aud can never reach data.
+    const r = await validateMcpToken('eyJ.forged.aud')
     expect(r.ok).toBe(false)
-    if (!r.ok) expect(r.reason).toBe('customer_not_configured')
-  })
-
-  it('rejects an invalid token signature once the issuer is set', async () => {
-    // A garbage token cannot pass @clerk/backend verifyToken (no real JWKS) —
-    // exercises the signature_or_claims_invalid fail-closed branch end to end.
-    const r = await validateMcpToken('not.a.real.jwt', customer())
-    expect(r.ok).toBe(false)
-    if (!r.ok) expect(r.reason).toBe('signature_or_claims_invalid')
+    if (!r.ok) expect(r.reason).toBe('signature_invalid')
   })
 })
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,5 +3,14 @@
   "compilerOptions": {
     "types": ["@cloudflare/workers-types/2023-07-01"]
   },
+  "include": [
+    "${configDir}/.astro/types.d.ts",
+    "${configDir}/**/*",
+    // TypeScript's default include glob (`**/*`) skips dot-prefixed
+    // directories. The OAuth/MCP discovery routes must live under the literal
+    // `src/pages/.well-known/` path (RFC 9728), so include it explicitly or
+    // eslint's projectService cannot resolve those route files.
+    "${configDir}/src/pages/.well-known/**/*"
+  ],
   "exclude": ["workers", "dist", ".astro", "coverage", ".claude/worktrees"]
 }


### PR DESCRIPTION
**A0 spike** for the Operator ⇄ Claude MCP connector. Stacked on #1381 (the `mcp_connector` block) — review/merge that first.

Scaffolds the console-hosted `/api/mcp` endpoint a client org's Claude connects to, with fail-closed Clerk OAuth validation. **Spike scaffold**: one stub tool (`operator_status`), real read/handoff tools are later slices. Cannot be fully exercised without a live Clerk app (the Captain's part of A0).

## Key spike finding — build-vs-adapt

- **Clerk's `@clerk/mcp-tools` is Next/Express-only → unusable in Astro/CF Workers.** But its underlying primitive, `verifyToken` from `@clerk/backend` (already a transitive dep of `@clerk/astro`; promoted to direct), is runtime-agnostic web-crypto — no Node APIs. So we **adapt** `verifyToken` for JWT validation (Clerk's own docs bless manual verification), not hand-roll JWKS.
- **Transport: build, don't adapt.** The MCP TS SDK transport is Node-req/res-bound; Streamable HTTP permits a single `application/json` JSON-RPC response for a stateless read/handoff surface. So a ~150-line dispatcher, no Node shims, CF-Workers-clean.
- **Path, not subdomain:** `/api/mcp` under existing middleware (apex already serves `/api/*` unauthenticated; only `/admin`+`/portal` gated) — no DNS/cert/Worker-route/middleware change.

## Security (honors the review's F1/F2 invariants)

- **F1:** customer derives ONLY from the verified token (`aud` primary, per-customer `iss` fallback, ambiguity → refuse). The path is an untrusted existence check, never the selector — no `/mcp/<customer>` routing.
- **F2:** wrong-`aud`/wrong-`iss` token 401s (RFC 9728 `WWW-Authenticate`) **before** any customer resolution or data access.
- Fail-closed throughout; per-user `access[]` (from #1381) is the authz *within* the resolved customer. Empty `access[]` in the pilot stub ⇒ nobody is granted until real config is wired.

## Files
`src/lib/operator/mcp/{customer-resolution,token-validation,oauth-metadata,mcp-handler,tools}.ts`, `src/pages/api/mcp.ts`, `src/pages/.well-known/oauth-protected-resource/[...resource].ts`, `tests/operator-mcp-endpoint.test.ts` (16 tests), `docs/design/operator/mcp-clerk-setup.md` (Captain runbook).

## Verification
`astro check` 0 errors; `astro build` succeeds (confirms `@clerk/backend` bundles in the Worker); 16/16 unit tests. The signature path + OAuth round-trip need a live Clerk app — the Captain runbook covers it.

## Captain-only to validate the spike (A0)
1. Create a per-customer Clerk OAuth app (steps in `mcp-clerk-setup.md`); wire issuer/client-id/audience into the `PILOT_STUB` + set `enabled:true` + a real `access[]` entry.
2. Add the connector in claude.ai → `https://smd.services/api/mcp`; complete OAuth; confirm one authed `tools/list` + `operator_status`.
3. Decode the minted token: does Clerk bind a per-resource `aud` (RFC 8707)? Code handles both (aud-pin when present; per-customer iss+azp fallback either way).

🤖 Generated with [Claude Code](https://claude.com/claude-code)