### PR TITLE
chore(operator): bump OVERLAY_REF to a548086 — peer-memory plugin (ADR 0048 learned lane)

### DIFF
--- a/operator/bin/lib/seam_pull.py
+++ b/operator/bin/lib/seam_pull.py
@@ -71,6 +71,7 @@ MEMORY_EXPORT_TABLES: tuple[str, ...] = (
     "persona_observations",
     "persona_observations_archive",
     "agent_skills_inventory",
+    "peer_preferences",
 )
 
 _PAGE_LIMIT = 200  # overlay MAX_LIMIT
@@ -233,7 +234,21 @@ class SeamAuditLogPreserver:
         try:
             _write_audit_snapshot(conn, audit_rows)
             for table in MEMORY_EXPORT_TABLES:
-                rows = self._client.read_all("memory_export", table=table)
+                try:
+                    rows = self._client.read_all("memory_export", table=table)
+                except urllib.error.HTTPError as exc:
+                    # A 400 means this Machine's overlay predates the table
+                    # (gradual OVERLAY_REF rollout) — it legitimately has no
+                    # such table, so it is zero rows, NOT a partial-pull halt.
+                    # Any other status (500, auth, transport) still fails loud.
+                    if exc.code != 400:
+                        raise
+                    logging.getLogger(__name__).warning(
+                        "preserve: memory table %s not served by this Machine "
+                        "(HTTP 400, overlay predates it); recording 0 rows",
+                        table,
+                    )
+                    rows = []
                 _write_memory_snapshot(conn, table, rows)
                 memory_counts[table] = len(rows)
         finally:

--- a/operator/bin/tests/test_seam_pull.py
+++ b/operator/bin/tests/test_seam_pull.py
@@ -120,6 +120,9 @@ class _FakeSeamClient:
             "agent_skills_inventory": [
                 {"_rowid": 1, "skill_name": "follow-up-cadence", "status": "persisted"},
             ],
+            "peer_preferences": [
+                {"_rowid": 1, "peer_id": "chris", "preference": "Wants bullets", "source": "stated"},
+            ],
         }
 
     def read_all(self, kind: str, *, table: Optional[str] = None) -> list[dict]:
@@ -140,6 +143,7 @@ def test_preserver_writes_csv_snapshot_and_manifest(tmp_path):
     assert result["rows_preserved"] == 2
     assert result["memory_rows_preserved"]["persona_observations"] == 1
     assert result["memory_rows_preserved"]["agent_skills_inventory"] == 1
+    assert result["memory_rows_preserved"]["peer_preferences"] == 1
 
     # CSV: full canonical columns, both rows.
     with Path(result["csv_path"]).open(encoding="utf-8") as fp:
@@ -197,4 +201,5 @@ def test_memory_export_tables_match_overlay_allowlist():
         "persona_observations",
         "persona_observations_archive",
         "agent_skills_inventory",
+        "peer_preferences",
     }

