### PR TITLE
feat(operator): manifest-driven connector secret staging + ADR 0053 amendment (ADR 0053 PR3)

### DIFF
--- a/docs/adr/0053-author-built-mcp-connectors-per-customer-installed.md
+++ b/docs/adr/0053-author-built-mcp-connectors-per-customer-installed.md
@@ -8,7 +8,26 @@ related-adr: 0020-connector-strategy.md, 0015-hermes-fork-vs-upstream.md, 0007-p
 
 # ADR 0053 — Author-Built MCP Connectors Are Per-Customer-Installed Units, Not Baked Into the Overlay
 
-**Status:** Accepted (Captain decision, 2026-06-22).
+**Status:** Accepted (Captain decision, 2026-06-22). **Amended 2026-06-23** — the physical mechanism was corrected during implementation; see **§ Amendment** below before reading the original Decision.
+
+## Amendment (2026-06-23) — baked into the shared image, activated on bind
+
+Implementation corrected the physical model. The original Decisions 2, 3, and 5 proposed standalone, separately-packaged units (own repo/package) installed onto a Machine only when bound. That solved a distribution problem that does not exist and contradicted the proven precedents already in this repo:
+
+- **The skill-catalog precedent.** The entire skill catalog is baked into every image (`COPY operator/skills/`); per-customer **selection is pure config** in `customer.yaml`. Nothing ships per-customer; the binding selects.
+- **The activation rail.** `translate.py::_materialize_mcp_servers` already launches an MCP server **only** when a `customer.yaml` binds it. A baked-but-unbound connector is inert — never launched, no tools, no secrets.
+
+**Corrected mechanism:**
+
+1. **Home = in-repo.** An author-built connector is a Python stdio MCP server at `operator/connectors/<name>/` (the Dockerfile's "Tier-1 custom MCP wrappers" dir), built on the shared `operator/connectors/_sdk/`. **No separate repo, org, release pipeline, or runtime fetch.**
+2. **Baked into the shared image, one isolated venv per connector.** The Dockerfile installs each connector into its own venv (`/opt/connectors/<dir>/.venv`, the proven workspace-broker pattern); the overlay registry launches it by the **absolute venv console-script path**. The image stays the single governed deploy unit (`OVERLAY_REF` + image tag).
+3. **Activated per-customer by binding — not per-customer installed.** A connector is present-but-inert on every Machine; it launches, surfaces tools, and receives secrets only when a `customer.yaml` binds `mcp:<name>` — identical posture to a catalog skill no persona enables. This supersedes the original "install only on bound Machines" and "the fleet never rebuilds to add a connector": adding a connector is an image change like adding a skill, shipped on the next reprovision. The only cost of a dormant connector is disk for inert code, paid once — never a running process.
+4. **Governance authority is the overlay literal map.** Each connector's `mcp_<server>_<tool>` action classes are hand-authored **literal lines** in `shared/action_classes.py`, reviewed in the overlay PR; the connector's `manifest.toml` `tool_classes` is only a conformance **oracle** (checked against the map, never a runtime input). The connector cannot self-certify trust. An unclassified tool fails closed to `REFUSED`.
+5. **Future hardening (not now): per-customer image bake.** If baked connector count / image size ever makes the shared image too heavy, move to per-customer images carrying only bound connectors. Deferred until weight demands it — it would fracture the single-image trust surface.
+
+**Unchanged:** Decision 1 (a tool-surfacing connector we author is an MCP server, not a `build:` CLI) and Decision 4 (runs in-Machine, scoped to per-customer credentials, never a shared hosted service) hold as written. The Context and the named-shape framing stand.
+
+---
 
 **Source:** A walk-through of how a connector reaches a live Operator Machine, prompted by the Smokeball connector build for the Ashton & Price pilot. Smokeball has no first-party MCP and no vetted-community MCP, so it is the **first connector we must author ourselves that surfaces runtime tools.** That exposed a question the existing connector strategy (ADR 0020) does not answer: where does connector code _we write_ physically live, and how does it reach only the Machines that need it — without rebuilding the shared overlay image for every new client connector.
 
@@ -37,6 +56,8 @@ The open question is purely physical: that server's code has to live somewhere o
 We are at N = 1. This is the moment to set the pattern correctly.
 
 ## Decision
+
+> **Read § Amendment (2026-06-23) first.** Decisions 2, 3, and 5 below describe the original pre-implementation mechanism (standalone per-customer-installed units); the Amendment supersedes their physical model with **in-repo + baked-into-the-shared-image + activated-on-bind**. Decisions 1 and 4 stand as written.
 
 ### 1. A tool-surfacing connector we author is an MCP server, not a `build:` CLI
 

--- a/operator/bin/provision-customer.sh
+++ b/operator/bin/provision-customer.sh
@@ -493,6 +493,52 @@ fi
 # delegation impersonating each customer's authored subject).
 stage_secret_from_env GOOGLE_SERVICE_ACCOUNT_JSON "${GOOGLE_SERVICE_ACCOUNT_JSON:-}" "base64 service-account key (domain-wide delegation)"
 
+# ---------- Step 6b-authored: author-built connector secrets (ADR 0053) ----------
+# Data-driven from each author-built connector's manifest.toml
+# (operator/connectors/<name>/manifest.toml) — the generic replacement for
+# per-connector grep blocks. For static / client_credentials connectors we stage
+# every declared required_secret NAME from the operator env (Infisical /ss),
+# warn+skip when unset, same no-paste pattern as the vendor blocks above. Adding
+# an author-built connector needs NO edit here.
+#
+# authorization_code connectors are deliberately NOT handled here: their
+# token-on-volume custody (the *_TOKENS_ENC_B64 seed + any var remap) stays in
+# the overlay registry + its dedicated custody step, so the manifest never
+# becomes a second, contradictory wiring spec. The manifest carries secret NAMES
+# only; the registry owns how each is wired.
+_CONNECTORS_DIR="${REPO_ROOT}/operator/connectors"
+if [ -d "${_CONNECTORS_DIR}" ]; then
+  while IFS=$'\t' read -r _conn_name _secret_name; do
+    [ -n "${_secret_name}" ] || continue
+    stage_secret_from_env "${_secret_name}" "${!_secret_name:-}" \
+      "author-built connector ${_conn_name} secret (ADR 0053)"
+  done < <(
+    python3 - "${_CONNECTORS_DIR}" <<'PY'
+import pathlib
+import sys
+import tomllib
+
+root = pathlib.Path(sys.argv[1])
+for manifest in sorted(root.glob("*/manifest.toml")):
+    try:
+        data = tomllib.loads(manifest.read_text())
+    except (OSError, tomllib.TOMLDecodeError):
+        continue
+    conn = data.get("connector", data)
+    # static / client_credentials → flat env staging here. authorization_code →
+    # token-on-volume custody (handled outside this loop).
+    if conn.get("auth_model") not in ("static", "client_credentials"):
+        continue
+    for secret in conn.get("required_secrets", []):
+        name = secret.get("runtime_env")
+        if name:
+            print(f"{manifest.parent.name}\t{name}")
+PY
+  )
+  unset _conn_name _secret_name
+fi
+unset _CONNECTORS_DIR
+
 # ---------- Step 6c: healthchecks.io check (ADR 0023 Wave 1) ----------
 # Idempotent create-or-find. Healthchecks.io's POST /api/v3/checks/ creates
 # a new check; if a check with the same `unique` keys (tags+name) already


### PR DESCRIPTION
## What

PR-3 of the author-built MCP connector platform (ADR 0053) — ss-console provisioning + doctrine. Follows merged PR #1500 (SDK + reference connector) and overlay #107 (registry + classification).

## Changes

- **`provision-customer.sh` — generic secret staging.** A data-driven loop stages secrets for the **author-built connector family**: for each `operator/connectors/<name>/manifest.toml` whose `auth_model` is `static`/`client_credentials`, it stages every declared `required_secret` **name** from the operator env via the existing `stage_secret_from_env` (warn+skip when unset). This is the generic replacement for per-connector grep blocks — **adding a connector needs no edit here.**
  - `authorization_code` connectors are deliberately excluded: their token-on-volume custody and any var remap stay in the **overlay registry** (the single wiring source), so the manifest carries secret **names only** and never becomes a second, contradictory wiring spec.
  - Existing vendor blocks (Clio / AgentMail / Google) are **untouched** — they are not author-built and have no `operator/connectors` manifest.
- **ADR 0053 amendment.** The original Decisions 2/3/5 (standalone per-customer-**installed** units in their own repo) are superseded by the corrected, as-built model: **in-repo** at `operator/connectors/<name>/`, **baked into the shared image** (one isolated venv per connector), **activated per-customer by binding** — identical posture to a catalog skill no persona enables. Governance authority is the overlay's hand-authored literal map; the manifest's `tool_classes` is only an oracle. Per-customer image bake is named as future hardening. Decisions 1 (MCP not `build:`) and 4 (in-Machine isolation) stand.

## Verified

`bash -n` + `shellcheck` clean; the loop stages `REFERENCE_API_KEY` when set and warn-skips when unset; operator `bin/tests` + `safety-substrate` (**242**) pass.

## Not in this PR (→ PR-4, the platform proof)

The `OVERLAY_REF` bump (the current pin is behind overlay main, so a bump deploys other in-flight overlay work — a coordinated deploy event), the **boot-smoke runtime-classification probe** (needs the bumped overlay to classify `mcp_reference_*`, and has both the baked manifest and installed overlay present to assert manifest⊆map agreement), binding `mcp:reference` on a **test seat**, and the Captain-authorized reprovision + live verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)