### PR TITLE
test(operator): boot-smoke proves the R2 account-key strip materialized (OP-P2-1)

### DIFF
--- a/operator/bin/boot-smoke-test.sh
+++ b/operator/bin/boot-smoke-test.sh
@@ -143,4 +143,16 @@ ssh_exec "overlay-pack-root-owned" "[ \"\$(stat -c %U /app/overlay-pack)\" = roo
 ssh_exec "overlay-pack-not-agent-writable" "setpriv --reuid=hermes --regid=hermes --init-groups sh -c \"! test -w /app/overlay-pack\""
 ssh_exec "activation-handler-not-agent-writable" "setpriv --reuid=hermes --regid=hermes --init-groups sh -c \"! test -w /app/overlay-pack/hooks/smd-overlay-activation/handler.py\""
 
+# ---------- Step 13: the account-wide R2 key is stripped from the LIVE agent (OP-P2-1) ----------
+# bootstrap.sh unsets R2_ACCESS_KEY_ID / R2_SECRET_ACCESS_KEY before forking any
+# same-uid child or exec'ing the gateway, so a code-executing agent cannot read
+# the account-wide R2 key (from its own env or a sibling's /proc/<pid>/environ)
+# and rewrite the R2 config object — the loopback that would walk around the
+# keystone's filesystem lock (ADR 0044 Decision 8). test_deploy_ordering.py
+# proves the SOURCE strips it in the right order; this proves it MATERIALIZED on
+# the running Machine. Runs as root (reads agent-uid /proc/environ); the probe
+# excludes root processes (PID 1 + the config applier legitimately keep the key)
+# and never echoes the value.
+ssh_exec "r2-account-key-stripped-from-agent" "/opt/hermes/.venv/bin/python3 /app/r2-account-key-strip-probe.py"
+
 log "All boot smoke checks passed for ${APP_NAME}"

--- a/operator/templates/Dockerfile
+++ b/operator/templates/Dockerfile
@@ -410,6 +410,9 @@ COPY operator/templates/ensure-telegram-allowlist.py /app/ensure-telegram-allowl
 # OP-P1-4 affirmative proof: boot-smoke runs this as the agent uid to confirm
 # the ledger is not agent-writable.
 COPY operator/templates/audit-write-fail-probe.py /app/audit-write-fail-probe.py
+# OP-P2-1 affirmative proof: boot-smoke runs this as root to confirm NO agent-uid
+# process (gateway or same-uid child) still carries the account-wide R2 key.
+COPY operator/templates/r2-account-key-strip-probe.py /app/r2-account-key-strip-probe.py
 
 # NOTE: customer.yaml is NOT copied into the image. It lives on the Fly
 # volume at /opt/data/customer.yaml; bootstrap.sh fetches it from R2 on

