### PR TITLE
feat(operator): author-built MCP connector platform — SDK + reference connector (ADR 0053 PR1)

### DIFF
--- a/.github/workflows/operator-substrate.yml
+++ b/.github/workflows/operator-substrate.yml
@@ -95,3 +95,36 @@ jobs:
       # fetch failure -> exit 2 (env), and the workflow still fails.
       - name: Verify overlay runtime hashes (SEC-32 drift gate)
         run: python3 operator/bin/verify-overlay-pairs.py
+
+      # Author-built MCP connector conformance. The bare pytest env above
+      # deliberately installs only pytest+pyyaml; the connector conformance suite
+      # spawns a real stdio MCP server and speaks the protocol, so it needs the
+      # `mcp` SDK and the connector itself installed. We build each connector's
+      # OWN venv here — exactly as operator/templates/Dockerfile does — so CI
+      # tests the real shipped artifact (the venv + `<name>-mcp` console-script),
+      # not a source-tree import. Per-connector venv = the same isolation the
+      # image gets.
+      - name: Set up uv (connector venvs)
+        uses: astral-sh/setup-uv@v5
+
+      - name: Author-built connector conformance
+        working-directory: operator/connectors
+        run: |
+          set -euo pipefail
+          # SDK unit tests once, in their own venv.
+          uv venv /tmp/sdkv
+          uv pip install --python /tmp/sdkv/bin/python ./_sdk pytest
+          /tmp/sdkv/bin/python -m pytest _sdk/tests -q
+          # Each connector: isolated venv with the shared SDK + itself, run its
+          # tests with the console-script on PATH so the live stdio round-trip
+          # exercises the real `<name>-mcp` entry point.
+          for cdir in */; do
+            name="${cdir%/}"
+            [ "$name" = "_sdk" ] && continue
+            [ -f "${cdir}pyproject.toml" ] || continue
+            echo "== conformance: ${name} =="
+            venv="/tmp/connv-${name}"
+            uv venv "$venv"
+            uv pip install --python "$venv/bin/python" ./_sdk "$cdir" pytest
+            PATH="$venv/bin:$PATH" "$venv/bin/python" -m pytest "${cdir}tests" -q
+          done

--- a/operator/connectors/README.md
+++ b/operator/connectors/README.md
@@ -1,0 +1,50 @@
+# Author-built MCP connectors
+
+When the Operator must connect to a system that has **no acceptable vendor or
+community MCP server**, we author one. This directory is where those connectors
+live. See **ADR 0053** for the doctrine.
+
+A connector here is a **Python stdio MCP server** that is baked into the shared
+Operator image, registered once in the overlay
+(`hermes-smd-overlay` `MCP_CONNECTOR_REGISTRY`), and **activated per-customer**
+only when a `customer.yaml` binds it (`backend: mcp:<name>`). A connector that no
+customer binds is inert — it is never launched, surfaces no tools, and receives
+no secrets, exactly like a skill in the catalog that no persona enables. There is
+no separate repo, release pipeline, or runtime fetch.
+
+## Layout
+
+```
+_sdk/         the shared contract every connector is built on (NOT published):
+              ConnectorServer (non-empty inputSchema), the manifest schema, and
+              the conformance harness with the runtime-name oracle.
+_reference/   a SYNTHETIC self-test connector (echo / record / surprise). It is
+              not a vendor integration — it proves every rail of the platform,
+              including fail-closed refusal of an unclassified tool.
+```
+
+## Adding a connector (the declarative contract)
+
+1. **Write the package** under `connectors/<name>/` — a stdio MCP server built on
+   `ConnectorServer`, exposing a `<name>-mcp` console-script
+   (`[project.scripts]` in its `pyproject.toml`).
+2. **Ship a `manifest.toml`** — capability, required-secret _names_, `auth_model`,
+   static launch env, and `tool_classes` (the conformance **oracle**, keyed by
+   bare tool name).
+3. **Add a conformance test** under `connectors/<name>/tests/` that runs
+   `operator_connector_sdk.conformance` against the server.
+4. **Register it** in the overlay: one `McpConnectorSpec` (with the absolute venv
+   `command` and `auth_model`) **and** the `mcp_<server>_<tool>: ActionClass`
+   literal lines in `shared/action_classes.py`. The literal map is the enforced
+   authority; the manifest is checked _against_ it. This is the deliberate
+   two-repo review gate for any tool that can take an action.
+5. **Bind it** in a `customer.yaml` (`backend: mcp:<name>`).
+
+The image install (one isolated venv per connector), the secret staging, and the
+fail-closed governance are built once and apply to every connector — adding #N is
+declarative, not bespoke wiring.
+
+## What the platform generalizes — and does not
+
+The connector **lifecycle** (author → install → activate → govern → verify) is
+general. The tool **vocabulary** is not — skills stay connector-native by design.

