### PR TITLE
feat(operator): relationship authored-preference channel (ADR 0048 Phase 2)

### DIFF
--- a/operator/contracts/customer-yaml-blocks.yaml
+++ b/operator/contracts/customer-yaml-blocks.yaml
@@ -112,6 +112,20 @@ top_level:
       webhook-router recognizing source="mcp". Fail-closed: absent/enabled:false
       => no user reaches the Operator through Claude. See
       docs/design/operator/03-mcp-server-exposure.md.
+  relationship:
+    status: implemented
+    materializer: translate _persona_config (config.yaml relationship) + _soul_body ("Working relationships" section) + overlay runtime_read config_export
+    note: >-
+      ADR 0048 authored behavioral lane. Per-person standing working
+      preferences, validated console-side by
+      src/lib/operator/customer-yaml/sections-relationship.ts. Materialized into
+      each persona SOUL.md so the Operator works the authored way, and surfaced
+      read-only on the admin relationship view via the secret-safe
+      `config_export?section=relationship` seam (allow-listed — never returns the
+      whole config.yaml). Informational only (ADR 0048 §2c): preferences never
+      grant capability; entitlements stay in scope/escalation, enforced by
+      trust_ceiling.enforce(). Distinct from voice_corrections (§2d): style
+      corrections, not behavioral preferences.
   # ---- deliberately not wired (validated authoring affordances) ----
   addons:
     status: inert

--- a/operator/customers/smd/customer.yaml
+++ b/operator/customers/smd/customer.yaml
@@ -206,3 +206,27 @@ memory:
   d1_namespace: smd
   r2_vault_path: 'vaults/smd/'
   vectorize_index: 'hermes-smd-vault'
+
+# ---- RELATIONSHIP (authored behavioral lane, ADR 0048) ----
+# How each person here likes Crane to work with them. INFORMATIONAL ONLY: these
+# shape how Crane drafts and helps and NEVER grant capability — entitlements live
+# in scope/escalation and are enforced by trust_ceiling regardless of this text.
+# Distinct from the style lane (voice_corrections): behavioral working
+# preferences, not draft phrasing.
+#
+# Seeded from Scott's standing working preferences (documented working feedback);
+# authored content, human-reviewed — not inferred or fabricated. Refine as the
+# working relationship develops. Materialized into Crane's SOUL.md by the overlay
+# and surfaced read-only on the admin relationship view.
+relationship:
+  people:
+    - id: scott-durgan
+      name: Scott Durgan
+      role: Principal
+      prefers:
+        - 'Lead with the material change and its consequence; skip process and bookkeeping narration'
+        - 'Decide what the context already determines; reserve questions for genuinely ambiguous calls'
+        - 'Move fast with low ceremony; engage as a peer, surface real risk once, then proceed'
+      avoid:
+        - 'Inventing time or effort estimates for work that has not been scoped'
+        - 'Relitigating a decision that has already been made'

--- a/src/lib/admin/relationship-observe.ts
+++ b/src/lib/admin/relationship-observe.ts
@@ -109,6 +109,76 @@ export function parseStyleCorrections(data: unknown): StyleCorrection[] {
   return out
 }
 
