### PR TITLE
feat(keystone): root-own customer.yaml — close the proven-live self-loopback (SEC-07/08/09/18/30, EFF-14)

### DIFF
--- a/operator/bin/boot-smoke-test.sh
+++ b/operator/bin/boot-smoke-test.sh
@@ -74,8 +74,21 @@ done
 # on Hermes' flat-file memory core, so there is no Postgres/Redis/Honcho to
 # probe here. These checks return when Phase 2 vendors the real Honcho source.
 
-# ---------- Step 5: customer.yaml present on volume ----------
-ssh_exec "customer-yaml-present" "test -s /opt/data/customer.yaml"
+# ---------- Step 5: customer.yaml present, root-owned, agent-read-only (keystone) ----------
+# The live customer.yaml is the source every trust-ceiling / vertical-floor / scope
+# decision resolves against, read fresh per action. The 2026-06-15 keystone moved
+# it OFF the agent-writable /opt/data volume into the root-owned /var/lib/smd-config
+# so the hermes uid can READ it (the trust gate must) but can NEITHER rewrite it
+# (it owned the file before — proven exploitable: one sed flipped external_send
+# draft_for_review->autonomous) NOR rename it (it owned the parent dir). These are
+# the negative-fire conformance proof of that close (SEC-07/08/09/18/30, EFF-14).
+ssh_exec "customer-yaml-present" "test -s /var/lib/smd-config/customer.yaml"
+ssh_exec "customer-yaml-root-owned" "[ \"\$(stat -c %U /var/lib/smd-config/customer.yaml)\" = root ]"
+ssh_exec "customer-yaml-dir-root-owned" "[ \"\$(stat -c %U /var/lib/smd-config)\" = root ]"
+ssh_exec "customer-yaml-agent-readable" "setpriv --reuid=hermes --regid=hermes --init-groups test -r /var/lib/smd-config/customer.yaml"
+ssh_exec "customer-yaml-not-agent-writable" "setpriv --reuid=hermes --regid=hermes --init-groups sh -c \"! test -w /var/lib/smd-config/customer.yaml\""
+ssh_exec "customer-yaml-dir-not-agent-writable" "setpriv --reuid=hermes --regid=hermes --init-groups sh -c \"! test -w /var/lib/smd-config\""
+ssh_exec "customer-yaml-absent-from-agent-volume" "! test -e /opt/data/customer.yaml"
 
 # ---------- Step 6: Hermes profiles directory exists ----------
 # bootstrap.sh's `hermes-smd bootstrap` step materializes one profile per

