### PR TITLE
chore(operator): bump OVERLAY_REF → 3dcef42 — MCP conversational channel

### DIFF
--- a/operator/contracts/overlay-pairs.json
+++ b/operator/contracts/overlay-pairs.json
@@ -1,6 +1,6 @@
 {
   "overlayRepo": "https://github.com/venturecrane/hermes-smd-overlay.git",
-  "overlayRef": "72fa21def0baa9ba873e3b6c9195451f4e6000ed",
+  "overlayRef": "3dcef4290767cdac914a1184c0fef88069a169e2",
   "overlayRefNote": "MUST equal the ARG OVERLAY_REF pinned in operator/templates/Dockerfile — that is the overlay commit a customer Machine actually ships. The vitest gate asserts the two agree so the manifest cannot pin a stale overlay. Bump both together when OVERLAY_REF moves, then re-record each overlaySha256 from the runtime file at the new ref.",
   "pairs": [
     {

--- a/operator/templates/Dockerfile
+++ b/operator/templates/Dockerfile
@@ -193,8 +193,11 @@ ARG OVERLAY_REPO="https://github.com/venturecrane/hermes-smd-overlay.git"
 # inbox-read fence; #91 SEC-33 hook-parity guard), which is atop 0e491f9 (#88 ADR
 # 0047 phase 2: materialize wake_policy: pre_run_decides; unblocks pilot-law /
 # pilot-smokeball boot), carrying #87/#86/#85.
-# Voice Layer 2: wire transform_llm_output hook → transform_draft() (#96).
-ARG OVERLAY_REF="72fa21def0baa9ba873e3b6c9195451f4e6000ed"
+# MCP conversational channel (#97): one ask_operator verb, principal-namespaced
+# thread continuity, source==mcp turns fenced+tainted like inbound email. Lands
+# the previously-unmerged channel spine (echo/fetch/store retired) + Clerk OAuth
+# front door onto main, so reprovisions no longer revert it. Superset of 72fa21d.
+ARG OVERLAY_REF="3dcef4290767cdac914a1184c0fef88069a169e2"
 
 ARG CUSTOMER_SLUG=customer-zero
 

--- a/tests/operator-dockerfile.test.ts
+++ b/tests/operator-dockerfile.test.ts
@@ -100,8 +100,12 @@ describe('Operator customer Machine Dockerfile', () => {
     // escalate-up) seam. Superset of 5a1e3e7.
     // 72fa21d (#96) wires the previously-orphaned transform_draft() into the
     // transform_llm_output hook — Voice Layer 2 structural reshape post-LLM.
-    // Superset of 0f51821.
-    expect(DOCKERFILE).toContain('ARG OVERLAY_REF="72fa21def0baa9ba873e3b6c9195451f4e6000ed"')
+    // 3dcef42 (#97) lands the MCP conversational channel: one ask_operator verb
+    // (echo/fetch/store retired), principal-namespaced thread continuity, and
+    // source==mcp turns fenced+tainted like inbound email — plus the Clerk OAuth
+    // front door. Merging it to main is the durable fix for the reprovision-revert.
+    // Superset of 72fa21d.
+    expect(DOCKERFILE).toContain('ARG OVERLAY_REF="3dcef4290767cdac914a1184c0fef88069a169e2"')
   })
 
   it('does NOT swallow a failed plugin install (no fail-open `|| echo ... continuing`)', () => {


### PR DESCRIPTION
## What

Bumps the customer-Machine `OVERLAY_REF` to overlay `3dcef42` (overlay PR venturecrane/hermes-smd-overlay#97), landing the **inbound conversational channel** on the SMD Operator.

## Why

The founder couldn't *talk* to the Operator through the claude.ai MCP connector — it exposed only typed RPC verbs and narrated the menu. The conversational spine existed on an unmerged overlay branch and kept getting reverted by reprovision-from-main. #97 merges it to overlay main (the durable fix); this bump ships it.

## The channel (per #97)

- **One verb, `ask_operator(message, thread_id?)`** — the connector is a communication channel, not an RPC menu. The worker decides what to do with its own tools (Drive, managed inbox, memory).
- **Thread continuity**, overlay-only (Hermes' webhook adapter forces a per-delivery session, so native memory can't carry the thread): a transcript keyed by `<hash(clerk_subject)>:<thread_id>`, injected into each turn. Built from the **authenticated principal** → a caller can only read/extend their own thread.
- **Governance**: `source==mcp` turns are fenced + session-tainted like inbound email — an injected instruction can't drive autonomous sensitive actions; reads/drafts/the in-line reply are unaffected; taint is sticky across the conversation.

## This PR's changes

- `operator/templates/Dockerfile` — `ARG OVERLAY_REF` → `3dcef42`.
- `operator/contracts/overlay-pairs.json` — `overlayRef` → `3dcef42`. The 4 paired overlay runtime files are byte-identical between `72fa21d` and `3dcef42`, so every `overlaySha256` is unchanged.
- `tests/operator-dockerfile.test.ts` — update the pinned-SHA assertion + provenance comment.

## Verification

`operator-overlay-pairs` + `operator-dockerfile` gates green (22 tests); `operator/` substrate pytest 344 passed; `npm run verify` 3517 passed. Overlay suite at the merged ref: 1039 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)