### PR TITLE
fix(marketing): restore Contact link to primary nav

### DIFF
--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -6,6 +6,7 @@ const navLinks = [
   { href: '/operator#industries', label: 'Industries' },
   { href: '/why', label: 'Why' },
   { href: '/consulting', label: 'Consulting' },
+  { href: '/contact', label: 'Contact' },
 ]
 ---
 


### PR DESCRIPTION
## What

Re-adds the `Contact` entry to the marketing nav's `navLinks` array in `Nav.astro`.

## Why

"At some point we lost the contact form on smd.services." — Captain, this session.

The form was never broken. Verified live this session:
- `/contact` page + form render ✅
- `/api/contact` endpoint live, returns `{"ok":true}` on a real submission ✅
- `RESEND_API_KEY` deployed on the Worker — real email sent to team@ ✅

What it lost was its **front door**. PR #1364 (Operator-forward homepage, 2026-06-12) removed the `/contact` nav link, replacing it with Industries/Why/Consulting:

```diff
-  { href: '/contact', label: 'Contact' },
+  { href: '/operator#industries', label: 'Industries' },
+  { href: '/why', label: 'Why' },
+  { href: '/consulting', label: 'Consulting' },
```

After that, the only path to `/contact` was a small grey footer link. The prominent "Get in touch" CTA has always pointed at `/book` (the booking-slots lead-intake flow), so anyone who just wanted to send a message hit a scheduling calendar instead — the message form effectively vanished.

This restores the deliberate two-door design from PR #696 (`/contact` = general comms, `/book` = lead intake).

## Change

One line. The shared `navLinks` array drives both the desktop bar and the mobile dialog, so desktop + mobile are both covered; `data-ev` resolves to `nav-contact` / `nav-mobile-contact` automatically.

The "Get in touch" → `/book` CTA is unchanged (kept as the lead-intake path, per Captain's choice).

## Verification

- `npm run verify` — 0 errors
- `tests/landing-page.test.ts` + `tests/services.test.ts` — 52 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)