--- a/operator/connectors/_reference/manifest.toml
+++ b/operator/connectors/_reference/manifest.toml
@@ -1,0 +1,25 @@
+# Reference connector self-description. Exercises the manifest schema the
+# platform consumes.
+#
+# `tool_classes` is the conformance ORACLE, not a runtime input: the overlay's
+# hand-authored `_RAW_TOOL_ACTION_CLASS_MAP` is the enforced authority, and a
+# PR-2 test asserts these declarations agree with it under the runtime-prefixed
+# names (mcp_reference_echo, mcp_reference_record). `surprise` is deliberately
+# omitted here AND from the overlay map, so runtime registration must REFUSE it.
+[connector]
+name = "reference"
+capability = "Reference"
+auth_model = "static"
+description = "Synthetic platform self-test connector. Not a vendor integration."
+
+[connector.env_static]
+REFERENCE_MODE = "selftest"
+
+[connector.tool_classes]
+echo = "read"
+record = "internal_write"
+# surprise: intentionally absent — proves fail-closed refusal.
+
+[[connector.required_secrets]]
+runtime_env = "REFERENCE_API_KEY"
+purpose = "Dummy key proving the static-auth env path and the data-driven secret-staging step."

--- a/operator/connectors/_reference/pyproject.toml
+++ b/operator/connectors/_reference/pyproject.toml
@@ -1,0 +1,20 @@
+[project]
+name = "reference-connector"
+version = "0.1.0"
+description = "Synthetic reference connector — the platform's self-test fixture. NOT a vendor integration."
+requires-python = ">=3.11"
+dependencies = ["operator-connector-sdk"]
+
+# The console-script the overlay registry launches as `command`. Every
+# author-built connector exposes `<name>-mcp`; the registry points `command` at
+# the absolute path of this script inside the connector's own venv
+# (/opt/connectors/reference/.venv/bin/reference-mcp).
+[project.scripts]
+reference-mcp = "reference_connector.__main__:main"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["reference_connector"]

--- a/operator/connectors/_reference/reference_connector/__init__.py
+++ b/operator/connectors/_reference/reference_connector/__init__.py
@@ -1,0 +1,9 @@
+"""Synthetic reference connector — the connector-platform self-test fixture.
+
+It is NOT a vendor integration. It exists only to exercise every rail of the
+platform end-to-end without any external API: build, per-connector venv install,
+the conformance suite, secret staging, the auth-model paths, and — crucially —
+fail-closed governance. To prove that last guarantee it deliberately exposes a
+tool (``surprise``) that nothing classifies, so the overlay's registration must
+REFUSE it at runtime.
+"""

--- a/operator/connectors/_reference/reference_connector/__main__.py
+++ b/operator/connectors/_reference/reference_connector/__main__.py
@@ -1,0 +1,15 @@
+"""Entrypoint: serve the reference connector over stdio (the transport Hermes
+launches author-built connectors with). Installed as the ``reference-mcp``
+console-script."""
+
+from __future__ import annotations
+
+from .server import server
+
+
+def main() -> None:
+    server.run_stdio()
+
+
+if __name__ == "__main__":
+    main()

--- a/operator/connectors/_reference/reference_connector/server.py
+++ b/operator/connectors/_reference/reference_connector/server.py
@@ -1,0 +1,44 @@
+"""The reference connector's MCP server: three tools spanning the cases the
+platform must handle.
+
+- ``echo``     — a READ-shaped tool (no side effect).
+- ``record``   — an INTERNAL_WRITE-shaped tool (mutates ephemeral in-process state).
+- ``surprise`` — DELIBERATELY left unclassified everywhere (manifest + overlay),
+                 so the overlay's fail-closed registration must REFUSE to wire it.
+                 Its presence is the whole point: it proves a connector cannot
+                 surface an ungoverned tool.
+
+Classification does not live here — the manifest declares intent (the oracle) and
+the overlay's hand-authored literal map enforces it. The server just exposes
+tools; the platform governs them.
+"""
+
+from __future__ import annotations
+
+from operator_connector_sdk.server import ConnectorServer
+
+server = ConnectorServer("reference")
+
+# Ephemeral, per-process state — the reference connector keeps nothing durable.
+_STORE: dict[str, str] = {}
+
+
+@server.tool()
+def echo(text: str) -> str:
+    """Return ``text`` unchanged. A pure read; no side effect."""
+    return text
+
+
+@server.tool()
+def record(key: str, value: str) -> dict[str, str]:
+    """Store ``value`` under ``key`` in ephemeral memory and confirm. An
+    internal write."""
+    _STORE[key] = value
+    return {"stored": key}
+
+
+@server.tool()
+def surprise(payload: str) -> str:
+    """A tool nothing classifies, so fail-closed registration must refuse it. Do
+    NOT classify this — in the manifest or the overlay map."""
+    return f"surprise:{payload}"

