### PR TITLE
fix(operator): root-own /app governance artifacts — agent can't rewrite its own gate (SEC-31)

### DIFF
--- a/operator/bin/boot-smoke-test.sh
+++ b/operator/bin/boot-smoke-test.sh
@@ -132,4 +132,15 @@ ssh_exec "agent-state-owner-is-hermes" "[ \"\$(stat -c %U /opt/data/agent-state.
 # would collide with the outer quote and mangle the command.
 ssh_exec "broker-respawn-supervised" "pid=\$(pgrep -f workspace_broker.server | head -1); [ -n \"\$pid\" ] && ppid=\$(grep -m1 PPid /proc/\$pid/status | tr -dc 0-9) && [ \"\$(stat -c %U /proc/\$ppid)\" = root ]"
 
+# ---------- Step 12: /app governance artifacts are root-owned, not agent-writable (SEC-31) ----------
+# The activation-gate source the gateway:startup hook force-loads
+# (/app/overlay-pack, incl. hooks/smd-overlay-activation/handler.py) must be owned
+# by root so a code-executing agent cannot rewrite its own governance self-check.
+# bootstrap only READS it (copies to the volume; the gateway loads from there), so
+# root ownership is functionally inert. /app is image-backed and resets each boot,
+# but the agent's write path is removed regardless — defense in depth.
+ssh_exec "overlay-pack-root-owned" "[ \"\$(stat -c %U /app/overlay-pack)\" = root ]"
+ssh_exec "overlay-pack-not-agent-writable" "setpriv --reuid=hermes --regid=hermes --init-groups sh -c \"! test -w /app/overlay-pack\""
+ssh_exec "activation-handler-not-agent-writable" "setpriv --reuid=hermes --regid=hermes --init-groups sh -c \"! test -w /app/overlay-pack/hooks/smd-overlay-activation/handler.py\""
+
 log "All boot smoke checks passed for ${APP_NAME}"

--- a/operator/templates/Dockerfile
+++ b/operator/templates/Dockerfile
@@ -429,6 +429,24 @@ RUN chmod -R a+rX /opt/hermes /app \
       /app \
       /opt/data
 
+# SEC-31 (audit 2026-06-15): the blanket `chown -R hermes:hermes /app` above
+# swept the GOVERNANCE artifacts to the agent uid — the pinned overlay pack the
+# gateway:startup activation gate force-loads, the boot scripts, and the
+# boot-smoke probes. A code-executing agent must not own its own governance
+# self-check. Re-assert root ownership on them. This is functionally inert:
+# bootstrap only READS these (it COPIES /app/overlay-pack to the hermes-owned
+# volume and the gateway loads from THERE; it execs the *.sh; it runs the *.py as
+# scripts) — none are imported in place, so no __pycache__ write depends on the
+# agent owning them. They stay world-readable/executable (a+rX from the chmod
+# above). NOTE: /app/safety-substrate is intentionally NOT re-owned — its
+# run_invariants.py writes a boot log under that tree, so it must stay
+# hermes-writable (a smaller, separately-tracked residual).
+RUN chown -R root:root \
+      /app/overlay-pack \
+      /app/_env-arrays.generated.sh \
+ && chown root:root /app/*.sh /app/*.py \
+ && chmod -R a+rX /app/overlay-pack
+
 ENV HERMES_WEB_DIST=/opt/hermes/hermes_cli/web_dist
 
 VOLUME [ "/opt/data" ]


### PR DESCRIPTION
## Summary
- The image's `chown -R hermes:hermes /app` swept the **governance artifacts** to the agent uid: `/app/overlay-pack` (the pinned overlay the gateway:startup activation gate force-loads, incl. `hooks/smd-overlay-activation/handler.py`), the boot scripts, and the boot-smoke probes. A code-executing agent owning its own governance self-check is **SEC-31**.
- Re-asserts `root:root` on those artifacts after the blanket chown. **Functionally inert**: bootstrap only *reads* them — it copies `/app/overlay-pack` to the hermes-owned volume (the gateway loads from there, never in place), execs the `*.sh`, runs the `*.py` as scripts — so no `__pycache__` write depends on the agent owning them. They stay `a+rX`.
- `/app/safety-substrate` is deliberately left hermes-owned (its `run_invariants.py` writes a boot log there) — a smaller residual tracked separately.
- **boot-smoke Step 12** affirmatively proves `overlay-pack` + the activation handler are root-owned and not agent-writable on the running Machine.

## Severity note
Live exploitability was *low*: `/app` is image-backed (resets each boot) and the gate loads from a pre-agent volume copy, so the agent couldn't actually persist a tampered gate. This closes the sloppy ownership as defense-in-depth.

## Test plan
- [x] `bash -n boot-smoke-test.sh` clean; operator suites green (86 passed)
- [x] Dockerfile-inspecting tests (overlay-ref drift, overlay-pairs) unaffected
- [ ] **Requires a staging boot before it rides a customer-zero deploy** — confirms the root-owned `/app/overlay-pack` copy-to-volume + script exec still boot cleanly (staging was in use by another session this session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)