### PR TITLE
feat(operator): author SMD mcp_connector + DCR Clerk runbook

### DIFF
--- a/docs/design/operator/mcp-clerk-setup.md
+++ b/docs/design/operator/mcp-clerk-setup.md
@@ -1,14 +1,22 @@
 # Clerk setup for the Operator ⇄ Claude MCP connector (Captain runbook)
 
-**Status:** A0 spike. This guide is what unblocks the live spike — it walks the
-Captain through creating a per-customer Clerk OAuth application and copying the
-values the console needs to validate tokens. Everything in `src/lib/operator/mcp/`
-typechecks and is unit-tested, but cannot be exercised end-to-end (real
-`claude.ai` connector add → OAuth → authed `tools/call`) until a real Clerk app
-exists and its issuer is wired into the customer descriptor.
+**Status:** live (DCR model). This guide is what stands up the connector for a
+customer end-to-end: a real `claude.ai` connector add → OAuth → authed
+`tools/call`. The console code (`src/lib/operator/mcp/`) is DB-backed and the
+data plane (migration 0071) is deployed; what remains is a Clerk instance
+setting (one toggle) plus recording the customer's issuer, both covered below.
 
-Audience: the Captain (Scott). Mechanical, click-by-click. Where a value must be
-copied into config, the field name is in **bold** and the destination is named.
+Audience: the Captain (Scott). Mechanical. Where a value must be copied into
+config, the field name is in **bold** and the destination is named.
+
+> **Why DCR, not a pre-created OAuth app.** Clerk's own docs: _"For most client
+> implementations of MCP, dynamic client registration is required."_ claude.ai
+> self-registers its OAuth client during the flow — so we do **not** pre-create a
+> per-customer OAuth app or manage a client id / secret. We enable **Dynamic
+> Client Registration (DCR)** on the customer's Clerk instance and record only
+> the instance **issuer**. Isolation rests on the per-customer issuer pin +
+> Clerk's auto-enforced consent screen + the authored `mcp_connector.access[]`
+> per-user gate.
 
 ---
 
@@ -21,206 +29,155 @@ Server (AS)**. The flow:
    at our MCP endpoint: `https://smd.services/api/mcp`.
 2. Claude fetches `https://smd.services/.well-known/oauth-protected-resource/api/mcp`
    (RFC 9728). That document names the customer's Clerk instance as the AS.
-3. Claude runs OAuth 2.1 + PKCE against Clerk. The user signs in with their Clerk
-   identity. Clerk issues an **OAuth access token** (a signed RS256 JWT).
+3. Claude **dynamically registers** itself with Clerk (RFC 7591 DCR), then runs
+   OAuth 2.1 + PKCE. The user signs in with their Clerk identity and approves the
+   **consent screen** (auto-enforced whenever DCR is on). Clerk issues an **OAuth
+   access token** (a signed RS256 JWT).
 4. Claude calls `POST /api/mcp` with `Authorization: Bearer <token>`.
 5. The console validates the token, security-ordered: verify signature (Clerk's
    JWKS) → **derive which customer the token is for from its verified `aud`**
-   (else the per-customer `iss`) → enforce that customer's binding (`iss`/`azp`) →
+   (else the per-customer `iss`) → enforce that customer's binding (issuer pin) →
    map the identity (`email`) to the customer's authored `mcp_connector.access[]`.
    The customer is taken from the **token**, never from the URL or body; a token
-   whose `aud` matches no customer 401s before any data access. No authored
-   access entry ⇒ 401 (fail-closed).
+   whose claims match no customer 401s before any data access. No authored access
+   entry ⇒ 401 (fail-closed).
 
