### PR TITLE
chore(operator): bump OVERLAY_REF e93a3ff→a97013e (/webhooks/handoff)

### DIFF
--- a/operator/contracts/overlay-pairs.json
+++ b/operator/contracts/overlay-pairs.json
@@ -1,6 +1,6 @@
 {
   "overlayRepo": "https://github.com/venturecrane/hermes-smd-overlay.git",
-  "overlayRef": "e93a3ffb89c386f56a7ddb6d69ed86a5b6b62c0a",
+  "overlayRef": "a97013efc4a8b586f4b4f801adef7a93cf5c51ec",
   "overlayRefNote": "MUST equal the ARG OVERLAY_REF pinned in operator/templates/Dockerfile — that is the overlay commit a customer Machine actually ships. The vitest gate asserts the two agree so the manifest cannot pin a stale overlay. Bump both together when OVERLAY_REF moves, then re-record each overlaySha256 from the runtime file at the new ref.",
   "pairs": [
     {
@@ -13,7 +13,7 @@
     {
       "adapterPath": "operator/adapter/audit_log.py",
       "overlayPath": "plugins/hermes-smd-audit/emit.py",
-      "syncNote": "2026-06-17: overlayRef bumped d8c178e→e93a3ff for native Hermes tool classification in shared/action_classes.py + hermes-smd-trust/enforce.py. emit.py is unchanged at this ref; overlaySha256 rechecked and remains stable. Prior note: 2026-06-17 emit.py overlaySha256 re-recorded for OVERLAY_REF bump 3dcef42→8d633a4. The runtime change was overlay #95: unknown tool → fail-closed REFUSED action class instead of READ default (issue #1327). One-sided runtime change: the fail-closed default-class logic lives runtime-side, not in this adapter port, so operator/adapter/audit_log.py is unaffected and its sha256 is unchanged.",
+      "syncNote": "2026-06-18: overlayRef bumped e93a3ff→a97013e for /webhooks/handoff handler in webhook_gate.py (overlay#101, Phase 2 MCP handoff). emit.py is unchanged at this ref; overlaySha256 rechecked and confirmed stable. Prior note: 2026-06-17: overlayRef bumped d8c178e→e93a3ff for native Hermes tool classification in shared/action_classes.py + hermes-smd-trust/enforce.py. emit.py unchanged; sha256 stable.",
       "sha256": "b797b2ac3fcff021db140eab9634c3e30a2bf99df13fd21cf9ed8f14a1fa7f82",
       "overlaySha256": "38efd8ed3f92964b21fd2889a68e470cc87aa8faa7d9e0abd92b942b262ff321"
     },

--- a/operator/templates/Dockerfile
+++ b/operator/templates/Dockerfile
@@ -206,7 +206,7 @@ ARG OVERLAY_REPO="https://github.com/venturecrane/hermes-smd-overlay.git"
 # orientation reads (read_file/search_files/skills/session/memory/vision),
 # internal session writes (todo/record_peer_preference/clarify), keeps
 # high-power native tools CODE_EXECUTION, and removes stale unmapped->READ prose.
-ARG OVERLAY_REF="e93a3ffb89c386f56a7ddb6d69ed86a5b6b62c0a"
+ARG OVERLAY_REF="a97013efc4a8b586f4b4f801adef7a93cf5c51ec"
 
 ARG CUSTOMER_SLUG=customer-zero
 

--- a/tests/operator-dockerfile.test.ts
+++ b/tests/operator-dockerfile.test.ts
@@ -115,7 +115,11 @@ describe('Operator customer Machine Dockerfile', () => {
     // e93a3ff classifies native Hermes orientation reads and in-band session
     // writes so mission-critical reads do not get refused after the unknown-tool
     // fail-closed change.
-    expect(DOCKERFILE).toContain('ARG OVERLAY_REF="e93a3ffb89c386f56a7ddb6d69ed86a5b6b62c0a"')
+    // a97013e (#101) adds /webhooks/handoff to webhook_gate.py — console→Machine
+    // async task handoff (Phase 2, ADR 0043). HMAC bearer auth (WEBHOOK_SECRET_MCP),
+    // stamps source=handoff, forwards to Hermes adapter. Enables operator_handoff_task
+    // MCP tool (ss-console#1458). Superset of e93a3ff.
+    expect(DOCKERFILE).toContain('ARG OVERLAY_REF="a97013efc4a8b586f4b4f801adef7a93cf5c51ec"')
   })
 
   it('does NOT swallow a failed plugin install (no fail-open `|| echo ... continuing`)', () => {


### PR DESCRIPTION
## Summary

- Bumps `OVERLAY_REF` in `operator/templates/Dockerfile` to `a97013efc4a8b586f4b4f801adef7a93cf5c51ec`
- Updates `operator/contracts/overlay-pairs.json` syncNote; all 4 sha256 fingerprints verified stable (only `webhook_gate.py` changed)
- Updates `tests/operator-dockerfile.test.ts` to pin new SHA with changelog entry

## overlay#101 — what this ships

Adds `/webhooks/handoff` to `webhook_gate.py` — the console→Machine async task handoff route (Phase 2, ADR 0043):
- HMAC bearer auth against `WEBHOOK_SECRET_MCP` (fail-closed when unset)
- Parses `HandoffEnvelope` JSON, stamps `source=handoff`
- Forwards to Hermes adapter with `X-Webhook-Signature`; returns 202 + `{accepted, handoff_id}`

After this merges, reprovision hermes-smd sets `WEBHOOK_SECRET_MCP` + `WEBHOOK_SECRET_HANDOFF` on the Machine, making `operator_handoff_task` (ss-console#1458, already merged) live end-to-end.

## Test plan

- [x] `tests/operator-dockerfile.test.ts` — 15/15 pass
- [x] All 4 overlay-pairs sha256s verified at new ref
- [ ] Reprovision hermes-smd and call `operator_handoff_task` via MCP → verify audit log shows `source=handoff` turn

🤖 Generated with [Claude Code](https://claude.com/claude-code)