### PR TITLE
fix(operator): bump OVERLAY_REF to 8d633a4 — MCP Clerk plural-subjects fix (#98)

### DIFF
--- a/operator/contracts/overlay-pairs.json
+++ b/operator/contracts/overlay-pairs.json
@@ -1,6 +1,6 @@
 {
   "overlayRepo": "https://github.com/venturecrane/hermes-smd-overlay.git",
-  "overlayRef": "3dcef4290767cdac914a1184c0fef88069a169e2",
+  "overlayRef": "8d633a4c943443035e75628f6704d80ff25f7b12",
   "overlayRefNote": "MUST equal the ARG OVERLAY_REF pinned in operator/templates/Dockerfile — that is the overlay commit a customer Machine actually ships. The vitest gate asserts the two agree so the manifest cannot pin a stale overlay. Bump both together when OVERLAY_REF moves, then re-record each overlaySha256 from the runtime file at the new ref.",
   "pairs": [
     {
@@ -13,9 +13,9 @@
     {
       "adapterPath": "operator/adapter/audit_log.py",
       "overlayPath": "plugins/hermes-smd-audit/emit.py",
-      "syncNote": "2026-06-16: removed SENT_DETECTED / SENT_DIFF_INDEXED action types (declared-only, never emitted — vocabulary for the killed sent-watch/draft-diff lane, ADR 0048 amend). The paired overlay removal lives in hermes-smd-audit/schemas.py (overlay PR #86), NOT emit.py — so the emit.py overlaySha256 (SEC-32) is unchanged. src/lib/portal/operator/audit.ts updated in the same PR (TS parity is test-enforced).",
+      "syncNote": "2026-06-17: emit.py overlaySha256 re-recorded for OVERLAY_REF bump 3dcef42→8d633a4. The runtime change is overlay #95 (already merged): unknown tool → fail-closed REFUSED action class instead of READ default (issue #1327) — a docstring + default-class change on the runtime emitter. One-sided runtime change: the fail-closed default-class logic lives runtime-side (hermes-smd-trust/enforce.py + shared/action_classes.py), not in this adapter port, so operator/adapter/audit_log.py is unaffected and its sha256 is unchanged. Prior note: 2026-06-16 removed SENT_DETECTED / SENT_DIFF_INDEXED action types (overlay PR #86, in schemas.py not emit.py).",
       "sha256": "b797b2ac3fcff021db140eab9634c3e30a2bf99df13fd21cf9ed8f14a1fa7f82",
-      "overlaySha256": "1f54717e80cdc474266ee637ed5cae1e689c1cdb35c5855799b754739b6576c6"
+      "overlaySha256": "38efd8ed3f92964b21fd2889a68e470cc87aa8faa7d9e0abd92b942b262ff321"
     },
     {
       "adapterPath": "operator/adapter/namespace_assertion.py",

--- a/operator/templates/Dockerfile
+++ b/operator/templates/Dockerfile
@@ -197,7 +197,12 @@ ARG OVERLAY_REPO="https://github.com/venturecrane/hermes-smd-overlay.git"
 # thread continuity, source==mcp turns fenced+tainted like inbound email. Lands
 # the previously-unmerged channel spine (echo/fetch/store retired) + Clerk OAuth
 # front door onto main, so reprovisions no longer revert it. Superset of 72fa21d.
-ARG OVERLAY_REF="3dcef4290767cdac914a1184c0fef88069a169e2"
+# MCP Clerk auth fix (#98): _load_mcp_binding now authorizes clerk_subjects
+# (plural) — the authored form SMD's seat uses — not only the singular key, which
+# had built an EMPTY access list and refused every real token identity_not_authored
+# (proven live on hermes-smd 2026-06-17). Superset of 3dcef42; also carries the
+# already-merged #95 (unmapped tool → REFUSED fail-closed) + #94 (SOUL.md principal).
+ARG OVERLAY_REF="8d633a4c943443035e75628f6704d80ff25f7b12"
 
 ARG CUSTOMER_SLUG=customer-zero
 

--- a/tests/operator-dockerfile.test.ts
+++ b/tests/operator-dockerfile.test.ts
@@ -104,8 +104,12 @@ describe('Operator customer Machine Dockerfile', () => {
     // (echo/fetch/store retired), principal-namespaced thread continuity, and
     // source==mcp turns fenced+tainted like inbound email — plus the Clerk OAuth
     // front door. Merging it to main is the durable fix for the reprovision-revert.
-    // Superset of 72fa21d.
-    expect(DOCKERFILE).toContain('ARG OVERLAY_REF="3dcef4290767cdac914a1184c0fef88069a169e2"')
+    // 8d633a4 (#98) fixes the Machine Clerk binding to authorize clerk_subjects
+    // (plural — the authored form), not only the singular key, which had refused
+    // every real token identity_not_authored (proven live on hermes-smd 2026-06-17).
+    // Superset of 3dcef42; also carries already-merged #95 (unmapped tool → REFUSED)
+    // and #94 (SOUL.md principal materialization).
+    expect(DOCKERFILE).toContain('ARG OVERLAY_REF="8d633a4c943443035e75628f6704d80ff25f7b12"')
   })
 
   it('does NOT swallow a failed plugin install (no fail-open `|| echo ... continuing`)', () => {


### PR DESCRIPTION
## Why

The SMD Operator connector failed with **"Authorization with the MCP server failed"** on every attempt. Proven live on `hermes-smd` 2026-06-17 — the Machine's own diagnostic:

\`\`\`
mcp: Clerk auth refused (identity_not_authored)
  token.sub='user_3EEs0aMBRgu6PRxBa4g5YhHjggD'  ← an AUTHORED subject the console accepts
  token.iss='https://clerk.smd.services'         ← matches
\`\`\`

Root cause (overlay #98): `_load_mcp_binding` read only the singular `clerk_subject` key; the authored `customer.yaml` uses `clerk_subjects` (plural) → the entry was filtered out → empty access list → every real token refused. The console's TS validator always honoured both, which is why console auth worked and only the Machine surface failed.

## What

Bump `OVERLAY_REF` `3dcef42` → `8d633a4` (overlay main tip). Lands #98 (the fix) and brings the deployed image current with main: also #95 (unmapped tool → REFUSED fail-closed) and #94 (SOUL.md principal materialization), both already merged.

- `operator/templates/Dockerfile` — ARG OVERLAY_REF + provenance comment
- `operator/contracts/overlay-pairs.json` — `overlayRef` bump; `emit.py` `overlaySha256` re-recorded (changed by #95, runtime-only; adapter port unaffected — syncNote explains). Other 3 pairs byte-identical between refs (verified).
- `tests/operator-dockerfile.test.ts` — assertion + provenance updated

## Verification

- vitest drift gates (dockerfile + overlay-pairs): **22 passed**
- operator-substrate pytest (bin/tests + safety-substrate + adapter): **344 passed**
- overlay #98 suite: 1053 passed; emit.py sha256 @ 8d633a4 computed directly = `38efd8…` (matches recorded)

Deploy is the follow-on `reprovision.sh smd` (staging rehearsal first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)