-**One Clerk OAuth application per customer** is the isolation mechanism for the
-pilot (see §6, the audience open question). Customer B's token is issued by a
-different Clerk app / issuer and will not validate against customer A.
+**Isolation under DCR.** With DCR, the OAuth client id (`azp`) is dynamic and
+unknown to us, so it is **not** pinned. The cross-tenant wall is: (a) the
+per-customer **issuer** — a token from customer B's Clerk instance has a
+different `iss` and resolves to a different (or no) customer; (b) Clerk's
+**consent screen**; and (c) the authored **`access[]`** email gate — only
+authored emails with a valid identity in that instance pass.
 
 ---
 
 ## 1. Pick the Clerk instance
 
-SMD already runs a Clerk application **"SMD Services"** (see `astro.config.mjs`).
-The pilot customer (customer-zero, `smd`) uses **that same Clerk instance** — the
-pilot user already has an identity there.
+For the SMD dogfood (customer-zero, `smd`), the connector uses **SMD's existing
+Clerk instance** — `https://clerk.smd.services` — the same instance that backs
+admin/portal login. Scott already has an identity there.
 
-- For a real external client later, the decision is: a **separate Clerk
-  application** under SMD's Clerk account per client org (recommended — clean
-  issuer isolation), vs. one shared instance with per-app OAuth clients. For the
-  pilot, reuse the existing SMD Services instance.
+- For a real external client later, the recommended pattern is a **separate Clerk
+  instance per client org** (clean issuer isolation, and the DCR registration
+  surface is scoped away from any production auth instance). The dogfood reuses
+  SMD's instance deliberately, accepting that DCR opens a public client-
+  registration endpoint on it (mitigated by the consent screen + `access[]`).
 
 Dashboard home: **https://dashboard.clerk.com**
 
 ---
 
-## 2. Create the OAuth application
+## 2. Enable Dynamic Client Registration (the one toggle)
 
-1. In the Clerk Dashboard, open the OAuth applications page directly:
+This is the single manual Clerk-side setup step.
+
+1. In the Clerk Dashboard, open the OAuth applications page:
    **https://dashboard.clerk.com/~/oauth-applications**
    (Or: left sidebar → **Configure** → **OAuth applications**.)
-2. Click **Add OAuth application**. A modal opens.
-3. **Name:** `SMD Operator MCP — <customer slug>` (e.g. `SMD Operator MCP — smd`).
-   The name is only for your own identification.
-4. **Scopes:** enable exactly these three:
-   - `openid`
-   - `profile`
-   - `email` ← **required.** The console maps the token's `email` claim to
-     `mcp_connector.access[]`. Without the `email` scope the token carries no
-     email, the identity mapping fails, and every call 401s. (See the SEAM NOTE
-     in `token-validation.ts` for the Backend-API `sub`→email fallback — not
-     wired in the spike, so `email` scope is mandatory for now.)
-5. Click **Add**.
+2. Enable **Dynamic client registration**.
+3. Note: enabling DCR **auto-enforces the OAuth consent screen** (Clerk does this
+   to prevent CSRF; it cannot be disabled while DCR is on). That is the desired
+   posture.
+
+**Verify it took.** Re-fetch the instance's discovery document and confirm a
+`registration_endpoint` now appears (it is absent when DCR is off):
+
+```bash
+curl -s https://clerk.smd.services/.well-known/openid-configuration \
+  | python3 -c "import sys,json;print(json.load(sys.stdin).get('registration_endpoint','(none — DCR still off)'))"
+```
+
+> Confirm the token's scopes include `email`. SMD's instance already advertises
+> `email` in `scopes_supported`; the console maps the token's `email` claim to
+> `mcp_connector.access[]`, so without it every call 401s.
 
 ---
 
-## 3. Copy the credentials (and where each goes)
+## 3. Record the customer's issuer in the binding (agent-run)
 
-After you click **Add**, Clerk shows the **Client Secret once** and then the
-app's settings page.
+No OAuth app to create, no client id/secret to copy. The only per-customer Clerk
+fact the console needs is the **issuer**, written to the `mcp_clerk_bindings`
+table (migration 0071) keyed on the customer's `entity_id`:
 
