### PR TITLE
feat(operator): admin Learned-preferences lane (peer_preferences seam)

### DIFF
--- a/src/lib/admin/relationship-observe.ts
+++ b/src/lib/admin/relationship-observe.ts
@@ -2,13 +2,18 @@
  * Relationship-surface view-model for the admin Operator console
  * (`/admin/operator/[customer]/memory`) — ADR 0048.
  *
- * Loads the authored **standing-preferences lane** — the per-person working
- * preferences from the `customer.yaml` `relationship:` block — live across the
- * isolation boundary via the frozen `config_export` read path (ADR 0043 path A,
- * `section=relationship`). That block is the authored *seed* of the per-person
- * working relationship; the learned lane (per-peer working-preference memory on
- * Hermes' native memory loop) and the inferred lane (`persona_observations` /
- * Honcho) are not read here.
+ * Loads two lanes of the working relationship, both live across the isolation
+ * boundary via the frozen runtime-read seam (ADR 0043 path A):
+ *   • the authored **standing-preferences lane** — the per-person working
+ *     preferences from the `customer.yaml` `relationship:` block, read via
+ *     `config_export?section=relationship`. The authored *seed* of the
+ *     per-person working relationship.
+ *   • the **learned-preferences lane** — per-peer working-preference memory the
+ *     operator captured from how each person works with it (stated or
+ *     demonstrated), read via `memory_export?table=peer_preferences` from
+ *     Hermes' native memory loop. Only active rows surface (a superseded row was
+ *     replaced).
+ * The inferred lane (Honcho) is rejected doctrine (2026-06-16) and not read.
  *
  * Same fail-closed discipline as runtime-observe: when the read path is not
  * configured we return `not_enabled` WITHOUT a read (no audit noise on a dark
@@ -98,6 +103,119 @@ export function parseStandingPreferences(data: unknown): StandingPreferencePerso
     })
   }
   return out
