### PR TITLE
chore(operator): bump OVERLAY_REF to 37a27aa — voice_corrections via memory_export

### DIFF
--- a/operator/templates/Dockerfile
+++ b/operator/templates/Dockerfile
@@ -184,7 +184,10 @@ ARG HERMES_UPSTREAM_SHA=a91a57fa5a13d516c38b07a141a9ce8a3daabeb0
 # check is unchanged. Fixes demo-law DEMO_RELAY_BLOCKED reason=content_sensitive
 # on a benign disclaimer (2026-06-14 live test). Superset of ed96cebe.
 ARG OVERLAY_REPO="https://github.com/venturecrane/hermes-smd-overlay.git"
-ARG OVERLAY_REF="c410c523264fd206badbe8282f171280986ae5e1"
+# 37a27aa — #79 expose voice_corrections via memory_export (ADR 0048): the legible
+# relationship surface ("what I've learned about working with you") reads the
+# operator's taught style rules through the runtime-read seam. Superset of c410c52.
+ARG OVERLAY_REF="37a27aa39d5c033b56d750d50ef99b40a9dd1b22"
 
 ARG CUSTOMER_SLUG=customer-zero
 

--- a/tests/operator-dockerfile.test.ts
+++ b/tests/operator-dockerfile.test.ts
@@ -71,7 +71,10 @@ describe('Operator customer Machine Dockerfile', () => {
     // disclaimer boilerplate out of the content-floor LEGAL category (clause-
     // local; genuinely sensitive content elsewhere still forces draft) — fixes
     // demo-law DEMO_RELAY_BLOCKED on a benign disclaimer. Atop ed96cebe.
-    expect(DOCKERFILE).toContain('ARG OVERLAY_REF="c410c523264fd206badbe8282f171280986ae5e1"')
+    // 37a27aa (#79) exposes voice_corrections via memory_export (ADR 0048) — the
+    // legible relationship surface reads the operator's taught style rules through
+    // the runtime-read seam. Superset of c410c52.
+    expect(DOCKERFILE).toContain('ARG OVERLAY_REF="37a27aa39d5c033b56d750d50ef99b40a9dd1b22"')
   })
 
   it('does NOT swallow a failed plugin install (no fail-open `|| echo ... continuing`)', () => {


### PR DESCRIPTION
## Summary
- Pins the customer-zero Machine image to overlay #79 (\`37a27aa\`) — adds \`voice_corrections\` to the \`memory_export\` allow-list.
- Lights up the live **style lane** of the relationship surface (ADR 0048) once \`reprovision.sh smd\` applies it.
- Updates the OVERLAY_REF guard test.

## Test plan
- [x] Before-state verified: \`memory_export?table=voice_corrections\` → 400 on the live Machine (old overlay).
- [ ] After reprovision: → 200 + gate triple.

🤖 Generated with [Claude Code](https://claude.com/claude-code)