### PR TITLE
chore(operator): audit MCP token audience

### DIFF
--- a/migrations/0073_operator_mcp_audit_token_audience.sql
+++ b/migrations/0073_operator_mcp_audit_token_audience.sql
@@ -1,0 +1,3 @@
+-- Record the verified JWT audience for MCP authentication diagnostics.
+-- The audience is a public OAuth identifier, not bearer-token material.
+ALTER TABLE operator_mcp_audit ADD COLUMN token_audience TEXT;

--- a/src/lib/operator/mcp/mcp-audit.ts
+++ b/src/lib/operator/mcp/mcp-audit.ts
@@ -10,6 +10,7 @@ export interface McpAuditEvent {
   decision: McpAuditDecision
   reason: string
   clerkSubject: string | null
+  tokenAudience: string | null
   localUserId: string | null
   profile: string | null
   tool: string | null
@@ -20,7 +21,7 @@ export async function recordMcpAudit(db: D1Database, event: McpAuditEvent): Prom
     .prepare(
       'INSERT INTO operator_mcp_audit ' +
         '(entity_id, customer_slug, event_type, decision, reason, clerk_subject, ' +
-        'local_user_id, profile, tool) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)'
+        'token_audience, local_user_id, profile, tool) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
     )
     .bind(
       event.entityId,
@@ -29,6 +30,7 @@ export async function recordMcpAudit(db: D1Database, event: McpAuditEvent): Prom
       event.decision,
       event.reason,
       event.clerkSubject,
+      event.tokenAudience,
       event.localUserId,
       event.profile,
       event.tool

--- a/src/lib/operator/mcp/mcp-route.ts
+++ b/src/lib/operator/mcp/mcp-route.ts
@@ -54,6 +54,8 @@ async function recordAuth(
     decision,
     reason: auth.ok ? 'authenticated' : auth.reason,
     clerkSubject: auth.ok ? auth.subject : (auth.subject ?? null),
+    tokenAudience:
+      'tokenAudience' in auth && auth.tokenAudience ? JSON.stringify(auth.tokenAudience) : null,
     localUserId: auth.ok ? auth.localUserId : null,
     profile: auth.ok ? auth.profile : null,
     tool: null,
@@ -102,6 +104,7 @@ export async function handleMcpPost(
       decision: 'allow',
       reason: 'dispatched',
       clerkSubject: auth.subject,
+      tokenAudience: JSON.stringify(auth.tokenAudience),
       localUserId: auth.localUserId,
       profile: auth.profile,
       tool,

--- a/src/lib/operator/mcp/token-validation.ts
+++ b/src/lib/operator/mcp/token-validation.ts
@@ -26,6 +26,7 @@ export type McpAuthResult =
       ok: true
       customer: ResolvedMcpCustomer
       subject: string
+      tokenAudience: string[]
       localUserId: string
       email: string
       profile: string
@@ -35,6 +36,7 @@ export type McpAuthResult =
       reason: McpAuthFailureReason
       detail: string
       subject?: string
+      tokenAudience?: string[]
     }
 
 export type McpTokenVerifier = (token: string, customer: ResolvedMcpCustomer) => Promise<unknown>
@@ -63,6 +65,11 @@ function audIncludes(aud: string | string[] | undefined, expected: string): bool
   return Array.isArray(aud) ? aud.includes(expected) : aud === expected
 }
 
+function normalizeAudience(aud: string | string[] | undefined): string[] {
+  if (!aud) return []
+  return Array.isArray(aud) ? aud : [aud]
+}
+
 function validateClaims(
   rawClaims: unknown,
   customer: ResolvedMcpCustomer
@@ -81,6 +88,7 @@ function validateClaims(
       reason: 'wrong_audience',
       detail: claims.aud ? 'token is bound to another resource' : 'token has no audience claim',
       subject: claims.sub,
+      tokenAudience: normalizeAudience(claims.aud),
     }
   }
   if (customer.clerkOrgId && claims.org_id !== customer.clerkOrgId) {
@@ -89,6 +97,7 @@ function validateClaims(
       reason: 'organization_mismatch',
       detail: 'token organization does not match customer',
       subject: claims.sub,
+      tokenAudience: normalizeAudience(claims.aud),
     }
   }
   return claims
@@ -123,6 +132,7 @@ export async function validateMcpToken(
       reason: 'connector_disabled',
       detail: 'mcp_connector is disabled',
       subject: claims.sub,
+      tokenAudience: normalizeAudience(claims.aud),
     }
   }
 
@@ -133,6 +143,7 @@ export async function validateMcpToken(
       reason: 'identity_not_authored',
       detail: 'Clerk subject is not authorized for this Operator',
       subject: claims.sub,
+      tokenAudience: normalizeAudience(claims.aud),
     }
   }
 