+}
+
+/** One active learned preference on the learned lane — a `peer_preferences`
+ * row the operator captured from how a person works with it, served by
+ * `memory_export?table=peer_preferences` (the relationship model's learned
+ * lane on Hermes' native memory loop). `source` records whether the person
+ * stated the preference or the operator demonstrated/observed it. */
+export interface LearnedPreference {
+  preference: string
+  why: string | null
+  howToApply: string | null
+  source: 'stated' | 'demonstrated'
+  recordedAt: string | null
+}
+
+/** One person on the learned lane — keyed by the stable sender id (`peer_id`),
+ * with their active preferences newest-first. No display name: the learned lane
+ * has only the peer id, not an authored name. */
+export interface LearnedPreferencePerson {
+  peerId: string
+  preferences: LearnedPreference[]
+}
+
+export type LearnedPreferencesResult =
+  | { status: 'not_enabled' }
+  | { status: 'unreachable'; reason: string }
+  | { status: 'empty' }
+  | { status: 'items'; people: LearnedPreferencePerson[] }
+
+/**
+ * Load the learned-preferences lane (per-peer working-preference memory) for one
+ * customer. Same fail-closed discipline as {@link loadStandingPreferences}: no
+ * read (and no audit row) when the seam is unconfigured; otherwise reads
+ * `memory_export?table=peer_preferences` via the fail-closed seam and classifies
+ * the outcome. The Machine serves the live `peer_preferences` table, so this is
+ * what the running Operator has actually learned — not a console copy.
+ */
+export async function loadLearnedPreferences(
+  deps: RuntimeReadDeps,
+  customerSlug: string,
+  actor: RuntimeReadActor,
+  configured: boolean
+): Promise<LearnedPreferencesResult> {
+  if (!configured) return { status: 'not_enabled' }
+  const result = await readMachineRuntime(
+    deps,
+    customerSlug,
+    { kind: 'memory_export', table: 'peer_preferences' },
+    actor
+  )
+  if (!result.ok) return { status: 'unreachable', reason: result.reason }
+  const people = parseLearnedPreferences(result.data)
+  return people.length === 0 ? { status: 'empty' } : { status: 'items', people }
+}
+
+/**
+ * Parse the opaque `memory_export` payload (`{ entries: [...] }`) into people
+ * with their active learned preferences. Defensive by construction:
+ *   • a row missing `peer_id` or `preference` is skipped (never half-rendered);
+ *   • a row whose `superseded_by` is non-null was replaced — it is filtered out
+ *     so only ACTIVE preferences surface;
+ *   • `source` must be one of the two valid values (`stated`/`demonstrated`); a
+ *     row with any other source is skipped rather than mislabeled;
+ *   • `why`/`how_to_apply`/`recorded_at` normalize to `null`.
+ * Rows are grouped by `peer_id` and each person's list is sorted newest-first by
+ * `recorded_at` (a null `recorded_at` sorts last). Total on malformed payloads
+ * (null/garbage → `[]`). The console never trusts the wire shape — parse, never
+ * cast (coding-standards: parse external inputs).
+ */
+export function parseLearnedPreferences(data: unknown): LearnedPreferencePerson[] {
+  const byPeer = new Map<string, LearnedPreference[]>()
+  for (const entry of extractEntries(data)) {
+    if (!entry || typeof entry !== 'object') continue
+    const row = entry as Record<string, unknown>
+    if (asStringOrNull(row.superseded_by) !== null) continue
+    const peerId = asNonEmptyString(row.peer_id)
+    const preference = asNonEmptyString(row.preference)
+    if (peerId === null || preference === null) continue
+    const source = asLearnedSource(row.source)
+    if (source === null) continue
+    const pref: LearnedPreference = {
+      preference,
+      why: asStringOrNull(row.why),
+      howToApply: asStringOrNull(row.how_to_apply),
+      source,
+      recordedAt: asStringOrNull(row.recorded_at),
+    }
+    const list = byPeer.get(peerId)
+    if (list) list.push(pref)
+    else byPeer.set(peerId, [pref])
+  }
+  const out: LearnedPreferencePerson[] = []
+  for (const [peerId, preferences] of byPeer) {
+    preferences.sort(byRecordedAtDescending)
+    out.push({ peerId, preferences })
+  }
+  return out
+}
+
+/** Newest-first by `recordedAt`. A null `recordedAt` (unknown time) sorts last,
+ * so dated preferences always lead. */
+function byRecordedAtDescending(a: LearnedPreference, b: LearnedPreference): number {
+  if (a.recordedAt === null && b.recordedAt === null) return 0
+  if (a.recordedAt === null) return 1
+  if (b.recordedAt === null) return -1
+  if (a.recordedAt < b.recordedAt) return 1
+  if (a.recordedAt > b.recordedAt) return -1
+  return 0
+}
+
+/** Coerce an unknown to one of the two valid `source` values, or null. */
+function asLearnedSource(v: unknown): 'stated' | 'demonstrated' | null {
+  return v === 'stated' || v === 'demonstrated' ? v : null
 }
 
 /** Pull the row list from the seam payload shape (`{ entries: [...] }`). */

--- a/src/lib/operator/runtime-read.ts
+++ b/src/lib/operator/runtime-read.ts
@@ -29,8 +29,9 @@
  * read-only endpoint on the Machine. Extend as drill-in surfaces are added.
  *
  * `memory_export` serves an allow-listed Machine-local memory table one at a