-| Clerk dashboard field | Where it lives                           | Notes                                                                                                                                                                                                             |
-| --------------------- | ---------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Client Secret**     | Worker secret (later slice)              | Shown once. Copy it now into Infisical `/ss` as `MCP_CLERK_CLIENT_SECRET_<slug>` (or hold it). Confidential clients only; if you register Claude via DCR (public client) you may not need it.                     |
-| **Client ID**         | `ClerkCustomerBinding.authorizedParties` | Settings page → **Application credentials** → **Client ID**. This is the `azp` value the console pins.                                                                                                            |
-| **Discovery URL**     | derive the **issuer** from it            | Settings page → **Application configuration URLs** → **Discovery URL**. It looks like `https://<issuer>/.well-known/openid-configuration`. The **issuer** is that URL with the `/.well-known/...` suffix removed. |
+| Field           | Value (SMD)                                            |
+| --------------- | ------------------------------------------------------ |
+| `entity_id`     | `f03ffe58-db0d-47bb-a409-922a7ee62ea7`                 |
+| `customer_slug` | `smd`                                                  |
+| `issuer`        | `https://clerk.smd.services` (from §2's discovery doc) |
+| `client_id`     | `NULL` (DCR — dynamic)                                 |
+| `audience`      | `NULL` (until §5 confirms RFC 8707; see below)         |
+| `clerk_app_id`  | `NULL` (no app we own)                                 |
 
-### The issuer + JWKS
-
-- **Issuer** (`iss`): the origin of the Discovery URL. For an SMD production
-  instance this is typically `https://clerk.smd.services`; for a dev instance it
-  is `https://<slug>.clerk.accounts.dev`. The console pins `iss` to this exact
-  string (`ClerkCustomerBinding.issuer`).
-- **JWKS:** the console does **not** need the JWKS URL hand-copied —
-  `@clerk/backend`'s `verifyToken` discovers and caches the JWKS from the token's
-  issuer automatically. (The JWKS is at `<issuer>/.well-known/jwks.json` if you
-  ever want to inspect it.)
+The agent writes this row with a `wrangler d1 execute --remote` UPSERT (see
+`docs/design/operator/03-mcp-server-exposure.md` and the provisioning notes).
+Once the row exists, the public discovery doc the console serves advertises
+`authorization_servers: ["https://clerk.smd.services"]`.
 
 ---
 
-## 4. Redirect URIs
+## 4. Author the `mcp_connector` block (agent-run)
 
-The redirect URI is where Clerk sends the user back after they authenticate.
-**The MCP client supplies this**, not the console.
+In `operator/customers/<slug>/customer.yaml`, author the connector + the per-user
+`access[]`. For SMD:
 
-- **claude.ai custom connector:** when you add the connector in the claude.ai UI,
-  claude.ai tells you the redirect URI to register. Paste it into the Clerk app's
-  **Redirect URIs** field (Settings page). It will be a `https://claude.ai/...`
-  callback URL.
-- **Claude Desktop:** Desktop uses a localhost loopback redirect
-  (`http://localhost:<port>/...` or a custom scheme). Register whatever Desktop
-  shows you. (Localhost redirects are standard for native OAuth clients.)
-- If you enable **Dynamic Client Registration** (§5), the client registers its own
-  redirect URI automatically and you do not hand-enter it.
+```yaml
+mcp_connector:
+  enabled: true
+  data_posture: open
+  access:
+    - email: scott@smd.services # MUST match a users[] email AND the Clerk identity email
+      profile: crane
+```
 
-> Add the redirect URI **before** completing the connector add in Claude, or the
-> first OAuth round-trip fails with `redirect_uri_mismatch`.
+Then the projection (`scripts/project-customer-config.ts` →
+`wrangler d1 execute --remote`) writes `customer_configs.mcp_connector_json`.
+Until both the binding row (§3) and this projection exist, the endpoint stays
+**dark** — every token 401s.
 
----
-
-## 5. Dynamic Client Registration (DCR) vs. pre-registered
-
-Clerk supports **Dynamic Client Registration** (RFC 7591) — a toggle on the
-OAuth applications page (**Dynamic client registration**).
-
-- **For the pilot: leave DCR OFF and pre-register the client** (one OAuth app,
-  redirect URI hand-entered per §4). Simpler, fewer moving parts, and the pilot is
-  a single known client. This matches the build plan's "Out of scope (Phase 1):
-  DCR-based multi-client onboarding."
-- **DCR ON** is the path for onboarding many client orgs without hand-creating an
-  app each time (claude.ai registers itself). Revisit when the connector graduates
-  past the single pilot.
+> **Email match is the one gotcha.** `access[].email` must equal the email on the
+> user's Clerk identity (the OAuth token's `email` claim), case-insensitive. If
+> Scott's `clerk.smd.services` login uses a different email than
+> `scott@smd.services`, add that email to BOTH `users[]` and `access[]` and
+> re-project — otherwise the per-user check fail-closes with `identity_not_authored`.
 
 ---
 
