### PR TITLE
feat(operator): durable task-execution substrate (B1, ADR 0051)

### DIFF
--- a/docs/adr/0051-operator-durable-task-execution-substrate.md
+++ b/docs/adr/0051-operator-durable-task-execution-substrate.md
@@ -1,0 +1,54 @@
+---
+title: Operator Durable Task-Execution Substrate (B1)
+date: 2026-06-18
+status: accepted
+captain: Scott Durgan
+related-adr: 0050-operator-task-execution-framework.md, 0037-operator-thesis.md, 0021-leverage-hermes-native-primitives.md, 0045-mediated-connector-capability-broker.md, 0049-operator-model-selection.md, 0043-operator-runtime-read-path.md, 0007-per-customer-machine-isolation.md, 0016-honcho-disposition.md
+---
+
+# ADR 0051 — Operator Durable Task-Execution Substrate (B1)
+
+**Status:** Accepted (Captain decision, 2026-06-18; plan rev. 2, hardened against three critique rounds + a source-level Phase-0 verification). This ADR is the **decision record**; the full design (decisions, lifecycle, file map, verification) lives in [`docs/design/operator/durable-task-execution-substrate.md`](../design/operator/durable-task-execution-substrate.md).
+
+**Purpose.** Lock how the Operator runs a job that is too big for one synchronous turn: take it, run it **unattended** to completion, survive compaction / crashes / Machine restarts, and deliver a **retrievable result** — while keeping cost on reasoning (not data volume) and honoring the safety floors. This is build item **B1** from [ADR 0050](./0050-operator-task-execution-framework.md). The receipts failure that motivated the work is **B2** (process-in-code), separate; this substrate is for genuinely long **Class-D / multi-step** work.
+
+## Context
+
+Today a long task runs in one synchronous turn against a hard 55s reply budget (`hermes-smd-overlay/webhook_gate.py:264`), times out, and restarts from zero. The design is grounded in a source-level audit (every claim carries a file:line in the design doc). The load-bearing verified facts:
+
+- **V1 — resume needs the session _lineage_, not a pinned id.** `state.db` is append-only; on compaction Hermes **forks a new `session_id`** (`run_agent.py:10732-10761`) and never deletes rows; reload via `get_messages_as_conversation(tip, include_ancestors=True)`. `run_job` is callable but _fire-fresh_ (mints `cron_<id>_<ts>`, no `conversation_history`) so it cannot resume. The dangerous guardrails (taint/entitlement/outbound) are **process-global plugin hooks**, not per-agent wiring.
+- **V2 — real provider-reported usage + cost already exist** (`agent/usage_pricing.py`; the agent accumulates `session_*_tokens`). No tokenizer guessing.
+- **V3 — delivery is standalone-capable** (`_deliver_result` falls back to a standalone send when no live adapter is passed); managed mail routes through the broker.
+- **V4 — a long in-gateway job does not block the event loop** _iff it runs as a thread_: the gateway already runs cron on a separate `threading.Thread` + `ThreadPoolExecutor` (`gateway/run.py:16572,16991`; `cron/scheduler.py:1669-1743`), off the asyncio loop that services inbound/MCP; `run_conversation` is synchronous and I/O-bound (GIL released on LLM/tool waits).
+- **Blueprint exists:** the broker-owned audit ledger (uid-gated socket, bind-mounted past Hermes' boot-time `chmod 0700`) + the `entrypoint.sh` supervisor pattern.
+
+## Decision — the tenets
+
+1. **Leverage `state.db` lineage for durable resume; build no persistence engine.** A job is a **lean control row** in the broker-owned ledger + a Hermes run whose conversation lives in `state.db`. The ledger stores `root_session_id` and a transactionally-updated `current_tip_session_id`; resume prefers the recorded tip (the lineage can be a _tree_ after abandoned branches) and **repairs a trailing `tool_call` with no `tool_result`** with a synthetic "interrupted" result before resuming.
+
+2. **The worker is an in-gateway background _thread_ (V1 + V4), not an asyncio task and not a separate replicated process.** It reuses the `config→AIAgent` construction `run_job` uses; the net-new surface is the _resume invocation_ (`run_conversation(conversation_history=…)`, tip selection, partial-pair repair, cross-segment usage accumulation). Guardrails come from the process-global plugins, so they are inherited, not replicated. Conformance asserts **concrete invariants** on the net-new surface, not "behaves like cron."
+
+3. **Fold the ledger into the existing broker DB/socket; restart-survival via a boot-sweep behind a readiness barrier.** No new uid / mount / supervisor for MVP. On boot, jobs are re-claimed only after the broker socket pings, plugins are registered, and the delivery adapter (if needed) is connected — so a startup race can never construct a half-wired worker.
+
+4. **Lease fencing.** Each claim mints a monotonic `lease_epoch`; every privileged broker write carries it; the broker rejects stale-epoch writes (defeats the respawn-produces-two-workers double-spend/double-deliver).
+
+5. **Cost is enforced, pre-spend, from real usage.** Wire the existing `sticky_stop` (built but unwired today) plus a per-job `budget_cents`. Pre-flight skip via `estimate_request_tokens_rough()`; the **authoritative guard is real accumulated tokens at the per-tool-iteration boundary** (catches mid-segment input blowups). Reuse `agent/usage_pricing.py`. This is also the first real per-job cost measurement (feeds B6).
+
+6. **Safety floors hold inside the runner.** Taint-mark the worker session **at construction, fail-closed** (a new untrusted-by-default origin); validate `deliver_to` against a `customer.yaml` channel allowlist (broker-enforced, anti-exfiltration); record idempotency keys (logical-effect keyed) **before** the effect; on broker-socket failure, never proceed past an un-journaled effect → park to `needs_review`.
+
+7. **Delivery is a first-class, retried, fenced state** (`complete → delivering → delivered`); the result artifact persists to **per-customer R2** before `delivering` so a Fly host reschedule can't orphan it. Leverage `_deliver_result` for gateway channels; managed mail via the broker.
+
+8. **Operational invariants.** Worker identity (`customer_slug`, `persona_id`, `model`) is captured at intake and loaded from the row, never defaulted (boot assertion → `needs_review` on mismatch). A `job_cancel` kill switch ships in MVP, checked at the per-iteration boundary. Work _inside_ a background turn still obeys its execution class (process-in-code) — the runner provides duration + delivery only.
+
+## Consequences
+
+- **MVP is read-mostly:** the broker ledger (folded), the in-gateway worker thread, the `hermes-smd-jobs` plugin (`start_background_job` / `job_status` / `job_cancel`), pre-spend cost, taint-at-construction, the `deliver_to` allowlist, and the delivery state machine. Proof is a long **Class-D** job (multi-document review), not receipts.
+- **Deferred (sequenced, not a 20-phase build):** send-capable jobs (full idempotency enforcement + the dedicated `smd-jobs` uid/isolation), concurrency >1, progress streaming, the console D1 mirror + `jobs` runtime-read kind, TTL/archival.
+- **Hard prerequisites:** a **broker respawn-supervisor** (for the broker-down protocol); **B0 generalized** to taint the worker session (MVP's read-mostly + fail-closed taint lets it proceed alongside).
+- **CI is the durability guard:** a deterministic crash test (`os._exit` after a journaled effect, before completion → no re-execution), a fencing test, a pre-spend + mid-segment cost test, a readiness-barrier test, and an identity test. The real Fly machine-restart is a documented one-time staging acceptance, not a CI claim.
+
+## Honesty banner — what is NOT yet true
+
+- The substrate is **not built**; this ADR + the design doc are the spec.
+- It does **not** make the receipts task cheap — that is B2 (process-in-code), independent.
+- The global `sticky_stop` breaker is still unwired on the main turn path; this substrate enforces cost in the worker loop and does not depend on the global wiring (which remains its own fix).

--- a/docs/adr/0051-operator-durable-task-execution-substrate.md
+++ b/docs/adr/0051-operator-durable-task-execution-substrate.md
@@ -42,8 +42,8 @@ Today a long task runs in one synchronous turn against a hard 55s reply budget (
 
 ## Consequences
 
-- **MVP is read-mostly:** the broker ledger (folded), the in-gateway worker thread, the `hermes-smd-jobs` plugin (`start_background_job` / `job_status` / `job_cancel`), pre-spend cost, taint-at-construction, the `deliver_to` allowlist, and the delivery state machine. Proof is a long **Class-D** job (multi-document review), not receipts.
-- **Deferred (sequenced, not a 20-phase build):** send-capable jobs (full idempotency enforcement + the dedicated `smd-jobs` uid/isolation), concurrency >1, progress streaming, the console D1 mirror + `jobs` runtime-read kind, TTL/archival.
+- **MVP is read-mostly:** the broker ledger (folded), the in-gateway worker thread, the `hermes-smd-jobs` plugin (`start_background_job` / `job_status` / `job_cancel`), pre-spend cost, taint-at-construction, the `deliver_to` allowlist, the delivery state machine, the R2 result store, and the `jobs` runtime-read observability seam (`GET /runtime/jobs` + `job_status`/`job_cancel` MCP verbs). Proof is a long **Class-D** job (multi-document review), not receipts.
+- **Deferred (sequenced, not a 20-phase build):** send-capable jobs (full idempotency enforcement + the dedicated `smd-jobs` uid/isolation), concurrency >1, progress streaming, the console D1 mirror, TTL/archival.
 - **Hard prerequisites:** a **broker respawn-supervisor** (for the broker-down protocol); **B0 generalized** to taint the worker session (MVP's read-mostly + fail-closed taint lets it proceed alongside).
 - **CI is the durability guard:** a deterministic crash test (`os._exit` after a journaled effect, before completion → no re-execution), a fencing test, a pre-spend + mid-segment cost test, a readiness-barrier test, and an identity test. The real Fly machine-restart is a documented one-time staging acceptance, not a CI claim.
 

--- a/docs/design/operator/durable-task-execution-substrate.md
+++ b/docs/design/operator/durable-task-execution-substrate.md
@@ -43,9 +43,9 @@ intake (`start_background_job` → control row w/ identity, ticket <55s) → cla
 
 ## MVP (read-mostly) and deferred
 
-**MVP:** folded broker ledger + verbs · in-gateway worker thread (no new uid) · `hermes-smd-jobs` plugin (`start_background_job`, `job_status`, `job_cancel`) · pre-spend cost via wired `sticky_stop` + `budget_cents` · taint-at-construction · `deliver_to` allowlist · delivery state machine. Proof: a long **Class-D** job (multi-document review), **not receipts**.
+**MVP:** folded broker ledger + verbs · in-gateway worker thread (no new uid) · `hermes-smd-jobs` plugin (`start_background_job`, `job_status`, `job_cancel`) · pre-spend cost via wired `sticky_stop` + `budget_cents` · taint-at-construction (B0) · `deliver_to` allowlist · delivery state machine · R2 result store · `jobs` runtime-read observability (`GET /runtime/jobs`) + `job_status`/`job_cancel` MCP verbs. Proof: a long **Class-D** job (multi-document review), **not receipts**.
 
-**Deferred (sequenced):** send-capable jobs (full idempotency enforcement + the `smd-jobs` uid/isolation) · concurrency >1 · progress streaming · console D1 mirror + `jobs` runtime-read kind · TTL/archival.
+**Deferred (sequenced):** send-capable jobs (full idempotency enforcement + the `smd-jobs` uid/isolation) · concurrency >1 · progress streaming · console D1 mirror · TTL/archival.
 
 ## File map
 

--- a/docs/design/operator/durable-task-execution-substrate.md
+++ b/docs/design/operator/durable-task-execution-substrate.md
@@ -1,0 +1,68 @@
+# Durable Task-Execution Substrate (B1) — Design
+
+**Decision record:** [ADR 0051](../../adr/0051-operator-durable-task-execution-substrate.md). This document is its backing detail — the spec the implementation follows. Status: accepted (2026-06-18), hardened against three critique rounds + a source-level Phase-0 verification.
+
+## Context
+
+The SMD Operator is sold as a coordinator **hire** (ADR 0037): it must take a job, run it **unattended** to completion, survive crashes/restarts, and deliver a **retrievable result**. Today a long task runs in one synchronous turn against a hard **55s reply budget** (`hermes-smd-overlay/webhook_gate.py:264`), times out, and restarts from zero — the receipts job burned ~$50 and delivered nothing.
+
+This is **B1** from ADR 0050's backlog. The receipts task itself is **B2** (process-in-code), separate; the runner is for genuinely long **Class-D / multi-step** work.
+
+## Verified facts (source-level)
+
+- **Resume is lossless via the session _lineage_, not a pinned id.** `state.db` `messages` is append-only (`hermes-agent/hermes_state.py:1480`); on compaction Hermes **forks a new session_id** (`parent_session_id` set) and never deletes rows (`run_agent.py:10732-10761`); reload via `get_messages_as_conversation(tip, include_ancestors=True)` (`hermes_state.py:1686`).
+- **V1 — `run_job` is a _fire-fresh_ executor.** `cron/scheduler.py:1024` is standalone (no gateway dep), loads `config.yaml`, resolves model (`:1298-1314`), constructs its own `AIAgent`, and mints a fresh `cron_<job_id>_<ts>` session (`:1205`) with no `conversation_history` — so it cannot resume. The taint/entitlement/outbound guardrails are **process-global plugin hooks**, inherited by any agent in a plugin-loaded process.
+- **V2 — real provider-reported usage + cost exist.** `agent/usage_pricing.py` (`normalize_usage`, `estimate_usage_cost`, imported `run_agent.py:164`); the agent accumulates `session_input/output/cache_tokens` (`run_agent.py:2428,13500-13522`). Pre-flight via `estimate_request_tokens_rough()`.
+- **V3 — delivery is standalone-capable.** `_deliver_result(job, content, adapters=None, loop=None)` (`cron/scheduler.py:489`) falls back to a standalone send when no live adapter is passed; managed mail (Gmail) routes through the broker (DWD).
+- **V4 — a long in-gateway job does not block the event loop _iff it is a thread_.** `run_conversation` is synchronous (`run_agent.py:12094`); the gateway runs cron on a separate `threading.Thread` (`gateway/run.py:16572,16991`) whose `tick()` dispatches via a `ThreadPoolExecutor` under a file lock (`cron/scheduler.py:1669-1743`), off the asyncio loop. Agent work is I/O-bound (GIL released on LLM/tool waits) — which is why cron already coexists with live traffic.
+- **B0 taint hole:** the gate keys on `session_id` (`enforce.py:877`) but `SESSION_TAINT.mark()` runs only at the two inbound chokepoints (`plugins/hermes-smd-inbound/__init__.py:83,217`). A worker session is a new unmarked origin.
+- **B3 cost breaker built-but-unwired:** `operator/safety-substrate/sticky_stop.py` (`record_cost_cents:608`, `record_runtime_seconds:565`, `assert_allowed:663`) has no live turn-path caller.
+- **Blueprint:** the broker-owned audit ledger (uid-gated socket, bind-mounted past `chmod 0700`) + the `entrypoint.sh` supervisor pattern.
+
+## Architecture
+
+A long job = a **lean control row in the broker-owned ledger** + a **Hermes run whose conversation lives in `state.db`**, driven by an **in-gateway background thread** (the cron model, off the event loop).
+
+### Decisions
+
+1. **Resume by lineage, with a recorded tip.** The ledger stores `root_session_id` and a transactionally-updated `current_tip_session_id`. Resume prefers the recorded tip (the lineage may be a _tree_; root-walk alone is ambiguous). Before handing reloaded history to the LLM, repair a trailing `tool_call` with no matching `tool_result` by injecting a synthetic "interrupted — not executed" result so the model re-plans rather than the runtime re-executing or erroring.
+2. **In-gateway background _thread_ (V1 + V4).** Mirror the cron-ticker + `ThreadPoolExecutor` model. **Reuse** the `config→AIAgent` construction `run_job` uses (`cron/scheduler.py:1298-1342`); **net-new** is the _invocation_ — `run_conversation(conversation_history=…)`, tip selection, partial-pair repair, cross-segment usage accumulation. Guardrails are inherited from the process-global plugins. Conformance asserts concrete invariants on the net-new surface: after a resume the agent's `session_*_tokens` reflect the reloaded history; taint state is fail-closed-present; a repaired trailing `tool_call` yields exactly one synthetic result. **Defer the dedicated `smd-jobs` uid to the send-capable milestone.**
+3. **Restart-survival via ledger + boot-sweep behind a readiness barrier.** The worker thread is disposable. On boot, the sweep re-claims/resumes non-terminal jobs only after the broker socket pings, the expected plugin tool set is registered, and (if `deliver_to` needs it) the live adapter is connected. Fold the job ledger into the existing broker DB/socket (reuse the audit DB's mount, uid, `SO_PEERCRED` gating).
+4. **Lean control row.** `jobs(id, customer_slug, persona_id, model, brief_digest, status, root_session_id, current_tip_session_id, lease_owner, lease_epoch, attempts, budget_cents, spent_cents, deliver_to, result_ref, error)` + `idempotency_keys(job_id, step_key, state)`. `state.db` owns conversation recovery; the ledger holds only control facts it can't.
+5. **Lease fencing token.** Each claim mints a monotonic `lease_epoch`; every privileged broker write carries it; the broker rejects stale-epoch writes.
+6. **Cost: wire `sticky_stop`, enforce pre-spend from real usage.** Add the per-job `budget_cents` `sticky_stop` lacks. Pre-flight skip via `estimate_request_tokens_rough()`. The authoritative guard is real accumulated tokens at the **per-tool-iteration boundary**: after each tool result is appended, recompute projected next-request input cost and hard-stop if `spent + projected_next_input > budget`. Record real usage (`session_*_tokens` + `estimate_usage_cost`) into `spent_cents` after each segment. Count metered reads against the budget.
+7. **Safety.** (a) Taint at construction, fail-closed. (b) `deliver_to` validated against a `customer.yaml` channel allowlist, broker-enforced. (c) Idempotency key recorded **before** the effect (claim-then-act), keyed on the logical effect (action + target + stable content id); on broker-socket failure → bounded backoff, never proceed past an un-journaled effect, then park to `needs_review`. The broker respawn-supervisor is a hard prerequisite.
+8. **Delivery is a first-class, retried state:** `complete → delivering → delivered` (idempotent, epoch-fenced, own dead-letter). The result artifact persists to per-customer R2 before `complete → delivering`. Leverage `_deliver_result` for gateway channels; managed mail via the broker.
+9. **Worker identity from the ledger row** (`customer_slug`, `persona_id`, `model`) captured at intake, loaded from the row, never defaulted; boot assertion on mismatch → `needs_review`.
+10. **Kill switch in MVP:** `job_cancel(ticket)` sets a `cancel_requested` flag checked at the per-tool-iteration boundary, then dead-letters as `cancelled`.
+11. **In-turn work obeys its execution class** (process-in-code); the runner provides duration + delivery only.
+
+### Lifecycle
+
+intake (`start_background_job` → control row w/ identity, ticket <55s) → claim (`lease_epoch++`, `attempts++`) → resume? (prefer recorded tip, repair trailing tool_call) → per segment: pre-spend + cancel check → run (Hermes agent path) → record real usage + advance tip transactionally → complete → result to R2 → **delivering → delivered** (retried, epoch-fenced) → done. Any breach/cancel/broker-stall → dead-letter (`needs_review` / `cancelled`) → notify.
+
+## MVP (read-mostly) and deferred
+
+**MVP:** folded broker ledger + verbs · in-gateway worker thread (no new uid) · `hermes-smd-jobs` plugin (`start_background_job`, `job_status`, `job_cancel`) · pre-spend cost via wired `sticky_stop` + `budget_cents` · taint-at-construction · `deliver_to` allowlist · delivery state machine. Proof: a long **Class-D** job (multi-document review), **not receipts**.
+
+**Deferred (sequenced):** send-capable jobs (full idempotency enforcement + the `smd-jobs` uid/isolation) · concurrency >1 · progress streaming · console D1 mirror + `jobs` runtime-read kind · TTL/archival.
+
+## File map
+
+**Overlay (`hermes-smd-overlay`):** `plugins/hermes-smd-jobs/__init__.py` (new); `shared/job_ledger_client.py` (new — `BrokerJobClient`, twin of the audit client); `webhook_gate.py` (read-only `job_status` + `job_cancel` verbs); the in-gateway worker module + boot-sweep (new).
+
+**Console (`ss-console`):** `operator/workspace_broker/job_ledger.py` (new) + verbs in `server.py` (epoch-fenced, on the existing audit DB); `operator/templates/entrypoint.sh` (broker respawn-supervisor; worker in-gateway, no new uid for MVP); `operator/migrations/00xx_operator_jobs.sql` (new); `operator/contracts/customer-yaml-blocks.yaml` (declare new blocks).
+
+**Reuse, do not reinvent:** audit-ledger + `SO_PEERCRED` (`operator/workspace_broker/`); supervisor/bind-mount (`operator/templates/entrypoint.sh`); taint register (`hermes-smd-overlay/shared/inbound.py:311,334`); cost breaker (`operator/safety-substrate/sticky_stop.py`); resume (`hermes_state.py:1686`). **Leverage:** Hermes' in-process `AIAgent`/`run_conversation` construction (the one `run_job` uses); `agent/usage_pricing.py`; `_deliver_result` (standalone fallback). **Do not:** fork the agent path into a separate replicated process; use the Hermes Runs API (in-memory); build an external durable-execution engine.
+
+## Verification
+
+- **Deterministic crash test (CI):** `os._exit(1)` after committing step N's effect but before recording completion; restart in-test; assert N is not re-executed (idempotency hit) and N+1 proceeds. Variant: kill between a `tool_call` and its `tool_result`; assert the synthetic-interrupt repair prevents double-execution.
+- **Fencing test (CI):** two claimants; the stale-epoch one's writes are rejected; no double-delivery/double-spend.
+- **Cost test (CI):** a segment that would exceed `budget_cents` is refused before the call and dead-letters; a tool returning an oversized payload mid-segment hard-stops at the next iteration boundary; provider-reported usage matches `spent_cents`.
+- **Readiness-barrier test (CI):** worker started with the broker socket not-yet-listening claims nothing until broker + plugins + adapter are ready.
+- **Identity test (CI):** worker loads `model`/`persona` from the row; a mismatch parks to `needs_review`.
+- **Staging acceptance (one-time, manual):** `OVERLAY_REF` bump + `reprovision.sh <staging-slug>` (explicit Captain authorization) — boot-smoke; `start_background_job` returns a ticket <55s; a real Fly machine-restart mid-run resumes with no duplicated work; budget breach + `job_cancel` dead-letter; an injection fixture cannot drive an autonomous send; an off-allowlist `deliver_to` is refused; result lands on the authored surface; `job_status` returns `done` + `result_ref`.
+- **CI suite:** `cd operator && python3 -m pytest bin/tests safety-substrate/tests adapter/tests -q`; overlay tests; the `run_job` construction-equivalence smoke.
+
+**Acceptance:** MVP completes a long Class-D proof job, survives a deterministic mid-step crash (CI) and a real Fly restart (staging) with no duplicated work, enforces a pre-spend cost ceiling, honors a manual cancel, and resists the injection/exfiltration fixtures.

--- a/operator/contracts/overlay-pairs.json
+++ b/operator/contracts/overlay-pairs.json
@@ -1,6 +1,6 @@
 {
   "overlayRepo": "https://github.com/venturecrane/hermes-smd-overlay.git",
-  "overlayRef": "baa949583bd5584e98d5398f43d1cd4091136d70",
+  "overlayRef": "7f493c605ec0999db1bd4fb15a7cca34a4442cec",
   "overlayRefNote": "MUST equal the ARG OVERLAY_REF pinned in operator/templates/Dockerfile — that is the overlay commit a customer Machine actually ships. The vitest gate asserts the two agree so the manifest cannot pin a stale overlay. Bump both together when OVERLAY_REF moves, then re-record each overlaySha256 from the runtime file at the new ref.",
   "pairs": [
     {

--- a/operator/contracts/overlay-pairs.json
+++ b/operator/contracts/overlay-pairs.json
@@ -1,6 +1,6 @@
 {
   "overlayRepo": "https://github.com/venturecrane/hermes-smd-overlay.git",
-  "overlayRef": "1c2171f69a8086e575bc9de8cea42504546f3478",
+  "overlayRef": "baa949583bd5584e98d5398f43d1cd4091136d70",
   "overlayRefNote": "MUST equal the ARG OVERLAY_REF pinned in operator/templates/Dockerfile — that is the overlay commit a customer Machine actually ships. The vitest gate asserts the two agree so the manifest cannot pin a stale overlay. Bump both together when OVERLAY_REF moves, then re-record each overlaySha256 from the runtime file at the new ref.",
   "pairs": [
     {

--- a/operator/contracts/overlay-pairs.json
+++ b/operator/contracts/overlay-pairs.json
@@ -1,6 +1,6 @@
 {
   "overlayRepo": "https://github.com/venturecrane/hermes-smd-overlay.git",
-  "overlayRef": "7d1561bf1a70daf50d8cd909a2cb4124bc80ceb6",
+  "overlayRef": "e8411cae37824515e584f596f0f74701a983d622",
   "overlayRefNote": "MUST equal the ARG OVERLAY_REF pinned in operator/templates/Dockerfile — that is the overlay commit a customer Machine actually ships. The vitest gate asserts the two agree so the manifest cannot pin a stale overlay. Bump both together when OVERLAY_REF moves, then re-record each overlaySha256 from the runtime file at the new ref.",
   "pairs": [
     {

--- a/operator/contracts/overlay-pairs.json
+++ b/operator/contracts/overlay-pairs.json
@@ -1,6 +1,6 @@
 {
   "overlayRepo": "https://github.com/venturecrane/hermes-smd-overlay.git",
-  "overlayRef": "7f493c605ec0999db1bd4fb15a7cca34a4442cec",
+  "overlayRef": "7d1561bf1a70daf50d8cd909a2cb4124bc80ceb6",
   "overlayRefNote": "MUST equal the ARG OVERLAY_REF pinned in operator/templates/Dockerfile — that is the overlay commit a customer Machine actually ships. The vitest gate asserts the two agree so the manifest cannot pin a stale overlay. Bump both together when OVERLAY_REF moves, then re-record each overlaySha256 from the runtime file at the new ref.",
   "pairs": [
     {

--- a/operator/templates/Dockerfile
+++ b/operator/templates/Dockerfile
@@ -210,7 +210,12 @@ ARG OVERLAY_REPO="https://github.com/venturecrane/hermes-smd-overlay.git"
 # its orphaned managed job removed at boot (was firing forever); two-pass
 # fail-closed across the reconcile set; HERMES_HOME snapshot/restore. Also
 # bundles a pre-existing ruff-format fix of webhook_gate.py (no logic change).
-ARG OVERLAY_REF="1c2171f69a8086e575bc9de8cea42504546f3478"
+# baa9495 — B1 durable task-execution substrate (overlay half, ADR 0051): job
+# ledger client + hermes-smd-jobs plugin (start_background_job / job_status /
+# job_cancel / job_record_sideeffect) + the in-gateway worker thread
+# (claim / lineage-resume / per-segment cost+cancel / delivery state machine).
+# Pairs with the console broker job_* verbs COPYied into this image. STAGING.
+ARG OVERLAY_REF="baa949583bd5584e98d5398f43d1cd4091136d70"
 
 ARG CUSTOMER_SLUG=customer-zero
 

--- a/operator/templates/Dockerfile
+++ b/operator/templates/Dockerfile
@@ -210,12 +210,12 @@ ARG OVERLAY_REPO="https://github.com/venturecrane/hermes-smd-overlay.git"
 # its orphaned managed job removed at boot (was firing forever); two-pass
 # fail-closed across the reconcile set; HERMES_HOME snapshot/restore. Also
 # bundles a pre-existing ruff-format fix of webhook_gate.py (no logic change).
-# baa9495 — B1 durable task-execution substrate (overlay half, ADR 0051): job
-# ledger client + hermes-smd-jobs plugin (start_background_job / job_status /
-# job_cancel / job_record_sideeffect) + the in-gateway worker thread
-# (claim / lineage-resume / per-segment cost+cancel / delivery state machine).
-# Pairs with the console broker job_* verbs COPYied into this image. STAGING.
-ARG OVERLAY_REF="baa949583bd5584e98d5398f43d1cd4091136d70"
+# 7f493c6 — B1 durable task-execution substrate (overlay half, ADR 0051): job
+# ledger client + hermes-smd-jobs plugin + the in-gateway worker thread. Adds
+# the fan-out registration (plugin.yaml) + consumes.yaml env declarations that
+# the first staging boot surfaced as missing. Pairs with the console broker
+# job_* verbs COPYied into this image. STAGING (iteration 2).
+ARG OVERLAY_REF="7f493c605ec0999db1bd4fb15a7cca34a4442cec"
 
 ARG CUSTOMER_SLUG=customer-zero
 

--- a/operator/templates/Dockerfile
+++ b/operator/templates/Dockerfile
@@ -215,10 +215,11 @@ ARG OVERLAY_REPO="https://github.com/venturecrane/hermes-smd-overlay.git"
 # the fan-out registration (plugin.yaml) + consumes.yaml env declarations that
 # the first staging boot surfaced as missing. Pairs with the console broker
 # job_* verbs COPYied into this image. STAGING (iteration 2).
-# 7d1561b — B1 wave 2: observability (`jobs` runtime-read + job_status/job_cancel
-# MCP verbs), R2 result store, and B0 worker-session taint (fail-closed). Twins
-# unchanged; only the ref moves.
-ARG OVERLAY_REF="7d1561bf1a70daf50d8cd909a2cb4124bc80ceb6"
+# e8411ca — B1 merged to overlay main (#104, squash): the wave-2 work
+# (observability `jobs` runtime-read + job_status/job_cancel MCP verbs, R2 result
+# store, B0 worker-session taint) plus the ruff/format/per-plugin-manifest CI
+# fixes. Twins unchanged; only the ref moves.
+ARG OVERLAY_REF="e8411cae37824515e584f596f0f74701a983d622"
 
 ARG CUSTOMER_SLUG=customer-zero
 

--- a/operator/templates/Dockerfile
+++ b/operator/templates/Dockerfile
@@ -215,7 +215,10 @@ ARG OVERLAY_REPO="https://github.com/venturecrane/hermes-smd-overlay.git"
 # the fan-out registration (plugin.yaml) + consumes.yaml env declarations that
 # the first staging boot surfaced as missing. Pairs with the console broker
 # job_* verbs COPYied into this image. STAGING (iteration 2).
-ARG OVERLAY_REF="7f493c605ec0999db1bd4fb15a7cca34a4442cec"
+# 7d1561b — B1 wave 2: observability (`jobs` runtime-read + job_status/job_cancel
+# MCP verbs), R2 result store, and B0 worker-session taint (fail-closed). Twins
+# unchanged; only the ref moves.
+ARG OVERLAY_REF="7d1561bf1a70daf50d8cd909a2cb4124bc80ceb6"
 
 ARG CUSTOMER_SLUG=customer-zero
 

--- a/operator/workspace_broker/job_ledger.py
+++ b/operator/workspace_broker/job_ledger.py
@@ -1,0 +1,352 @@
+"""Broker-owned job ledger writer for the durable task-execution substrate (B1).
+
+The job ledger is the *control plane* for long-running background jobs: one
+mutable `jobs` row per job plus an `idempotency_keys` table that guards
+side-effecting steps against replay. The agent's *conversation* lives in
+Hermes `state.db` (append-only lineage); this ledger holds only the control
+facts `state.db` cannot — status, the rotating session tip, lease/fencing,
+cost, delivery target, and the result reference. See ADR 0051 +
+docs/design/operator/durable-task-execution-substrate.md.
+
+WHY broker-owned, like the audit ledger: only the broker uid
+(``workspace-broker``) holds a read-write handle; the agent uid can read (via
+the ``audit-readers`` group) but the ONLY write path is a gateway-PID-gated
+verb on the broker socket (``server.py`` checks ``peer_pid == gateway_pid``
+before any job verb). So an ``execute_code`` child — a different peer PID —
+cannot claim a lease, raise a budget, mark a step done, or flip a status. The
+agent cannot rewrite its own job control state any more than it can rewrite
+its own audit log.
+
+WHY this differs from ``audit_ledger.LedgerWriter``: the audit log is
+append-only (the immutability guarantee is the *absence* of any update/delete
+verb). The job ledger is intrinsically MUTABLE — leases are claimed, spend
+accrues, status advances. We keep that mutation safe two ways: (1) every
+privileged mutation is **epoch-fenced** — it carries the ``lease_epoch`` minted
+at claim time and the UPDATE's WHERE clause rejects a stale epoch, so a
+respawned-but-not-dead predecessor's writes become no-ops; (2) every transition
+is *also* mirrored to the append-only audit log by the caller (mirror, don't
+gate — ADR 0016), so the tamper-evident record is independent of this mutable
+table.
+
+The job tables share the audit DB *file* (one bind-mounted store, one uid
+boundary — "one less thing to own", per the design's build-vs-leverage pass).
+The audit_log append-only guarantee is unaffected: no verb here touches
+``audit_log``; these verbs touch only ``jobs`` / ``idempotency_keys``.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+
+from .audit_ledger import _iso_utc, _ulid  # ULID/timestamp format in lockstep
+
+logger = logging.getLogger(__name__)
+
+# Terminal statuses never re-claimed by the boot-sweep or a claim attempt.
+TERMINAL_STATUSES: frozenset[str] = frozenset({"delivered", "done", "needs_review", "cancelled"})
+# Non-terminal statuses the boot-sweep / claim path may pick up.
+CLAIMABLE_STATUSES: tuple[str, ...] = ("queued", "running", "complete", "delivering")
+
+# Columns a caller may set at job creation. id/created_at/updated_at/lease_*/
+# spent_cents/attempts/cancel_requested/result_ref/error are stamped or owned
+# by the ledger, never supplied at create.
+_CREATE_COLUMNS: tuple[str, ...] = (
+    "customer_slug",
+    "persona_id",
+    "model",
+    "brief",
+    "brief_digest",
+    "deliver_to",
+    "budget_cents",
+    "root_session_id",
+)
+# Fields an epoch-fenced ``record`` may mutate. Deliberately NOT lease_*,
+# budget_cents, attempts, or the immutable identity columns.
+_RECORD_COLUMNS: frozenset[str] = frozenset(
+    {"status", "current_tip_session_id", "spent_cents", "result_ref", "error"}
+)
+
+CREATE_JOBS_SQL = (
+    "CREATE TABLE IF NOT EXISTS jobs ("
+    "id TEXT PRIMARY KEY, "
+    "created_at TEXT NOT NULL, "
+    "updated_at TEXT NOT NULL, "
+    "customer_slug TEXT NOT NULL, "
+    "persona_id TEXT NOT NULL, "
+    "model TEXT, "
+    "brief TEXT NOT NULL, "
+    "brief_digest TEXT, "
+    "status TEXT NOT NULL DEFAULT 'queued', "
+    "root_session_id TEXT, "
+    "current_tip_session_id TEXT, "
+    "deliver_to TEXT, "
+    "lease_owner TEXT, "
+    "lease_epoch INTEGER NOT NULL DEFAULT 0, "
+    "lease_ts TEXT, "
+    "attempts INTEGER NOT NULL DEFAULT 0, "
+    "budget_cents INTEGER NOT NULL, "
+    "spent_cents INTEGER NOT NULL DEFAULT 0, "
+    "cancel_requested INTEGER NOT NULL DEFAULT 0, "
+    "result_ref TEXT, "
+    "error TEXT"
+    ")"
+)
+# step_key is the LOGICAL effect (action+target+stable content id), not a
+# payload hash — so a re-run that regenerates a different payload still dedupes.
+CREATE_IDEMPOTENCY_SQL = (
+    "CREATE TABLE IF NOT EXISTS idempotency_keys ("
+    "job_id TEXT NOT NULL, "
+    "step_key TEXT NOT NULL, "
+    "state TEXT NOT NULL, "  # 'in_progress' | 'done'
+    "lease_epoch INTEGER NOT NULL, "
+    "created_at TEXT NOT NULL, "
+    "updated_at TEXT NOT NULL, "
+    "PRIMARY KEY (job_id, step_key)"
+    ")"
+)
+CREATE_INDEX_SQL: tuple[str, ...] = (
+    # Boot-sweep / claim scan: non-terminal jobs, oldest first.
+    "CREATE INDEX IF NOT EXISTS idx_jobs_claimable ON jobs(updated_at) "
+    "WHERE status NOT IN ('delivered','done','needs_review','cancelled')",
+    "CREATE INDEX IF NOT EXISTS idx_jobs_customer ON jobs(customer_slug, created_at)",
+)
+
+_ALL_JOB_COLUMNS: tuple[str, ...] = (
+    "id", "created_at", "updated_at", "customer_slug", "persona_id", "model",
+    "brief", "brief_digest", "status", "root_session_id", "current_tip_session_id",
+    "deliver_to", "lease_owner", "lease_epoch", "lease_ts", "attempts",
+    "budget_cents", "spent_cents", "cancel_requested", "result_ref", "error",
+)
+
+
+class JobLedgerWriter:
+    """Mutable, epoch-fenced control-plane writer over a per-operation sqlite
+    connection.
+
+    Connection discipline matches ``audit_ledger.LedgerWriter`` deliberately:
+    a FRESH connection per operation in the calling thread, ``journal_mode=
+    DELETE`` (keeps the agent-uid mode=ro read seam off the cross-uid -wal/-shm
+    surface), ``busy_timeout`` to serialize concurrent writers. The job write
+    rate is low (a handful per segment), so per-op connections cost nothing
+    material and sidestep the stale-pager SQLITE_READONLY failure mode observed
+    with a long-lived broker connection.
+    """
+
+    def __init__(self, db_path: str) -> None:
+        self._db_path = db_path
+        self.ensure_schema()
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self._db_path, timeout=5.0)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA journal_mode=DELETE")
+        conn.execute("PRAGMA busy_timeout=5000")
+        return conn
+
+    def ensure_schema(self) -> None:
+        conn = self._connect()
+        try:
+            conn.execute(CREATE_JOBS_SQL)
+            conn.execute(CREATE_IDEMPOTENCY_SQL)
+            for index_sql in CREATE_INDEX_SQL:
+                conn.execute(index_sql)
+            conn.commit()
+        finally:
+            conn.close()
+
+    # -- intake ------------------------------------------------------------
+    def create(self, row: dict) -> str:
+        """Create a queued job from caller-supplied create columns. Returns the
+        broker-stamped ULID. Identity/lease/cost-progress columns are owned by
+        the ledger and cannot be supplied here.
+
+        Raises ValueError on unknown/missing columns.
+        """
+        unknown = set(row) - set(_CREATE_COLUMNS)
+        if unknown:
+            raise ValueError(f"job create: unknown column(s) {sorted(unknown)}")
+        for required in ("customer_slug", "persona_id", "brief", "budget_cents"):
+            if row.get(required) in (None, ""):
+                raise ValueError(f"job create: '{required}' is required")
+        job_id = _ulid()
+        now = _iso_utc()
+        cols = ("id", "created_at", "updated_at", *_CREATE_COLUMNS)
+        vals = [job_id, now, now, *(row.get(c) for c in _CREATE_COLUMNS)]
+        sql = (
+            "INSERT INTO jobs (" + ", ".join(cols) + ") "
+            "VALUES (" + ", ".join("?" for _ in cols) + ")"
+        )
+        conn = self._connect()
+        try:
+            conn.execute(sql, vals)
+            conn.commit()
+        finally:
+            conn.close()
+        return job_id
+
+    # -- read --------------------------------------------------------------
+    def read(self, job_id: str) -> dict | None:
+        conn = self._connect()
+        try:
+            r = conn.execute("SELECT * FROM jobs WHERE id=?", (job_id,)).fetchone()
+            return dict(r) if r is not None else None
+        finally:
+            conn.close()
+
+    def list_claimable(self, now: str, lease_expiry_cutoff: str) -> list[dict]:
+        """Non-terminal jobs that are unleased or whose lease has expired
+        (``lease_ts < lease_expiry_cutoff``). Used by the boot-sweep and the
+        claim scan. Oldest-updated first for fairness.
+        """
+        placeholders = ", ".join("?" for _ in CLAIMABLE_STATUSES)
+        conn = self._connect()
+        try:
+            rows = conn.execute(
+                f"SELECT * FROM jobs WHERE status IN ({placeholders}) "
+                "AND (lease_ts IS NULL OR lease_ts < ?) ORDER BY updated_at ASC",
+                (*CLAIMABLE_STATUSES, lease_expiry_cutoff),
+            ).fetchall()
+            return [dict(r) for r in rows]
+        finally:
+            conn.close()
+
+    # -- lease / fencing ---------------------------------------------------
+    def claim(self, job_id: str, worker_id: str, now: str, lease_expiry_cutoff: str) -> int | None:
+        """Atomically claim a job: bump ``lease_epoch``, set owner+heartbeat,
+        increment ``attempts``, move to 'running'. Succeeds only if the job is
+        non-terminal AND (unleased OR its lease has expired). Returns the NEW
+        ``lease_epoch`` the worker must carry on every privileged write, or
+        None if the job was not claimable (already owned by a live lease, or
+        terminal). The UPDATE+SELECT run in one transaction so two racing
+        claimants cannot both win.
+        """
+        placeholders = ", ".join("?" for _ in CLAIMABLE_STATUSES)
+        conn = self._connect()
+        try:
+            cur = conn.execute(
+                "UPDATE jobs SET lease_owner=?, lease_epoch=lease_epoch+1, "
+                "lease_ts=?, attempts=attempts+1, status='running', updated_at=? "
+                f"WHERE id=? AND status IN ({placeholders}) "
+                "AND (lease_ts IS NULL OR lease_ts < ?)",
+                (worker_id, now, now, job_id, *CLAIMABLE_STATUSES, lease_expiry_cutoff),
+            )
+            if cur.rowcount != 1:
+                conn.rollback()
+                return None
+            epoch = conn.execute(
+                "SELECT lease_epoch FROM jobs WHERE id=?", (job_id,)
+            ).fetchone()[0]
+            conn.commit()
+            return int(epoch)
+        finally:
+            conn.close()
+
+    def heartbeat(self, job_id: str, lease_epoch: int, now: str) -> bool:
+        """Refresh the lease heartbeat. Epoch-fenced: a stale worker can't
+        keep a lease it no longer owns alive. Returns False if fenced out.
+        """
+        conn = self._connect()
+        try:
+            cur = conn.execute(
+                "UPDATE jobs SET lease_ts=?, updated_at=? WHERE id=? AND lease_epoch=?",
+                (now, now, job_id, lease_epoch),
+            )
+            conn.commit()
+            return cur.rowcount == 1
+        finally:
+            conn.close()
+
+    def record(self, job_id: str, lease_epoch: int, fields: dict) -> bool:
+        """Epoch-fenced mutation of progress fields (status, tip, spent_cents,
+        result_ref, error). Returns False (no rows) if the caller's epoch is
+        stale — its write is a no-op and it should stop. Rejects any field not
+        in the allowed mutable set.
+        """
+        unknown = set(fields) - _RECORD_COLUMNS
+        if unknown:
+            raise ValueError(f"job record: non-mutable field(s) {sorted(unknown)}")
+        if not fields:
+            return False
+        now = _iso_utc()
+        assignments = ", ".join(f"{c}=?" for c in fields) + ", updated_at=?"
+        vals = [*fields.values(), now, job_id, lease_epoch]
+        conn = self._connect()
+        try:
+            cur = conn.execute(
+                f"UPDATE jobs SET {assignments} WHERE id=? AND lease_epoch=?", vals
+            )
+            conn.commit()
+            return cur.rowcount == 1
+        finally:
+            conn.close()
+
+    def request_cancel(self, job_id: str) -> bool:
+        """Set the cancel flag. NOT epoch-fenced: anyone holding the ticket may
+        request a cancel; the worker observes the flag at its next per-iteration
+        check and dead-letters as 'cancelled'. Returns True if the job exists
+        and is non-terminal.
+        """
+        now = _iso_utc()
+        placeholders = ", ".join("?" for _ in CLAIMABLE_STATUSES)
+        conn = self._connect()
+        try:
+            cur = conn.execute(
+                "UPDATE jobs SET cancel_requested=1, updated_at=? "
+                f"WHERE id=? AND status IN ({placeholders})",
+                (now, job_id, *CLAIMABLE_STATUSES),
+            )
+            conn.commit()
+            return cur.rowcount == 1
+        finally:
+            conn.close()
+
+    # -- idempotency (record-key-before-effect) ----------------------------
+    def idempotency_begin(self, job_id: str, step_key: str, lease_epoch: int) -> str:
+        """Claim a side-effecting step BEFORE performing it. Returns:
+          - 'proceed': key newly inserted — the caller owns this effect, do it.
+          - 'skip': key already 'done' — the effect already happened, skip it.
+          - 'review': key is 'in_progress' from a prior (crashed) attempt — we
+            cannot know whether the effect landed, so fail closed: the caller
+            must NOT re-fire and should park the job to needs_review.
+        The insert is the journal: it survives the crash that would lose an
+        in-context decision, so a resume sees 'done'/'in_progress' and does not
+        double-fire.
+        """
+        now = _iso_utc()
+        conn = self._connect()
+        try:
+            cur = conn.execute(
+                "INSERT OR IGNORE INTO idempotency_keys "
+                "(job_id, step_key, state, lease_epoch, created_at, updated_at) "
+                "VALUES (?,?,'in_progress',?,?,?)",
+                (job_id, step_key, lease_epoch, now, now),
+            )
+            conn.commit()
+            if cur.rowcount == 1:
+                return "proceed"
+            state = conn.execute(
+                "SELECT state FROM idempotency_keys WHERE job_id=? AND step_key=?",
+                (job_id, step_key),
+            ).fetchone()[0]
+            return "skip" if state == "done" else "review"
+        finally:
+            conn.close()
+
+    def idempotency_complete(self, job_id: str, step_key: str, lease_epoch: int) -> bool:
+        """Mark a side-effecting step done AFTER it succeeded. Epoch-fenced so a
+        stale worker cannot retroactively mark a step it didn't own. Returns
+        False if fenced out or the key is absent.
+        """
+        now = _iso_utc()
+        conn = self._connect()
+        try:
+            cur = conn.execute(
+                "UPDATE idempotency_keys SET state='done', updated_at=? "
+                "WHERE job_id=? AND step_key=? AND lease_epoch=?",
+                (now, job_id, step_key, lease_epoch),
+            )
+            conn.commit()
+            return cur.rowcount == 1
+        finally:
+            conn.close()

--- a/operator/workspace_broker/job_ledger.py
+++ b/operator/workspace_broker/job_ledger.py
@@ -215,6 +215,23 @@ class JobLedgerWriter:
         finally:
             conn.close()
 
+    def list_all(self) -> list[dict]:
+        """Every job row, newest-created first. Powers the observability seam
+        (the console's ``jobs`` runtime-read kind) — unlike ``list_claimable``,
+        it includes terminal and live-leased jobs and applies no lease filter,
+        so an operator surface can show the full job history. Read-only: opens
+        the same per-op connection as every other read."""
+        conn = self._connect()
+        try:
+            # Tiebreak on id (a ULID) so jobs created in the same millisecond
+            # have a stable, deterministic newest-first order on the seam.
+            rows = conn.execute(
+                "SELECT * FROM jobs ORDER BY created_at DESC, id DESC"
+            ).fetchall()
+            return [dict(r) for r in rows]
+        finally:
+            conn.close()
+
     def list_claimable(self, now: str, lease_expiry_cutoff: str) -> list[dict]:
         """Non-terminal jobs that are unleased or whose lease has expired
         (``lease_ts < lease_expiry_cutoff``). Used by the boot-sweep and the

--- a/operator/workspace_broker/job_ledger.py
+++ b/operator/workspace_broker/job_ledger.py
@@ -38,10 +38,31 @@ from __future__ import annotations
 
 import logging
 import sqlite3
+from datetime import UTC, datetime, timedelta
 
 from .audit_ledger import _iso_utc, _ulid  # ULID/timestamp format in lockstep
 
 logger = logging.getLogger(__name__)
+
+# A lease older than this (relative to the broker's clock) is reclaimable. The
+# broker — one process per Machine — is the single clock of record for lease
+# timing, so callers never supply time over the wire (a worker can't lie its
+# lease alive). Set generously above a worst-case segment's wall-clock so a
+# live-but-busy worker is not stolen from; the worker heartbeats well inside it.
+LEASE_TTL_SECONDS = 900
+
+
+def _fmt_iso(dt: datetime) -> str:
+    """Format a datetime exactly like ``audit_ledger._iso_utc`` (ms + Z) so
+    job timestamps sort against each other and against audit rows."""
+    return dt.strftime("%Y-%m-%dT%H:%M:%S.") + f"{dt.microsecond // 1000:03d}Z"
+
+
+def now_and_lease_cutoff(ttl_seconds: int = LEASE_TTL_SECONDS) -> tuple[str, str]:
+    """Return ``(now_iso, expiry_cutoff_iso)`` from the broker's clock. A job
+    whose ``lease_ts < expiry_cutoff_iso`` is reclaimable."""
+    now = datetime.now(UTC)
+    return _fmt_iso(now), _fmt_iso(now - timedelta(seconds=ttl_seconds))
 
 # Terminal statuses never re-claimed by the boot-sweep or a claim attempt.
 TERMINAL_STATUSES: frozenset[str] = frozenset({"delivered", "done", "needs_review", "cancelled"})

--- a/operator/workspace_broker/server.py
+++ b/operator/workspace_broker/server.py
@@ -18,6 +18,7 @@ from typing import Any
 
 from .audit_ledger import LedgerWriter
 from .google_auth import materialize_credential
+from .job_ledger import LEASE_TTL_SECONDS, JobLedgerWriter, now_and_lease_cutoff
 from .operations import WorkspaceOperations
 
 MAX_REQUEST_BYTES = 1_048_576
@@ -90,6 +91,10 @@ class Broker:
     # Class default so instances built via ``__new__`` (tests) and pre-WS5
     # images without SMD_AUDIT_DB_PATH have a defined, audit-disabled ledger.
     ledger: LedgerWriter | None = None
+    # B1 job-control plane. Same default-disabled posture as ``ledger`` so
+    # instances built via ``__new__`` (tests) and pre-B1 images have a defined,
+    # job-disabled ledger.
+    job_ledger: JobLedgerWriter | None = None
 
     def __init__(self) -> None:
         self.socket_path = Path(os.environ["SMD_WORKSPACE_BROKER_SOCKET"])
@@ -107,6 +112,11 @@ class Broker:
         # this broker does not touch it.
         audit_db_path = os.environ.get("SMD_AUDIT_DB_PATH")
         self.ledger = LedgerWriter(audit_db_path) if audit_db_path else None
+        # B1: the job ledger folds into the SAME broker-owned DB file (one
+        # mount, one uid boundary). Mutable control state, distinct table set;
+        # the audit_log append-only guarantee is untouched (no job verb writes
+        # audit_log). Disabled when the audit DB is unconfigured (pre-B1 image).
+        self.job_ledger = JobLedgerWriter(audit_db_path) if audit_db_path else None
 
     def handle(self, request: dict[str, Any], peer_pid: int) -> dict[str, Any]:
         action = request.get("action")
@@ -116,6 +126,7 @@ class Broker:
                 "credential_ready": self.credential_path.is_file(),
                 "customer_ready": self.customer_path.is_file(),
                 "audit_ready": self.ledger is not None,
+                "jobs_ready": self.job_ledger is not None,
                 "supported_ops": self.operations.supported_operations(),
             }
         if peer_pid != self.gateway_pid:
@@ -132,6 +143,14 @@ class Broker:
                 raise ValueError("audit_append requires a 'row' object")
             row_id = self.ledger.append(row)
             return {"ok": True, "id": row_id}
+        # B1 durable-job control plane. PID-gated (above): only the gateway
+        # (which hosts the worker thread) reaches these; execute_code/terminal
+        # children get a different peer PID and are rejected, so the agent
+        # cannot claim leases, raise budgets, or flip job status directly.
+        if isinstance(action, str) and action.startswith("job_"):
+            if self.job_ledger is None:
+                raise ValueError("job ledger not configured on this broker")
+            return self._handle_job(action, request)
         operation = str(request.get("operation") or "")
         payload = request.get("payload")
         if not operation.startswith("workspace_") or not isinstance(payload, dict):
@@ -176,6 +195,57 @@ class Broker:
             journal.chmod(0o600)
             return {"ok": True, "result": result, "receipt": receipt}
         raise ValueError("unsupported broker action")
+
+    def _handle_job(self, action: str, request: dict[str, Any]) -> dict[str, Any]:
+        """Dispatch the B1 job-ledger verbs. Time is stamped server-side
+        (``now_and_lease_cutoff``) — the broker is the single clock of record
+        for lease timing, so callers never pass time over the wire."""
+        jl = self.job_ledger
+        assert jl is not None  # guarded by the caller
+        if action == "job_create":
+            row = request.get("row")
+            if not isinstance(row, dict):
+                raise ValueError("job_create requires a 'row' object")
+            return {"ok": True, "id": jl.create(row)}
+        if action == "job_list_claimable":
+            now, cutoff = now_and_lease_cutoff(LEASE_TTL_SECONDS)
+            return {"ok": True, "jobs": jl.list_claimable(now, cutoff)}
+
+        job_id = str(request.get("job_id") or "")
+        if not job_id:
+            raise ValueError(f"{action} requires job_id")
+        if action == "job_read":
+            return {"ok": True, "job": jl.read(job_id)}
+        if action == "job_cancel":
+            return {"ok": jl.request_cancel(job_id)}
+        if action == "job_claim":
+            worker_id = str(request.get("worker_id") or "")
+            if not worker_id:
+                raise ValueError("job_claim requires worker_id")
+            now, cutoff = now_and_lease_cutoff(LEASE_TTL_SECONDS)
+            return {"ok": True, "lease_epoch": jl.claim(job_id, worker_id, now, cutoff)}
+
+        # The remaining verbs are epoch-fenced: a stale worker's write is a
+        # no-op (the ledger checks lease_epoch in the WHERE clause).
+        epoch = request.get("lease_epoch")
+        if not isinstance(epoch, int):
+            raise ValueError(f"{action} requires an integer lease_epoch")
+        if action == "job_heartbeat":
+            now, _ = now_and_lease_cutoff(LEASE_TTL_SECONDS)
+            return {"ok": jl.heartbeat(job_id, epoch, now)}
+        if action == "job_record":
+            fields = request.get("fields")
+            if not isinstance(fields, dict):
+                raise ValueError("job_record requires a 'fields' object")
+            return {"ok": jl.record(job_id, epoch, fields)}
+        step_key = str(request.get("step_key") or "")
+        if not step_key:
+            raise ValueError(f"{action} requires step_key")
+        if action == "job_idem_begin":
+            return {"ok": True, "decision": jl.idempotency_begin(job_id, step_key, epoch)}
+        if action == "job_idem_complete":
+            return {"ok": jl.idempotency_complete(job_id, step_key, epoch)}
+        raise ValueError(f"unsupported job action: {action}")
 
 
 class RequestHandler(socketserver.StreamRequestHandler):

--- a/operator/workspace_broker/server.py
+++ b/operator/workspace_broker/server.py
@@ -217,7 +217,11 @@ class Broker:
         if action == "job_read":
             return {"ok": True, "job": jl.read(job_id)}
         if action == "job_cancel":
-            return {"ok": jl.request_cancel(job_id)}
+            # ``ok`` == request processed; ``result`` == the verb's boolean
+            # outcome. Keeping them separate lets a legitimately-false outcome
+            # (e.g. a fenced-out record) return False instead of reading as a
+            # transport refusal on the client.
+            return {"ok": True, "result": jl.request_cancel(job_id)}
         if action == "job_claim":
             worker_id = str(request.get("worker_id") or "")
             if not worker_id:
@@ -232,19 +236,19 @@ class Broker:
             raise ValueError(f"{action} requires an integer lease_epoch")
         if action == "job_heartbeat":
             now, _ = now_and_lease_cutoff(LEASE_TTL_SECONDS)
-            return {"ok": jl.heartbeat(job_id, epoch, now)}
+            return {"ok": True, "result": jl.heartbeat(job_id, epoch, now)}
         if action == "job_record":
             fields = request.get("fields")
             if not isinstance(fields, dict):
                 raise ValueError("job_record requires a 'fields' object")
-            return {"ok": jl.record(job_id, epoch, fields)}
+            return {"ok": True, "result": jl.record(job_id, epoch, fields)}
         step_key = str(request.get("step_key") or "")
         if not step_key:
             raise ValueError(f"{action} requires step_key")
         if action == "job_idem_begin":
             return {"ok": True, "decision": jl.idempotency_begin(job_id, step_key, epoch)}
         if action == "job_idem_complete":
-            return {"ok": jl.idempotency_complete(job_id, step_key, epoch)}
+            return {"ok": True, "result": jl.idempotency_complete(job_id, step_key, epoch)}
         raise ValueError(f"unsupported job action: {action}")
 
 

--- a/operator/workspace_broker/server.py
+++ b/operator/workspace_broker/server.py
@@ -210,6 +210,11 @@ class Broker:
         if action == "job_list_claimable":
             now, cutoff = now_and_lease_cutoff(LEASE_TTL_SECONDS)
             return {"ok": True, "jobs": jl.list_claimable(now, cutoff)}
+        if action == "job_list":
+            # Observability read: every job row (terminal + live), newest first.
+            # Powers the console's ``jobs`` runtime-read kind so the worker is
+            # verifiable end-to-end over HTTPS. Read-only — no lease filter.
+            return {"ok": True, "jobs": jl.list_all()}
 
         job_id = str(request.get("job_id") or "")
         if not job_id:

--- a/operator/workspace_broker/tests/test_job_dispatch.py
+++ b/operator/workspace_broker/tests/test_job_dispatch.py
@@ -1,0 +1,111 @@
+"""Broker dispatch tests for the B1 job verbs.
+
+These cover the *glue*: that job verbs are gateway-PID-gated (an execute_code
+child with a different peer PID is rejected) and route to the ledger. The
+ledger logic itself is covered in test_job_ledger.py.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from workspace_broker.job_ledger import JobLedgerWriter
+from workspace_broker.server import Broker
+
+GATEWAY_PID = 4321
+CHILD_PID = 9999
+
+
+def _broker(tmp_path) -> Broker:
+    # Build via __new__ to skip env/credential setup; wire only what the job
+    # path touches (gateway_pid + job_ledger). The audit ledger stays disabled.
+    b = Broker.__new__(Broker)
+    b.gateway_pid = GATEWAY_PID
+    b.ledger = None
+    b.job_ledger = JobLedgerWriter(str(tmp_path / "broker.db"))
+    return b
+
+
+def _create_row() -> dict:
+    return {
+        "customer_slug": "demo-law",
+        "persona_id": "intake-coordinator",
+        "brief": "Long multi-document review.",
+        "budget_cents": 500,
+    }
+
+
+def test_job_create_and_read_route_through_broker(tmp_path):
+    b = _broker(tmp_path)
+    created = b.handle({"action": "job_create", "row": _create_row()}, GATEWAY_PID)
+    assert created["ok"] is True
+    job_id = created["id"]
+
+    read = b.handle({"action": "job_read", "job_id": job_id}, GATEWAY_PID)
+    assert read["job"]["status"] == "queued"
+    assert read["job"]["budget_cents"] == 500
+
+
+def test_job_verbs_reject_non_gateway_peer(tmp_path):
+    """The core gating property: an execute_code child (different peer PID)
+    cannot drive the job ledger."""
+    b = _broker(tmp_path)
+    with pytest.raises(PermissionError):
+        b.handle({"action": "job_create", "row": _create_row()}, CHILD_PID)
+    with pytest.raises(PermissionError):
+        b.handle({"action": "job_claim", "job_id": "x", "worker_id": "w"}, CHILD_PID)
+
+
+def test_claim_record_flow_through_broker(tmp_path):
+    b = _broker(tmp_path)
+    job_id = b.handle({"action": "job_create", "row": _create_row()}, GATEWAY_PID)["id"]
+
+    claim = b.handle({"action": "job_claim", "job_id": job_id, "worker_id": "w1"}, GATEWAY_PID)
+    epoch = claim["lease_epoch"]
+    assert epoch == 1
+
+    rec = b.handle(
+        {"action": "job_record", "job_id": job_id, "lease_epoch": epoch,
+         "fields": {"spent_cents": 42}},
+        GATEWAY_PID,
+    )
+    assert rec["ok"] is True
+    # Stale epoch is fenced out at the dispatch boundary too.
+    stale = b.handle(
+        {"action": "job_record", "job_id": job_id, "lease_epoch": epoch - 1,
+         "fields": {"spent_cents": 999}},
+        GATEWAY_PID,
+    )
+    assert stale["ok"] is False
+
+
+def test_idempotency_decision_through_broker(tmp_path):
+    b = _broker(tmp_path)
+    job_id = b.handle({"action": "job_create", "row": _create_row()}, GATEWAY_PID)["id"]
+    epoch = b.handle({"action": "job_claim", "job_id": job_id, "worker_id": "w1"}, GATEWAY_PID)["lease_epoch"]
+
+    begin = b.handle(
+        {"action": "job_idem_begin", "job_id": job_id, "lease_epoch": epoch, "step_key": "send:x"},
+        GATEWAY_PID,
+    )
+    assert begin["decision"] == "proceed"
+    done = b.handle(
+        {"action": "job_idem_complete", "job_id": job_id, "lease_epoch": epoch, "step_key": "send:x"},
+        GATEWAY_PID,
+    )
+    assert done["ok"] is True
+
+
+def test_unconfigured_job_ledger_raises(tmp_path):
+    b = _broker(tmp_path)
+    b.job_ledger = None
+    with pytest.raises(ValueError):
+        b.handle({"action": "job_read", "job_id": "x"}, GATEWAY_PID)
+
+
+def test_missing_required_args_raise(tmp_path):
+    b = _broker(tmp_path)
+    with pytest.raises(ValueError):
+        b.handle({"action": "job_read"}, GATEWAY_PID)  # no job_id
+    with pytest.raises(ValueError):
+        b.handle({"action": "job_record", "job_id": "x"}, GATEWAY_PID)  # no lease_epoch

--- a/operator/workspace_broker/tests/test_job_dispatch.py
+++ b/operator/workspace_broker/tests/test_job_dispatch.py
@@ -69,14 +69,16 @@ def test_claim_record_flow_through_broker(tmp_path):
          "fields": {"spent_cents": 42}},
         GATEWAY_PID,
     )
-    assert rec["ok"] is True
-    # Stale epoch is fenced out at the dispatch boundary too.
+    assert rec["result"] is True
+    # Stale epoch is fenced out at the dispatch boundary too (ok=processed,
+    # result=False).
     stale = b.handle(
         {"action": "job_record", "job_id": job_id, "lease_epoch": epoch - 1,
          "fields": {"spent_cents": 999}},
         GATEWAY_PID,
     )
-    assert stale["ok"] is False
+    assert stale["ok"] is True
+    assert stale["result"] is False
 
 
 def test_idempotency_decision_through_broker(tmp_path):
@@ -93,7 +95,7 @@ def test_idempotency_decision_through_broker(tmp_path):
         {"action": "job_idem_complete", "job_id": job_id, "lease_epoch": epoch, "step_key": "send:x"},
         GATEWAY_PID,
     )
-    assert done["ok"] is True
+    assert done["result"] is True
 
 
 def test_unconfigured_job_ledger_raises(tmp_path):

--- a/operator/workspace_broker/tests/test_job_durability_scenarios.py
+++ b/operator/workspace_broker/tests/test_job_durability_scenarios.py
@@ -1,0 +1,188 @@
+"""End-to-end durability scenarios against the REAL job ledger (B1, ADR 0051).
+
+``test_job_ledger.py`` covers each ledger primitive in isolation; this file
+proves the cross-primitive SCENARIOS the design's Verification section names —
+the ones a single-method unit test cannot, because the property is emergent from
+several operations wired together against the same persistent sqlite store:
+
+  * Deterministic crash test: a side-effecting step journals its idempotency
+    key BEFORE the effect; a crash AFTER the effect but BEFORE completion-record
+    leaves the key 'in_progress'; on resume the step is NOT re-executed (it fails
+    closed to 'review'). Variant: a step that DID complete is 'skip'ped, not
+    re-fired.
+  * Fencing test: two live claimants (the respawn-produces-two-workers case);
+    the stale-epoch one cannot deliver or spend — no double-delivery, no
+    double-spend, against the real epoch-fenced UPDATE.
+  * Cost accounting: provider-reported usage recorded across segments sums into
+    spent_cents monotonically, and a record that would set spent over budget is
+    visible to the caller's breach check.
+
+The ledger persists across an in-test "crash" because it is a real on-disk
+sqlite file — closing/reopening a ``JobLedgerWriter`` over the same path is
+exactly what a process restart does (per-op connections, no shared handle).
+"""
+
+from __future__ import annotations
+
+from workspace_broker.job_ledger import JobLedgerWriter
+
+T0 = "2026-06-18T00:00:00.000Z"
+T1 = "2026-06-18T00:01:00.000Z"
+T2 = "2026-06-18T00:10:00.000Z"
+CUTOFF_NONE_EXPIRED = "2026-06-17T00:00:00.000Z"
+CUTOFF_ALL_EXPIRED = "2026-06-18T09:00:00.000Z"
+
+
+def _new_job(w: JobLedgerWriter, budget_cents: int = 500) -> str:
+    return w.create(
+        {
+            "customer_slug": "demo-law",
+            "persona_id": "intake-coordinator",
+            "model": "claude-sonnet-4-6",
+            "brief": "Review the three production documents and surface gaps.",
+            "budget_cents": budget_cents,
+        }
+    )
+
+
+# -- Deterministic crash test (ADR 0051 Verification) -------------------------
+def test_crash_after_effect_before_completion_does_not_reexecute(tmp_path):
+    """The canonical durability invariant. A worker journals the step key, does
+    the (side-effecting) effect, then CRASHES before recording completion. A
+    fresh worker reopens the ledger, re-claims, and must NOT re-execute the
+    effect: the in_progress key fails closed to 'review' (we cannot know if the
+    effect landed, so we never blindly re-fire)."""
+    db = str(tmp_path / "broker.db")
+    w = JobLedgerWriter(db)
+    job_id = _new_job(w)
+    epoch = w.claim(job_id, "worker-A", now=T0, lease_expiry_cutoff=CUTOFF_NONE_EXPIRED)
+
+    step = "send:invoice-42"
+    # Record-key-BEFORE-effect: the journal survives the crash the in-context
+    # decision would not.
+    assert w.idempotency_begin(job_id, step, epoch) == "proceed"
+    # ... the effect fires here (e.g. an email is sent) ...
+    # CRASH before idempotency_complete + before status advances. Simulate by
+    # dropping the writer entirely (no completion recorded).
+    del w
+
+    # A fresh process reopens the SAME on-disk ledger and re-claims after the
+    # lease expires.
+    w2 = JobLedgerWriter(db)
+    epoch2 = w2.claim(job_id, "worker-B", now=T2, lease_expiry_cutoff=CUTOFF_ALL_EXPIRED)
+    assert epoch2 == epoch + 1
+    # The resume sees the un-completed step and fails closed — it does NOT
+    # re-execute the effect.
+    assert w2.idempotency_begin(job_id, step, epoch2) == "review"
+
+
+def test_crash_after_completion_skips_not_refire(tmp_path):
+    """The complement: a step that DID complete before the crash is 'skip'ped on
+    resume — the durable progress is honored, no needless re-run."""
+    db = str(tmp_path / "broker.db")
+    w = JobLedgerWriter(db)
+    job_id = _new_job(w)
+    epoch = w.claim(job_id, "worker-A", now=T0, lease_expiry_cutoff=CUTOFF_NONE_EXPIRED)
+
+    step = "send:report-7"
+    assert w.idempotency_begin(job_id, step, epoch) == "proceed"
+    assert w.idempotency_complete(job_id, step, epoch) is True
+    del w  # crash after the step fully completed
+
+    w2 = JobLedgerWriter(db)
+    epoch2 = w2.claim(job_id, "worker-B", now=T2, lease_expiry_cutoff=CUTOFF_ALL_EXPIRED)
+    # Resume sees the completed step and skips it (no double-fire).
+    assert w2.idempotency_begin(job_id, step, epoch2) == "skip"
+
+
+def test_progress_survives_reopen_and_resumes_from_recorded_tip(tmp_path):
+    """A non-side-effecting checkpoint (spend + rotated session tip) persists
+    across a crash so the resume reloads the right lineage and the spend is not
+    lost (it counts against the budget on the next segment)."""
+    db = str(tmp_path / "broker.db")
+    w = JobLedgerWriter(db)
+    job_id = _new_job(w, budget_cents=1000)
+    epoch = w.claim(job_id, "worker-A", now=T0, lease_expiry_cutoff=CUTOFF_NONE_EXPIRED)
+    assert w.record(job_id, epoch, {"spent_cents": 300, "current_tip_session_id": "sess-7"}) is True
+    del w  # crash mid-job
+
+    w2 = JobLedgerWriter(db)
+    row = w2.read(job_id)
+    # Durable control facts survived the reopen.
+    assert row["spent_cents"] == 300
+    assert row["current_tip_session_id"] == "sess-7"
+    assert row["status"] not in {"delivered", "done", "needs_review", "cancelled"}
+
+
+# -- Fencing test: no double-delivery / no double-spend -----------------------
+def test_two_live_workers_no_double_delivery(tmp_path):
+    """Respawn-produces-two-workers: A claims; its lease lapses; B re-claims; A
+    wakes and tries to deliver (record result_ref + status). A's writes are all
+    fenced no-ops, so the result is delivered exactly once — B's."""
+    db = str(tmp_path / "broker.db")
+    w = JobLedgerWriter(db)
+    job_id = _new_job(w)
+    epoch_a = w.claim(job_id, "worker-A", now=T0, lease_expiry_cutoff=CUTOFF_NONE_EXPIRED)
+    epoch_b = w.claim(job_id, "worker-B", now=T2, lease_expiry_cutoff=CUTOFF_ALL_EXPIRED)
+    assert epoch_b == epoch_a + 1
+
+    # B drives the job to delivered.
+    assert w.record(job_id, epoch_b, {"result_ref": "r2://B", "status": "complete"}) is True
+    assert w.record(job_id, epoch_b, {"status": "delivering"}) is True
+    assert w.record(job_id, epoch_b, {"status": "delivered"}) is True
+
+    # Stale A wakes and tries to deliver its own result — every write a no-op.
+    assert w.record(job_id, epoch_a, {"result_ref": "r2://A", "status": "complete"}) is False
+    assert w.record(job_id, epoch_a, {"status": "delivering"}) is False
+
+    row = w.read(job_id)
+    assert row["result_ref"] == "r2://B"  # B's result, never overwritten by A
+    assert row["status"] == "delivered"
+
+
+def test_two_live_workers_no_double_spend(tmp_path):
+    """The cost analogue of no-double-delivery: a stale worker cannot add its
+    segment's spend on top of the live worker's. Spend reflects exactly one
+    lineage of segments."""
+    db = str(tmp_path / "broker.db")
+    w = JobLedgerWriter(db)
+    job_id = _new_job(w, budget_cents=1000)
+    epoch_a = w.claim(job_id, "worker-A", now=T0, lease_expiry_cutoff=CUTOFF_NONE_EXPIRED)
+    epoch_b = w.claim(job_id, "worker-B", now=T2, lease_expiry_cutoff=CUTOFF_ALL_EXPIRED)
+
+    assert w.record(job_id, epoch_b, {"spent_cents": 200}) is True
+    # Stale A's spend write is fenced — it does NOT add on top.
+    assert w.record(job_id, epoch_a, {"spent_cents": 999}) is False
+    assert w.read(job_id)["spent_cents"] == 200
+
+
+# -- Cost accounting across segments ------------------------------------------
+def test_spend_accumulates_monotonically_across_segments(tmp_path):
+    """Provider-reported usage recorded after each segment sums into spent_cents;
+    the worker computes new_spent = prev + delta and records the absolute, so
+    the ledger reflects the running total the budget guard reads."""
+    db = str(tmp_path / "broker.db")
+    w = JobLedgerWriter(db)
+    job_id = _new_job(w, budget_cents=1000)
+    epoch = w.claim(job_id, "worker-A", now=T0, lease_expiry_cutoff=CUTOFF_NONE_EXPIRED)
+
+    spent = 0
+    for delta in (120, 85, 200):
+        spent += delta  # worker accumulates real per-segment usage
+        assert w.record(job_id, epoch, {"spent_cents": spent}) is True
+    assert w.read(job_id)["spent_cents"] == 405
+
+
+def test_recorded_spend_over_budget_is_visible_to_breach_check(tmp_path):
+    """A mid-segment overshoot lands in the ledger as an absolute spent_cents the
+    next read sees as over budget — the worker's breach check (spent >= budget)
+    then dead-letters. The ledger does not itself reject the overshoot record (it
+    is the worker's job to act on it), so we assert the recorded value is what the
+    breach check reads."""
+    db = str(tmp_path / "broker.db")
+    w = JobLedgerWriter(db)
+    job_id = _new_job(w, budget_cents=300)
+    epoch = w.claim(job_id, "worker-A", now=T0, lease_expiry_cutoff=CUTOFF_NONE_EXPIRED)
+    assert w.record(job_id, epoch, {"spent_cents": 360}) is True
+    row = w.read(job_id)
+    assert row["spent_cents"] >= row["budget_cents"]  # the breach the worker acts on

--- a/operator/workspace_broker/tests/test_job_ledger.py
+++ b/operator/workspace_broker/tests/test_job_ledger.py
@@ -1,0 +1,182 @@
+"""Unit tests for the broker-owned job ledger (B1, ADR 0051).
+
+Focus: the trust-critical invariants — lease fencing (a stale epoch's write is
+a no-op) and idempotency (a side-effecting step recorded before the effect
+cannot double-fire on resume). These are the properties the durable runner's
+correctness rests on, so they are tested in isolation, not assumed.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from workspace_broker.job_ledger import JobLedgerWriter
+
+# Lexicographically-ordered fixed timestamps (the ISO format is sortable).
+T0 = "2026-06-18T00:00:00.000Z"
+T1 = "2026-06-18T00:01:00.000Z"
+T2 = "2026-06-18T00:10:00.000Z"
+# A cutoff EARLIER than any live lease (nothing expired) vs LATER (all expired).
+CUTOFF_NONE_EXPIRED = "2026-06-17T00:00:00.000Z"
+CUTOFF_ALL_EXPIRED = "2026-06-18T09:00:00.000Z"
+
+
+def _writer(tmp_path) -> JobLedgerWriter:
+    return JobLedgerWriter(str(tmp_path / "broker.db"))
+
+
+def _new_job(w: JobLedgerWriter, budget_cents: int = 500) -> str:
+    return w.create(
+        {
+            "customer_slug": "demo-law",
+            "persona_id": "intake-coordinator",
+            "model": "claude-sonnet-4-6",
+            "brief": "Review the three production documents and surface gaps.",
+            "brief_digest": "sha256:abc",
+            "deliver_to": "telegram:123",
+            "budget_cents": budget_cents,
+        }
+    )
+
+
+def test_create_and_read_roundtrip(tmp_path):
+    w = _writer(tmp_path)
+    job_id = _new_job(w)
+    row = w.read(job_id)
+    assert row is not None
+    assert row["status"] == "queued"
+    assert row["customer_slug"] == "demo-law"
+    assert row["budget_cents"] == 500
+    assert row["spent_cents"] == 0
+    assert row["lease_epoch"] == 0
+    assert row["attempts"] == 0
+    assert row["cancel_requested"] == 0
+
+
+def test_create_rejects_unknown_and_missing_columns(tmp_path):
+    w = _writer(tmp_path)
+    with pytest.raises(ValueError):
+        w.create({"customer_slug": "x", "persona_id": "p", "brief": "b", "budget_cents": 1, "status": "running"})
+    with pytest.raises(ValueError):
+        w.create({"customer_slug": "x", "persona_id": "p", "brief": "b"})  # no budget_cents
+
+
+def test_ensure_schema_is_idempotent(tmp_path):
+    db = str(tmp_path / "broker.db")
+    JobLedgerWriter(db)
+    # A second writer over the same file must not raise (CREATE IF NOT EXISTS).
+    w2 = JobLedgerWriter(db)
+    assert w2.read("nope") is None
+
+
+def test_claim_is_exclusive_until_lease_expires(tmp_path):
+    w = _writer(tmp_path)
+    job_id = _new_job(w)
+
+    epoch1 = w.claim(job_id, "worker-A", now=T0, lease_expiry_cutoff=CUTOFF_NONE_EXPIRED)
+    assert epoch1 == 1
+    row = w.read(job_id)
+    assert row["status"] == "running"
+    assert row["lease_owner"] == "worker-A"
+    assert row["attempts"] == 1
+
+    # A second claimant while the lease is live is rejected.
+    assert w.claim(job_id, "worker-B", now=T1, lease_expiry_cutoff=CUTOFF_NONE_EXPIRED) is None
+
+    # Once the lease is considered expired, a new claim wins with a HIGHER epoch.
+    epoch2 = w.claim(job_id, "worker-B", now=T2, lease_expiry_cutoff=CUTOFF_ALL_EXPIRED)
+    assert epoch2 == 2
+    row = w.read(job_id)
+    assert row["lease_owner"] == "worker-B"
+    assert row["attempts"] == 2
+
+
+def test_record_is_epoch_fenced(tmp_path):
+    w = _writer(tmp_path)
+    job_id = _new_job(w)
+    epoch = w.claim(job_id, "worker-A", now=T0, lease_expiry_cutoff=CUTOFF_NONE_EXPIRED)
+
+    # Correct epoch writes.
+    assert w.record(job_id, epoch, {"spent_cents": 120, "current_tip_session_id": "sess-2"}) is True
+    assert w.read(job_id)["spent_cents"] == 120
+
+    # A stale (older) epoch is fenced out — its write is a silent no-op.
+    assert w.record(job_id, epoch - 1, {"spent_cents": 999}) is False
+    assert w.read(job_id)["spent_cents"] == 120  # unchanged
+
+    # Non-mutable fields are rejected outright.
+    with pytest.raises(ValueError):
+        w.record(job_id, epoch, {"budget_cents": 1})
+    with pytest.raises(ValueError):
+        w.record(job_id, epoch, {"lease_owner": "x"})
+
+
+def test_fencing_defeats_two_live_workers(tmp_path):
+    """The respawn-produces-two-workers scenario: A claims, B re-claims after
+    expiry, A wakes and tries to write — A's write must be rejected."""
+    w = _writer(tmp_path)
+    job_id = _new_job(w)
+    epoch_a = w.claim(job_id, "worker-A", now=T0, lease_expiry_cutoff=CUTOFF_NONE_EXPIRED)
+    epoch_b = w.claim(job_id, "worker-B", now=T2, lease_expiry_cutoff=CUTOFF_ALL_EXPIRED)
+    assert epoch_b == epoch_a + 1
+
+    # Stale worker A's checkpoint and completion are both no-ops.
+    assert w.record(job_id, epoch_a, {"result_ref": "A-wrote-this"}) is False
+    assert w.record(job_id, epoch_b, {"result_ref": "B-wrote-this"}) is True
+    assert w.read(job_id)["result_ref"] == "B-wrote-this"
+
+
+def test_idempotency_begin_then_complete_then_skip(tmp_path):
+    w = _writer(tmp_path)
+    job_id = _new_job(w)
+    epoch = w.claim(job_id, "worker-A", now=T0, lease_expiry_cutoff=CUTOFF_NONE_EXPIRED)
+
+    # First sight of the logical effect: proceed and perform it.
+    assert w.idempotency_begin(job_id, "send:invoice-42", epoch) == "proceed"
+    # While in_progress (e.g. crashed before completion), a resume must NOT
+    # re-fire — fail closed to review.
+    assert w.idempotency_begin(job_id, "send:invoice-42", epoch) == "review"
+    # After the effect succeeds, mark done.
+    assert w.idempotency_complete(job_id, "send:invoice-42", epoch) is True
+    # A later resume now sees it done and skips.
+    assert w.idempotency_begin(job_id, "send:invoice-42", epoch) == "skip"
+
+
+def test_idempotency_complete_is_epoch_fenced(tmp_path):
+    w = _writer(tmp_path)
+    job_id = _new_job(w)
+    epoch = w.claim(job_id, "worker-A", now=T0, lease_expiry_cutoff=CUTOFF_NONE_EXPIRED)
+    assert w.idempotency_begin(job_id, "send:x", epoch) == "proceed"
+    # A stale worker cannot retroactively mark the step done.
+    assert w.idempotency_complete(job_id, "send:x", epoch - 1) is False
+
+
+def test_request_cancel_sets_flag_and_respects_terminal(tmp_path):
+    w = _writer(tmp_path)
+    job_id = _new_job(w)
+    epoch = w.claim(job_id, "worker-A", now=T0, lease_expiry_cutoff=CUTOFF_NONE_EXPIRED)
+    assert w.request_cancel(job_id) is True
+    assert w.read(job_id)["cancel_requested"] == 1
+
+    # A terminal job cannot be cancelled.
+    assert w.record(job_id, epoch, {"status": "done"}) is True
+    assert w.request_cancel(job_id) is False
+
+
+def test_list_claimable_excludes_terminal_and_live_leases(tmp_path):
+    w = _writer(tmp_path)
+    queued = _new_job(w)
+    leased = _new_job(w)
+    terminal = _new_job(w)
+
+    epoch_t = w.claim(terminal, "w", now=T0, lease_expiry_cutoff=CUTOFF_NONE_EXPIRED)
+    w.record(terminal, epoch_t, {"status": "done"})
+    w.claim(leased, "w", now=T0, lease_expiry_cutoff=CUTOFF_NONE_EXPIRED)  # live lease
+
+    # Nothing expired yet: only the never-claimed queued job is claimable.
+    ids = {r["id"] for r in w.list_claimable(now=T1, lease_expiry_cutoff=CUTOFF_NONE_EXPIRED)}
+    assert ids == {queued}
+
+    # With all leases expired: the leased job re-appears; terminal stays out.
+    ids = {r["id"] for r in w.list_claimable(now=T2, lease_expiry_cutoff=CUTOFF_ALL_EXPIRED)}
+    assert ids == {queued, leased}

--- a/operator/workspace_broker/tests/test_job_ledger.py
+++ b/operator/workspace_broker/tests/test_job_ledger.py
@@ -163,6 +163,36 @@ def test_request_cancel_sets_flag_and_respects_terminal(tmp_path):
     assert w.request_cancel(job_id) is False
 
 
+def test_list_all_returns_every_job_newest_first(tmp_path):
+    """The observability seam (``jobs`` runtime-read kind) needs ALL jobs —
+    terminal and live-leased included — newest-created first, with no lease
+    filter (unlike ``list_claimable``)."""
+    w = _writer(tmp_path)
+    first = _new_job(w)
+    second = _new_job(w)
+    third = _new_job(w)
+
+    # Drive them to distinct states: one terminal, one live-leased, one queued.
+    epoch = w.claim(first, "w", now=T0, lease_expiry_cutoff=CUTOFF_NONE_EXPIRED)
+    w.record(first, epoch, {"status": "done"})
+    w.claim(second, "w", now=T0, lease_expiry_cutoff=CUTOFF_NONE_EXPIRED)  # live lease
+
+    rows = w.list_all()
+    ids = [r["id"] for r in rows]
+    # All three present regardless of status/lease.
+    assert set(ids) == {first, second, third}
+    # Newest-created first (ULIDs are lexicographically time-sortable).
+    assert ids == sorted(ids, reverse=True)
+    # The terminal and live-leased jobs that list_claimable would hide are here.
+    by_id = {r["id"]: r for r in rows}
+    assert by_id[first]["status"] == "done"
+    assert by_id[second]["lease_owner"] == "w"
+
+
+def test_list_all_empty_when_no_jobs(tmp_path):
+    assert _writer(tmp_path).list_all() == []
+
+
 def test_list_claimable_excludes_terminal_and_live_leases(tmp_path):
     w = _writer(tmp_path)
     queued = _new_job(w)

--- a/src/lib/operator/runtime-read.ts
+++ b/src/lib/operator/runtime-read.ts
@@ -39,7 +39,13 @@
  * authored behavioral lane, ADR 0048) is the only section today. Unlike a whole
  * config read, it is allow-listed to non-secret sections so the connector
  * secrets in `customer.yaml` can never cross the seam. The Machine refuses any
- * section outside its allow-list. */
+ * section outside its allow-list.
+ *
+ * `jobs` serves the B1 durable-job control plane (ADR 0051) — the broker-owned
+ * job ledger projected to the operator-visible control facts (status, cost,
+ * lease, result, error) so a background job is verifiable end-to-end over the
+ * same authenticated read seam. It takes no extra query field; the Machine
+ * reads its own ledger over the broker socket and returns a single page. */
 export const RUNTIME_READ_KINDS = [
   'audit_log',
   'draft',
@@ -47,6 +53,7 @@ export const RUNTIME_READ_KINDS = [
   'activity',
   'memory_export',
   'config_export',
+  'jobs',
 ] as const
 export type RuntimeReadKind = (typeof RUNTIME_READ_KINDS)[number]
 

--- a/tests/operator-dockerfile.test.ts
+++ b/tests/operator-dockerfile.test.ts
@@ -124,7 +124,11 @@ describe('Operator customer Machine Dockerfile', () => {
     // two-pass fail-closed across the reconcile set; HERMES_HOME snapshot/restore.
     // Also a pure ruff-format pass on webhook_gate.py (no logic change). Superset
     // of a97013e.
-    expect(DOCKERFILE).toContain('ARG OVERLAY_REF="1c2171f69a8086e575bc9de8cea42504546f3478"')
+    // baa9495 (B1 staging): adds the durable task-execution overlay half (job
+    // ledger client + hermes-smd-jobs plugin + in-gateway worker). Additive on
+    // top of 1c2171f; the vendored adapter twins (and their overlaySha256) are
+    // unchanged, so only overlayRef is re-pinned in overlay-pairs.json.
+    expect(DOCKERFILE).toContain('ARG OVERLAY_REF="baa949583bd5584e98d5398f43d1cd4091136d70"')
   })
 
   it('does NOT swallow a failed plugin install (no fail-open `|| echo ... continuing`)', () => {

--- a/tests/operator-dockerfile.test.ts
+++ b/tests/operator-dockerfile.test.ts
@@ -128,7 +128,7 @@ describe('Operator customer Machine Dockerfile', () => {
     // ledger client + hermes-smd-jobs plugin + in-gateway worker). Additive on
     // top of 1c2171f; the vendored adapter twins (and their overlaySha256) are
     // unchanged, so only overlayRef is re-pinned in overlay-pairs.json.
-    expect(DOCKERFILE).toContain('ARG OVERLAY_REF="baa949583bd5584e98d5398f43d1cd4091136d70"')
+    expect(DOCKERFILE).toContain('ARG OVERLAY_REF="7f493c605ec0999db1bd4fb15a7cca34a4442cec"')
   })
 
   it('does NOT swallow a failed plugin install (no fail-open `|| echo ... continuing`)', () => {

--- a/tests/operator-dockerfile.test.ts
+++ b/tests/operator-dockerfile.test.ts
@@ -128,7 +128,7 @@ describe('Operator customer Machine Dockerfile', () => {
     // ledger client + hermes-smd-jobs plugin + in-gateway worker). Additive on
     // top of 1c2171f; the vendored adapter twins (and their overlaySha256) are
     // unchanged, so only overlayRef is re-pinned in overlay-pairs.json.
-    expect(DOCKERFILE).toContain('ARG OVERLAY_REF="7d1561bf1a70daf50d8cd909a2cb4124bc80ceb6"')
+    expect(DOCKERFILE).toContain('ARG OVERLAY_REF="e8411cae37824515e584f596f0f74701a983d622"')
   })
 
   it('does NOT swallow a failed plugin install (no fail-open `|| echo ... continuing`)', () => {

--- a/tests/operator-dockerfile.test.ts
+++ b/tests/operator-dockerfile.test.ts
@@ -128,7 +128,7 @@ describe('Operator customer Machine Dockerfile', () => {
     // ledger client + hermes-smd-jobs plugin + in-gateway worker). Additive on
     // top of 1c2171f; the vendored adapter twins (and their overlaySha256) are
     // unchanged, so only overlayRef is re-pinned in overlay-pairs.json.
-    expect(DOCKERFILE).toContain('ARG OVERLAY_REF="7f493c605ec0999db1bd4fb15a7cca34a4442cec"')
+    expect(DOCKERFILE).toContain('ARG OVERLAY_REF="7d1561bf1a70daf50d8cd909a2cb4124bc80ceb6"')
   })
 
   it('does NOT swallow a failed plugin install (no fail-open `|| echo ... continuing`)', () => {


### PR DESCRIPTION
**Draft / WIP.** Implements **B1** from ADR 0050 — the durable runner that takes a long job, runs it unattended, survives compaction/crash/restart via the `state.db` session lineage, and delivers a retrievable result. Built per the approved, critique-hardened plan (3 critique rounds + a source-level Phase-0 verification; every load-bearing claim is file:line-cited in the design doc).

### Landed so far
- **ADR 0051 + design doc** (`docs/adr/0051-*`, `docs/design/operator/durable-task-execution-substrate.md`) — the spec.
- **Broker-owned job ledger** (`operator/workspace_broker/job_ledger.py` + 10 unit tests, all green) — the mutable control plane, modeled on the audit ledger, with **epoch-fenced** mutation (defeats two-live-workers double-spend) and **record-before-effect idempotency** (no double-fire on resume). Schema in code (local Machine control plane); the D1 mirror is deferred.

### Remaining (this PR)
- Wire `job_*` verbs into `workspace_broker/server.py` (gateway-PID-gated like `audit_append`).
- Overlay: `shared/job_ledger_client.py`, `plugins/hermes-smd-jobs/` (`start_background_job` / `job_status` / `job_cancel` / `job_record_sideeffect`), `webhook_gate.py` read verbs.
- In-gateway worker **thread** (cron model, off the loop): claim → lineage-resume → per-iteration pre-spend cost + cancel → `run_conversation` → checkpoint → R2 result → delivery state machine; boot-sweep behind a readiness barrier; `entrypoint.sh` broker respawn-supervisor.
- CI: crash/fencing/cost/readiness/identity tests + the `run_job` construction-equivalence smoke.

### Notes
- Receipts ($50 failure) is **B2** (process-in-code), separate — not this PR.
- MVP is read-mostly; send-capable jobs + the dedicated `smd-jobs` uid are deferred (ADR 0051 Consequences).
- Overlay-side changes land in `venturecrane/hermes-smd-overlay`; this PR is the console/broker half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)