### PR TITLE
feat(operator): mcp:smokeball connector — phase-1 reads + create_memo (ADR 0053)

### DIFF
--- a/operator/connectors/smokeball/manifest.toml
+++ b/operator/connectors/smokeball/manifest.toml
@@ -1,0 +1,67 @@
+# mcp:smokeball — author-built connector for the Smokeball practice-management
+# API (the law-firm wedge system of record). ADR 0053.
+#
+# auth_model = client_credentials: for our own staging tenant the server mints
+# its own Bearer from client_id/secret (no user-consent round-trip). At go-live
+# the real firm's seat uses authorization_code (user-delegated); the connector
+# supports adding that grant without changing the tool surface.
+#
+# required_secrets are the RUNTIME env-var names the connector reads; the overlay
+# registry remaps them from the vault names (SMOKEBALL_STAGING_* in /ss). Every
+# API call carries x-api-key (SMOKEBALL_API_KEY) + Authorization: Bearer.
+#
+# tool_classes is the conformance ORACLE: every entry must agree with the
+# hand-authored overlay map (shared/action_classes.py) under the runtime name
+# mcp_smokeball_<tool>. The phase-1 surface is the reads + create_memo. The
+# trust-account fund-movement tools are NEVER exposed here and are hard-BANNED at
+# the overlay.
+[connector]
+name = "smokeball"
+capability = "PracticeManagement"
+auth_model = "client_credentials"
+description = "Smokeball practice-management API connector (law wedge system of record)."
+
+[connector.env_static]
+SMOKEBALL_REGION = "us"
+SMOKEBALL_ENVIRONMENT = "staging"
+
+[[connector.required_secrets]]
+runtime_env = "SMOKEBALL_CLIENT_ID"
+purpose = "OAuth client id (client_credentials grant). Remapped from SMOKEBALL_STAGING_CLIENT_ID."
+
+[[connector.required_secrets]]
+runtime_env = "SMOKEBALL_CLIENT_SECRET"
+purpose = "OAuth client secret. Remapped from SMOKEBALL_STAGING_CLIENT_SECRET."
+
+[[connector.required_secrets]]
+runtime_env = "SMOKEBALL_API_KEY"
+purpose = "The x-api-key header value (identifies the app on every request). Remapped from SMOKEBALL_STAGING_API_KEY."
+
+[connector.tool_classes]
+auth_status = "read"
+list_matters = "read"
+get_matter = "read"
+list_matter_types = "read"
+get_stage_sets = "read"
+get_stage_to_matter_mappings = "read"
+get_contacts = "read"
+get_contact = "read"
+get_contact_relations = "read"
+list_tasks = "read"
+get_task = "read"
+search_staff = "read"
+get_staff = "read"
+get_roles_on_matter = "read"
+get_relationships_on_matter = "read"
+get_files_on_matter = "read"
+get_file = "read"
+get_download_url = "read"
+get_memos_on_matter = "read"
+get_bank_accounts = "read"
+get_matter_balances = "read"
+get_matter_billing_config = "read"
+get_fees = "read"
+get_expenses = "read"
+get_webhook_subscriptions = "read"
+get_event_types = "read"
+create_memo = "internal_write"

--- a/operator/connectors/smokeball/pyproject.toml
+++ b/operator/connectors/smokeball/pyproject.toml
@@ -1,0 +1,21 @@
+[project]
+name = "smokeball-connector"
+version = "0.1.0"
+description = "Author-built MCP connector for the Smokeball practice-management API (the law-firm wedge system of record). ADR 0053."
+requires-python = ">=3.11"
+dependencies = [
+    "operator-connector-sdk",
+    "httpx>=0.27",
+]
+
+# The console-script the overlay registry launches as `command` (absolute path to
+# this connector's venv: /opt/connectors/smokeball/.venv/bin/smokeball-mcp).
+[project.scripts]
+smokeball-mcp = "smokeball_connector.__main__:main"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["smokeball_connector"]

