### PR TITLE
feat(handbook): independent sidebar scroll, deeper portal docs, currency gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -414,6 +414,8 @@ The franchise operations manual lives in `docs/handbook/` and renders in the adm
 
 **Maintenance contract:** when a change to the venture changes what a handbook page says, update that page in the same PR. The docs live next to the code so each page is edited in the same breath as the thing it documents. See `docs/handbook/README.md` for the page map and the "if you change X, update Y" table.
 
+**Enforcement:** `tests/handbook-integrity.test.ts` runs in `npm run verify` and CI - it blocks merge on malformed frontmatter, a dead `/admin/playbook/<slug>` cross-link, a cited same-repo source file that no longer exists, a `(section, order)` collision, or an em dash. The advisory `npm run handbook:drift` reports pages whose cited sources changed after the page (git-mtime), for a periodic review pass. Both are documented in `docs/handbook/README.md`.
+
 ## Key Reference
 
 - **Decision Stack:** `docs/adr/decision-stack.md` (29 locked decisions across 6 layers — buy box, scope, pricing, assessment, distribution, delivery. Source of truth for all collateral and processes.)

--- a/docs/handbook/README.md
+++ b/docs/handbook/README.md
@@ -27,7 +27,9 @@ Rough "if you change X, update Y":
 | Pricing, rate ladder, payment terms | `pricing-economics.md` |
 | The Operator architecture / ceilings / memory | `operator-platform.md`, `autonomy-governance.md`, `knowledge-memory.md` |
 | A connector or delivery channel | `connectors-channels.md` |
-| An admin or portal surface | `admin-console.md` / `client-portal.md`, and `customer-lifecycle.md` if the motion changed |
+| An admin surface | `admin-console.md`, and `customer-lifecycle.md` if the motion changed |
+| A consulting portal surface | `client-portal.md` |
+| A client-facing Operator surface | `operator-console.md` |
 | The deploy or secrets flow | `deployment-release.md` / `secrets-access.md` |
 | The repo layout or a new top-level dir | `repository-map.md`, `architecture-map.md`, `docs-map.md` |
 
@@ -71,5 +73,22 @@ order and labels are set in `_HandbookSidebar.astro` and `index.astro`.
 
 `README.md` is excluded from the rendered collection (it is this guide, not a page).
 
-> Follow-on (filed, not yet built): a CI drift-check that flags any page whose `sources[]`
-> files have a newer git timestamp than the page, so staleness surfaces automatically.
+## How the handbook is kept current
+
+Three mechanisms, in order of strength:
+
+1. **The maintenance contract (primary).** Update the adjacent page in the same PR that
+   changes the venture. This is the only mechanism that keeps the *meaning* true; the other
+   two only catch what it misses.
+
+2. **The structural gate (hard, blocks merge).** `tests/handbook-integrity.test.ts` runs in
+   `npm run verify` and CI. It fails the build on malformed frontmatter, a dead
+   `/admin/playbook/<slug>` cross-link, a cited same-repo source file that no longer exists
+   (the check that forces a doc update when a source is moved, renamed, or deleted), two pages
+   colliding on one `(section, order)` slot, or an em dash. Deterministic, so it is safe to
+   block on.
+
+3. **The drift radar (advisory).** `npm run handbook:drift` compares each page's last-commit
+   time to its cited sources' last-commit times and reports pages whose sources changed after
+   them. Advisory, not a gate - a source edit does not always change what the page says - so a
+   human reads the report and decides. Run it before a handbook review pass.

--- a/docs/handbook/admin-console.md
+++ b/docs/handbook/admin-console.md
@@ -2,19 +2,23 @@
 title: The Admin Console
 section: system
 order: 4
-summary: The admin portal surface map - the nine top-nav sections and what each does, plus the Operator fleet pages and per-customer drill-in tabs
+summary: The operator-facing console at admin.smd.services - every surface, the lead-to-cash working spine, the Operator fleet cockpit, and the cross-cutting patterns that hold across all of it
 sources:
-  - label: src/layouts/AdminLayout.astro (top nav)
+  - label: src/layouts/AdminLayout.astro (top nav + shell)
     href: https://github.com/venturecrane/ss-console/blob/main/src/layouts/AdminLayout.astro
   - label: src/pages/admin/ (route tree)
     href: https://github.com/venturecrane/ss-console/tree/main/src/pages/admin
+  - label: src/pages/api/admin/ (action endpoints)
+    href: https://github.com/venturecrane/ss-console/tree/main/src/pages/api/admin
   - label: src/pages/admin/operator/ (Operator fleet)
     href: https://github.com/venturecrane/ss-console/tree/main/src/pages/admin/operator
 ---
 
 ## What the admin console is
 
-The admin console is the operator-facing surface served at `admin.smd.services`. The subdomain rewrites to `/admin/*` and every route is gated on `role='admin'` at the middleware layer (`src/middleware.ts`), re-checked in the page where it matters. Today `admin` equals the Captain. The source lives under `src/pages/admin/` and the shell is `src/layouts/AdminLayout.astro`.
+The admin console is the operator-facing surface served at `admin.smd.services`. The subdomain rewrites to `/admin/*` and every route is gated on `role='admin'` at the middleware layer (`src/middleware.ts`), re-checked in the page where it matters (the explicit `if (session.role !== 'admin')` guard at the top of each page is defense-in-depth over the middleware gate). Today `admin` equals the Captain. The source lives under `src/pages/admin/`, the action endpoints under `src/pages/api/admin/`, and the shell is `src/layouts/AdminLayout.astro`.
+
+The console renders server-side with no client charting library and minimal client JS. Most mutations are plain HTML `<form method="POST">` that hit an endpoint under `src/pages/api/admin/`, which validates, writes, and redirects back to the source page with a status param (`?saved=1`, `?error=...`) that the page turns into a flash banner. This POST-then-redirect shape is the dominant interaction pattern across the whole console.
 
 ## Top navigation
 
