### PR TITLE
feat(operator): operator_status MCP tool reads live Machine activity

### DIFF
--- a/src/lib/operator/mcp/tools.ts
+++ b/src/lib/operator/mcp/tools.ts
@@ -1,20 +1,27 @@
 /**
- * SPIKE SCAFFOLD (A0) — MCP tool registry for the Operator ⇄ Claude connector.
+ * MCP tool registry for the Operator ⇄ Claude connector.
  *
- * Phase 1 ships exactly one STUB read tool, `operator_status`, returning a
- * placeholder payload. Real data wiring (the runtime-read seam in
- * runtime-read-transport.ts → the Machine's `GET /runtime/<kind>`) is a later
- * slice per the build plan (Workstream B). The read/handoff tool surface
- * (`operator_search_memory`, `operator_get_context`, `operator_handoff_task`)
- * is intentionally NOT built here — B0 decides the final surface from observed
- * bytes against the running Machine.
+ * Phase 1 ships one LIVE read tool, `operator_status`, backed by the runtime-read
+ * seam (ADR 0043 path A): the console→Machine `GET /runtime/audit_log` call,
+ * summarized into a liveness + recent-activity view. The handler is fail-closed
+ * — if the Machine is unreachable or the read path is unconfigured it reports
+ * `reachable: false` with a reason, never fabricated activity.
  *
- * Each tool is a pure descriptor + handler so the JSON-RPC layer (mcp-handler.ts)
- * stays transport-only. Handlers receive the authenticated identity so a real
- * tool can scope its read to the entitled user; the stub ignores it beyond echo.
+ * The read capability is injected via {@link McpToolContext.readRuntime}: the
+ * route layer (src/pages/api/mcp.ts) builds a capability already scoped to THIS
+ * customer + actor (one customer per call, audited), so a tool handler cannot
+ * express a cross-customer read. Tools stay free of env/db wiring.
+ *
+ * Deferred (fast-follow, intentionally not here): `operator_search_memory`
+ * (memory_export needs a `table` param threaded through the frozen
+ * RuntimeReadQuery, and the mirror tables may be sparse for customer-zero) and
+ * `operator_handoff_task` (Phase 2 — two-repo: console emitter + overlay
+ * `source=mcp` recognition + deploy). See docs/design/operator/03-mcp-server-exposure.md.
  */
 