--- a/operator/connectors/smokeball/smokeball_connector/__init__.py
+++ b/operator/connectors/smokeball/smokeball_connector/__init__.py
@@ -1,0 +1,8 @@
+"""mcp:smokeball — author-built MCP connector for the Smokeball practice-management
+API (the law-firm wedge system of record). ADR 0053.
+
+The first REAL author-built connector on the platform (the reference connector is
+the synthetic self-test). Phase-1 exposes the Smokeball read surface + create_memo;
+the trust-account fund-movement tools are never implemented and are hard-banned at
+the overlay. See operator/verticals/law-firm/smokeball-surface.md.
+"""

--- a/operator/connectors/smokeball/smokeball_connector/__main__.py
+++ b/operator/connectors/smokeball/smokeball_connector/__main__.py
@@ -1,0 +1,15 @@
+"""Entrypoint: serve the Smokeball connector over stdio. Installed as the
+``smokeball-mcp`` console-script; the overlay registry launches it by the absolute
+venv path."""
+
+from __future__ import annotations
+
+from .server import server
+
+
+def main() -> None:
+    server.run_stdio()
+
+
+if __name__ == "__main__":
+    main()

--- a/operator/connectors/smokeball/smokeball_connector/client.py
+++ b/operator/connectors/smokeball/smokeball_connector/client.py
@@ -1,0 +1,170 @@
+"""SmokeballClient — the REST/OAuth engine the tool layer wraps.
+
+Auth contract (confirmed against docs.smokeball.com, 2026-06-23, not assumed):
+
+- client_credentials grant → AWS Cognito token endpoint ``{auth_host}/oauth2/token``,
+  POST with ``Authorization: Basic base64(client_id:client_secret)`` and
+  ``Content-Type: application/x-www-form-urlencoded``, body
+  ``grant_type=client_credentials`` (+ ``client_id``). Response carries
+  ``access_token`` / ``expires_in`` / ``token_type: Bearer``.
+- EVERY API request carries TWO headers: ``x-api-key`` (the Smokeball-issued
+  client key, identifies the app) and ``Authorization: Bearer <token>``.
+- Region+environment select the host pair; the two MUST match (never cross
+  US/AU/UK or prod/staging hosts).
+
+This client is a FAITHFUL passthrough: read tools pass params straight through
+and return the raw JSON. It deliberately does NOT bake the still-unverified
+response/pagination shape or the ``updatedSince`` .NET-ticks conversion — those
+are confirmed at the connect step against a live tenant (see smokeball-surface.md
+ASSUMED list), and encoding a guess here would be the wrong kind of certainty.
+"""
+
+from __future__ import annotations
+
+import base64
+import time
+from typing import Any
+
+import httpx
+
+# region -> environment -> (auth_host, api_host). Confirmed from the base-URLs doc.
+_HOSTS: dict[tuple[str, str], tuple[str, str]] = {
+    ("us", "production"): ("https://auth.smokeball.com", "https://api.smokeball.com"),
+    ("us", "staging"): ("https://datastaging-auth.smokeball.com", "https://stagingapi.smokeball.com"),
+    ("au", "production"): ("https://auth.smokeball.com.au", "https://api.smokeball.com.au"),
+    ("au", "staging"): (
+        "https://datastaging-auth.smokeball.com.au",
+        "https://stagingapi.smokeball.com.au",
+    ),
+    ("uk", "production"): ("https://auth.smokeball.co.uk", "https://api.smokeball.co.uk"),
+    ("uk", "staging"): ("https://datastaging-auth.smokeball.co.uk", "https://stagingapi.smokeball.co.uk"),
+}
+
+_TOKEN_SKEW_SECONDS = 60
+_MAX_ATTEMPTS = 4
+
+
+def _clean(params: dict[str, Any] | None) -> dict[str, Any] | None:
+    """Drop None-valued query params so optional tool args don't send ``None``."""
+    if not params:
+        return None
+    return {k: v for k, v in params.items() if v is not None}
+
+
+class SmokeballAuthError(RuntimeError):
+    """Token mint failed — bad client creds, wrong region/env host, or the auth
+    server rejected the grant. Surfaced (without the secret) so the agent gets a
+    clear refusal rather than a raw 4xx."""
+
+
+class SmokeballClient:
+    def __init__(
+        self,
+        *,
+        region: str,
+        environment: str,
+        client_id: str,
+        client_secret: str,
+        api_key: str,
+        timeout: float = 30.0,
+    ) -> None:
+        key = (region.lower(), environment.lower())
+        if key not in _HOSTS:
+            raise ValueError(
+                f"unknown region/environment {region!r}/{environment!r}; "
+                f"valid: {sorted(_HOSTS)}"
+            )
+        self.region = region.lower()
+        self.environment = environment.lower()
+        self.auth_host, self.api_host = _HOSTS[key]
+        self._client_id = client_id
+        self._client_secret = client_secret
+        self._api_key = api_key
+        self._token: str | None = None
+        self._token_deadline = 0.0
+        self._http = httpx.Client(timeout=timeout)
+
+    # ---- auth -------------------------------------------------------------
+    def _mint_token(self) -> int:
+        basic = base64.b64encode(f"{self._client_id}:{self._client_secret}".encode()).decode()
+        try:
+            resp = self._http.post(
+                f"{self.auth_host}/oauth2/token",
+                headers={
+                    "Authorization": f"Basic {basic}",
+                    "Content-Type": "application/x-www-form-urlencoded",
+                },
+                data={"grant_type": "client_credentials", "client_id": self._client_id},
+            )
+        except httpx.HTTPError as exc:
+            raise SmokeballAuthError(f"token request to {self.auth_host} failed: {exc}") from exc
+        if resp.status_code != 200:
+            # Never include the response body verbatim — it can echo the grant.
+            raise SmokeballAuthError(
+                f"token mint rejected with HTTP {resp.status_code} at {self.auth_host}/oauth2/token"
+            )
+        body = resp.json()
+        token = body.get("access_token")
+        if not token:
+            raise SmokeballAuthError("token response had no access_token")
+        expires_in = int(body.get("expires_in", 3600))
+        self._token = token
+        self._token_deadline = time.monotonic() + max(expires_in - _TOKEN_SKEW_SECONDS, 0)
+        return expires_in
+
+    def _bearer(self) -> str:
+        if self._token is None or time.monotonic() >= self._token_deadline:
+            self._mint_token()
+        assert self._token is not None
+        return self._token
+
+    # ---- requests ---------------------------------------------------------
+    def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: dict[str, Any] | None = None,
+        json: Any | None = None,
+    ) -> Any:
+        """Issue an authenticated request. Returns parsed JSON (or None for an
+        empty body). Retries 429 with backoff and refreshes once on a 401."""
+        url = f"{self.api_host}{path}"
+        refreshed = False
+        last: httpx.Response | None = None
+        for attempt in range(_MAX_ATTEMPTS):
+            headers = {
+                "x-api-key": self._api_key,
+                "Authorization": f"Bearer {self._bearer()}",
+                "Accept": "application/json",
+            }
+            last = self._http.request(method, url, params=_clean(params), json=json, headers=headers)
+            if last.status_code == 429:
+                time.sleep(min(2**attempt, 8))
+                continue
+            if last.status_code == 401 and not refreshed:
+                self._token = None  # force a fresh mint, then retry once
+                refreshed = True
+                continue
+            last.raise_for_status()
+            if last.status_code == 204 or not last.content:
+                return None
+            return last.json()
+        assert last is not None
+        last.raise_for_status()
+        return None
+
+    def get(self, path: str, **params: Any) -> Any:
+        return self.request("GET", path, params=params)
+
+    # ---- health -----------------------------------------------------------
+    def auth_status(self) -> dict[str, Any]:
+        """Mint a token and report connectivity — never the token value."""
+        expires_in = self._mint_token()
+        return {
+            "authenticated": True,
+            "region": self.region,
+            "environment": self.environment,
+            "api_host": self.api_host,
+            "token_expires_in": expires_in,
+        }

