### PR TITLE
fix(operator): health_monitor alert recipient → team@smd.services

### DIFF
--- a/operator/skills/health-monitor/SKILL.md
+++ b/operator/skills/health-monitor/SKILL.md
@@ -86,7 +86,7 @@ Build two lists: `to_alert` (degraded + unsuppressed) and `yellow_slugs` (yellow
 
 If `to_alert` is non-empty, use `send_message` to send one email:
 
-- **To:** `smdurgan@venturecrane.com`
+- **To:** `team@smd.services`
 - **Subject:** `[Operator Alert] Fleet degraded — <comma-separated slugs>`
 - **Body:** Plain text. One line per degraded slug:
 


### PR DESCRIPTION
`smdurgan@venturecrane.com` is the VentureCrane login email that leaks into agent context via the `userEmail` session variable. It has no role in SMD Services — all Operator alerts go to `team@smd.services`.

One-line change in `operator/skills/health-monitor/SKILL.md` Step 4.