--- a/operator/contracts/overlay-pairs.json
+++ b/operator/contracts/overlay-pairs.json
@@ -1,6 +1,6 @@
 {
   "overlayRepo": "https://github.com/venturecrane/hermes-smd-overlay.git",
-  "overlayRef": "8d6f1a95189641366c5ff10b01e65d29b6a895fe",
+  "overlayRef": "a5480862017c4214acce5a3f48d19b7067306ca5",
   "overlayRefNote": "MUST equal the ARG OVERLAY_REF pinned in operator/templates/Dockerfile — that is the overlay commit a customer Machine actually ships. The vitest gate asserts the two agree so the manifest cannot pin a stale overlay. Bump both together when OVERLAY_REF moves, then re-record each overlaySha256 from the runtime file at the new ref.",
   "pairs": [
     {

--- a/operator/templates/Dockerfile
+++ b/operator/templates/Dockerfile
@@ -184,12 +184,13 @@ ARG HERMES_UPSTREAM_SHA=a91a57fa5a13d516c38b07a141a9ce8a3daabeb0
 # check is unchanged. Fixes demo-law DEMO_RELAY_BLOCKED reason=content_sensitive
 # on a benign disclaimer (2026-06-14 live test). Superset of ed96cebe.
 ARG OVERLAY_REPO="https://github.com/venturecrane/hermes-smd-overlay.git"
-# b3294de — #81 live-reconfiguration overlay (ADR 0044): WS2 live reads (demo/webhook
-# re-read per action), validator parity + on-box secret scan, and the root-owned
-# config_applier (pull → validate → safety → atomic write of /opt/data/customer.yaml).
-# Verified end-to-end on hermes-smd-staging. Superset of e4d1f23 (#82 relationship
-# authored lane, ADR 0048 Phase 2), which it merges and carries forward.
-ARG OVERLAY_REF="8d6f1a95189641366c5ff10b01e65d29b6a895fe"
+# a548086 — #87 per-peer working-preference memory (ADR 0048 learned lane): the
+# hermes-smd-peer-memory plugin (pre_llm_call sender stash + inject, agent-callable
+# record_peer_preference tool, post_tool_call server-side attribution + taint-gate,
+# peer_preferences on the agent-state D1 binding + runtime_read seam). Superset of
+# 8d6f1a95 (#85 Clerk-id secret-scan exemption) and carries #86 (voice_corrections
+# seam rip).
+ARG OVERLAY_REF="a5480862017c4214acce5a3f48d19b7067306ca5"
 
 ARG CUSTOMER_SLUG=customer-zero
 

--- a/tests/operator-dockerfile.test.ts
+++ b/tests/operator-dockerfile.test.ts
@@ -83,7 +83,11 @@ describe('Operator customer Machine Dockerfile', () => {
     // Superset of e4d1f23 — merges and carries the relationship lane forward.
     // 8d6f1a95 (#85, ss-console #1408) exempts Clerk public IDs (user_/org_) from the
     // secret-scan high-entropy heuristic — fixes a customer-zero crash-loop. Superset of b3294de.
-    expect(DOCKERFILE).toContain('ARG OVERLAY_REF="8d6f1a95189641366c5ff10b01e65d29b6a895fe"')
+    // a548086 (overlay #87) adds the hermes-smd-peer-memory plugin (ADR 0048 learned lane:
+    // per-peer working-preference memory — pre_llm_call sender stash + inject, record_peer_preference
+    // tool, post_tool_call server-side attribution + taint-gate, peer_preferences on the agent-state
+    // D1 binding + runtime_read seam). Carries overlay #86 (voice_corrections seam rip). Superset of 8d6f1a95.
+    expect(DOCKERFILE).toContain('ARG OVERLAY_REF="a5480862017c4214acce5a3f48d19b7067306ca5"')
   })
 
   it('does NOT swallow a failed plugin install (no fail-open `|| echo ... continuing`)', () => {


### PR DESCRIPTION
## What

Rolls the per-peer working-preference memory plugin (overlay #87, now on overlay `main`) into the customer Machine image, and closes a decommission-preservation gap it surfaced.

- **`operator/templates/Dockerfile`** — `ARG OVERLAY_REF` `8d6f1a95 → a548086` (carries overlay #87 peer-memory + #86 voice_corrections seam rip).
- **`operator/contracts/overlay-pairs.json`** — `overlayRef` bumped to match. The 4 paired `overlaySha256` are **unchanged** (none of transform.py/emit.py/d1_client.py/d1_env.py changed between the refs; the overlay-pairs vitest gate confirms).
- **`tests/operator-dockerfile.test.ts`** — expected-ref assertion updated.
- **`operator/bin/lib/seam_pull.py` (+ tests)** — add `peer_preferences` to the decommission preserver's `MEMORY_EXPORT_TABLES` (the pull-before-destroy table set) so a decommissioned customer's learned memory is archived before `fly apps destroy`. Also make the preserve loop tolerant of a Machine whose overlay predates a memory table (a 400 "unknown table" during gradual rollout is now 0 rows, not a halt; other statuses still fail loud).

## Verified on staging (hermes-smd-staging, reprovisioned at a548086)

- Image built + deployed at `a548086`; **all 17 boot-smoke checks pass** (ownership, isolation, broker respawn).
- invariant_8 live activation gate: **"overlay active (10 plugins registered, hooks attached, audit schema present, trust gated banned 'email_send')"** — the count went 9→10; peer-memory is the 10th, registered on the live gateway (fan-out is best-effort, so 10 = all declared registered). Confirmed across deploy boot + a restart boot.
- Runtime-read seam: good-key `memory_export?table=peer_preferences` → **200**; unknown table → **400**; wrong-key → **401**.
- `npm run verify` green; operator-substrate pytest **214 passed**.

## Rollout note

Merging this changes what a **future** `reprovision` builds; it does not reprovision live Machines by itself. customer-zero / clients pick up peer-memory on their next reprovision after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)