--- a/operator/connectors/smokeball/smokeball_connector/server.py
+++ b/operator/connectors/smokeball/smokeball_connector/server.py
@@ -1,0 +1,295 @@
+"""The mcp:smokeball tool surface — Smokeball-native names over the real REST API.
+
+Phase-1 scope (per operator/verticals/law-firm/smokeball-surface.md): the read
+surface + ``create_memo`` (the one internal-log write the wedge uses). Gated
+writes (create_matter/patch_matter/create_task/...) are a phase-2 cut; the
+trust-account fund-movement tools (create_transaction/protect_funds/
+unprotect_funds) are NEVER implemented here and are hard-BANNED at the overlay.
+
+Paths and query params are taken from the live OpenAPI spec
+(docs.smokeball.com/openapi.json, 2026-06-23), which corrected several guesses in
+the surface doc (e.g. /mattertypes not /matter-types; files at
+/matters/{id}/documents/files; webhooks at /webhooks + /webhooks/types). Items
+still marked ASSUMED are confirmed at the connect step against a live tenant.
+
+The client is built LAZILY on first tool call, so the tool surface introspects
+(conformance, list_tools) without credentials.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from operator_connector_sdk.server import ConnectorServer
+
+from .client import SmokeballClient
+
+server = ConnectorServer("smokeball")
+
+_client: SmokeballClient | None = None
+
+
+def _get_client() -> SmokeballClient:
+    global _client
+    if _client is None:
+        _client = SmokeballClient(
+            region=os.environ.get("SMOKEBALL_REGION", "us"),
+            environment=os.environ.get("SMOKEBALL_ENVIRONMENT", "staging"),
+            client_id=os.environ["SMOKEBALL_CLIENT_ID"],
+            client_secret=os.environ["SMOKEBALL_CLIENT_SECRET"],
+            api_key=os.environ["SMOKEBALL_API_KEY"],
+        )
+    return _client
+
+
+# ---- Auth -----------------------------------------------------------------
+@server.tool()
+def auth_status() -> dict[str, Any]:
+    """Confirm the connector can authenticate (mints a token; never returns it)."""
+    return _get_client().auth_status()
+
+
+# ---- Matters --------------------------------------------------------------
+@server.tool()
+def list_matters(
+    status: str | None = None,
+    is_lead: bool | None = None,
+    matter_type_id: str | None = None,
+    contact_id: str | None = None,
+    search: str | None = None,
+    updated_since: str | None = None,
+    sort: str | None = None,
+    limit: int = 500,
+    offset: int = 0,
+) -> Any:
+    """List matters/leads. status=Open|Pending|Closed|Deleted|Cancelled;
+    is_lead splits leads vs matters. updated_since is passed verbatim (the
+    .NET-ticks vs ISO format is confirmed at connect)."""
+    return _get_client().get(
+        "/matters",
+        Status=status,
+        IsLead=is_lead,
+        MatterTypeId=matter_type_id,
+        ContactId=contact_id,
+        Search=search,
+        UpdatedSince=updated_since,
+        Sort=sort,
+        Limit=limit,
+        Offset=offset,
+    )
+
+
+@server.tool()
+def get_matter(matter_id: str) -> Any:
+    """Get one matter by id (includes personResponsibleStaffId, status, isLead)."""
+    return _get_client().get(f"/matters/{matter_id}")
+
+
+@server.tool()
+def list_matter_types() -> Any:
+    """List the firm's matter types (practice areas)."""
+    return _get_client().get("/mattertypes")
+
+
+@server.tool()
+def get_stage_sets() -> Any:
+    """List stage sets (the matter-stage definitions)."""
+    return _get_client().get("/stagesets")
+
+
+@server.tool()
+def get_stage_to_matter_mappings() -> Any:
+    """List matter stages (the stage model joined to matters). ASSUMED to be the
+    global /stages list; the exact stage<->matter-type join is confirmed at connect."""
+    return _get_client().get("/stages")
+
+
+# ---- Contacts -------------------------------------------------------------
+@server.tool()
+def get_contacts(
+    search: str | None = None,
+    type: str | None = None,
+    updated_since: str | None = None,
+    sort: str | None = None,
+    limit: int = 500,
+    offset: int = 0,
+) -> Any:
+    """Search/list contacts (intake dedupe + conflict cross-check)."""
+    return _get_client().get(
+        "/contacts",
+        Search=search,
+        Type=type,
+        UpdatedSince=updated_since,
+        Sort=sort,
+        Limit=limit,
+        Offset=offset,
+    )
+
+
+@server.tool()
+def get_contact(contact_id: str) -> Any:
+    """Get one contact by id."""
+    return _get_client().get(f"/contacts/{contact_id}")
+
+
+@server.tool()
+def get_contact_relations(contact_id: str) -> Any:
+    """Get a contact's relationships to other contacts."""
+    return _get_client().get(f"/contacts/{contact_id}/relations")
+
+
+# ---- Tasks ----------------------------------------------------------------
+@server.tool()
+def list_tasks(
+    matter_id: str | None = None,
+    is_completed: bool | None = None,
+    updated_since: str | None = None,
+    limit: int = 500,
+    offset: int = 0,
+) -> Any:
+    """List tasks (authored court/filing deadlines carry a due date). Filter by
+    matter and completion state."""
+    return _get_client().get(
+        "/tasks",
+        MatterId=matter_id,
+        IsCompleted=is_completed,
+        UpdatedSince=updated_since,
+        Limit=limit,
+        Offset=offset,
+    )
+
+
+@server.tool()
+def get_task(task_id: str) -> Any:
+    """Get one task by id."""
+    return _get_client().get(f"/tasks/{task_id}")
+
+
+# ---- Staff ----------------------------------------------------------------
+@server.tool()
+def search_staff(search: str | None = None, limit: int = 500, offset: int = 0) -> Any:
+    """Search staff/users (responsible-attorney attribution)."""
+    return _get_client().get("/staff", Search=search, Limit=limit, Offset=offset)
+
+
+@server.tool()
+def get_staff(staff_id: str) -> Any:
+    """Get one staff member by id."""
+    return _get_client().get(f"/staff/{staff_id}")
+
+
+# ---- Roles / relationships ------------------------------------------------
+@server.tool()
+def get_roles_on_matter(matter_id: str) -> Any:
+    """Get the roles (parties) on a matter."""
+    return _get_client().get(f"/matters/{matter_id}/roles")
+
+
+@server.tool()
+def get_relationships_on_matter(matter_id: str, role_id: str) -> Any:
+    """Get the relationships attached to a role on a matter. (The API nests
+    relationships under a role, so role_id is required — a connect-step
+    refinement of the surface-doc single-arg signature.)"""
+    return _get_client().get(f"/matters/{matter_id}/roles/{role_id}/relationships")
+
+
+# ---- Files / documents ----------------------------------------------------
+@server.tool()
+def get_files_on_matter(matter_id: str, limit: int = 500, offset: int = 0) -> Any:
+    """List documents/files on a matter."""
+    return _get_client().get(
+        f"/matters/{matter_id}/documents/files", Limit=limit, Offset=offset
+    )
+
+
+@server.tool()
+def get_file(matter_id: str, file_id: str) -> Any:
+    """Get one file's metadata. (Needs matter_id + file_id — the file lives under
+    its matter, not a flat /files/{id}.)"""
+    return _get_client().get(f"/matters/{matter_id}/documents/files/{file_id}")
+
+
+@server.tool()
+def get_download_url(matter_id: str, file_id: str) -> Any:
+    """Get a download URL/stream reference for a file."""
+    return _get_client().get(f"/matters/{matter_id}/documents/files/{file_id}/download")
+
+
+# ---- Memos ----------------------------------------------------------------
+@server.tool()
+def get_memos_on_matter(matter_id: str, limit: int = 500, offset: int = 0) -> Any:
+    """List memos (internal log entries) on a matter."""
+    return _get_client().get(f"/matters/{matter_id}/memos", Limit=limit, Offset=offset)
+
+
+@server.tool()
+def create_memo(matter_id: str, text: str) -> Any:
+    """Create an internal-log memo on a matter (the Clio create_note analogue —
+    the one autonomous internal write the wedge uses). The exact body field is
+    ASSUMED ``text`` and confirmed at the connect step against the live memo
+    schema; classified INTERNAL_WRITE at the overlay (never external send)."""
+    return _get_client().request("POST", f"/matters/{matter_id}/memos", json={"text": text})
+
+
+# ---- Trust / bank accounts (READS ONLY — fund movement is hard-banned) -----
+@server.tool()
+def get_bank_accounts(type: str | None = None, matter_id: str | None = None) -> Any:
+    """List bank accounts (trust/operating). Read-only — no fund movement."""
+    return _get_client().get("/bankaccounts", type=type, matterId=matter_id)
+
+
+@server.tool()
+def get_matter_balances(
+    bank_account_id: str,
+    matter_id: str | None = None,
+    limit: int = 500,
+    offset: int = 0,
+) -> Any:
+    """Per-matter trust balances (balance / protectedBalance / availableBalance).
+    The low-trust flag is availableBalance vs the firm's authored floor."""
+    return _get_client().get(
+        f"/bankaccounts/{bank_account_id}/matter-balances",
+        MatterId=matter_id,
+        Limit=limit,
+        Offset=offset,
+    )
+
+
+# ---- Billing (AR — kept distinct from trust) ------------------------------
+@server.tool()
+def get_matter_billing_config(matter_id: str) -> Any:
+    """Get a matter's billing configuration."""
+    return _get_client().get(f"/matters/{matter_id}/billingconfiguration")
+
+
+@server.tool()
+def get_fees(matter_id: str, limit: int = 500, offset: int = 0) -> Any:
+    """List fee entries on a matter (AR, not trust)."""
+    return _get_client().get(f"/matters/{matter_id}/fees", Limit=limit, Offset=offset)
+
+
+@server.tool()
+def get_expenses(
+    matter_id: str, updated_since: str | None = None, limit: int = 500, offset: int = 0
+) -> Any:
+    """List expense entries on a matter (AR, not trust)."""
+    return _get_client().get(
+        f"/matters/{matter_id}/expenses",
+        UpdatedSince=updated_since,
+        Limit=limit,
+        Offset=offset,
+    )
+
+
+# ---- Webhooks (provisioning-time event wiring) ----------------------------
+@server.tool()
+def get_webhook_subscriptions() -> Any:
+    """List the firm's webhook subscriptions."""
+    return _get_client().get("/webhooks")
+
+
+@server.tool()
+def get_event_types() -> Any:
+    """List the webhook event types the API can push (drives the event skills)."""
+    return _get_client().get("/webhooks/types")

