### PR TITLE
feat(operator): relationship-model foundation — ADR 0048 + live-edit correction extractor

### DIFF
--- a/docs/adr/0048-operator-relationship-model.md
+++ b/docs/adr/0048-operator-relationship-model.md
@@ -1,0 +1,151 @@
+---
+title: Operator Relationship Model — Composition, Deterministic Foundation, and the Legible Surface
+date: 2026-06-14
+status: accepted
+captain: Scott Durgan
+related-adr: 0037-operator-thesis.md, 0016-honcho-disposition.md, 0035-no-imposed-entitlement-defaults.md, 0026-config-surface-is-security-boundary.md, 0043-operator-runtime-read-path.md
+related-issues: 855
+---
+
+# ADR 0048 - Operator Relationship Model
+
+**Status: ACCEPTED. Captain decision, 2026-06-14.**
+
+The Operator should build a per-person **working relationship** — learning how each
+person it serves likes to be worked with — because that relationship is the moat
+(ADR 0037: the moat is the harness + the guide + the **memory**) and the switching
+cost. "Help" is not a docs site bolted onto the product; it is the early, explicit
+phase of that relationship, which later runs on tacit understanding. This ADR fixes
+what the relationship model _is_, what we build first, and the policies that keep it
+honest and safe — **before** capture code accretes, so we do not grow a parallel,
+overlapping, or fabrication-prone store next to the ones already in the tree.
+
+## Context
+
+Reconnaissance on 2026-06-14 (verified against the live customer-zero Machine via the
+ADR-0043 runtime-read seam, not just the docs) established the ground truth this ADR
+is built on:
+
+1. **Honcho is not running.** ADR 0016's 2026-05-30 revision deferred the inference
+   engine to Phase 2; the in-container version was never booted. A `memory_export`
+   read of `persona_observations` on customer-zero returns `{"entries": []}`. So the
+   automatic "infer unstated preferences from conversation" capability does not exist
+   today, and standing it up is a separate, heavy, per-Machine infrastructure effort.
+
+2. **`persona_observations` (migration 0007) is Honcho-shaped and explicitly
+   non-runtime-read.** Its own header forbids agent-runtime reads ("No skill ... reads
+   from this table at agent runtime") because Honcho over-attributes (bug #626) and an
+   unreviewed inferred conclusion must not silently shape drafts. It also carries
+   active schema drift with the overlay mirror's writer (see Open Items). It is a
+   Captain-review mirror, not a runtime relationship store.
+
+3. **`voice_corrections` (migration 0010) already is the deterministic correction
+   store** — and reaches, in its own header, the identical conclusion this ADR makes:
+   corrections are _deterministic, authored, must-apply_ facts that the transform reads
+   at runtime, which is exactly why they live in a dedicated table and not in
+   `persona_observations`. Its read+apply primitive (`operator/adapter/voice/corrections.py`)
+   exists; its `live_edit` capture _writer_ does not.
+
+4. **Sent-capture is unbuilt.** `draft_queue.r2_sent_key` is defined but never
+   populated; the sent-folder watcher (`hermes-smd-voice/pipeline.py`) is a stub. So the
+   _runtime input_ to any live-edit correction writer (the human's sent version) does
+   not exist end to end yet.
+
+5. **Entitlements are code-enforced and authored-only** (ADR 0035 / 0026;
+   `trust_ceiling`/`enforce()`). The agent never raises its own ceiling.
+
+## Decision
+
+### 1. The relationship model is a composition, not a new monolith
+
+The model has three lanes, unified by **one legible surface**. Two lanes already exist;
+we do not fork parallel stores for them.
+
+| Lane                                 | Store                                                              | Status                              |
+| ------------------------------------ | ------------------------------------------------------------------ | ----------------------------------- |
+| Style / correction (how drafts read) | `voice_corrections` (0010), runtime-applied by the voice transform | exists; live-edit writer is the gap |
+| Behavioral / authored (how to act)   | `customer.yaml` authored preferences, materialized to config       | this ADR adds the block             |
+| Inferred (unstated patterns)         | `persona_observations` / Honcho (0016)                             | deferred until Honcho runs          |
+
+The **legible surface** — "here's what I've learned about working with you" — composes
+these into one human-readable, Captain-reviewable view (admin first; client portal
+later). A human employee's model of you is opaque; the Operator's is legible and
+correctable. That is delight, trust, and governance in one surface.
+
+### 2. Binding policies (these constrain every future PR on this model)
+
+- **a. Deterministic floor only.** The overlay captures _only_ deterministic signals
+  Honcho will never compute. All probabilistic / free-text inference is Honcho's job,
+  deferred. We never ship a heuristic dressed as a fact.
+- **b. Honest evidence vocabulary.** Reuse the closed-set evidence discipline. A
+  classification is labeled by how it was derived, never inflated to "fact."
+- **c. Informational only.** Relationship state shapes help, style, and anticipation.
+  It **never** self-grants capability or autonomy. Entitlements stay authored in
+  `customer.yaml` and enforced in code; the model may _propose_ a trust change, a human
+  _grants_ it. (A good employee learns your coffee order on their own; they do not start
+  wiring money because they feel trusted.)
+- **d. No duplication.** `voice_corrections` is THE correction/style store. The
+  relationship model composes it; it does not fork a second one. (Repo rule: shared
+  flows stay shared once canonicalized.)
+- **e. Runtime-read discipline preserved.** `persona_observations` stays
+  non-runtime-read (the Honcho-hallucination defense). Deterministic must-apply stores
+  (`voice_corrections`) are runtime-read. The relationship model never reads
+  `persona_observations` at agent runtime.
+- **f. Taint-aware learning.** A capture sourced from a session that ingested untrusted
+  inbound (`SESSION_TAINT`) is not promoted to a standing correction/preference — an
+  injected message must never become a learned rule.
+
+### 3. Live-edit capture is content-free, derived from structural-category change
+
+A live-edit correction is derived **without persisting any body text**: compute
+`extract_structural_diff` (`operator/adapter/voice/diff.py`) over the agent draft and
+the human's sent version, compare the **closed-set** `greeting_style` / `signoff_style`
+categories, and emit a `voice_corrections` row (`source='live_edit'`) only on a category
+change, with `before_pattern`/`after_text` drawn from a **fixed, non-PII template map**
+(category → canonical literal). This preserves the Voice Layer 2 privacy floor (raw
+bodies are never persisted). Lexical and honorific live-edit corrections are **out of
+scope** for this deterministic floor — they would require persisting real phrases, so
+they remain calibration-session-authored.
+
+### 4. Phase 1 scope (the foundation we build now)
+
+1. **The pure live-edit extractor primitive** (`operator/adapter/voice/live_edit.py`) —
+   `(draft, sent, reviewer, cohort) → voice_corrections rows`. Pure, deterministic,
+   fully unit-tested. Ships now as the canonical primitive (the repo's established
+   "primitive now, runtime call site later" pattern, per `corrections.py`).
+2. **The legible surface** — add `memory_export` to the console `RUNTIME_READ_KINDS`,
+   expose `voice_corrections` through the seam allow-list, and an admin view composing
+   `voice_corrections` (taught style rules) + authored `customer.yaml` preferences.
+   Read-only, honest confidence rendering.
+3. **The authored-preference channel** — a `relationship:` block in `customer.yaml`
+   (authored behavioral preferences + capture knobs), registered in
+   `operator/contracts/customer-yaml-blocks.yaml`.
+4. **This ADR.**
+
+The live-edit **runtime trigger** (invoking the primitive when a draft is approved with
+a captured sent version) depends on the unbuilt sent-capture pipeline (Context 4) and
+**activates when that lands**. That dependency is filed as the blocking follow-on; we do
+not build the sent-capture epic under this ADR.
+
+## Consequences
+
+- **Nothing is throwaway when Honcho lands.** It joins the inferred lane into
+  `persona_observations`; the composition surface already renders multiple lanes; the
+  deterministic lanes (voice/authored) remain the high-confidence backbone.
+- **The spine ships now; automated style-learning activates when sent-capture lands.**
+  The capture _logic_ is tested and ready; only its runtime input is pending.
+- **Privacy floor preserved** — no body text persisted; corrections are
+  category + fixed template.
+- **Roadmap:** Phase 2 — pull / help-on-request reading the composed model + the
+  client-portal surface; Phase 3 — proactive tips with gating + decay; Phase 4 — Honcho
+  inferred lane + the throughput-up-while-help-need-down value metric.
+
+## Open Items / Follow-ons
+
+- **Sent-capture pipeline** (`draft_queue.r2_sent_key` population / sent-folder watcher)
+  — blocks the live-edit runtime trigger. File as the activating follow-on.
+- **`persona_observations` schema drift** — migration `0007` (`conclusion_id` PK) and
+  the overlay mirror's `schemas.py` DDL (`observation_id` PK, `honcho_conclusion_id`)
+  define different shapes for the same table, and the mirror's INSERT columns match
+  neither cleanly. Dormant (Honcho off) but real. File as a separate hardening issue;
+  out of scope here.

--- a/docs/adr/0048-operator-relationship-model.md
+++ b/docs/adr/0048-operator-relationship-model.md
@@ -114,13 +114,16 @@ they remain calibration-session-authored.
    fully unit-tested. Ships now as the canonical primitive (the repo's established
    "primitive now, runtime call site later" pattern, per `corrections.py`).
 2. **The legible surface** — add `memory_export` to the console `RUNTIME_READ_KINDS`,
-   expose `voice_corrections` through the seam allow-list, and an admin view composing
-   `voice_corrections` (taught style rules) + authored `customer.yaml` preferences.
-   Read-only, honest confidence rendering.
-3. **The authored-preference channel** — a `relationship:` block in `customer.yaml`
-   (authored behavioral preferences + capture knobs), registered in
-   `operator/contracts/customer-yaml-blocks.yaml`.
-4. **This ADR.**
+   expose `voice_corrections` through the seam allow-list, and the admin
+   `.../[customer]/memory` view rendering the style lane (`voice_corrections`) live,
+   with the authored and inferred lanes shown honestly. Read-only.
+3. **This ADR.**
+
+The **authored-preference channel** (a `relationship:` block in `customer.yaml`) is
+**deferred to Phase 2** so it ships WITH its materializer rather than as an inert block
+that materializes nothing — consistent with the anti-silent-drop discipline that
+`operator/contracts/customer-yaml-blocks.yaml` exists to enforce (the cron lesson). The
+surface's "Standing preferences" lane renders honestly until then.
 
 The live-edit **runtime trigger** (invoking the primitive when a draft is approved with
 a captured sent version) depends on the unbuilt sent-capture pipeline (Context 4) and

--- a/operator/adapter/voice/live_edit.py
+++ b/operator/adapter/voice/live_edit.py
@@ -1,0 +1,151 @@
+"""Live-edit correction extractor — the deterministic capture half of A2.
+
+When a `draft_for_review` draft goes out, the human often edits it before
+sending. The difference between what the Operator drafted and what the human
+actually sent is a *correction*: a deterministic, must-apply preference the
+Operator should learn ("you sign off `Best,` not `Sincerely,`"). This module
+turns a (draft, sent) pair into proposed ``voice_corrections`` rows
+(``source='live_edit'``) — the write-side complement to
+:mod:`adapter.voice.corrections` (the read + apply side).
+
+Two hard constraints shape this module (ADR 0048):
+
+* **Content-free (the Voice Layer 2 privacy floor).** A raw body is never
+  persisted, and a correction must not smuggle body text out through
+  ``before_pattern`` / ``after_text``. So a correction is derived from a change
+  in a **closed-set structural category** (``signoff_style``) and rendered
+  through a **fixed, non-PII template map** (category → canonical literal). The
+  output literals come from this module's constants, never from the input.
+* **Deterministic.** Same (draft, sent) produces the same proposals. No model
+  calls, no network I/O. Pure module — the D1 loader, supersession, and the
+  runtime call site land in the overlay when sent-capture is wired (ADR 0048
+  Open Items); this is the canonical primitive they vendor, exactly as
+  :mod:`adapter.voice.corrections` is for the read side.
+
+Scope of this version: **signoff** corrections only. Signoff categories are
+name-independent closed phrases (`Best,` / `Thanks,` / `Regards,` / `Sincerely,`),
+so a category change maps cleanly to a content-free literal substitution.
+Greeting corrections are largely name-bearing (`Dear Mr. Smith,`) and cannot be
+rendered content-free, so they stay calibration-session-authored; the
+machinery here is general (keyed by ``correction_kind``) so a future name-free
+greeting story is a template-map addition, not a rewrite. Lexical and honorific
+live-edit corrections are out of the privacy-safe floor by construction.
+
+Conservative ethos (matching :mod:`adapter.voice.diff`): when either side of a
+change is not a clean content-free phrase, emit nothing rather than guess.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .diff import extract_structural_diff, structural_diff_digest
+
+# ---------------------------------------------------------------------------
+# Content-free template maps — closed-set category → canonical literal.
+#
+# These are the ONLY strings that can appear in a proposed correction's
+# before/after; they are fixed constants, never drawn from the message body.
+# A category absent from a map (e.g. signoff 'named' / 'initial' / 'none' /
+# 'unknown', which carry or imply a person's name) has no clean content-free
+# literal, so any change touching it is skipped.
+# ---------------------------------------------------------------------------
+
+_SIGNOFF_TEMPLATES: dict[str, str] = {
+    "best": "Best,",
+    "thanks": "Thanks,",
+    "regards": "Regards,",
+    "sincerely": "Sincerely,",
+}
+
+# correction_kind -> (StructuralDiff field, template map). Adding a content-free
+# greeting story later is a single entry here.
+_KIND_SPECS: tuple[tuple[str, str, dict[str, str]], ...] = (
+    ("signoff", "signoff_style", _SIGNOFF_TEMPLATES),
+)
+
+_PATTERN_KIND = "literal_ci"
+_SOURCE = "live_edit"
+
+
+@dataclass(frozen=True)
+class ProposedCorrection:
+    """A ``voice_corrections`` row proposed from one live edit.
+
+    Maps 1:1 onto the migration-0010 columns. ``before_pattern`` / ``after_text``
+    are always fixed template constants (never body text). The caller (the
+    overlay runtime writer) assigns the row ``id``, applies supersession against
+    existing live-edit rows for the same ``(reviewer, cohort, correction_kind)``,
+    and performs the D1 insert.
+    """
+
+    correction_kind: str  # 'signoff' (closed set per migration 0010)
+    pattern_kind: str  # 'literal_ci'
+    before_pattern: str  # canonical literal for the draft category
+    after_text: str  # canonical literal for the sent category
+    source: str  # 'live_edit'
+    reviewer_user_id: str | None
+    recipient_cohort: str | None
+    source_ref: str | None  # structural-diff digest of the sent message
+
+
+def extract_live_edit_corrections(
+    *,
+    draft_body: str | None,
+    sent_body: str | None,
+    recipient_cohort: str,
+    reviewer_user_id: str | None = None,
+    draft_subject: str | None = None,
+    sent_subject: str | None = None,
+) -> list[ProposedCorrection]:
+    """Propose ``voice_corrections`` rows from one draft→sent edit.
+
+    Computes the structural diff of each body (the privacy primitive — raw text
+    is gone when each call returns), compares the closed-set style categories,
+    and emits a proposal only when a category genuinely changed AND both sides
+    have a clean content-free template. Returns ``[]`` when nothing changed or
+    nothing is safely renderable.
+
+    The returned ``source_ref`` is the structural-diff digest of the *sent*
+    message, so a row is traceable to the edit that produced it without
+    retaining the message.
+    """
+    draft_diff = extract_structural_diff(
+        body_text=draft_body, subject=draft_subject, recipient_cohort=recipient_cohort
+    )
+    sent_diff = extract_structural_diff(
+        body_text=sent_body, subject=sent_subject, recipient_cohort=recipient_cohort
+    )
+    sent_ref = structural_diff_digest(sent_diff)
+
+    proposals: list[ProposedCorrection] = []
+    for correction_kind, field_name, templates in _KIND_SPECS:
+        draft_cat = getattr(draft_diff, field_name)
+        sent_cat = getattr(sent_diff, field_name)
+        if draft_cat == sent_cat:
+            continue
+        before = templates.get(draft_cat)
+        after = templates.get(sent_cat)
+        # One side is not a clean content-free phrase (carries/implies a name,
+        # or is 'none'/'unknown'): skip rather than guess.
+        if before is None or after is None or before == after:
+            continue
+        proposals.append(
+            ProposedCorrection(
+                correction_kind=correction_kind,
+                pattern_kind=_PATTERN_KIND,
+                before_pattern=before,
+                after_text=after,
+                source=_SOURCE,
+                reviewer_user_id=reviewer_user_id,
+                recipient_cohort=recipient_cohort,
+                source_ref=sent_ref,
+            )
+        )
+    return proposals
+
+
+__all__ = [
+    "ProposedCorrection",
+    "extract_live_edit_corrections",
+]

--- a/operator/adapter/voice/tests/test_live_edit.py
+++ b/operator/adapter/voice/tests/test_live_edit.py
@@ -1,0 +1,119 @@
+"""Live-edit correction extractor (ADR 0048) — the deterministic capture half.
+
+Covers: a signoff category change yields a content-free correction; no change
+yields nothing; a change touching an untemplated (name-bearing) category is
+skipped; and the privacy floor holds — body text never leaks into the proposed
+before/after.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))  # operator/ on path
+
+from adapter.voice.live_edit import (  # noqa: E402
+    ProposedCorrection,
+    extract_live_edit_corrections,
+)
+
+
+def _body(*, greeting: str, sentence: str, signoff: str, name: str) -> str:
+    return f"{greeting}\n\n{sentence}\n\n{signoff}\n{name}"
+
+
+# ---------------------------------------------------------------------------
+# Happy path: a signoff change becomes a content-free correction
+# ---------------------------------------------------------------------------
+
+
+def test_signoff_change_yields_correction():
+    draft = _body(
+        greeting="Dear Mr. Smith,",
+        sentence="The deposition is scheduled for Tuesday.",
+        signoff="Sincerely,",
+        name="Chris",
+    )
+    sent = _body(
+        greeting="Dear Mr. Smith,",
+        sentence="The deposition is scheduled for Tuesday.",
+        signoff="Best,",
+        name="Chris",
+    )
+    out = extract_live_edit_corrections(
+        draft_body=draft, sent_body=sent, recipient_cohort="client"
+    )
+    assert len(out) == 1
+    c = out[0]
+    assert isinstance(c, ProposedCorrection)
+    assert c.correction_kind == "signoff"
+    assert c.pattern_kind == "literal_ci"
+    assert c.before_pattern == "Sincerely,"
+    assert c.after_text == "Best,"
+    assert c.source == "live_edit"
+    assert c.recipient_cohort == "client"
+    assert c.source_ref  # structural-diff digest of the sent message
+
+
+def test_no_change_yields_nothing():
+    draft = _body(greeting="Hi,", sentence="On track.", signoff="Best,", name="Chris")
+    sent = _body(greeting="Hi,", sentence="On track.", signoff="Best,", name="Chris")
+    assert extract_live_edit_corrections(
+        draft_body=draft, sent_body=sent, recipient_cohort="client"
+    ) == []
+
+
+def test_change_touching_untemplated_category_is_skipped():
+    # Sent ends on a bare name line (signoff_style='named') — no clean
+    # content-free literal exists, so the change is skipped, not guessed.
+    draft = _body(
+        greeting="Hi,", sentence="Done.", signoff="Sincerely,", name="Chris"
+    )
+    sent = "Hi,\n\nDone.\n\nChris Ashton"  # name-only closer → 'named', untemplated
+    assert extract_live_edit_corrections(
+        draft_body=draft, sent_body=sent, recipient_cohort="client"
+    ) == []
+
+
+# ---------------------------------------------------------------------------
+# Privacy floor: no body text ever reaches the proposed correction
+# ---------------------------------------------------------------------------
+
+
+def test_proposal_is_content_free():
+    draft = _body(
+        greeting="Dear Ms. Vanderberg,",
+        sentence="Wire the retainer to account 4471 by Friday.",
+        signoff="Regards,",
+        name="Christa",
+    )
+    sent = _body(
+        greeting="Dear Ms. Vanderberg,",
+        sentence="Wire the retainer to account 4471 by Friday.",
+        signoff="Thanks,",
+        name="Christa",
+    )
+    out = extract_live_edit_corrections(
+        draft_body=draft, sent_body=sent, recipient_cohort="client"
+    )
+    assert len(out) == 1
+    blob = (out[0].before_pattern + out[0].after_text).lower()
+    for leaked in ("vanderberg", "retainer", "4471", "christa", "friday"):
+        assert leaked not in blob
+    assert out[0].before_pattern == "Regards,"
+    assert out[0].after_text == "Thanks,"
+
+
+def test_scope_fields_propagate():
+    draft = _body(greeting="Hi,", sentence="Ok.", signoff="Sincerely,", name="Chris")
+    sent = _body(greeting="Hi,", sentence="Ok.", signoff="Best,", name="Chris")
+    out = extract_live_edit_corrections(
+        draft_body=draft,
+        sent_body=sent,
+        recipient_cohort="opposing_counsel",
+        reviewer_user_id="chris",
+    )
+    assert len(out) == 1
+    assert out[0].reviewer_user_id == "chris"
+    assert out[0].recipient_cohort == "opposing_counsel"

