### PR TITLE
feat(operator-mcp): ship operator_handoff_task (Phase 2)

### DIFF
--- a/operator/bin/provision-customer.sh
+++ b/operator/bin/provision-customer.sh
@@ -430,6 +430,22 @@ else
   log "WARN: OPERATOR_RUNTIME_READ_SECRET not set in operator env — skipping runtime read key (runtime drill-ins stay empty for this Machine)"
 fi
 
+# WEBHOOK_SECRET_MCP — per-customer bearer for the console→Machine async handoff
+# endpoint (/webhooks/handoff, ADR 0043 Phase 2). Same derivation as the runtime
+# read key: HMAC-SHA256(OPERATOR_MCP_WEBHOOK_SECRET, slug), printf '%s' (no
+# newline), matching src/lib/operator/mcp/webhook-transport.ts → deriveRuntimeReadKey.
+# The console sends the derived bearer; the Machine verifies it. Gate also re-uses
+# it as WEBHOOK_SECRET_HANDOFF so the internal Hermes adapter can re-verify the
+# forwarded hop.
+if [ -n "${OPERATOR_MCP_WEBHOOK_SECRET:-}" ]; then
+  _mcp_key="$(printf '%s' "${SLUG}" | openssl dgst -sha256 -hmac "${OPERATOR_MCP_WEBHOOK_SECRET}" | sed 's/^.*= //')"
+  stage_secret_from_env WEBHOOK_SECRET_MCP     "${_mcp_key}" "per-customer MCP handoff bearer (Phase 2)"
+  stage_secret_from_env WEBHOOK_SECRET_HANDOFF "${_mcp_key}" "Hermes adapter re-verify secret for the handoff route (= WEBHOOK_SECRET_MCP)"
+  unset _mcp_key
+else
+  log "WARN: OPERATOR_MCP_WEBHOOK_SECRET not set in operator env — skipping MCP handoff key (operator_handoff_task returns not_configured)"
+fi
+
 # ---------- Step 6b-clio: connector secrets (law vertical + Google DWD) ----------
 # Staged from operator env (Infisical /ss, injected by reprovision.sh's
 # `infisical run --path=/ss`), same no-paste pattern as observability. Each is

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -260,6 +260,16 @@ declare namespace Cloudflare {
      */
     OPERATOR_RUNTIME_READ_SECRET?: string
     /**
+     * Master secret for the per-customer MCP webhook delivery key. The console
+     * derives `HMAC-SHA256(master, customer_slug)` and sends it as a bearer
+     * token to the Machine's `/webhooks/mcp` gate; each Machine holds only its
+     * own derived key (`WEBHOOK_SECRET_MCP` set at provision). The master lives
+     * ONLY on the console. Required (with OPERATOR_RUNTIME_READ_URL) to enable
+     * `operator_handoff_task` (Phase 2 MCP connector).
+     * See src/lib/operator/mcp/webhook-transport.ts.
+     */
+    OPERATOR_MCP_WEBHOOK_SECRET?: string
+    /**
      * Sentry Internal Integration Client Secret used to verify
      * `Sentry-Hook-Signature` headers on inbound alert-rule webhook
      * deliveries to `/api/webhooks/sentry`. Pulled from the SMD-owned

--- a/src/lib/operator/mcp/mcp-route.ts
+++ b/src/lib/operator/mcp/mcp-route.ts
@@ -27,6 +27,10 @@ export interface McpRouteDependencies {
     auth: Extract<McpAuthResult, { ok: true }>,
     query: RuntimeReadQuery
   ) => Promise<RuntimeReadResult>
+  sendHandoff?: (
+    auth: Extract<McpAuthResult, { ok: true }>,
+    params: { handoff_id: string; task: string; context?: string }
+  ) => Promise<void>
 }
 
 function jsonWithCors(body: unknown, status: number, extra?: Record<string, string>): Response {
@@ -117,6 +121,7 @@ export async function handleMcpPost(
     email: auth.email,
     profile: auth.profile,
     readRuntime: (query) => deps.readRuntime(auth, query),
+    sendHandoff: deps.sendHandoff ? (params) => deps.sendHandoff!(auth, params) : undefined,
   })
   return withCorsHeaders(response)
 }

--- a/src/lib/operator/mcp/tools.ts
+++ b/src/lib/operator/mcp/tools.ts
@@ -1,22 +1,18 @@
 /**
  * MCP tool registry for the Operator ⇄ Claude connector.
  *
- * Phase 1 ships one LIVE read tool, `operator_status`, backed by the runtime-read
- * seam (ADR 0043 path A): the console→Machine `GET /runtime/audit_log` call,
- * summarized into a liveness + recent-activity view. The handler is fail-closed
- * — if the Machine is unreachable or the read path is unconfigured it reports
- * `reachable: false` with a reason, never fabricated activity.
+ * Phase 1: `operator_status` — read-only reachability + recent activity via
+ * the runtime-read seam (ADR 0043 path A).
  *
- * The read capability is injected via {@link McpToolContext.readRuntime}: the
- * route layer builds a capability already scoped to THIS
- * customer + actor (one customer per call, audited), so a tool handler cannot
- * express a cross-customer read. Tools stay free of env/db wiring.
+ * Phase 2: `operator_handoff_task` — post an async work request to the Machine
+ * via the signed webhook gate (`/webhooks/mcp`). The Operator works it and
+ * reports back via its authored channels.
  *
- * Deferred (fast-follow, intentionally not here): `operator_search_memory`
- * (memory_export needs a `table` param threaded through the frozen
- * RuntimeReadQuery, and the mirror tables may be sparse for customer-zero) and
- * `operator_handoff_task` (Phase 2 — two-repo: console emitter + overlay
- * `source=mcp` recognition + deploy). See docs/design/operator/03-mcp-server-exposure.md.
+ * Both capabilities are injected via {@link McpToolContext} so tool handlers
+ * stay free of env/db wiring. `sendHandoff` is optional — when unconfigured the
+ * tool returns a `not_configured` error rather than throwing.
+ *
+ * See docs/design/operator/03-mcp-server-exposure.md.
  */
 
 import type { RuntimeReadQuery, RuntimeReadResult } from '../runtime-read'
@@ -36,9 +32,16 @@ export interface McpToolDescriptor {
 }
 
 /**
- * The authenticated caller context handed to a tool handler. `readRuntime` is a
- * customer+actor-scoped, read-only, audited runtime read (the route layer binds
- * the customer and actor; there is no way to express a cross-customer read).
+ * The authenticated caller context handed to a tool handler.
+ *
+ * `readRuntime` — customer+actor-scoped, read-only, audited runtime read (the
+ * route layer binds the customer and actor; there is no way to express a
+ * cross-customer read).
+ *
+ * `sendHandoff` — optional. When configured (Phase 2), posts an async work
+ * request to the Machine and returns once the Machine acknowledges receipt.
+ * Absent when `OPERATOR_MCP_WEBHOOK_SECRET` is unset; the handoff tool returns
+ * `not_configured` rather than throwing.
  */
 export interface McpToolContext {
   customerId: string
@@ -46,6 +49,7 @@ export interface McpToolContext {
   email: string
   profile: string
   readRuntime: (query: RuntimeReadQuery) => Promise<RuntimeReadResult>
+  sendHandoff?: (params: { handoff_id: string; task: string; context?: string }) => Promise<void>
 }
 
 /** MCP `tools/call` result content block (text only for the spike). */
@@ -152,8 +156,76 @@ const operatorStatus: McpTool = {
   },
 }
 
+/**
+ * Phase 2 tool: `operator_handoff_task`. Posts an async work request to the
+ * Operator. The Operator acknowledges receipt immediately and works the task
+ * through its authored channels (email, Telegram, etc.). The caller receives
+ * a `handoff_id` for correlation.
+ *
+ * Fail-closed: returns `not_configured` when the webhook transport is absent,
+ * `delivery_failed` when the Machine returns an error.
+ */
+const operatorHandoffTask: McpTool = {
+  descriptor: {
+    name: 'operator_handoff_task',
+    description:
+      'Hand a task to the Operator to work asynchronously. The Operator acknowledges ' +
+      'immediately and reports back via its authored channels (email, Telegram, etc.). ' +
+      'Returns a handoff_id for correlation.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        task: {
+          type: 'string',
+          description: 'The task to hand off — be specific about what you want the Operator to do.',
+        },
+        context: {
+          type: 'string',
+          description: 'Optional additional context or constraints for the Operator.',
+        },
+      },
+      required: ['task'],
+    },
+  },
+  handle: async (args, ctx) => {
+    const task = typeof args.task === 'string' ? args.task.trim() : ''
+    if (!task) {
+      return {
+        content: [{ type: 'text', text: JSON.stringify({ ok: false, error: 'task_required' }) }],
+        isError: true,
+      }
+    }
+    if (!ctx.sendHandoff) {
+      return {
+        content: [{ type: 'text', text: JSON.stringify({ ok: false, error: 'not_configured' }) }],
+        isError: true,
+      }
+    }
+    const handoff_id = crypto.randomUUID()
+    const context =
+      typeof args.context === 'string' && args.context.trim() ? args.context.trim() : undefined
+    try {
+      await ctx.sendHandoff({ handoff_id, task, context })
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({ ok: true, accepted: true, handoff_id }),
+          },
+        ],
+      }
+    } catch {
+      return {
+        content: [{ type: 'text', text: JSON.stringify({ ok: false, error: 'delivery_failed' }) }],
+        isError: true,
+      }
+    }
+  },
+}
+
 const REGISTRY: ReadonlyMap<string, McpTool> = new Map([
   [operatorStatus.descriptor.name, operatorStatus],
+  [operatorHandoffTask.descriptor.name, operatorHandoffTask],
 ])
 
 /** All tool descriptors for `tools/list`. */