--- a/operator/connectors/smokeball/tests/test_conformance.py
+++ b/operator/connectors/smokeball/tests/test_conformance.py
@@ -1,0 +1,105 @@
+"""Smokeball connector conformance — the platform standard, plus a live stdio
+round-trip via the real console-script. No live Smokeball calls (those need creds
+and are exercised at the connect step); the tool surface introspects credlessly
+because the REST client is built lazily."""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import anyio
+import pytest
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+from operator_connector_sdk import conformance
+from operator_connector_sdk.manifest import AuthModel, ConnectorManifest
+from operator_connector_sdk.naming import runtime_tool_name
+from smokeball_connector.server import server
+
+MANIFEST_PATH = Path(__file__).resolve().parents[1] / "manifest.toml"
+
+EXPECTED_TOOLS = {
+    "auth_status",
+    "list_matters",
+    "get_matter",
+    "list_matter_types",
+    "get_stage_sets",
+    "get_stage_to_matter_mappings",
+    "get_contacts",
+    "get_contact",
+    "get_contact_relations",
+    "list_tasks",
+    "get_task",
+    "search_staff",
+    "get_staff",
+    "get_roles_on_matter",
+    "get_relationships_on_matter",
+    "get_files_on_matter",
+    "get_file",
+    "get_download_url",
+    "get_memos_on_matter",
+    "get_bank_accounts",
+    "get_matter_balances",
+    "get_matter_billing_config",
+    "get_fees",
+    "get_expenses",
+    "get_webhook_subscriptions",
+    "get_event_types",
+    "create_memo",
+}
+
+_SCRIPT = shutil.which("smokeball-mcp")
+
+
+def _manifest() -> ConnectorManifest:
+    return ConnectorManifest.from_toml(MANIFEST_PATH)
+
+
+def test_manifest_loads_and_is_client_credentials() -> None:
+    m = _manifest()
+    assert m.name == "smokeball"
+    assert m.capability == "PracticeManagement"
+    assert m.auth_model is AuthModel.CLIENT_CREDENTIALS
+    assert {s.runtime_env for s in m.required_secrets} == {
+        "SMOKEBALL_CLIENT_ID",
+        "SMOKEBALL_CLIENT_SECRET",
+        "SMOKEBALL_API_KEY",
+    }
+
+
+def test_full_surface_matches() -> None:
+    assert {t.name for t in server.tool_surface()} == EXPECTED_TOOLS
+
+
+def test_conformance_every_tool_classified() -> None:
+    # No expected_unclassified: every Smokeball tool the server exposes MUST be
+    # declared, and every declaration MUST map to a live tool. Returns the
+    # runtime-prefixed map the overlay's manifest<=map test consumes.
+    runtime_map = conformance.run_all(server, _manifest())
+    # Trust-account fund-movement tools are never exposed here.
+    assert not any("transaction" in k or "protect" in k for k in runtime_map)
+    # The one write is an internal write under its runtime name; reads are reads.
+    assert runtime_map[runtime_tool_name("smokeball", "create_memo")] == "internal_write"
+    assert runtime_map[runtime_tool_name("smokeball", "get_matter_balances")] == "read"
+    assert runtime_map[runtime_tool_name("smokeball", "list_matters")] == "read"
+
+
+def test_only_create_memo_is_a_write() -> None:
+    m = _manifest()
+    writes = {t for t, c in m.tool_classes.items() if c != "read"}
+    assert writes == {"create_memo"}
+
+
+@pytest.mark.skipif(_SCRIPT is None, reason="smokeball-mcp console-script not on PATH")
+def test_stdio_serves_over_console_script() -> None:
+    async def _roundtrip() -> None:
+        async with stdio_client(StdioServerParameters(command=_SCRIPT)) as (read, write):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+                listed = await session.list_tools()
+                assert {t.name for t in listed.tools} == EXPECTED_TOOLS
+                for t in listed.tools:
+                    assert t.inputSchema.get("type") == "object"
+
+    anyio.run(_roundtrip)

