### PR TITLE
fix(voice): correct voice_library.samples_path in SMD customer.yaml

### DIFF
--- a/operator/customers/smd/customer.yaml
+++ b/operator/customers/smd/customer.yaml
@@ -210,10 +210,14 @@ escalation:
     - team@smd.services
 
 # ---- VOICE LIBRARY ----
-# Deterministic R2 path. The principal supplied NO writing samples in the interview —
-# sample collection is an open onboarding item (onboarding-plan.md Phase 1). Not fabricated.
+# Actual R2 layout: vaults/smd/voice/cohort/{cohort-id}/{ulid}.json
+# (written by voice-ingest-corpus.py; read by samples.retrieve_relevant_samples).
+# The runtime derives the prefix from the customer slug — this block is metadata only.
 voice_library:
-  samples_path: 'r2://vaults/smd/voice/samples/'
+  samples_path: 'r2://vaults/smd/voice/cohort/'
+  cohorts:
+    - id: general
+      label: General
 
 # ---- MEMORY (per-customer isolation invariants; must match customer_id) ----
 # Phase 1 runs on Hermes' flat-file memory core (MEMORY.md/USER.md). Inferred memory


### PR DESCRIPTION
## Summary

- Fixes `voice_library.samples_path` in `operator/customers/smd/customer.yaml` from the wrong path (`r2://vaults/smd/voice/samples/`) to the actual R2 layout path (`r2://vaults/smd/voice/cohort/`)
- Also fixes pre-existing typecheck error: removes `workflowName` from `WorkflowEvent<EnrichmentWorkflowParams>` literal in `tests/enrichment-workflow.test.ts` (field was removed from the `@cloudflare/workers-types` definition)

The `samples_path` value is metadata-only (the runtime derives the R2 prefix from the customer slug via `voice-ingest-corpus.py`), but the corrected value matches the actual vault layout written by the seeding toolchain, preventing confusion during ops.

## Test plan

- [x] `npm run typecheck` — 0 errors
- [x] Full `npm run verify` passes (ran via pre-push hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)