### PR TITLE
feat(operator): fleet health read endpoint for health_monitor skill (#1440)

### DIFF
--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -275,6 +275,13 @@ declare namespace Cloudflare {
      * UI (ADR 0023 Wave 1).
      */
     HEALTHCHECKS_WEBHOOK_SECRET?: string
+    /**
+     * Bearer secret that authenticates the SMD dogfood Operator (customer-zero)
+     * reading the fleet-health endpoint (`GET /api/admin/fleet/health`). Only
+     * customer-zero holds this key — it is NOT the shared machine heartbeat key,
+     * which is a write credential. Generated with `openssl rand -hex 32`.
+     */
+    OPERATOR_HEALTH_READ_KEY?: string
   }
 }
 

--- a/src/lib/auth/health-read-key.ts
+++ b/src/lib/auth/health-read-key.ts
@@ -1,0 +1,32 @@
+/**
+ * Auth verifier for the fleet-health read endpoint
+ * (`GET /api/admin/fleet/health`). The caller is the SMD dogfood Operator
+ * (customer-zero) — a Machine, not a browser — so Clerk session auth is not
+ * applicable. Instead, a dedicated bearer secret (`OPERATOR_HEALTH_READ_KEY`)
+ * is held only by customer-zero and verified here with a constant-time compare.
+ *
+ * This is intentionally separate from `machine-key.ts` (the write credential
+ * for heartbeat / runtime-summary pushes). Keeping the read and write keys
+ * distinct means a compromised heartbeat key cannot be used to read fleet data,
+ * and vice versa.
+ *
+ * No DB lookup is required: this endpoint is fleet-wide, not per-tenant, so
+ * there is no slug to resolve.
+ */
+
+export function verifyHealthReadKey(request: Request, expectedKey: string | undefined): boolean {
+  if (!expectedKey) return false
+  const auth = request.headers.get('Authorization') ?? ''
+  if (!auth.startsWith('Bearer ')) return false
+  const provided = auth.slice('Bearer '.length)
+  return constantTimeEqual(provided, expectedKey)
+}
+
+function constantTimeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false
+  let mismatch = 0
+  for (let i = 0; i < a.length; i++) {
+    mismatch |= a.charCodeAt(i) ^ b.charCodeAt(i)
+  }
+  return mismatch === 0
+}

