### PR TITLE
chore(operator): bump OVERLAY_REF 1c2171f→31ea5ab (ADR 0050 B0)

### DIFF
--- a/operator/contracts/overlay-pairs.json
+++ b/operator/contracts/overlay-pairs.json
@@ -1,6 +1,6 @@
 {
   "overlayRepo": "https://github.com/venturecrane/hermes-smd-overlay.git",
-  "overlayRef": "1c2171f69a8086e575bc9de8cea42504546f3478",
+  "overlayRef": "31ea5ab05b97bb5d4ae5375ee6dd20325680ee58",
   "overlayRefNote": "MUST equal the ARG OVERLAY_REF pinned in operator/templates/Dockerfile — that is the overlay commit a customer Machine actually ships. The vitest gate asserts the two agree so the manifest cannot pin a stale overlay. Bump both together when OVERLAY_REF moves, then re-record each overlaySha256 from the runtime file at the new ref.",
   "pairs": [
     {
@@ -13,7 +13,7 @@
     {
       "adapterPath": "operator/adapter/audit_log.py",
       "overlayPath": "plugins/hermes-smd-audit/emit.py",
-      "syncNote": "2026-06-18: overlayRef bumped a97013e→1c2171f for the cron reconcile fix (overlay#103) — bootstrap/cron_materialize.py + bootstrap/translate.py only (not a tracked pair); also a pure ruff-format pass on webhook_gate.py. emit.py is unchanged at this ref; overlaySha256 rechecked and confirmed stable. Prior note: 2026-06-18: overlayRef bumped e93a3ff→a97013e for /webhooks/handoff handler in webhook_gate.py (overlay#101, Phase 2 MCP handoff). emit.py is unchanged at this ref; overlaySha256 rechecked and confirmed stable. Prior note: 2026-06-17: overlayRef bumped d8c178e→e93a3ff for native Hermes tool classification in shared/action_classes.py + hermes-smd-trust/enforce.py. emit.py unchanged; sha256 stable.",
+      "syncNote": "2026-06-19: overlayRef bumped 1c2171f→31ea5ab for ADR 0050 B0 (overlay#105) — plugins/hermes-smd-inbound/__init__.py (not a tracked pair) taints the code-execution channel. Release branch release/b0-taint-code-exec = 1c2171f + B0 only, cherry-picked to EXCLUDE the WIP B1 substrate (e8411ca) on overlay main. No tracked-pair file changed; emit.py unchanged; overlaySha256 stable. Prior note: 2026-06-18: overlayRef bumped a97013e→1c2171f for the cron reconcile fix (overlay#103) — bootstrap/cron_materialize.py + bootstrap/translate.py only (not a tracked pair); also a pure ruff-format pass on webhook_gate.py. emit.py is unchanged at this ref; overlaySha256 rechecked and confirmed stable. Prior note: 2026-06-18: overlayRef bumped e93a3ff→a97013e for /webhooks/handoff handler in webhook_gate.py (overlay#101, Phase 2 MCP handoff). emit.py is unchanged at this ref; overlaySha256 rechecked and confirmed stable. Prior note: 2026-06-17: overlayRef bumped d8c178e→e93a3ff for native Hermes tool classification in shared/action_classes.py + hermes-smd-trust/enforce.py. emit.py unchanged; sha256 stable.",
       "sha256": "b797b2ac3fcff021db140eab9634c3e30a2bf99df13fd21cf9ed8f14a1fa7f82",
       "overlaySha256": "38efd8ed3f92964b21fd2889a68e470cc87aa8faa7d9e0abd92b942b262ff321"
     },

--- a/operator/templates/Dockerfile
+++ b/operator/templates/Dockerfile
@@ -210,7 +210,13 @@ ARG OVERLAY_REPO="https://github.com/venturecrane/hermes-smd-overlay.git"
 # its orphaned managed job removed at boot (was firing forever); two-pass
 # fail-closed across the reconcile set; HERMES_HOME snapshot/restore. Also
 # bundles a pre-existing ruff-format fix of webhook_gate.py (no logic change).
-ARG OVERLAY_REF="1c2171f69a8086e575bc9de8cea42504546f3478"
+# 31ea5ab — ADR 0050 B0 (overlay#105): the code-execution channel (execute_code/
+# terminal/process/computer_use) now taints the session, closing the confirmed
+# bypass where reading injected content in code left the session untainted and an
+# autonomous send allowed. RELEASE BRANCH (release/b0-taint-code-exec) = 1c2171f +
+# B0 only, cherry-picked to EXCLUDE the WIP B1 substrate (e8411ca) that sits
+# between them on overlay main. No hashed-twin file changed → overlaySha256 stable.
+ARG OVERLAY_REF="31ea5ab05b97bb5d4ae5375ee6dd20325680ee58"
 
 ARG CUSTOMER_SLUG=customer-zero
 

--- a/tests/operator-dockerfile.test.ts
+++ b/tests/operator-dockerfile.test.ts
@@ -124,7 +124,12 @@ describe('Operator customer Machine Dockerfile', () => {
     // two-pass fail-closed across the reconcile set; HERMES_HOME snapshot/restore.
     // Also a pure ruff-format pass on webhook_gate.py (no logic change). Superset
     // of a97013e.
-    expect(DOCKERFILE).toContain('ARG OVERLAY_REF="1c2171f69a8086e575bc9de8cea42504546f3478"')
+    // 31ea5ab (#105, ADR 0050 B0) taints the code-execution channel (execute_code/
+    // terminal/process/computer_use) so reading injected content in code no longer
+    // leaves the session untainted with an autonomous send allowed. RELEASE branch
+    // release/b0-taint-code-exec = 1c2171f + B0 only (cherry-pick), excluding the
+    // WIP B1 substrate (e8411ca) on overlay main. No tracked-pair file changed.
+    expect(DOCKERFILE).toContain('ARG OVERLAY_REF="31ea5ab05b97bb5d4ae5375ee6dd20325680ee58"')
   })
 
   it('does NOT swallow a failed plugin install (no fail-open `|| echo ... continuing`)', () => {


### PR DESCRIPTION
## Summary
- Ships overlay#105 (ADR 0050 B0) to the customer Machine image: the code-execution channel (`execute_code`/`terminal`/`process`/`computer_use`) now taints the session, closing the confirmed injection bypass where reading injected content *in code* left the session untainted and an autonomous send allowed.
- `OVERLAY_REF` points at `release/b0-taint-code-exec` = the live ref `1c2171f` + B0 only (cherry-pick), **deliberately excluding the WIP B1 substrate** (`e8411ca`) that sits between them on overlay main. No WIP to a live Machine.
- No tracked-pair (twin) file changed — SEC-32 `verify-overlay-pairs` passes at the new ref, all 4 `overlaySha256` stable; the `operator-dockerfile` pin guard updated in lockstep.

## Test plan
- [x] `verify-overlay-pairs.py` PASS at 31ea5ab (4/4 twins)
- [x] `operator-overlay-pairs.test.ts` 7/7, `operator-dockerfile.test.ts` 15/15
- [x] `npm run verify` passes (pre-push)
- [ ] Deploy is the separate, auth-gated, **staging-first** reprovision — this PR only moves the pin

🤖 Generated with [Claude Code](https://claude.com/claude-code)