### PR TITLE
chore(operator): disable all scheduled crons (Captain directive)

### DIFF
--- a/operator/customers/pilot-law/customer.yaml
+++ b/operator/customers/pilot-law/customer.yaml
@@ -151,11 +151,13 @@ personas:
     # heartbeat is the dead-man's-switch — a scheduled tick with no audit row
     # alarms the watcher-health view. The deadline-watch is advisory, never the
     # firm's system of record (compliance-floor.md).
-    cron:
-      - skill: deadline-miss-escalator
-        schedule: '0 8 * * *' # daily 08:00 in Hermes' configured timezone
-        pre_run: pre_run.py
-        wake_policy: pre_run_decides
+    # ALL CRON DISABLED 2026-06-18 (Captain directive): no scheduled firing yet.
+    # Re-enable by uncommenting this block and restarting the Machine.
+    # cron:
+    #   - skill: deadline-miss-escalator
+    #     schedule: '0 8 * * *' # daily 08:00 in Hermes' configured timezone
+    #     pre_run: pre_run.py
+    #     wake_policy: pre_run_decides
 
 # ---- CONNECTORS ----
 connectors:

--- a/operator/customers/smd/customer.yaml
+++ b/operator/customers/smd/customer.yaml
@@ -128,11 +128,14 @@ personas:
       - himalaya
     # inbox-triage cron disabled — wrong mailbox, dead-drop output, token burn.
     # Run on-demand only until args + delivery path are verified.
-    cron:
-      # Fleet health check every 30 minutes. Emails Captain on red/open-alerts.
-      - skill: health-monitor
-        schedule: '*/30 * * * *'
-        wake_policy: always
+    # ALL CRON DISABLED 2026-06-18 (Captain directive): not in a position to have
+    # any scheduled firing yet. health-monitor stays defined and runs on-demand;
+    # re-enable by uncommenting this block and restarting the Machine.
+    # cron:
+    #   # Fleet health check every 30 minutes. Emails Captain on red/open-alerts.
+    #   - skill: health-monitor
+    #     schedule: '*/30 * * * *'
+    #     wake_policy: always
 
 # ---- MCP CONNECTOR (Operator ⇄ Claude, Phase 1) ----
 # Lets authored users reach this Operator from inside their own Claude


### PR DESCRIPTION
## Why

We are not in a position to have any cron jobs firing on a schedule yet. This disables every active cron across operator machines.

## What fires today (verified live)

| Machine | Cron | Status before |
|---|---|---|
| `hermes-smd` (customer-zero) | `health-monitor` `*/30 * * * *`, `wake_policy: always` | **firing** — caught `cron_…20260618_173028` session in live logs |
| `hermes-pilot-law` | `deadline-miss-escalator` daily 08:00, `pre_run_decides` | scheduled (pre_run-gated) |
| `hermes-demo-law` | none | — |
| `hermes-smd-staging` | none | — |

`pilot-smokeball` has a cron block but no deployed Machine. No Cloudflare Worker crons exist (`wrangler.toml`).

## Change

Comment out (reversibly) both `cron:` blocks. Skills stay defined and run on-demand; only the schedule is removed. Re-enable = uncomment + restart the Machine.

## Apply path (no rebuild)

`sync-customer-yaml.sh <slug>` pushes the edited yaml to R2; `fly machine restart` (~1 min) re-materializes cron from the new config via `cron_materialize.py` at boot. Reprovision is **not** required. Steady-state instant path is ADR 0044 live reconfig.

## Verification

- `validate-customer-yaml.ts` OK for both files
- operator-substrate pytest: 353 passed
- no active `cron:` / `- skill:` lines remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)