--- a/operator/connectors/_reference/tests/test_conformance.py
+++ b/operator/connectors/_reference/tests/test_conformance.py
@@ -1,0 +1,91 @@
+"""The reference connector runs the platform conformance suite against itself.
+This is the template every real connector's tests follow.
+
+It proves both directions of the governance contract that the platform exists to
+guarantee:
+
+- POSITIVE: a tool the connector means to govern (`record`) is classified, and
+  is classified under its RUNTIME-prefixed name (`mcp_reference_record`) — the
+  bug class (bare vs runtime name) that has slipped governance before.
+- NEGATIVE: a tool nothing classifies (`surprise`) is flagged as ungoverned and
+  fails the oracle unless explicitly expected — the structural precondition for
+  the overlay's fail-closed REFUSED at runtime.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from operator_connector_sdk import conformance
+from operator_connector_sdk.manifest import AuthModel, ConnectorManifest
+from operator_connector_sdk.naming import runtime_tool_name
+from reference_connector.server import server
+
+MANIFEST_PATH = Path(__file__).resolve().parents[1] / "manifest.toml"
+
+
+def _manifest() -> ConnectorManifest:
+    return ConnectorManifest.from_toml(MANIFEST_PATH)
+
+
+def test_manifest_loads_and_validates() -> None:
+    m = _manifest()
+    assert m.name == "reference"
+    assert m.capability == "Reference"
+    assert m.auth_model is AuthModel.STATIC
+    assert [s.runtime_env for s in m.required_secrets] == ["REFERENCE_API_KEY"]
+
+
+def test_full_surface_present() -> None:
+    names = {t.name for t in server.tool_surface()}
+    assert names == {"echo", "record", "surprise"}
+
+
+def test_every_tool_has_nonempty_input_schema() -> None:
+    for tool in server.tool_surface():
+        props = tool.inputSchema["properties"]
+        assert props, f"{tool.name}: empty inputSchema.properties"
+
+
+def test_structural_conformance_passes_with_surprise_expected() -> None:
+    runtime_map = conformance.run_all(
+        server,
+        _manifest(),
+        banned=("forbidden_tool",),
+        expected_unclassified=("surprise",),
+    )
+    # The oracle returns the runtime-prefixed classification the overlay test
+    # will check against _RAW_TOOL_ACTION_CLASS_MAP.
+    assert runtime_map == {
+        "mcp_reference_echo": "read",
+        "mcp_reference_record": "internal_write",
+    }
+
+
+def test_positive_binding_record_is_internal_write_under_runtime_name() -> None:
+    runtime_map = conformance.run_all(
+        server, _manifest(), expected_unclassified=("surprise",)
+    )
+    key = runtime_tool_name("reference", "record")
+    assert key == "mcp_reference_record"
+    assert runtime_map[key] == "internal_write"
+
+
+def test_unclassified_tool_fails_oracle_when_not_expected() -> None:
+    # surprise is live but unclassified; without listing it as expected, the
+    # oracle must fail — this is the structural guarantee behind runtime REFUSED.
+    with pytest.raises(AssertionError):
+        conformance.check_tool_classes(server, _manifest())
+
+
+def test_phantom_classification_fails_oracle() -> None:
+    m = _manifest()
+    m.tool_classes["ghost"] = "read"  # no such live tool
+    with pytest.raises(AssertionError):
+        conformance.check_tool_classes(server, m, expected_unclassified=("surprise",))
+
+
+def test_banned_tool_absent_is_enforced() -> None:
+    with pytest.raises(AssertionError):
+        conformance.check_no_banned_tools(server, banned=("echo",))

--- a/operator/connectors/_reference/tests/test_stdio_roundtrip.py
+++ b/operator/connectors/_reference/tests/test_stdio_roundtrip.py
@@ -1,0 +1,44 @@
+"""End-to-end proof that the connector serves over real stdio MCP via the
+console-script the registry launches — not the module form.
+
+This is the rail the overlay's `command` (an absolute path to
+/opt/connectors/reference/.venv/bin/reference-mcp) must satisfy: spawn the
+script, speak the protocol, list tools, call one. If the console-script entry
+point is wrong, this fails here instead of as a runtime MCP-spawn error on a
+live Machine.
+"""
+
+from __future__ import annotations
+
+import shutil
+
+import anyio
+import pytest
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+# Resolve the installed console-script the same way the gateway would (on PATH
+# of the connector's venv). Skip cleanly if the package was imported but not
+# installed as a script (e.g. a bare `pytest` against the source tree).
+_SCRIPT = shutil.which("reference-mcp")
+
+
+async def _roundtrip(command: str) -> None:
+    params = StdioServerParameters(command=command)
+    async with stdio_client(params) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+
+            listed = await session.list_tools()
+            names = {t.name for t in listed.tools}
+            assert names == {"echo", "record", "surprise"}
+            for t in listed.tools:
+                assert t.inputSchema.get("type") == "object"
+
+            result = await session.call_tool("echo", {"text": "ping"})
+            assert result.content[0].text == "ping"
+
+
+@pytest.mark.skipif(_SCRIPT is None, reason="reference-mcp console-script not on PATH")
+def test_stdio_roundtrip_via_console_script() -> None:
+    anyio.run(_roundtrip, _SCRIPT)

--- a/operator/connectors/_sdk/operator_connector_sdk/__init__.py
+++ b/operator/connectors/_sdk/operator_connector_sdk/__init__.py
@@ -1,0 +1,35 @@
+"""operator_connector_sdk — the contract every author-built MCP connector is built on.
+
+Deliberately minimal. It ships exactly the pieces with teeth:
+
+- ``ConnectorServer`` — a stdio MCP server base that guarantees each tool ships a
+  well-formed, non-empty ``inputSchema`` where Hermes' MCP client reads it.
+- ``ConnectorManifest`` — the in-package self-description (capability, required
+  secret *names*, ``auth_model``, and ``tool_classes`` as a conformance ORACLE).
+- the conformance harness — spawns/introspects the server and proves the tool
+  surface is well-formed and that every live tool is classified under its
+  *runtime-prefixed* name (``mcp_<server>_<tool>``), the exact thing that has
+  slipped governance before.
+
+What is NOT here: auth-strategy base classes (deferred until a real
+static/client_credentials connector exists) and the enforced tool->ActionClass
+map. The enforced map is the hand-authored literal in the overlay
+(``shared/action_classes.py``); the manifest's ``tool_classes`` is only the
+oracle a conformance test checks that map against. Trust is reviewed in the
+trust repo, not self-certified here.
+"""
+
+from __future__ import annotations
+
+from .manifest import ACTION_CLASSES, AuthModel, ConnectorManifest, SecretSpec
+from .naming import runtime_tool_name
+from .server import ConnectorServer
+
+__all__ = [
+    "ACTION_CLASSES",
+    "AuthModel",
+    "ConnectorManifest",
+    "ConnectorServer",
+    "SecretSpec",
+    "runtime_tool_name",
+]

--- a/operator/connectors/_sdk/operator_connector_sdk/conformance.py
+++ b/operator/connectors/_sdk/operator_connector_sdk/conformance.py
@@ -1,0 +1,118 @@
+"""The reusable conformance suite every connector package runs.
+
+These checks are what make "adding connector #N is cheap *and* safe" true: a
+package that passes them is wired the same way as every other and cannot ship a
+malformed or silently-ungoverned tool surface.
+
+Two layers of classification check live in two repos, by design:
+
+- HERE (ss-console, no overlay dependency): every live tool is either declared
+  in the manifest's ``tool_classes`` or explicitly expected to be unclassified;
+  the runtime-prefixed name is the unit of declaration. This catches the bare-vs-
+  runtime-name bug locally, before the overlay is even involved.
+- OVERLAY (PR-2): the manifest's declared classes are checked *against* the
+  hand-authored ``_RAW_TOOL_ACTION_CLASS_MAP`` (the authority). That is where
+  enforcement lives; it is not duplicated here.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from .manifest import ConnectorManifest
+from .naming import runtime_tool_name
+from .server import ConnectorServer
+
+
+def check_tool_schemas(server: ConnectorServer) -> list[str]:
+    """Every exposed tool has a well-formed object inputSchema (present where
+    Hermes reads it). Returns the tool names."""
+    tools = server.tool_surface()
+    if not tools:
+        raise AssertionError(f"{server.name}: exposes no tools")
+    for t in tools:
+        schema = t.inputSchema
+        if not isinstance(schema, dict):
+            raise AssertionError(f"{server.name}.{t.name}: inputSchema is not a dict")
+        if schema.get("type") != "object":
+            raise AssertionError(f"{server.name}.{t.name}: inputSchema.type != 'object'")
+        if "properties" not in schema:
+            raise AssertionError(f"{server.name}.{t.name}: inputSchema has no 'properties'")
+    return [t.name for t in tools]
+
+
+def check_no_banned_tools(server: ConnectorServer, banned: Iterable[str]) -> None:
+    """The server must not expose any tool the connector declares as banned
+    (defense in depth: never on the menu *and* refused at the trust layer)."""
+    names = {t.name for t in server.tool_surface()}
+    leaked = names & set(banned)
+    if leaked:
+        raise AssertionError(f"{server.name}: exposes banned tools {sorted(leaked)}")
+
+
+def check_manifest(manifest: ConnectorManifest) -> None:
+    """The manifest validates and is internally consistent."""
+    if not manifest.name or not manifest.capability:
+        raise AssertionError("manifest: name and capability are required")
+
+
+def check_tool_classes(
+    server: ConnectorServer,
+    manifest: ConnectorManifest,
+    *,
+    expected_unclassified: Iterable[str] = (),
+) -> dict[str, str]:
+    """Every live tool is accounted for: either declared in the manifest's
+    ``tool_classes`` or explicitly listed in ``expected_unclassified`` (a tool
+    the connector deliberately leaves ungoverned to prove fail-closed refusal).
+
+    A live tool that is neither is a silent governance gap and fails here. A
+    declared class with no matching live tool is a phantom classification and
+    fails here. Returns the runtime-prefixed name -> class map the overlay test
+    will check against ``_RAW_TOOL_ACTION_CLASS_MAP``.
+    """
+    live = {t.name for t in server.tool_surface()}
+    declared = set(manifest.tool_classes)
+    expected_unclassified = set(expected_unclassified)
+
+    phantom = declared - live
+    if phantom:
+        raise AssertionError(
+            f"{server.name}: tool_classes declares {sorted(phantom)} but the server "
+            f"exposes no such tool"
+        )
+
+    ungoverned = live - declared - expected_unclassified
+    if ungoverned:
+        raise AssertionError(
+            f"{server.name}: live tools {sorted(ungoverned)} are neither classified "
+            f"nor listed as expected-unclassified — they would fall through to the "
+            f"fail-closed default at runtime"
+        )
+
+    overlap = declared & expected_unclassified
+    if overlap:
+        raise AssertionError(
+            f"{server.name}: {sorted(overlap)} are both classified and listed as "
+            f"expected-unclassified — pick one"
+        )
+
+    return {
+        runtime_tool_name(manifest.name, tool): cls
+        for tool, cls in manifest.tool_classes.items()
+    }
+
+
+def run_all(
+    server: ConnectorServer,
+    manifest: ConnectorManifest,
+    *,
+    banned: Iterable[str] = (),
+    expected_unclassified: Iterable[str] = (),
+) -> dict[str, str]:
+    """Run the full structural conformance suite. Returns the runtime-prefixed
+    name -> ActionClass map (for the overlay's manifest<=map test to consume)."""
+    check_manifest(manifest)
+    check_tool_schemas(server)
+    check_no_banned_tools(server, banned)
+    return check_tool_classes(server, manifest, expected_unclassified=expected_unclassified)