@@ -22,45 +26,140 @@ The information architecture is flow-ordered (acquire, serve, deliver, get paid,
 
 | Section | Route | What it does |
 |---|---|---|
-| **Home** | `/admin` | The launchpad. Action-first: "Needs you today" leads, the two revenue shapes (one-time and recurring), then three motion cards (Acquisition / Delivery / Fleet). |
-| **Leads** | `/admin/entities` | The lead working view - a unified list of all businesses across their lifecycle. Replaces the separate Lead Inbox and Clients list at the lead stage. |
-| **Clients** | `/admin/clients` | The post-acceptance account directory: entities past the acceptance line (engaged, delivered, ongoing). |
-| **Services** | `/admin/services` | The global, cross-client delivery list - every in-flight service across all clients, risk-sorted. |
-| **Billing** | `/admin/billing` | The bi-modal money surface (ADR 0046). One-time totals derive from invoices; the recurring side shows the Operator subscription state. |
-| **Operator** | `/admin/operator` | The Operator fleet - the roster and per-customer drill-ins (detailed below). |
-| **Analytics** | `/admin/analytics` | Business-intelligence views, rendered server-side with no client charting library. |
-| **Playbook** | `/admin/playbook` | This handbook. The Venture Handbook renders here as the admin-only operations manual. |
-| **Settings** | `/admin/settings` | The utility and configuration hub. Home for surfaces demoted from the top nav: lead generators (`generators`) and follow-up cadences (`follow-ups`). |
+| **Home** | `/admin` | The launchpad. Action-first: what needs you today, the two revenue shapes, then the three motion cards. |
+| **Leads** | `/admin/entities` | The lead working view - every business across its lifecycle, tabbed by stage. |
+| **Clients** | `/admin/clients` | The post-acceptance account directory: entities past the acceptance line. |
+| **Services** | `/admin/services` | The global, cross-client delivery list - every in-flight service, risk-sorted. |
+| **Billing** | `/admin/billing` | The bi-modal money surface (ADR 0046): one-time invoices and the recurring Operator line. |
+| **Operator** | `/admin/operator` | The Operator fleet cockpit - roster and per-customer drill-ins. |
+| **Analytics** | `/admin/analytics` | Business-intelligence views, rendered server-side. |
+| **Playbook** | `/admin/playbook` | This handbook. |
+| **Settings** | `/admin/settings` | The configuration hub: lead generators, follow-ups, pipeline tuning, Google connect. |
 
-`assessments` and `engagements` also live under `src/pages/admin/` and are reached from within the flow (a lead's assessment, a client's engagement) rather than from a dedicated top-nav tab.
+`assessments` and `engagements` also live under `src/pages/admin/` and are reached from within the flow (a lead's meeting, a client's engagement) rather than from a dedicated top-nav tab.
 
-## The Operator section
+## Home: the launchpad
 
-`/admin/operator` is itself a multi-page surface, designed per `docs/design/operator/01-admin-portal.md`. It splits into fleet-wide pages and per-customer drill-ins.
+`/admin/index.astro` is action-first. It opens with "Needs you today" - overdue invoices, at-risk services, and overdue follow-ups pulled into one queue - then shows the two revenue shapes (one-time: invoiced / paid / outstanding; recurring: active operators and MRR, with any unpriced count called out), then three motion cards that summarise the funnel and link into it:
+
+- **Acquisition** - active leads, in triage, proposing, upcoming follow-ups.
+- **Delivery** - services in motion, at risk, consulting.
+- **Fleet** - operators, healthy, alerting.
+
+Every tile is a deep link; the home page itself takes no action. Its queries are parallelised (`Promise.all`) so the launchpad stays fast as the data grows.
+
+## The lead-to-cash spine
+
+The core working flow is a single path: a business enters as a lead, moves through stages, gets a meeting, receives a quote, and (if it accepts) becomes an engagement that gets delivered and invoiced. The stages are `signal -> prospect -> meetings -> proposing -> engaged -> delivered -> ongoing`, with `lost` reachable from anywhere. How a business travels this path is the subject of `/admin/playbook/customer-lifecycle`; this section documents the surfaces that drive it.
+
+### Leads list (`/admin/entities`)
+
+The unified lead working view. It tabs by stage with a count badge per tab and a pipeline dropdown filter (Review Mining, Job Monitor, New Business, Social Listening). Each stage hydrates its rows differently, because what you need to see about a raw signal is not what you need to see about a lead in proposing:
+
+- **signal** - the evidence from the latest pipeline signal plus a last-activity timestamp.
+- **prospect** - whether an outreach draft exists, and the first contact email.
+- **meetings** - all meetings and quotes for the entity; the row derives sub-state, next-meeting date, and whether a quote can be drafted.
+- **proposing** - the top active quote per entity, sorted oldest-sent-first so an expiring quote surfaces.
+- **engaged** - engagement progress (actual vs estimated hours) and an invoice rollup (outstanding count and amount, overdue flag).
+- **lost** - a structured lost-reason rollup (code plus detail).
+
+Bulk select and bulk actions are offered only on the `signal`, `prospect`, and `meetings` stages; the later contractual stages deliberately omit bulk operations for safety. Dismiss is a signal-stage action. Every stage carries empty-state copy that names the next action rather than leaving a blank.
+
+### Lead detail (`/admin/entities/[id]`)
+
+The decision surface for one business. It shows an identity strip (name, stage, tier, pain score out of ten, vertical, area), an enrichment summary (pain observations, address, when it was generated, and which enrichment module produced it), a contacts panel, and a deduplicated timeline of context entries (signals, notes, outreach, observations) with an inline add-note form. A right-hand decision rail carries the stage-appropriate actions and surfaces missing-data warnings (no pain score, no contacts) and stale-outreach-draft warnings.
+
+The actions on the rail each hit an endpoint under `src/pages/api/admin/entities/[id]/`:
+
+- **Promote** (`promote`) - moves signal to prospect, dispatches enrichment, and schedules the follow-up cadence.
+- **Re-enrich** (`dossier`) - runs the reviews-and-news enrichment mode in the background.
+- **Send booking link** (`send-booking-link`) - creates a meeting, transitions prospect to meetings, and sends the booking email.
+- **Draft quote** (`quotes`) - creates an empty draft quote shell (preconditions: not already engaged, no open quote, a prior meeting exists).
+- **Add note** (`context`) - appends a note to the timeline.
+- **Stage change** (`stage`) - transitions stage against a valid-transition table, optionally recording a lost reason and detail.
+- **Merge** (`merge`) - folds a duplicate entity into this one.
+
+Enrichment itself is a background pipeline; the per-module retry and full-run endpoints live under `entities/[id]/enrichment/`. The enrichment model and what it may infer are bounded by the extractive prompt-contract policy in `/admin/playbook/security-trust`.
+
+### Meeting detail (`/admin/entities/[id]/meetings/[meetingId]`)
+
+The assessment-call working surface. It shows the entity and meeting info, the schedule details when the meeting is booked (slot, timezone, guest, join link, calendar link), a live-notes textarea, and a complete-meeting form. Live notes auto-save after a short idle or on blur (`meetings/[meetingId]/live-notes`). Completing the meeting (`meetings/[meetingId]/complete`) records outcome notes, a duration, and an explicit next-stage choice - the admin picks the next stage rather than the system hardcoding "proposing," and completing a meeting never creates a quote (that is a separate, deliberate step). The legacy `/admin/assessments/[id]` route 301-redirects here; meetings were backfilled from the old assessments table preserving IDs.
+
+### Quote detail (`/admin/entities/[id]/quotes/[quoteId]`)
+
+Where a proposal is built and sent. A draft quote is editable: line items (problem, description, estimated hours) can be added, edited inline, and deleted, and the deposit percentage can be changed. Once sent, the quote is read-only. The page computes the payment structure from the totals - a deposit split for smaller engagements, a three-milestone breakdown for larger ones (the thresholds and terms are in `/admin/playbook/pricing-economics` and the Decision Stack). It carries a separate authored-client-content block (schedule, deliverables, engagement overview, milestone labels) that renders only what a human authored and shows a `TBD in SOW` marker otherwise - this is the no-fabrication policy applied at the quote.
+
+From the quote, the admin generates the SOW PDF and sends it for signature. Sending requires a generated SOW and no already-open signature request (`/api/admin/quotes/[id]/sign`); the page warns if the quote was modified after the last PDF was generated. The client never sees an hourly rate or an hours breakdown. The full consulting motion this sits inside is documented at `/admin/playbook/consulting-engagement`.
+
+### Engagement detail (`/admin/engagements/[id]`)
+
+The delivery surface once a quote is accepted. It shows the engagement header (status, the key dates - start, estimated end, handoff, completed - and the quote summary), conditional status-transition buttons, and an editable details block (scope summary, dates, hours, and the originating signal for ROI attribution). Below that:
+
+- **Milestones** - a list with per-row status transitions and a payment-trigger toggle; completing a milestone whose payment trigger is set auto-creates the corresponding invoice (`engagements/[id]/milestones`).
+- **Parking lot** - scope-discovery items, each with a requester and a disposition (fold in, follow on, or dropped) that requires a rationale note at the time of disposition (`engagements/[id]/parking-lot`).
+- **Contacts** - engagement-scoped roles (`engagements/[id]/contacts`).
+- **Deliverables and consultant photo** - file uploads to R2 (`engagements/[id]/deliverables`, `engagements/[id]/consultant-photo`).
+- **Time entries** - logged hours against the engagement (`/api/admin/time-entries`).
+
+Invoices are sent and voided from the invoice endpoints (`/api/admin/invoices/[id]`): `send` creates the invoice in Stripe and emails the hosted link, `void` voids it, and a mark-paid path records an offline payment. The integration mechanics (Stripe, SignWell, R2, Google) are in `/admin/playbook/integrations-tooling`.
+
+## Clients, Services, and Billing
+
+These three surfaces watch the post-acceptance business.
+
+- **Clients** (`/admin/clients`) is the account directory: entities past the acceptance line (engaged, delivered, ongoing), with a billing rollup and an Operator badge when one is provisioned. The client hub (`clients/[id]`) is the per-account view - identity, billing at a glance, the services on the account (consulting engagements and, if present, the Operator with its posture and monthly price), recent activity, open invoices, and contacts. The Operator monthly price is set here via a form that accepts a value or clears it to unpriced (`/api/admin/clients/[id]/operator-price`).
+- **Services** (`/admin/services`) is the global delivery list - every in-flight service across all clients, risk-sorted, with a contextual risk column (at risk if overdue, next handoff, not yet priced). It runs a spine-drift check and surfaces any drift loudly (orphan engagements, childless services, unpriced operators, configs without a service) so the operator reconciles it manually rather than letting the money model and the delivery model silently diverge (ADR 0046).
+- **Billing** (`/admin/billing`) is the bi-modal money surface. A two-revenue band shows one-time (invoiced / paid / outstanding, with overdue called out) beside recurring (active operators and MRR, with unpriced called out), and three tabs break out Quotes, Invoices, and Recurring. MRR is computed from the service spine, not from a subscriptions table.
+
+## Analytics
+
+`/admin/analytics` renders business intelligence server-side: the pipeline funnel by stage, engagement health (average days to completion, on-time percentage, average parking-lot size), a revenue summary (invoiced, paid, outstanding, with monthly and by-vertical breakdowns), follow-up compliance (on-time / late / missed), quote accuracy (estimated vs actual hours per client, with a variance and accuracy readout), and site traffic (top paths, CTAs, funnel, daily uniques). Operational state uses the attention and error tones rather than the "complete" green, keeping the completion colour meaningful.
+
+## The Operator fleet cockpit
+
+`/admin/operator` is the SMD-side cockpit for the Operator fleet, distinct from the client-facing console documented at `/admin/playbook/operator-console`. It is designed per `docs/design/operator/01-admin-portal.md` and splits into fleet-wide pages and per-customer drill-ins.
 
 ### Fleet-wide pages
 
-- **Roster** (`operator/index.astro`) - the default landing. One row per operator, built for scanning a growing fleet: "is anything on fire across all my operators." It composes three console-side projections only (customer identity and posture, the runtime-summary mirror, and heartbeat) and never reads a Machine's runtime D1 directly or joins two customers (per ADR 0009).
-- **Alerts** (`operator/alerts.astro`) - fleet alerts (§4.2).
-- **Requests** (`operator/requests.astro`) - the change-request inbox (§4.4): client-originated config change requests awaiting Captain action.
-- **Provision** (`operator/provision.astro`) - provisioning (§4.5): author and validate a `customer.yaml`, then record provisioning intent.
+- **Roster** (`operator/index.astro`) - the default landing, one row per operator, built for scanning a growing fleet: is anything on fire across all my operators. It composes three console-side projections only (customer identity and posture, the runtime-summary mirror, and heartbeat) and never reads a Machine's runtime D1 directly or joins two customers (ADR 0009).
+- **Alerts** (`operator/alerts.astro`) - fleet alerts.
+- **Requests** (`operator/requests.astro`) - the change-request inbox: client-originated config-change requests awaiting Captain action. These are the requests raised by the client-facing console's Read-and-Request surfaces.
+- **Provision** (`operator/provision.astro`) - author and validate a `customer.yaml`, then record provisioning intent.
 - **Costs** (`operator/costs/index.astro` and `operator/costs/[customer_slug].astro`) - the SMD-only economics surface, fleet summary and per-customer drill-down. Cost is deliberately not a roster column.
-- **Config history** (`operator/config-history/[customer_slug].astro`) - the per-customer `customer.yaml` materialization history: every applied config version with its digest.
+- **Config history** (`operator/config-history/[customer_slug].astro`) - the per-customer `customer.yaml` materialization history, every applied version with its digest.
 
 ### Per-customer drill-in tabs
 
-Each operator drills into `src/pages/admin/operator/[customer]/*`. The tabs:
+Each operator drills into `src/pages/admin/operator/[customer]/*`:
 
 | Tab | File | What it shows |
 |---|---|---|
 | **Overview** | `index.astro` | The per-operator drill-in hub. |
-| **Authority** | `authority.astro` | The authority panel (§5.9, ADR 0041) - the per-domain client authority switches. |
-| **Config** | `config.astro` | The configuration view (§5.2) - the authored `customer.yaml` rendered for reading. |
-| **Connectors** | `connectors.astro` | Connectors and credentials (§5.4, ADR 0042 / 0020) - which systems the operator is wired to and their health. |
-| **Governance** | `governance.astro` | Trust and governance (§5.3, ADR 0025 / 0035) - the authored entitlement ceilings. See `/admin/playbook/autonomy-governance`. |
-| **People** | `people.astro` | People and access (§5.7) - who at the client can reach and configure the operator. |
-| **Memory** | `memory.astro` | The relationship surface (§5.6, ADR 0048): "what I've learned about working with you." Composes the authored and learned relationship lanes, read-only and fail-closed; it never grants any capability. See `/admin/playbook/knowledge-memory`. |
-| **Lifecycle** | `lifecycle.astro` | Lifecycle (§5.10) - provisioning, reprovision, and decommission state. |
-| **Runtime** | `runtime.astro` | Runtime observe (§5.5, ADR 0043 path A) - live runtime detail (audit log, drafts, activity) pulled across the read seam one customer at a time. |
+| **Authority** | `authority.astro` | The per-domain client authority switches (ADR 0041). |
+| **Config** | `config.astro` | The authored `customer.yaml` rendered for reading. |
+| **Connectors** | `connectors.astro` | Which systems the operator is wired to, and their health (ADR 0042 / 0020). |
+| **Governance** | `governance.astro` | The authored entitlement ceilings (ADR 0025 / 0035). See `/admin/playbook/autonomy-governance`. |
+| **People** | `people.astro` | Who at the client can reach and configure the operator. |
+| **Memory** | `memory.astro` | The relationship surface (ADR 0048): what the operator has learned about working with the client, read-only and fail-closed. See `/admin/playbook/knowledge-memory`. |
+| **Lifecycle** | `lifecycle.astro` | Provisioning, reprovision, and decommission state. |
+| **Runtime** | `runtime.astro` | Live runtime detail (audit log, drafts, activity) pulled across the read seam one customer at a time (ADR 0043 path A). |
 
-All per-customer runtime detail comes through the read seam in `src/lib/operator/runtime-read.ts`: single customer per call, read-only, audited, fail-closed. The console observes a running operator; it governs what the operator may do through the authored config it writes, not by querying or mutating the Machine live. The architecture behind these surfaces is at `/admin/playbook/operator-platform` and `/admin/playbook/architecture-map`; the integrations they read from are at `/admin/playbook/integrations-tooling`.
+All per-customer runtime detail comes through the read seam in `src/lib/operator/runtime-read.ts`: single customer per call, read-only, audited, fail-closed. The console observes a running operator; it governs what the operator may do through the authored config it writes, not by querying or mutating the Machine live. The architecture behind these surfaces is at `/admin/playbook/operator-platform` and `/admin/playbook/architecture-map`.
+
+## Settings
+
+`/admin/settings` is the configuration hub. It links to:
+
+- **Lead generators** (`/admin/generators`) - the four ingestion pipelines (New Business, Job Monitor, Review Mining, Social Listening), each with a card showing signal volume, fill rates for the key fields, last-run status, and an enabled flag. The detail page (`generators/[type]`) carries the per-pipeline configuration form (target verticals, geos, search or discovery queries, geo center and radius for review mining) and a run-now button that invokes the ingestion worker. The pipelines qualify and score signals with models matched to the source; social listening is context-only and creates no entity.
+- **Follow-ups** (`/admin/follow-ups`) - the cadence working list, tabbed Upcoming / Overdue / Completed with a type filter.
+- **Pipeline settings** (`/admin/settings/pipelines`) - the tunable per-pipeline parameters, each validated against bounds twice (in the form and in the data layer), with an immutable audit trail of every change (old value, new value, actor, time). Changes take effect on the next cron run without a deploy.
+- **Google connect** (`/admin/settings/google-connect`) - the Google Calendar OAuth connection used for booking, showing the connected account or a connect button.
+
+## Patterns that hold across the console
+
+- **Auth.** Every page requires `role='admin'`; an API request without it returns 401.
+- **Empty states.** Every surface renders explicit prose that names the next action rather than leaving a blank, per `docs/style/empty-state-pattern.md`.
+- **POST then redirect.** Mutations submit to an API endpoint that validates, writes, and redirects back with a status param the page turns into a flash banner.
+- **Status badges and tone dots.** A shared badge component and a small set of tones (attention, error, muted, and the reserved completion green) signal health consistently.
+- **Spine drift is loud.** Where the money model and the delivery model can diverge, the divergence is surfaced for manual reconciliation rather than silently reconciled.
+- **No fabricated client-facing content.** Anything that can reach a client - quote content, SOW fields, invoice line items - renders authored data or an explicit TBD marker, never invented copy. The policy and the tests that enforce it are in `/admin/playbook/security-trust`.

--- a/docs/handbook/client-portal.md
+++ b/docs/handbook/client-portal.md
@@ -2,53 +2,80 @@
 title: The Client Portal
 section: system
 order: 5
-summary: The portal.smd.services surface where a client reviews and signs proposals, tracks an engagement, and manages their Operator - gated to role=client and authenticated by Clerk
+summary: The portal.smd.services surface where a consulting client reviews and signs proposals, pays invoices, reads documents, and tracks an engagement - the auth model, every surface, and the integrations behind them
 sources:
   - label: src/pages/portal/ (portal surfaces)
     href: https://github.com/venturecrane/ss-console/tree/main/src/pages/portal
   - label: src/middleware.ts (subdomain rewrite + portal auth)
     href: https://github.com/venturecrane/ss-console/blob/main/src/middleware.ts
+  - label: src/lib/portal/session.ts (getPortalClient)
+    href: https://github.com/venturecrane/ss-console/blob/main/src/lib/portal/session.ts
   - label: migration 0038 - portal Clerk subscriptions substrate
     href: https://github.com/venturecrane/ss-console/blob/main/migrations/0038_portal_clerk_subscriptions_substrate.sql
 ---
 
 ## What the portal is
 
-The client portal is the surface a paying client sees. It is served at `portal.smd.services` and lives in source under `src/pages/portal/`. One Astro app, one Worker; the `portal.` subdomain is a front door, not a separate deployment (the rewrite mechanics live in `/admin/playbook/the-website`). Pages are marked `noindex, nofollow` - this is private client space, never a marketing surface.
+The client portal is the surface a paying client sees. It is served at `portal.smd.services` and lives in source under `src/pages/portal/`. One Astro app, one Worker; the `portal.` subdomain is a front door, not a separate deployment (the rewrite mechanics live in `/admin/playbook/the-website`). Pages are marked `noindex, nofollow` - this is private client space, never a marketing surface, and it ships effectively no client JavaScript: mutations are HTML forms validated server-side.
 
-The portal serves clients who arrive two ways: through a consulting engagement, or as an Operator subscriber. A client can have one, the other, or both. See `/admin/playbook/customer-lifecycle` for how a business travels from lead to portal account.
+The portal serves clients who arrive two ways: through a consulting engagement, or as an Operator subscriber. A client can have one, the other, or both. This page documents the consulting surfaces and the shared auth model. The client-facing Operator product console - a large surface in its own right - is documented separately at `/admin/playbook/operator-console`. How a business travels from lead to portal account is `/admin/playbook/customer-lifecycle`.
 
-## What a client sees and does
+## The consulting surfaces
 
-Derived from the surfaces in `src/pages/portal/`:
+Every surface scopes to the signed-in client's own entity and renders authored data only. The surfaces, from `src/pages/portal/`:
 
-- **Home** (`index.astro`) - the dashboard. Action-first above the fold (a pending invoice to pay, or a next check-in), with a recent-activity timeline below. The timeline is assembled from real events - proposals sent or signed, invoices sent or paid, milestones completed - never synthesized copy.
-- **Proposals / quotes** (`quotes/[id].astro`) - review a proposal and sign it. This is the conversion surface: the client reads the scoped project, the price, and the terms, and signs.
-- **Invoices** (`invoices/`) - view and pay deposit, milestone, and completion invoices (Stripe-hosted).
-- **Documents** (`documents/`) - engagement documents and deliverables.
-- **Engagement** (`engagement/`) - the in-flight project: scope, consultant, next touchpoint, progress.
-- **Operator product** (`products/operator/`) - the managed-Operator console, shown only when the client has an active Operator subscription. It is a large surface in its own right: matters, drafts, calendar, audit, connections, calibration, compliance, team, notifications, settings, onboarding. These are the client-facing controls over their own Operator; the autonomy and governance model behind them is in `/admin/playbook/autonomy-governance`.
+### Home (`index.astro`)
 
-The top tabs (`src/components/portal/PortalTabs.astro`) switch between the consulting set (Proposals, Invoices, Documents, Progress) and the Operator tab, depending on what the client is subscribed to.
+The dashboard. Action-first above the fold (a pending invoice to pay, or the next touchpoint), with a recent-activity timeline below. The timeline is assembled from real events - a proposal sent or signed, an invoice sent or paid, a milestone completed - each in concrete past tense, capped at the most recent few, sorted newest first. It is never synthesized copy: if nothing has happened yet, the surface says so. The consultant name and next-touchpoint label appear only when authored on the engagement.
+
+### Proposals (`quotes/index.astro`, `quotes/[id].astro`)
+
+The conversion surface. The list shows every proposal with its status (sent, accepted, declined, expired) and, for a pending one, the time remaining. The detail page renders the scoped project in sections: the deliverables and the schedule (each rendered only from the authored fields on the quote, omitted entirely when absent), the terms (total price and the payment split), and a review-and-sign block.
+
+Signing runs through SignWell. When an open signature request exists for the quote, the detail page presents the review-and-sign surface pointing at the SignWell document; the client signs there. SignWell calls back to the webhook handler (`src/pages/api/webhooks/signwell.ts`), which records the signed state and stores the signed PDF. The client can then download the executed SOW (`/api/portal/quotes/[id]/sow`, streamed from R2). The client never sees an hourly rate or an hours breakdown in any of this.
+
+### Invoices (`invoices/index.astro`, `invoices/[id].astro`)
+
+View and pay. The list leads with the money that matters (paid to date, balance due, engagement total) and lists each invoice with its type, amount, status, and date. The detail page shows the line items (from the invoice's own line-item rows, never borrowed from the engagement scope) and a Pay button when a Stripe hosted-checkout URL is present on the invoice. Payment happens on Stripe; its webhook marks the invoice paid, and the portal then shows the paid state. When no payment link is attached yet, the surface shows a pending state rather than a dead button.
+
+### Documents (`documents/index.astro`)
+
+The engagement document library. It lists files stored in R2 under the client's own org-and-engagement prefix, plus the signed SOW when one exists. Downloads stream through `/api/portal/documents/[...key]`, which validates that the requested key carries the client's org prefix, rejects path traversal, and confirms the key belongs to one of the client's own engagements or quotes before serving it. PDFs render inline; other types download.
+
+### Engagement (`engagement/index.astro`)
+
+The in-flight project tracker. It shows the active engagement overview (scope summary, start, estimated end) and the milestone list with each milestone's status and dates. It shows status and evidence, not a reassuring progress bar - there is no synthesized percent-complete.
+
+### Tabs
+
+The top tabs (`src/components/portal/PortalTabs.astro`) switch between the consulting set (Proposals, Invoices, Documents, Progress) and the Operator tab. The Operator tab appears only when the client has an active Operator subscription; otherwise the portal is the consulting set alone.
 
 ## The auth model
 
 Portal auth is enforced in `src/middleware.ts`. Two paths are accepted, with Clerk primary:
 
-1. **Clerk (primary).** `clerkMiddleware` runs first in the composed pipeline and populates `locals.auth()`. `enforcePortalAuth` lets a request through if a Clerk session is present; if not, it redirects to `/auth/sign-in` (or returns 401 on `/api/portal/*`). The bridge from a Clerk identity to the local user and business runs lazily per route via `getPortalClient()`.
-2. **Legacy magic-link (fallback).** Before Clerk, the portal used emailed magic links that created a KV/D1 session (set by `/auth/verify`). `resolveLegacyPortalSession` still accepts those cookies, but only for a session whose `role === 'client'`, and renews them on a sliding window. This path exists solely to keep in-flight invitation emails working through the Clerk transition; new onboarding will move to Clerk invitations (per the middleware's own header comment). Treat the legacy path as temporary, not a second permanent auth system.
+1. **Clerk (primary).** `clerkMiddleware` runs first in the composed pipeline and populates `locals.auth()`. `enforcePortalAuth` lets a request through if a Clerk session is present; if not, it redirects to `/auth/sign-in` (or returns 401 on `/api/portal/*`). The bridge from a Clerk identity to the local user and business runs lazily per route via `getPortalClient()` (`src/lib/portal/session.ts`), which maps the Clerk user to the local `users` row and its `entity_id` and `org_id`. Every query is scoped to that entity, so a client sees only their own data.
+2. **Legacy magic-link (fallback).** Before Clerk, the portal used emailed magic links that created a KV/D1 session. `resolveLegacyPortalSession` still accepts those cookies, but only for a session whose `role === 'client'`, and renews them on a sliding window. This path exists solely to keep in-flight invitation emails working through the Clerk transition; treat it as temporary, not a second permanent auth system.
 
 ### The role=client gate
 
 The portal is for clients, the admin console is for staff, and the boundary is the `users.role` column (`admin` or `client`). The gate is asymmetric:
 
 - The **admin** console requires `role === 'admin'`; a signed-in client who hits an admin path is redirected to `/portal` (`enforceAdminAuth`).
-- The **portal** accepts any Clerk-authenticated user at the middleware layer, then narrows per route. The Operator surfaces narrow hardest: a request needs a Clerk session, a local user linked to an entity, an active `subscriptions` row on `(entity, 'operator')`, and at least one granted role on `(user, entity, 'operator')` in `product_roles` - vocabulary `principal | staff | compliance` (per migration 0038 and the access-model comment in `products/operator/index.astro`). Anything less degrades to the appropriate empty state, never to fabricated content (per `docs/style/empty-state-pattern.md`).
+- The **portal** accepts any Clerk-authenticated user at the middleware layer, then narrows per route. The Operator surfaces narrow hardest: a request needs a Clerk session, a local user linked to an entity, an active `subscriptions` row on `(entity, 'operator')`, and at least one granted role on `(user, entity, 'operator')` in `product_roles` - the vocabulary is `principal | staff | compliance` (migration 0038). Anything less degrades to the appropriate empty state, never to fabricated content.
 
 ### Cookie boundaries
 
 Session cookies are per-host (no `Domain` attribute), so a portal cookie lives only on `portal.smd.services` and an admin cookie only on `admin.smd.services`. The subdomain and cookie-isolation mechanics are owned by `/admin/playbook/the-website`.
 
+## The integrations behind the portal
+
+The consulting portal is a read-and-act surface over three external systems, all documented in `/admin/playbook/integrations-tooling`:
+
+- **SignWell** signs proposals. The admin creates the signature request from the quote; the portal presents it; SignWell's webhook records the signed state and the executed PDF.
+- **Stripe** collects payment. The admin attaches a hosted-checkout URL to the invoice; the portal links to it; Stripe's webhook marks the invoice paid.
+- **R2** stores documents and the signed SOW, served only through the org-scoped, traversal-checked download endpoint.
+
 ## What the portal never does
 
-The portal renders authored data only. Timelines, next-touchpoint copy, consultant outreach sentences, and invoice line items come from database columns a human authored, or they render nothing. This is the no-fabricated-client-facing-content policy applied at the surface that faces a real customer; the policy, its Pattern A/B failure modes, and the tests that enforce it are in `/admin/playbook/security-trust`.
+The portal renders authored data only. Timelines, next-touchpoint copy, consultant outreach sentences, deliverables, schedules, and invoice line items come from columns a human authored, or they render nothing. This is the no-fabricated-client-facing-content policy applied at the surface that faces a real customer; the policy, its Pattern A and Pattern B failure modes, and the tests that enforce it are in `/admin/playbook/security-trust`.

--- a/docs/handbook/integrations-tooling.md
+++ b/docs/handbook/integrations-tooling.md
@@ -1,7 +1,7 @@
 ---
 title: Integrations & Tooling
 section: system
-order: 6
+order: 7
 summary: The external-service inventory - every third party the platform depends on and what each one is for, derived from package.json dependencies, wrangler.toml bindings, and CLAUDE.md
 sources:
   - label: package.json (dependencies)

--- a/docs/handbook/operating-model.md
+++ b/docs/handbook/operating-model.md
@@ -6,8 +6,8 @@ summary: Who decides and who executes - the Captain, the fleet of agents, and th
 sources:
   - label: Operating Ethos (global instruction module)
     href: crane_doc('global', 'operating-ethos.md')
-  - label: Playbook - The Operator Model
-    href: https://github.com/venturecrane/ss-console/blob/main/src/pages/admin/playbook.astro
+  - label: ADR 0035 - No imposed entitlement defaults (authored ceilings)
+    href: https://github.com/venturecrane/ss-console/blob/main/docs/adr/0035-no-imposed-entitlement-defaults.md
   - label: ADR 0030 - Control plane / human-principal surface
     href: https://github.com/venturecrane/ss-console/blob/main/docs/adr/0030-control-plane-human-principal-surface.md
 ---
@@ -51,8 +51,8 @@ the venture itself.
 ## Agent Execution
 
 Everything that is not a Captain decision is agent execution. Agents run the work
-inside the ceilings the Captain authored (`src/pages/admin/playbook.astro`, the
-Agent Execution block):
+inside the ceilings the Captain authored - the no-imposed-defaults model in ADR
+0035, surfaced at `/admin/playbook/autonomy-governance`:
 
 - Inbound client communications - email, voice, chat - handled within the
   configured autonomy ceilings.
@@ -60,8 +60,8 @@ Agent Execution block):
   result and closing.
 - Consulting analysis and deliverable drafting executed by agents; the Captain
   reviews before any client-facing send.
-- Fleet health monitoring, which runs autonomously on a 30-minute cadence with
-  the Captain notified on degradation.
+- Fleet health monitoring, which runs autonomously with the Captain notified on
+  degradation.
 - Platform maintenance and deployment, handled through PRs (never a direct push
   to main - see `/admin/playbook/building-the-platform`).
 - Learned preferences, which accumulate automatically; the Captain can dismiss
@@ -107,10 +107,11 @@ irreversible, shared, or external actions (a merge, a deploy, a message sent on
 the Captain's behalf) get confirmed. The ethos is about removing ceremony, not
 removing safety.
 
-> TODO(why): The 30-minute fleet-health cadence is asserted in
-> `src/pages/admin/playbook.astro` (Agent Execution). I did not find the
-> scheduler config or worker that enforces exactly 30 minutes; the figure is
-> taken from the playbook copy, not from a verified cron definition.
+> TODO(why): The fleet-health monitor runs on a recurring cadence, but the exact
+> interval is unverified - no scheduler config or worker enforcing a specific
+> period was found in the repo, and the prior "30-minute" figure traced only to
+> the retired playbook page, not to a cron definition. Confirm the real interval
+> against the running scheduler before quoting one.
 
 ## The tools of the fleet
 

--- a/docs/handbook/operator-console.md
+++ b/docs/handbook/operator-console.md
@@ -1,0 +1,87 @@
+---
+title: The Operator Console
+section: system
+order: 6
+summary: The client-facing Operator product console inside the portal - the authority-domain model that governs every settable surface, the work, governance, team, and configuration surfaces, and how the surfaces stay honest before the runtime bridge is wired
+sources:
+  - label: src/pages/portal/products/operator/ (console surfaces)
+    href: https://github.com/venturecrane/ss-console/tree/main/src/pages/portal/products/operator
+  - label: src/pages/api/portal/operator/ and .../products/operator/ (actions)
+    href: https://github.com/venturecrane/ss-console/tree/main/src/pages/api/portal/operator
+  - label: migration 0038 - portal Clerk subscriptions substrate (roles)
+    href: https://github.com/venturecrane/ss-console/blob/main/migrations/0038_portal_clerk_subscriptions_substrate.sql
+  - label: docs/design/operator/ (portal-management design)
+    href: https://github.com/venturecrane/ss-console/tree/main/docs/design/operator
+---
+
+## What the Operator console is
+
+When a client subscribes to the Operator, the portal grows a second, larger surface: the client-facing console for their own managed Operator, served under `/portal/products/operator/`. It is where the people at the client read what the Operator has done, act on the work it routes to them, and - to the extent SMD has handed them the controls - configure how it works. The product itself (what the Operator is, the runtime, the governance model) is documented across `/admin/playbook/operator-platform`, `/admin/playbook/autonomy-governance`, and `/admin/playbook/knowledge-memory`; this page documents the console a client clicks.
+
+The console ships effectively no client JavaScript. Every mutation is an HTML form that posts to an endpoint under `src/pages/api/portal/operator/` or `.../products/operator/`, which validates the actor, the role, and the authority posture server-side, writes, and redirects back with a status param.
+
+## Two things govern every surface
+
+### Who you are: the three roles
+
+Reaching the console at all requires a Clerk session, a local user linked to the client entity, an active Operator subscription on that entity, and at least one granted product role. The roles (migration 0038) are `principal`, `staff`, and `compliance`, and they gate what you see and can do:
+
+- **principal** - the firm's owner of the relationship; the only role that can manage users, raise trust ceilings, and run calibration.
+- **staff** - day-to-day operators who act on the Operator's work (review and send drafts, work matters).
+- **compliance** - read and oversight: audit, retention, separation-of-duties, without the ability to act on work or change people.
+
+A user with no granted role on an active subscription sees an access-pending state, not the dashboard.
+
+### What is delegated: authority domains
+
+This is the load-bearing idea of the whole console. Every settable surface operates through a named **authority domain**, and each domain has a switch (on `customer_configs.authority`) that SMD controls. The default at launch is **off (managed)**: SMD operates that part of the Operator on the client's behalf. The surface still renders, but in **Read and Request** mode - the client sees the current state read-only and can file a change request rather than change it directly. When SMD flips a domain **on (operable)**, the same surface becomes **Read and Operable** and the appropriate role can mutate it directly.
+
+This dual-mode rendering is provided by `DomainSurface` and `RequestChangeForm`; a request posts to `/api/portal/operator/change-request` and lands in the admin change-request inbox (`/admin/playbook/admin-console`, the Operator fleet cockpit). The domains:
+
+| Domain | Governs | Operable by |
+|---|---|---|
+| `configuration` | Skills, voice, scope, business hours, escalation contacts | principal |
+| `trust` | Governance ceilings (action-class floors plus per-skill ceilings) | principal |
+| `connectors` | Credential custody, connector re-consent and secrets | principal |
+| `people_access` | Roster, role grants, PTO and coverage | principal |
+| `provisioning` | The subscription itself | SMD only, never client-operable |
+| `compliance` | Audit retention and evidence export | principal / compliance |
+| `runtime` | Whether the work queue is operable or read-only | principal / staff |
+
+The design behind this model is in `docs/design/operator/` and ADR 0041; the governance it expresses is `/admin/playbook/autonomy-governance`.
+
+## Honest before it is wired
+
+Many surfaces read live runtime state - drafts, matters, calendar items, the activity log, the "where is the agent right now" header - through the runtime read seam (ADR 0043, `/admin/playbook/architecture-map`). That seam is built and the surfaces are built, but the per-customer runtime bridge that fills them is staged work; until it is wired for a given customer, those surfaces render honest empty states rather than fabricated content. This is the same no-fabrication discipline the rest of the product holds (`/admin/playbook/security-trust`): an empty queue says "nothing needs a person," never invents one.
+
+## Home
+
+`/portal/products/operator` is the landing. It renders one of several states - not subscribed, provisioning, paused (audit history stays available), access pending (no role), or active. The active dashboard shows an aliveness header (idle / running / sticky-stop / offline plus the last action), a "what needs you" count that renders only when there is actually something routed to a human, a recent-activity list, any escalations, principal-only promotion cards (recommendations such as a trust-ceiling raise), and a grid of cards into the surfaces below, with a sidebar listing the user's roles and quick links.
+
+## Work surfaces
+
+Where people act on what the Operator produces.
+
+- **Work** (`work/`) - the queue of items the Operator has routed to a human. It is entirely entitlement-conditional: it shows only what the authored governance routes to a person, imposes no review stage of its own, and when nothing is routed it says so.
+- **Drafts** (`drafts/`, `drafts/[id]`) - the review-and-send queue. A draft carries its sender, recipient, skill, the trust-ceiling decision that produced it, age, and sources. From the detail page a principal or staff member approves and sends it (`drafts/[id]/send`), which validates the reviewer, sends through the connector, emits a `send_approved` audit event, and honours a short configurable undo window. A teach action (`drafts/[id]/teach`) feeds correction back. Compliance can read but not send.
+- **Matters** (`matters/`, `matters/[id]`) - the case or account view (for the law vertical, legal matters). The list scopes to "mine" or "all," the detail page shows the Operator's stated facts, the assignment, a material-event timeline, drafts in flight, and audit history. A principal or staff member assigns or unassigns a matter to a team member (`matter-assignment`), which checks the target has a role and emits an audit event.
+- **Calendar** (`calendar/`) - the items the Operator has scheduled or proposed, with server-side conflict detection, filling once a calendar connector is active.
+- **Activity** (`activity/`) - the full audit log: every action the Operator took, filterable and paginated. For principal and compliance it also carries the retention window and the evidence-export entry point.
+
+## Governance and configuration surfaces
+
+- **Configure** (`configure/`) - the consolidated configuration view across the `configuration` and `trust` domains: skills (per-skill on/off), voice (tone samples and calibration), scope (which folders and systems the Operator can see), business hours, and the governance ceilings (the non-raisable per-vertical action-class floors shown for reference, and the per-skill ceilings of `autonomous`, `draft_for_review`, or `refused`). At launch these render Read-and-Request; when a domain is operable, the principal changes them directly.
+- **Settings** (`settings/`) - the principal's operable dashboard for the same controls: trust ceiling per skill (`settings/trust-ceiling`, floor-checked against the vertical floor and recorded to an immutable change-audit, never mutating live config in place), voice samples (`settings/voice-samples`), skill toggles (`settings/skill-toggle`), and connector re-consent (`settings/connector-reconsent`). Sub-pages cover users, notifications, PTO, and advanced (custom configuration).
+- **Compliance** (`compliance/`) - principal and compliance only, and itself opt-in: when the compliance view is not enabled it says so plainly; when enabled it shows separation-of-duties, audit history, the retention posture, and evidence-packet generation.
+- **Calibration** (`calibration/`) - principal only: the calibration cycle (a set of working sessions over a couple of weeks) that tunes the Operator to the firm, with a session schedule and a start-cycle action.
+
+## Connections, team, and account
+
+- **Connections** (`connections/`) - the systems the Operator is wired to, each with status, health, and credential custody (SMD-managed or customer-held). When the `connectors` domain is operable, a principal re-authorizes OAuth connectors and enters static secrets through a write-only field whose value never appears in a URL, a log, or the database (`connectors/[connector]/secret`); ADR 0042.
+- **Team** (`team/`) and **Users** (`settings/users`) - the roster and access. Team is the readable roster (names, roles, last login, who is away, coverage). Users is the principal-only management surface where roles are granted and revoked (`role-action`) and people are invited through Clerk Organizations (`invitations`); a principal cannot revoke their own last principal role, which would lock the firm out. PTO and backup coverage are set on the PTO page (`pto`). All of these run through the `people_access` domain, so when SMD manages the roster the surface is read-and-request and direct mutation returns a not-permitted result.
+- **Account** (`account/`) - the subscription status (provisioning-only, SMD-managed, read-only) and the escalation contacts (who to alert on a red flag or a failure, and the acknowledgment window).
+- **Onboarding** (`onboarding/`) - the get-started hub: invite the team, connect systems, calibrate, with each step's done/to-do status computed from the same readers the destinations use, so the status is honest by construction.
+
+## Everything is audited
+
+Acting on the Operator emits audit events: `send_approved` on every draft send, an RBAC event on every role grant, revoke, assignment, and PTO change, and an immutable config-change-audit row on every governance change. Governance changes are recorded as intent and applied to the running Operator through the apply path, never by editing the live Machine in place. The data model behind these tables (`product_roles`, `matter_assignments`, `pto`, `escalation_contacts`, `operator_change_requests`, the audit ledgers) is in `/admin/playbook/data-model`, and the trust model the audits exist to prove is in `/admin/playbook/security-trust`.

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "typecheck:workers": "for dir in workers/*/; do [ -f \"${dir}package.json\" ] || continue; echo \"Typechecking $dir\" && npm run typecheck --prefix \"$dir\" || exit 1; done",
     "test:workers": "for dir in workers/*/; do [ -f \"${dir}package.json\" ] || continue; echo \"Testing $dir\" && npm run test --prefix \"$dir\" || exit 1; done",
     "verify": "npm run typecheck && npm run typecheck:workers && npm run format:check && npm run lint && npm run build && npm run test && npm run test:workers",
+    "handbook:drift": "node scripts/handbook-drift.mjs",
     "db:migrate:local": "wrangler d1 migrations apply ss-console-db --local",
     "prepare": "node -e \"if(process.env.CI)process.exit(0)\" && husky"
   },

--- a/scripts/handbook-drift.mjs
+++ b/scripts/handbook-drift.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+/**
+ * Venture Handbook drift radar (advisory).
+ *
+ * For each page under docs/handbook/, compares the page's own last-commit time to
+ * the last-commit time of every same-repo file it cites in `sources[]`. If a cited
+ * source changed after the page, the page is *possibly* stale and is reported.
+ *
+ * This is advisory, not a gate: a source edit does not always change what the page
+ * says, so a human reads the report and decides. The hard structural gate (dead
+ * links, missing sources, bad frontmatter) lives in tests/handbook-integrity.test.ts
+ * and runs in CI. Run this on demand:  npm run handbook:drift
+ *
+ * Exit code is always 0 (informational). Pass --strict to exit 1 when any page is
+ * flagged - useful if you ever want to wire it into CI as a soft warning step.
+ *
+ * @see docs/handbook/README.md - the maintenance contract
+ */
+
+import { readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { execSync } from 'node:child_process'
+import { parse as parseYaml } from 'yaml'
+
+const HANDBOOK = 'docs/handbook'
+const strict = process.argv.includes('--strict')
+
+function lastCommitEpoch(path) {
+  try {
+    const out = execSync(`git log -1 --format=%ct -- "${path}"`, { encoding: 'utf8' }).trim()
+    return out ? Number(out) : null
+  } catch {
+    return null
+  }
+}
+
+function repoPathOf(href) {
+  if (!href) return null
+  const blob = href.match(
+    /^https:\/\/github\.com\/venturecrane\/ss-console\/(?:blob|tree)\/[^/]+\/(.+)$/
+  )
+  if (blob) return blob[1].replace(/[#?].*$/, '')
+  if (!/^[a-z]+:\/\//.test(href) && !href.includes('(')) {
+    const clean = href.replace(/[#?].*$/, '')
+    if (/^(src|docs|migrations|workers|operator|scripts|public|tests|\.github)\//.test(clean))
+      return clean
+  }
+  return null
+}
+
+function frontmatter(raw) {
+  const m = raw.match(/^---\n([\s\S]*?)\n---/)
+  if (!m) return {}
+  try {
+    return parseYaml(m[1]) ?? {}
+  } catch {
+    return {}
+  }
+}
+
+const files = readdirSync(HANDBOOK).filter((f) => f.endsWith('.md') && f !== 'README.md')
+const flagged = []
+
+for (const file of files) {
+  const path = join(HANDBOOK, file)
+  const fm = frontmatter(readFileSync(path, 'utf8'))
+  const sources = Array.isArray(fm.sources) ? fm.sources : []
+  const pageTime = lastCommitEpoch(path)
+  if (!pageTime) continue // uncommitted/new page - nothing to compare yet
+
+  const stale = []
+  for (const s of sources) {
+    const repoPath = repoPathOf(s?.href)
+    if (!repoPath) continue
+    const srcTime = lastCommitEpoch(repoPath)
+    if (srcTime && srcTime > pageTime) {
+      const days = Math.round((srcTime - pageTime) / 86400)
+      stale.push({ repoPath, days })
+    }
+  }
+  if (stale.length) flagged.push({ file, stale })
+}
+
+if (flagged.length === 0) {
+  console.log('Handbook drift radar: all pages are newer than their cited sources. Clean.')
+  process.exit(0)
+}
+
+console.log(
+  `Handbook drift radar: ${flagged.length} page(s) possibly stale (a cited source changed after the page).\n`
+)
+for (const { file, stale } of flagged) {
+  console.log(`  ${file}`)
+  for (const { repoPath, days } of stale) {
+    console.log(`     source changed ~${days}d after the page: ${repoPath}`)
+  }
+}
+console.log(
+  '\nAdvisory only. Review each page; update it if the source change altered what it says.'
+)
+process.exit(strict ? 1 : 0)

--- a/src/pages/admin/playbook/[...slug].astro
+++ b/src/pages/admin/playbook/[...slug].astro
@@ -37,7 +37,9 @@ const LINK =
   breadcrumbs={[{ label: 'Playbook', href: '/admin/playbook' }, { label: title }]}
 >
   <div class="grid grid-cols-1 gap-8 md:grid-cols-[220px_1fr]">
-    <aside class="md:sticky md:top-20 md:self-start">
+    <aside
+      class="md:sticky md:top-20 md:self-start md:max-h-[calc(100vh-6rem)] md:overflow-y-auto md:overscroll-contain md:pr-2"
+    >
       <HandbookSidebar currentSlug={entry.id} />
     </aside>
 

--- a/src/pages/admin/playbook/index.astro
+++ b/src/pages/admin/playbook/index.astro
@@ -56,7 +56,9 @@ const BODY = 'text-sm leading-relaxed text-[color:var(--ss-color-text-secondary)
 
 <AdminLayout title="Handbook | SMD Services" maxWidth="max-w-6xl">
   <div class="grid grid-cols-1 gap-8 md:grid-cols-[220px_1fr]">
-    <aside class="md:sticky md:top-20 md:self-start">
+    <aside
+      class="md:sticky md:top-20 md:self-start md:max-h-[calc(100vh-6rem)] md:overflow-y-auto md:overscroll-contain md:pr-2"
+    >
       <HandbookSidebar />
     </aside>
 

--- a/tests/handbook-integrity.test.ts
+++ b/tests/handbook-integrity.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Structural-integrity gate for the Venture Handbook (docs/handbook/).
+ *
+ * The handbook is the E-Myth operations manual rendered at /admin/playbook. It is
+ * only useful if it stays structurally sound and its citations stay honest. This
+ * test is the hard gate behind the maintenance contract in docs/handbook/README.md:
+ * it runs in `npm run verify` and CI, and blocks merge on
+ *
+ *   1. malformed frontmatter (missing title, bad section, non-numeric order),
+ *   2. a /admin/playbook/<slug> cross-link that points at no page (dead link),
+ *   3. a cited same-repo source file that does not exist (moved/renamed/deleted
+ *      source the page was never updated to match - the accuracy-forcing check),
+ *   4. two pages colliding on the same (section, order) sidebar slot,
+ *   5. an em dash in any page (house style; these files are not covered by the
+ *      .astro forbidden-strings scan).
+ *
+ * The complementary git-mtime staleness signal (a source changed after the page)
+ * is advisory and lives in scripts/handbook-drift.mjs (`npm run handbook:drift`),
+ * not here, because a source edit does not always require a doc edit.
+ *
+ * @see docs/handbook/README.md - the maintenance contract
+ */
+
+import { describe, it, expect } from 'vitest'
+import { readdirSync, readFileSync, existsSync } from 'fs'
+import { resolve, join } from 'path'
+import { parse as parseYaml } from 'yaml'
+
+const HANDBOOK = resolve('docs/handbook')
+const REPO_ROOT = resolve('.')
+const SECTIONS = ['business', 'product', 'system', 'operations', 'reference']
+
+// Bare (non-URL) hrefs are treated as repo paths only when rooted here. Anything
+// else with no scheme (e.g. a crane_doc('global', ...) pseudo-ref) is skipped.
+const REPO_PATH_ROOTS = [
+  'src/',
+  'docs/',
+  'migrations/',
+  'workers/',
+  'operator/',
+  'scripts/',
+  'public/',
+  'tests/',
+  '.github/',
+]
+
+interface Page {
+  file: string
+  slug: string
+  frontmatter: Record<string, unknown>
+  body: string
+  raw: string
+}
+
+function splitFrontmatter(raw: string): { fm: Record<string, unknown>; body: string } {
+  const m = raw.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/)
+  if (!m) return { fm: {}, body: raw }
+  const fm = (parseYaml(m[1]) as Record<string, unknown>) ?? {}
+  return { fm, body: m[2] }
+}
+
+const pages: Page[] = readdirSync(HANDBOOK)
+  .filter((f) => f.endsWith('.md') && f !== 'README.md')
+  .map((file) => {
+    const raw = readFileSync(join(HANDBOOK, file), 'utf8')
+    const { fm, body } = splitFrontmatter(raw)
+    return { file, slug: file.replace(/\.md$/, ''), frontmatter: fm, body, raw }
+  })
+
+const slugSet = new Set(pages.map((p) => p.slug))
+
+/** Resolve a source href to a same-repo path, or null if it is external/non-path. */
+function repoPathOf(href: string): string | null {
+  const blob = href.match(
+    /^https:\/\/github\.com\/venturecrane\/ss-console\/(?:blob|tree)\/[^/]+\/(.+)$/
+  )
+  if (blob) return blob[1].replace(/[#?].*$/, '')
+  if (!/^[a-z]+:\/\//.test(href) && !href.includes('(')) {
+    const clean = href.replace(/[#?].*$/, '')
+    if (REPO_PATH_ROOTS.some((r) => clean.startsWith(r))) return clean
+  }
+  return null
+}
+
+describe('handbook integrity', () => {
+  it('finds the handbook pages', () => {
+    expect(pages.length).toBeGreaterThan(20)
+  })
+
+  it('every page has valid frontmatter', () => {
+    const errors: string[] = []
+    for (const p of pages) {
+      const { title, section, order } = p.frontmatter as {
+        title?: unknown
+        section?: unknown
+        order?: unknown
+      }
+      if (typeof title !== 'string' || title.trim() === '')
+        errors.push(`${p.file}: missing or empty 'title'`)
+      if (typeof section !== 'string' || !SECTIONS.includes(section))
+        errors.push(
+          `${p.file}: 'section' must be one of ${SECTIONS.join(', ')} (got ${String(section)})`
+        )
+      if (order !== undefined && typeof order !== 'number')
+        errors.push(`${p.file}: 'order' must be a number when present`)
+    }
+    expect(errors, errors.join('\n')).toEqual([])
+  })
+
+  it('every /admin/playbook/<slug> cross-link resolves to a real page', () => {
+    const errors: string[] = []
+    for (const p of pages) {
+      const refs = p.body.match(/\/admin\/playbook\/([a-z0-9-]+)/g) ?? []
+      for (const ref of refs) {
+        const slug = ref.replace('/admin/playbook/', '')
+        if (!slugSet.has(slug)) errors.push(`${p.file}: dead cross-link -> /admin/playbook/${slug}`)
+      }
+    }
+    expect(errors, errors.join('\n')).toEqual([])
+  })
+
+  it('every cited same-repo source file exists', () => {
+    const errors: string[] = []
+    for (const p of pages) {
+      const sources = (p.frontmatter.sources as { label?: string; href?: string }[]) ?? []
+      for (const s of sources) {
+        if (!s?.href) continue
+        const repoPath = repoPathOf(s.href)
+        if (repoPath && !existsSync(resolve(REPO_ROOT, repoPath)))
+          errors.push(`${p.file}: cited source does not exist -> ${repoPath}`)
+      }
+    }
+    expect(errors, errors.join('\n')).toEqual([])
+  })
+
+  it('no two pages share a (section, order) sidebar slot', () => {
+    const seen = new Map<string, string>()
+    const errors: string[] = []
+    for (const p of pages) {
+      const { section, order } = p.frontmatter as { section?: string; order?: number }
+      if (order === undefined) continue
+      const key = `${section}#${order}`
+      if (seen.has(key))
+        errors.push(`${section} order ${order}: ${seen.get(key)} and ${p.file} collide`)
+      else seen.set(key, p.file)
+    }
+    expect(errors, errors.join('\n')).toEqual([])
+  })
+
+  it('no page contains an em dash (house style)', () => {
+    const errors: string[] = []
+    for (const p of pages) {
+      if (p.raw.includes('—')) errors.push(`${p.file}: contains an em dash (use a spaced hyphen)`)
+    }
+    expect(errors, errors.join('\n')).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary

Three changes to the Venture Handbook (`/admin/playbook`):

- **Sidebar scroll fix.** The nav `<aside>` now caps its height and scrolls independently (`md:max-h-[calc(100vh-6rem)] md:overflow-y-auto md:overscroll-contain`) instead of pinning the 31-item list off-screen until the article was scrolled to the bottom. Applied in both `index.astro` and `[...slug].astro`.
- **Deeper admin + client portal docs**, grounded in the real route/API trees (gathered by read-only exploration of the actual page code):
  - `admin-console.md` now walks the lead-to-cash spine (Leads → lead detail → meeting → quote → engagement), the Operator fleet cockpit, and the cross-cutting patterns.
  - `client-portal.md` covers every consulting surface, the Clerk + legacy auth model, and the SignWell/Stripe/R2 integrations behind them.
  - **New `operator-console.md`** documents the client-facing Operator product console: the authority-domain model (Read-and-Request vs Read-and-Operable), the three roles, and all work / governance / team / configuration surfaces, with honest empty states before the runtime bridge wires.
- **Currency & accuracy strategy** to keep the handbook true as the venture is built:
  - `tests/handbook-integrity.test.ts` — hard gate in `npm run verify`/CI: malformed frontmatter, dead `/admin/playbook/<slug>` cross-links, **a cited same-repo source file that no longer exists**, `(section, order)` collisions, em dashes.
  - `scripts/handbook-drift.mjs` (`npm run handbook:drift`) — advisory git-mtime staleness radar.
  - Documented in `docs/handbook/README.md` and `CLAUDE.md`.

The new gate already earned its keep: it caught a stale citation to the deleted `playbook.astro` in `operating-model.md` (fixed here, grounding the autonomy-ceilings claim in ADR 0035 and softening an unverifiable cadence figure).

## Test plan
- [x] `npm run verify` passes (typecheck 0 errors, 3558 tests pass, build clean)
- [x] `npx vitest run tests/handbook-integrity.test.ts` — 6/6 pass
- [x] `npm run handbook:drift` — clean
- [ ] Visual: open `admin.smd.services/admin/playbook`, confirm the sidebar scrolls independently of the article and the three deepened pages render

🤖 Generated with [Claude Code](https://claude.com/claude-code)