-/** JSON-Schema-ish shape for a tool's input. Kept minimal for the spike. */
+import type { RuntimeReadQuery, RuntimeReadResult } from '../runtime-read'
+
+/** JSON-Schema-ish shape for a tool's input. */
 export interface McpToolInputSchema {
   type: 'object'
   properties: Record<string, unknown>
@@ -28,12 +35,17 @@ export interface McpToolDescriptor {
   inputSchema: McpToolInputSchema
 }
 
-/** The authenticated caller context handed to a tool handler. */
+/**
+ * The authenticated caller context handed to a tool handler. `readRuntime` is a
+ * customer+actor-scoped, read-only, audited runtime read (the route layer binds
+ * the customer and actor; there is no way to express a cross-customer read).
+ */
 export interface McpToolContext {
   customerId: string
   subject: string
   email: string
   profile: string
+  readRuntime: (query: RuntimeReadQuery) => Promise<RuntimeReadResult>
 }
 
 /** MCP `tools/call` result content block (text only for the spike). */
@@ -53,31 +65,90 @@ export interface McpTool {
 }
 
 /**
- * STUB tool: `operator_status`. Real version surfaces Operator liveness + this
- * user's handoff queue via the runtime-read seam (build plan B1). The spike
- * returns a clearly-labeled placeholder so a `claude.ai` connector add can make
- * one real authed `tools/call` round-trip end to end.
+ * One audit_log entry as the Machine serves it (overlay `_shape_audit_row`):
+ * id/ts/action/actor required, the rest nullable. We surface only the
+ * non-sensitive fields (never the internal digest columns, which the Machine
+ * does not expose anyway).
+ */
+interface AuditEntry {
+  ts: string
+  action: string
+  skill: string | null
+  matterRef: string | null
+}
+
+/** Defensively parse the Machine's `{entries,cursor}` audit_log page. */
+function parseAuditEntries(data: unknown): AuditEntry[] {
+  if (data === null || typeof data !== 'object') return []
+  const entries = (data as { entries?: unknown }).entries
+  if (!Array.isArray(entries)) return []
+  return entries.flatMap((e) => {
+    if (e === null || typeof e !== 'object') return []
+    const o = e as Record<string, unknown>
+    if (typeof o.ts !== 'string' || typeof o.action !== 'string') return []
+    return [
+      {
+        ts: o.ts,
+        action: o.action,
+        skill: typeof o.skill === 'string' ? o.skill : null,
+        matterRef: typeof o.matterRef === 'string' ? o.matterRef : null,
+      },
+    ]
+  })
+}
+
+const RECENT_LIMIT = 10
+const RECENT_SHOWN = 5
+
+/**
+ * LIVE tool: `operator_status`. Reports the Operator's reachability and the
+ * caller's recent activity, read from the Machine's audit_log via the
+ * runtime-read seam. Fail-closed: an unreachable/unconfigured Machine reports
+ * `reachable: false` + a reason; an empty log reports zero activity honestly —
+ * never fabricated.
  */
 const operatorStatus: McpTool = {
   descriptor: {
     name: 'operator_status',
     description:
-      'Report this Operator’s current status and the calling user’s handoff queue. ' +
-      'SPIKE STUB: returns a placeholder; live data wiring is a later slice.',
+      'Report this Operator’s current reachability and a summary of its most ' +
+      'recent activity (newest first). Read-only; reflects live Machine state.',
     inputSchema: { type: 'object', properties: {} },
   },
-  // Not `async`: the stub does no I/O. The live version (runtime-read seam) will
-  // be async; the interface already returns a Promise, so swapping in real I/O
-  // is a body change, not a signature change.
-  handle: (_args, ctx) => {
-    const payload = {
-      stub: true,
-      note: 'SPIKE placeholder — not live Operator data.',
+  handle: async (_args, ctx) => {
+    const res = await ctx.readRuntime({ kind: 'audit_log', limit: RECENT_LIMIT })
+
+    const base = {
       customer_id: ctx.customerId,
       authenticated_as: { profile: ctx.profile, email: ctx.email },
-      operator: { status: 'unknown', handoff_queue_depth: null },
     }
-    return Promise.resolve({ content: [{ type: 'text', text: JSON.stringify(payload, null, 2) }] })
+
+    if (!res.ok) {
+      // Fail-closed: the Machine is unreachable or the read path is unconfigured.
+      // Report honestly; never invent a status.
+      const payload = {
+        ...base,
+        operator: { reachable: false as const, reason: res.reason },
+      }
+      return { content: [{ type: 'text', text: JSON.stringify(payload, null, 2) }] }
+    }
+
+    const entries = parseAuditEntries(res.data)
+    const payload = {
+      ...base,
+      operator: {
+        reachable: true as const,
+        recent_activity_count: entries.length,
+        latest_activity_at: entries[0]?.ts ?? null,
+        recent: entries.slice(0, RECENT_SHOWN).map((e) => ({
+          at: e.ts,
+          action: e.action,
+          skill: e.skill,
+          matter: e.matterRef,
+        })),
+      },
+    }
+    return { content: [{ type: 'text', text: JSON.stringify(payload, null, 2) }] }
   },
 }
 

--- a/src/pages/api/mcp.ts
+++ b/src/pages/api/mcp.ts
@@ -48,6 +48,11 @@ import {
 } from '../../lib/operator/mcp/token-validation'
 import { dispatchMcpRequest, parseMcpBody } from '../../lib/operator/mcp/mcp-handler'
 import type { McpToolContext } from '../../lib/operator/mcp/tools'
+import { readMachineRuntime } from '../../lib/operator/runtime-read'
+import {
+  createMachineRuntimeTransport,
+  createRuntimeReadAudit,
+} from '../../lib/operator/runtime-read-transport'
 
 const RESOURCE_PATH = MCP_RESOURCE_PATH
 
@@ -110,11 +115,23 @@ export const POST: APIRoute = async ({ request, url }) => {
   if (!auth.ok) {
     return denyFor(url, auth)
   }
+  // Build a runtime-read capability already scoped to THIS customer + actor:
+  // one customer per call (the isolation guarantee), read-only, and audited
+  // (operator_runtime_read_audit). readMachineRuntime is fail-closed — an
+  // unreachable/unconfigured Machine yields an empty result with a reason, never
+  // a throw. Tool handlers get this capability and cannot widen its scope.
+  const transport = createMachineRuntimeTransport(env)
+  const readAudit = createRuntimeReadAudit(env.DB, { actorUserId: auth.subject })
   const ctx: McpToolContext = {
     customerId: auth.customer.customerId,
     subject: auth.subject,
     email: auth.email,
     profile: auth.profile,
+    readRuntime: (query) =>
+      readMachineRuntime({ transport, audit: readAudit }, auth.customer.customerId, query, {
+        actor: auth.subject,
+        actorRole: 'mcp_client',
+      }),
   }
 
   // --- Parse JSON-RPC body ---

--- a/tests/operator-mcp-endpoint.test.ts
+++ b/tests/operator-mcp-endpoint.test.ts
@@ -22,11 +22,23 @@ import {
 import { dispatchMcpRequest, parseMcpBody } from '../src/lib/operator/mcp/mcp-handler'
 import type { McpToolContext } from '../src/lib/operator/mcp/tools'
 
+import type { RuntimeReadResult } from '../src/lib/operator/runtime-read'
+
+/** A fail-closed readRuntime stub: every read reports the Machine unreachable. */
+const unreachableRead = (): Promise<RuntimeReadResult> =>
+  Promise.resolve({ ok: false, kind: 'audit_log', reason: 'unreachable' })
+
 const CTX: McpToolContext = {
   customerId: 'smd',
   subject: 'user_123',
   email: 'pilot@example.com',
   profile: 'marcus',
+  readRuntime: unreachableRead,
+}
+
+/** Build a tool context whose readRuntime returns a fixed result. */
+function ctxWithRead(read: () => Promise<RuntimeReadResult>): McpToolContext {
+  return { ...CTX, readRuntime: read }
 }
 
 /** Build a provisioned-customer fixture for the pure resolver tests. */
@@ -273,14 +285,15 @@ describe('JSON-RPC dispatcher', () => {
     expect(body.result.serverInfo.name).toBe('smd-operator-connector')
   })
 
-  it('tools/list returns the operator_status stub', async () => {
+  it('tools/list returns operator_status', async () => {
     const resp = await dispatchMcpRequest({ jsonrpc: '2.0', id: 2, method: 'tools/list' }, CTX)
     const body: { result: { tools: { name: string }[] } } = await resp.json()
     const names = body.result.tools.map((t) => t.name)
     expect(names).toContain('operator_status')
   })
 
-  it('tools/call operator_status echoes the authenticated identity', async () => {
+  it('tools/call operator_status reports unreachable fail-closed (no fabricated status)', async () => {
+    // CTX's readRuntime stub reports the Machine unreachable.
     const resp = await dispatchMcpRequest(
       {
         jsonrpc: '2.0',
@@ -291,11 +304,96 @@ describe('JSON-RPC dispatcher', () => {
       CTX
     )
     const body: { result: { content: { text: string }[] } } = await resp.json()
-    const payload: { stub: boolean; authenticated_as: { email: string } } = JSON.parse(
-      body.result.content[0].text
-    )
-    expect(payload.stub).toBe(true)
+    const payload: {
+      customer_id: string
+      authenticated_as: { email: string }
+      operator: { reachable: boolean; reason?: string }
+    } = JSON.parse(body.result.content[0].text)
+    expect(payload.customer_id).toBe('smd')
     expect(payload.authenticated_as.email).toBe('pilot@example.com')
+    expect(payload.operator.reachable).toBe(false)
+    expect(payload.operator.reason).toBe('unreachable')
+  })
+
+  it('tools/call operator_status summarizes live audit_log activity (newest first)', async () => {
+    const ctx = ctxWithRead(() =>
+      Promise.resolve({
+        ok: true,
+        kind: 'audit_log',
+        data: {
+          entries: [
+            {
+              id: '2',
+              ts: '2026-06-14T10:00:00Z',
+              action: 'email.draft',
+              skill: 'inbox',
+              matterRef: 'M-1',
+            },
+            {
+              id: '1',
+              ts: '2026-06-13T09:00:00Z',
+              action: 'email.triage',
+              skill: 'inbox',
+              matterRef: null,
+            },
+          ],
+          cursor: null,
+        },
+      })
+    )
+    const resp = await dispatchMcpRequest(
+      {
+        jsonrpc: '2.0',
+        id: 3,
+        method: 'tools/call',
+        params: { name: 'operator_status', arguments: {} },
+      },
+      ctx
+    )
+    const body: { result: { content: { text: string }[] } } = await resp.json()
+    const payload: {
+      operator: {
+        reachable: boolean
+        recent_activity_count: number
+        latest_activity_at: string | null
+        recent: { at: string; action: string; skill: string | null; matter: string | null }[]
+      }
+    } = JSON.parse(body.result.content[0].text)
+    expect(payload.operator.reachable).toBe(true)
+    expect(payload.operator.recent_activity_count).toBe(2)
+    expect(payload.operator.latest_activity_at).toBe('2026-06-14T10:00:00Z')
+    expect(payload.operator.recent[0]).toEqual({
+      at: '2026-06-14T10:00:00Z',
+      action: 'email.draft',
+      skill: 'inbox',
+      matter: 'M-1',
+    })
+  })
+
+  it('tools/call operator_status reports zero activity honestly on an empty log', async () => {
+    const ctx = ctxWithRead(() =>
+      Promise.resolve({ ok: true, kind: 'audit_log', data: { entries: [], cursor: null } })
+    )
+    const resp = await dispatchMcpRequest(
+      {
+        jsonrpc: '2.0',
+        id: 3,
+        method: 'tools/call',
+        params: { name: 'operator_status', arguments: {} },
+      },
+      ctx
+    )
+    const body: { result: { content: { text: string }[] } } = await resp.json()
+    const payload: {
+      operator: {
+        reachable: boolean
+        recent_activity_count: number
+        latest_activity_at: string | null
+      }
+    } = JSON.parse(body.result.content[0].text)
+    expect(payload.operator.reachable).toBe(true)
+    expect(payload.operator.recent_activity_count).toBe(0)
+    expect(payload.operator.latest_activity_at).toBeNull()
   })
 
   it('tools/call on an unknown tool is method-not-found', async () => {


### PR DESCRIPTION
## What

Replaces the A0 spike's `operator_status` stub with a **live** tool backed by the runtime-read seam (ADR 0043 path A): the console→Machine `GET /runtime/audit_log` call, summarized into a reachability + recent-activity view. This is **step 4** of the SMD dogfood — the one genuinely useful read that makes "talk to your Operator from Claude" real.

The tool returns:
- `operator.reachable` + a recent-activity summary (`recent_activity_count`, `latest_activity_at`, the 5 most-recent actions newest-first), **or**
- `reachable: false` + `reason` when the Machine is unreachable/unconfigured.

## Fail-closed by construction

- Unreachable / unconfigured Machine → `reachable: false`, never fabricated status.
- Empty audit log → zero activity reported honestly.
- The read capability is injected via `McpToolContext.readRuntime`, which the route layer builds **already scoped to this customer + actor** (one customer per call, read-only, audited to `operator_runtime_read_audit`). A tool handler cannot widen the read to another customer; tools stay free of env/db wiring.

## Deferred (fast-follow)

`operator_search_memory` — `memory_export` needs a `table` param threaded through the frozen `RuntimeReadQuery`, and the mirror tables may be sparse for customer-zero. Punted until the dogfood proves the path. `operator_handoff_task` is Phase 2 (two-repo).

## Tests

Live happy-path summary (newest-first ordering), empty-log honesty, fail-closed unreachable. Full suite 3471 pass, astro check 0 errors, lint clean. Endpoint stays **dark** in prod until SMD's connector is provisioned (migration 0071 + binding row + authored `mcp_connector`).

Builds on #1383 (data plane). Part of the Operator ⇄ Claude MCP connector (#1379 design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)