### PR TITLE
feat(operator): wire customer-zero to the ADR 0049 two-tier model (Sonnet main + Opus escalation)

### DIFF
--- a/operator/contracts/overlay-pairs.json
+++ b/operator/contracts/overlay-pairs.json
@@ -1,6 +1,6 @@
 {
   "overlayRepo": "https://github.com/venturecrane/hermes-smd-overlay.git",
-  "overlayRef": "5a1e3e74ff61e36e3750d1004b62dad03b6ed829",
+  "overlayRef": "0f51821d54182888b1d68348187360d9bc4a05ea",
   "overlayRefNote": "MUST equal the ARG OVERLAY_REF pinned in operator/templates/Dockerfile — that is the overlay commit a customer Machine actually ships. The vitest gate asserts the two agree so the manifest cannot pin a stale overlay. Bump both together when OVERLAY_REF moves, then re-record each overlaySha256 from the runtime file at the new ref.",
   "pairs": [
     {

--- a/operator/customers/smd/customer.yaml
+++ b/operator/customers/smd/customer.yaml
@@ -23,10 +23,19 @@ vertical: mixed # interview §Runtime; enum has no consulting/services value (#1
 fly_region: lax # "We're in Phoenix" → closest Fly region
 
 # ---- RUNTIME ----
-# Interview wants TIERED models (routine: claude-sonnet-4-6, sensitive: claude-opus-4-8).
-# The schema has a single `model:` string — per-task tiering is a schema gap (open-item).
-# Set to the sensitive-tier default; drafting the principal's mail is sensitive work.
-model: claude-opus-4-8
+# Two-tier model (ADR 0049). The interview asked for tiered models (routine vs
+# sensitive); the schema now supports it natively. `model` is the lighter main
+# that runs the conversation and every in-line skill (inbox-triage, drafting);
+# `escalation_model` is the heavier tier a delegate_task call escalates to, wired
+# into Hermes' native `delegation` block by translate.py. Escalation fires only
+# because this seat authors `code_execution: autonomous` below (delegate_task is a
+# CODE_EXECUTION action) AND the skill delegates before reading untrusted content
+# (the taint gate withholds escalation post-read). Customer-zero cost test: the
+# high-frequency hourly triage runs cheaply on Sonnet, genuinely heavy reasoning
+# escalates to Opus. NOTE: principal-mail drafting runs in-loop on the Sonnet main,
+# not Opus — the interview's sensitive-tier intent is traded for the cost test.
+model: claude-sonnet-4-6
+escalation_model: claude-opus-4-8
 hermes_ref: v2026.5.16@a91a57fa5a13d516c38b07a141a9ce8a3daabeb0
 
 machine:
@@ -184,8 +193,13 @@ scope:
   # ---- TRUST CEILINGS (per-action, ADR 0025) ----
   # Crane may send from its own AgentMail identity within the authored ceiling.
   # Sending from the principal Workspace identity remains permanently banned.
+  # code_execution: autonomous enables the ADR 0049 escalate-up path (delegate_task
+  # is a CODE_EXECUTION action, fail-closed unless authored). Re-opened on the
+  # customer-zero dogfood seat for the two-tier cost test; the sticky taint gate
+  # still withholds subagent-spawning on any turn that has read untrusted content.
   action_ceilings:
     external_send: autonomous
+    code_execution: autonomous
 
 # ---- ESCALATION ----
 # "just flag it to me" → red flags + run failures go to the boss/escalation address.

--- a/operator/templates/Dockerfile
+++ b/operator/templates/Dockerfile
@@ -184,13 +184,16 @@ ARG HERMES_UPSTREAM_SHA=a91a57fa5a13d516c38b07a141a9ce8a3daabeb0
 # check is unchanged. Fixes demo-law DEMO_RELAY_BLOCKED reason=content_sensitive
 # on a benign disclaimer (2026-06-14 live test). Superset of ed96cebe.
 ARG OVERLAY_REPO="https://github.com/venturecrane/hermes-smd-overlay.git"
-# 0e491f9 — #88 ADR 0047 phase 2: materialize wake_policy: pre_run_decides. Maps
-# the watcher policy to Hermes' native wakeAgent gate (skill-bearing job +
-# staged pre-run script; suppressed_wake heartbeat on the quiet path). Unblocks
-# pilot-law / pilot-smokeball boot (the deadline-miss-escalator cron). Superset
-# of a548086 (#87 per-peer working-preference memory, ADR 0048 learned lane) and
-# carries #86 (voice_corrections seam rip) + #85 (Clerk-id secret-scan exemption).
-ARG OVERLAY_REF="5a1e3e74ff61e36e3750d1004b62dad03b6ed829"
+# 0f51821 — #89 ADR 0049 model selection: emit Hermes' native `delegation` block
+# from customer.yaml `escalation_model`, render the roster-conditional SOUL
+# escalation instruction, and read the skill weight marker. Enables the two-tier
+# (light main + escalate-up) seam. Superset of 5a1e3e7 (#92, the security-audit
+# remediation wave tip: #93 full Clio MCP classification — closes the live
+# autonomous-write fail-open; #92 EFF-07 completeness gate; #90 SEC-05/13 AgentMail
+# inbox-read fence; #91 SEC-33 hook-parity guard), which is atop 0e491f9 (#88 ADR
+# 0047 phase 2: materialize wake_policy: pre_run_decides; unblocks pilot-law /
+# pilot-smokeball boot), carrying #87/#86/#85.
+ARG OVERLAY_REF="0f51821d54182888b1d68348187360d9bc4a05ea"
 
 ARG CUSTOMER_SLUG=customer-zero
 

--- a/tests/operator-dockerfile.test.ts
+++ b/tests/operator-dockerfile.test.ts
@@ -94,7 +94,11 @@ describe('Operator customer Machine Dockerfile', () => {
     // autonomous on injection-tainted turns), the EFF-07 tool-classification
     // completeness gate (unmapped writes fail-closed), the SEC-05/13 AgentMail
     // inbox-read fence (#90), and the SEC-33 hook-parity guard (#91). Superset of 0e491f9.
-    expect(DOCKERFILE).toContain('ARG OVERLAY_REF="5a1e3e74ff61e36e3750d1004b62dad03b6ed829"')
+    // 0f51821 (#89) emits Hermes' native `delegation` block from customer.yaml
+    // `escalation_model`, renders the roster-conditional SOUL escalation instruction,
+    // and reads the skill weight marker — the ADR 0049 two-tier (light main +
+    // escalate-up) seam. Superset of 5a1e3e7.
+    expect(DOCKERFILE).toContain('ARG OVERLAY_REF="0f51821d54182888b1d68348187360d9bc4a05ea"')
   })
 
   it('does NOT swallow a failed plugin install (no fail-open `|| echo ... continuing`)', () => {


### PR DESCRIPTION
## What

Wires the SMD customer-zero seat to the ADR 0049 two-tier model as a **live cost test**, and bumps OVERLAY_REF to ship the delegation runtime.

**OVERLAY_REF `5a1e3e7` → `0f51821`** (overlay #89: emits Hermes' native `delegation` block from `escalation_model`, renders the roster-conditional SOUL escalation instruction, reads the skill weight marker). Layers directly on the security-audit remediation wave already pinned at `5a1e3e7` (#1429) — one reprovision ships both.

**SMD seat** (`operator/customers/smd/customer.yaml`):
- `model`: `claude-opus-4-8` → **`claude-sonnet-4-6`** (lighter main; hourly inbox-triage + conversation run cheaply)
- **`escalation_model: claude-opus-4-8`** (heavy reasoning escalates up via the native delegation block)
- **`action_ceilings.code_execution: autonomous`** — re-opens the `delegate_task` path Phase-1 hardening shut; **required** for escalation to fire (delegate_task is a CODE_EXECUTION action, fail-closed unless authored). The sticky taint gate still withholds subagent-spawning on any untrusted-fed turn.

## Trade-off (noted in-file)

Principal-mail drafting runs in-loop on the Sonnet main, not Opus — the interview's sensitive-tier intent is traded for the cost test. Acceptable on the dogfood seat; revisit if quality dips.

## Drift gate

`overlay-pairs.json` overlayRef bumped to match (SEC-32). The 4 paired overlay files are **byte-identical** `5a1e3e7..0f51821` (verified — #89 only touched `bootstrap/translate.py`), so each `overlaySha256` is unchanged. `operator-dockerfile` pin test + changelog updated.

## Verification

- `operator-dockerfile` + `operator-overlay-pairs` tests: 22/22
- operator-substrate pytest (validates customer.yaml): 344 passed
- Full pre-push `npm run verify` green

Runtime verification (delegation block in profile config, SOUL escalation section, a heavy task actually escalating) happens at reprovision — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)