--- a/operator/connectors/_sdk/operator_connector_sdk/manifest.py
+++ b/operator/connectors/_sdk/operator_connector_sdk/manifest.py
@@ -1,0 +1,112 @@
+"""The in-package connector manifest — how a connector self-describes.
+
+A connector ships a ``manifest.toml`` declaring the facts the platform needs to
+wire it: the capability it serves, the NAMES of the secrets it requires at
+runtime, its auth model, any static launch env, and ``tool_classes``.
+
+``tool_classes`` is the **conformance oracle, not a runtime input.** The enforced
+tool->ActionClass mapping is the hand-authored literal in the overlay
+(``shared/action_classes.py::_RAW_TOOL_ACTION_CLASS_MAP``), reviewed in the trust
+repo. A conformance test asserts the manifest agrees with that map (manifest is
+checked *against* the map; the map is authority). The manifest carries the
+classes here so the connector author declares intent in one place and the test
+has something to check — never so the connector can self-certify its own trust.
+"""
+
+from __future__ import annotations
+
+import enum
+import tomllib
+from pathlib import Path
+
+from pydantic import BaseModel, Field, field_validator
+
+# The action-class vocabulary, mirrored from the overlay's ActionClass enum
+# (shared/action_classes.py). REFUSED is deliberately excluded — it is the
+# fail-closed sentinel for an *un*classified tool, never a class a connector may
+# declare. A PR-2 conformance test asserts this set equals the overlay enum
+# (minus REFUSED), the same way capability_contract.py mirrors the TS union.
+ACTION_CLASSES: frozenset[str] = frozenset(
+    {
+        "read",
+        "internal_write",
+        "external_send",
+        "commitment",
+        "destructive",
+        "code_execution",
+    }
+)
+
+
+class AuthModel(str, enum.Enum):
+    """How the platform provisions this connector's credentials.
+
+    - ``static``: a long-lived secret (e.g. API key) injected as an env var.
+    - ``client_credentials``: OAuth2 client-credentials grant; the server mints
+      its own bearer from client id/secret env vars.
+    - ``authorization_code``: OAuth2 auth-code + refresh; the platform supplies
+      the credential via the existing per-customer OAuth custody path (portal
+      consent -> staged secret -> on-volume refresh). No per-connector
+      consent/seeding code.
+    """
+
+    STATIC = "static"
+    CLIENT_CREDENTIALS = "client_credentials"
+    AUTHORIZATION_CODE = "authorization_code"
+
+
+class SecretSpec(BaseModel):
+    """One secret the connector needs at runtime. The connector declares the
+    runtime env-var NAME and why; the *source* (where the value comes from) and
+    any var remap are bound by the overlay registry per customer, not here — so
+    the manifest never becomes a second, contradictory wiring spec."""
+
+    runtime_env: str = Field(..., min_length=1)
+    purpose: str = ""
+
+    @field_validator("runtime_env")
+    @classmethod
+    def _env_shape(cls, v: str) -> str:
+        if not v.replace("_", "").isalnum() or not v[0].isalpha():
+            raise ValueError(f"runtime_env {v!r} must be an env-var-shaped identifier")
+        return v
+
+
+class ConnectorManifest(BaseModel):
+    """Self-description loaded from a connector's ``manifest.toml``."""
+
+    name: str = Field(..., min_length=1)
+    capability: str = Field(..., min_length=1)
+    auth_model: AuthModel
+    required_secrets: list[SecretSpec] = Field(default_factory=list)
+    env_static: dict[str, str] = Field(default_factory=dict)
+    # Bare-tool-name -> ActionClass string. Oracle only (see module docstring).
+    # A tool the connector intends to leave UNCLASSIFIED (to prove fail-closed
+    # refusal) is simply omitted here.
+    tool_classes: dict[str, str] = Field(default_factory=dict)
+    description: str = ""
+
+    @field_validator("required_secrets")
+    @classmethod
+    def _unique_envs(cls, v: list[SecretSpec]) -> list[SecretSpec]:
+        envs = [s.runtime_env for s in v]
+        if len(envs) != len(set(envs)):
+            raise ValueError("duplicate runtime_env names in required_secrets")
+        return v
+
+    @field_validator("tool_classes")
+    @classmethod
+    def _known_classes(cls, v: dict[str, str]) -> dict[str, str]:
+        for tool, cls_name in v.items():
+            if cls_name not in ACTION_CLASSES:
+                raise ValueError(
+                    f"tool_classes[{tool!r}] = {cls_name!r} is not a known ActionClass "
+                    f"(allowed: {sorted(ACTION_CLASSES)}; 'refused' is never declarable)"
+                )
+        return v
+
+    @classmethod
+    def from_toml(cls, path: str | Path) -> ConnectorManifest:
+        data = tomllib.loads(Path(path).read_text())
+        # Accept either a top-level table or a [connector] table.
+        return cls.model_validate(data.get("connector", data))

