### PR TITLE
fix(operator): support Clerk MCP tokens without audience

### DIFF
--- a/docs/design/operator/mcp-clerk-setup.md
+++ b/docs/design/operator/mcp-clerk-setup.md
@@ -81,17 +81,22 @@ mcp_connector:
   access:
     - email: scott@smd.services
       profile: crane
-      clerk_subject: user_3E1RPGrTMxkSqciXMTyybUNSJWu
+      clerk_subjects:
+        - user_3EEs0aMBRgu6PRxBa4g5YhHjggD
+        - user_3E1RPGrTMxkSqciXMTyybUNSJWu
 ```
 
-The email resolves the local customer user. `clerk_subject`, when present,
-authorizes the exact Clerk account the user employs for Claude even when that
-account carries a different email. When omitted, the connector falls back to
-that local user's `users.clerk_user_id`. If neither is present, it fails closed.
+The email resolves the local customer user. `clerk_subjects`, when present,
+authorizes the exact Clerk accounts the user may employ for Claude even when
+those accounts carry different emails. The singular `clerk_subject` remains
+supported for one-account bindings. When both are omitted, the connector falls
+back to that local user's `users.clerk_user_id`. If none is present, it fails
+closed.
 
 When `entities.clerk_org_id` is populated, the token must also carry that exact
-`org_id`. When the entity has no Clerk Organization, issuer + audience + subject
-remain mandatory.
+`org_id`. A non-empty token audience must exactly include the MCP resource URI.
+Clerk dynamically registered clients currently omit `aud`; in that case the
+exact issuer plus the customer-scoped Clerk subject allowlist is mandatory.
 
 ## 4. Deploy and activate
 

--- a/operator/customers/smd/customer.yaml
+++ b/operator/customers/smd/customer.yaml
@@ -122,11 +122,13 @@ mcp_connector:
   data_posture: open
   access:
     # Scott reaches Crane from his own Claude. This email MUST match both a
-    # users[] entry above. clerk_subject is the stable identity from the Clerk
-    # account Scott actually uses for Claude; it may carry a different email.
+    # users[] entry above. clerk_subjects are the stable identities from the
+    # Clerk accounts Scott may use for Claude; their emails may differ.
     - email: scott@smd.services
       profile: crane
-      clerk_subject: user_3E1RPGrTMxkSqciXMTyybUNSJWu
+      clerk_subjects:
+        - user_3EEs0aMBRgu6PRxBa4g5YhHjggD
+        - user_3E1RPGrTMxkSqciXMTyybUNSJWu
 
 # ---- CONNECTORS ----
 # Google Workspace rides first-class tools mediated by the ADR 0045 broker.

--- a/src/lib/operator/customer-yaml/secret-detector.ts
+++ b/src/lib/operator/customer-yaml/secret-detector.ts
@@ -145,6 +145,7 @@ const SHAPE_HEURISTIC_ALLOWLIST_PATHS: ReadonlyArray<string> = [
   'users[*].full_name',
   // Clerk user IDs are public stable identifiers, not credentials.
   'mcp_connector.access[*].clerk_subject',
+  'mcp_connector.access[*].clerk_subjects',
   'escalation.red_flag_recipients',
   'escalation.failure_recipients',
   // token_ref is the ONE permitted secret-reference channel. The value is an

--- a/src/lib/operator/customer-yaml/sections-mcp-connector.ts
+++ b/src/lib/operator/customer-yaml/sections-mcp-connector.ts
@@ -62,6 +62,50 @@ interface AccessValidationContext {
   errors: ValidationError[]
 }
 
+function parseClerkSubjects(
+  entry: Record<string, unknown>,
+  path: string,
+  errors: ValidationError[]
+): Pick<McpConnectorAccess, 'clerk_subject' | 'clerk_subjects'> | null {
+  const clerkSubject = entry['clerk_subject']
+  if (
+    clerkSubject !== undefined &&
+    (typeof clerkSubject !== 'string' || !/^user_[A-Za-z0-9]+$/.test(clerkSubject))
+  ) {
+    errors.push({
+      code: 'TypeMismatch',
+      path: `${path}.clerk_subject`,
+      message: `${path}.clerk_subject must be a Clerk user ID`,
+    })
+    return null
+  }
+
+  const clerkSubjects = entry['clerk_subjects']
+  const validClerkSubjects =
+    Array.isArray(clerkSubjects) &&
+    clerkSubjects.length > 0 &&
+    clerkSubjects.every(
+      (subject): subject is string =>
+        typeof subject === 'string' && /^user_[A-Za-z0-9]+$/.test(subject)
+    ) &&
+    new Set(clerkSubjects).size === clerkSubjects.length
+      ? clerkSubjects
+      : null
+  if (clerkSubjects !== undefined && validClerkSubjects === null) {
+    errors.push({
+      code: 'TypeMismatch',
+      path: `${path}.clerk_subjects`,
+      message: `${path}.clerk_subjects must be a non-empty list of unique Clerk user IDs`,
+    })
+    return null
+  }
+
+  return {
+    ...(typeof clerkSubject === 'string' ? { clerk_subject: clerkSubject } : {}),
+    ...(validClerkSubjects ? { clerk_subjects: validClerkSubjects } : {}),
+  }
+}
+
 function parseAccessEntry(
   entry: unknown,
   index: number,
@@ -75,7 +119,6 @@ function parseAccessEntry(
 
   const email = entry['email']
   const profile = entry['profile']
-  const clerkSubject = entry['clerk_subject']
   if (typeof email !== 'string' || email.trim() === '') {
     context.errors.push({
       code: 'MissingField',
@@ -92,17 +135,8 @@ function parseAccessEntry(
     })
     return null
   }
-  if (
-    clerkSubject !== undefined &&
-    (typeof clerkSubject !== 'string' || !/^user_[A-Za-z0-9]+$/.test(clerkSubject))
-  ) {
-    context.errors.push({
-      code: 'TypeMismatch',
-      path: `${path}.clerk_subject`,
-      message: `${path}.clerk_subject must be a Clerk user ID`,
-    })
-    return null
-  }
+  const subjects = parseClerkSubjects(entry, path, context.errors)
+  if (!subjects) return null
   if (!context.authoredEmails.has(email)) {
     context.errors.push({
       code: 'EnumViolation',
@@ -132,7 +166,7 @@ function parseAccessEntry(
   return {
     email,
     profile,
-    ...(typeof clerkSubject === 'string' ? { clerk_subject: clerkSubject } : {}),
+    ...subjects,
   }
 }
 

--- a/src/lib/operator/customer-yaml/types.ts
+++ b/src/lib/operator/customer-yaml/types.ts
@@ -739,6 +739,7 @@ export interface McpConnectorAccess {
   email: string
   profile: string
   clerk_subject?: string
+  clerk_subjects?: string[]
 }
 
 /**

--- a/src/lib/operator/mcp/customer-resolution.ts
+++ b/src/lib/operator/mcp/customer-resolution.ts
@@ -75,16 +75,18 @@ function resolvePrincipals(
   const usersByEmail = new Map(userRows.map((user) => [user.email.toLowerCase(), user]))
   return connector.access.flatMap((entry) => {
     const user = usersByEmail.get(entry.email.toLowerCase())
-    const clerkUserId = entry.clerk_subject ?? user?.clerk_user_id
-    if (!user || !clerkUserId) return []
-    return [
-      {
-        localUserId: user.id,
-        clerkUserId,
-        email: user.email,
-        profile: entry.profile,
-      },
-    ]
+    if (!user) return []
+    const clerkUserIds = [
+      ...(entry.clerk_subjects ?? []),
+      ...(entry.clerk_subject ? [entry.clerk_subject] : []),
+      ...(entry.clerk_subject || entry.clerk_subjects ? [] : [user.clerk_user_id]),
+    ].filter((subject): subject is string => subject !== null)
+    return [...new Set(clerkUserIds)].map((clerkUserId) => ({
+      localUserId: user.id,
+      clerkUserId,
+      email: user.email,
+      profile: entry.profile,
+    }))
   })
 }
 

--- a/src/lib/operator/mcp/token-validation.ts
+++ b/src/lib/operator/mcp/token-validation.ts
@@ -82,11 +82,14 @@ function validateClaims(
   if (claims.iss !== customer.clerk.issuer) {
     return { ok: false, reason: 'wrong_issuer', detail: 'token issuer does not match resource' }
   }
-  if (!audIncludes(claims.aud, customer.clerk.resourceUri)) {
+  // Clerk DCR JWTs currently omit aud. In that shape, the exact issuer plus the
+  // customer-scoped subject allowlist below form the isolation boundary. A
+  // present audience remains authoritative and must match this resource.
+  if (claims.aud && !audIncludes(claims.aud, customer.clerk.resourceUri)) {
     return {
       ok: false,
       reason: 'wrong_audience',
-      detail: claims.aud ? 'token is bound to another resource' : 'token has no audience claim',
+      detail: 'token is bound to another resource',
       subject: claims.sub,
       tokenAudience: normalizeAudience(claims.aud),
     }

--- a/src/lib/portal/customer-config.ts
+++ b/src/lib/portal/customer-config.ts
@@ -185,6 +185,10 @@ const mcpConnectorAccessSchema = z.object({
     .string()
     .regex(/^user_[A-Za-z0-9]+$/)
     .optional(),
+  clerk_subjects: z
+    .array(z.string().regex(/^user_[A-Za-z0-9]+$/))
+    .min(1)
+    .optional(),
 })
 
 /**

--- a/tests/customer-config-projection.test.ts
+++ b/tests/customer-config-projection.test.ts
@@ -81,7 +81,7 @@ describe('customer-config projection: real smd yaml', () => {
       {
         email: 'scott@smd.services',
         profile: 'crane',
-        clerk_subject: 'user_3E1RPGrTMxkSqciXMTyybUNSJWu',
+        clerk_subjects: ['user_3EEs0aMBRgu6PRxBa4g5YhHjggD', 'user_3E1RPGrTMxkSqciXMTyybUNSJWu'],
       },
     ])
   })

--- a/tests/customer-yaml-validator.test.ts
+++ b/tests/customer-yaml-validator.test.ts
@@ -1522,6 +1522,47 @@ describe('validate — mcp_connector', () => {
     })
   })
 
+  it('accepts multiple customer-scoped Clerk subjects', () => {
+    const f = validFixture()
+    f['mcp_connector'] = {
+      enabled: true,
+      access: [
+        {
+          email: 'partner@firm.com',
+          profile: 'marcus',
+          clerk_subjects: ['user_primary', 'user_secondary'],
+        },
+      ],
+    }
+    const r = validate(f)
+    if (!r.ok) throw new Error(`expected ok; got: ${JSON.stringify(r.errors)}`)
+    expect(r.value.mcp_connector.access[0]).toMatchObject({
+      clerk_subjects: ['user_primary', 'user_secondary'],
+    })
+  })
+
+  it('rejects duplicate Clerk subjects', () => {
+    const f = validFixture()
+    f['mcp_connector'] = {
+      enabled: true,
+      access: [
+        {
+          email: 'partner@firm.com',
+          profile: 'marcus',
+          clerk_subjects: ['user_duplicate', 'user_duplicate'],
+        },
+      ],
+    }
+    const r = validate(f)
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(
+      r.errors.some(
+        (e) => e.path === 'mcp_connector.access[0].clerk_subjects' && e.code === 'TypeMismatch'
+      )
+    ).toBe(true)
+  })
+
   it('rejects a malformed Clerk subject', () => {
     const f = validFixture()
     f['mcp_connector'] = {

--- a/tests/operator-mcp-endpoint.test.ts
+++ b/tests/operator-mcp-endpoint.test.ts
@@ -216,12 +216,24 @@ describe('validateMcpToken', () => {
   it.each([
     ['wrong_issuer', claims({ iss: 'https://other.example' })],
     ['wrong_audience', claims({ aud: 'https://smd.services/api/operator/other/mcp' })],
-    ['wrong_audience', claims({ aud: undefined })],
     ['claims_invalid', claims({ sub: undefined })],
     ['identity_not_authored', claims({ sub: 'user_unknown' })],
   ])('rejects %s', async (reason, payload) => {
     const result = await validateMcpToken('token', customerFixture(), claimsVerifier(payload))
     expect(result).toMatchObject({ ok: false, reason })
+  })
+
+  it('accepts Clerk DCR tokens without an audience after issuer and subject checks', async () => {
+    const result = await validateMcpToken(
+      'token',
+      customerFixture(),
+      claimsVerifier(claims({ aud: undefined }))
+    )
+    expect(result).toMatchObject({
+      ok: true,
+      subject: CLERK_USER_ID,
+      tokenAudience: [],
+    })
   })
 
   it('returns the verified audience when the resource audience is wrong', async () => {
@@ -345,6 +357,34 @@ describe('loadMcpCustomer and migration 0072', () => {
       clerkUserId: 'user_externalaccount',
       email: 'pilot@example.com',
     })
+  })
+
+  it('resolves multiple approved Clerk subjects to one local customer user', async () => {
+    await db
+      .prepare('UPDATE customer_configs SET mcp_connector_json = ? WHERE entity_id = ?')
+      .bind(
+        JSON.stringify({
+          enabled: true,
+          data_posture: 'open',
+          access: [
+            {
+              email: 'pilot@example.com',
+              profile: 'crane',
+              clerk_subjects: ['user_primary', 'user_secondary'],
+            },
+          ],
+        }),
+        ENTITY_ID
+      )
+      .run()
+    const customer = await loadMcpCustomer(db, 'smd')
+    expect(customer?.principals.map((principal) => principal.clerkUserId)).toEqual([
+      'user_primary',
+      'user_secondary',
+    ])
+    expect(customer?.principals.every((principal) => principal.localUserId === LOCAL_USER_ID)).toBe(
+      true
+    )
   })
 
   it('returns null for unknown or malformed customer slugs', async () => {


### PR DESCRIPTION
## Summary
- accept Clerk DCR JWTs that omit `aud` only after exact issuer and authored-subject validation
- continue rejecting every non-empty audience that does not match the MCP resource URI
- allow multiple explicit Clerk subjects to map to one local Operator user
- authorize both known Scott Clerk accounts for SMD customer-zero

## Verification
- 297 focused tests passed
- changed files pass ESLint and Prettier
- diff check passed