- * time via the `table` query field (ADR 0016 mirror tables + `voice_corrections`,
- * the relationship model's style lane per ADR 0048). The Machine refuses any
+ * time via the `table` query field (ADR 0016 mirror tables + `peer_preferences`,
+ * the relationship model's learned lane — per-peer working-preference memory the
+ * operator captured on Hermes' native memory loop). The Machine refuses any
  * table outside its allow-list.
  *
  * `config_export` serves an allow-listed authored CONTENT block from the live
@@ -58,7 +59,7 @@ export interface RuntimeReadQuery {
   /** Page size hint for list kinds; the Machine clamps it. */
   limit?: number | null
   /** Allow-listed table name for the `memory_export` kind (e.g.
-   * `voice_corrections`); ignored by other kinds. The Machine refuses any
+   * `peer_preferences`); ignored by other kinds. The Machine refuses any
    * table outside its allow-list. */
   table?: string | null
   /** Allow-listed section name for the `config_export` kind (e.g.

--- a/src/pages/admin/operator/[customer]/memory.astro
+++ b/src/pages/admin/operator/[customer]/memory.astro
@@ -3,7 +3,9 @@ import AdminLayout from '../../../../layouts/AdminLayout.astro'
 import { resolveEntityIdBySlug } from '../../../../lib/admin/operator-overview'
 import {
   loadStandingPreferences,
+  loadLearnedPreferences,
   type StandingPreferencesResult,
+  type LearnedPreferencesResult,
 } from '../../../../lib/admin/relationship-observe'
 import {
   isRuntimeReadConfigured,
@@ -22,8 +24,11 @@ import { env } from 'cloudflare:workers'
  *     `config_export` seam (ADR 0043 path A). The authored seed of the
  *     relationship.
  *   • Learned — per-peer working-preference memory on Hermes' native memory
- *     loop (forthcoming; not read here yet).
- *   • Inferred — Honcho conclusions (deferred, ADR 0016).
+ *     loop, read live via `memory_export?table=peer_preferences`. Stated or
+ *     demonstrated preferences the operator captured from how each person works
+ *     with it; only active (non-superseded) rows surface.
+ *   • Inferred — Honcho conclusions are rejected doctrine (2026-06-16); no
+ *     inferred lane is rendered.
  *
  * Read-only and fail-closed: the authored lane renders `not_enabled` WITHOUT a
  * read when the seam is unconfigured (no audit noise). Relationship state is
@@ -42,6 +47,7 @@ const notFound = entityId === null
 
 const configured = isRuntimeReadConfigured(env)
 let standing: StandingPreferencesResult = { status: 'not_enabled' }
+let learned: LearnedPreferencesResult = { status: 'not_enabled' }
 if (!notFound) {
   const deps = {
     transport: createMachineRuntimeTransport(env),
@@ -49,6 +55,7 @@ if (!notFound) {
   }
   const who = { actor: session.email, actorRole: session.role }
   standing = await loadStandingPreferences(deps, slug, who, configured)
+  learned = await loadLearnedPreferences(deps, slug, who, configured)
 }
 ---
 
@@ -160,16 +167,67 @@ if (!notFound) {
             )}
           </section>
 
-          {/* Lane 2 — Inferred observations (Honcho, deferred) */}
-          <section class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card">
-            <h3 class="text-base font-semibold text-[color:var(--ss-color-text-primary)]">
-              Inferred observations
-            </h3>
-            <p class="text-sm text-[color:var(--ss-color-text-secondary)] mt-1">
-              Patterns the operator infers from conversation (with their evidence status, and SMD
-              dismiss) appear here when Honcho memory lands — Phase 2, ADR 0016. Until then this
-              lane is deliberately dark rather than fabricated.
-            </p>
+          {/* Lane 2 — Learned preferences (peer_preferences memory — what the operator captured) */}
+          <section class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card space-y-stack">
+            <div>
+              <h3 class="text-base font-semibold text-[color:var(--ss-color-text-primary)]">
+                Learned preferences
+              </h3>
+              <p class="text-sm text-[color:var(--ss-color-text-secondary)] mt-1">
+                Preferences the operator captured from how each person works with it, whether they
+                stated it or the operator demonstrated it over time. Read live from the running
+                operator. Everything here is reversible and inspectable.
+              </p>
+            </div>
+
+            {learned.status === 'not_enabled' ? (
+              <p class="text-xs text-[color:var(--ss-color-text-muted)]">
+                The live read path is not enabled yet (<code>OPERATOR_RUNTIME_READ_URL</code>, ADR
+                0043). Learned preferences appear here the moment it is wired.
+              </p>
+            ) : learned.status === 'unreachable' ? (
+              <p class="text-xs text-[color:var(--ss-color-text-muted)]">
+                This operator's runtime is unreachable right now ({learned.reason}). The read fails
+                closed; try again shortly.
+              </p>
+            ) : learned.status === 'empty' ? (
+              <p class="text-sm text-[color:var(--ss-color-text-secondary)]">
+                Nothing learned yet. As each person works with the operator, the preferences it
+                captures appear here.
+              </p>
+            ) : (
+              <ul class="space-y-stack">
+                {learned.people.map((person) => (
+                  <li class="border-t border-[color:var(--ss-color-border)] pt-3 first:border-t-0 first:pt-0">
+                    <p class="text-sm font-medium text-[color:var(--ss-color-text-primary)]">
+                      {person.peerId}
+                    </p>
+                    <ul class="mt-1 space-y-2">
+                      {person.preferences.map((pref) => (
+                        <li>
+                          <p class="text-sm text-[color:var(--ss-color-text-primary)]">
+                            <span class="inline-block rounded bg-[color:var(--ss-color-surface-muted)] px-1.5 py-0.5 text-xs font-medium uppercase tracking-wide text-[color:var(--ss-color-text-muted)] align-middle mr-2">
+                              {pref.source}
+                            </span>
+                            {pref.preference}
+                          </p>
+                          {pref.why && (
+                            <p class="text-xs text-[color:var(--ss-color-text-secondary)] mt-0.5">
+                              Why: {pref.why}
+                            </p>
+                          )}
+                          {pref.howToApply && (
+                            <p class="text-xs text-[color:var(--ss-color-text-secondary)] mt-0.5">
+                              How to apply: {pref.howToApply}
+                            </p>
+                          )}
+                        </li>
+                      ))}
+                    </ul>
+                  </li>
+                ))}
+              </ul>
+            )}
           </section>
         </>
       )

--- a/tests/relationship-observe.test.ts
+++ b/tests/relationship-observe.test.ts
@@ -14,6 +14,8 @@ import { describe, it, expect } from 'vitest'
 import {
   parseStandingPreferences,
   loadStandingPreferences,
+  parseLearnedPreferences,
+  loadLearnedPreferences,
 } from '../src/lib/admin/relationship-observe'
 import type {
   MachineRuntimeTransport,
@@ -121,6 +123,149 @@ describe('loadStandingPreferences', () => {
       },
     }
     const res = await loadStandingPreferences({ transport, audit }, 'smd', actor, true)
+    expect(res.status).toBe('unreachable')
+  })
+})
+
+const aRow = (over: Record<string, unknown> = {}) => ({
+  id: 'row-1',
+  customer_slug: 'smd',
+  peer_id: 'chris@ashtonprice.com',
+  persona_slug: 'default',
+  preference: 'Highlight, never draft',
+  why: 'He is the litigator and wants control of the words',
+  how_to_apply: 'Surface the matter, leave the drafting to him',
+  source: 'stated',
+  session_id: 'sess-1',
+  recorded_at: '2026-06-15T10:00:00Z',
+  superseded_by: null,
+  ...over,
+})
+
+describe('parseLearnedPreferences', () => {
+  it('parses a valid active row', () => {
+    const out = parseLearnedPreferences({ entries: [aRow()] })
+    expect(out).toEqual([
+      {
+        peerId: 'chris@ashtonprice.com',
+        preferences: [
+          {
+            preference: 'Highlight, never draft',
+            why: 'He is the litigator and wants control of the words',
+            howToApply: 'Surface the matter, leave the drafting to him',
+            source: 'stated',
+            recordedAt: '2026-06-15T10:00:00Z',
+          },
+        ],
+      },
+    ])
+  })
+
+  it('normalizes optional fields (absent why/how_to_apply/recorded_at → null)', () => {
+    const out = parseLearnedPreferences({
+      entries: [{ peer_id: 'p1', preference: 'P', source: 'demonstrated' }],
+    })
+    expect(out[0].preferences[0]).toEqual({
+      preference: 'P',
+      why: null,
+      howToApply: null,
+      source: 'demonstrated',
+      recordedAt: null,
+    })
+  })
+
+  it('skips rows missing peer_id or preference', () => {
+    expect(parseLearnedPreferences({ entries: [aRow({ peer_id: undefined })] })).toEqual([])
+    expect(parseLearnedPreferences({ entries: [aRow({ preference: '' })] })).toEqual([])
+  })
+
+  it('filters out superseded rows (non-null superseded_by)', () => {
+    const out = parseLearnedPreferences({
+      entries: [aRow({ superseded_by: 'row-9', preference: 'old' }), aRow({ preference: 'new' })],
+    })
+    expect(out).toHaveLength(1)
+    expect(out[0].preferences.map((p) => p.preference)).toEqual(['new'])
+  })
+
+  it('skips rows with an invalid source', () => {
+    expect(parseLearnedPreferences({ entries: [aRow({ source: 'guessed' })] })).toEqual([])
+    expect(parseLearnedPreferences({ entries: [aRow({ source: null })] })).toEqual([])
+  })
+
+  it('groups multiple rows by peer_id', () => {
+    const out = parseLearnedPreferences({
+      entries: [
+        aRow({ peer_id: 'a', preference: 'a1' }),
+        aRow({ peer_id: 'b', preference: 'b1' }),
+        aRow({ peer_id: 'a', preference: 'a2' }),
+      ],
+    })
+    const byPeer = Object.fromEntries(out.map((p) => [p.peerId, p.preferences.length]))
+    expect(byPeer).toEqual({ a: 2, b: 1 })
+  })
+
+  it('sorts a peer preferences newest-first, null recorded_at last', () => {
+    const out = parseLearnedPreferences({
+      entries: [
+        aRow({ preference: 'older', recorded_at: '2026-06-10T00:00:00Z' }),
+        aRow({ preference: 'no-date', recorded_at: undefined }),
+        aRow({ preference: 'newer', recorded_at: '2026-06-15T00:00:00Z' }),
+      ],
+    })
+    expect(out[0].preferences.map((p) => p.preference)).toEqual(['newer', 'older', 'no-date'])
+  })
+
+  it('is total on malformed payloads', () => {
+    expect(parseLearnedPreferences(null)).toEqual([])
+    expect(parseLearnedPreferences({ entries: 'nope' })).toEqual([])
+    expect(parseLearnedPreferences({ entries: [null, 7] })).toEqual([])
+  })
+})
+
+describe('loadLearnedPreferences', () => {
+  it('returns not_enabled WITHOUT a read when unconfigured', async () => {
+    const { audit, getCalls } = countingAudit()
+    const res = await loadLearnedPreferences(
+      { transport: transportReturning({ entries: [aRow()] }), audit },
+      'smd',
+      actor,
+      false
+    )
+    expect(res).toEqual({ status: 'not_enabled' })
+    expect(getCalls()).toBe(0)
+  })
+
+  it('classifies people as items', async () => {
+    const { audit } = countingAudit()
+    const res = await loadLearnedPreferences(
+      { transport: transportReturning({ entries: [aRow()] }), audit },
+      'smd',
+      actor,
+      true
+    )
+    expect(res.status).toBe('items')
+    if (res.status === 'items') expect(res.people).toHaveLength(1)
+  })
+
+  it('classifies no people as empty', async () => {
+    const { audit } = countingAudit()
+    const res = await loadLearnedPreferences(
+      { transport: transportReturning({ entries: [] }), audit },
+      'smd',
+      actor,
+      true
+    )
+    expect(res).toEqual({ status: 'empty' })
+  })
+
+  it('fails closed to unreachable on a read error', async () => {
+    const { audit } = countingAudit()
+    const transport: MachineRuntimeTransport = {
+      read: async () => {
+        throw new Error('boom')
+      },
+    }
+    const res = await loadLearnedPreferences({ transport, audit }, 'smd', actor, true)
     expect(res.status).toBe('unreachable')
   })
 })


