### PR TITLE
fix(test): drop invalid workflowName from WorkflowEvent literal

### DIFF
--- a/tests/enrichment-workflow.test.ts
+++ b/tests/enrichment-workflow.test.ts
@@ -134,7 +134,6 @@ async function runWorkflow(
     payload: params,
     timestamp: new Date(),
     instanceId: 'test-instance',
-    workflowName: 'enrichment-workflow',
   }
   await wf.run(event, step as never)
   return { stats }


### PR DESCRIPTION
`tests/enrichment-workflow.test.ts` built a `WorkflowEvent<EnrichmentWorkflowParams>` literal with a `workflowName` property that doesn't exist in the type (`@cloudflare/workers-types`: `{ payload, timestamp, instanceId }`). `astro check` flagged it (ts 2353), which the **local pre-push hook** treats as fatal — blocking pushes on any branch that updates to main, even though the remote CI tolerates it.

Removing the stray property. Typecheck now reports 0 errors; the test is otherwise unchanged (8/8 pass). Unblocks the strict-up-to-date updates for the ADR 0044 PRs (#1387, #1390).

🤖 Generated with [Claude Code](https://claude.com/claude-code)