--- a/src/lib/operator/mcp/webhook-transport.ts
+++ b/src/lib/operator/mcp/webhook-transport.ts
@@ -1,0 +1,84 @@
+/**
+ * Production transport for the async MCP handoff path (Phase 2 / ADR 0043).
+ *
+ * Delivers a signed `HandoffEnvelope(surface="mcp")` to the Machine's
+ * `/webhooks/mcp` gate over HTTPS. The bearer is
+ * `HMAC-SHA256(OPERATOR_MCP_WEBHOOK_SECRET, slug)` — same derivation as the
+ * runtime-read key (a different master). Each Machine holds only its own derived
+ * key (`WEBHOOK_SECRET_MCP` set at provision); the master lives only on the
+ * console.
+ *
+ * The Machine acknowledges receipt synchronously (2xx). The Operator works the
+ * task async and reports via its authored channels (email, Telegram, etc.).
+ */
+
+import { deriveRuntimeReadKey } from '../runtime-read-transport'
+import { resolveCustomerFlyApp } from '../fly-app-registry'
+
+export interface MachineWebhookEnv {
+  /** Same Machine base URL template as the runtime-read path
+   * (e.g. `https://{app}.fly.dev`). Reused — both paths target the same Machine. */
+  OPERATOR_RUNTIME_READ_URL?: string
+  /** Master secret from which each Machine's per-customer MCP webhook key is
+   * derived (`HMAC-SHA256(master, slug)`). Lives only on the console. */
+  OPERATOR_MCP_WEBHOOK_SECRET?: string
+}
+
+export function isWebhookConfigured(env: MachineWebhookEnv): boolean {
+  return (
+    typeof env.OPERATOR_RUNTIME_READ_URL === 'string' &&
+    env.OPERATOR_RUNTIME_READ_URL.length > 0 &&
+    typeof env.OPERATOR_MCP_WEBHOOK_SECRET === 'string' &&
+    env.OPERATOR_MCP_WEBHOOK_SECRET.length > 0
+  )
+}
+
+export interface HandoffEnvelope {
+  handoff_id: string
+  surface: 'mcp'
+  trust_class: 'known_external'
+  task: string
+  context?: string
+  from_email: string
+  from_profile: string
+  submitted_at: string
+}
+
+export interface MachineWebhookTransport {
+  send(customerSlug: string, envelope: HandoffEnvelope): Promise<void>
+}
+
+function machineBaseUrl(template: string, app: string): string {
+  return template.includes('{app}') ? template.replace('{app}', app) : `https://${app}.fly.dev`
+}
+
+/**
+ * Construct the production console→Machine webhook transport. Throws on
+ * transport failure so the caller can map it to a fail-closed result.
+ * A 4xx/5xx from the Machine is treated as a delivery failure.
+ */
+export function createMachineWebhookTransport(env: MachineWebhookEnv): MachineWebhookTransport {
+  return {
+    send: async (customerSlug, envelope) => {
+      if (!isWebhookConfigured(env)) {
+        throw new Error('MCP webhook transport not configured (OPERATOR_MCP_WEBHOOK_SECRET unset)')
+      }
+      const app = resolveCustomerFlyApp(customerSlug)
+      if (!app) throw new Error(`webhook transport: unknown customer ${customerSlug}`)
+
+      const baseUrl = machineBaseUrl(env.OPERATOR_RUNTIME_READ_URL!, app)
+      const bearer = await deriveRuntimeReadKey(env.OPERATOR_MCP_WEBHOOK_SECRET!, customerSlug)
+
+      const resp = await fetch(`${baseUrl}/webhooks/mcp`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${bearer}`,
+          'X-Tenant-Slug': customerSlug,
+        },
+        body: JSON.stringify(envelope),
+      })
+      if (!resp.ok) throw new Error(`webhook delivery failed: ${resp.status}`)
+    },
+  }
+}

--- a/src/lib/operator/mcp/webhook-transport.ts
+++ b/src/lib/operator/mcp/webhook-transport.ts
@@ -69,7 +69,7 @@ export function createMachineWebhookTransport(env: MachineWebhookEnv): MachineWe
       const baseUrl = machineBaseUrl(env.OPERATOR_RUNTIME_READ_URL!, app)
       const bearer = await deriveRuntimeReadKey(env.OPERATOR_MCP_WEBHOOK_SECRET!, customerSlug)
 
-      const resp = await fetch(`${baseUrl}/webhooks/mcp`, {
+      const resp = await fetch(`${baseUrl}/webhooks/handoff`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/src/pages/api/operator/[customer]/mcp.ts
+++ b/src/pages/api/operator/[customer]/mcp.ts
@@ -9,6 +9,11 @@ import {
   handleMcpOptions,
   handleMcpPost,
 } from '../../../../lib/operator/mcp/mcp-route'
+import type { HandoffEnvelope } from '../../../../lib/operator/mcp/webhook-transport'
+import {
+  createMachineWebhookTransport,
+  isWebhookConfigured,
+} from '../../../../lib/operator/mcp/webhook-transport'
 import { readMachineRuntime } from '../../../../lib/operator/runtime-read'
 import {
   createMachineRuntimeTransport,
@@ -28,6 +33,8 @@ export const POST: APIRoute = async ({ request, url, params }) => {
   if (!customer) return new Response('Not found', { status: 404 })
 
   const transport = createMachineRuntimeTransport(env)
+  const webhookTransport = isWebhookConfigured(env) ? createMachineWebhookTransport(env) : null
+
   return handleMcpPost(request, url, {
     db: env.DB,
     customer,
@@ -38,6 +45,21 @@ export const POST: APIRoute = async ({ request, url, params }) => {
         actorRole: 'mcp_client',
       })
     },
+    sendHandoff: webhookTransport
+      ? (auth, params) => {
+          const envelope: HandoffEnvelope = {
+            handoff_id: params.handoff_id,
+            surface: 'mcp',
+            trust_class: 'known_external',
+            task: params.task,
+            context: params.context,
+            from_email: auth.email,
+            from_profile: auth.profile,
+            submitted_at: new Date().toISOString(),
+          }
+          return webhookTransport.send(customer.customerId, envelope)
+        }
+      : undefined,
   })
 }
 

--- a/tests/operator-mcp-endpoint.test.ts
+++ b/tests/operator-mcp-endpoint.test.ts
@@ -590,3 +590,131 @@ describe('JSON-RPC dispatcher', () => {
     expect(reads).toBe(0)
   })
 })
+
+describe('operator_handoff_task', () => {
+  it('lists operator_handoff_task in tools/list', async () => {
+    const listed = await dispatchMcpRequest({ jsonrpc: '2.0', id: 1, method: 'tools/list' }, CTX)
+    const body = await listed.json<{ result: { tools: { name: string }[] } }>()
+    expect(body.result.tools.map((t) => t.name)).toContain('operator_handoff_task')
+  })
+
+  it('returns not_configured when sendHandoff is absent', async () => {
+    const response = await dispatchMcpRequest(
+      {
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'tools/call',
+        params: { name: 'operator_handoff_task', arguments: { task: 'do something' } },
+      },
+      CTX
+    )
+    const body = await response.json<{ result: { content: { text: string }[] } }>()
+    const payload = JSON.parse(body.result.content[0].text)
+    expect(payload).toMatchObject({ ok: false, error: 'not_configured' })
+  })
+
+  it('returns task_required when task is missing or empty', async () => {
+    for (const args of [{}, { task: '' }, { task: '   ' }]) {
+      const response = await dispatchMcpRequest(
+        {
+          jsonrpc: '2.0',
+          id: 3,
+          method: 'tools/call',
+          params: { name: 'operator_handoff_task', arguments: args },
+        },
+        { ...CTX, sendHandoff: async () => {} }
+      )
+      const body = await response.json<{ result: { content: { text: string }[] } }>()
+      expect(JSON.parse(body.result.content[0].text)).toMatchObject({
+        ok: false,
+        error: 'task_required',
+      })
+    }
+  })
+
+  it('calls sendHandoff with the handoff_id and returns accepted on success', async () => {
+    const calls: { handoff_id: string; task: string; context?: string }[] = []
+    const response = await dispatchMcpRequest(
+      {
+        jsonrpc: '2.0',
+        id: 4,
+        method: 'tools/call',
+        params: {
+          name: 'operator_handoff_task',
+          arguments: { task: 'review receipts mailbox', context: 'focus on last 30 days' },
+        },
+      },
+      {
+        ...CTX,
+        sendHandoff: async (params) => {
+          calls.push(params)
+        },
+      }
+    )
+    expect(calls).toHaveLength(1)
+    expect(calls[0].task).toBe('review receipts mailbox')
+    expect(calls[0].context).toBe('focus on last 30 days')
+    expect(typeof calls[0].handoff_id).toBe('string')
+    expect(calls[0].handoff_id.length).toBeGreaterThan(0)
+    const body = await response.json<{ result: { content: { text: string }[] } }>()
+    const payload = JSON.parse(body.result.content[0].text)
+    expect(payload).toMatchObject({ ok: true, accepted: true, handoff_id: calls[0].handoff_id })
+  })
+
+  it('returns delivery_failed when sendHandoff throws', async () => {
+    const response = await dispatchMcpRequest(
+      {
+        jsonrpc: '2.0',
+        id: 5,
+        method: 'tools/call',
+        params: { name: 'operator_handoff_task', arguments: { task: 'do something' } },
+      },
+      {
+        ...CTX,
+        sendHandoff: async () => {
+          throw new Error('machine unreachable')
+        },
+      }
+    )
+    const body = await response.json<{ result: { content: { text: string }[] } }>()
+    expect(JSON.parse(body.result.content[0].text)).toMatchObject({
+      ok: false,
+      error: 'delivery_failed',
+    })
+  })
+
+  it('routes sendHandoff through mcp-route with auth-bound fields', async () => {
+    const db: D1Database = await freshDb()
+    await seedCustomer(db)
+    const loaded = await loadMcpCustomer(db, 'smd')
+    if (!loaded) throw new Error('test customer did not load')
+
+    const handoffs: { handoff_id: string; task: string }[] = []
+    const response = await handleMcpPost(
+      new Request(RESOURCE_URI, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token' },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tools/call',
+          params: { name: 'operator_handoff_task', arguments: { task: 'triage inbox' } },
+        }),
+      }),
+      new URL(RESOURCE_URI),
+      {
+        db,
+        customer: loaded,
+        verifier: claimsVerifier(claims()),
+        readRuntime: unreachableRead,
+        sendHandoff: async (_auth, params) => {
+          handoffs.push(params)
+        },
+      }
+    )
+    expect(response.status).toBe(200)
+    expect(handoffs).toHaveLength(1)
+    expect(handoffs[0].task).toBe('triage inbox')
+    expect(typeof handoffs[0].handoff_id).toBe('string')
+  })
+})


### PR DESCRIPTION
## Summary

- Adds \`operator_handoff_task\` MCP tool — posts an async work request to the Machine's \`/webhooks/handoff\` gate and returns \`{accepted: true, handoff_id}\` synchronously
- New \`webhook-transport.ts\`: signed HMAC(OPERATOR_MCP_WEBHOOK_SECRET, slug) bearer, same pattern as runtime-read but different master secret; reuses OPERATOR_RUNTIME_READ_URL as Machine base URL template
- \`sendHandoff\` is optional in McpToolContext — absent when OPERATOR_MCP_WEBHOOK_SECRET unset → tool returns not_configured (fail-closed)
- Route fixed to /webhooks/handoff (not /webhooks/mcp which is the synchronous JSON-RPC channel)
- provision-customer.sh: derives WEBHOOK_SECRET_MCP and WEBHOOK_SECRET_HANDOFF from the master (same HMAC pattern as runtime-read key)
- OPERATOR_MCP_WEBHOOK_SECRET provisioned to Infisical /ss prod and live on the Worker

## Depends on

**hermes-smd-overlay#101** — adds /webhooks/handoff handler to webhook_gate.py (HMAC bearer auth, HandoffEnvelope parse, forward to Hermes adapter). After that merges: bump OVERLAY_REF in Dockerfile, reprovision hermes-smd so Machine gets WEBHOOK_SECRET_MCP + WEBHOOK_SECRET_HANDOFF.

## Test plan

- [x] 31 tests pass (operator-mcp-endpoint.test.ts: 6 new handoff_task cases)
- [x] All CI checks green
- [ ] After overlay merge + reprovision: call operator_handoff_task via MCP, verify 202 + handoff_id, agent turn appears in audit log with source=handoff

Generated with Claude Code