### PR TITLE
fix(operator): bash-3.2-safe provisioning + .dockerignore (ADR 0053 connect-step)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,26 @@
+# Build-context hygiene for the operator Machine image.
+#
+# operator/templates/Dockerfile only COPYs from operator/* and runs its own
+# `npm install` inside the build, so NONE of the dirs below belong in the build
+# context. Their absence here was uploading the entire ~650M worktree (almost
+# all node_modules) to the Depot remote builder, which stalled `load build
+# context` on a cold first build (pilot-smokeball, 2026-06-23). Everything the
+# image needs lives under operator/ and is left intact.
+node_modules
+.git
+dist
+.astro
+.vercel
+.wrangler
+coverage
+playwright-report
+test-results
+.claude
+.vscode
+.idea
+*.log
+.DS_Store
+.env
+.env.*
+.dev.vars
+operator/.rendered

--- a/operator/bin/provision-customer.sh
+++ b/operator/bin/provision-customer.sh
@@ -524,19 +524,23 @@ fi
 # only; the registry owns how each is wired.
 _CONNECTORS_DIR="${REPO_ROOT}/operator/connectors"
 if [ -d "${_CONNECTORS_DIR}" ]; then
-  while IFS=$'\t' read -r _conn_name _secret_name; do
-    [ -n "${_secret_name}" ] || continue
-    stage_secret_from_env "${_secret_name}" "${!_secret_name:-}" \
-      "author-built connector ${_conn_name} secret (ADR 0053)"
-  done < <(
+  # Capture via $(...) command substitution + a <<< here-string — NOT a
+  # `done < <(python3 ... <<'PY')` process substitution. A heredoc INSIDE a <(...)
+  # process substitution trips a "bad substitution: no closing ')' in <(" parse
+  # error on some bash builds (it aborted a live reprovision 2026-06-23); a
+  # heredoc inside $() command substitution is fine (see the CLIO_ENABLED probe).
+  _authored_secrets="$(
     python3 - "${_CONNECTORS_DIR}" <<'PY'
 import pathlib
 import sys
 import tomllib
 
 # Connectors whose operator-env credential NAMES differ from their runtime names
-# (a remap the flat loop can't do) are staged by a dedicated block above; skip
-# them here so the loop doesn't warn that the runtime name is unset.
+# (a remap the flat loop cannot do) are staged by a dedicated block above; skip
+# them here so the loop does not warn that the runtime name is unset.
+# NOTE: keep this heredoc body free of apostrophes. macOS bash 3.2 mis-parses a
+# stray apostrophe inside a heredoc-in-command-substitution and consumes to EOF
+# (that aborted a reprovision on 2026-06-23).
 REMAP_HANDLED = {"smokeball"}
 root = pathlib.Path(sys.argv[1])
 for manifest in sorted(root.glob("*/manifest.toml")):
@@ -556,8 +560,13 @@ for manifest in sorted(root.glob("*/manifest.toml")):
         if name:
             print(f"{manifest.parent.name}\t{name}")
 PY
-  )
-  unset _conn_name _secret_name
+  )"
+  while IFS=$'\t' read -r _conn_name _secret_name; do
+    [ -n "${_secret_name}" ] || continue
+    stage_secret_from_env "${_secret_name}" "${!_secret_name:-}" \
+      "author-built connector ${_conn_name} secret (ADR 0053)"
+  done <<< "${_authored_secrets}"
+  unset _conn_name _secret_name _authored_secrets
 fi
 unset _CONNECTORS_DIR
 


### PR DESCRIPTION
## What

Three deploy-plumbing bugs surfaced during the **first real reprovision after the connector platform landed** (`pilot-smokeball`, the Smokeball staging seat). None are in the connector — which built and live-verified cleanly; all three are macOS bash 3.2 / build-context issues.

1. **bash-3.2 process-substitution heredoc.** The author-built-connector secrets loop used `done < <(python3 - <<'PY' … )` — a heredoc inside a `<(…)` process substitution, which bash 3.2 (`/usr/bin/env bash`, what `reprovision` runs under) errors on: `bad substitution: no closing ')'`. Rewritten to `$()` command substitution + a `<<<` here-string (the pattern the working `CLIO_ENABLED` probe already uses).
2. **bash-3.2 apostrophe-in-heredoc.** A stray `can't`/`doesn't` inside the heredoc body made bash 3.2 mis-match quotes and consume to EOF. Body is now apostrophe-free, with a NOTE.
3. **Missing `.dockerignore`.** There was none, so `fly deploy` uploaded the entire **~650M** worktree (almost all `node_modules`, which the image never uses) to the Depot builder and **stalled `load build context`** on a cold build. The image only COPYs `operator/*`; excluding `node_modules/.git/dist/.claude/caches` drops the context to **2.4MB** (`transferring context: 2.40MB 4.8s done`). Speeds every operator build.

## Verified

Under the **deploy bash** this time (`/bin/bash` 3.2): `bash -n` clean, `shellcheck` clean — and the live reprovision of `pilot-smokeball` ran **end to end**: Machine healthy, and the in-Machine boot-smoke reported `connector-classification-probe: OK (29 declared tool(s) across 2 author-built connector(s) agree with the overlay map)`.

## Lesson / follow-up

`bash -n` passed under homebrew bash 5.x (the shell's `bash`) while the deploy bash (3.2) failed — provisioning scripts must be validated under `/usr/bin/env bash`. Follow-up: a CI lint of `provision-customer.sh` under bash 3.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)