### PR TITLE
fix(operator/broker): gmail_search tolerates a missing query (list = empty q)

### DIFF
--- a/operator/workspace_broker/operations.py
+++ b/operator/workspace_broker/operations.py
@@ -75,13 +75,18 @@ class WorkspaceOperations:
         return service(api, version, self._credential_path, self._customer_path, mailbox)
 
     def gmail_search(self, payload: dict[str, Any]) -> Any:
+        # `query` is optional: a bare "list/read the mailbox" request carries no
+        # search term. Gmail's messages.list accepts an empty `q` (returns the
+        # most recent messages across the mailbox), so default to "" rather than
+        # KeyError on a missing key — listing is a first-class use of this tool,
+        # not only term searches.
         return (
             self._service("gmail", "v1", str(payload.get("mailbox") or ""))
             .users()
             .messages()
             .list(
                 userId="me",
-                q=str(payload["query"]),
+                q=str(payload.get("query") or ""),
                 maxResults=int(payload.get("max_results", 25)),
             )
             .execute()

--- a/operator/workspace_broker/tests/test_managed_mailbox.py
+++ b/operator/workspace_broker/tests/test_managed_mailbox.py
@@ -115,6 +115,24 @@ def test_gmail_search_default_subject_when_no_mailbox(tmp_path: Path, monkeypatc
     assert captured["subject"] == ""  # broker resolves "" → authored default
 
 
+def test_gmail_search_without_query_lists_all(tmp_path: Path, monkeypatch) -> None:
+    # Regression: a bare "list/read the mailbox" request (e.g. "review the receipts
+    # mailbox") carries no `query`. The broker must default q to "" — Gmail's
+    # messages.list returns recent messages on an empty q — not KeyError on the
+    # missing key. The KeyError previously surfaced to the agent as
+    # `BrokerError: 'query'`, which it then confabulated into a fake result.
+    svc = MagicMock()
+
+    def fake_service(api, version, cred, customer, subject=""):
+        return svc
+
+    monkeypatch.setattr(ops_mod, "service", fake_service)
+    # No "query" key present — must not raise.
+    _ops(tmp_path).gmail_search({"mailbox": MANAGED})
+    list_call = svc.users.return_value.messages.return_value.list
+    assert list_call.call_args.kwargs["q"] == ""
+
+
 def test_create_draft_sets_from_and_threads_mailbox(tmp_path: Path, monkeypatch) -> None:
     captured: dict = {}
     built = MagicMock()


### PR DESCRIPTION
## The bug

`workspace_broker` `gmail_search` did `q=str(payload["query"])` — a hard subscript that `KeyError`s whenever the agent **lists** a mailbox with no search term ("review the receipts mailbox", "read the inbox"). The broker surfaced this to the agent as `BrokerError: 'query'`.

Caught live on customer-zero (hermes-smd) right after #1443 deployed: three `workspace_gmail_search` attempts, all `BrokerError: 'query'`, **zero successful reads** — and the agent **confabulated** "5 message IDs, no errors" to the principal off the failed calls.

## Fix

Default `q` to `""` (Gmail's `messages.list` accepts an empty `q` = return recent messages). `query` is genuinely optional for a list/read; the other hard-required params (`message_id`, `to`, `subject`, `body`) stay required. One-line handler change + a regression test asserting a query-less call doesn't raise and passes `q=""`.

## Why it surfaced now

#1443 made the governed `workspace_gmail_*` tools the agent's **only** Gmail path (the legacy connector-CLI fallback was removed). This broker bug was pre-existing but previously masked. DWD + scopes are healthy — `gmail-sa-smoke.py` reads mail directly against the SA credential; this was purely the broker operation handler.

## Verification

- `python3 -m pytest operator/workspace_broker/tests/test_managed_mailbox.py -q` → 12 passed (incl. new `test_gmail_search_without_query_lists_all`).
- After merge + reprovision: re-run the **actual** read on customer-zero and confirm a **successful** `workspace_gmail_search` in the runtime log (not the agent's self-report).

## Related

Confabulation (agent reporting fake success off a fenced error) is filed separately as a trust/safety follow-up — it is the more serious finding and not addressed by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)