--- a/operator/connectors/_sdk/operator_connector_sdk/naming.py
+++ b/operator/connectors/_sdk/operator_connector_sdk/naming.py
@@ -1,0 +1,23 @@
+"""Runtime tool-name derivation — the single source of the ``mcp_<server>_<tool>``
+form Hermes registers connector tools under.
+
+This exists as its own module because getting it wrong is the platform's most
+dangerous silent failure: the overlay's tool->ActionClass map is keyed by the
+*runtime* name, and a connector that classifies bare tool names (``echo``)
+instead of runtime names (``mcp_reference_echo``) passes its local tests while
+its governance keys match nothing at runtime — tools then fall through to the
+fail-closed default. The conformance oracle and the overlay's manifest<=map test
+both derive the key here so the two sides cannot drift.
+"""
+
+from __future__ import annotations
+
+
+def runtime_tool_name(server_name: str, tool_name: str) -> str:
+    """The name Hermes registers a connector tool under at runtime.
+
+    The MCP server key is dash->underscore folded and prefixed with ``mcp_``;
+    the tool name is appended verbatim. e.g. ("clio-oktopeak", "list_matters")
+    -> "mcp_clio_oktopeak_list_matters".
+    """
+    return f"mcp_{server_name.replace('-', '_')}_{tool_name}"