--- a/src/pages/api/admin/fleet/health.ts
+++ b/src/pages/api/admin/fleet/health.ts
@@ -1,0 +1,125 @@
+/**
+ * GET /api/admin/fleet/health
+ *
+ * Fleet-health snapshot for the SMD dogfood Operator (customer-zero). Returns
+ * one entry per provisioned Machine, composed from the two console-side mirrors
+ * that each Machine pushes to:
+ *
+ *   - `fleet_status`              — heartbeat liveness (ADR 0023)
+ *   - `operator_runtime_summary`  — operational health rollup (ADR 0043 path B)
+ *
+ * The SMD Operator's `health_monitor` skill polls this on a cron cadence and
+ * emails Captain when any entry is in a degraded state. The admin portal fleet
+ * view reads the same underlying tables — this endpoint is the machine-callable
+ * surface over that data, not a new data pipeline.
+ *
+ * Auth: dedicated bearer secret (`OPERATOR_HEALTH_READ_KEY`) held only by
+ * customer-zero. NOT the shared machine heartbeat key. Verified with
+ * constant-time compare; no DB lookup required (fleet-wide read, not per-tenant).
+ *
+ * Isolation (ADR 0009): the query reads per-customer summary rows from both
+ * tables but never joins across two Machines' runtime D1. Each row was pushed
+ * by exactly one Machine.
+ *
+ * Response shape:
+ *   {
+ *     "generated_at": "<ISO 8601 UTC>",
+ *     "entries": [
+ *       {
+ *         "slug":              "<customer_slug>",
+ *         "heartbeat_status":  "green"|"yellow"|"red"|"unknown",
+ *         "last_heartbeat_ts": "<ISO 8601 UTC>" | null,
+ *         "last_audit_ts":     "<ISO 8601 UTC>" | null,
+ *         "summary_status":    "green"|"yellow"|"red"|"unknown" | null,
+ *         "open_alerts":       <integer> | null,
+ *         "last_activity_ts":  "<ISO 8601 UTC>" | null,
+ *         "pushed_at":         "<ISO 8601 UTC>" | null
+ *       },
+ *       ...
+ *     ]
+ *   }
+ *
+ * `summary_status` and related fields are null when no runtime summary has been
+ * pushed yet (Machine alive but summary push not yet implemented or not yet run).
+ * Slugs with no fleet_status row are omitted — this endpoint describes
+ * provisioned Machines, not the full customer list.
+ */
+
+import type { APIRoute } from 'astro'
+import { env } from 'cloudflare:workers'
+import { verifyHealthReadKey } from '../../../../lib/auth/health-read-key'
+
+export interface HealthEntry {
+  slug: string
+  heartbeat_status: 'green' | 'yellow' | 'red' | 'unknown'
+  last_heartbeat_ts: string | null
+  last_audit_ts: string | null
+  summary_status: 'green' | 'yellow' | 'red' | 'unknown' | null
+  open_alerts: number | null
+  last_activity_ts: string | null
+  pushed_at: string | null
+}
+
+interface HealthRow {
+  customer_slug: string
+  heartbeat_status: string
+  last_heartbeat_ts: string | null
+  last_audit_ts: string | null
+  summary_status: string | null
+  open_alerts: number | null
+  last_activity_ts: string | null
+  pushed_at: string | null
+}
+
+function json(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+const VALID_STATUSES = new Set(['green', 'yellow', 'red', 'unknown'])
+
+function parseHeartbeatStatus(s: string): 'green' | 'yellow' | 'red' | 'unknown' {
+  return VALID_STATUSES.has(s) ? (s as 'green' | 'yellow' | 'red' | 'unknown') : 'unknown'
+}
+
+function parseSummaryStatus(s: string | null): 'green' | 'yellow' | 'red' | 'unknown' | null {
+  if (s === null) return null
+  return VALID_STATUSES.has(s) ? (s as 'green' | 'yellow' | 'red' | 'unknown') : 'unknown'
+}
+
+export const GET: APIRoute = async ({ request }) => {
+  if (!verifyHealthReadKey(request, env.OPERATOR_HEALTH_READ_KEY)) {
+    return json({ error: 'unauthorized' }, 401)
+  }
+
+  const rows = await env.DB.prepare(
+    `SELECT
+       fs.customer_slug,
+       fs.heartbeat_status,
+       fs.last_heartbeat_ts,
+       fs.last_audit_ts,
+       ors.summary_status,
+       ors.open_alerts,
+       ors.last_activity_ts,
+       ors.pushed_at
+     FROM fleet_status fs
+     LEFT JOIN operator_runtime_summary ors
+       ON fs.customer_slug = ors.customer_slug
+     ORDER BY fs.customer_slug ASC`
+  ).all<HealthRow>()
+
+  const entries: HealthEntry[] = (rows.results ?? []).map((r) => ({
+    slug: r.customer_slug,
+    heartbeat_status: parseHeartbeatStatus(r.heartbeat_status),
+    last_heartbeat_ts: r.last_heartbeat_ts,
+    last_audit_ts: r.last_audit_ts,
+    summary_status: parseSummaryStatus(r.summary_status),
+    open_alerts: r.open_alerts,
+    last_activity_ts: r.last_activity_ts,
+    pushed_at: r.pushed_at,
+  }))
+
+  return json({ generated_at: new Date().toISOString(), entries }, 200)
+}

--- a/tests/operator-health-read.test.ts
+++ b/tests/operator-health-read.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Tests for GET /api/admin/fleet/health (issue #1440).
+ *
+ * Covers: auth rejection (missing key, wrong key), empty fleet, single-slug
+ * with no runtime summary (LEFT JOIN null fields), and multi-slug fleet with
+ * mixed status values.
+ *
+ * Auth is a dedicated bearer secret (`OPERATOR_HEALTH_READ_KEY`) distinct from
+ * the machine heartbeat write key. The handler verifies with constant-time
+ * compare; no DB lookup is needed for auth.
+ */
+
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest'
+import {
+  createTestD1,
+  discoverNumericMigrations,
+  runMigrations,
+  installWorkerdPolyfills,
+} from '@venturecrane/crane-test-harness'
+import path from 'node:path'
+import { GET } from '../src/pages/api/admin/fleet/health'
+import { env as testEnv } from 'cloudflare:workers'
+
+installWorkerdPolyfills()
+
+const migrationsDir = path.resolve(__dirname, '../migrations')
+const HEALTH_KEY = 'test-health-read-key-32-chars-xxxx'
+
+const ORG_ID = 'org-health-test'
+const ENTITY_A = 'ent-alpha'
+const ENTITY_B = 'ent-beta'
+
+function buildRequest(opts: { key?: string } = {}): Parameters<typeof GET>[0] {
+  const headers: Record<string, string> = { Accept: 'application/json' }
+  if (opts.key !== undefined) headers['Authorization'] = `Bearer ${opts.key}`
+  const request = new Request('http://test.local/api/admin/fleet/health', { headers })
+  return { request, params: {}, locals: {} } as unknown as Parameters<typeof GET>[0]
+}
+
+async function seedOrg(db: D1Database): Promise<void> {
+  await db
+    .prepare(
+      `INSERT INTO organizations (id, name, slug, created_at, updated_at)
+       VALUES (?, 'Health Test Org', 'health-test', datetime('now'), datetime('now'))`
+    )
+    .bind(ORG_ID)
+    .run()
+}
+
+async function seedEntity(db: D1Database, entityId: string, slug: string): Promise<void> {
+  await db
+    .prepare(
+      `INSERT INTO entities (id, org_id, name, slug, stage, stage_changed_at, created_at, updated_at)
+       VALUES (?, ?, ?, ?, 'ongoing', datetime('now'), datetime('now'), datetime('now'))`
+    )
+    .bind(entityId, ORG_ID, slug, slug)
+    .run()
+}
+
+async function seedFleetStatus(
+  db: D1Database,
+  entityId: string,
+  slug: string,
+  opts: {
+    heartbeat_status?: string
+    last_heartbeat_ts?: string
+    last_audit_ts?: string
+  } = {}
+): Promise<void> {
+  await db
+    .prepare(
+      `INSERT INTO fleet_status
+         (entity_id, customer_slug, heartbeat_status, last_heartbeat_ts, last_audit_ts, updated_at)
+       VALUES (?, ?, ?, ?, ?, datetime('now'))`
+    )
+    .bind(
+      entityId,
+      slug,
+      opts.heartbeat_status ?? 'green',
+      opts.last_heartbeat_ts ?? new Date().toISOString(),
+      opts.last_audit_ts ?? null
+    )
+    .run()
+}
+
+async function seedRuntimeSummary(
+  db: D1Database,
+  entityId: string,
+  slug: string,
+  opts: {
+    summary_status?: string
+    open_alerts?: number
+    last_activity_ts?: string
+  } = {}
+): Promise<void> {
+  await db
+    .prepare(
+      `INSERT INTO operator_runtime_summary
+         (entity_id, customer_slug, summary_status, open_alerts, last_activity_ts, pushed_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, datetime('now'), datetime('now'))`
+    )
+    .bind(
+      entityId,
+      slug,
+      opts.summary_status ?? 'green',
+      opts.open_alerts ?? 0,
+      opts.last_activity_ts ?? null
+    )
+    .run()
+}
+
+describe('GET /api/admin/fleet/health', () => {
+  beforeAll(() => {
+    const files = discoverNumericMigrations(migrationsDir)
+    expect(files.length).toBeGreaterThan(0)
+  })
+
+  beforeEach(async () => {
+    const db = createTestD1()
+    const files = discoverNumericMigrations(migrationsDir)
+    await runMigrations(db, { files })
+    await seedOrg(db)
+    for (const k of Object.keys(testEnv)) delete (testEnv as unknown as Record<string, unknown>)[k]
+    Object.assign(testEnv, { DB: db, OPERATOR_HEALTH_READ_KEY: HEALTH_KEY })
+  })
+
+  it('returns 401 when Authorization header is absent', async () => {
+    const res = await GET(buildRequest())
+    expect(res.status).toBe(401)
+    const body = await res.json<{ error: string }>()
+    expect(body.error).toBe('unauthorized')
+  })
+
+  it('returns 401 when bearer value is wrong', async () => {
+    const res = await GET(buildRequest({ key: 'wrong-key' }))
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 401 when OPERATOR_HEALTH_READ_KEY is unset', async () => {
+    const db = (testEnv as unknown as Record<string, unknown>).DB
+    for (const k of Object.keys(testEnv)) delete (testEnv as unknown as Record<string, unknown>)[k]
+    Object.assign(testEnv, { DB: db })
+    const res = await GET(buildRequest({ key: HEALTH_KEY }))
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 200 with empty entries when no Machines are provisioned', async () => {
+    const res = await GET(buildRequest({ key: HEALTH_KEY }))
+    expect(res.status).toBe(200)
+    const body = await res.json<{ generated_at: string; entries: unknown[] }>()
+    expect(Array.isArray(body.entries)).toBe(true)
+    expect(body.entries).toHaveLength(0)
+    expect(typeof body.generated_at).toBe('string')
+  })
+
+  it('returns an entry with null summary fields when no runtime summary has been pushed', async () => {
+    const db = (testEnv as unknown as { DB: D1Database }).DB
+    await seedEntity(db, ENTITY_A, 'alpha')
+    await seedFleetStatus(db, ENTITY_A, 'alpha', {
+      heartbeat_status: 'green',
+      last_heartbeat_ts: '2026-06-17T10:00:00Z',
+      last_audit_ts: '2026-06-17T09:55:00Z',
+    })
+
+    const res = await GET(buildRequest({ key: HEALTH_KEY }))
+    expect(res.status).toBe(200)
+    const body = await res.json<{ entries: Array<Record<string, unknown>> }>()
+    expect(body.entries).toHaveLength(1)
+
+    const entry = body.entries[0]
+    expect(entry.slug).toBe('alpha')
+    expect(entry.heartbeat_status).toBe('green')
+    expect(entry.last_heartbeat_ts).toBe('2026-06-17T10:00:00Z')
+    expect(entry.last_audit_ts).toBe('2026-06-17T09:55:00Z')
+    expect(entry.summary_status).toBeNull()
+    expect(entry.open_alerts).toBeNull()
+    expect(entry.last_activity_ts).toBeNull()
+    expect(entry.pushed_at).toBeNull()
+  })
+
+  it('includes summary fields when a runtime summary has been pushed', async () => {
+    const db = (testEnv as unknown as { DB: D1Database }).DB
+    await seedEntity(db, ENTITY_A, 'alpha')
+    await seedFleetStatus(db, ENTITY_A, 'alpha', { heartbeat_status: 'red' })
+    await seedRuntimeSummary(db, ENTITY_A, 'alpha', { summary_status: 'red', open_alerts: 3 })
+
+    const res = await GET(buildRequest({ key: HEALTH_KEY }))
+    expect(res.status).toBe(200)
+    const body = await res.json<{ entries: Array<Record<string, unknown>> }>()
+    const entry = body.entries[0]
+    expect(entry.heartbeat_status).toBe('red')
+    expect(entry.summary_status).toBe('red')
+    expect(entry.open_alerts).toBe(3)
+  })
+
+  it('returns multiple entries ordered by slug', async () => {
+    const db = (testEnv as unknown as { DB: D1Database }).DB
+    await seedEntity(db, ENTITY_A, 'alpha')
+    await seedEntity(db, ENTITY_B, 'beta')
+    await seedFleetStatus(db, ENTITY_A, 'alpha', { heartbeat_status: 'green' })
+    await seedFleetStatus(db, ENTITY_B, 'beta', { heartbeat_status: 'yellow' })
+
+    const res = await GET(buildRequest({ key: HEALTH_KEY }))
+    expect(res.status).toBe(200)
+    const body = await res.json<{ entries: Array<{ slug: string }> }>()
+    expect(body.entries).toHaveLength(2)
+    expect(body.entries[0].slug).toBe('alpha')
+    expect(body.entries[1].slug).toBe('beta')
+  })
+
+  it('omits customers that have no fleet_status row', async () => {
+    const db = (testEnv as unknown as { DB: D1Database }).DB
+    await seedEntity(db, ENTITY_A, 'alpha')
+    // no fleet_status row for alpha — it has no Machine yet
+
+    const res = await GET(buildRequest({ key: HEALTH_KEY }))
+    expect(res.status).toBe(200)
+    const body = await res.json<{ entries: unknown[] }>()
+    expect(body.entries).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
## Summary

- Adds `GET /api/admin/fleet/health` — a machine-callable endpoint that returns one health entry per provisioned Operator Machine
- Composes data from `fleet_status` (heartbeat liveness, ADR 0023) and `operator_runtime_summary` (operational rollup, ADR 0043 path B) via a LEFT JOIN — the same tables the admin portal fleet view reads, no new data pipeline
- Auth: dedicated bearer secret `OPERATOR_HEALTH_READ_KEY`, separate from the machine heartbeat write key, verified with constant-time compare
- Adds `src/lib/auth/health-read-key.ts` — thin verifier reusable by any future machine-read endpoint
- 8 tests covering: auth rejection (absent header, wrong key, unset env var), empty fleet, heartbeat-only entry (null summary fields), full entry, multi-slug ordering, entity-with-no-machine omission

## Design decisions

**Why a separate key from `MACHINE_HEARTBEAT_KEY`?** The heartbeat key is a write credential; the health read key is a read credential. Keeping them distinct means a compromised write key cannot read fleet data. Only customer-zero holds `OPERATOR_HEALTH_READ_KEY`.

**Why not Clerk session auth?** The caller is the SMD Operator (a Machine), not a browser.

**Why `LEFT JOIN`?** A Machine with a heartbeat but no runtime summary yet (e.g. the summary push hasn't been implemented) still appears in the response with null summary fields — honest about what's known.

## Test plan

- [ ] `npm run verify` passes (all 8 new tests + full suite)
- [ ] `OPERATOR_HEALTH_READ_KEY` secret set on the Fly worker before deploy
- [ ] `GET /api/admin/fleet/health` with correct bearer returns 200 + entries
- [ ] `GET /api/admin/fleet/health` with wrong bearer returns 401

Closes #1440

🤖 Generated with [Claude Code](https://claude.com/claude-code)