### PR TITLE
feat(operator): MCP connector data plane — DB-backed customer resolution

### DIFF
--- a/migrations/0071_operator_mcp_clerk_bindings.sql
+++ b/migrations/0071_operator_mcp_clerk_bindings.sql
@@ -1,0 +1,64 @@
+-- MCP connector data plane — Operator ⇄ Claude connector (Phase 1)
+-- ============================================================================
+-- Two additions, both consumed by the console-hosted MCP endpoint
+-- (src/pages/api/mcp.ts) when it validates a Clerk OAuth token and resolves the
+-- customer the token was issued for:
+--
+--   1. customer_configs.mcp_connector_json — the projected `mcp_connector` block
+--      (enabled / data_posture / access[]) from customer.yaml. Authored content,
+--      git source of truth (ADR 0012), projected by customer-config-projection.ts
+--      exactly like every other customer_configs column. NULLABLE: a row that
+--      predates this column, or a customer.yaml with no mcp_connector block,
+--      resolves on read to the fail-closed default (disabled, empty access).
+--
+--   2. mcp_clerk_bindings — the per-customer Clerk OAuth binding. This is
+--      provisioning OUTPUT, not customer.yaml content: it is produced when the
+--      Clerk OAuth application is created for the customer (oauthApplications
+--      .create, a Worker-side action) and has no home in the git-sourced config.
+--      The MCP token validator reads it to (a) DERIVE which customer a verified
+--      token is for — `aud`-primary, per-customer `iss`-fallback, security
+--      invariant F1 — and (b) pin the customer's issuer / azp. NO client secret
+--      is stored: the console is an OAuth RESOURCE server and verifies tokens via
+--      the issuer JWKS (public key); a public PKCE client has no secret to keep.
+--
+-- ISOLATION: both live on the console control-plane D1, NOT per-customer runtime
+-- D1 (ADR 0007/0009). mcp_clerk_bindings is the cross-tenant wall —
+-- resolveCustomerFromClaims gates on it before any per-user authz or data access.
+--
+-- Refers to: docs/design/operator/03-mcp-server-exposure.md
+--            docs/design/operator/mcp-clerk-setup.md (§6 audience binding)
+--            docs/adr/0012-customer-yaml-storage.md (git source of truth)
+-- ============================================================================
+
+ALTER TABLE customer_configs ADD COLUMN mcp_connector_json TEXT;
+
+CREATE TABLE IF NOT EXISTS mcp_clerk_bindings (
+  -- The customer this binding belongs to. entity_id is the customer_configs PK,
+  -- the join key the validator uses to read the projected mcp_connector block.
+  entity_id      TEXT PRIMARY KEY,
+  -- Customer slug — human-readable audit + the customerId the endpoint surfaces
+  -- to a tool handler.
+  customer_slug  TEXT NOT NULL,
+  -- Clerk instance issuer; the token `iss` MUST equal this exactly. Shared
+  -- across OAuth apps within one Clerk instance, so `iss` alone identifies the
+  -- customer only when each customer has its own instance; otherwise `audience`
+  -- (RFC 8707) / `client_id` (azp) disambiguate.
+  issuer         TEXT NOT NULL,
+  -- The OAuth app client id; the token `azp` MUST be in this set (one id today).
+  client_id      TEXT NOT NULL,
+  -- The resource-bound audience (RFC 8707) when Clerk emits one for this app,
+  -- else NULL (issuer-keyed fallback). See mcp-clerk-setup.md §6.
+  audience       TEXT,
+  -- The Clerk OAuth application id (oauth_app_...) — provenance for update/delete.
+  clerk_app_id   TEXT NOT NULL,
+  created_at     TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  updated_at     TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+
+-- iss is always present on a verified token; index it for the resolution read.
+CREATE INDEX IF NOT EXISTS idx_mcp_clerk_bindings_issuer
+  ON mcp_clerk_bindings (issuer);
+
+-- One binding per customer slug.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_mcp_clerk_bindings_slug
+  ON mcp_clerk_bindings (customer_slug);

--- a/migrations/0071_operator_mcp_clerk_bindings.sql
+++ b/migrations/0071_operator_mcp_clerk_bindings.sql
@@ -44,13 +44,18 @@ CREATE TABLE IF NOT EXISTS mcp_clerk_bindings (
   -- customer only when each customer has its own instance; otherwise `audience`
   -- (RFC 8707) / `client_id` (azp) disambiguate.
   issuer         TEXT NOT NULL,
-  -- The OAuth app client id; the token `azp` MUST be in this set (one id today).
-  client_id      TEXT NOT NULL,
-  -- The resource-bound audience (RFC 8707) when Clerk emits one for this app,
-  -- else NULL (issuer-keyed fallback). See mcp-clerk-setup.md §6.
+  -- The OAuth app client id; the token `azp` MUST be in this set when present.
+  -- NULLABLE: most MCP clients (claude.ai included) self-register via Dynamic
+  -- Client Registration, so their client id is dynamic and unknown to us — the
+  -- azp check is skipped and isolation rests on issuer + the consent screen +
+  -- the per-user access[] gate. Set only for a pre-registered OAuth app.
+  client_id      TEXT,
+  -- The resource-bound audience (RFC 8707) when Clerk emits one, else NULL
+  -- (issuer-keyed fallback). See mcp-clerk-setup.md §6.
   audience       TEXT,
-  -- The Clerk OAuth application id (oauth_app_...) — provenance for update/delete.
-  clerk_app_id   TEXT NOT NULL,
+  -- The Clerk OAuth application id (oauth_app_...) when we pre-created one;
+  -- NULL under Dynamic Client Registration (no app we own). Provenance only.
+  clerk_app_id   TEXT,
   created_at     TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
   updated_at     TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
 );

--- a/migrations/rollbacks/0071_operator_mcp_clerk_bindings_down.sql
+++ b/migrations/rollbacks/0071_operator_mcp_clerk_bindings_down.sql
@@ -1,0 +1,12 @@
+-- Rollback for 0071_operator_mcp_clerk_bindings.sql — MANUAL, Captain-coordinated.
+-- See migrations/rollbacks/README.md. Reverses the MCP connector data plane.
+--
+-- Safe to run: the MCP endpoint fail-closes when no binding row resolves, so
+-- dropping these leaves the endpoint dark (401s everything) rather than broken.
+-- D1 (modern SQLite) supports DROP COLUMN and DROP TABLE.
+
+DROP INDEX IF EXISTS idx_mcp_clerk_bindings_slug;
+DROP INDEX IF EXISTS idx_mcp_clerk_bindings_issuer;
+DROP TABLE IF EXISTS mcp_clerk_bindings;
+
+ALTER TABLE customer_configs DROP COLUMN mcp_connector_json;

--- a/src/lib/operator/mcp/customer-resolution.ts
+++ b/src/lib/operator/mcp/customer-resolution.ts
@@ -1,33 +1,39 @@
 /**
- * SPIKE SCAFFOLD (A0) — customer-resolution seam for the Operator ⇄ Claude MCP
- * connector. See docs/design/operator/03-mcp-server-exposure.md and the build
- * plan (Workstream A). This is the one seam the spike deliberately stubs: it
- * answers "which customer does this MCP request serve, and what is that
- * customer's authored `mcp_connector` block + Clerk binding?"
+ * Customer-resolution seam for the Operator ⇄ Claude MCP connector. See
+ * docs/design/operator/03-mcp-server-exposure.md. This answers "which customer
+ * does this MCP request serve, and what is that customer's authored
+ * `mcp_connector` block + Clerk binding?" — now backed by D1, not a stub.
  *
  * SECURITY CONTRACT (from the console-hosting security review — these are app-code
  * authz invariants because one console validates tokens for ALL customers):
  *
  *   1. The customer is DERIVED FROM THE VERIFIED TOKEN — its `aud` when Clerk
- *      binds a per-resource audience (RFC 8707), else the per-customer `iss`
- *      (one Clerk app per customer ⇒ unique issuer). It is NEVER read from a URL
- *      path segment or request body. A path/body slug, if present, is UNTRUSTED
- *      and may only be used to CHECK-MATCH the token-derived customer, never to
- *      select it. A `/mcp/<customer>` routing shape would be a confused-deputy
- *      bug one layer up — so the endpoint serves ONE fixed path and the customer
- *      falls out of the token. See `resolveCustomerFromClaims`.
+ *      binds a per-resource audience (RFC 8707), else the per-customer `iss`. It
+ *      is NEVER read from a URL path segment or request body. A path/body slug,
+ *      if present, is UNTRUSTED and may only CHECK-MATCH the token-derived
+ *      customer, never select it. The endpoint serves ONE fixed path and the
+ *      customer falls out of the token. See `resolveCustomerFromClaims`.
  *
  *   2. Cross-customer isolation rests entirely on `aud` (or the `iss` fallback)
  *      enforcement. `resolveCustomerFromClaims` returning the wrong/none customer
  *      for a token IS the cross-tenant wall; the validator gates on it before any
  *      per-user authorization or data access.
  *
- * Fail-closed: claims that match no registered customer resolve to `null` → the
- * endpoint refuses. This mirrors `resolveCustomerFlyApp` in fly-app-registry.ts,
- * which the live implementation will extend rather than duplicate.
+ * Data sources (the two-table data plane, migration 0071):
+ *   - mcp_clerk_bindings — per-customer Clerk binding (issuer / client_id /
+ *     audience). Provisioning OUTPUT; written when the Clerk OAuth app is created.
+ *   - customer_configs.mcp_connector_json — the authored `mcp_connector` block
+ *     (enabled / access[]), projected from customer.yaml (ADR 0012).
+ *
+ * Fail-closed: `loadMcpCustomers` returns `[]` when nothing is provisioned;
+ * claims that match no customer resolve to `null` → the endpoint refuses. A
+ * binding with no customer_configs row resolves its connector to the disabled
+ * default (parseMcpConnector), so a token still 401s on the per-user check.
  */
 
+import type { D1Database } from '@cloudflare/workers-types'
 import type { McpConnector } from '../customer-yaml/types'
+import { parseMcpConnector } from '../../portal/customer-config'
 
 /**
  * The per-customer Clerk OAuth binding the token validator needs. One Clerk
@@ -38,12 +44,10 @@ import type { McpConnector } from '../customer-yaml/types'
  */
 export interface ClerkCustomerBinding {
   /**
-   * The customer's Clerk instance issuer, e.g.
-   * `https://clerk.smd.services` (prod) or `https://<slug>.clerk.accounts.dev`
-   * (dev). Copied from the Clerk dashboard per the setup guide. The token's
-   * `iss` claim MUST equal this exactly. When `audience` is null this `iss` is
-   * ALSO the customer-identity key (the token-derived customer is whichever
-   * registered binding owns this issuer).
+   * The customer's Clerk instance issuer, e.g. `https://clerk.smd.services`
+   * (prod) or `https://<slug>.clerk.accounts.dev` (dev). The token's `iss` claim
+   * MUST equal this exactly. When `audience` is null this `iss` is ALSO the
+   * customer-identity key.
    */
   issuer: string
   /**
@@ -64,9 +68,9 @@ export interface ClerkCustomerBinding {
 
 /**
  * Everything the MCP endpoint needs to serve one authenticated request for one
- * customer: the customer id (→ Fly app via the registry), the authored
- * connector block (enabled flag + `access[]` email→profile bindings + posture),
- * and the Clerk binding for token validation.
+ * customer: the customer id (→ Fly app via the registry), the authored connector
+ * block (enabled flag + `access[]` email→profile bindings + posture), and the
+ * Clerk binding for token validation.
  */
 export interface ResolvedMcpCustomer {
   customerId: string
@@ -82,37 +86,45 @@ export interface CustomerIdentityClaims {
   iss?: string
 }
 
-/**
- * SPIKE STUB. The pilot customer descriptor. Replaced in the live slice by a
- * read of the materialized `customer.yaml` (the `mcp_connector` block authored
- * in C1) plus the provisioned Clerk binding, indexed for claim-based lookup.
- *
- * The `access` list here is intentionally empty: with no authored access entry,
- * EVERY email fails the per-user check and the endpoint fail-closes. That is the
- * correct spike posture — the endpoint cannot grant access to anyone until a real
- * `customer.yaml` with a real `access[]` is wired in. The Captain populates
- * `issuer` (and, per the §6 finding, `audience`) from the Clerk dashboard to
- * exercise discovery + OAuth; identity mapping then 401s until `access[]` is
- * sourced from the real config (the documented next slice).
- */
-const PILOT_STUB: ResolvedMcpCustomer = {
-  customerId: 'smd',
-  connector: {
-    enabled: false,
-    data_posture: 'open',
-    access: [],
-  },
-  clerk: {
-    // Captain fills these from the Clerk dashboard per mcp-clerk-setup.md.
-    // Empty issuer ⇒ no token can resolve to this customer (fail-closed).
-    issuer: '',
-    audience: null,
-    authorizedParties: [],
-  },
+/** The mcp_clerk_bindings ⋈ customer_configs row shape `loadMcpCustomers` reads. */
+interface McpBindingRow {
+  customer_slug: string
+  issuer: string
+  client_id: string
+  audience: string | null
+  mcp_connector_json: string | null
 }
 
-/** The registry of all customers this console serves. SPIKE: just the pilot. */
-const CUSTOMERS: readonly ResolvedMcpCustomer[] = [PILOT_STUB]
+/**
+ * Load every provisioned MCP customer from D1 — the registry the pure resolver
+ * matches a token against. Reads the Clerk binding (mcp_clerk_bindings) joined to
+ * the projected connector block (customer_configs.mcp_connector_json). A binding
+ * with no config row LEFT-JOINs to a null connector_json, which parseMcpConnector
+ * resolves to the fail-closed default (disabled) — so the customer is known for
+ * resolution but grants no access until its config projects.
+ *
+ * Fail-closed: returns `[]` when nothing is provisioned (the dark default). The
+ * read is small (one row per provisioned customer); Phase 1 has a handful.
+ */
+export async function loadMcpCustomers(db: D1Database): Promise<ResolvedMcpCustomer[]> {
+  const { results } = await db
+    .prepare(
+      'SELECT b.customer_slug, b.issuer, b.client_id, b.audience, c.mcp_connector_json ' +
+        'FROM mcp_clerk_bindings b ' +
+        'LEFT JOIN customer_configs c ON c.entity_id = b.entity_id'
+    )
+    .all<McpBindingRow>()
+  return (results ?? []).map((row) => ({
+    customerId: row.customer_slug,
+    connector: parseMcpConnector(row.mcp_connector_json),
+    clerk: {
+      issuer: row.issuer,
+      // Treat empty-string audience as "no binding" (issuer-keyed fallback).
+      audience: row.audience && row.audience.length > 0 ? row.audience : null,
+      authorizedParties: row.client_id ? [row.client_id] : [],
+    },
+  }))
+}
 
 /** Does the token's `aud` (string or array) include the customer's bound audience? */
 function audMatches(aud: string | string[] | undefined, expected: string): boolean {
@@ -124,27 +136,28 @@ function audMatches(aud: string | string[] | undefined, expected: string): boole
  * SECURITY-CRITICAL (invariant 1 + 2): derive the customer from VERIFIED token
  * claims — never from a path or body. Call this ONLY with claims that came out of
  * a successful signature verification; passing unverified claims would let a
- * forged `aud`/`iss` select a customer.
+ * forged `aud`/`iss` select a customer. `customers` is the provisioned registry
+ * from {@link loadMcpCustomers}.
  *
  * Resolution order, per the §6 audience finding:
  *   - If a registered customer binds an `audience` and the token's `aud` matches
  *     it → that customer. This is the RFC 8707 mis-redemption gate: a token whose
  *     `aud` is another resource matches no customer here and the validator 401s
  *     BEFORE any data access.
- *   - Else (no audience-bound match) fall back to the per-customer `iss`: the
- *     token's issuer uniquely identifies the customer's Clerk app (one app per
- *     customer). A customer whose binding has `audience: null` is matched by
- *     issuer; a customer WITH an audience is matched ONLY by audience (so an
- *     issuer-only match never bypasses a resource-bound customer).
+ *   - Else fall back to the per-customer `iss`: the token's issuer identifies the
+ *     customer's Clerk app. A customer whose binding has `audience: null` is
+ *     matched by issuer; a customer WITH an audience is matched ONLY by audience
+ *     (so an issuer-only match never bypasses a resource-bound customer).
  *
  * Returns the single matching customer, or `null` when none matches (fail-closed)
  * or when more than one matches (ambiguous ⇒ refuse rather than guess).
  */
 export function resolveCustomerFromClaims(
-  claims: CustomerIdentityClaims
+  claims: CustomerIdentityClaims,
+  customers: readonly ResolvedMcpCustomer[]
 ): ResolvedMcpCustomer | null {
   // Pass 1: audience-bound customers (the strong, spec-compliant key).
-  const audMatched = CUSTOMERS.filter(
+  const audMatched = customers.filter(
     (c) => c.clerk.audience !== null && audMatches(claims.aud, c.clerk.audience)
   )
   if (audMatched.length === 1) return audMatched[0]
@@ -155,7 +168,7 @@ export function resolveCustomerFromClaims(
   // failed the audience match above cannot sidestep into an issuer match against a
   // resource-bound customer.
   if (typeof claims.iss !== 'string' || claims.iss.length === 0) return null
-  const issMatched = CUSTOMERS.filter(
+  const issMatched = customers.filter(
     (c) => c.clerk.audience === null && c.clerk.issuer.length > 0 && c.clerk.issuer === claims.iss
   )
   return issMatched.length === 1 ? issMatched[0] : null
@@ -180,10 +193,10 @@ export function isMcpResourcePath(resourcePath: string): boolean {
  * for the MCP resource. This is discovery only — it tells a client WHERE to
  * authenticate and carries no customer-selecting power (isolation is enforced at
  * token validation via {@link resolveCustomerFromClaims}). Returns the distinct
- * non-empty issuers of every registered customer; empty when none provisioned
+ * non-empty issuers of the provisioned customers; empty when none provisioned
  * (honest "no AS configured", never fabricated).
  */
-export function discoveryAuthorizationServers(): string[] {
-  const issuers = CUSTOMERS.map((c) => c.clerk.issuer).filter((i) => i.length > 0)
+export function discoveryAuthorizationServers(customers: readonly ResolvedMcpCustomer[]): string[] {
+  const issuers = customers.map((c) => c.clerk.issuer).filter((i) => i.length > 0)
   return [...new Set(issuers)]
 }

--- a/src/lib/operator/mcp/customer-resolution.ts
+++ b/src/lib/operator/mcp/customer-resolution.ts
@@ -90,7 +90,8 @@ export interface CustomerIdentityClaims {
 interface McpBindingRow {
   customer_slug: string
   issuer: string
-  client_id: string
+  /** Null under Dynamic Client Registration (dynamic client id) ⇒ azp skipped. */
+  client_id: string | null
   audience: string | null
   mcp_connector_json: string | null
 }

--- a/src/lib/operator/mcp/token-validation.ts
+++ b/src/lib/operator/mcp/token-validation.ts
@@ -199,8 +199,16 @@ function enforceBinding(
  * verified token, never from the request path/body (invariant 1). A token whose
  * `aud` matches no customer here is rejected (`wrong_audience`) before any data
  * access (invariant 2).
+ *
+ * `customers` is the provisioned registry loaded from D1 by the route layer
+ * (`loadMcpCustomers`). Passing it in (rather than reading D1 here) keeps this
+ * validator pure and unit-testable. An empty registry ⇒ every token 401s
+ * (`wrong_audience`) — the fail-closed dark default.
  */
-export async function validateMcpToken(token: string | null): Promise<McpAuthResult> {
+export async function validateMcpToken(
+  token: string | null,
+  customers: readonly ResolvedMcpCustomer[]
+): Promise<McpAuthResult> {
   if (!token) return { ok: false, reason: 'missing_token', detail: 'no bearer token' }
 
   // 1. Signature first — establishes trusted claims.
@@ -211,7 +219,7 @@ export async function validateMcpToken(token: string | null): Promise<McpAuthRes
   // 2. Derive the customer FROM the verified claims (aud-first; iss fallback).
   //    This is the cross-tenant gate: a valid-but-wrong-aud token matches no
   //    customer and is rejected here, before any per-user authz or data access.
-  const customer = resolveCustomerFromClaims(toIdentityClaims(claims))
+  const customer = resolveCustomerFromClaims(toIdentityClaims(claims), customers)
   if (!customer) {
     return {
       ok: false,

--- a/src/lib/portal/customer-config-projection.ts
+++ b/src/lib/portal/customer-config-projection.ts
@@ -92,6 +92,10 @@ export function projectCustomerYamlToConfigRow(
     // authority is always non-null on a validated CustomerYaml; guard anyway.
     authority_json: yaml.authority ? JSON.stringify(yaml.authority) : null,
     credential_custody_default: yaml.credential_custody_default ?? null,
+    // mcp_connector is always present on a validated CustomerYaml (the validator
+    // defaults it to disabled); guard for null anyway, which the read side
+    // resolves to the same fail-closed default via parseMcpConnector.
+    mcp_connector_json: yaml.mcp_connector ? JSON.stringify(yaml.mcp_connector) : null,
     git_sha: ctx.gitSha,
     synced_at: ctx.syncedAt,
   }
@@ -125,6 +129,7 @@ const CONFIG_COLUMNS = [
   'vertical',
   'authority_json',
   'credential_custody_default',
+  'mcp_connector_json',
   'git_sha',
   'synced_at',
 ] as const
@@ -154,6 +159,7 @@ export function buildProjectionSql(row: CustomerConfigDbRow, actor: string): str
     e(row.vertical),
     e(row.authority_json),
     e(row.credential_custody_default),
+    e(row.mcp_connector_json),
     e(row.git_sha),
     e(row.synced_at),
   ]

--- a/src/lib/portal/customer-config.ts
+++ b/src/lib/portal/customer-config.ts
@@ -25,6 +25,12 @@ import {
   parseCredentialCustody,
   type CredentialCustody,
 } from '../operator/credential-custody'
+import {
+  ACCEPTED_DATA_POSTURES,
+  type DataPosture,
+  type McpConnector,
+  type McpConnectorAccess,
+} from '../operator/customer-yaml/types'
 
 export type PersonaStatus = 'active' | 'archived'
 
@@ -99,6 +105,15 @@ export interface CustomerConfigRow {
    * src/lib/operator/credential-custody.ts.
    */
   credential_custody_default: CredentialCustody
+  /**
+   * Resolved `mcp_connector` block (Operator ⇄ Claude connector, Phase 1) —
+   * projected from `customer.yaml.mcp_connector`. Always present: a null
+   * `mcp_connector_json` column (a row predating the column, or a customer.yaml
+   * with no block) resolves to the fail-closed default (disabled, empty access)
+   * via {@link parseMcpConnector}. The MCP endpoint reads this for the per-user
+   * `access[]` mapping; the Clerk binding lives separately in mcp_clerk_bindings.
+   */
+  mcp_connector: McpConnector
   git_sha: string
   synced_at: string
 }
@@ -118,6 +133,7 @@ export interface CustomerConfigDbRow {
   vertical: string | null
   authority_json: string | null
   credential_custody_default: string | null
+  mcp_connector_json: string | null
   git_sha: string
   synced_at: string
 }
@@ -153,6 +169,48 @@ function parseJsonRequired<T>(value: string, column: string, entityId: string): 
   }
 }
 
+/** Fail-closed `mcp_connector`: no user reaches the Operator through Claude. */
+const MCP_CONNECTOR_FAIL_CLOSED: McpConnector = {
+  enabled: false,
+  data_posture: 'open',
+  access: [],
+}
+
+/**
+ * Parse the projected `mcp_connector_json` column into a runtime `McpConnector`.
+ *
+ * DEFENSIVE / FAIL-CLOSED, unlike `parseJsonRequired`: a null column, malformed
+ * JSON, or a shape-wrong value all resolve to the disabled default rather than
+ * throwing. Two reasons: (1) this column is read on the live client portal, and
+ * a corrupt value must not 500 the page the way a corrupt `personas_json` does;
+ * (2) for the MCP endpoint, "config we can't trust" must mean "grant nothing",
+ * never "open up". A well-formed enabled block with valid `access[]` entries is
+ * honored exactly; anything else collapses to disabled + empty access.
+ */
+export function parseMcpConnector(json: string | null | undefined): McpConnector {
+  if (json === null || json === undefined) return { ...MCP_CONNECTOR_FAIL_CLOSED, access: [] }
+  let raw: unknown
+  try {
+    raw = JSON.parse(json)
+  } catch {
+    return { ...MCP_CONNECTOR_FAIL_CLOSED, access: [] }
+  }
+  if (raw === null || typeof raw !== 'object') return { ...MCP_CONNECTOR_FAIL_CLOSED, access: [] }
+  const o = raw as Record<string, unknown>
+  const data_posture: DataPosture = ACCEPTED_DATA_POSTURES.includes(o.data_posture as DataPosture)
+    ? (o.data_posture as DataPosture)
+    : 'open'
+  const access: McpConnectorAccess[] = Array.isArray(o.access)
+    ? o.access.flatMap((e) => {
+        if (e === null || typeof e !== 'object') return []
+        const entry = e as Record<string, unknown>
+        if (typeof entry.email !== 'string' || typeof entry.profile !== 'string') return []
+        return [{ email: entry.email, profile: entry.profile }]
+      })
+    : []
+  return { enabled: o.enabled === true, data_posture, access }
+}
+
 export function projectRow(row: CustomerConfigDbRow): CustomerConfigRow {
   return {
     entity_id: row.entity_id,
@@ -173,6 +231,7 @@ export function projectRow(row: CustomerConfigDbRow): CustomerConfigRow {
     authority: parseAuthorityPosture(parseJsonNullable(row.authority_json)),
     credential_custody_default:
       parseCredentialCustody(row.credential_custody_default) ?? DEFAULT_CREDENTIAL_CUSTODY,
+    mcp_connector: parseMcpConnector(row.mcp_connector_json),
     git_sha: row.git_sha,
     synced_at: row.synced_at,
   }

--- a/src/pages/.well-known/oauth-protected-resource/[...resource].ts
+++ b/src/pages/.well-known/oauth-protected-resource/[...resource].ts
@@ -15,9 +15,11 @@
  */
 
 import type { APIRoute } from 'astro'
+import { env } from 'cloudflare:workers'
 import {
   discoveryAuthorizationServers,
   isMcpResourcePath,
+  loadMcpCustomers,
 } from '../../../lib/operator/mcp/customer-resolution'
 import { buildProtectedResourceMetadata } from '../../../lib/operator/mcp/oauth-metadata'
 
@@ -44,7 +46,7 @@ function resourcePathFromParam(resource: string | undefined): string {
   return `/${tail}`
 }
 
-export const GET: APIRoute = ({ params, url }) => {
+export const GET: APIRoute = async ({ params, url }) => {
   const resourcePath = resourcePathFromParam(params.resource)
   // Public discovery: only confirm the path is the MCP resource. This does NOT
   // select a customer (that happens at token validation from the verified aud);
@@ -54,9 +56,15 @@ export const GET: APIRoute = ({ params, url }) => {
   }
 
   // The canonical resource URL is this origin + the resource path. Must match
-  // what the client used for discovery and (when bound) Clerk's `aud`.
+  // what the client used for discovery and (when bound) Clerk's `aud`. The
+  // advertised AS issuers are the distinct issuers of provisioned customers —
+  // an honest empty list when none are provisioned (the dark default).
   const resourceUrl = new URL(resourcePath, url.origin).toString()
-  const metadata = buildProtectedResourceMetadata(resourceUrl, discoveryAuthorizationServers())
+  const customers = await loadMcpCustomers(env.DB)
+  const metadata = buildProtectedResourceMetadata(
+    resourceUrl,
+    discoveryAuthorizationServers(customers)
+  )
   return json(metadata, 200)
 }
 

--- a/src/pages/api/mcp.ts
+++ b/src/pages/api/mcp.ts
@@ -34,7 +34,12 @@
  */
 
 import type { APIRoute } from 'astro'
-import { isMcpResourcePath, MCP_RESOURCE_PATH } from '../../lib/operator/mcp/customer-resolution'
+import { env } from 'cloudflare:workers'
+import {
+  isMcpResourcePath,
+  loadMcpCustomers,
+  MCP_RESOURCE_PATH,
+} from '../../lib/operator/mcp/customer-resolution'
 import { buildWwwAuthenticate } from '../../lib/operator/mcp/oauth-metadata'
 import {
   extractBearerToken,
@@ -96,9 +101,12 @@ export const POST: APIRoute = async ({ request, url }) => {
   // --- Auth (fail-closed, security-ordered) ---
   // validateMcpToken: verify signature → derive customer from verified aud/iss →
   // enforce binding → per-user access[]. A wrong-aud token 401s before any data
-  // access (invariant 2). The customer comes OUT of validation, not in.
+  // access (invariant 2). The customer comes OUT of validation, not in. The
+  // provisioned registry is loaded from D1 here and passed in (keeping the
+  // validator pure); an empty registry ⇒ every token 401s (dark default).
   const token = extractBearerToken(request.headers.get('authorization'))
-  const auth = await validateMcpToken(token)
+  const customers = await loadMcpCustomers(env.DB)
+  const auth = await validateMcpToken(token, customers)
   if (!auth.ok) {
     return denyFor(url, auth)
   }

--- a/tests/customer-config-projection.test.ts
+++ b/tests/customer-config-projection.test.ts
@@ -68,6 +68,18 @@ describe('customer-config projection: real smd yaml', () => {
     expect(config.authority).toBeDefined()
     expect(config.credential_custody_default).toBeTruthy()
   })
+
+  it('mcp_connector survives the round-trip (defaults to disabled/fail-closed)', () => {
+    // smd's customer.yaml authors no mcp_connector block yet, so the validator
+    // defaults it to disabled — the projection must carry that through, never
+    // dropping the column (which would also fail-close on read, but explicitly
+    // is better).
+    const row = projectCustomerYamlToConfigRow(smdYaml(), CTX)
+    expect(row.mcp_connector_json).not.toBeNull()
+    const config = projectRow(row)
+    expect(config.mcp_connector.enabled).toBe(false)
+    expect(config.mcp_connector.access).toEqual([])
+  })
 })
 
 describe('customer-config projection: null normalization', () => {

--- a/tests/customer-config.test.ts
+++ b/tests/customer-config.test.ts
@@ -26,6 +26,7 @@ import {
   getActivePersona,
   getLatestSyncMeta,
   listCustomerConfigHistory,
+  parseMcpConnector,
   recordCustomerConfigSync,
   shouldRecordSync,
   type PersonaConfig,
@@ -59,6 +60,8 @@ interface SeedOptions {
   business_hours?: unknown
   connectors?: unknown
   scope?: unknown
+  /** Raw mcp_connector_json column value; undefined ⇒ NULL (fail-closed default). */
+  mcp_connector_json?: string | null
   git_sha?: string
   synced_at?: string
 }
@@ -70,8 +73,8 @@ async function seedConfig(db: D1Database, opts: SeedOptions = {}): Promise<void>
       `INSERT INTO customer_configs
         (entity_id, org_id, customer_slug, schema_version,
          personas_json, voice_library_json, escalation_json, business_hours_json,
-         connectors_json, scope_json, git_sha, synced_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+         connectors_json, scope_json, mcp_connector_json, git_sha, synced_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
     )
     .bind(
       opts.entity_id ?? ENTITY_ID,
@@ -84,6 +87,7 @@ async function seedConfig(db: D1Database, opts: SeedOptions = {}): Promise<void>
       opts.business_hours === undefined ? null : JSON.stringify(opts.business_hours),
       opts.connectors === undefined ? null : JSON.stringify(opts.connectors),
       opts.scope === undefined ? null : JSON.stringify(opts.scope),
+      opts.mcp_connector_json === undefined ? null : opts.mcp_connector_json,
       opts.git_sha ?? 'a1b2c3d4e5f6',
       opts.synced_at ?? '2026-05-21T12:00:00Z'
     )
@@ -266,6 +270,90 @@ describe('customer_configs schema integrity', () => {
     await expect(
       seedConfig(db, { entity_id: 'entity-other', customer_slug: 'same-slug' })
     ).rejects.toThrow()
+  })
+})
+
+describe('mcp_connector projection column (migration 0071)', () => {
+  let db: D1Database
+
+  beforeEach(async () => {
+    db = await freshDb()
+    await seedEntity(db)
+  })
+
+  it('a NULL mcp_connector_json column reads back as the fail-closed default', async () => {
+    // A row that predates the column, or a customer.yaml with no block.
+    await seedConfig(db) // mcp_connector_json omitted ⇒ NULL
+    const config = await getCustomerConfig(db, ENTITY_ID)
+    expect(config?.mcp_connector.enabled).toBe(false)
+    expect(config?.mcp_connector.access).toEqual([])
+  })
+
+  it('an authored, enabled mcp_connector reads back intact', async () => {
+    await seedConfig(db, {
+      mcp_connector_json: JSON.stringify({
+        enabled: true,
+        data_posture: 'firm_only',
+        access: [{ email: 'owner@firm.com', profile: 'crane' }],
+      }),
+    })
+    const config = await getCustomerConfig(db, ENTITY_ID)
+    expect(config?.mcp_connector.enabled).toBe(true)
+    expect(config?.mcp_connector.data_posture).toBe('firm_only')
+    expect(config?.mcp_connector.access).toEqual([{ email: 'owner@firm.com', profile: 'crane' }])
+  })
+})
+
+describe('parseMcpConnector (fail-closed, defensive)', () => {
+  it('null / undefined ⇒ disabled, empty access', () => {
+    expect(parseMcpConnector(null)).toEqual({ enabled: false, data_posture: 'open', access: [] })
+    expect(parseMcpConnector(undefined)).toEqual({
+      enabled: false,
+      data_posture: 'open',
+      access: [],
+    })
+  })
+
+  it('malformed JSON ⇒ fail-closed (never throws)', () => {
+    expect(parseMcpConnector('{not json')).toEqual({
+      enabled: false,
+      data_posture: 'open',
+      access: [],
+    })
+  })
+
+  it('a non-object value ⇒ fail-closed', () => {
+    expect(parseMcpConnector('"a string"')).toEqual({
+      enabled: false,
+      data_posture: 'open',
+      access: [],
+    })
+    expect(parseMcpConnector('42')).toEqual({ enabled: false, data_posture: 'open', access: [] })
+  })
+
+  it('an unknown data_posture falls back to open; enabled requires literal true', () => {
+    const c = parseMcpConnector(
+      JSON.stringify({ enabled: 'yes', data_posture: 'bogus', access: [] })
+    )
+    expect(c.enabled).toBe(false) // only literal true enables
+    expect(c.data_posture).toBe('open')
+  })
+
+  it('drops malformed access entries, keeps well-formed ones', () => {
+    const c = parseMcpConnector(
+      JSON.stringify({
+        enabled: true,
+        data_posture: 'open',
+        access: [
+          { email: 'good@firm.com', profile: 'crane' },
+          { email: 'no-profile@firm.com' },
+          { profile: 'orphan' },
+          'not-an-object',
+          null,
+        ],
+      })
+    )
+    expect(c.access).toEqual([{ email: 'good@firm.com', profile: 'crane' }])
   })
 })
 

--- a/tests/operator-mcp-endpoint.test.ts
+++ b/tests/operator-mcp-endpoint.test.ts
@@ -11,8 +11,14 @@
  */
 
 import { describe, it, expect } from 'vitest'
+import type { D1Database } from '@cloudflare/workers-types'
 import { extractBearerToken, validateMcpToken } from '../src/lib/operator/mcp/token-validation'
-import { resolveCustomerFromClaims } from '../src/lib/operator/mcp/customer-resolution'
+import {
+  resolveCustomerFromClaims,
+  loadMcpCustomers,
+  discoveryAuthorizationServers,
+  type ResolvedMcpCustomer,
+} from '../src/lib/operator/mcp/customer-resolution'
 import { dispatchMcpRequest, parseMcpBody } from '../src/lib/operator/mcp/mcp-handler'
 import type { McpToolContext } from '../src/lib/operator/mcp/tools'
 
@@ -21,6 +27,39 @@ const CTX: McpToolContext = {
   subject: 'user_123',
   email: 'pilot@example.com',
   profile: 'marcus',
+}
+
+/** Build a provisioned-customer fixture for the pure resolver tests. */
+function customerFixture(
+  over: Partial<{
+    customerId: string
+    issuer: string
+    audience: string | null
+    clientId: string
+    enabled: boolean
+    access: { email: string; profile: string }[]
+  }> = {}
+): ResolvedMcpCustomer {
+  return {
+    customerId: over.customerId ?? 'smd',
+    connector: {
+      enabled: over.enabled ?? true,
+      data_posture: 'open',
+      access: over.access ?? [{ email: 'pilot@example.com', profile: 'marcus' }],
+    },
+    clerk: {
+      issuer: over.issuer ?? 'https://clerk.smd.services',
+      audience: over.audience ?? null,
+      authorizedParties: over.clientId ? [over.clientId] : [],
+    },
+  }
+}
+
+/** Minimal D1 stub: every prepare().all() returns the same fixed rows. */
+function fakeDb(rows: unknown[]): D1Database {
+  return {
+    prepare: () => ({ all: async () => ({ results: rows }) }),
+  } as unknown as D1Database
 }
 
 describe('extractBearerToken', () => {
@@ -40,7 +79,7 @@ describe('extractBearerToken', () => {
 
 describe('validateMcpToken — token gates (no live Clerk app)', () => {
   it('rejects when no token is present', async () => {
-    const r = await validateMcpToken(null)
+    const r = await validateMcpToken(null, [])
     expect(r.ok).toBe(false)
     if (!r.ok) expect(r.reason).toBe('missing_token')
   })
@@ -48,9 +87,9 @@ describe('validateMcpToken — token gates (no live Clerk app)', () => {
   it('rejects an unverifiable token at the signature gate (FIRST gate)', async () => {
     // A garbage token cannot pass @clerk/backend verifyToken (no real JWKS).
     // Signature is verified BEFORE any customer resolution or data access, so a
-    // forged token never reaches the aud/customer logic. Exercises the
-    // security-ordered fail-closed branch end to end.
-    const r = await validateMcpToken('not.a.real.jwt')
+    // forged token never reaches the aud/customer logic — the registry passed in
+    // is irrelevant here. Exercises the security-ordered fail-closed branch.
+    const r = await validateMcpToken('not.a.real.jwt', [customerFixture()])
     expect(r.ok).toBe(false)
     if (!r.ok) expect(r.reason).toBe('signature_invalid')
   })
@@ -60,20 +99,64 @@ describe('validateMcpToken — token gates (no live Clerk app)', () => {
  * SECURITY INVARIANTS (console-hosting review). The customer is DERIVED from the
  * verified token's aud/iss — never a path/body. resolveCustomerFromClaims is the
  * cross-tenant gate; these test it directly with already-"verified" claim shapes
- * (the function is only ever called post-signature-verification in production).
+ * (the function is only ever called post-signature-verification in production)
+ * against an explicit provisioned registry.
  */
 describe('resolveCustomerFromClaims — customer derives from verified claims', () => {
-  it('returns null when claims match no registered customer (wrong-aud rejection)', () => {
-    // The spike pilot ships with empty issuer/audience, so NOTHING resolves —
-    // the fail-closed posture until the Captain provisions the Clerk binding.
-    expect(resolveCustomerFromClaims({ aud: 'https://evil.example/api/mcp' })).toBeNull()
-    expect(resolveCustomerFromClaims({ iss: 'https://attacker.clerk.dev' })).toBeNull()
-    expect(resolveCustomerFromClaims({})).toBeNull()
+  it('returns null when the registry is empty (dark default)', () => {
+    // Nothing provisioned ⇒ no token resolves, regardless of its claims.
+    expect(resolveCustomerFromClaims({ aud: 'https://smd.services/api/mcp' }, [])).toBeNull()
+    expect(resolveCustomerFromClaims({ iss: 'https://clerk.smd.services' }, [])).toBeNull()
+    expect(resolveCustomerFromClaims({}, [])).toBeNull()
   })
 
-  it('does not resolve a customer from an empty/unprovisioned issuer', () => {
-    // Guards against an empty-string issuer matching an empty claim.
-    expect(resolveCustomerFromClaims({ iss: '' })).toBeNull()
+  it('matches an issuer-keyed customer by iss when audience is unbound', () => {
+    const c = customerFixture({ issuer: 'https://clerk.smd.services', audience: null })
+    expect(resolveCustomerFromClaims({ iss: 'https://clerk.smd.services' }, [c])).toBe(c)
+    expect(resolveCustomerFromClaims({ iss: 'https://other.clerk.dev' }, [c])).toBeNull()
+  })
+
+  it('does not match an issuer-keyed customer from an empty issuer claim', () => {
+    const c = customerFixture({ issuer: 'https://clerk.smd.services', audience: null })
+    expect(resolveCustomerFromClaims({ iss: '' }, [c])).toBeNull()
+  })
+
+  it('matches an audience-bound customer by aud (string or array)', () => {
+    const aud = 'https://smd.services/api/mcp'
+    const c = customerFixture({ audience: aud })
+    expect(resolveCustomerFromClaims({ aud }, [c])).toBe(c)
+    expect(resolveCustomerFromClaims({ aud: [aud, 'urn:x'] }, [c])).toBe(c)
+    expect(resolveCustomerFromClaims({ aud: 'https://evil.example/api/mcp' }, [c])).toBeNull()
+  })
+
+  it('an audience-bound customer is NEVER matched by issuer alone (no aud sidestep)', () => {
+    // A token issued by the same instance but WITHOUT the bound aud must not
+    // resolve an aud-bound customer via the issuer fallback.
+    const c = customerFixture({
+      issuer: 'https://clerk.smd.services',
+      audience: 'https://smd.services/api/mcp',
+    })
+    expect(resolveCustomerFromClaims({ iss: 'https://clerk.smd.services' }, [c])).toBeNull()
+  })
+
+  it('refuses (null) when more than one customer matches — ambiguous', () => {
+    // Two issuer-keyed customers sharing an issuer ⇒ refuse rather than guess.
+    const a = customerFixture({
+      customerId: 'a',
+      issuer: 'https://shared.clerk.dev',
+      audience: null,
+    })
+    const b = customerFixture({
+      customerId: 'b',
+      issuer: 'https://shared.clerk.dev',
+      audience: null,
+    })
+    expect(resolveCustomerFromClaims({ iss: 'https://shared.clerk.dev' }, [a, b])).toBeNull()
+    // Two customers sharing an audience ⇒ likewise refuse.
+    const aud = 'https://smd.services/api/mcp'
+    const c = customerFixture({ customerId: 'c', audience: aud })
+    const d = customerFixture({ customerId: 'd', audience: aud })
+    expect(resolveCustomerFromClaims({ aud }, [c, d])).toBeNull()
   })
 })
 
@@ -81,10 +164,88 @@ describe('validateMcpToken — wrong-aud rejection ordering', () => {
   it('a syntactically-valid but unverifiable token never selects a customer', async () => {
     // Even if an attacker crafts a token whose aud names our resource, it fails
     // at the signature gate first (no valid JWKS signature). The customer is only
-    // derived AFTER verification, so a wrong/forged aud can never reach data.
-    const r = await validateMcpToken('eyJ.forged.aud')
+    // derived AFTER verification, so a wrong/forged aud can never reach data —
+    // even with a real customer provisioned in the registry.
+    const r = await validateMcpToken('eyJ.forged.aud', [
+      customerFixture({ audience: 'https://smd.services/api/mcp' }),
+    ])
     expect(r.ok).toBe(false)
     if (!r.ok) expect(r.reason).toBe('signature_invalid')
+  })
+})
+
+describe('loadMcpCustomers — D1 → registry mapping', () => {
+  it('maps a binding+config row into a ResolvedMcpCustomer', async () => {
+    const db = fakeDb([
+      {
+        customer_slug: 'smd',
+        issuer: 'https://clerk.smd.services',
+        client_id: 'client_abc',
+        audience: null,
+        mcp_connector_json: JSON.stringify({
+          enabled: true,
+          data_posture: 'open',
+          access: [{ email: 'pilot@example.com', profile: 'marcus' }],
+        }),
+      },
+    ])
+    const [c] = await loadMcpCustomers(db)
+    expect(c.customerId).toBe('smd')
+    expect(c.clerk.issuer).toBe('https://clerk.smd.services')
+    expect(c.clerk.authorizedParties).toEqual(['client_abc'])
+    expect(c.connector.enabled).toBe(true)
+    expect(c.connector.access).toEqual([{ email: 'pilot@example.com', profile: 'marcus' }])
+  })
+
+  it('fail-closes the connector when the config row is absent (null json)', async () => {
+    const db = fakeDb([
+      {
+        customer_slug: 'smd',
+        issuer: 'https://clerk.smd.services',
+        client_id: 'client_abc',
+        audience: null,
+        mcp_connector_json: null,
+      },
+    ])
+    const [c] = await loadMcpCustomers(db)
+    expect(c.connector.enabled).toBe(false)
+    expect(c.connector.access).toEqual([])
+  })
+
+  it('treats an empty-string audience as no binding (issuer-keyed)', async () => {
+    const db = fakeDb([
+      {
+        customer_slug: 'smd',
+        issuer: 'https://clerk.smd.services',
+        client_id: 'client_abc',
+        audience: '',
+        mcp_connector_json: null,
+      },
+    ])
+    const [c] = await loadMcpCustomers(db)
+    expect(c.clerk.audience).toBeNull()
+  })
+
+  it('returns an empty registry for no rows (dark default)', async () => {
+    expect(await loadMcpCustomers(fakeDb([]))).toEqual([])
+  })
+})
+
+describe('discoveryAuthorizationServers — advertised issuers', () => {
+  it('returns the distinct non-empty issuers of provisioned customers', () => {
+    const customers = [
+      customerFixture({ customerId: 'a', issuer: 'https://clerk.smd.services' }),
+      customerFixture({ customerId: 'b', issuer: 'https://clerk.smd.services' }),
+      customerFixture({ customerId: 'c', issuer: 'https://other.clerk.dev' }),
+    ]
+    expect(discoveryAuthorizationServers(customers).sort()).toEqual([
+      'https://clerk.smd.services',
+      'https://other.clerk.dev',
+    ])
+  })
+
+  it('returns an empty list when nothing is provisioned (honest no-AS)', () => {
+    expect(discoveryAuthorizationServers([])).toEqual([])
   })
 })
 

--- a/tests/operator-mcp-endpoint.test.ts
+++ b/tests/operator-mcp-endpoint.test.ts
@@ -226,6 +226,20 @@ describe('loadMcpCustomers — D1 → registry mapping', () => {
     expect(c.clerk.audience).toBeNull()
   })
 
+  it('maps a null client_id (DCR self-registration) to no azp pin', async () => {
+    const db = fakeDb([
+      {
+        customer_slug: 'smd',
+        issuer: 'https://clerk.smd.services',
+        client_id: null, // DCR: claude.ai self-registers; client id is dynamic
+        audience: null,
+        mcp_connector_json: null,
+      },
+    ])
+    const [c] = await loadMcpCustomers(db)
+    expect(c.clerk.authorizedParties).toEqual([])
+  })
+
   it('returns an empty registry for no rows (dark default)', async () => {
     expect(await loadMcpCustomers(fakeDb([]))).toEqual([])
   })


### PR DESCRIPTION
## What

Replaces the A0 spike's hard-coded `PILOT_STUB` with a real, fail-closed, **DB-backed** customer-resolution path for the console-hosted Operator ⇄ Claude MCP endpoint. This is **step 2** of the SMD dogfood run (the data plane). The endpoint stays **dark** — every token still 401s — until a customer's Clerk binding is provisioned (next PR) and its `mcp_connector` block is authored + projected (step 5). Nothing here grants access to anyone.

## Two-table data plane (migration 0071)

- **`customer_configs.mcp_connector_json`** — the authored `mcp_connector` block (enabled / data_posture / access[]) projected from `customer.yaml` via the canonical mapper, exactly like every other `customer_configs` column. Nullable → fail-closed default on read.
- **`mcp_clerk_bindings`** — the per-customer Clerk binding (issuer / client_id / audience). This is provisioning **output**, with no home in the git-sourced config. **No client secret is stored**: the console is an OAuth *resource* server and verifies tokens via the issuer JWKS (public PKCE client).

## Security shape (F1/F2 preserved)

- `resolveCustomerFromClaims` stays a **pure function** over the provisioned registry — the F1 (customer derives only from verified `aud`/`iss`) and F2 (wrong-token 401s before any data access) invariants and their tests are unchanged; it just takes the registry as a parameter now.
- `loadMcpCustomers(db)` builds that registry from D1 (LEFT JOIN so a binding with no config row fail-closes its connector to disabled). The endpoint + RFC 9728 discovery route load it from `env.DB` and pass it in — the validator never touches D1, stays unit-testable.
- `parseMcpConnector` is the defensive read: null / malformed / shape-wrong all collapse to disabled + empty access, never throw.

## Tests

Pure-resolver coverage (aud-primary, iss-fallback, audience-over-issuer precedence, ambiguity→refuse, empty-issuer), `loadMcpCustomers` D1 mapping, `parseMcpConnector` fail-closed cases, and a **real-D1 integration test** that applies migration 0071 and round-trips `mcp_connector` through the projection. Full suite: 3468 pass. astro check: 0 errors. Lint: 0 errors. Endpoint remains dark in prod (verified live: 401 + WWW-Authenticate, discovery `authorization_servers: []`).

Part of the Operator ⇄ Claude MCP connector — design `docs/design/operator/03-mcp-server-exposure.md` (#1379), connector block #1381, endpoint scaffold #1382.

🤖 Generated with [Claude Code](https://claude.com/claude-code)