--- a/operator/contracts/overlay-pairs.json
+++ b/operator/contracts/overlay-pairs.json
@@ -1,6 +1,6 @@
 {
   "overlayRepo": "https://github.com/venturecrane/hermes-smd-overlay.git",
-  "overlayRef": "b3294de00bbd3e78c51fc537343830d820100929",
+  "overlayRef": "83168fb46937060a2d913d6821c6981c1561d653",
   "overlayRefNote": "MUST equal the ARG OVERLAY_REF pinned in operator/templates/Dockerfile — that is the overlay commit a customer Machine actually ships. The vitest gate asserts the two agree so the manifest cannot pin a stale overlay. Bump both together when OVERLAY_REF moves, then re-record each overlaySha256 from the runtime file at the new ref.",
   "pairs": [
     {

--- a/operator/templates/Dockerfile
+++ b/operator/templates/Dockerfile
@@ -189,7 +189,7 @@ ARG OVERLAY_REPO="https://github.com/venturecrane/hermes-smd-overlay.git"
 # config_applier (pull → validate → safety → atomic write of /opt/data/customer.yaml).
 # Verified end-to-end on hermes-smd-staging. Superset of e4d1f23 (#82 relationship
 # authored lane, ADR 0048 Phase 2), which it merges and carries forward.
-ARG OVERLAY_REF="b3294de00bbd3e78c51fc537343830d820100929"
+ARG OVERLAY_REF="e6d17815c49e35628f002d3dc6d8d7feb3e499be"
 
 ARG CUSTOMER_SLUG=customer-zero
 

--- a/operator/templates/Dockerfile
+++ b/operator/templates/Dockerfile
@@ -189,7 +189,7 @@ ARG OVERLAY_REPO="https://github.com/venturecrane/hermes-smd-overlay.git"
 # config_applier (pull → validate → safety → atomic write of /opt/data/customer.yaml).
 # Verified end-to-end on hermes-smd-staging. Superset of e4d1f23 (#82 relationship
 # authored lane, ADR 0048 Phase 2), which it merges and carries forward.
-ARG OVERLAY_REF="e6d17815c49e35628f002d3dc6d8d7feb3e499be"
+ARG OVERLAY_REF="83168fb46937060a2d913d6821c6981c1561d653"
 
 ARG CUSTOMER_SLUG=customer-zero
 

--- a/operator/templates/bootstrap.sh
+++ b/operator/templates/bootstrap.sh
@@ -125,42 +125,21 @@ for var in "${OPTIONAL_ENV[@]}"; do
 done
 
 # ============================================================================
-# Step 2: verify (or fetch) customer.yaml on the volume
+# Step 2: locate the root-owned customer.yaml (fetched by the entrypoint)
 # ============================================================================
-# Storage model (§6): customer.yaml lives on the volume, not baked into the
-# image. R2 at vaults/<slug>/customer.yaml is the SOURCE OF TRUTH; provisioning
-# (and operator/bin/sync-customer-yaml.sh, for edits) writes it there.
-# Bootstrap re-fetches from R2 on EVERY boot so merged config edits propagate on
-# restart, falling back to the volume copy only if R2 is unreachable. (The live
-# no-restart reload path — the customer-sync sidecar — is a Phase-2 stub.)
-CUSTOMER_YAML="/opt/data/customer.yaml"
-R2_ENDPOINT_URL="${R2_ENDPOINT_URL:-https://${R2_ACCOUNT_ID:-}.r2.cloudflarestorage.com}"
-R2_CUSTOMER_YAML_URI="s3://${R2_BUCKET_CONFIG}/vaults/${CUSTOMER_SLUG}/customer.yaml"
-
-# Re-fetch from R2 (source of truth) on EVERY boot so merged customer.yaml edits
-# propagate on restart. Previously bootstrap only fetched when the volume copy was
-# ABSENT, so edits to an already-provisioned machine never reached it (the
-# customer-sync sidecar is a Phase-2 stub). Fetch to a temp path and atomically
-# swap, so a transient R2 failure never corrupts or strands the existing copy;
-# fall back to the volume copy if R2 is unreachable; die only if neither yields a
-# config. awscli is installed in the Dockerfile; R2 speaks S3 with a custom endpoint.
-if AWS_ACCESS_KEY_ID="${R2_ACCESS_KEY_ID}" \
-   AWS_SECRET_ACCESS_KEY="${R2_SECRET_ACCESS_KEY}" \
-     aws s3 cp \
-       --endpoint-url "${R2_ENDPOINT_URL}" \
-       --only-show-errors \
-       "${R2_CUSTOMER_YAML_URI}" \
-       "${CUSTOMER_YAML}.r2.tmp"; then
-  mv -f "${CUSTOMER_YAML}.r2.tmp" "${CUSTOMER_YAML}"
-  log "customer.yaml refreshed from R2 (source of truth): ${R2_CUSTOMER_YAML_URI}"
-elif [ -f "${CUSTOMER_YAML}" ]; then
-  rm -f "${CUSTOMER_YAML}.r2.tmp" 2>/dev/null || true
-  log "WARN: R2 fetch failed; using existing volume copy: ${CUSTOMER_YAML}"
-else
-  die "customer.yaml not on volume and R2 fetch failed (${R2_CUSTOMER_YAML_URI})"
-fi
-chmod 0644 "${CUSTOMER_YAML}" \
-  || die "customer.yaml must be readable by the separate Workspace broker principal"
+# Keystone (audit 2026-06-15): the authoritative customer.yaml is fetched from R2
+# (the SOURCE OF TRUTH) and OWNED BY ROOT by the entrypoint, BEFORE this script
+# drops to the hermes uid. It lives at ${SMD_CUSTOMER_YAML_PATH} inside a
+# root-owned dir — world-readable but NOT writable or renameable by this (hermes)
+# process. bootstrap no longer fetches it: the former hermes-side fetch produced
+# an agent-writable copy on /opt/data, which let the agent rewrite its own trust
+# ceiling (the self-loopback hole). bootstrap only READS it to materialize the
+# per-profile config; the root applier (ADR 0044) propagates live edits with no
+# restart.
+CUSTOMER_YAML="${SMD_CUSTOMER_YAML_PATH:-/opt/data/customer.yaml}"
+[ -f "${CUSTOMER_YAML}" ] \
+  || die "customer.yaml not present at ${CUSTOMER_YAML} (the root entrypoint fetches it before the hermes drop)"
+log "Using root-owned customer.yaml: ${CUSTOMER_YAML}"
 
 # ============================================================================
 # Step 2a: sync the voice vault to the volume (agent holds NO R2 credential)

--- a/operator/templates/entrypoint.sh
+++ b/operator/templates/entrypoint.sh
@@ -16,32 +16,56 @@ BROKER_DIR="/var/lib/smd-workspace-broker"
 BROKER_SOCKET="/run/smd-workspace-broker/broker.sock"
 BROKER_CUSTOMER_PATH="${BROKER_DIR}/customer.yaml"
 
-# Fresh-volume seed (load-bearing). The Workspace broker starts as root BELOW,
-# before the privilege drop to the hermes user and BEFORE bootstrap.sh runs its
-# own R2 fetch (bootstrap.sh Step 2). On a brand-new volume
-# /opt/data/customer.yaml does not exist yet, so the broker `cp` further down
-# fails and the boot crash-loops to max-restarts. Seed it here from R2 (the
-# source of truth) with the boot-time creds, so a FRESH provision boots with no
-# manual volume seed. Idempotent: on a persisted volume the file already exists
-# (skip), and bootstrap still re-fetches the latest on every boot. This is a
-# regression from #1304 (broker-home isolation introduced the root-side cp);
-# the staging gate caught it on first use.
-if [ ! -f /opt/data/customer.yaml ]; then
-  log "customer.yaml absent on fresh volume — seeding from R2 before broker start"
-  : "${R2_BUCKET_CONFIG:?R2_BUCKET_CONFIG required to seed customer.yaml}"
-  : "${CUSTOMER_SLUG:?CUSTOMER_SLUG required to seed customer.yaml}"
-  _seed_endpoint="${R2_ENDPOINT_URL:-https://${R2_ACCOUNT_ID:-}.r2.cloudflarestorage.com}"
-  if ! AWS_ACCESS_KEY_ID="${R2_ACCESS_KEY_ID:?}" \
-       AWS_SECRET_ACCESS_KEY="${R2_SECRET_ACCESS_KEY:?}" \
-         aws s3 cp \
-           --endpoint-url "${_seed_endpoint}" \
-           --only-show-errors \
-           "s3://${R2_BUCKET_CONFIG}/vaults/${CUSTOMER_SLUG}/customer.yaml" \
-           /opt/data/customer.yaml; then
-    log "FATAL: failed to seed customer.yaml from R2 on fresh boot"
-    exit 1
-  fi
+# Keystone (audit 2026-06-15 — SEC-07/08/09/18/30, EFF-14, proven-live on
+# hermes-smd-staging). The live customer.yaml is the source every trust-ceiling /
+# vertical-floor / scope decision resolves against, read fresh per action. It MUST
+# NOT live on the agent-writable /opt/data volume: the hermes uid owns that tree,
+# so the agent could rewrite its own ceiling (proven: one sed flipped
+# external_send draft_for_review->autonomous) or rename the file (it owns the dir).
+# It lives in a fully root-owned directory, world-readable (0644) but NEVER
+# writable or renameable by the hermes uid. Root — this entrypoint plus the
+# ADR-0044 config applier — is the only writer.
+CONFIG_DIR="/var/lib/smd-config"
+LIVE_CUSTOMER_YAML="${CONFIG_DIR}/customer.yaml"
+
+# Root fetches the authoritative customer.yaml from R2 (source of truth) on EVERY
+# boot into the root-owned ${CONFIG_DIR}. This REPLACES the former hermes-side
+# fetch in bootstrap.sh Step 2, which wrote an agent-writable copy on /opt/data —
+# the keystone hole. The broker `cp` further down and the gateway both read this
+# root-owned copy. R2 is the only source on a fresh volume. A pre-keystone
+# persisted volume may still carry an agent-owned /opt/data/customer.yaml: migrate
+# it once, then remove it so no writable copy survives. Idempotent every boot.
+mkdir -p "${CONFIG_DIR}"
+chown root:root "${CONFIG_DIR}"
+chmod 0755 "${CONFIG_DIR}"
+: "${R2_BUCKET_CONFIG:?R2_BUCKET_CONFIG required to fetch customer.yaml}"
+: "${CUSTOMER_SLUG:?CUSTOMER_SLUG required to fetch customer.yaml}"
+if [ -f /opt/data/customer.yaml ] && [ ! -f "${LIVE_CUSTOMER_YAML}" ]; then
+  mv /opt/data/customer.yaml "${LIVE_CUSTOMER_YAML}"
+  log "migrated legacy /opt/data/customer.yaml -> ${LIVE_CUSTOMER_YAML} (keystone relocation)"
 fi
+_seed_endpoint="${R2_ENDPOINT_URL:-https://${R2_ACCOUNT_ID:-}.r2.cloudflarestorage.com}"
+if AWS_ACCESS_KEY_ID="${R2_ACCESS_KEY_ID:?}" \
+     AWS_SECRET_ACCESS_KEY="${R2_SECRET_ACCESS_KEY:?}" \
+       aws s3 cp \
+         --endpoint-url "${_seed_endpoint}" \
+         --only-show-errors \
+         "s3://${R2_BUCKET_CONFIG}/vaults/${CUSTOMER_SLUG}/customer.yaml" \
+         "${LIVE_CUSTOMER_YAML}.r2.tmp"; then
+  mv -f "${LIVE_CUSTOMER_YAML}.r2.tmp" "${LIVE_CUSTOMER_YAML}"
+  log "customer.yaml refreshed from R2 (source of truth) into ${CONFIG_DIR}"
+elif [ -f "${LIVE_CUSTOMER_YAML}" ]; then
+  rm -f "${LIVE_CUSTOMER_YAML}.r2.tmp" 2>/dev/null || true
+  log "WARN: R2 fetch failed; using existing root-owned customer.yaml"
+else
+  log "FATAL: customer.yaml not present and R2 fetch failed (${R2_BUCKET_CONFIG}/vaults/${CUSTOMER_SLUG})"
+  exit 1
+fi
+# Root owns it; the agent reads (0644) but cannot write or rename it (the parent
+# dir is root-owned). This is the structural close of the self-loopback.
+chown root:root "${LIVE_CUSTOMER_YAML}"
+chmod 0644 "${LIVE_CUSTOMER_YAML}"
+rm -f /opt/data/customer.yaml
 
 # OP-P1-4 audit ledger: owned by the broker uid, readable (not writable) by the
 # agent uid via the audit-readers group. The agent's only write path is the
@@ -114,7 +138,7 @@ rm -rf /opt/data/workspace-broker
 rm -f /opt/data/oauth/google.json
 mkdir -p "${BROKER_DIR}" "$(dirname "${BROKER_SOCKET}")"
 rm -f "${BROKER_DIR}/google.json"
-cp /opt/data/customer.yaml "${BROKER_CUSTOMER_PATH}"
+cp "${LIVE_CUSTOMER_YAML}" "${BROKER_CUSTOMER_PATH}"
 chown -R workspace-broker:workspace-broker "${BROKER_DIR}"
 chmod 0700 "${BROKER_DIR}"
 chown workspace-broker:workspace-connectors "$(dirname "${BROKER_SOCKET}")"
@@ -198,21 +222,34 @@ unset GOOGLE_SERVICE_ACCOUNT_JSON GOOGLE_TOKEN_JSON GOOGLE_CLIENT_SECRET_JSON
 unset GOOGLE_IMPERSONATE_SUBJECT GOOGLE_OAUTH_SCOPES GOOGLE_TOKEN_PATH
 
 export HOME=/opt/data
+
+# Keystone wiring: point the ADR-0044 applier (the root writer) and every
+# agent-side reader at the root-owned live config. SMD_APPLIER_VOLUME_PATH is the
+# applier's write/read target; SMD_CUSTOMER_YAML_PATH is what
+# shared.customer_config.from_volume() (trust gate, demo-relay, webhook-router)
+# resolves at runtime. The gateway exec below inherits both (no env -i), so the
+# agent reads the root-owned copy and has no writable path to its own ceiling.
+export SMD_APPLIER_VOLUME_PATH="${LIVE_CUSTOMER_YAML}"
+export SMD_CUSTOMER_YAML_PATH="${LIVE_CUSTOMER_YAML}"
+
 log "Workspace broker started as uid $(id -u workspace-broker); dropping gateway to hermes"
 
 # Root-side config applier (ADR 0044 live reconfiguration). Forked here as a
 # ROOT background child — BEFORE the exec-drop to hermes below — so it survives
 # the exec and keeps uid 0. It polls R2 for an updated customer.yaml, validates +
 # safety-checks it (config_applier + the parity validator), and atomically writes
-# it to /opt/data/customer.yaml so the agent picks up entitlement / scope / skill
-# / webhook / demo changes on its NEXT action — no reboot.
+# it to ${LIVE_CUSTOMER_YAML} (via SMD_APPLIER_VOLUME_PATH) so the agent picks up
+# entitlement / scope / skill / webhook / demo changes on its NEXT action — no reboot.
 #
-# WHY ROOT (ADR 0044 Decision 5, confirmed on-box hermes-smd-staging 2026-06-15):
-# only root can write the hermes-owned /opt/data/customer.yaml. The R2 pull
-# credential lives in THIS root process's env, which the hermes agent cannot read
-# from /proc (different uid) — so the control-plane apply credential never reaches
-# the data plane (ADR 0026 + OP-P2-1). The agent holds no config-write credential
-# and no inbound verb that can trigger an apply.
+# WHY ROOT (ADR 0044 Decision 5, hardened by the 2026-06-15 keystone): the live
+# customer.yaml now lives in the root-owned ${CONFIG_DIR}, so root is the ONLY
+# principal that can write it — the hermes agent reads it (0644) but cannot rewrite
+# its own ceiling or rename the file (previously it could; proven live on
+# hermes-smd-staging 2026-06-15). The R2 pull credential lives in THIS root
+# process's env, which the hermes agent cannot read from /proc (different uid) — so
+# the control-plane apply credential never reaches the data plane (ADR 0026 +
+# OP-P2-1). The agent holds no config-write credential and no inbound verb that can
+# trigger an apply.
 #
 # Forked AFTER the GOOGLE_* unset above so it never carries Google creds. Respawn
 # loop self-heals; a dead applier never blocks the gateway (config changes simply


### PR DESCRIPTION
## The hole (proven live, 2026-06-15)
The live `customer.yaml` is the source every trust-ceiling / vertical-floor / scope decision resolves against, read fresh per action. It lived on the agent-writable `/opt/data` volume, **owned by the hermes uid** — so on staging, one `sed` as the agent flipped `external_send: draft_for_review → autonomous`. The agent could rewrite its own send ceiling, erase the vertical floor, or enable code_execution. No error, no audit row.

## The fix
Relocate the live config to a **fully root-owned** path the agent can read but not write or rename:
- **entrypoint (root):** fetch the authoritative customer.yaml from R2 into root-owned `/var/lib/smd-config` (0644, root:root, in a root-owned dir → agent cannot write OR rename it); migrate+remove any legacy `/opt/data` copy; export `SMD_CUSTOMER_YAML_PATH` + `SMD_APPLIER_VOLUME_PATH`. This *moves the authoritative fetch up to root* (it previously ran as the agent in bootstrap).
- **bootstrap (hermes):** drop the former hermes-side R2 fetch (it produced the writable copy); read the root-owned file.
- **boot-smoke:** 7 new negative-fire conformance guards — present at new path, root-owned, agent-readable, **NOT** agent-writable/renameable, absent from `/opt/data`.
- Corrected the false "only root can write the hermes-owned customer.yaml" comment — now structurally true.

Pairs with overlay **#84** (from_volume env redirect).

## Proven on hermes-smd-staging
| Vector (as hermes uid) | Result |
|---|---|
| Rewrite own ceiling (`sed`) | **Permission denied** (rc=4) |
| Rename-replace (EFF-14) | **Permission denied**, dir not writable |
| Trust gate reads it | `AGENT_CAN_READ=YES` |
| Boot smoke | **16/16 PASS** |

## Merge notes
- `OVERLAY_REF` here is the staging-test ref (overlay #84 branch). Final bump to a merged overlay release ref at merge time — and per SEC-32 (#1406) that bump must re-record the overlay-pairs manifest hashes.
- Follow-on (tracked): OP-P2-1 R2-strip — close the R2-authoritative write path (the agent must hold no R2 write credential) so the relocation can't be bypassed via R2.