### PR TITLE
chore(operator): bump OVERLAY_REF to 8d633a4c — clerk_subjects MCP auth fix (overlay #98)

### DIFF
--- a/operator/contracts/overlay-pairs.json
+++ b/operator/contracts/overlay-pairs.json
@@ -1,6 +1,6 @@
 {
   "overlayRepo": "https://github.com/venturecrane/hermes-smd-overlay.git",
-  "overlayRef": "3dcef4290767cdac914a1184c0fef88069a169e2",
+  "overlayRef": "8d633a4c943443035e75628f6704d80ff25f7b12",
   "overlayRefNote": "MUST equal the ARG OVERLAY_REF pinned in operator/templates/Dockerfile — that is the overlay commit a customer Machine actually ships. The vitest gate asserts the two agree so the manifest cannot pin a stale overlay. Bump both together when OVERLAY_REF moves, then re-record each overlaySha256 from the runtime file at the new ref.",
   "pairs": [
     {
@@ -13,9 +13,9 @@
     {
       "adapterPath": "operator/adapter/audit_log.py",
       "overlayPath": "plugins/hermes-smd-audit/emit.py",
-      "syncNote": "2026-06-16: removed SENT_DETECTED / SENT_DIFF_INDEXED action types (declared-only, never emitted — vocabulary for the killed sent-watch/draft-diff lane, ADR 0048 amend). The paired overlay removal lives in hermes-smd-audit/schemas.py (overlay PR #86), NOT emit.py — so the emit.py overlaySha256 (SEC-32) is unchanged. src/lib/portal/operator/audit.ts updated in the same PR (TS parity is test-enforced).",
+      "syncNote": "2026-06-17: overlaySha256 updated for overlay #95 (fail-closed for unknown tool names in the unmapped-tool → READ default path). The ss-console adapter is unchanged — overlaySha256 tracks the runtime emit.py content at OVERLAY_REF 8d633a4c.",
       "sha256": "b797b2ac3fcff021db140eab9634c3e30a2bf99df13fd21cf9ed8f14a1fa7f82",
-      "overlaySha256": "1f54717e80cdc474266ee637ed5cae1e689c1cdb35c5855799b754739b6576c6"
+      "overlaySha256": "38efd8ed3f92964b21fd2889a68e470cc87aa8faa7d9e0abd92b942b262ff321"
     },
     {
       "adapterPath": "operator/adapter/namespace_assertion.py",

--- a/operator/templates/Dockerfile
+++ b/operator/templates/Dockerfile
@@ -197,7 +197,7 @@ ARG OVERLAY_REPO="https://github.com/venturecrane/hermes-smd-overlay.git"
 # thread continuity, source==mcp turns fenced+tainted like inbound email. Lands
 # the previously-unmerged channel spine (echo/fetch/store retired) + Clerk OAuth
 # front door onto main, so reprovisions no longer revert it. Superset of 72fa21d.
-ARG OVERLAY_REF="3dcef4290767cdac914a1184c0fef88069a169e2"
+ARG OVERLAY_REF="8d633a4c943443035e75628f6704d80ff25f7b12"
 
 ARG CUSTOMER_SLUG=customer-zero
 

--- a/tests/operator-dockerfile.test.ts
+++ b/tests/operator-dockerfile.test.ts
@@ -105,7 +105,11 @@ describe('Operator customer Machine Dockerfile', () => {
     // source==mcp turns fenced+tainted like inbound email — plus the Clerk OAuth
     // front door. Merging it to main is the durable fix for the reprovision-revert.
     // Superset of 72fa21d.
-    expect(DOCKERFILE).toContain('ARG OVERLAY_REF="3dcef4290767cdac914a1184c0fef88069a169e2"')
+    // 8d633a4c (#98) fixes the Clerk Machine auth binding: _mcp_access_entries()
+    // now expands clerk_subjects (plural list — the authored schema) as well as
+    // clerk_subject (singular), matching the console's customer-resolution.ts.
+    // Superset of 3dcef42.
+    expect(DOCKERFILE).toContain('ARG OVERLAY_REF="8d633a4c943443035e75628f6704d80ff25f7b12"')
   })
 
   it('does NOT swallow a failed plugin install (no fail-open `|| echo ... continuing`)', () => {


### PR DESCRIPTION
## Summary

- Bumps `ARG OVERLAY_REF` in `operator/templates/Dockerfile` to `8d633a4c943443035e75628f6704d80ff25f7b12` (overlay PR #98)
- Updates `overlay-pairs.json` `overlayRef` to match (required by the vitest gate that asserts the two agree)
- Re-records `overlaySha256` for `plugins/hermes-smd-audit/emit.py` — changed in overlay #95 (fail-closed for unknown tool names). Other three pairs unchanged at the new ref.
- Advances the minimum-ref marker in `tests/operator-dockerfile.test.ts` with the #98 summary

**What overlay #98 fixes:** `_mcp_access_entries()` now expands `clerk_subjects` (plural list — the authored `customer.yaml` schema) as well as `clerk_subject` (singular), matching the console's `customer-resolution.ts`. Previously the Machine only read the singular key, built an empty access list, and refused every valid token with `identity_not_authored`. Proven live on `hermes-smd` 2026-06-17.

## Test plan
- [x] `npm run verify` passes (pre-push hook ran clean)
- [x] `overlay-pairs.json overlayRef` matches `Dockerfile ARG OVERLAY_REF` (vitest gate)
- [x] All four `overlaySha256` values verified against overlay files at `8d633a4c`
- [ ] Reprovision `smd` after merge to pick up overlay #95/#97/#98

🤖 Generated with [Claude Code](https://claude.com/claude-code)