### PR TITLE
chore(operator): bump OVERLAY_REF a97013e→1c2171f (cron reconcile fix, overlay#103)

### DIFF
--- a/operator/contracts/overlay-pairs.json
+++ b/operator/contracts/overlay-pairs.json
@@ -1,6 +1,6 @@
 {
   "overlayRepo": "https://github.com/venturecrane/hermes-smd-overlay.git",
-  "overlayRef": "a97013efc4a8b586f4b4f801adef7a93cf5c51ec",
+  "overlayRef": "1c2171f69a8086e575bc9de8cea42504546f3478",
   "overlayRefNote": "MUST equal the ARG OVERLAY_REF pinned in operator/templates/Dockerfile — that is the overlay commit a customer Machine actually ships. The vitest gate asserts the two agree so the manifest cannot pin a stale overlay. Bump both together when OVERLAY_REF moves, then re-record each overlaySha256 from the runtime file at the new ref.",
   "pairs": [
     {
@@ -13,7 +13,7 @@
     {
       "adapterPath": "operator/adapter/audit_log.py",
       "overlayPath": "plugins/hermes-smd-audit/emit.py",
-      "syncNote": "2026-06-18: overlayRef bumped e93a3ff→a97013e for /webhooks/handoff handler in webhook_gate.py (overlay#101, Phase 2 MCP handoff). emit.py is unchanged at this ref; overlaySha256 rechecked and confirmed stable. Prior note: 2026-06-17: overlayRef bumped d8c178e→e93a3ff for native Hermes tool classification in shared/action_classes.py + hermes-smd-trust/enforce.py. emit.py unchanged; sha256 stable.",
+      "syncNote": "2026-06-18: overlayRef bumped a97013e→1c2171f for the cron reconcile fix (overlay#103) — bootstrap/cron_materialize.py + bootstrap/translate.py only (not a tracked pair); also a pure ruff-format pass on webhook_gate.py. emit.py is unchanged at this ref; overlaySha256 rechecked and confirmed stable. Prior note: 2026-06-18: overlayRef bumped e93a3ff→a97013e for /webhooks/handoff handler in webhook_gate.py (overlay#101, Phase 2 MCP handoff). emit.py is unchanged at this ref; overlaySha256 rechecked and confirmed stable. Prior note: 2026-06-17: overlayRef bumped d8c178e→e93a3ff for native Hermes tool classification in shared/action_classes.py + hermes-smd-trust/enforce.py. emit.py unchanged; sha256 stable.",
       "sha256": "b797b2ac3fcff021db140eab9634c3e30a2bf99df13fd21cf9ed8f14a1fa7f82",
       "overlaySha256": "38efd8ed3f92964b21fd2889a68e470cc87aa8faa7d9e0abd92b942b262ff321"
     },

--- a/operator/templates/Dockerfile
+++ b/operator/templates/Dockerfile
@@ -206,7 +206,11 @@ ARG OVERLAY_REPO="https://github.com/venturecrane/hermes-smd-overlay.git"
 # orientation reads (read_file/search_files/skills/session/memory/vision),
 # internal session writes (todo/record_peer_preference/clarify), keeps
 # high-power native tools CODE_EXECUTION, and removes stale unmapped->READ prose.
-ARG OVERLAY_REF="a97013efc4a8b586f4b4f801adef7a93cf5c51ec"
+# 1c2171f — cron reconcile fix (#103): a persona that drops ALL its cron now has
+# its orphaned managed job removed at boot (was firing forever); two-pass
+# fail-closed across the reconcile set; HERMES_HOME snapshot/restore. Also
+# bundles a pre-existing ruff-format fix of webhook_gate.py (no logic change).
+ARG OVERLAY_REF="1c2171f69a8086e575bc9de8cea42504546f3478"
 
 ARG CUSTOMER_SLUG=customer-zero
 

--- a/tests/operator-dockerfile.test.ts
+++ b/tests/operator-dockerfile.test.ts
@@ -119,7 +119,12 @@ describe('Operator customer Machine Dockerfile', () => {
     // async task handoff (Phase 2, ADR 0043). HMAC bearer auth (WEBHOOK_SECRET_MCP),
     // stamps source=handoff, forwards to Hermes adapter. Enables operator_handoff_task
     // MCP tool (ss-console#1458). Superset of e93a3ff.
-    expect(DOCKERFILE).toContain('ARG OVERLAY_REF="a97013efc4a8b586f4b4f801adef7a93cf5c51ec"')
+    // 1c2171f (#103) fixes cron reconciliation: a persona that drops ALL its cron
+    // now has its orphaned managed job removed at boot (it was firing forever);
+    // two-pass fail-closed across the reconcile set; HERMES_HOME snapshot/restore.
+    // Also a pure ruff-format pass on webhook_gate.py (no logic change). Superset
+    // of a97013e.
+    expect(DOCKERFILE).toContain('ARG OVERLAY_REF="1c2171f69a8086e575bc9de8cea42504546f3478"')
   })
 
   it('does NOT swallow a failed plugin install (no fail-open `|| echo ... continuing`)', () => {


### PR DESCRIPTION
## Why

Ships the cron-reconciliation fix (overlay venturecrane/hermes-smd-overlay#103) to customer Machines. A persona that drops **all** its cron entries was leaving its already-registered Hermes managed job orphaned in `jobs.json` — it persisted across reboots and kept firing. Confirmed live on `hermes-smd`: `op-managed:crane:health-monitor` (`*/30`) fired again after the cron was commented out of `customer.yaml` and the Machine restarted.

## What the overlay fix does

Reconciles **every authored persona** against its own cron store, converging it to exactly the authored set — including empty. Two-pass, fail-closed across the whole reconcile set (validate + acquire all stores before any mutation); `HERMES_HOME` snapshot/restore around the reconcile. The overlay PR also carried a pure ruff-format pass on `webhook_gate.py` (pre-existing drift, no logic change).

## This PR

- `operator/templates/Dockerfile` `ARG OVERLAY_REF` and `operator/contracts/overlay-pairs.json` `overlayRef` bumped together to `1c2171f` (vitest gate asserts they match).
- The 4 tracked pair files are **unchanged** at the new ref (`cron_materialize.py`/`translate.py` are not tracked pairs); `overlaySha256` re-verified stable via `verify-overlay-pairs.py` (SEC-32, all 4 OK).
- `operator-dockerfile.test.ts` expected-ref assertion updated.

## Local verification

- `verify-overlay-pairs.py` → PASS (4/4 match at `1c2171f`)
- `vitest tests/operator-overlay-pairs.test.ts tests/operator-dockerfile.test.ts` → 22 passed
- overlay#103 CI green; 71 cron/translate tests pass

## Deploy

Takes effect via reprovision — the fixed materializer removes the live orphan at boot. Reprovision of staging + `hermes-smd` is gated on Captain authorization + a low-traffic window. `hermes-pilot-law` deferred (pre-existing 0/1 health failure; benign gated orphan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)