--- a/operator/verticals/law-firm/smokeball-surface.md
+++ b/operator/verticals/law-firm/smokeball-surface.md
@@ -6,6 +6,16 @@
 
 > Re-pin this file whenever the API or the `mcp:smokeball` server version bumps. The connect step replaces "published-doc assumptions" here with a real staging-tenant round-trip; until then, treat every shape below as the **contract of record but unverified against a live tenant**. Items marked ⚠️ or ASSUMED must be confirmed at connect.
 
+## CONFIRMED LIVE — 2026-06-23 (mcp:smokeball v0.1.0, staging round-trip)
+
+The `mcp:smokeball` connector was built against the OpenAPI spec and round-tripped against the real US staging tenant (`stagingapi.smokeball.com`) with the `SMOKEBALL_STAGING_*` credentials in Infisical `/ss`:
+
+- **Auth CONFIRMED.** `client_credentials` grant works: `POST {auth_host}/oauth2/token` with `Authorization: Basic base64(client_id:secret)` + `Content-Type: application/x-www-form-urlencoded`, body `grant_type=client_credentials` → `access_token` (`token_type: Bearer`, `expires_in: 21600` = 6h). AWS Cognito.
+- **Request contract CONFIRMED.** Every API call needs **two** headers: `x-api-key` (the `SMOKEBALL_STAGING_API_KEY`) + `Authorization: Bearer`. `GET /matters?Limit=1` returned 200.
+- **Pagination envelope CONFIRMED.** List responses are a HATEOAS envelope `{ value: [...], offset, limit, size, first, previous, next, last, href }` — not a bare array. Skills read `value`.
+- **Path corrections (OpenAPI vs the guesses above).** `/mattertypes` (not `/matter-types`); files at `/matters/{matterId}/documents/files` (+ `/{fileId}`, `/{fileId}/download`) — `get_file`/`get_download_url` need **matterId + fileId**, not a flat file id; webhooks at `/webhooks` + event types at `/webhooks/types`; query params are **PascalCase** (`Status`, `IsLead`, `MatterTypeId`, `ContactId`, `UpdatedSince`, `Sort`, `Limit`, `Offset`); tasks filter by `IsCompleted` (bool), `MatterId`.
+- **Still ASSUMED (verify when the wedge wires writes).** `create_memo` request-body field (the server sends `{text}`; the live memo schema is an inline object the OpenAPI did not expand); the `UpdatedSince` .NET-ticks-vs-ISO format; the stage<->matter-type join (`get_stage_to_matter_mappings` hits `/stages`).
+
 ## Base URLs and auth (US region — confirm region with the firm)
 
 |           | Production                   | Staging / dev                            |


