### PR TITLE
chore(operator): bump OVERLAY_REF to 72fa21de — Voice Layer 2 (transform_llm_output hook)

### DIFF
--- a/operator/contracts/overlay-pairs.json
+++ b/operator/contracts/overlay-pairs.json
@@ -1,6 +1,6 @@
 {
   "overlayRepo": "https://github.com/venturecrane/hermes-smd-overlay.git",
-  "overlayRef": "0f51821d54182888b1d68348187360d9bc4a05ea",
+  "overlayRef": "72fa21def0baa9ba873e3b6c9195451f4e6000ed",
   "overlayRefNote": "MUST equal the ARG OVERLAY_REF pinned in operator/templates/Dockerfile — that is the overlay commit a customer Machine actually ships. The vitest gate asserts the two agree so the manifest cannot pin a stale overlay. Bump both together when OVERLAY_REF moves, then re-record each overlaySha256 from the runtime file at the new ref.",
   "pairs": [
     {

--- a/operator/templates/Dockerfile
+++ b/operator/templates/Dockerfile
@@ -193,7 +193,8 @@ ARG OVERLAY_REPO="https://github.com/venturecrane/hermes-smd-overlay.git"
 # inbox-read fence; #91 SEC-33 hook-parity guard), which is atop 0e491f9 (#88 ADR
 # 0047 phase 2: materialize wake_policy: pre_run_decides; unblocks pilot-law /
 # pilot-smokeball boot), carrying #87/#86/#85.
-ARG OVERLAY_REF="0f51821d54182888b1d68348187360d9bc4a05ea"
+# Voice Layer 2: wire transform_llm_output hook → transform_draft() (#96).
+ARG OVERLAY_REF="72fa21def0baa9ba873e3b6c9195451f4e6000ed"
 
 ARG CUSTOMER_SLUG=customer-zero
 

--- a/tests/operator-dockerfile.test.ts
+++ b/tests/operator-dockerfile.test.ts
@@ -98,7 +98,10 @@ describe('Operator customer Machine Dockerfile', () => {
     // `escalation_model`, renders the roster-conditional SOUL escalation instruction,
     // and reads the skill weight marker — the ADR 0049 two-tier (light main +
     // escalate-up) seam. Superset of 5a1e3e7.
-    expect(DOCKERFILE).toContain('ARG OVERLAY_REF="0f51821d54182888b1d68348187360d9bc4a05ea"')
+    // 72fa21d (#96) wires the previously-orphaned transform_draft() into the
+    // transform_llm_output hook — Voice Layer 2 structural reshape post-LLM.
+    // Superset of 0f51821.
+    expect(DOCKERFILE).toContain('ARG OVERLAY_REF="72fa21def0baa9ba873e3b6c9195451f4e6000ed"')
   })
 
   it('does NOT swallow a failed plugin install (no fail-open `|| echo ... continuing`)', () => {


### PR DESCRIPTION
## Summary

- Bumps `OVERLAY_REF` to `72fa21def0baa9ba873e3b6c9195451f4e6000ed` (overlay PR #96)
- Updates `operator/contracts/overlay-pairs.json` `overlayRef` to match (SEC-32 drift gate)
- Updates `tests/operator-dockerfile.test.ts` pin comment + assertion

## What shipped in the overlay

Voice Layer 2: the `transform_draft()` function was fully built but never called — it was orphaned with no hook attachment. PR #96 wires it to the Hermes `transform_llm_output` hook. On each turn, post-LLM, the plugin reads the customer's VoiceProfileBundle (lazily built from R2 samples, cached per process), runs `transform_draft()`, and if `TransformStatus.TRANSFORMED` is returned, replaces the response with the reshaped text. All passthrough cases (no samples, insufficient profile, draft already in voice, fabrication guard, any exception) return `None` so the response is unchanged.

## Test plan

- [x] `tests/operator-dockerfile.test.ts` and `tests/operator-overlay-pairs.test.ts` pass locally
- [x] Full `npm run verify` passes (pre-push hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)