-## 6. OPEN QUESTION for the Captain — does Clerk bind a per-resource `aud`? (RFC 8707)
+## 5. Add the connector in Claude + answer the audience question
 
-This is the one thing the spike cannot answer from docs and needs you to confirm
-against a **real minted token**. It decides the cross-tenant isolation story.
+The irreducible Captain step (your account, your consent — cannot be automated):
 
-**Why it matters.** The MCP authorization spec (2025-11-25 / 2026-03-15) mandates
-RFC 8707 **resource indicators**: the client sends a `resource` parameter naming
-our endpoint, and a compliant AS binds the token's `aud` claim to that resource.
-The resource server (us) MUST then reject any token whose `aud` is not our
-resource. This is what stops a token minted for one resource being replayed at
-another ("confused-deputy" / token mis-redemption).
+1. In claude.ai, add a custom connector pointed at `https://smd.services/api/mcp`.
+2. Claude discovers the AS, dynamically registers, and shows Clerk's sign-in +
+   consent screen. Sign in as Scott and approve.
+3. Confirm one authed `tools/list` and one `operator_status` `tools/call` return
+   real data (the Operator's recent activity).
 
-**What to check.** After you complete one OAuth handshake (the A0 spike), decode
-the issued access token (paste it into https://jwt.io or inspect it in the
-console logs) and look at the `aud` claim:
+**Then answer the RFC 8707 audience question** (the one thing only a real token
+can settle). Decode the issued access token (paste into https://jwt.io or read it
+from the console logs) and look at `aud`:
 
 - **If `aud` equals `https://smd.services/api/mcp`** (our resource URL): Clerk
-  binds a per-resource audience. Set `ClerkCustomerBinding.audience` to that exact
-  string in the customer descriptor. The console then enforces it via
-  `verifyToken({ audience })` — best-in-class isolation, spec-compliant.
-- **If `aud` is absent, or is a generic value** (e.g. the instance or client id,
-  not our resource URL): Clerk does **not** resource-bind `aud` for this token
-  type. Leave `ClerkCustomerBinding.audience = null` and rely on the **fallback
-  isolation**: one Clerk OAuth app per customer + the per-customer **issuer pin**
-  (`iss` must equal this customer's instance) + the **`azp`/Client ID pin**
-  (`authorizedParties`). The console already enforces all three. A customer-B
-  token then fails customer A because its `iss` (and `azp`) are a different app.
+  binds a per-resource audience. Set `mcp_clerk_bindings.audience` to that exact
+  string for the customer — best-in-class, spec-compliant mis-redemption
+  protection layered on top of the issuer pin.
+- **If `aud` is absent or generic**: leave `audience = NULL` and rely on the
+  issuer pin + consent screen + `access[]` (already enforced unconditionally).
 
-**Record the answer** in this file (edit the line below) once confirmed, so the
-next person provisioning a customer knows which isolation mode is in force:
+> **Audience binding status:** _TBD — confirm against a real token on first connect._
 
-> **Audience binding status:** _TBD — Captain to confirm against a real token._
-
-Either way the console is safe: the fallback (issuer + azp pin, one app per
-customer) is enforced unconditionally, and the audience check layers on top when
-available.
-
----
-
-## 7. Wire the values into the console (where the spike stub is)
-
-The spike ships a single hard-coded descriptor in
-`src/lib/operator/mcp/customer-resolution.ts` (`PILOT_STUB`). To light up the live
-path for the pilot:
-
-1. Set `PILOT_STUB.clerk.issuer` to the issuer from §3 (e.g.
-   `https://clerk.smd.services`).
-2. Set `PILOT_STUB.clerk.authorizedParties` to `[<Client ID>]` from §3.
-3. Set `PILOT_STUB.clerk.audience` per the §6 finding (the resource URL, or null).
-4. Set `PILOT_STUB.connector` from the pilot's real `mcp_connector` block — most
-   importantly `enabled: true` and the `access: [{ email, profile }]` entry for
-   the pilot user. (Live slice: read this from the materialized `customer.yaml`
-   instead of hard-coding — that is the documented next slice, not the spike.)
-
-Until step 4 authors a real `access[]`, the endpoint **fail-closes**: a Clerk-valid
-token still 401s because its email is not authored. That is the correct posture —
-the spike cannot grant access to anyone until a real config is wired in.
-
----
-
-## 8. What the Captain runs to finish A0 (the part the agent cannot do)
-
-The agent built and unit-tested everything that does not need a live Clerk app.
-The signature-verification path and the real OAuth round-trip need a live app +
-a real client. The Captain's A0 steps:
-
-1. Create the Clerk OAuth app (§2–§3).
-2. Wire `PILOT_STUB` (§7) and deploy the console (or run it against a dev Clerk
-   instance).
-3. Add the connector in claude.ai pointed at `https://smd.services/api/mcp`
-   (register the redirect URI it gives you, §4).
-4. Complete the OAuth sign-in. Confirm one authed `tools/list` + one
-   `operator_status` `tools/call` returns the stub payload.
-5. Decode the token and **answer the §6 audience question**; set `audience`
-   accordingly.
-6. Negative test (build-plan A1): a token minted for a different Clerk app/issuer
-   must 401. Once a second customer exists, this becomes the cross-tenant test
-   added to the operator-substrate suite.
+Either way the console is safe: the issuer pin + `access[]` gate are enforced
+unconditionally, and the audience check layers on top when available.
 
 ---
 
 ## Reference
 
-- Clerk OAuth applications: https://dashboard.clerk.com/~/oauth-applications
-- Clerk — how Clerk implements OAuth (DCR, scopes):
+- Clerk — how Clerk implements OAuth (DCR):
   https://clerk.com/docs/guides/configure/auth-strategies/oauth/how-clerk-implements-oauth
-- Clerk — verifying OAuth access tokens:
-  https://clerk.com/docs/guides/configure/auth-strategies/oauth/verify-oauth-tokens
+- Clerk — connect an MCP client (DCR requirement):
+  https://clerk.com/docs/guides/ai/mcp/connect-mcp-client
 - RFC 9728 (Protected Resource Metadata): https://datatracker.ietf.org/doc/html/rfc9728
+- RFC 7591 (Dynamic Client Registration): https://www.rfc-editor.org/rfc/rfc7591
 - RFC 8707 (Resource Indicators): https://www.rfc-editor.org/rfc/rfc8707.html
 - MCP authorization spec:
   https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization

--- a/operator/customers/smd/customer.yaml
+++ b/operator/customers/smd/customer.yaml
@@ -108,6 +108,25 @@ personas:
         schedule: '0 7-19 * * *' # hourly 0700–1900 (fly_region: lax tz)
         wake_policy: always
 
+# ---- MCP CONNECTOR (Operator ⇄ Claude, Phase 1) ----
+# Lets authored users reach this Operator from inside their own Claude
+# (claude.ai / Claude Desktop) via the console-hosted MCP endpoint at
+# https://smd.services/api/mcp. Console-side only — no Machine surface.
+# Fail-closed: enabled:false (or an absent block) means no one connects; each
+# access[] entry binds a users[] email to an active persona slug.
+# See docs/design/operator/03-mcp-server-exposure.md.
+mcp_connector:
+  enabled: true
+  # 'open' = the authored user reaches the Operator with no extra data fence
+  # beyond the entitlement ceilings already in this config (Phase 1 posture).
+  data_posture: open
+  access:
+    # Scott reaches Crane from his own Claude. This email MUST match both a
+    # users[] entry (above) AND the email on his clerk.smd.services identity
+    # (the OAuth token's `email` claim) — else the per-user check fail-closes.
+    - email: scott@smd.services
+      profile: crane
+
 # ---- CONNECTORS ----
 # Google Workspace rides first-class tools mediated by the ADR 0045 broker.
 connectors:

--- a/tests/customer-config-projection.test.ts
+++ b/tests/customer-config-projection.test.ts
@@ -69,16 +69,15 @@ describe('customer-config projection: real smd yaml', () => {
     expect(config.credential_custody_default).toBeTruthy()
   })
 
-  it('mcp_connector survives the round-trip (defaults to disabled/fail-closed)', () => {
-    // smd's customer.yaml authors no mcp_connector block yet, so the validator
-    // defaults it to disabled — the projection must carry that through, never
-    // dropping the column (which would also fail-close on read, but explicitly
-    // is better).
+  it('mcp_connector survives the round-trip (smd authors an enabled connector)', () => {
+    // smd's customer.yaml authors the Phase-1 MCP connector: enabled, with Scott
+    // (scott@smd.services) bound to the crane persona. The projection must carry
+    // the authored values through the write → read round-trip intact.
     const row = projectCustomerYamlToConfigRow(smdYaml(), CTX)
     expect(row.mcp_connector_json).not.toBeNull()
     const config = projectRow(row)
-    expect(config.mcp_connector.enabled).toBe(false)
-    expect(config.mcp_connector.access).toEqual([])
+    expect(config.mcp_connector.enabled).toBe(true)
+    expect(config.mcp_connector.access).toEqual([{ email: 'scott@smd.services', profile: 'crane' }])
   })
 })
 


### PR DESCRIPTION
## What

**Step 5 (authoring half)** of the SMD dogfood. Two changes:

1. **Author SMD's `mcp_connector` block** in `operator/customers/smd/customer.yaml` — `enabled: true`, `scott@smd.services` → `crane` persona, `data_posture: open`.
2. **Rewrite the Clerk runbook** (`docs/design/operator/mcp-clerk-setup.md`) for the **DCR model** the connector actually uses.

## Authoring ≠ activation (safe to merge)

Adding the block does **not** turn the connector on. The endpoint stays **dark** until two deliberate provisioning steps run after merge:
- the `mcp_clerk_bindings` row is written (issuer recorded), and
- `customer.yaml` is projected into `customer_configs.mcp_connector_json`.

So merging this is safe — nothing goes live implicitly.

## Runbook: DCR, not a pre-created app

Per Clerk's docs, *"for most MCP clients, dynamic client registration is required"* — claude.ai self-registers. So the runbook drops the pre-created-app + client-id/secret model. The Captain's only Clerk-side step is **one Dashboard toggle** (DCR on → consent screen auto-enforced), verifiable via the discovery doc's `registration_endpoint`. Isolation = per-customer issuer pin + consent screen + the authored `access[]` email gate. The runbook also documents the one gotcha: `access[].email` must match the email on Scott's `clerk.smd.services` identity.

## Tests

Updated the projection round-trip test to assert SMD's now-authored connector (enabled, `scott@smd.services` → `crane`) projects intact. operator-substrate pytest 306 pass; full suite 3469 pass.

Builds on #1383 (data plane). Part of the Operator ⇄ Claude MCP connector (#1379 design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)