### PR TITLE
feat(operator): overlay-ref drift check — surface Machines on a stale overlay

### DIFF
--- a/operator/bin/lib/seam_pull.py
+++ b/operator/bin/lib/seam_pull.py
@@ -120,6 +120,29 @@ class SeamClient:
             raise ValueError(f"seam read {kind}: malformed page shape")
         return payload
 
+    def read_config(self) -> dict:
+        """GET /runtime/config — the materialized-state snapshot.
+
+        Unlike the paginated kinds this returns a single dict (no ``entries``
+        envelope), so it has its own reader. Used by the overlay-ref drift
+        check to read each Machine's running ``overlay_ref.value``.
+        """
+        url = f"{self._base}/runtime/config"
+        req = urllib.request.Request(
+            url,
+            headers={
+                "Authorization": f"Bearer {self._key}",
+                "X-Tenant-Slug": self._slug,
+            },
+            method="GET",
+        )
+        # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected — scheme is constructor-enforced https://; host from operator env; path is a module constant.
+        with urllib.request.urlopen(req, timeout=self._timeout) as resp:  # noqa: S310 — https enforced at construction
+            payload = json.loads(resp.read().decode("utf-8"))
+        if not isinstance(payload, dict):
+            raise ValueError("seam read config: malformed snapshot shape")
+        return payload
+
     def read_all(self, kind: str, *, table: Optional[str] = None) -> list[dict]:
         """Drain every page of one kind/table. Raises on any transport or
         shape error — preservation must fail LOUD, never archive a partial

--- a/operator/bin/overlay-ref-drift.py
+++ b/operator/bin/overlay-ref-drift.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""overlay-ref-drift.py — detect Machines running a stale overlay.
+
+WHY THIS EXISTS: an ``OVERLAY_REF`` bump only reaches a customer Machine when
+someone manually reprovisions it. Nothing tracked which live Machines were
+behind, so a bump could silently leave Machines on an old overlay and the only
+"reminder" was a human remembering. This closes that gap: it reads each
+Machine's RUNNING overlay commit from the live ``config`` runtime-read seam and
+compares it to the ref pinned in ``operator/templates/Dockerfile`` (the desired
+state), so drift is a surfaced fact, not something to remember.
+
+Run on demand or on a schedule. Exit code is gate-friendly:
+  0  every reachable Machine is on the pinned ref (no drift)
+  1  at least one Machine is DRIFTED (or reachable but its ref is unknown)
+  2  --strict and at least one Machine was unreachable/unconfigured
+
+Reachability needs the seam master key, so run under Infisical:
+  infisical run --env=prod --path=/ss --silent -- operator/bin/overlay-ref-drift.py
+
+Usage:
+  overlay-ref-drift.py [SLUG ...] [--strict] [--dockerfile PATH] [--customers-dir PATH]
+
+With no SLUG args it checks every customer dir under operator/customers/
+(excluding _template). An undeployed/paused customer shows as "unreachable" —
+that is informational, not drift, unless --strict.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Optional
+
+sys.path.insert(0, str(Path(__file__).resolve().parent / "lib"))
+import seam_pull  # noqa: E402 — path injected above
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_DEFAULT_DOCKERFILE = _REPO_ROOT / "operator" / "templates" / "Dockerfile"
+_DEFAULT_CUSTOMERS_DIR = _REPO_ROOT / "operator" / "customers"
+
+_OVERLAY_REF_RE = re.compile(r'^\s*ARG\s+OVERLAY_REF="([0-9a-fA-F]{7,40})"', re.MULTILINE)
+
+
+@dataclass
+class DriftResult:
+    slug: str
+    status: str  # current | drift | unknown | unreachable | unconfigured
+    running_ref: Optional[str]
+    source: Optional[str]
+    detail: str = ""
+
+
+def desired_ref_from_dockerfile(path: Path) -> str:
+    """Parse the pinned ``ARG OVERLAY_REF`` from the Dockerfile (desired state)."""
+    text = path.read_text(encoding="utf-8")
+    m = _OVERLAY_REF_RE.search(text)
+    if not m:
+        raise ValueError(f"no ARG OVERLAY_REF=\"...\" found in {path}")
+    return m.group(1)
+
+
+def discover_slugs(customers_dir: Path) -> list[str]:
+    """Every customer dir under ``customers_dir`` except the template."""
+    if not customers_dir.is_dir():
+        return []
+    return sorted(
+        p.name
+        for p in customers_dir.iterdir()
+        if p.is_dir() and p.name != "_template" and not p.name.startswith(".")
+    )
+
+
+def refs_match(desired: str, running: Optional[str]) -> bool:
+    """Match exact, or by common prefix so a short ref equals its full SHA."""
+    if not running:
+        return False
+    a, b = desired.lower(), running.lower()
+    return a == b or a.startswith(b) or b.startswith(a)
+
+
+def classify(
+    desired: str,
+    slugs: list[str],
+    make_client: Callable[[str], Optional["seam_pull.SeamClient"]],
+) -> list[DriftResult]:
+    """Pure core: resolve each slug's running ref and compare to ``desired``.
+
+    ``make_client(slug)`` returns a SeamClient or None (unconfigured). Any
+    transport error reading the seam is classified ``unreachable`` (a paused or
+    not-yet-deployed Machine), never a crash — drift detection must be total.
+    """
+    results: list[DriftResult] = []
+    for slug in slugs:
+        try:
+            client = make_client(slug)
+        except Exception as exc:  # noqa: BLE001 — defensive; a factory error is unreachable
+            results.append(DriftResult(slug, "unreachable", None, None, f"client init: {exc}"))
+            continue
+        if client is None:
+            results.append(DriftResult(slug, "unconfigured", None, None, "seam env not set"))
+            continue
+        try:
+            snap = client.read_config()
+        except Exception as exc:  # noqa: BLE001 — paused/undeployed/unreachable Machine
+            results.append(DriftResult(slug, "unreachable", None, None, f"{type(exc).__name__}: {exc}"))
+            continue
+        ref_obj = snap.get("overlay_ref") if isinstance(snap, dict) else None
+        running = ref_obj.get("value") if isinstance(ref_obj, dict) else None
+        source = ref_obj.get("source") if isinstance(ref_obj, dict) else None
+        if running is None:
+            results.append(DriftResult(slug, "unknown", None, source, "snapshot has no overlay_ref.value"))
+        elif refs_match(desired, running):
+            results.append(DriftResult(slug, "current", running, source))
+        else:
+            results.append(DriftResult(slug, "drift", running, source, "running ref != pinned ref"))
+    return results
+
+
+def _short(ref: Optional[str]) -> str:
+    return (ref[:12] if ref else "-")
+
+
+def render(desired: str, results: list[DriftResult]) -> str:
+    lines = [f"Desired overlay ref (Dockerfile): {desired[:12]}", ""]
+    width = max((len(r.slug) for r in results), default=4)
+    for r in results:
+        mark = {
+            "current": "OK   ",
+            "drift": "DRIFT",
+            "unknown": "?    ",
+            "unreachable": "unrch",
+            "unconfigured": "uncfg",
+        }.get(r.status, "?    ")
+        line = f"  [{mark}] {r.slug.ljust(width)}  running={_short(r.running_ref)}"
+        if r.detail:
+            line += f"  ({r.detail})"
+        lines.append(line)
+    drifted = [r.slug for r in results if r.status in ("drift", "unknown")]
+    unreachable = [r.slug for r in results if r.status in ("unreachable", "unconfigured")]
+    lines.append("")
+    if drifted:
+        lines.append(f"DRIFT: {len(drifted)} Machine(s) behind the pinned ref: {', '.join(drifted)}")
+        lines.append("  → reprovision each: yes s | operator/bin/reprovision.sh <slug>")
+    else:
+        lines.append("No drift: every reachable Machine is on the pinned overlay ref.")
+    if unreachable:
+        lines.append(f"Unreachable/unconfigured (not assessed): {', '.join(unreachable)}")
+    return "\n".join(lines)
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="Detect Machines running a stale overlay ref.")
+    parser.add_argument("slugs", nargs="*", help="customer slugs to check (default: all)")
+    parser.add_argument("--strict", action="store_true", help="exit non-zero on unreachable/unconfigured too")
+    parser.add_argument("--dockerfile", default=str(_DEFAULT_DOCKERFILE))
+    parser.add_argument("--customers-dir", default=str(_DEFAULT_CUSTOMERS_DIR))
+    args = parser.parse_args(argv)
+
+    desired = desired_ref_from_dockerfile(Path(args.dockerfile))
+    slugs = args.slugs or discover_slugs(Path(args.customers_dir))
+    if not slugs:
+        print("no customer slugs to check", file=sys.stderr)
+        return 0
+
+    results = classify(desired, slugs, seam_pull.seam_client_from_env)
+    print(render(desired, results))
+
+    has_drift = any(r.status in ("drift", "unknown") for r in results)
+    has_unreachable = any(r.status in ("unreachable", "unconfigured") for r in results)
+    if has_drift:
+        return 1
+    if args.strict and has_unreachable:
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/operator/bin/tests/test_overlay_ref_drift.py
+++ b/operator/bin/tests/test_overlay_ref_drift.py
@@ -1,0 +1,148 @@
+"""Tests for overlay-ref-drift.py — the stale-overlay detector."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[1] / "overlay-ref-drift.py"
+
+
+def _load():
+    import sys
+
+    spec = importlib.util.spec_from_file_location("overlay_ref_drift", _SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    # Register before exec so the @dataclass can resolve its own module (the
+    # dataclass machinery reads sys.modules[cls.__module__] under
+    # `from __future__ import annotations`).
+    sys.modules["overlay_ref_drift"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+drift = _load()
+
+DESIRED = "a5480862017c4214acce5a3f48d19b7067306ca5"
+
+
+class _FakeClient:
+    def __init__(self, ref):
+        self._ref = ref
+
+    def read_config(self):
+        if self._ref == "__raise__":
+            raise OSError("machine down")
+        return {"schema": "x", "overlay_ref": {"value": self._ref, "source": "direct_url"}}
+
+
+def _factory(mapping):
+    def make(slug):
+        val = mapping.get(slug, "__missing__")
+        if val == "__missing__":
+            return None  # unconfigured
+        return _FakeClient(val)
+
+    return make
+
+
+# --- desired_ref_from_dockerfile -------------------------------------------
+
+
+def test_desired_ref_parses(tmp_path):
+    df = tmp_path / "Dockerfile"
+    df.write_text(f'ARG OVERLAY_REPO="x"\nARG OVERLAY_REF="{DESIRED}"\n', encoding="utf-8")
+    assert drift.desired_ref_from_dockerfile(df) == DESIRED
+
+
+def test_desired_ref_missing_raises(tmp_path):
+    df = tmp_path / "Dockerfile"
+    df.write_text("FROM scratch\n", encoding="utf-8")
+    with pytest.raises(ValueError):
+        drift.desired_ref_from_dockerfile(df)
+
+
+# --- discover_slugs ---------------------------------------------------------
+
+
+def test_discover_slugs_excludes_template(tmp_path):
+    for name in ("smd", "demo-law", "_template", ".hidden"):
+        (tmp_path / name).mkdir()
+    assert drift.discover_slugs(tmp_path) == ["demo-law", "smd"]
+
+
+# --- refs_match -------------------------------------------------------------
+
+
+def test_refs_match_exact_and_prefix():
+    assert drift.refs_match(DESIRED, DESIRED)
+    assert drift.refs_match(DESIRED, DESIRED[:7])  # short ref equals full
+    assert drift.refs_match(DESIRED[:7], DESIRED)
+    assert not drift.refs_match(DESIRED, "deadbeef")
+    assert not drift.refs_match(DESIRED, None)
+
+
+# --- classify ---------------------------------------------------------------
+
+
+def test_classify_current_drift_unreachable_unconfigured_unknown():
+    mapping = {
+        "current-one": DESIRED,
+        "drifted": "8d6f1a95189641366c5ff10b01e65d29b6a895fe",
+        "down": "__raise__",
+        # 'never-seen' omitted → unconfigured (factory returns None)
+    }
+    results = drift.classify(
+        DESIRED,
+        ["current-one", "drifted", "down", "never-seen"],
+        _factory(mapping),
+    )
+    by = {r.slug: r.status for r in results}
+    assert by == {
+        "current-one": "current",
+        "drifted": "drift",
+        "down": "unreachable",
+        "never-seen": "unconfigured",
+    }
+
+
+def test_classify_unknown_when_no_ref_value():
+    class _NoRef:
+        def read_config(self):
+            return {"schema": "x", "overlay_ref": {"value": None, "source": None}}
+
+    results = drift.classify(DESIRED, ["x"], lambda s: _NoRef())
+    assert results[0].status == "unknown"
+
+
+# --- main exit codes --------------------------------------------------------
+
+
+def _write_dockerfile(tmp_path):
+    df = tmp_path / "Dockerfile"
+    df.write_text(f'ARG OVERLAY_REF="{DESIRED}"\n', encoding="utf-8")
+    cust = tmp_path / "customers"
+    return df, cust
+
+
+def test_main_exit_zero_when_all_current(tmp_path, monkeypatch):
+    df, _ = _write_dockerfile(tmp_path)
+    monkeypatch.setattr(drift.seam_pull, "seam_client_from_env", lambda s: _FakeClient(DESIRED))
+    rc = drift.main(["smd", "demo-law", "--dockerfile", str(df)])
+    assert rc == 0
+
+
+def test_main_exit_one_on_drift(tmp_path, monkeypatch):
+    df, _ = _write_dockerfile(tmp_path)
+    monkeypatch.setattr(drift.seam_pull, "seam_client_from_env", lambda s: _FakeClient("deadbeef0000"))
+    rc = drift.main(["smd", "--dockerfile", str(df)])
+    assert rc == 1
+
+
+def test_main_unreachable_zero_unless_strict(tmp_path, monkeypatch):
+    df, _ = _write_dockerfile(tmp_path)
+    monkeypatch.setattr(drift.seam_pull, "seam_client_from_env", lambda s: None)
+    assert drift.main(["smd", "--dockerfile", str(df)]) == 0
+    assert drift.main(["smd", "--dockerfile", str(df), "--strict"]) == 2


### PR DESCRIPTION
## Why

An `OVERLAY_REF` bump only reaches a customer Machine when someone manually reprovisions it, and nothing tracked which live Machines were behind. The only "reminder" that a Machine was stale was a human remembering. This closes that gap so drift is a surfaced fact, not a thing to remember.

## What

`operator/bin/overlay-ref-drift.py` reads each Machine's **running** overlay commit from the live `config` runtime-read seam (`overlay_ref.value`) and compares it to the ref pinned in `operator/templates/Dockerfile` (desired state).

Gate-friendly exit codes (on-demand or scheduled):
- `0` — every reachable Machine is on the pinned ref
- `1` — at least one Machine is **drifted** (or reachable but ref unknown)
- `2` — `--strict` and something was unreachable/unconfigured

```
infisical run --env=prod --path=/ss --silent -- operator/bin/overlay-ref-drift.py
```

With no args it checks every customer under `operator/customers/` (excluding `_template`); an undeployed/paused Machine is reported as `unreachable` (informational, not drift, unless `--strict`).

- Adds `SeamClient.read_config()` — the `config` snapshot is a single dict, not the paginated `entries` envelope the other reads use.
- Pure `classify()` / `refs_match()` (short-vs-full SHA tolerant) / `desired_ref_from_dockerfile()` with full unit coverage; an unreachable Machine is classified, never a crash.

## Follow-up (not in this PR)
A scheduled invocation (cron/CI) so drift is reported automatically without anyone running it. Wiring that is a small separate change once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)