--- a/operator/connectors/_sdk/operator_connector_sdk/server.py
+++ b/operator/connectors/_sdk/operator_connector_sdk/server.py
@@ -1,0 +1,39 @@
+"""ConnectorServer — the stdio MCP server base every author-built connector uses.
+
+Thin wrapper over the MCP SDK's FastMCP. Two jobs:
+
+1. Guarantee tools register with a well-formed, non-empty ``inputSchema`` placed
+   where Hermes' MCP client reads it. (FastMCP derives the schema from the tool
+   signature and type hints and emits it under the correct ``inputSchema`` key,
+   so this avoids the historical bug where tools shipped with empty param
+   schemas and the model could not call them.)
+2. Expose the tool surface synchronously (``tool_surface``) so the conformance
+   harness can enumerate exactly what the server offers.
+"""
+
+from __future__ import annotations
+
+import anyio
+from mcp.server.fastmcp import FastMCP
+from mcp.types import Tool
+
+
+class ConnectorServer:
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self._mcp = FastMCP(name)
+
+    def tool(self, *args, **kwargs):
+        """Register a tool. Delegates to FastMCP; the input schema is derived
+        from the function signature and type hints."""
+        return self._mcp.tool(*args, **kwargs)
+
+    def tool_surface(self) -> list[Tool]:
+        """The exact set of tools this server exposes, with their inputSchemas.
+        Synchronous convenience over FastMCP's async ``list_tools`` — call from
+        sync code (tests, conformance), not from inside a running event loop."""
+        return anyio.run(self._mcp.list_tools)
+
+    def run_stdio(self) -> None:
+        """Serve over stdio — the transport Hermes launches the connector with."""
+        self._mcp.run(transport="stdio")