@@ -140,6 +151,7 @@ export async function validateMcpToken(
     ok: true,
     customer,
     subject: claims.sub,
+    tokenAudience: normalizeAudience(claims.aud),
     localUserId: principal.localUserId,
     email: principal.email,
     profile: principal.profile,

--- a/tests/operator-mcp-endpoint.test.ts
+++ b/tests/operator-mcp-endpoint.test.ts
@@ -207,6 +207,7 @@ describe('validateMcpToken', () => {
     expect(result).toMatchObject({
       ok: true,
       subject: CLERK_USER_ID,
+      tokenAudience: [RESOURCE_URI],
       localUserId: LOCAL_USER_ID,
       profile: 'crane',
     })
@@ -221,6 +222,19 @@ describe('validateMcpToken', () => {
   ])('rejects %s', async (reason, payload) => {
     const result = await validateMcpToken('token', customerFixture(), claimsVerifier(payload))
     expect(result).toMatchObject({ ok: false, reason })
+  })
+
+  it('returns the verified audience when the resource audience is wrong', async () => {
+    const result = await validateMcpToken(
+      'token',
+      customerFixture(),
+      claimsVerifier(claims({ aud: ['dynamic-client-id', 'secondary-audience'] }))
+    )
+    expect(result).toMatchObject({
+      ok: false,
+      reason: 'wrong_audience',
+      tokenAudience: ['dynamic-client-id', 'secondary-audience'],
+    })
   })
 
   it('requires the exact Clerk organization when the entity is organization-bound', async () => {
@@ -342,7 +356,10 @@ describe('loadMcpCustomer and migration 0072', () => {
     const isolated = createTestD1()
     const migrations = discoverNumericMigrations(migrationsDir)
     await runMigrations(isolated, {
-      files: migrations.filter((file) => !migrationBasename(file).startsWith('0072_')),
+      files: migrations.filter((file) => {
+        const name = migrationBasename(file)
+        return !name.startsWith('0072_') && !name.startsWith('0073_')
+      }),
     })
     await isolated
       .prepare('INSERT INTO entities (id, org_id, name, slug) VALUES (?, ?, ?, ?)')
@@ -354,7 +371,10 @@ describe('loadMcpCustomer and migration 0072', () => {
       .run()
 
     await runMigrations(isolated, {
-      files: migrations.filter((file) => migrationBasename(file).startsWith('0072_')),
+      files: migrations.filter((file) => {
+        const name = migrationBasename(file)
+        return name.startsWith('0072_') || name.startsWith('0073_')
+      }),
     })
 
     const backfilled = await isolated
@@ -412,9 +432,19 @@ describe('MCP route authorization and audit', () => {
     expect(response.status).toBe(401)
     expect(reads).toBe(0)
     const audit = await db
-      .prepare('SELECT decision, reason, tool FROM operator_mcp_audit')
-      .first<{ decision: string; reason: string; tool: string | null }>()
-    expect(audit).toEqual({ decision: 'deny', reason: 'wrong_audience', tool: null })
+      .prepare('SELECT decision, reason, token_audience, tool FROM operator_mcp_audit')
+      .first<{
+        decision: string
+        reason: string
+        token_audience: string | null
+        tool: string | null
+      }>()
+    expect(audit).toEqual({
+      decision: 'deny',
+      reason: 'wrong_audience',
+      token_audience: '["https://wrong.example/mcp"]',
+      tool: null,
+    })
   })
 
   it('serves an authenticated tool call and records auth plus tool audit rows', async () => {
@@ -436,7 +466,7 @@ describe('MCP route authorization and audit', () => {
     expect(response.status).toBe(200)
     const rows = await db
       .prepare(
-        'SELECT event_type, decision, clerk_subject, local_user_id, profile, tool ' +
+        'SELECT event_type, decision, clerk_subject, token_audience, local_user_id, profile, tool ' +
           'FROM operator_mcp_audit ORDER BY id'
       )
       .all<Record<string, unknown>>()
@@ -445,6 +475,7 @@ describe('MCP route authorization and audit', () => {
         event_type: 'auth',
         decision: 'allow',
         clerk_subject: CLERK_USER_ID,
+        token_audience: `["${RESOURCE_URI}"]`,
         local_user_id: LOCAL_USER_ID,
         profile: 'crane',
         tool: null,
@@ -453,6 +484,7 @@ describe('MCP route authorization and audit', () => {
         event_type: 'tool_call',
         decision: 'allow',
         clerk_subject: CLERK_USER_ID,
+        token_audience: `["${RESOURCE_URI}"]`,
         local_user_id: LOCAL_USER_ID,
         profile: 'crane',
         tool: 'operator_status',


### PR DESCRIPTION
## Summary
- persist only the verified JWT audience on MCP audit rows
- expose the normalized audience through internal auth results
- preserve strict audience validation while diagnosing Clerk DCR behavior

## Verification
- 24 MCP endpoint tests passed
- changed TypeScript files pass ESLint
- changed source and tests pass Prettier
- migration sequencing covered by the endpoint test suite