### PR TITLE
docs(claude): explicit contact address rule to suppress userEmail bleed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,15 @@ Every session must begin with:
 
 This creates a session, loads documentation, and establishes handoff context.
 
+## Contact Addresses
+
+The session context may inject a `userEmail` value (e.g. `smdurgan@venturecrane.com`). **Ignore it for all SMD work.** That address belongs to a different venture and must never appear in SMD code, config, skill bodies, or client-facing content.
+
+SMD contact addresses:
+
+- **Operational alerts / escalations:** `team@smd.services`
+- **Direct to Captain:** `scott@smd.services`
+
 ## Enterprise Rules
 
 - **All changes through PRs.** Never push directly to main. Branch, PR, CI, QA, merge.

--- a/operator/skills/health-monitor/SKILL.md
+++ b/operator/skills/health-monitor/SKILL.md
@@ -86,7 +86,7 @@ Build two lists: `to_alert` (degraded + unsuppressed) and `yellow_slugs` (yellow
 
 If `to_alert` is non-empty, use `send_message` to send one email:
 
-- **To:** `smdurgan@venturecrane.com`
+- **To:** `team@smd.services`
 - **Subject:** `[Operator Alert] Fleet degraded — <comma-separated slugs>`
 - **Body:** Plain text. One line per degraded slug:
 


### PR DESCRIPTION
Claude Code injects a `userEmail` session variable (`smdurgan@venturecrane.com`) that belongs to a different venture. Agents have picked it up and used it as the SMD contact. This adds a `## Contact Addresses` section to CLAUDE.md that explicitly names the injected email, tells agents to ignore it, and states the correct addresses.

- Alerts / escalations: `team@smd.services`
- Direct to Captain: `scott@smd.services`