+/** One authored person on the standing-preferences (authored behavioral) lane —
+ * a `relationship.people[]` entry served by `config_export?section=relationship`
+ * (ADR 0048). */
+export interface StandingPreferencePerson {
+  id: string
+  name: string
+  role: string | null
+  prefers: string[]
+  avoid: string[]
+}
+
+export type StandingPreferencesResult =
+  | { status: 'not_enabled' }
+  | { status: 'unreachable'; reason: string }
+  | { status: 'empty' }
+  | { status: 'items'; people: StandingPreferencePerson[] }
+
+/**
+ * Load the standing-preferences lane (authored `relationship:` block) for one
+ * customer. Mirrors {@link loadStyleLane}: no read (and no audit row) when the
+ * seam is unconfigured; otherwise reads `config_export?section=relationship`
+ * via the fail-closed seam and classifies the outcome. The Machine serves the
+ * live `customer.yaml` block normalized to the closed-set fields, so this is the
+ * truth the running Operator works from — not a possibly-stale console copy.
+ */
+export async function loadStandingPreferences(
+  deps: RuntimeReadDeps,
+  customerSlug: string,
+  actor: RuntimeReadActor,
+  configured: boolean
+): Promise<StandingPreferencesResult> {
+  if (!configured) return { status: 'not_enabled' }
+  const result = await readMachineRuntime(
+    deps,
+    customerSlug,
+    { kind: 'config_export', section: 'relationship' },
+    actor
+  )
+  if (!result.ok) return { status: 'unreachable', reason: result.reason }
+  const people = parseStandingPreferences(result.data)
+  return people.length === 0 ? { status: 'empty' } : { status: 'items', people }
+}
+
+/**
+ * Parse the opaque `config_export` payload (`{ entries: [...] }`) into authored
+ * people. Defensive by construction: id and name are required (a row missing
+ * either is skipped rather than half-rendered); role/prefers/avoid normalize to
+ * `null`/`[]`; non-string list items are dropped. (The Machine already
+ * normalizes to the closed set, but the console never trusts the wire shape —
+ * coding-standards: parse external inputs, never cast.)
+ */
+export function parseStandingPreferences(data: unknown): StandingPreferencePerson[] {
+  const out: StandingPreferencePerson[] = []
+  for (const entry of extractEntries(data)) {
+    if (!entry || typeof entry !== 'object') continue
+    const row = entry as Record<string, unknown>
+    const id = asNonEmptyString(row.id)
+    const name = asNonEmptyString(row.name)
+    if (id === null || name === null) continue
+    out.push({
+      id,
+      name,
+      role: asStringOrNull(row.role),
+      prefers: asStringList(row.prefers),
+      avoid: asStringList(row.avoid),
+    })
+  }
+  return out
+}
+
 /** Pull the row list from the seam payload shape (`{ entries: [...] }`). */
 function extractEntries(data: unknown): unknown[] {
   if (data && typeof data === 'object') {
@@ -128,4 +198,10 @@ function asNonEmptyString(v: unknown): string | null {
 
 function asStringOrNull(v: unknown): string | null {
   return typeof v === 'string' && v.length > 0 ? v : null
+}
+
+/** Coerce an unknown to a list of non-empty strings, dropping anything else. */
+function asStringList(v: unknown): string[] {
+  if (!Array.isArray(v)) return []
+  return v.filter((item): item is string => typeof item === 'string' && item.length > 0)
 }

--- a/src/lib/operator/customer-yaml/index.ts
+++ b/src/lib/operator/customer-yaml/index.ts
@@ -78,6 +78,8 @@ export {
   type MachineSpec,
   type CostEstimate,
   type Demo,
+  type Relationship,
+  type RelationshipPerson,
   type Vertical,
   type TrustCeiling,
   type Pronouns,

--- a/src/lib/operator/customer-yaml/sections-relationship.ts
+++ b/src/lib/operator/customer-yaml/sections-relationship.ts
@@ -1,0 +1,226 @@
+/**
+ * Validator for the optional `relationship:` block — the **authored behavioral
+ * lane** of the relationship model (ADR 0048).
+ *
+ * The block holds per-person, human-reviewed, standing preferences for HOW the
+ * Operator should work with each person it serves. The overlay materializes it
+ * into each persona's `SOUL.md` (so the Operator actually works the authored
+ * way) and the admin relationship surface renders it read-only via the
+ * `config_export` seam.
+ *
+ * Two binding policies from ADR 0048 §2 shape what this validator does — and,
+ * just as importantly, what it deliberately does NOT do:
+ *
+ *   - **§2c Informational only.** Preferences shape drafting/help; they never
+ *     grant capability. Entitlements stay in `scope:`/`escalation:` and are
+ *     enforced by `trust_ceiling.enforce()`. So this validator does NOT try to
+ *     police preference *content* for entitlement-shaped phrasing — `enforce()`
+ *     is the real and only gate, and a heuristic content filter here would be
+ *     both brittle and security-theatre. Validation stays structural.
+ *   - **§2d Not the style lane.** Greeting/sign-off/honorific/lexical STYLE
+ *     corrections live in `voice_corrections` (migration 0010). This block must
+ *     not duplicate them; it carries behavioral working preferences, not draft
+ *     phrasing. (Not machine-enforceable without content heuristics — documented
+ *     here and in the schema doc as authoring guidance.)
+ *
+ * Validation is therefore structural + bounded only: shape, required fields,
+ * unique ids, and size caps that keep the rendered `SOUL.md` section bounded.
+ * Absent block ⇒ `{ people: [] }` (fail-safe empty, never fabricated).
+ */
+
+import { isPlainObject } from './helpers'
+import { type Relationship, type RelationshipPerson, type ValidationError } from './types'
+
+/** Caps that keep the materialized `SOUL.md` "Working relationships" section
+ * bounded — a `customer.yaml` is human-authored, so these are generous ceilings
+ * that only catch runaway/pasted input, not real authoring. */
+const MAX_PEOPLE = 50
+const MAX_ITEMS_PER_LIST = 25
+const MAX_STRING_LEN = 400
+
+/** Stable per-person id: kebab-case, so it can align with a
+ * `voice_corrections.reviewer_user_id`. */
+const ID_PATTERN = /^[a-z0-9][a-z0-9-]*$/
+
+export function checkRelationship(
+  root: Record<string, unknown>,
+  errors: ValidationError[]
+): Relationship {
+  const raw = root['relationship']
+  if (raw === undefined || raw === null) return { people: [] }
+  if (!isPlainObject(raw)) {
+    errors.push({
+      code: 'TypeMismatch',
+      path: 'relationship',
+      message: 'relationship must be a mapping when present',
+    })
+    return { people: [] }
+  }
+
+  const peopleRaw = raw['people']
+  if (peopleRaw === undefined || peopleRaw === null) return { people: [] }
+  if (!Array.isArray(peopleRaw)) {
+    errors.push({
+      code: 'TypeMismatch',
+      path: 'relationship.people',
+      message: 'relationship.people must be a list when present',
+    })
+    return { people: [] }
+  }
+  if (peopleRaw.length > MAX_PEOPLE) {
+    errors.push({
+      code: 'TypeMismatch',
+      path: 'relationship.people',
+      message: `relationship.people must not exceed ${MAX_PEOPLE} entries`,
+    })
+    return { people: [] }
+  }
+
+  const people: RelationshipPerson[] = []
+  const seenIds = new Set<string>()
+
+  peopleRaw.forEach((entry, i) => {
+    const path = `relationship.people[${i}]`
+    if (!isPlainObject(entry)) {
+      errors.push({ code: 'TypeMismatch', path, message: `${path} must be a mapping` })
+      return
+    }
+
+    const id = requireBoundedString(entry, 'id', `${path}.id`, errors)
+    if (id !== null) {
+      if (!ID_PATTERN.test(id)) {
+        errors.push({
+          code: 'InvalidSlug',
+          path: `${path}.id`,
+          message: `${path}.id must be kebab-case (lowercase letters, digits, hyphens)`,
+        })
+      } else if (seenIds.has(id)) {
+        errors.push({
+          code: 'DuplicateRelationshipPersonId',
+          path: `${path}.id`,
+          message: `relationship.people id "${id}" is duplicated`,
+        })
+      } else {
+        seenIds.add(id)
+      }
+    }
+
+    const name = requireBoundedString(entry, 'name', `${path}.name`, errors)
+    const role = optionalBoundedString(entry, 'role', `${path}.role`, errors)
+    const prefers = boundedNonEmptyStringList(entry, 'prefers', `${path}.prefers`, errors)
+    const avoid = boundedNonEmptyStringList(entry, 'avoid', `${path}.avoid`, errors)
+
+    // Only assemble a person when the required fields are well-formed; a
+    // malformed entry has already pushed an error and is dropped rather than
+    // rendered half-formed.
+    if (id !== null && ID_PATTERN.test(id) && name !== null) {
+      people.push({ id, name, role, prefers, avoid })
+    }
+  })
+
+  // On any error the caller (`validate`) early-returns before assembly, so this
+  // value is only inspected by unit tests asserting the well-formed subset.
+  return { people }
+}
+
+function requireBoundedString(
+  rec: Record<string, unknown>,
+  key: string,
+  path: string,
+  errors: ValidationError[]
+): string | null {
+  const v = rec[key]
+  if (v === undefined || v === null) {
+    errors.push({ code: 'MissingField', path, message: `${path} is required` })
+    return null
+  }
+  if (typeof v !== 'string') {
+    errors.push({ code: 'TypeMismatch', path, message: `${path} must be a string` })
+    return null
+  }
+  if (v.length === 0) {
+    errors.push({ code: 'EmptyField', path, message: `${path} must not be empty` })
+    return null
+  }
+  if (v.length > MAX_STRING_LEN) {
+    errors.push({
+      code: 'TypeMismatch',
+      path,
+      message: `${path} must not exceed ${MAX_STRING_LEN} characters`,
+    })
+    return null
+  }
+  return v
+}
+
+function optionalBoundedString(
+  rec: Record<string, unknown>,
+  key: string,
+  path: string,
+  errors: ValidationError[]
+): string | null {
+  const v = rec[key]
+  if (v === undefined || v === null) return null
+  if (typeof v !== 'string') {
+    errors.push({ code: 'TypeMismatch', path, message: `${path} must be a string when present` })
+    return null
+  }
+  if (v.length === 0) {
+    errors.push({ code: 'EmptyField', path, message: `${path} must not be empty when present` })
+    return null
+  }
+  if (v.length > MAX_STRING_LEN) {
+    errors.push({
+      code: 'TypeMismatch',
+      path,
+      message: `${path} must not exceed ${MAX_STRING_LEN} characters`,
+    })
+    return null
+  }
+  return v
+}
+
+/** Optional list of non-empty, bounded strings. Absent ⇒ `[]`. */
+function boundedNonEmptyStringList(
+  rec: Record<string, unknown>,
+  key: string,
+  path: string,
+  errors: ValidationError[]
+): string[] {
+  const v = rec[key]
+  if (v === undefined || v === null) return []
+  if (!Array.isArray(v)) {
+    errors.push({ code: 'TypeMismatch', path, message: `${path} must be a list when present` })
+    return []
+  }
+  if (v.length > MAX_ITEMS_PER_LIST) {
+    errors.push({
+      code: 'TypeMismatch',
+      path,
+      message: `${path} must not exceed ${MAX_ITEMS_PER_LIST} items`,
+    })
+    return []
+  }
+  const out: string[] = []
+  v.forEach((item, i) => {
+    const itemPath = `${path}[${i}]`
+    if (typeof item !== 'string') {
+      errors.push({ code: 'TypeMismatch', path: itemPath, message: `${itemPath} must be a string` })
+      return
+    }
+    if (item.length === 0) {
+      errors.push({ code: 'EmptyField', path: itemPath, message: `${itemPath} must not be empty` })
+      return
+    }
+    if (item.length > MAX_STRING_LEN) {
+      errors.push({
+        code: 'TypeMismatch',
+        path: itemPath,
+        message: `${itemPath} must not exceed ${MAX_STRING_LEN} characters`,
+      })
+      return
+    }
+    out.push(item)
+  })
+  return out
+}

--- a/src/lib/operator/customer-yaml/types.ts
+++ b/src/lib/operator/customer-yaml/types.ts
@@ -682,6 +682,53 @@ export interface Demo {
 }
 
 /**
+ * One person the Operator works with, as authored in the `relationship:` block
+ * (ADR 0048). This is the **authored behavioral lane** of the relationship
+ * model — standing, human-reviewed preferences for HOW to work with a specific
+ * person. It is deliberately constrained:
+ *
+ *   - **Informational only (ADR 0048 §2c).** Preferences shape how the Operator
+ *     drafts and helps; they NEVER grant capability or autonomy. Entitlements
+ *     stay authored in `scope:`/`escalation:` and enforced in code
+ *     (`trust_ceiling.enforce()`). A `prefers:` line that reads like an
+ *     entitlement grant ("auto-send routine confirmations") changes nothing the
+ *     agent is permitted to do — `enforce()` remains the only gate.
+ *   - **Not the style lane (ADR 0048 §2d).** Greeting/sign-off/honorific/lexical
+ *     STYLE corrections live in `voice_corrections` (migration 0010), read at
+ *     transform time. This block must NOT duplicate them — keep it to behavioral
+ *     working preferences (how someone likes to receive information, what they
+ *     care about), not how a draft is phrased.
+ */
+export interface RelationshipPerson {
+  /** Stable per-person key (kebab-case). Ideally matches the person's
+   * `voice_corrections.reviewer_user_id` so the style and authored lanes compose
+   * per-person on the relationship surface. */
+  id: string
+  /** Display name shown to the Operator and on the relationship surface. */
+  name: string
+  /** The person's role/title for context (e.g. "Managing partner"). `null`
+   * when unauthored. */
+  role: string | null
+  /** Free-text working preferences — how this person likes to be worked with.
+   * Authored, human-reviewed (so not subject to the runtime-fabrication ban —
+   * this is engagement-authored config, the sanctioned source). */
+  prefers: string[]
+  /** Free-text things to avoid when working with this person. */
+  avoid: string[]
+}
+
+/**
+ * Authored behavioral lane of the relationship model (`relationship:` block,
+ * ADR 0048). Per-person standing preferences, materialized by the overlay into
+ * each persona's `SOUL.md` (so the Operator actually works the authored way) and
+ * surfaced read-only on the admin relationship view. Absent block ⇒
+ * `{ people: [] }`. See {@link RelationshipPerson} for the binding policies.
+ */
+export interface Relationship {
+  people: RelationshipPerson[]
+}
+
+/**
  * One authored user → profile binding for the Operator ⇄ Claude MCP connector.
  * `email` MUST match a `users[]` entry; `profile` MUST match an active persona
  * slug. This is the per-user seam: the pilot authors exactly one, multi-user
@@ -819,6 +866,14 @@ export interface CustomerYaml {
    * `checkMcpConnector`. Fail-closed — see {@link McpConnector}.
    */
   mcp_connector: McpConnector
+  /**
+   * Authored behavioral lane of the relationship model (ADR 0048). Always
+   * non-null on a validated CustomerYaml: an absent `relationship:` block
+   * resolves to `{ people: [] }` via `checkRelationship`. Materialized by the
+   * overlay into each persona's `SOUL.md`; surfaced read-only on the admin
+   * relationship view via the `config_export` seam. See {@link Relationship}.
+   */
+  relationship: Relationship
 }
 
 export type ValidationErrorCode =
@@ -859,6 +914,7 @@ export type ValidationErrorCode =
   | 'InvalidActionClass'
   | 'InvalidActionCeiling'
   | 'UnknownAuthorityDomain'
+  | 'DuplicateRelationshipPersonId'
 
 export interface ValidationError {
   code: ValidationErrorCode

--- a/src/lib/operator/customer-yaml/validator.ts
+++ b/src/lib/operator/customer-yaml/validator.ts
@@ -64,6 +64,7 @@ import { checkDemo } from './sections-demo'
 import { checkMcpConnector } from './sections-mcp-connector'
 import { checkGoogleAuth } from './sections-google-auth'
 import { checkAuthority } from './sections-authority'
+import { checkRelationship } from './sections-relationship'
 import type { AuthorityPosture } from '../authority'
 import type { CredentialCustody } from '../credential-custody'
 
@@ -102,6 +103,8 @@ export type {
   Demo,
   McpConnector,
   McpConnectorAccess,
+  Relationship,
+  RelationshipPerson,
   DataPosture,
   Vertical,
   TrustCeiling,
@@ -236,6 +239,7 @@ interface ParsedSections {
   credentialCustodyDefault: CredentialCustody
   demo: Demo
   mcpConnector: ReturnType<typeof checkMcpConnector>
+  relationship: ReturnType<typeof checkRelationship>
 }
 
 function validateSections(
@@ -290,6 +294,7 @@ function validateSections(
     credentialCustodyDefault: checkCredentialCustodyDefault(root, errors),
     demo: checkDemo(root, errors),
     mcpConnector: checkMcpConnector(root, users, personas, errors),
+    relationship: checkRelationship(root, errors),
   }
 }
 
@@ -327,5 +332,6 @@ function assembleCustomerYaml(root: Record<string, unknown>, p: ParsedSections):
     credential_custody_default: p.credentialCustodyDefault,
     demo: p.demo,
     mcp_connector: p.mcpConnector,
+    relationship: p.relationship,
   }
 }

--- a/src/lib/operator/runtime-read-transport.ts
+++ b/src/lib/operator/runtime-read-transport.ts
@@ -94,6 +94,8 @@ function appendQuery(url: URL, query: RuntimeReadQuery): void {
   if (query.id) url.searchParams.set('id', query.id)
   // memory_export requires a table; the Machine refuses one outside its allow-list.
   if (query.table) url.searchParams.set('table', query.table)
+  // config_export requires a section; the Machine refuses one outside its allow-list.
+  if (query.section) url.searchParams.set('section', query.section)
 }
 
 /**

--- a/src/lib/operator/runtime-read.ts
+++ b/src/lib/operator/runtime-read.ts
@@ -31,13 +31,21 @@
  * `memory_export` serves an allow-listed Machine-local memory table one at a
  * time via the `table` query field (ADR 0016 mirror tables + `voice_corrections`,
  * the relationship model's style lane per ADR 0048). The Machine refuses any
- * table outside its allow-list. */
+ * table outside its allow-list.
+ *
+ * `config_export` serves an allow-listed authored CONTENT block from the live
+ * `customer.yaml` via the `section` query field — `relationship` (the model's
+ * authored behavioral lane, ADR 0048) is the only section today. Unlike a whole
+ * config read, it is allow-listed to non-secret sections so the connector
+ * secrets in `customer.yaml` can never cross the seam. The Machine refuses any
+ * section outside its allow-list. */
 export const RUNTIME_READ_KINDS = [
   'audit_log',
   'draft',
   'matter',
   'activity',
   'memory_export',
+  'config_export',
 ] as const
 export type RuntimeReadKind = (typeof RUNTIME_READ_KINDS)[number]
 
@@ -53,6 +61,10 @@ export interface RuntimeReadQuery {
    * `voice_corrections`); ignored by other kinds. The Machine refuses any
    * table outside its allow-list. */
   table?: string | null
+  /** Allow-listed section name for the `config_export` kind (e.g.
+   * `relationship`); ignored by other kinds. The Machine refuses any section
+   * outside its allow-list. */
+  section?: string | null
 }
 
 export interface RuntimeReadActor {

--- a/src/lib/portal/operator/customer-yaml-editor.ts
+++ b/src/lib/portal/operator/customer-yaml-editor.ts
@@ -454,6 +454,7 @@ function lockedFromCurrent(
   | 'credential_custody_default'
   | 'demo'
   | 'mcp_connector'
+  | 'relationship'
 > {
   return {
     schema_version: current.schema_version,
@@ -493,6 +494,10 @@ function lockedFromCurrent(
     // mcp_connector (Operator <-> Claude) is provisioning/admin-set, not
     // client-editable in this portal flow yet. Preserve verbatim.
     mcp_connector: current.mcp_connector,
+    // relationship (ADR 0048 authored behavioral lane) is SMD/provisioning-set —
+    // per-person working preferences are not a client self-serve config. Preserve
+    // verbatim across portal edits.
+    relationship: current.relationship,
   }
 }
 

--- a/src/pages/admin/operator/[customer]/memory.astro
+++ b/src/pages/admin/operator/[customer]/memory.astro
@@ -1,7 +1,12 @@
 ---
 import AdminLayout from '../../../../layouts/AdminLayout.astro'
 import { resolveEntityIdBySlug } from '../../../../lib/admin/operator-overview'
-import { loadStyleLane, type StyleLaneResult } from '../../../../lib/admin/relationship-observe'
+import {
+  loadStyleLane,
+  loadStandingPreferences,
+  type StyleLaneResult,
+  type StandingPreferencesResult,
+} from '../../../../lib/admin/relationship-observe'
 import {
   isRuntimeReadConfigured,
   createMachineRuntimeTransport,
@@ -38,16 +43,19 @@ const notFound = entityId === null
 
 const configured = isRuntimeReadConfigured(env)
 let style: StyleLaneResult = { status: 'not_enabled' }
+let standing: StandingPreferencesResult = { status: 'not_enabled' }
 if (!notFound) {
-  style = await loadStyleLane(
-    {
-      transport: createMachineRuntimeTransport(env),
-      audit: createRuntimeReadAudit(env.DB, { actorUserId: session.userId }),
-    },
-    slug,
-    { actor: session.email, actorRole: session.role },
-    configured
-  )
+  const deps = {
+    transport: createMachineRuntimeTransport(env),
+    audit: createRuntimeReadAudit(env.DB, { actorUserId: session.userId }),
+  }
+  const who = { actor: session.email, actorRole: session.role }
+  // Style lane (voice_corrections) and standing-preferences lane (authored
+  // relationship: block) are independent seam reads — fetch concurrently.
+  ;[style, standing] = await Promise.all([
+    loadStyleLane(deps, slug, who, configured),
+    loadStandingPreferences(deps, slug, who, configured),
+  ])
 }
 
 function sourceLabel(source: string): string {
@@ -149,15 +157,74 @@ function scopeLabel(reviewer: string | null, cohort: string | null): string {
           </section>
 
           {/* Lane 2 — Authored preferences (customer.yaml relationship block) */}
-          <section class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card">
-            <h3 class="text-base font-semibold text-[color:var(--ss-color-text-primary)]">
-              Standing preferences
-            </h3>
-            <p class="text-sm text-[color:var(--ss-color-text-secondary)] mt-1">
-              Behavioral preferences authored for this engagement (the <code>relationship:</code>{' '}
-              block in <code>customer.yaml</code>) appear here once that block is materialized into
-              the operator's config.
-            </p>
+          <section class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card space-y-stack">
+            <div>
+              <h3 class="text-base font-semibold text-[color:var(--ss-color-text-primary)]">
+                Standing preferences
+              </h3>
+              <p class="text-sm text-[color:var(--ss-color-text-secondary)] mt-1">
+                Behavioral preferences authored for this engagement (the <code>relationship:</code>{' '}
+                block in <code>customer.yaml</code>) — how each person here likes to be worked with.
+                Read live from the operator's running config.
+              </p>
+            </div>
+
+            {standing.status === 'not_enabled' ? (
+              <p class="text-xs text-[color:var(--ss-color-text-muted)]">
+                The live read path is not enabled yet (<code>OPERATOR_RUNTIME_READ_URL</code>, ADR
+                0043). Authored preferences appear here the moment it is wired.
+              </p>
+            ) : standing.status === 'unreachable' ? (
+              <p class="text-xs text-[color:var(--ss-color-text-muted)]">
+                This operator's runtime is unreachable right now ({standing.reason}). The read fails
+                closed; try again shortly.
+              </p>
+            ) : standing.status === 'empty' ? (
+              <p class="text-sm text-[color:var(--ss-color-text-secondary)]">
+                No standing preferences authored yet. Add a <code>relationship:</code> block to this
+                operator's <code>customer.yaml</code> to capture how each person likes to work.
+              </p>
+            ) : (
+              <ul class="space-y-stack">
+                {standing.people.map((person) => (
+                  <li class="border-t border-[color:var(--ss-color-border)] pt-3 first:border-t-0 first:pt-0">
+                    <p class="text-sm font-medium text-[color:var(--ss-color-text-primary)]">
+                      {person.name}
+                      {person.role && (
+                        <span class="font-normal text-[color:var(--ss-color-text-secondary)]">
+                          {' '}
+                          — {person.role}
+                        </span>
+                      )}
+                    </p>
+                    {person.prefers.length > 0 && (
+                      <div class="mt-1">
+                        <p class="text-xs uppercase tracking-wide text-[color:var(--ss-color-text-muted)]">
+                          Prefers
+                        </p>
+                        <ul class="list-disc list-inside text-sm text-[color:var(--ss-color-text-secondary)]">
+                          {person.prefers.map((p) => (
+                            <li>{p}</li>
+                          ))}
+                        </ul>
+                      </div>
+                    )}
+                    {person.avoid.length > 0 && (
+                      <div class="mt-1">
+                        <p class="text-xs uppercase tracking-wide text-[color:var(--ss-color-text-muted)]">
+                          Avoid
+                        </p>
+                        <ul class="list-disc list-inside text-sm text-[color:var(--ss-color-text-secondary)]">
+                          {person.avoid.map((a) => (
+                            <li>{a}</li>
+                          ))}
+                        </ul>
+                      </div>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            )}
           </section>
 
           {/* Lane 3 — Inferred observations (Honcho, deferred) */}

--- a/tests/customer-yaml-validator.test.ts
+++ b/tests/customer-yaml-validator.test.ts
@@ -2520,3 +2520,115 @@ describe('validate — credential custody', () => {
     ).toBe(true)
   })
 })
+
+// -----------------------------------------------------------------------------
+// relationship: block — authored behavioral lane (ADR 0048)
+// -----------------------------------------------------------------------------
+
+describe('validate — relationship block (ADR 0048)', () => {
+  it('defaults to { people: [] } when the block is absent', () => {
+    const r = validate(validFixture())
+    if (!r.ok) throw new Error(`expected ok; got: ${JSON.stringify(r.errors)}`)
+    expect(r.value.relationship).toEqual({ people: [] })
+  })
+
+  it('accepts a well-formed people list and normalizes optional fields', () => {
+    const f = validFixture()
+    f['relationship'] = {
+      people: [
+        {
+          id: 'scott-durgan',
+          name: 'Scott Durgan',
+          role: 'Principal',
+          prefers: ['Lead with the material change and its consequence'],
+          avoid: ['Inventing time/effort estimates for unscoped work'],
+        },
+        { id: 'office-manager', name: 'Office Manager' },
+      ],
+    }
+    const r = validate(f)
+    if (!r.ok) throw new Error(`expected ok; got: ${JSON.stringify(r.errors)}`)
+    expect(r.value.relationship.people).toHaveLength(2)
+    expect(r.value.relationship.people[0]).toEqual({
+      id: 'scott-durgan',
+      name: 'Scott Durgan',
+      role: 'Principal',
+      prefers: ['Lead with the material change and its consequence'],
+      avoid: ['Inventing time/effort estimates for unscoped work'],
+    })
+    // Optional fields normalize: absent role → null, absent lists → [].
+    expect(r.value.relationship.people[1]).toEqual({
+      id: 'office-manager',
+      name: 'Office Manager',
+      role: null,
+      prefers: [],
+      avoid: [],
+    })
+  })
+
+  it('rejects a non-mapping relationship block', () => {
+    const f = validFixture()
+    f['relationship'] = ['not', 'a', 'map']
+    const r = validate(f)
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(r.errors.some((e) => e.path === 'relationship' && e.code === 'TypeMismatch')).toBe(true)
+  })
+
+  it('requires id and name on each person', () => {
+    const f = validFixture()
+    f['relationship'] = { people: [{ role: 'Partner' }] }
+    const r = validate(f)
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(
+      r.errors.some((e) => e.path === 'relationship.people[0].id' && e.code === 'MissingField')
+    ).toBe(true)
+    expect(
+      r.errors.some((e) => e.path === 'relationship.people[0].name' && e.code === 'MissingField')
+    ).toBe(true)
+  })
+
+  it('rejects a non-kebab-case id (InvalidSlug)', () => {
+    const f = validFixture()
+    f['relationship'] = { people: [{ id: 'Scott Durgan', name: 'Scott' }] }
+    const r = validate(f)
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(
+      r.errors.some((e) => e.path === 'relationship.people[0].id' && e.code === 'InvalidSlug')
+    ).toBe(true)
+  })
+
+  it('rejects duplicate person ids', () => {
+    const f = validFixture()
+    f['relationship'] = {
+      people: [
+        { id: 'chris', name: 'Chris A' },
+        { id: 'chris', name: 'Chris B' },
+      ],
+    }
+    const r = validate(f)
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(r.errors.some((e) => e.code === 'DuplicateRelationshipPersonId')).toBe(true)
+  })
+
+  it('rejects non-string / empty preference items', () => {
+    const f = validFixture()
+    f['relationship'] = { people: [{ id: 'p1', name: 'P', prefers: ['', 42] }] }
+    const r = validate(f)
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(
+      r.errors.some(
+        (e) => e.path === 'relationship.people[0].prefers[0]' && e.code === 'EmptyField'
+      )
+    ).toBe(true)
+    expect(
+      r.errors.some(
+        (e) => e.path === 'relationship.people[0].prefers[1]' && e.code === 'TypeMismatch'
+      )
+    ).toBe(true)
+  })
+})

--- a/tests/relationship-observe.test.ts
+++ b/tests/relationship-observe.test.ts
@@ -11,7 +11,12 @@
  */
 
 import { describe, it, expect } from 'vitest'
-import { parseStyleCorrections, loadStyleLane } from '../src/lib/admin/relationship-observe'
+import {
+  parseStyleCorrections,
+  loadStyleLane,
+  parseStandingPreferences,
+  loadStandingPreferences,
+} from '../src/lib/admin/relationship-observe'
 import type {
   MachineRuntimeTransport,
   RuntimeReadAudit,
@@ -127,6 +132,99 @@ describe('loadStyleLane', () => {
       },
     }
     const res = await loadStyleLane({ transport, audit }, 'smd', actor, true)
+    expect(res.status).toBe('unreachable')
+  })
+})
+
+const aPerson = (over: Record<string, unknown> = {}) => ({
+  id: 'scott-durgan',
+  name: 'Scott Durgan',
+  role: 'Principal',
+  prefers: ['Lead with the material change'],
+  avoid: ['Inventing estimates'],
+  ...over,
+})
+
+describe('parseStandingPreferences', () => {
+  it('parses a valid person', () => {
+    const out = parseStandingPreferences({ entries: [aPerson()] })
+    expect(out).toEqual([
+      {
+        id: 'scott-durgan',
+        name: 'Scott Durgan',
+        role: 'Principal',
+        prefers: ['Lead with the material change'],
+        avoid: ['Inventing estimates'],
+      },
+    ])
+  })
+
+  it('normalizes optional fields (absent role → null, lists → [])', () => {
+    const out = parseStandingPreferences({ entries: [{ id: 'p1', name: 'P' }] })
+    expect(out[0]).toEqual({ id: 'p1', name: 'P', role: null, prefers: [], avoid: [] })
+  })
+
+  it('drops non-string list items', () => {
+    const out = parseStandingPreferences({ entries: [aPerson({ prefers: ['ok', 42, ''] })] })
+    expect(out[0].prefers).toEqual(['ok'])
+  })
+
+  it('skips rows missing id or name', () => {
+    expect(parseStandingPreferences({ entries: [{ name: 'no id' }] })).toEqual([])
+    expect(parseStandingPreferences({ entries: [{ id: 'no-name' }] })).toEqual([])
+  })
+
+  it('is total on malformed payloads', () => {
+    expect(parseStandingPreferences(null)).toEqual([])
+    expect(parseStandingPreferences({ entries: 'nope' })).toEqual([])
+    expect(parseStandingPreferences({ entries: [null, 7] })).toEqual([])
+  })
+})
+
+describe('loadStandingPreferences', () => {
+  it('returns not_enabled WITHOUT a read when unconfigured', async () => {
+    const { audit, getCalls } = countingAudit()
+    const res = await loadStandingPreferences(
+      { transport: transportReturning({ entries: [aPerson()] }), audit },
+      'smd',
+      actor,
+      false
+    )
+    expect(res).toEqual({ status: 'not_enabled' })
+    expect(getCalls()).toBe(0)
+  })
+
+  it('classifies people as items', async () => {
+    const { audit } = countingAudit()
+    const res = await loadStandingPreferences(
+      { transport: transportReturning({ entries: [aPerson()] }), audit },
+      'smd',
+      actor,
+      true
+    )
+    expect(res.status).toBe('items')
+    if (res.status === 'items') expect(res.people).toHaveLength(1)
+  })
+
+  it('classifies no people as empty', async () => {
+    const { audit } = countingAudit()
+    const res = await loadStandingPreferences(
+      { transport: transportReturning({ entries: [] }), audit },
+      'smd',
+      actor,
+      true
+    )
+    expect(res).toEqual({ status: 'empty' })
+  })
+
+  it('fails closed to unreachable on a read error', async () => {
+    const { audit } = countingAudit()
+    const transport: MachineRuntimeTransport = {
+      read: async () => {
+        throw new Error('boom')
+      },
+    }
+    const res = await loadStandingPreferences({ transport, audit }, 'smd', actor, true)
     expect(res.status).toBe('unreachable')
   })
 })


### PR DESCRIPTION
## Summary
Phase 2 of the Operator relationship model (ADR 0048) — the **authored behavioral lane**: per-person standing working preferences authored in `customer.yaml`, read live and rendered on the admin relationship surface.

- **`relationship:` block** schema + structural validation (`sections-relationship.ts`) + block-registry entry (`implemented`). Informational only (§2c — never grants capability; `enforce()` stays the gate); distinct from `voice_corrections` (§2d — behavioral preferences, not draft style).
- **`config_export?section=relationship`** runtime-read kind — secret-safe, allow-listed to the relationship block so the whole secret-bearing config can never cross the seam (mirrors `memory_export`'s table allow-list).
- **Standing-preferences lane** on `/admin/operator/[customer]/memory`, read live from the running Machine (same seam as the Style lane) — fail-closed.
- **SMD dogfood seat** authors Scott's standing preferences (from his documented working feedback — authored, human-reviewed, not fabricated).

Pairs with hermes-smd-overlay PR (translate.py materializer → `config.yaml` + SOUL.md). Per ADR 0048 the block ships **with** its materializer (no inert scaffolding). This kind reads empty/unreachable until the overlay lands + `OVERLAY_REF` bumps.

## Test plan
- [x] `npm run verify` (typecheck 0 errors, format clean, lint clean)
- [x] vitest: validator (+7 relationship cases), relationship-observe (+11), projection, editor
- [x] operator-substrate pytest (306 pass incl. block conformance with the new SMD block)
- [ ] Live verify on customer-zero after OVERLAY_REF bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)