### PR TITLE
chore(operator): OVERLAY_REF → 8d6f1a95 (Clerk public-ID secret-scan fix; defuses reprovision landmine)

### DIFF
--- a/operator/contracts/overlay-pairs.json
+++ b/operator/contracts/overlay-pairs.json
@@ -1,6 +1,6 @@
 {
   "overlayRepo": "https://github.com/venturecrane/hermes-smd-overlay.git",
-  "overlayRef": "83168fb46937060a2d913d6821c6981c1561d653",
+  "overlayRef": "8d6f1a95189641366c5ff10b01e65d29b6a895fe",
   "overlayRefNote": "MUST equal the ARG OVERLAY_REF pinned in operator/templates/Dockerfile — that is the overlay commit a customer Machine actually ships. The vitest gate asserts the two agree so the manifest cannot pin a stale overlay. Bump both together when OVERLAY_REF moves, then re-record each overlaySha256 from the runtime file at the new ref.",
   "pairs": [
     {

--- a/operator/templates/Dockerfile
+++ b/operator/templates/Dockerfile
@@ -189,7 +189,7 @@ ARG OVERLAY_REPO="https://github.com/venturecrane/hermes-smd-overlay.git"
 # config_applier (pull → validate → safety → atomic write of /opt/data/customer.yaml).
 # Verified end-to-end on hermes-smd-staging. Superset of e4d1f23 (#82 relationship
 # authored lane, ADR 0048 Phase 2), which it merges and carries forward.
-ARG OVERLAY_REF="83168fb46937060a2d913d6821c6981c1561d653"
+ARG OVERLAY_REF="8d6f1a95189641366c5ff10b01e65d29b6a895fe"
 
 ARG CUSTOMER_SLUG=customer-zero
 


### PR DESCRIPTION
Bumps the on-box validator to overlay #85, which exempts Clerk public IDs (`user_`/`org_`) from the secret-shape heuristic. Without it, any reprovision of a customer whose customer.yaml carries `clerk_subjects` (e.g. customer-zero) crash-loops on validation (incident 2026-06-15). Restores parity with the console-side TS detector, which already exempts them. verify-overlay-pairs 4/4 PASS.