### PR TITLE
chore(operator): bump OVERLAY_REF to 5a1e3e7 — security wave (Clio classification + taint fence + guards)

### DIFF
--- a/operator/contracts/overlay-pairs.json
+++ b/operator/contracts/overlay-pairs.json
@@ -1,6 +1,6 @@
 {
   "overlayRepo": "https://github.com/venturecrane/hermes-smd-overlay.git",
-  "overlayRef": "0e491f95950f9b31eb7aea5dd8d57c0c0bdfe8a3",
+  "overlayRef": "5a1e3e74ff61e36e3750d1004b62dad03b6ed829",
   "overlayRefNote": "MUST equal the ARG OVERLAY_REF pinned in operator/templates/Dockerfile — that is the overlay commit a customer Machine actually ships. The vitest gate asserts the two agree so the manifest cannot pin a stale overlay. Bump both together when OVERLAY_REF moves, then re-record each overlaySha256 from the runtime file at the new ref.",
   "pairs": [
     {

--- a/operator/templates/Dockerfile
+++ b/operator/templates/Dockerfile
@@ -190,7 +190,7 @@ ARG OVERLAY_REPO="https://github.com/venturecrane/hermes-smd-overlay.git"
 # pilot-law / pilot-smokeball boot (the deadline-miss-escalator cron). Superset
 # of a548086 (#87 per-peer working-preference memory, ADR 0048 learned lane) and
 # carries #86 (voice_corrections seam rip) + #85 (Clerk-id secret-scan exemption).
-ARG OVERLAY_REF="0e491f95950f9b31eb7aea5dd8d57c0c0bdfe8a3"
+ARG OVERLAY_REF="5a1e3e74ff61e36e3750d1004b62dad03b6ed829"
 
 ARG CUSTOMER_SLUG=customer-zero
 

--- a/tests/operator-dockerfile.test.ts
+++ b/tests/operator-dockerfile.test.ts
@@ -87,7 +87,14 @@ describe('Operator customer Machine Dockerfile', () => {
     // per-peer working-preference memory — pre_llm_call sender stash + inject, record_peer_preference
     // tool, post_tool_call server-side attribution + taint-gate, peer_preferences on the agent-state
     // D1 binding + runtime_read seam). Carries overlay #86 (voice_corrections seam rip). Superset of 8d6f1a95.
-    expect(DOCKERFILE).toContain('ARG OVERLAY_REF="0e491f95950f9b31eb7aea5dd8d57c0c0bdfe8a3"')
+    // 0e491f9 (#88) materializes wake_policy: pre_run_decides (ADR 0047 phase 2);
+    // unblocks pilot-law / pilot-smokeball boot. Superset of a548086.
+    // 5a1e3e7 (#92) is the security-audit remediation wave tip: classifies the full
+    // Clio MCP surface (#93 — closes a live fail-open where Clio writes ran
+    // autonomous on injection-tainted turns), the EFF-07 tool-classification
+    // completeness gate (unmapped writes fail-closed), the SEC-05/13 AgentMail
+    // inbox-read fence (#90), and the SEC-33 hook-parity guard (#91). Superset of 0e491f9.
+    expect(DOCKERFILE).toContain('ARG OVERLAY_REF="5a1e3e74ff61e36e3750d1004b62dad03b6ed829"')
   })
 
   it('does NOT swallow a failed plugin install (no fail-open `|| echo ... continuing`)', () => {


### PR DESCRIPTION
## Summary
Bumps OVERLAY_REF to overlay `5a1e3e7`, carrying four merged overlay PRs:
- **#93** classify the full Clio MCP surface — **closes the LIVE EFF-07 fail-open** on `pilot-law` (Ashton & Price) + `demo-law`. Every Clio write (`mcp_clio_oktopeak_create_matter`, etc.) was `unmapped → READ → autonomous` on an injection-tainted turn.
- **#90** fence the agent's own AgentMail inbox PULL reads (SEC-05/13 residual)
- **#91** hook-parity guard + hook-surface drift fix (SEC-33)
- **#92** tool-classification completeness gate (EFF-07 regression guard — fails CI if any bound connector ships unclassified)

## Ref-only bump
None of the 4 SEC-32-paired runtime files changed → `overlaySha256` values unchanged. `verify-overlay-pairs.py` → PASS.

## Goes live on reprovision (gated)
This bump alone changes nothing on a running Machine. It closes the Clio hole only when `demo-law` + `pilot-law` are reprovisioned off this ref — held for a staging boot proof + explicit go.

## Test plan
- [x] `verify-overlay-pairs.py` PASS (SEC-32 gate)
- [ ] staging boot proof before any live reprovision

🤖 Generated with [Claude Code](https://claude.com/claude-code)