### PR TITLE
chore(workers): disable all six Cloudflare Worker cron schedules (Captain directive)

### DIFF
--- a/workers/cost-anomaly/wrangler.toml
+++ b/workers/cost-anomaly/wrangler.toml
@@ -31,7 +31,7 @@ database_id = "65171b23-d615-42a7-84e7-a4fac20d063c"
 # 03:00 UTC daily — runs after ss-cost-telemetry's 02:00 ingest so the
 # trailing-day data is fresh.
 [triggers]
-crons = ["0 3 * * *"]
+# crons = ["0 3 * * *"]  # DISABLED 2026-06-20 — Captain directive, all crons off pre-launch; re-enable deliberately
 
 [vars]
 # Default anomaly threshold in basis points. 15000 = 150% per #886.

--- a/workers/cost-telemetry/wrangler.toml
+++ b/workers/cost-telemetry/wrangler.toml
@@ -31,7 +31,7 @@ database_id = "65171b23-d615-42a7-84e7-a4fac20d063c"
 
 # 02:00 UTC daily — matches the nightly cadence in cost-telemetry-events.md.
 [triggers]
-crons = ["0 2 * * *"]
+# crons = ["0 2 * * *"]  # DISABLED 2026-06-20 — Captain directive, all crons off pre-launch; re-enable deliberately
 
 # Secrets (set via `wrangler secret put` after first deploy):
 #   CF_ACCOUNT_ID       — Cloudflare account id for per-customer D1 HTTP API

--- a/workers/job-monitor/wrangler.toml
+++ b/workers/job-monitor/wrangler.toml
@@ -15,4 +15,4 @@ binding = "ENRICHMENT_WORKFLOW_SERVICE"
 service = "ss-enrichment-workflow"
 
 [triggers]
-crons = ["0 13 * * *"]  # 13:00 UTC = 6:00 AM MST (Arizona, no DST)
+# crons = ["0 13 * * *"]  # 13:00 UTC = 6:00 AM MST (Arizona, no DST)  # DISABLED 2026-06-20 — Captain directive, all crons off pre-launch; re-enable deliberately

--- a/workers/new-business/wrangler.toml
+++ b/workers/new-business/wrangler.toml
@@ -19,4 +19,4 @@ binding = "ENRICHMENT_WORKFLOW_SERVICE"
 service = "ss-enrichment-workflow"
 
 [triggers]
-crons = ["0 14 * * *"]  # 14:00 UTC = 7:00 AM MST (1 hour after job monitor)
+# crons = ["0 14 * * *"]  # 14:00 UTC = 7:00 AM MST (1 hour after job monitor)  # DISABLED 2026-06-20 — Captain directive, all crons off pre-launch; re-enable deliberately

--- a/workers/review-mining/wrangler.toml
+++ b/workers/review-mining/wrangler.toml
@@ -15,4 +15,4 @@ binding = "ENRICHMENT_WORKFLOW_SERVICE"
 service = "ss-enrichment-workflow"
 
 [triggers]
-crons = ["0 15 * * 1"]  # 15:00 UTC Monday = 8:00 AM MST weekly
+# crons = ["0 15 * * 1"]  # 15:00 UTC Monday = 8:00 AM MST weekly  # DISABLED 2026-06-20 — Captain directive, all crons off pre-launch; re-enable deliberately

--- a/workers/social-listening/wrangler.toml
+++ b/workers/social-listening/wrangler.toml
@@ -10,4 +10,4 @@ database_name = "ss-console-db"
 database_id = "65171b23-d615-42a7-84e7-a4fac20d063c"
 
 [triggers]
-crons = ["0 14 * * *"]  # 14:00 UTC = 7:00 AM MST (daily, same window as new-business)
+# crons = ["0 14 * * *"]  # 14:00 UTC = 7:00 AM MST (daily, same window as new-business)  # DISABLED 2026-06-20 — Captain directive, all crons off pre-launch; re-enable deliberately


### PR DESCRIPTION
## What
Disables the cron schedule on all six Cloudflare cron workers. Live schedules already cleared via the Cloudflare API; this aligns source so a future `wrangler deploy` does not re-arm them.

| Worker | Was |
|---|---|
| ss-review-mining | `0 15 * * 1` |
| ss-social-listening | `0 14 * * *` |
| ss-new-business | `0 14 * * *` |
| ss-job-monitor | `0 13 * * *` |
| ss-cost-anomaly | `0 3 * * *` |
| ss-cost-telemetry | `0 2 * * *` |

## Why
Yesterday's #1461 disabled the Operator (Hermes) crons in `customer.yaml` but never touched these six Worker crons — they kept firing unattended, several calling the LLM. Captain directive: all crons off pre-launch.

## Verified
- Operator/Hermes crons: dead at runtime (live `hermes-smd` logs show only `/health` pings, no scheduled firing).
- All six Worker schedules: read back empty from the Cloudflare API after the change.

`ss-cost-telemetry`'s cron returns only as part of the proper cost-tracking fix (admin key + `cost_telemetry` table), not re-armed broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)