--- a/src/lib/admin/relationship-observe.ts
+++ b/src/lib/admin/relationship-observe.ts
@@ -1,0 +1,131 @@
+/**
+ * Relationship-surface view-model for the admin Operator console
+ * (`/admin/operator/[customer]/memory`) — ADR 0048.
+ *
+ * The Operator's working relationship with a person is a *composition* of lanes
+ * (ADR 0048). This module loads the deterministic **style lane** — the taught
+ * style corrections in `voice_corrections` (migration 0010) — across the
+ * isolation boundary via the frozen `memory_export` read path (ADR 0043 path A).
+ *
+ * Same fail-closed discipline as runtime-observe: when the read path is not
+ * configured we return `not_enabled` WITHOUT a read (no audit noise on a dark
+ * feature); otherwise we read and classify honestly (unreachable / empty /
+ * items). The inferred lane (`persona_observations` / Honcho) is deferred
+ * (ADR 0016); the authored lane (`customer.yaml`) is the page's concern. This
+ * module owns only the style-lane read and a **defensive parse** of the opaque
+ * row payload — never a cast (coding-standards: parse external inputs).
+ */
+
+import {
+  readMachineRuntime,
+  type MachineRuntimeTransport,
+  type RuntimeReadAudit,
+  type RuntimeReadActor,
+} from '../operator/runtime-read'
+
+/** One taught style correction (an active `voice_corrections` row). */
+export interface StyleCorrection {
+  /** 'greeting' | 'signoff' | 'honorific' | 'lexical' (migration 0010). */
+  correctionKind: string
+  beforePattern: string
+  afterText: string
+  /** 'live_edit' (learned from an edit) | 'calibration_session' (authored). */
+  source: string
+  /** Scope: null = firm-wide / all cohorts. */
+  reviewerUserId: string | null
+  recipientCohort: string | null
+}
+
+export type StyleLaneResult =
+  | { status: 'not_enabled' }
+  | { status: 'unreachable'; reason: string }
+  | { status: 'empty' }
+  | { status: 'items'; corrections: StyleCorrection[] }
+
+interface RuntimeReadDeps {
+  transport: MachineRuntimeTransport
+  audit: RuntimeReadAudit
+}
+
+/**
+ * Load the style lane (taught corrections) for one customer. Mirrors
+ * `loadRuntimeView`: no read (and no audit row) when the path is unconfigured;
+ * otherwise reads `memory_export?table=voice_corrections` via the fail-closed
+ * seam and classifies the outcome.
+ */
+export async function loadStyleLane(
+  deps: RuntimeReadDeps,
+  customerSlug: string,
+  actor: RuntimeReadActor,
+  configured: boolean
+): Promise<StyleLaneResult> {
+  if (!configured) return { status: 'not_enabled' }
+  const result = await readMachineRuntime(
+    deps,
+    customerSlug,
+    { kind: 'memory_export', table: 'voice_corrections' },
+    actor
+  )
+  if (!result.ok) return { status: 'unreachable', reason: result.reason }
+  const corrections = parseStyleCorrections(result.data)
+  return corrections.length === 0 ? { status: 'empty' } : { status: 'items', corrections }
+}
+
+/**
+ * Parse the opaque `memory_export` payload (`{ entries: [...] }`) into active
+ * style corrections. Defensive by construction: every field is checked, never
+ * cast; a row missing a required field, or one that has been superseded, is
+ * skipped rather than rendered half-formed.
+ */
+export function parseStyleCorrections(data: unknown): StyleCorrection[] {
+  const out: StyleCorrection[] = []
+  for (const entry of extractEntries(data)) {
+    if (!entry || typeof entry !== 'object') continue
+    const row = entry as Record<string, unknown>
+    // Active only: a superseded correction was overridden by a newer/more-specific
+    // one (migration 0010 supersession chain) and must not be shown as current.
+    if (row.superseded_by != null) continue
+    const correctionKind = asNonEmptyString(row.correction_kind)
+    const beforePattern = asString(row.before_pattern)
+    const afterText = asString(row.after_text)
+    const source = asNonEmptyString(row.source)
+    if (
+      correctionKind === null ||
+      beforePattern === null ||
+      afterText === null ||
+      source === null
+    ) {
+      continue
+    }
+    out.push({
+      correctionKind,
+      beforePattern,
+      afterText,
+      source,
+      reviewerUserId: asStringOrNull(row.reviewer_user_id),
+      recipientCohort: asStringOrNull(row.recipient_cohort),
+    })
+  }
+  return out
+}
+
+/** Pull the row list from the seam payload shape (`{ entries: [...] }`). */
+function extractEntries(data: unknown): unknown[] {
+  if (data && typeof data === 'object') {
+    const entries = (data as { entries?: unknown }).entries
+    if (Array.isArray(entries)) return entries
+  }
+  return []
+}
+
+function asString(v: unknown): string | null {
+  return typeof v === 'string' ? v : null
+}
+
+function asNonEmptyString(v: unknown): string | null {
+  return typeof v === 'string' && v.length > 0 ? v : null
+}
+
+function asStringOrNull(v: unknown): string | null {
+  return typeof v === 'string' && v.length > 0 ? v : null
+}

