### PR TITLE
feat(operator): runtime-control conformance harness (wires-nothing subset)

### DIFF
--- a/.github/workflows/operator-substrate.yml
+++ b/.github/workflows/operator-substrate.yml
@@ -23,6 +23,8 @@ on:
       - 'operator/safety-substrate/**'
       - 'operator/connectors/**'
       - 'operator/contracts/overlay-pairs.json'
+      - 'operator/contracts/runtime-controls.yaml'
+      - 'operator/contracts/overlay-hook-surface.json'
       - 'operator/templates/Dockerfile'
       - '.github/workflows/operator-substrate.yml'
   push:
@@ -74,7 +76,7 @@ jobs:
         # the named files import only stdlib + adapter/bin.lib modules.
         # test_decommission.py + test_seam_pull.py joined the list with #1355
         # (the decommission data-plane fix) — they previously ran nowhere in CI.
-        run: python3 -m pytest adapter/tests adapter/evidence/tests adapter/voice/tests safety-substrate/tests bin/tests/test_voice_corpus.py bin/tests/test_deploy_ordering.py bin/tests/test_env_contract_conformance.py bin/tests/test_env_array_generation.py bin/tests/test_customer_yaml_block_conformance.py bin/tests/test_decommission.py bin/tests/test_seam_pull.py bin/tests/test_verify_overlay_pairs.py workspace_broker/tests -q
+        run: python3 -m pytest adapter/tests adapter/evidence/tests adapter/voice/tests safety-substrate/tests bin/tests/test_voice_corpus.py bin/tests/test_deploy_ordering.py bin/tests/test_env_contract_conformance.py bin/tests/test_env_array_generation.py bin/tests/test_customer_yaml_block_conformance.py bin/tests/test_runtime_control_conformance.py bin/tests/test_decommission.py bin/tests/test_seam_pull.py bin/tests/test_verify_overlay_pairs.py workspace_broker/tests -q
 
       # SEC-32: overlay-RUNTIME side of the adapter <-> overlay drift gate.
       #