--- a/operator/templates/r2-account-key-strip-probe.py
+++ b/operator/templates/r2-account-key-strip-probe.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Affirmative OP-P2-1 proof: NO agent-uid process holds the account-wide R2 key.
+
+bootstrap.sh unsets R2_ACCESS_KEY_ID / R2_SECRET_ACCESS_KEY before forking any
+same-uid child or exec'ing the gateway (operator/templates/bootstrap.sh, the
+``unset`` at the "Strip the account-wide R2 credential NOW" block). Two unit
+tests already assert the *source* contains that strip in the right order
+(operator/bin/tests/test_deploy_ordering.py) — but source-level proof is exactly
+what this whole hardening effort distrusts: a control that passes a static test
+can still fail to materialize on the running Machine. This probe closes that gap
+by reading the LIVE process table.
+
+It runs as ROOT (boot-smoke's SSH session) and scans every process owned by the
+agent uid (``hermes`` by default) — the gateway plus any same-uid children such
+as the webhook gate — reading each ``/proc/<pid>/environ``. It exits 0 only when
+NONE of them carry the account-wide R2 credential. Root processes (PID 1, the
+config applier) legitimately keep the key and are deliberately excluded: the
+loopback risk is a *hermes*-uid process holding a credential that can rewrite the
+R2 config object.
+
+The key VALUE is never printed — only the offending pid + comm, so the probe
+output is safe in a CI transcript.
+
+Usage:  r2-account-key-strip-probe.py [agent-username] [VAR ...]
+        defaults: agent-username=hermes  VARs=R2_ACCESS_KEY_ID R2_SECRET_ACCESS_KEY
+Intended to be invoked by boot-smoke-test.sh via:
+        /opt/hermes/.venv/bin/python3 /app/r2-account-key-strip-probe.py
+"""
+
+from __future__ import annotations
+
+import os
+import pwd
+import sys
+
+_DEFAULT_USER = "hermes"
+_DEFAULT_VARS = ("R2_ACCESS_KEY_ID", "R2_SECRET_ACCESS_KEY")
+
+
+def _proc_uid(proc_root: str, pid: str) -> int | None:
+    """Real UID of a process, or None if it vanished / is unreadable."""
+    try:
+        st = os.stat(os.path.join(proc_root, pid))
+    except OSError:
+        return None
+    return st.st_uid
+
+
+def _env_var_names(proc_root: str, pid: str) -> set[str] | None:
+    """The NAMES present in a process's environ (values are never returned).
+
+    Returns None when the environ cannot be read (process exited, or — when the
+    probe is not root — a foreign-uid process we are not permitted to inspect).
+    """
+    try:
+        with open(os.path.join(proc_root, pid, "environ"), "rb") as fh:
+            raw = fh.read()
+    except OSError:
+        return None
+    names: set[str] = set()
+    for entry in raw.split(b"\x00"):
+        if not entry:
+            continue
+        name, _, _ = entry.partition(b"=")
+        names.add(name.decode("utf-8", "replace"))
+    return names
+
+
+def _comm(proc_root: str, pid: str) -> str:
+    try:
+        with open(os.path.join(proc_root, pid, "comm")) as fh:
+            return fh.read().strip()
+    except OSError:
+        return "?"
+
+
+def scan(
+    proc_root: str,
+    target_uid: int,
+    var_names: list[str],
+    uid_of=_proc_uid,
+) -> tuple[int, list[str]]:
+    """Return (agent_proc_count, offenders).
+
+    ``offenders`` is a list of human-readable "<pid> (<comm>): <VAR>" strings —
+    pids of target-uid processes whose environ still carries one of ``var_names``.
+    The credential value is never included. ``uid_of`` is injectable so a unit
+    test can drive ownership without being root (the live caller uses the default,
+    which stats /proc/<pid>).
+    """
+    wanted = set(var_names)
+    agent_procs = 0
+    offenders: list[str] = []
+    for pid in os.listdir(proc_root):
+        if not pid.isdigit():
+            continue
+        if uid_of(proc_root, pid) != target_uid:
+            continue
+        names = _env_var_names(proc_root, pid)
+        if names is None:
+            continue
+        agent_procs += 1
+        leaked = sorted(wanted & names)
+        for var in leaked:
+            offenders.append(f"{pid} ({_comm(proc_root, pid)}): {var}")
+    return agent_procs, offenders
+
+
+def main(argv: list[str]) -> int:
+    username = argv[1] if len(argv) > 1 else _DEFAULT_USER
+    var_names = argv[2:] if len(argv) > 2 else list(_DEFAULT_VARS)
+
+    try:
+        target_uid = pwd.getpwnam(username).pw_uid
+    except KeyError:
+        print(f"FAIL: agent user {username!r} does not exist on this Machine", file=sys.stderr)
+        return 2
+
+    # Fail CLOSED, not with a traceback, if the process table is unreadable: a
+    # guard that cannot inspect /proc has proved nothing. (Also makes this a clean
+    # failure on a host without procfs, e.g. a dev macOS box, instead of a crash.)
+    try:
+        agent_procs, offenders = scan("/proc", target_uid, var_names)
+    except OSError as exc:
+        print(f"FAIL: cannot enumerate the process table at /proc ({exc.strerror})", file=sys.stderr)
+        return 4
+
+    if offenders:
+        for line in offenders:
+            print(f"FAIL: agent-uid process still holds account-wide R2 key — {line}", file=sys.stderr)
+        return 1
+
+    if agent_procs == 0:
+        # Vacuous "no offenders" is not a pass: if no agent process is running,
+        # the gateway never started and the guard proved nothing. Fail loud.
+        print(
+            f"FAIL: no processes found for uid {target_uid} ({username}) — gateway not up?",
+            file=sys.stderr,
+        )
+        return 3
+
+    print(f"OK: {agent_procs} agent-uid process(es) scanned; none carry {', '.join(var_names)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/operator/templates/tests/test_r2_account_key_strip_probe.py
+++ b/operator/templates/tests/test_r2_account_key_strip_probe.py
@@ -1,0 +1,116 @@
+"""Unit tests for the OP-P2-1 runtime probe (r2-account-key-strip-probe.py).
+
+The probe proves on the LIVE Machine that no agent-uid process carries the
+account-wide R2 key. These tests drive its ``scan`` over a FAKE /proc tree so the
+uid filter, the offender detection, the value-never-echoed property, and the
+"no agent process is not a pass" rule are all covered without being root.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_PROBE_PATH = Path(__file__).resolve().parents[1] / "r2-account-key-strip-probe.py"
+_spec = importlib.util.spec_from_file_location("r2_strip_probe", _PROBE_PATH)
+assert _spec and _spec.loader
+probe = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(probe)
+
+_AGENT_UID = 1000
+_ROOT_UID = 0
+_KEYS = ["R2_ACCESS_KEY_ID", "R2_SECRET_ACCESS_KEY"]
+# A realistic-looking but entirely fake credential value — asserts the probe
+# never echoes the value, only the var name.
+_FAKE_VALUE = "deadbeefdeadbeefdeadbeefdeadbeef"
+
+
+def _mkproc(proc_root: Path, pid: int, env: dict[str, str], comm: str = "python3") -> None:
+    d = proc_root / str(pid)
+    d.mkdir(parents=True)
+    blob = b"".join(f"{k}={v}".encode() + b"\x00" for k, v in env.items())
+    (d / "environ").write_bytes(blob)
+    (d / "comm").write_text(comm + "\n")
+
+
+def _uid_map(mapping: dict[int, int]):
+    def uid_of(_proc_root: str, pid: str) -> int | None:
+        return mapping.get(int(pid))
+
+    return uid_of
+
+
+def test_clean_agent_process_passes(tmp_path):
+    _mkproc(tmp_path, 100, {"PATH": "/usr/bin", "R2_ENDPOINT_URL": "https://x"})
+    count, offenders = probe.scan(
+        str(tmp_path), _AGENT_UID, _KEYS, uid_of=_uid_map({100: _AGENT_UID})
+    )
+    assert count == 1
+    assert offenders == []
+
+
+def test_agent_process_holding_account_key_is_flagged(tmp_path):
+    _mkproc(tmp_path, 100, {"R2_ACCESS_KEY_ID": _FAKE_VALUE}, comm="hermes")
+    count, offenders = probe.scan(
+        str(tmp_path), _AGENT_UID, _KEYS, uid_of=_uid_map({100: _AGENT_UID})
+    )
+    assert count == 1
+    assert len(offenders) == 1
+    assert "100" in offenders[0]
+    assert "R2_ACCESS_KEY_ID" in offenders[0]
+
+
+def test_offender_string_never_contains_the_value(tmp_path):
+    _mkproc(tmp_path, 100, {"R2_ACCESS_KEY_ID": _FAKE_VALUE, "R2_SECRET_ACCESS_KEY": _FAKE_VALUE})
+    _, offenders = probe.scan(
+        str(tmp_path), _AGENT_UID, _KEYS, uid_of=_uid_map({100: _AGENT_UID})
+    )
+    assert offenders
+    for line in offenders:
+        assert _FAKE_VALUE not in line
+
+
+def test_root_process_with_the_key_is_excluded(tmp_path):
+    # PID 1 (root) legitimately keeps the key (entrypoint + config applier).
+    _mkproc(tmp_path, 1, {"R2_ACCESS_KEY_ID": _FAKE_VALUE}, comm="entrypoint")
+    _mkproc(tmp_path, 100, {"PATH": "/usr/bin"}, comm="hermes")
+    count, offenders = probe.scan(
+        str(tmp_path), _AGENT_UID, _KEYS, uid_of=_uid_map({1: _ROOT_UID, 100: _AGENT_UID})
+    )
+    assert count == 1  # only the agent process is scanned
+    assert offenders == []
+
+
+def test_sibling_child_leak_is_caught(tmp_path):
+    # The gateway is clean but a same-uid child (e.g. a webhook-gate subshell
+    # forked before the strip) still holds the key — the exact /proc/environ
+    # sibling-leak bootstrap.sh closes with `env -u`.
+    _mkproc(tmp_path, 100, {"PATH": "/usr/bin"}, comm="hermes")
+    _mkproc(tmp_path, 101, {"R2_ACCESS_KEY_ID": _FAKE_VALUE}, comm="bash")
+    count, offenders = probe.scan(
+        str(tmp_path), _AGENT_UID, _KEYS, uid_of=_uid_map({100: _AGENT_UID, 101: _AGENT_UID})
+    )
+    assert count == 2
+    assert len(offenders) == 1
+    assert "101" in offenders[0]
+
+
+def test_no_agent_process_is_not_a_silent_pass(tmp_path):
+    # Only root processes exist -> scan finds zero agent procs. main() must turn
+    # that into a loud failure (exit 3), never a vacuous 0.
+    _mkproc(tmp_path, 1, {"R2_ACCESS_KEY_ID": _FAKE_VALUE}, comm="entrypoint")
+    count, offenders = probe.scan(
+        str(tmp_path), _AGENT_UID, _KEYS, uid_of=_uid_map({1: _ROOT_UID})
+    )
+    assert count == 0
+    assert offenders == []
+
+
+def test_unreadable_proc_root_raises_for_main_to_fail_closed(tmp_path):
+    # An unreadable/absent process table must surface as an OSError so main()
+    # fails closed (exit 4) rather than crashing or vacuously passing.
+    missing = tmp_path / "no-such-proc"
+    with pytest.raises(OSError):
+        probe.scan(str(missing), _AGENT_UID, _KEYS, uid_of=_uid_map({}))


### PR DESCRIPTION
## Summary
- OP-P2-1 (the account-wide R2 key strip in `bootstrap.sh`) was already implemented and is asserted at the **source** level by `test_deploy_ordering.py`. Nothing verified the strip **materialized** on the running Machine — the exact "tested ≠ live" gap this hardening effort exists to close.
- Adds `r2-account-key-strip-probe.py`: runs as root in boot-smoke, scans every agent-uid (`hermes`) process's `/proc/<pid>/environ`, and **fails if any still carries the account-wide R2 key**. Root processes (PID 1, the ADR-0044 config applier) legitimately keep it and are excluded; the credential value is never echoed.
- Wires it as **boot-smoke Step 12** so every provision affirmatively proves no `hermes` process can read the key and rewrite the R2 config object (the loopback around the keystone's filesystem lock).
- Fail-closed: an unreadable `/proc` or a missing gateway process is a loud failure (exit 3/4), never a vacuous pass.

## Why
This is verification, not a behavior change. It can only catch a regression of an already-shipped control. Pairs the source-level ordering guard with a runtime materialization guard, the same shape as the OP-P1-4 `audit-write-fail-probe.py`.

## Test plan
- [x] `cd operator && python3 -m pytest templates/tests/test_r2_account_key_strip_probe.py -q` → 7 passed (uid filter, offender detection, no-value-echo, sibling-child leak, no-agent-proc-fails-loud, unreadable-proc-fails-closed)
- [x] Full operator suite green: `python3 -m pytest bin/tests safety-substrate/tests adapter/tests templates/tests -q` → 355 passed
- [x] `ruff check` clean; `bash -n boot-smoke-test.sh` clean
- [ ] Machine boot-smoke Step 12 runs at the next staging/prod provision (staging was in use by another session, so not seized this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)