### PR TITLE
docs(operator): fix stale "AI employee" drift in design foundations

### DIFF
--- a/docs/design/operator/00-foundations.md
+++ b/docs/design/operator/00-foundations.md
@@ -12,7 +12,7 @@ both portals touch — the data substrate, the access model, the multi-operator 
 
 ## 1. Scope and the three documents
 
-We are designing how an **Operator** (the productized AI-employee SKU, [ADR 0004](../../adr/0004-productized-operator-offering.md))
+We are designing how an **Operator** (the productized Operator SKU, [ADR 0004](../../adr/0004-productized-operator-offering.md))
 is **configured, monitored, and managed** from each portal:
 
 - **Admin** (`admin.smd.services`) — SMD's side. Operating a _fleet_ of operators across many clients, and drilling
@@ -284,7 +284,7 @@ Two honest boundaries:
 
 ## 7. Design principles both portals adopt
 
-We adopt these because they are right for a product that operates an AI employee inside a client's business — not
+We adopt these because they are right for a product that runs an operator inside a client's business — not
 because a prior spec mandated them. Where an existing spec happens to state the same thing well, reuse is a bonus; where
 it doesn't, these govern:
 


### PR DESCRIPTION
## What

Two descriptive references in `docs/design/operator/00-foundations.md` still used the retired pre-rename name. The **AI Employee → Operator** pivot completed in #1188 / #1189; these were missed prose.

- **§1** — "the productized **AI-employee** SKU" → "the productized **Operator** SKU"
- **§7** — "a product that **operates an AI employee**" → "a product that **runs an operator**" (avoids the redundant "operates an Operator"; matches [ADR 0037](docs/adr/0037-operator-thesis.md)'s "a worker we build and run")

## Why now

Surfaced during a code review that hit an **untracked, reverse-renamed `ai-employee/voice-gate` copy** (stale duplicate of `operator/voice-gate`, on no branch, resurrecting the dead name). That copy has been deleted; reviewers should use `operator/voice-gate` (what the test suite already imports).

## Scope note

All *other* tracked "AI employee" references are intentional and left untouched:
- `src/middleware.ts` — `/ai-employee` → `/operator` **301 compat** redirects
- ADR 0039 / 0040 / talk-track — doctrine that **bans** the framing (BCG trust finding)
- `competitive-landscape.md` — describes **competitors'** branding

Docs-only, two lines. No code or test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)