--- a/operator/bin/tests/test_runtime_control_conformance.py
+++ b/operator/bin/tests/test_runtime_control_conformance.py
@@ -1,0 +1,224 @@
+"""Runtime-control conformance — the CI forcing function (wires-nothing subset).
+
+The validator-style precedents in this tree prove a thing is well-SHAPED. This
+proves the set of runtime safety controls is COMPLETE and DOCUMENTED, so a
+control cannot ship silently absent or silently undocumented — the exact gap that
+let `sticky_stop` (a complete, tested circuit breaker) sit with zero callers and
+zero overlay references while every other test stayed green.
+
+This is the deterministic, offline, CI-time tier. It does NOT prove a control
+fires on a live turn — that is the live negative-fire probe (harness Component 3),
+which overlaps ADR 0050 B3 and folds into B3's design review (Captain decision
+2026-06-18). What this tier enforces against operator/contracts/runtime-controls.yaml:
+
+  (a) completeness from the declared cross-repo surface — every safety-critical
+      hook in overlay-hook-surface.json maps to >=1 registry entry (sees
+      overlay-resident controls a single-repo grep cannot);
+  (b) KNOWN_CONTROLS subset of the registry — the day-one acceptance that the
+      harness actually catches the sticky_stop class;
+  (c) well-formedness — enforced => live_probe + wired_via + probe_surface;
+      unprobed/inert => owner + tracking + note;
+  (d) tracking hygiene — references are well-formed and (once the referenced ADR
+      is in-repo) actually resolve, so an inert control cannot point at a
+      vanished work item.
+
+Run::
+
+    cd operator && python3 -m pytest bin/tests/test_runtime_control_conformance.py -v
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import yaml
+
+_OP = Path(__file__).resolve().parents[2]
+_REGISTRY = _OP / "contracts" / "runtime-controls.yaml"
+_HOOK_SURFACE = _OP / "contracts" / "overlay-hook-surface.json"
+_ADR_DIR = _OP.parent / "docs" / "adr"
+
+_VALID_STATUS = {"enforced", "unprobed", "inert"}
+_VALID_CLASS = {"dispatch-guard", "emitter", "circuit-breaker"}
+_VALID_PROBE_SURFACE = {"staging", "prod-boot"}
+_TRACKING_RE = re.compile(r"^(ADR-\d{4}:B\d+|#\d+|https?://\S+)$")
+
+# Day-one acceptance: the harness is worthless if its discovery silently misses
+# the very class that motivated it. These MUST appear in the registry. If this
+# list and the registry ever diverge, that is the bug (a real control dropped, or
+# a stale expectation) — surfaced, never silent.
+_KNOWN_CONTROLS = {
+    "trust_ceiling",
+    "audit_emission",
+    "sticky_stop_cost_cap",
+    "sticky_stop_tool_failure",
+    "sticky_stop_refusal_cascade",
+    "sticky_stop_time_budget",
+}
+
+
+def _registry() -> dict:
+    return yaml.safe_load(_REGISTRY.read_text(encoding="utf-8")) or {}
+
+
+def _controls() -> dict:
+    return _registry().get("controls") or {}
+
+
+def _hook_surface() -> dict:
+    return json.loads(_HOOK_SURFACE.read_text(encoding="utf-8"))
+
+
+def _hook_of(wired_via: str) -> str:
+    """`"<hook> / <plugin>"` -> `<hook>`."""
+    return (wired_via or "").split("/", 1)[0].strip()
+
+
+# --------------------------------------------------------------------------- #
+# structure                                                                    #
+# --------------------------------------------------------------------------- #
+
+
+def test_registry_has_maintainer_and_controls() -> None:
+    reg = _registry()
+    assert reg.get("maintainer"), "registry must name an overall maintainer"
+    assert _controls(), "registry has no controls"
+
+
+def test_keys_match_control_ids() -> None:
+    for key, spec in _controls().items():
+        assert spec.get("control") == key, (
+            f"control map key {key!r} != entry's control id {spec.get('control')!r}"
+        )
+
+
+def test_status_and_class_are_valid() -> None:
+    for key, spec in _controls().items():
+        assert spec.get("status") in _VALID_STATUS, (
+            f"{key}: invalid status {spec.get('status')!r}"
+        )
+        assert spec.get("class") in _VALID_CLASS, (
+            f"{key}: invalid class {spec.get('class')!r}"
+        )
+        assert spec.get("owner"), f"{key}: every control needs a named owner"
+
+
+def test_well_formed_by_status() -> None:
+    for key, spec in _controls().items():
+        status = spec.get("status")
+        if status == "enforced":
+            assert spec.get("live_probe"), f"{key}: enforced => must name a live_probe"
+            assert spec.get("wired_via"), f"{key}: enforced => must name wired_via"
+            assert spec.get("probe_surface") in _VALID_PROBE_SURFACE, (
+                f"{key}: enforced => probe_surface must be one of {_VALID_PROBE_SURFACE}"
+            )
+        else:  # unprobed | inert
+            assert spec.get("tracking"), (
+                f"{key}: {status} => must carry a `tracking` work item (no silent dead control)"
+            )
+            assert spec.get("note"), f"{key}: {status} => must carry a `note` explaining why"
+
+
+# --------------------------------------------------------------------------- #
+# completeness                                                                 #
+# --------------------------------------------------------------------------- #
+
+
+def test_every_safety_critical_hook_is_covered() -> None:
+    """Drive completeness from the DECLARED surface, not a one-repo grep: every
+    safety-critical hook the overlay must register has >=1 registry control that
+    claims to be wired via it. Catches an overlay-resident control nobody listed.
+    """
+    required = _hook_surface().get("requiredHooks") or {}
+    safety_hooks = {h for h, meta in required.items() if meta.get("safetyCritical")}
+    covered = {
+        _hook_of(spec.get("wired_via", ""))
+        for spec in _controls().values()
+        if spec.get("wired_via")
+    }
+    missing = safety_hooks - covered
+    assert not missing, (
+        f"safety-critical hook(s) {sorted(missing)} are declared in "
+        "overlay-hook-surface.json but no runtime-controls.yaml entry is wired via them. "
+        "A governing hook with no registered control is exactly the inert-control gap."
+    )
+
+
+def test_known_controls_are_registered() -> None:
+    declared = set(_controls())
+    missing = _KNOWN_CONTROLS - declared
+    assert not missing, (
+        f"KNOWN_CONTROLS {sorted(missing)} are absent from the registry. The harness's "
+        "discovery is silently incomplete — this is the day-one acceptance that it catches "
+        "the sticky_stop class. Add the entry (or, if genuinely removed, update _KNOWN_CONTROLS)."
+    )
+
+
+def test_wired_via_hooks_exist_in_surface() -> None:
+    required = set(_hook_surface().get("requiredHooks") or {})
+    for key, spec in _controls().items():
+        wired = spec.get("wired_via")
+        if not wired:
+            continue
+        hook = _hook_of(wired)
+        assert hook in required, (
+            f"{key}: wired_via names hook {hook!r} which is not in overlay-hook-surface.json"
+        )
+
+
+# --------------------------------------------------------------------------- #
+# substrate + tracking hygiene                                                 #
+# --------------------------------------------------------------------------- #
+
+
+def test_ss_console_substrate_paths_exist() -> None:
+    """ss-console substrate modules must exist on disk. Overlay-resident modules
+    (prefixed `overlay:`) are not checked out here — the cross-repo limit
+    overlay-pairs.json / overlay-hook-surface.json already document."""
+    for key, spec in _controls().items():
+        module = spec.get("substrate_module") or ""
+        assert module, f"{key}: substrate_module is required"
+        if module.startswith("overlay:"):
+            continue
+        assert (_OP / module).is_file(), (
+            f"{key}: substrate_module {module!r} does not exist under operator/"
+        )
+
+
+def test_tracking_references_are_well_formed() -> None:
+    for key, spec in _controls().items():
+        if spec.get("status") == "enforced":
+            continue
+        tracking = spec.get("tracking", "")
+        assert _TRACKING_RE.match(tracking), (
+            f"{key}: tracking {tracking!r} must be `ADR-NNNN:Bx`, `#<issue>`, or a URL"
+        )
+
+
+def test_adr_tracking_resolves_when_present() -> None:
+    """Offline teeth: when a tracking ref points at an ADR that IS in-repo, that
+    ADR file must actually contain the cited backlog item — an inert control
+    cannot point at a vanished work item. Skips refs whose ADR is not yet merged
+    onto this branch (e.g. ADR 0050 lands via a sibling PR); activates on merge.
+    """
+    unresolved: list[str] = []
+    for key, spec in _controls().items():
+        tracking = spec.get("tracking", "")
+        m = re.match(r"^ADR-(\d{4}):(B\d+)$", tracking)
+        if not m:
+            continue
+        adr_num, item = m.group(1), m.group(2)
+        matches = list(_ADR_DIR.glob(f"{adr_num}-*.md"))
+        if not matches:
+            unresolved.append(f"{key}->{tracking} (ADR {adr_num} not in-repo yet; skipped)")
+            continue
+        text = matches[0].read_text(encoding="utf-8")
+        assert item in text, (
+            f"{key}: tracking {tracking!r} but ADR {adr_num} does not mention {item}. "
+            "An inert control may not point at a backlog item that no longer exists."
+        )
+    if unresolved:
+        # Visible, non-failing: these activate once the referenced ADR merges.
+        print("runtime-control tracking refs pending ADR merge:\n  " + "\n  ".join(unresolved))

--- a/operator/contracts/customer-yaml-blocks.yaml
+++ b/operator/contracts/customer-yaml-blocks.yaml
@@ -14,8 +14,16 @@
 #
 # ENFORCEMENT: operator/bin/tests/test_customer_yaml_block_conformance.py asserts
 #   authored-blocks ⊆ registry, every entry is implemented|inert, and every
-#   inert entry carries a reason. Cut D's drift audit is the RUNTIME backstop:
-#   it checks the live Machine actually reflects what `implemented` here claims.
+#   inert entry carries a reason.
+#
+# RUNTIME BACKSTOP. The "Cut D drift audit" once named here as the runtime check
+# (that the live Machine reflects what `implemented` claims) was never built — a
+# comment standing in for a control, the same defect this enforcement guards
+# against. The live-wiring backstop now lives in the runtime-control conformance
+# harness: operator/contracts/runtime-controls.yaml + its CI forcing function
+# (test_runtime_control_conformance.py), with the live negative-fire probe tier
+# folded into ADR 0050 B3's design review. THIS registry proves a customer.yaml
+# block is well-shaped + classified; that harness proves a runtime control fires.
 #
 # status:      implemented | inert
 # materializer: where the runtime effect is produced (file/function), or — for

--- a/operator/contracts/runtime-controls.yaml
+++ b/operator/contracts/runtime-controls.yaml
@@ -1,0 +1,211 @@
+# ============================================================================
+# Runtime-control conformance registry — the single truth ledger of every
+# safety/runtime control the Operator depends on, and whether it actually FIRES
+# on a live turn (not merely whether the code exists).
+#
+# WHY THIS EXISTS. This venture keeps shipping the same defect: a control is
+# built, tested, merged — and never wired into the live dispatch path on the
+# Machine. Tests pass because they exercise the function in isolation; nothing
+# proves it is invoked on a real turn. The motivating specimen:
+# `safety-substrate/sticky_stop.py` is complete and fully tested (cost cap,
+# tool-failure / refusal / time-budget circuit breakers) yet has ZERO callers in
+# ss-console and ZERO references in the overlay where dispatch runs. The circuit
+# breaker named in PRD §7.5 does not exist at runtime. ADR 0050 records the same
+# fact in its honesty banner ("There is no verified live cost circuit-breaker
+# (B3)").
+#
+# WHAT THIS REGISTRY GUARANTEES (the "wires-nothing" subset). It does NOT wire
+# any control. It makes a control's live status EXPLICIT and OWNED, and — via
+# operator/bin/tests/test_runtime_control_conformance.py — makes a control
+# impossible to ship SILENTLY absent or SILENTLY undocumented:
+#   * completeness: every safety-critical hook declared in overlay-hook-surface.json
+#     must map to a registry entry (catches an overlay-resident control nobody
+#     listed);
+#   * KNOWN_CONTROLS ⊆ registry (catches the sticky_stop class on day one);
+#   * well-formedness: `enforced` ⇒ names a live_probe + wired_via; `unprobed`
+#     and `inert` ⇒ carry owner + tracking + note (cannot rot undocumented).
+#
+# WHAT IS DEFERRED. The live negative-fire PROBE suite (boot-time / staging
+# "exceeding the caps actually halts") is Component 3 of the harness design and
+# overlaps ADR 0050 **B3** ("Confirm sticky-stop is live in the dispatch path …
+# verify on staging that exceeding the caps actually halts"). Per Captain
+# decision 2026-06-18 it folds into B3's mandated design review, NOT this change.
+# `live_probe` / `probe_surface` fields are recorded here so the registry is the
+# shared spec that review navigates by; the probe MECHANISM is not built here.
+#
+# RELATIONSHIP TO ADR 0050. ADR 0050 locks the task-execution taxonomy (7
+# archetypes; execution classes N/C/R/D/A/O; the cross-cutting safety guard).
+# This registry is an ORTHOGONAL axis — it inventories governance/safety CONTROLS
+# and their live-wiring status, not skills or their execution strategy. Unwired
+# controls reference the ADR 0050 backlog item that tracks their wiring rather
+# than forking duplicate issues.
+#
+# STATUS VOCABULARY:
+#   enforced  — wired into the live dispatch path AND has a named live_probe that
+#               proves it fires. (Today: only the two checks already proven by the
+#               overlay gateway:startup activation handler.)
+#   unprobed  — wired into dispatch, but no negative-fire probe proves it fires on
+#               a live turn. The #1285 risk surface (a hook can be registered yet
+#               inert on live turns). Requires owner + tracking + note.
+#   inert     — NOT wired into dispatch at all (the sticky_stop class). Requires
+#               owner + tracking + note.
+#
+# FIELDS:
+#   control          — stable id.
+#   class            — dispatch-guard | emitter | circuit-breaker.
+#   substrate_module — implementing code. ss-console paths are relative to
+#                      operator/. Overlay-resident code is prefixed `overlay:`
+#                      (path is in venturecrane/hermes-smd-overlay, not checked
+#                      out here — the same cross-repo limit overlay-pairs.json and
+#                      overlay-hook-surface.json document).
+#   wired_via        — "<hook> / <overlay-plugin>" that invokes the control.
+#                      Must reference a hook in overlay-hook-surface.json.
+#   live_probe       — name of the negative-fire probe that proves it fires.
+#                      Recorded for the B3 review; the probe itself is not built
+#                      here. Empty for unprobed/inert.
+#   probe_surface    — staging | prod-boot. Where the probe is permitted to run.
+#                      prod-boot is EARNED (a probe earns os._exit boot-gate
+#                      privilege only after a staging flakiness bar). Empty for
+#                      unprobed/inert.
+#   status           — enforced | unprobed | inert.
+#   owner            — named human accountable for the control.
+#   tracking         — for unprobed/inert: the work item that will wire/probe it.
+#                      `ADR-0050:Bx` (backlog item) or `#<issue>` or a URL.
+#   note             — for unprobed/inert: WHY it is not proven-live (free text).
+#
+# ENFORCEMENT: operator/bin/tests/test_runtime_control_conformance.py (CI).
+# ============================================================================
+
+maintainer: SMDurgan
+
+controls:
+  # ---- enforced: wired + proven live by the existing activation self-checks ----
+  trust_ceiling:
+    control: trust_ceiling
+    class: dispatch-guard
+    substrate_module: overlay:plugins/hermes-smd-trust/enforce.py
+    wired_via: 'pre_tool_call / hermes-smd-trust'
+    live_probe: trust_blocks_banned_send
+    probe_surface: prod-boot
+    status: enforced
+    owner: SMDurgan
+    note: >-
+      Proven live today by the overlay gateway:startup activation handler, which
+      drives a real pre_tool_call with a permanently-banned send tool and
+      os._exit(1) if it is not blocked. The B3 review formalizes this inline
+      self-check as a named registry-driven probe.
+
+  audit_emission:
+    control: audit_emission
+    class: emitter
+    substrate_module: overlay:plugins/hermes-smd-audit/emit.py
+    wired_via: 'post_tool_call / hermes-smd-audit'
+    live_probe: audit_writes_row
+    probe_surface: prod-boot
+    status: enforced
+    owner: SMDurgan
+    note: >-
+      Proven live today by the activation handler, which drives a real
+      post_llm_call and asserts an audit_log row was written (row-count
+      before/after) with os._exit(1) on failure. Formalized as a named probe in
+      the B3 review.
+
+  # ---- unprobed: wired into dispatch, but no negative-fire probe proves it ----
+  inbound_trust_boundary:
+    control: inbound_trust_boundary
+    class: dispatch-guard
+    substrate_module: overlay:plugins/hermes-smd-webhook-router/__init__.py
+    wired_via: 'pre_gateway_dispatch / hermes-smd-webhook-router'
+    live_probe: ''
+    probe_surface: ''
+    status: unprobed
+    owner: SMDurgan
+    tracking: ADR-0050:B3
+    note: >-
+      Safety-critical hook (routes inbound webhook payloads + applies the inbound
+      trust boundary, ADR 0027/0032). It IS registered, but no negative-fire probe
+      proves the boundary actually withholds on a live turn — the #1285 shape
+      (registered-but-inert-on-live-turns). A negative-fire probe is Component 3
+      of the harness, folded into the B3 design review.
+
+  taint_gate:
+    control: taint_gate
+    class: dispatch-guard
+    substrate_module: overlay:plugins/hermes-smd-trust/enforce.py
+    wired_via: 'pre_tool_call / hermes-smd-trust'
+    live_probe: ''
+    probe_surface: ''
+    status: unprobed
+    owner: SMDurgan
+    tracking: ADR-0050:B0
+    note: >-
+      Sticky SessionTaint gate (an untrusted-fed turn cannot autonomously
+      send/destroy/exec). Wired, but ADR 0050 B0 records a VERIFIED bypass: the
+      gate keys on session_id and a delegate_task child runs under a fresh,
+      never-tainted session. No negative-fire probe proves taint actually blocks
+      on a live turn, and the B0 hole is open. Tracked by ADR 0050 B0 (fix first,
+      blocks B2); probe coverage folds into the B3 review.
+
+  # ---- inert: NOT wired into dispatch at all (the motivating class) ----
+  # All four arms live in safety-substrate/sticky_stop.py: complete, fully
+  # tested, ZERO callers in ss-console, ZERO references in the overlay. One
+  # wiring effort (ADR 0050 B3) wires the StickyStopError-raising dispatch
+  # integration that covers every arm.
+  sticky_stop_cost_cap:
+    control: sticky_stop_cost_cap
+    class: circuit-breaker
+    substrate_module: safety-substrate/sticky_stop.py
+    wired_via: ''
+    live_probe: ''
+    probe_surface: ''
+    status: inert
+    owner: SMDurgan
+    tracking: ADR-0050:B3
+    note: >-
+      record_cost_cents()/assert_allowed() + the $50/day (cost_daily_cents=5000)
+      ladder. No caller anywhere; not referenced in the overlay dispatch path.
+      No verified financial circuit breaker on the live Machine (ADR 0050 honesty
+      banner #3). B3 wires it.
+
+  sticky_stop_tool_failure:
+    control: sticky_stop_tool_failure
+    class: circuit-breaker
+    substrate_module: safety-substrate/sticky_stop.py
+    wired_via: ''
+    live_probe: ''
+    probe_surface: ''
+    status: inert
+    owner: SMDurgan
+    tracking: ADR-0050:B3
+    note: >-
+      record_tool_failure() consecutive-failure ladder (WARN/SOFT_STOP/HARD_STOP).
+      Built + tested; no dispatch caller. Wired by B3 (StickyStopError integration
+      covers all sticky_stop arms).
+
+  sticky_stop_refusal_cascade:
+    control: sticky_stop_refusal_cascade
+    class: circuit-breaker
+    substrate_module: safety-substrate/sticky_stop.py
+    wired_via: ''
+    live_probe: ''
+    probe_surface: ''
+    status: inert
+    owner: SMDurgan
+    tracking: ADR-0050:B3
+    note: >-
+      record_refusal() refusal-cascade ladder. Built + tested; no dispatch caller.
+      Wired by B3.
+
+  sticky_stop_time_budget:
+    control: sticky_stop_time_budget
+    class: circuit-breaker
+    substrate_module: safety-substrate/sticky_stop.py
+    wired_via: ''
+    live_probe: ''
+    probe_surface: ''
+    status: inert
+    owner: SMDurgan
+    tracking: ADR-0050:B3
+    note: >-
+      record_runtime_seconds() 3600s wall-clock single-run cap → SOFT_STOP. Built
+      + tested; no dispatch caller. Wired by B3.


### PR DESCRIPTION
## What & why

This venture keeps shipping the same defect class: a safety/runtime control is built, tested, merged — and **never wired into the live dispatch path on the Machine**. Tests pass because they exercise the function in isolation; nothing proves it is invoked on a real turn.

Motivating specimen: `operator/safety-substrate/sticky_stop.py` is complete and fully tested (cost cap, tool-failure / refusal / time-budget circuit breakers) yet has **zero callers in ss-console and zero references in the overlay** dispatch path. The circuit breaker named in PRD §7.5 does not exist at runtime — exactly what ADR 0050's honesty banner #3 records ("no verified live cost circuit-breaker (B3)"). The block registry's own "Cut D drift audit" runtime backstop was a comment that was never built — the same defect.

## What this PR does (and does NOT do)

It **wires no control.** It builds the *prevention* layer — the truth ledger + the CI forcing function — so a control can't ship **silently absent** or **silently undocumented**:

- **`operator/contracts/runtime-controls.yaml`** — the truth ledger. 8 controls:
  - `enforced` (2): trust ceiling, audit emission — proven live by the existing overlay `gateway:startup` activation self-checks.
  - `unprobed` (2): inbound trust boundary; taint gate — wired but no negative-fire probe proves they fire (the #1285 shape). Taint also carries ADR 0050 **B0**'s verified `delegate_task` bypass.
  - `inert` (4): the four `sticky_stop` arms — built, tested, unwired.
- **`operator/bin/tests/test_runtime_control_conformance.py`** — the CI forcing function:
  - completeness driven from `overlay-hook-surface.json`'s declared **safety-critical hooks** (sees overlay-resident controls a one-repo grep can't);
  - `KNOWN_CONTROLS ⊆ registry` (day-one acceptance that it catches the `sticky_stop` class);
  - well-formedness by status; tracking hygiene with offline ADR-reference resolution.
  - **All five negative cases verified to bite** (drop a sticky_stop arm, drop the only `pre_gateway_dispatch` control, strip an inert tracking ref, blank an enforced probe, name a non-existent hook).
- **`customer-yaml-blocks.yaml`** — replace the never-built "Cut D drift audit" comment with a pointer to this harness.
- **`operator-substrate.yml`** — gate the new test; trigger on the registry + hook surface.

## Alignment with ADR 0050 (Captain decision 2026-06-18)

Per the **wires-nothing subset** call: inert/unprobed controls reference the ADR 0050 backlog item that tracks their wiring (**B3** sticky-stop; **B0** taint) — no duplicate issues. The live negative-fire **probe** tier (harness Component 3) overlaps ADR 0050 **B3** ("verify on staging that exceeding the caps actually halts") and **folds into B3's mandated design review**, not this PR.

## Verification

- `cd operator && python3 -m pytest bin/tests/test_runtime_control_conformance.py -v` → 10 passed.
- Negative-bite proof run against in-memory mutations → all 5 gates fire.
- Full adjacent suite (block conformance, env conformance, overlay-pairs) → 27 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)