### PR DESCRIPTION
## What

The **first real author-built connector** on the ADR 0053 platform (the reference connector was the synthetic self-test). A Python stdio MCP server for the **Smokeball** practice-management API — the law-firm wedge system of record.

## Built and VERIFIED LIVE

Round-tripped against the **US staging tenant** (`stagingapi.smokeball.com`) with the `SMOKEBALL_STAGING_*` creds in Infisical `/ss`:
- **Auth confirmed:** `client_credentials` → Cognito `/oauth2/token` (Basic auth) mints a Bearer (`expires_in 21600`).
- **Request contract confirmed:** `x-api-key` + `Authorization: Bearer` on every call; `GET /matters` → 200, HATEOAS `{value, offset, limit, size, first/last/href}` envelope.
- Built against the **live OpenAPI spec**, which corrected several `smokeball-surface.md` guesses (`/mattertypes` not `/matter-types`; files under `/matters/{id}/documents/files`; `get_file`/`get_download_url` need `matterId`+`fileId`; webhooks at `/webhooks` + `/webhooks/types`; PascalCase query params). The surface doc now carries a **CONFIRMED LIVE** section.

## Surface

- `client.py` — `client_credentials` OAuth, region/env host selection, `x-api-key`+Bearer, 429 backoff, 401 refresh-once. Faithful passthrough (no baked pagination/ticks guesses).
- `server.py` — phase-1: **26 read tools + `create_memo`** (Smokeball-native names → real REST paths). Lazy client → conformance runs **credlessly**.
- `manifest.toml` — capability `PracticeManagement`, `auth_model: client_credentials`, `tool_classes` matching the overlay map exactly (26 READ + `create_memo` INTERNAL_WRITE).
- **Trust-account fund-movement tools never exposed** (`create_transaction`/`protect_funds`/`unprotect_funds`) — hard-BANNED at the overlay. Gated writes (`create_matter`/`patch_matter`/...) are a phase-2 cut.

## Test

Platform conformance suite + a live stdio round-trip via the real `smokeball-mcp` console-script (27 tools, all classified); ruff clean. The Dockerfile per-connector venv install and the `operator-substrate` conformance step are generic — they pick this up with no edit.

## Next (separate)

- Overlay `MCP_CONNECTOR_REGISTRY['smokeball']` entry so `translate.py` materializes it (the `mcp_smokeball_*` classification already exists in the overlay map).
- Connect-step: stage the staging creds onto the `pilot-smokeball` Machine + `OVERLAY_REF` bump + reprovision + in-Machine live verify (Captain-authorized).

🤖 Generated with [Claude Code](https://claude.com/claude-code)