### PR TITLE
fix(test): WorkflowEvent type mismatch blocking typecheck

### DIFF
--- a/tests/enrichment-workflow.test.ts
+++ b/tests/enrichment-workflow.test.ts
@@ -134,7 +134,6 @@ async function runWorkflow(
     payload: params,
     timestamp: new Date(),
     instanceId: 'test-instance',
-    workflowName: 'enrichment-workflow',
   }
   await wf.run(event, step as never)
   return { stats }


### PR DESCRIPTION
## Problem

`npm run typecheck` failed with one error, blocking CI on every team PR:

```
tests/enrichment-workflow.test.ts:137:5 - error ts(2353): Object literal may only specify known properties, and 'workflowName' does not exist in type 'WorkflowEvent<EnrichmentWorkflowParams>'.
```

## Root cause (verified, not a worktree/node_modules artifact)

The test built a `WorkflowEvent` literal with a `workflowName` property. The real type from `cloudflare:workers` has exactly three properties:

```ts
export type WorkflowEvent<T> = {
  payload: Readonly<T>;
  timestamp: Date;
  instanceId: string;
};
```

Confirmed against `@cloudflare/workers-types/2023-07-01` — the version `tsconfig.json` pins via `"types": ["@cloudflare/workers-types/2023-07-01"]`. `workflowName` exists in **no** version of the type, and `EnrichmentWorkflow.run()` never reads `event.workflowName` — the property was dead. It entered via #1392.

## Fix

Remove the stray `workflowName` line. Minimal, one-line deletion in test-only code; no workflow types touched.

## Verification

- `npm run typecheck` → **0 errors** (was 1).
- `npx vitest run tests/enrichment-workflow.test.ts` → **8/8 pass** (behavior unchanged; the property was never read).
- Pre-push typecheck hook now passes (it blocked the earlier docs PR #1402, which had to use `--no-verify`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)