### PR TITLE
chore(operator): bump OVERLAY_REF e8411ca→af20ecd (ADR 0050 B0)

### DIFF
--- a/operator/contracts/overlay-pairs.json
+++ b/operator/contracts/overlay-pairs.json
@@ -1,6 +1,6 @@
 {
   "overlayRepo": "https://github.com/venturecrane/hermes-smd-overlay.git",
-  "overlayRef": "e8411cae37824515e584f596f0f74701a983d622",
+  "overlayRef": "af20ecd8c1831be4297c2d89018ca69984b09899",
   "overlayRefNote": "MUST equal the ARG OVERLAY_REF pinned in operator/templates/Dockerfile — that is the overlay commit a customer Machine actually ships. The vitest gate asserts the two agree so the manifest cannot pin a stale overlay. Bump both together when OVERLAY_REF moves, then re-record each overlaySha256 from the runtime file at the new ref.",
   "pairs": [
     {
@@ -13,7 +13,7 @@
     {
       "adapterPath": "operator/adapter/audit_log.py",
       "overlayPath": "plugins/hermes-smd-audit/emit.py",
-      "syncNote": "2026-06-18: overlayRef bumped a97013e→1c2171f for the cron reconcile fix (overlay#103) — bootstrap/cron_materialize.py + bootstrap/translate.py only (not a tracked pair); also a pure ruff-format pass on webhook_gate.py. emit.py is unchanged at this ref; overlaySha256 rechecked and confirmed stable. Prior note: 2026-06-18: overlayRef bumped e93a3ff→a97013e for /webhooks/handoff handler in webhook_gate.py (overlay#101, Phase 2 MCP handoff). emit.py is unchanged at this ref; overlaySha256 rechecked and confirmed stable. Prior note: 2026-06-17: overlayRef bumped d8c178e→e93a3ff for native Hermes tool classification in shared/action_classes.py + hermes-smd-trust/enforce.py. emit.py unchanged; sha256 stable.",
+      "syncNote": "2026-06-19: overlayRef bumped e8411ca→af20ecd for ADR 0050 B0 (overlay#105) — plugins/hermes-smd-inbound/__init__.py (not a tracked pair) taints the code-execution ingestion channel. Additive on top of e8411ca (B1); no tracked-pair file changed; emit.py unchanged; overlaySha256 stable (verified at af20ecd). Prior note: 2026-06-18: overlayRef bumped a97013e→1c2171f for the cron reconcile fix (overlay#103) — bootstrap/cron_materialize.py + bootstrap/translate.py only (not a tracked pair); also a pure ruff-format pass on webhook_gate.py. emit.py is unchanged at this ref; overlaySha256 rechecked and confirmed stable. Prior note: 2026-06-18: overlayRef bumped e93a3ff→a97013e for /webhooks/handoff handler in webhook_gate.py (overlay#101, Phase 2 MCP handoff). emit.py is unchanged at this ref; overlaySha256 rechecked and confirmed stable. Prior note: 2026-06-17: overlayRef bumped d8c178e→e93a3ff for native Hermes tool classification in shared/action_classes.py + hermes-smd-trust/enforce.py. emit.py unchanged; sha256 stable.",
       "sha256": "b797b2ac3fcff021db140eab9634c3e30a2bf99df13fd21cf9ed8f14a1fa7f82",
       "overlaySha256": "38efd8ed3f92964b21fd2889a68e470cc87aa8faa7d9e0abd92b942b262ff321"
     },

--- a/operator/templates/Dockerfile
+++ b/operator/templates/Dockerfile
@@ -219,7 +219,13 @@ ARG OVERLAY_REPO="https://github.com/venturecrane/hermes-smd-overlay.git"
 # (observability `jobs` runtime-read + job_status/job_cancel MCP verbs, R2 result
 # store, B0 worker-session taint) plus the ruff/format/per-plugin-manifest CI
 # fixes. Twins unchanged; only the ref moves.
-ARG OVERLAY_REF="e8411cae37824515e584f596f0f74701a983d622"
+# af20ecd — ADR 0050 B0 (overlay#105): the code-execution INGESTION channel
+# (execute_code/terminal/process/computer_use) now taints the session, closing
+# the confirmed injection bypass where reading injected content in code left the
+# session untainted and an autonomous send allowed. Distinct from e8411ca's
+# durable-worker session taint. Additive on top of e8411ca (= 1c2171f + B1 + B0);
+# twins unchanged, overlaySha256 stable.
+ARG OVERLAY_REF="af20ecd8c1831be4297c2d89018ca69984b09899"
 
 ARG CUSTOMER_SLUG=customer-zero
 

--- a/tests/operator-dockerfile.test.ts
+++ b/tests/operator-dockerfile.test.ts
@@ -128,7 +128,10 @@ describe('Operator customer Machine Dockerfile', () => {
     // ledger client + hermes-smd-jobs plugin + in-gateway worker). Additive on
     // top of 1c2171f; the vendored adapter twins (and their overlaySha256) are
     // unchanged, so only overlayRef is re-pinned in overlay-pairs.json.
-    expect(DOCKERFILE).toContain('ARG OVERLAY_REF="e8411cae37824515e584f596f0f74701a983d622"')
+    // af20ecd (#105, ADR 0050 B0): taints the code-execution ingestion channel
+    // (execute_code/terminal/process/computer_use). Additive on top of e8411ca;
+    // twins unchanged.
+    expect(DOCKERFILE).toContain('ARG OVERLAY_REF="af20ecd8c1831be4297c2d89018ca69984b09899"')
   })
 
   it('does NOT swallow a failed plugin install (no fail-open `|| echo ... continuing`)', () => {


### PR DESCRIPTION
Ships overlay#105 (B0 — taint the code-execution ingestion channel) to the customer Machine, additive on top of B1 (e8411ca). `af20ecd` = e8411ca + exactly the B0 commit; no twin changed (SEC-32 PASS 4/4, guards 22/22). Supersedes closed #1469. Deploy is staging-first reprovision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)