--- a/operator/connectors/_sdk/pyproject.toml
+++ b/operator/connectors/_sdk/pyproject.toml
@@ -1,0 +1,16 @@
+[project]
+name = "operator-connector-sdk"
+version = "0.1.0"
+description = "Minimal SDK + conformance contract for author-built MCP connectors (the Operator connector platform). NOT published — installed from this path into each connector's venv."
+requires-python = ">=3.11"
+dependencies = [
+    "mcp>=1.2",
+    "pydantic>=2.6",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["operator_connector_sdk"]

--- a/operator/connectors/_sdk/tests/test_manifest.py
+++ b/operator/connectors/_sdk/tests/test_manifest.py
@@ -1,0 +1,74 @@
+"""SDK-level tests for the manifest contract and runtime-name derivation."""
+
+from __future__ import annotations
+
+import pytest
+from operator_connector_sdk.manifest import AuthModel, ConnectorManifest, SecretSpec
+from operator_connector_sdk.naming import runtime_tool_name
+
+
+def test_minimal_manifest() -> None:
+    m = ConnectorManifest(name="x", capability="Cap", auth_model="static")
+    assert m.auth_model is AuthModel.STATIC
+    assert m.required_secrets == []
+    assert m.tool_classes == {}
+
+
+def test_rejects_duplicate_secret_envs() -> None:
+    with pytest.raises(ValueError):
+        ConnectorManifest(
+            name="x",
+            capability="Cap",
+            auth_model="static",
+            required_secrets=[
+                SecretSpec(runtime_env="DUP"),
+                SecretSpec(runtime_env="DUP"),
+            ],
+        )
+
+
+def test_rejects_bad_env_shape() -> None:
+    with pytest.raises(ValueError):
+        SecretSpec(runtime_env="1bad-name")
+
+
+def test_rejects_unknown_auth_model() -> None:
+    with pytest.raises(ValueError):
+        ConnectorManifest(name="x", capability="Cap", auth_model="magic")
+
+
+def test_accepts_known_tool_classes() -> None:
+    m = ConnectorManifest(
+        name="x",
+        capability="Cap",
+        auth_model="static",
+        tool_classes={"a": "read", "b": "internal_write"},
+    )
+    assert m.tool_classes["b"] == "internal_write"
+
+
+def test_rejects_unknown_tool_class() -> None:
+    with pytest.raises(ValueError):
+        ConnectorManifest(
+            name="x",
+            capability="Cap",
+            auth_model="static",
+            tool_classes={"a": "read_only"},
+        )
+
+
+def test_rejects_refused_as_a_declared_class() -> None:
+    # 'refused' is the fail-closed sentinel for an UNclassified tool — a
+    # connector must never be able to declare it.
+    with pytest.raises(ValueError):
+        ConnectorManifest(
+            name="x",
+            capability="Cap",
+            auth_model="static",
+            tool_classes={"a": "refused"},
+        )
+
+
+def test_runtime_tool_name_folds_dashes() -> None:
+    assert runtime_tool_name("clio-oktopeak", "list_matters") == "mcp_clio_oktopeak_list_matters"
+    assert runtime_tool_name("reference", "record") == "mcp_reference_record"

--- a/operator/templates/Dockerfile
+++ b/operator/templates/Dockerfile
@@ -418,6 +418,32 @@ COPY operator/skills/ /app/skills/
 # Tier-1 custom MCP wrappers (one subdir per connector)
 COPY operator/connectors/ /app/connectors/
 
+# ---------- Author-built MCP connectors: one isolated venv per connector ----------
+# Each connector under /app/connectors/ (except the `_sdk` library it shares) is
+# a Python stdio MCP server. Install each into its OWN venv via the proven
+# workspace-broker pattern above, so connectors never share a dependency closure
+# with each other or with the Hermes venv. The overlay registry launches each by
+# the ABSOLUTE path to its venv console-script
+# (/opt/connectors/<name>/.venv/bin/<name>-mcp) — no PATH manipulation, no
+# ~/.local/bin. A connector is INERT until a customer.yaml binds it; baking it
+# here costs only disk, never a running process (identical posture to a skill in
+# the catalog that no persona enables). The `*-mcp` assertion fails the build
+# loudly rather than letting a missing console-script surface as a runtime
+# MCP-spawn failure on a live Machine.
+RUN set -eu; \
+    for cdir in /app/connectors/*/; do \
+      name=$(basename "$cdir"); \
+      [ "$name" = "_sdk" ] && continue; \
+      [ -f "${cdir}pyproject.toml" ] || continue; \
+      venv="/opt/connectors/${name}/.venv"; \
+      echo "== installing author-built connector: ${name} =="; \
+      mkdir -p "/opt/connectors/${name}"; \
+      uv venv "$venv"; \
+      uv pip install --python "$venv/bin/python" --no-cache /app/connectors/_sdk "$cdir"; \
+      ls "$venv"/bin/*-mcp >/dev/null 2>&1 || { echo "FATAL: connector ${name} produced no *-mcp console-script"; exit 1; }; \
+    done; \
+    chmod -R a+rX /opt/connectors
+
 # Safety-substrate tests — bootstrap.sh runs these on container start
 COPY operator/safety-substrate/ /app/safety-substrate/
 


### PR DESCRIPTION
## What

PR-1 of the author-built MCP connector platform (ADR 0053). The **general, in-repo mechanism** for any connector we author ourselves when no acceptable vendor/community MCP exists. This is the **ss-console foundation** and lands independently of the overlay.

**Doctrine (no new repo, org, release pipeline, or runtime fetch):** a connector is code under `operator/connectors/<name>/`, baked into the shared image, registered once in the overlay, and **activated per-customer** only when a `customer.yaml` binds it. A baked-but-unbound connector is **inert** — never launched, no tools, no secrets — identical to a catalog skill no persona enables.

## In this PR

- **`operator/connectors/_sdk/`** — the minimal shared contract: `ConnectorServer` (guarantees non-empty `inputSchema`), the manifest schema (capability, required-secret **names**, `auth_model`, `tool_classes` as a conformance **oracle**), the runtime-name derivation `mcp_<server>_<tool>`, and the conformance harness. No speculative auth-strategy base classes (deferred until a real connector needs them).
- **`operator/connectors/_reference/`** — a **synthetic** self-test connector (`echo`=read, `record`=internal_write, `surprise`=deliberately unclassified). Proves **both** governance directions:
  - **Positive:** `record` is `internal_write` under its **runtime-prefixed** name `mcp_reference_record` — the bare-vs-runtime-name bug that has slipped governance before.
  - **Negative:** `surprise` is ungoverned and **fails the oracle** unless explicitly expected — the structural precondition for the overlay's fail-closed `REFUSED`.
  - Includes a **live stdio round-trip** via the real `reference-mcp` console-script.
- **`Dockerfile`** — installs each connector into its **own venv** via the proven workspace-broker pattern; the overlay launches each by the **absolute venv console-script path** (no PATH manipulation, no Hermes-venv coupling). Build fails loudly if a connector produces no `*-mcp` script.
- **`operator-substrate.yml`** — a dedicated conformance step builds each connector's venv **exactly as the image does** and runs its suite, so CI tests the real shipped artifact (the bare pytest env has no `mcp` SDK by design).

## Trust boundary

The enforced tool→ActionClass map stays the **hand-authored literal in the overlay** (`shared/action_classes.py`). The manifest's `tool_classes` is **only the oracle** a PR-2 test checks that map against. Trust is reviewed in the trust repo, never self-certified here.

## Test

`8` SDK unit tests + `9` reference conformance tests (incl. the live console-script round-trip) pass in isolated per-connector venvs; ruff clean. CI runs the same loop via the new `operator-substrate` step.

## Not in this PR

- **PR-2 (overlay):** additive `McpConnectorSpec.auth_model`, the `mcp_<server>_<tool>` literal-map lines for the reference connector, the manifest⊆map conformance test, the `customer.yaml`-binding drift guard, and the boot-smoke runtime-classification check.
- **PR-3 (ss-console):** manifest-driven secret staging for the author-built family + the ADR 0053 amendment.
- The **Smokeball** connector (a separate downstream effort built on this platform).

🤖 Generated with [Claude Code](https://claude.com/claude-code)