### PR TITLE
chore(operator): bump OVERLAY_REF to d8c178e — unfence workspace_gmail_search (#99)

### DIFF
--- a/operator/contracts/overlay-pairs.json
+++ b/operator/contracts/overlay-pairs.json
@@ -1,6 +1,6 @@
 {
   "overlayRepo": "https://github.com/venturecrane/hermes-smd-overlay.git",
-  "overlayRef": "8d633a4c943443035e75628f6704d80ff25f7b12",
+  "overlayRef": "d8c178e1047069cb2235a578b7bfd87d2b81650e",
   "overlayRefNote": "MUST equal the ARG OVERLAY_REF pinned in operator/templates/Dockerfile — that is the overlay commit a customer Machine actually ships. The vitest gate asserts the two agree so the manifest cannot pin a stale overlay. Bump both together when OVERLAY_REF moves, then re-record each overlaySha256 from the runtime file at the new ref.",
   "pairs": [
     {

--- a/operator/templates/Dockerfile
+++ b/operator/templates/Dockerfile
@@ -197,12 +197,12 @@ ARG OVERLAY_REPO="https://github.com/venturecrane/hermes-smd-overlay.git"
 # thread continuity, source==mcp turns fenced+tainted like inbound email. Lands
 # the previously-unmerged channel spine (echo/fetch/store retired) + Clerk OAuth
 # front door onto main, so reprovisions no longer revert it. Superset of 72fa21d.
-# MCP Clerk auth fix (#98): _load_mcp_binding now authorizes clerk_subjects
-# (plural) — the authored form SMD's seat uses — not only the singular key, which
-# had built an EMPTY access list and refused every real token identity_not_authored
-# (proven live on hermes-smd 2026-06-17). Superset of 3dcef42; also carries the
-# already-merged #95 (unmapped tool → REFUSED fail-closed) + #94 (SOUL.md principal).
-ARG OVERLAY_REF="8d633a4c943443035e75628f6704d80ff25f7b12"
+# Gmail-search unfence (#99): workspace_gmail_search returns only {id, threadId}
+# metadata (no body), so it left _FENCED_READ_TOOLS for UNFENCED_READ_BY_DESIGN —
+# fencing the id list tainted the result so the agent would not reuse the ids as
+# the message_id for the (still-fenced) body read, making a list→get mailbox read
+# impossible. Superset of 8d633a4 (#98 MCP Clerk clerk_subjects plural) + #95 + #94.
+ARG OVERLAY_REF="d8c178e1047069cb2235a578b7bfd87d2b81650e"
 
 ARG CUSTOMER_SLUG=customer-zero
 

--- a/tests/operator-dockerfile.test.ts
+++ b/tests/operator-dockerfile.test.ts
@@ -107,9 +107,12 @@ describe('Operator customer Machine Dockerfile', () => {
     // 8d633a4 (#98) fixes the Machine Clerk binding to authorize clerk_subjects
     // (plural — the authored form), not only the singular key, which had refused
     // every real token identity_not_authored (proven live on hermes-smd 2026-06-17).
-    // Superset of 3dcef42; also carries already-merged #95 (unmapped tool → REFUSED)
-    // and #94 (SOUL.md principal materialization).
-    expect(DOCKERFILE).toContain('ARG OVERLAY_REF="8d633a4c943443035e75628f6704d80ff25f7b12"')
+    // d8c178e (#99) unfences workspace_gmail_search: it returns only {id, threadId}
+    // metadata (no body), so fencing it tainted the result and blocked the agent
+    // from reusing the ids as the message_id for the still-fenced body read —
+    // making a list→get mailbox read impossible. Superset of 8d633a4; also carries
+    // already-merged #95 (unmapped tool → REFUSED) and #94 (SOUL.md principal).
+    expect(DOCKERFILE).toContain('ARG OVERLAY_REF="d8c178e1047069cb2235a578b7bfd87d2b81650e"')
   })
 
   it('does NOT swallow a failed plugin install (no fail-open `|| echo ... continuing`)', () => {


### PR DESCRIPTION
Pins the customer Machine image to overlay `d8c178e` (hermes-smd-overlay #99), which unfences `workspace_gmail_search` so a list→get mailbox read works.

**Why:** `workspace_gmail_search` returns only `{id, threadId}` metadata (no body), but it was in `_FENCED_READ_TOOLS` — so its result was nonce-fenced as untrusted and tainted the session. The agent, obeying the fence, would not reuse the returned ids as the `message_id` for `workspace_gmail_get`, so it could list message IDs but never open a message. Caught live on customer-zero.

**Security:** no hole opened. The message **body** read (`workspace_gmail_get`) stays fenced + still taints — that is where sender-authored content lives. An opaque message id carries no injection surface. Same rationale already applied to `workspace_drive_list` vs `workspace_drive_get`.

Bump-only: #99 changed the inbound plugin + tests, none of the four drift-paired runtime files, so all `overlaySha256` values are unchanged (gate tests green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)