--- a/src/lib/operator/runtime-read-transport.ts
+++ b/src/lib/operator/runtime-read-transport.ts
@@ -92,6 +92,8 @@ function appendQuery(url: URL, query: RuntimeReadQuery): void {
   if (query.cursor) url.searchParams.set('cursor', query.cursor)
   if (typeof query.limit === 'number') url.searchParams.set('limit', String(query.limit))
   if (query.id) url.searchParams.set('id', query.id)
+  // memory_export requires a table; the Machine refuses one outside its allow-list.
+  if (query.table) url.searchParams.set('table', query.table)
 }
 
 /**

--- a/src/lib/operator/runtime-read.ts
+++ b/src/lib/operator/runtime-read.ts
@@ -26,8 +26,19 @@
  */
 
 /** The classes of runtime detail a drill-in can request. Each maps to a
- * read-only endpoint on the Machine. Extend as drill-in surfaces are added. */
-export const RUNTIME_READ_KINDS = ['audit_log', 'draft', 'matter', 'activity'] as const
+ * read-only endpoint on the Machine. Extend as drill-in surfaces are added.
+ *
+ * `memory_export` serves an allow-listed Machine-local memory table one at a
+ * time via the `table` query field (ADR 0016 mirror tables + `voice_corrections`,
+ * the relationship model's style lane per ADR 0048). The Machine refuses any
+ * table outside its allow-list. */
+export const RUNTIME_READ_KINDS = [
+  'audit_log',
+  'draft',
+  'matter',
+  'activity',
+  'memory_export',
+] as const
 export type RuntimeReadKind = (typeof RUNTIME_READ_KINDS)[number]
 
 export interface RuntimeReadQuery {
@@ -38,6 +49,10 @@ export interface RuntimeReadQuery {
   id?: string | null
   /** Page size hint for list kinds; the Machine clamps it. */
   limit?: number | null
+  /** Allow-listed table name for the `memory_export` kind (e.g.
+   * `voice_corrections`); ignored by other kinds. The Machine refuses any
+   * table outside its allow-list. */
+  table?: string | null
 }
 
 export interface RuntimeReadActor {

--- a/src/pages/admin/operator/[customer]/memory.astro
+++ b/src/pages/admin/operator/[customer]/memory.astro
@@ -1,21 +1,30 @@
 ---
 import AdminLayout from '../../../../layouts/AdminLayout.astro'
 import { resolveEntityIdBySlug } from '../../../../lib/admin/operator-overview'
+import { loadStyleLane, type StyleLaneResult } from '../../../../lib/admin/relationship-observe'
+import {
+  isRuntimeReadConfigured,
+  createMachineRuntimeTransport,
+  createRuntimeReadAudit,
+} from '../../../../lib/operator/runtime-read-transport'
 import { env } from 'cloudflare:workers'
 
 /**
- * Operator admin console — memory & agent-skills (§5.6).
+ * Operator admin console — the relationship surface (§5.6, ADR 0048):
+ * "what I've learned about working with you."
  *
- * The operator's learned state: memory observations (with evidence status) and
- * agent-authored skills (with provenance + Captain-approval), mirrored from the
- * runtime with SMD dismiss / disable as a platform-safety capability.
+ * The Operator's working relationship is a composition of lanes (ADR 0048):
+ *   • Style — taught corrections (`voice_corrections`), read live across the
+ *     isolation boundary via the `memory_export` seam (ADR 0043 path A). Real
+ *     now; empty until a correction is taught or learned.
+ *   • Authored — behavioral preferences from `customer.yaml` (lands with the
+ *     `relationship:` block).
+ *   • Inferred — Honcho conclusions (deferred, ADR 0016).
  *
- * Honest state (foundations §7, §5.6): Honcho memory inference is Phase-2, and
- * the memory/agent-skill read path is not in the runtime read contract yet
- * (RUNTIME_READ_KINDS covers audit/draft/matter/activity only). So this surface
- * states that plainly rather than fabricating observations or a skill inventory.
- * It lights up when the memory read + mirror land; the dismiss/disable controls
- * are platform-safety actions wired with that path.
+ * Read-only and fail-closed: the style lane renders `not_enabled` WITHOUT a read
+ * when the seam is unconfigured (no audit noise). Relationship state is
+ * informational only — this surface never grants the Operator any capability
+ * (ADR 0048 §2c).
  */
 
 const session = Astro.locals.session!
@@ -26,15 +35,41 @@ if (session.role !== 'admin') {
 const slug = Astro.params.customer ?? ''
 const entityId = await resolveEntityIdBySlug(env.DB, slug)
 const notFound = entityId === null
+
+const configured = isRuntimeReadConfigured(env)
+let style: StyleLaneResult = { status: 'not_enabled' }
+if (!notFound) {
+  style = await loadStyleLane(
+    {
+      transport: createMachineRuntimeTransport(env),
+      audit: createRuntimeReadAudit(env.DB, { actorUserId: session.userId }),
+    },
+    slug,
+    { actor: session.email, actorRole: session.role },
+    configured
+  )
+}
+
+function sourceLabel(source: string): string {
+  if (source === 'live_edit') return 'Learned from an edit'
+  if (source === 'calibration_session') return 'Taught directly'
+  return source
+}
+
+function scopeLabel(reviewer: string | null, cohort: string | null): string {
+  const who = reviewer ?? 'Everyone'
+  const to = cohort ?? 'all recipients'
+  return `${who} → ${to}`
+}
 ---
 
 <AdminLayout
-  title={`Operator — Memory — ${slug}`}
+  title={`Operator — Relationship — ${slug}`}
   breadcrumbs={[
     { label: 'Home', href: '/admin' },
     { label: 'Operator', href: '/admin/operator' },
     { label: slug, href: `/admin/operator/${encodeURIComponent(slug)}` },
-    { label: 'Memory' },
+    { label: 'Relationship' },
   ]}
   maxWidth="max-w-5xl"
 >
@@ -57,35 +92,85 @@ const notFound = entityId === null
         <>
           <header>
             <h2 class="text-xl font-semibold text-[color:var(--ss-color-text-primary)]">
-              Memory &amp; agent-skills — {slug}
+              What this operator has learned about working with you — {slug}
             </h2>
             <p class="text-sm text-[color:var(--ss-color-text-secondary)] mt-1">
-              The operator's learned observations and agent-authored skills.
+              The working relationship, read-only. Everything here is informational — it shapes how
+              the operator drafts and helps, and never grants it any new capability.
             </p>
           </header>
 
-          <div class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card space-y-stack">
+          {/* Lane 1 — Style & corrections (live, voice_corrections via the seam) */}
+          <section class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card space-y-stack">
             <div>
               <h3 class="text-base font-semibold text-[color:var(--ss-color-text-primary)]">
-                Observations
+                Style &amp; corrections
               </h3>
               <p class="text-sm text-[color:var(--ss-color-text-secondary)] mt-1">
-                Memory inference is Phase-2. Observations with their evidence status appear here
-                once the memory mirror lands; SMD dismiss (removal from the learning loop) is wired
-                with it.
+                Style rules the operator applies to drafts — taught directly, or learned from how a
+                draft was edited before sending.
               </p>
             </div>
-            <div>
-              <h3 class="text-base font-semibold text-[color:var(--ss-color-text-primary)]">
-                Agent-authored skills
-              </h3>
-              <p class="text-sm text-[color:var(--ss-color-text-secondary)] mt-1">
-                Skills the operator wrote for itself, with provenance and Captain-approval state,
-                appear here once the skill-inventory mirror lands; SMD approve / disable (a
-                platform- safety capability) is wired with it.
+
+            {style.status === 'not_enabled' ? (
+              <p class="text-xs text-[color:var(--ss-color-text-muted)]">
+                The live read path is not enabled yet (<code>OPERATOR_RUNTIME_READ_URL</code>, ADR
+                0043). Corrections appear here the moment it is wired — the lane is dark, not empty.
               </p>
-            </div>
-          </div>
+            ) : style.status === 'unreachable' ? (
+              <p class="text-xs text-[color:var(--ss-color-text-muted)]">
+                This operator's runtime is unreachable right now ({style.reason}). The read fails
+                closed; try again shortly.
+              </p>
+            ) : style.status === 'empty' ? (
+              <p class="text-sm text-[color:var(--ss-color-text-secondary)]">
+                No style corrections learned yet. They accrue as drafts are taught or edited.
+              </p>
+            ) : (
+              <ul class="divide-y divide-[color:var(--ss-color-border)]">
+                {style.corrections.map((c) => (
+                  <li class="py-2 flex flex-wrap items-baseline gap-x-3 gap-y-1">
+                    <span class="text-xs uppercase tracking-wide text-[color:var(--ss-color-text-muted)] w-20">
+                      {c.correctionKind}
+                    </span>
+                    <span class="text-sm text-[color:var(--ss-color-text-primary)]">
+                      <span class="line-through text-[color:var(--ss-color-text-muted)]">
+                        {c.beforePattern}
+                      </span>{' '}
+                      → <span class="font-medium">{c.afterText}</span>
+                    </span>
+                    <span class="text-xs text-[color:var(--ss-color-text-secondary)]">
+                      {scopeLabel(c.reviewerUserId, c.recipientCohort)} · {sourceLabel(c.source)}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+
+          {/* Lane 2 — Authored preferences (customer.yaml relationship block) */}
+          <section class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card">
+            <h3 class="text-base font-semibold text-[color:var(--ss-color-text-primary)]">
+              Standing preferences
+            </h3>
+            <p class="text-sm text-[color:var(--ss-color-text-secondary)] mt-1">
+              Behavioral preferences authored for this engagement (the <code>relationship:</code>{' '}
+              block in <code>customer.yaml</code>) appear here once that block is materialized into
+              the operator's config.
+            </p>
+          </section>
+
+          {/* Lane 3 — Inferred observations (Honcho, deferred) */}
+          <section class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card">
+            <h3 class="text-base font-semibold text-[color:var(--ss-color-text-primary)]">
+              Inferred observations
+            </h3>
+            <p class="text-sm text-[color:var(--ss-color-text-secondary)] mt-1">
+              Patterns the operator infers from conversation (with their evidence status, and SMD
+              dismiss) appear here when Honcho memory lands — Phase 2, ADR 0016. Until then this
+              lane is deliberately dark rather than fabricated.
+            </p>
+          </section>
         </>
       )
     }

--- a/tests/relationship-observe.test.ts
+++ b/tests/relationship-observe.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Tests for the relationship-surface view-model
+ * (src/lib/admin/relationship-observe.ts) — admin Operator console §5.6, ADR 0048.
+ *
+ * Two contracts matter: (1) parseStyleCorrections defensively parses the opaque
+ * memory_export payload — skipping superseded rows and rows missing required
+ * fields rather than rendering them half-formed; (2) loadStyleLane mirrors the
+ * runtime-observe discipline — not_enabled WITHOUT a read (no audit noise) when
+ * the seam is unconfigured, fail-closed to unreachable on a read error, and
+ * empty/items otherwise. The transport + audit are injected stubs.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { parseStyleCorrections, loadStyleLane } from '../src/lib/admin/relationship-observe'
+import type {
+  MachineRuntimeTransport,
+  RuntimeReadAudit,
+  RuntimeReadActor,
+} from '../src/lib/operator/runtime-read'
+
+const actor: RuntimeReadActor = { actor: 'captain@example.com', actorRole: 'admin' }
+
+function countingAudit(): { audit: RuntimeReadAudit; getCalls: () => number } {
+  let calls = 0
+  return { audit: { record: async () => void (calls += 1) }, getCalls: () => calls }
+}
+
+function transportReturning(data: unknown): MachineRuntimeTransport {
+  return { read: async () => ({ data }) }
+}
+
+const aRow = (over: Record<string, unknown> = {}) => ({
+  _rowid: 1,
+  id: 'c1',
+  correction_kind: 'signoff',
+  pattern_kind: 'literal_ci',
+  before_pattern: 'Sincerely,',
+  after_text: 'Best,',
+  source: 'live_edit',
+  reviewer_user_id: null,
+  recipient_cohort: null,
+  superseded_by: null,
+  ...over,
+})
+
+describe('parseStyleCorrections', () => {
+  it('parses a valid row into a StyleCorrection', () => {
+    const out = parseStyleCorrections({ entries: [aRow()] })
+    expect(out).toHaveLength(1)
+    expect(out[0]).toEqual({
+      correctionKind: 'signoff',
+      beforePattern: 'Sincerely,',
+      afterText: 'Best,',
+      source: 'live_edit',
+      reviewerUserId: null,
+      recipientCohort: null,
+    })
+  })
+
+  it('preserves scope fields when present', () => {
+    const out = parseStyleCorrections({
+      entries: [aRow({ reviewer_user_id: 'chris', recipient_cohort: 'client' })],
+    })
+    expect(out[0].reviewerUserId).toBe('chris')
+    expect(out[0].recipientCohort).toBe('client')
+  })
+
+  it('skips superseded rows', () => {
+    expect(parseStyleCorrections({ entries: [aRow({ superseded_by: 'c2' })] })).toEqual([])
+  })
+
+  it('skips rows missing a required field', () => {
+    expect(parseStyleCorrections({ entries: [aRow({ correction_kind: null })] })).toEqual([])
+    expect(parseStyleCorrections({ entries: [aRow({ after_text: 42 })] })).toEqual([])
+    expect(parseStyleCorrections({ entries: [aRow({ source: '' })] })).toEqual([])
+  })
+
+  it('is total on malformed payloads', () => {
+    expect(parseStyleCorrections(null)).toEqual([])
+    expect(parseStyleCorrections({})).toEqual([])
+    expect(parseStyleCorrections({ entries: 'nope' })).toEqual([])
+    expect(parseStyleCorrections({ entries: [null, 7, 'x'] })).toEqual([])
+  })
+})
+
+describe('loadStyleLane', () => {
+  it('returns not_enabled WITHOUT a read when unconfigured', async () => {
+    const { audit, getCalls } = countingAudit()
+    const res = await loadStyleLane(
+      { transport: transportReturning({ entries: [aRow()] }), audit },
+      'smd',
+      actor,
+      false
+    )
+    expect(res).toEqual({ status: 'not_enabled' })
+    expect(getCalls()).toBe(0)
+  })
+
+  it('classifies rows as items', async () => {
+    const { audit } = countingAudit()
+    const res = await loadStyleLane(
+      { transport: transportReturning({ entries: [aRow()] }), audit },
+      'smd',
+      actor,
+      true
+    )
+    expect(res.status).toBe('items')
+    if (res.status === 'items') expect(res.corrections).toHaveLength(1)
+  })
+
+  it('classifies no rows as empty', async () => {
+    const { audit } = countingAudit()
+    const res = await loadStyleLane(
+      { transport: transportReturning({ entries: [] }), audit },
+      'smd',
+      actor,
+      true
+    )
+    expect(res).toEqual({ status: 'empty' })
+  })
+
+  it('fails closed to unreachable on a read error', async () => {
+    const { audit } = countingAudit()
+    const transport: MachineRuntimeTransport = {
+      read: async () => {
+        throw new Error('boom')
+      },
+    }
+    const res = await loadStyleLane({ transport, audit }, 'smd', actor, true)
+    expect(res.status).toBe('unreachable')
+  })
+})


### PR DESCRIPTION
## What this is

Slice 1 of the **Operator relationship model** — the per-person "working relationship" that makes *help* feel like a great colleague rather than a docs site (ADR 0037: the moat is the harness + the guide + the **memory**).

This slice lands the **design** and the **capture logic**. It is intentionally a foundation, not the full Phase 1 — see "Remaining" below.

## Contents

- **ADR 0048** — settles the relationship model as a **composition, not a new monolith**: `voice_corrections` (0010) is the style/correction lane, `customer.yaml` is the authored behavioral lane, `persona_observations`/Honcho (0016) is the inferred lane (deferred), unified by one legible *"what I've learned about working with you"* surface. Binding policies: deterministic-floor-only, **informational-only** (never self-grants entitlements), **no duplication** of `voice_corrections`, **taint-aware** learning, honest evidence vocabulary.
- **Live-edit correction extractor** (`operator/adapter/voice/live_edit.py`) — the pure, **content-free** capture primitive: derives `voice_corrections` rows from closed-set structural-category changes (signoff) between an agent draft and the human's sent version, via fixed non-PII templates. Preserves the Voice Layer 2 privacy floor (no body text persisted or leaked). Canonical primitive; the overlay runtime call site activates when sent-capture lands.

## Why composition (the recon that reshaped this)

Verified against the live customer-zero Machine, not the docs:
- Honcho isn't running (`memory_export` of `persona_observations` → empty); inference is deferred.
- `voice_corrections` (0010) **already is** the deterministic correction store — its header reaches the identical "dedicated table, runtime-read" conclusion. Building a parallel store would duplicate it.
- Sent-capture (`draft_queue.r2_sent_key`) is unbuilt — so the live-edit *runtime trigger* depends on it; the **extractor logic** ships now, ready to fire.

## Verification

- **Phase 0 live seam check** on customer-zero: `memory_export?table=persona_observations` → HTTP 200, `{"entries": []}`; wrong-key control → 401.
- **66 voice tests green**, incl. 5 new: signoff change → correction, no-change → none, untemplated-category skip, **content-free/no-leak**, scope propagation.

## Remaining (Phase 1, follow-on on this branch or separate PRs)

- Console legible surface: `memory_export` kind + `voice_corrections` seam exposure + admin "what I've learned" tab.
- `customer.yaml` `relationship:` authored-preference block + contracts registration.
- Overlay: add `voice_corrections` to `MEMORY_EXPORT_TABLES`.
- Follow-on (blocking the live-edit runtime trigger): the **sent-capture pipeline** (`r2_sent_key` population) — filed per ADR 0048 Open Items.
- Separate hardening issue: `persona_observations` migration-0007 ↔ overlay-`schemas.py` drift (dormant; Honcho off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)