### PR TITLE
fix(operator): voice-gate fails closed on incomplete runs; fix smoke command

### DIFF
--- a/operator/bin/run-voice-gate.sh
+++ b/operator/bin/run-voice-gate.sh
@@ -12,7 +12,14 @@
 #     --customer-slug smith-pi-firm \
 #     --panel-id panel-001 \
 #     --mode synthetic \
-#     --identifications operator/voice-gate/fixtures/example-identifications.json
+#     --identifications operator/voice-gate/fixtures/example-identifications.json \
+#     --allow-undersized
+#
+# The bundled fixture set is deliberately small (3 drafts/cohort), below
+# the production minimum of 10 drafts per authorship (issue #1124). Since
+# enforcement defaults ON, the synthetic smoke command MUST pass
+# --allow-undersized (honored in synthetic mode only) or it exits 4 at
+# validation before scoring.
 #
 # Usage (live mode — NOT YET IMPLEMENTED):
 #

--- a/operator/voice-gate/README.md
+++ b/operator/voice-gate/README.md
@@ -42,8 +42,11 @@ operator/bin/run-voice-gate.sh \
   --customer-slug smith-pi-firm \
   --panel-id panel-001 \
   --mode synthetic \
-  --identifications operator/voice-gate/fixtures/example-identifications.json
+  --identifications operator/voice-gate/fixtures/example-identifications.json \
+  --allow-undersized
 ```
+
+The bundled fixture set is deliberately small (3 drafts/cohort), below the production minimum of 10 drafts per authorship (issue #1124). Enforcement defaults ON, so the synthetic smoke command must pass `--allow-undersized` (honored in synthetic mode only) or it exits `4` at validation before scoring. A live customer run never passes this flag.
 
 Exit codes:
 

--- a/operator/voice-gate/harness.ts
+++ b/operator/voice-gate/harness.ts
@@ -50,6 +50,18 @@ export interface RunVoiceGateInput extends CreatePanelSessionInput {
  * One-shot orchestration: build the session, replay all identifications,
  * seal the run, score it. Returns the run + result so the caller can
  * persist both.
+ *
+ * Fails closed on an INCOMPLETE run — every judge must have identified
+ * every draft before scoring. Size validation (`enforceProductionMinimums`)
+ * checks draft/judge *counts*; it does not check *coverage*. Without this
+ * gate a run that clears the size minimums but submits a partial batch of
+ * identifications would still score, and because the indistinguishability
+ * denominator is only the agent judgments actually submitted (see
+ * `scoreForDraftSubset`), a partial batch can inflate to a false PASS on a
+ * fraction of the data. Since this gate decides whether the agent may send
+ * under a firm's name, an incomplete run is a hard error, not a free pass.
+ * Completeness is orthogonal to sample size, so it is enforced
+ * unconditionally — `--allow-undersized` does not relax it.
  */
 export function runVoiceGate(input: RunVoiceGateInput): {
   run: BlindTestRun
@@ -64,6 +76,14 @@ export function runVoiceGate(input: RunVoiceGateInput): {
   const session = new PanelSession(input)
   for (const id of input.identifications) {
     session.recordIdentification(id)
+  }
+  if (!session.isComplete()) {
+    const expected = session.run.drafts.length * session.run.panel.length
+    const got = session.run.identifications.length
+    throw new Error(
+      `voice-gate incomplete run: ${got}/${expected} (judge, draft) identifications recorded; ` +
+        `every judge must identify every draft before scoring (fail-closed)`
+    )
   }
   const run = session.seal()
   const result = scoreRun(run)

--- a/tests/voice-gate-harness.test.ts
+++ b/tests/voice-gate-harness.test.ts
@@ -72,6 +72,58 @@ describe('runVoiceGate', () => {
     ).toThrow(/need 10|need 3/)
   })
 
+  it('fails closed when the run is incomplete (not every judge identified every draft)', () => {
+    // Size validation passes (sizes are opted out here), but coverage is
+    // partial: 2 judges × 2 drafts = 4 expected pairs, only 3 submitted.
+    // Without the completeness gate this would score on the 1 submitted
+    // agent judgment and inflate to a false PASS. It must throw instead.
+    expect(() =>
+      runVoiceGate({
+        customer_slug: 'test-firm',
+        cohort: 'client',
+        run_id: 'run-incomplete',
+        drafts: [
+          { id: 'd-c-1', cohort: 'client', authorship: 'customer', body: 'b' },
+          { id: 'd-a-1', cohort: 'client', authorship: 'agent', body: 'b' },
+        ],
+        panel: ['j1', 'j2'],
+        cycle_count: 0,
+        identifications: [
+          { draft_id: 'd-c-1', judge_id: 'j1', choice: 'customer' },
+          { draft_id: 'd-a-1', judge_id: 'j1', choice: 'customer' },
+          { draft_id: 'd-c-1', judge_id: 'j2', choice: 'customer' },
+          // j2 never judged d-a-1 → 3/4 coverage.
+        ],
+        enforceProductionMinimums: false,
+      })
+    ).toThrow(/incomplete run: 3\/4/)
+  })
+
+  it('completeness is enforced even with --allow-undersized (orthogonal to size)', () => {
+    // A duplicate (judge, draft) pair overwrites the first, so unique
+    // coverage drops below drafts × panel even though the array length
+    // looks right. Size is opted out; completeness must still fail closed.
+    expect(() =>
+      runVoiceGate({
+        customer_slug: 'test-firm',
+        cohort: 'client',
+        run_id: 'run-dup',
+        drafts: [
+          { id: 'd-c-1', cohort: 'client', authorship: 'customer', body: 'b' },
+          { id: 'd-a-1', cohort: 'client', authorship: 'agent', body: 'b' },
+        ],
+        panel: ['j1'],
+        cycle_count: 0,
+        identifications: [
+          { draft_id: 'd-c-1', judge_id: 'j1', choice: 'customer' },
+          // Duplicate of the same pair overwrites; d-a-1 never covered.
+          { draft_id: 'd-c-1', judge_id: 'j1', choice: 'agent' },
+        ],
+        enforceProductionMinimums: false,
+      })
+    ).toThrow(/incomplete run: 1\/2/)
+  })
+
   it('rejects malformed input with all errors surfaced', () => {
     expect(() =>
       runVoiceGate({


### PR DESCRIPTION
## What

Two defects in `operator/voice-gate`, surfaced during code review of the tracked implementation.

### 1. High — incomplete runs could score (fail-open)

`runVoiceGate` (harness.ts) sealed and scored **without a completeness check**. `validatePanelInput` enforces draft/judge **counts** (≥10/≥10/≥3) but not **coverage**. The indistinguishability denominator (`scoreForDraftSubset`) is only the agent judgments *actually submitted*, so a run that cleared the size minimums but submitted a partial batch — or duplicate `(judge, draft)` pairs that overwrite earlier answers — could inflate to a **false PASS on a fraction of the data**.

This is the gate that unlocks the agent sending under a firm's name, so an incomplete run is now a hard error. `isComplete()` already existed and was tested at the panel layer (panel.ts:307) — it was simply never wired into the orchestration. Enforced **unconditionally**: completeness is orthogonal to sample size, so `--allow-undersized` does not relax it.

> Latent today (live mode is stubbed, dashboard form unbuilt; the only current caller is the synthetic fixture, which is complete). Fixed now while cheap — the live CLI already calls the vulnerable function (cli.ts:219).

### 2. Low/Medium — documented smoke command was broken

The synthetic smoke command in `run-voice-gate.sh` and `README.md` omitted `--allow-undersized`, but the bundled fixtures are 3 drafts/cohort (< the production minimum of 10) and enforcement defaults ON since #1124 — so the documented command died at validation (exit `4`) before scoring. Added the flag to both docs.

## Verification

- `npm test -- voice-gate`: **86/86 pass** (84 + 2 new: partial-coverage throw, duplicate-overwrite throw).
- Documented command now reaches scoring: `PASS at 94.4% across all cohorts`.
- `npm run typecheck`: 0 errors. `npm run lint`: 0 errors.

## Scope

Pre-existing bugs in tracked `operator/voice-gate`, unrelated to the doc-drift PR (#1472). No behavior change for complete runs; the synthetic fixture is already complete (27/27), so the new gate is transparent to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)