### PR DESCRIPTION
## What

The read/display side of the Operator's per-peer relationship memory (ADR 0048 **learned lane**). The overlay plugin `hermes-smd-peer-memory` (venturecrane/hermes-smd-overlay#87) writes a `peer_preferences` table per customer; this PR reads it live across the isolation boundary and renders it on the admin relationship surface (`/admin/operator/[customer]/memory`).

## Changes

- **`src/lib/admin/relationship-observe.ts`** — `LearnedPreference` / `LearnedPreferencePerson` types, `parseLearnedPreferences` (defensive: requires `peer_id` + `preference`, filters superseded rows, validates `source`, groups by peer, sorts newest-first), `loadLearnedPreferences` (fail-closed; `not_enabled` without a read when unconfigured). Mirrors the authored standing-preferences lane exactly.
- **`src/pages/admin/operator/[customer]/memory.astro`** — replaces the rejected Honcho inferred-observations placeholder (Honcho is rejected doctrine, 2026-06-16) with the real Learned lane. Lane 1 (authored) untouched; Lane 2 is now Learned. Renders all four statuses; per-person rows show the `source` tag + why / how-to-apply.
- **`src/lib/operator/runtime-read.ts`** — doc-only: cite `peer_preferences` (the live example) instead of the ripped `voice_corrections`. No allowlist change (`memory_export` already supports `table`).
- **`tests/relationship-observe.test.ts`** — parse + load suites for the learned lane.

## Contract

Reads via the existing seam: `{ kind: 'memory_export', table: 'peer_preferences' }`. The overlay routes that table to the per-customer agent-state DB. Tests mock the transport, so this PR is independently verifiable; the live read lights up once the overlay PR ships behind an `OVERLAY_REF` bump + reprovision.

## Verification

`npm run verify` green (typecheck + lint + full test, incl. forbidden-strings copy gate and the new Learned-lane suites).

## Note on history

Branched clean off current `main` (which already has the ADR 0048 style-lane rip, #1409). Carries only the Learned-lane commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)