### PR TITLE
feat(operator): Smokeball firm-delegated (authorization_code) connect flow — A&P pilot prep (ADR 0053)

### DIFF
--- a/bin/connect-smokeball.sh
+++ b/bin/connect-smokeball.sh
@@ -22,7 +22,9 @@
 #
 # Required env (Infisical /ss):
 #   OAUTH_STATE_SIGNING_KEY   32 bytes, base64 — the same key the callback verifies with
-#   PORTAL_BASE_URL           e.g. https://portal.smd.services (origin of the callback)
+#   APP_BASE_URL              the APEX origin, e.g. https://smd.services (the callback
+#                             must be on the apex — the portal/admin subdomains rewrite
+#                             /api/operator/* into a 404; see REDIRECT_URI note below)
 #   SMOKEBALL_STAGING_CLIENT_ID  (staging seats)  OR
 #   SMOKEBALL_PROD_CLIENT_ID     (production seats)
 #
@@ -86,7 +88,7 @@ fi
 
 MISSING=()
 [ -n "${OAUTH_STATE_SIGNING_KEY:-}" ] || MISSING+=("OAUTH_STATE_SIGNING_KEY")
-[ -n "${PORTAL_BASE_URL:-}" ]         || MISSING+=("PORTAL_BASE_URL")
+[ -n "${APP_BASE_URL:-}" ]            || MISSING+=("APP_BASE_URL")
 [ -n "${CLIENT_ID}" ]                 || MISSING+=("${CLIENT_ID_SRC}")
 if [ "${#MISSING[@]}" -gt 0 ]; then
   echo "FATAL: missing required env: ${MISSING[*]}" >&2
@@ -94,7 +96,13 @@ if [ "${#MISSING[@]}" -gt 0 ]; then
   exit 2
 fi
 
-REDIRECT_URI="${PORTAL_BASE_URL%/}/api/operator/smokeball/connect-callback"
+# The callback lives on the APEX (smd.services), NOT the portal/admin subdomains:
+# src/middleware.ts rewrites any non-/portal (or non-/admin) path on those
+# subdomains by prepending /portal (/admin), which would 404 /api/operator/*. The
+# apex serves /api/* directly. The callback itself is host-agnostic (it derives
+# redirect_uri from its own request URL), so the only requirement is that this
+# URL and the one registered on the Smokeball app agree — both the apex.
+REDIRECT_URI="${APP_BASE_URL%/}/api/operator/smokeball/connect-callback"
 PROVIDER="smokeball:${SB_REGION}:${SB_ENV}"
 REVIEWER_ID="${SMOKEBALL_CONNECT_REVIEWER_ID:-connect-script}"
 

--- a/bin/connect-smokeball.sh
+++ b/bin/connect-smokeball.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+#
+# connect-smokeball.sh CUSTOMER_SLUG
+#
+# Captain-invoked. Prints a Smokeball authorize URL for the firm-delegated
+# (authorization_code) connect flow (ADR 0053). The Captain hands the URL to the
+# firm; the firm signs into Smokeball + clicks Allow; Smokeball redirects to the
+# hosted callback (/api/operator/smokeball/connect-callback) which exchanges the
+# code, relays the refresh token to the Machine, and renders "✓ Connected".
+#
+# The seat's environment + region are read from its customer.yaml smokeball
+# connector block (default us / staging). The matching app client_id is sourced
+# from the operator env: SMOKEBALL_STAGING_CLIENT_ID (staging) or
+# SMOKEBALL_PROD_CLIENT_ID (production). The client SECRET is NOT needed here
+# (only the callback exchanges the code).
+#
+# This is the INITIATE half only — it prints a URL and never sends email and
+# never touches a secret value. Run under the operator env so the signing key +
+# client id are present:
+#
+#   infisical run --env=prod --path=/ss -- bin/connect-smokeball.sh ashton-price
+#
+# Required env (Infisical /ss):
+#   OAUTH_STATE_SIGNING_KEY   32 bytes, base64 — the same key the callback verifies with
+#   PORTAL_BASE_URL           e.g. https://portal.smd.services (origin of the callback)
+#   SMOKEBALL_STAGING_CLIENT_ID  (staging seats)  OR
+#   SMOKEBALL_PROD_CLIENT_ID     (production seats)
+#
+# Optional:
+#   SMOKEBALL_CONNECT_REVIEWER_ID  audit id carried in the state (default: "connect-script")
+
+set -euo pipefail
+
+usage() {
+  echo "Usage: connect-smokeball.sh CUSTOMER_SLUG" >&2
+  exit 1
+}
+
+[ "$#" -eq 1 ] || usage
+CUSTOMER_SLUG="$1"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CUSTOMER_YAML="$REPO_ROOT/operator/customers/$CUSTOMER_SLUG/customer.yaml"
+[ -f "$CUSTOMER_YAML" ] || { echo "FATAL: no customer.yaml at $CUSTOMER_YAML" >&2; exit 1; }
+
+# Read environment + region from the smokeball connector block (defaults staging/us).
+SB_FIELDS=()
+while IFS= read -r _line; do SB_FIELDS+=("${_line}"); done < <(
+  CUSTOMER_YAML="$CUSTOMER_YAML" uv run --quiet --with pyyaml python3 -c "
+import os, yaml
+with open(os.environ['CUSTOMER_YAML']) as f:
+    c = yaml.safe_load(f) or {}
+sb = {}
+for conn in (c.get('connectors') or {}).values():
+    if isinstance(conn, dict) and str(conn.get('backend', '')) == 'mcp:smokeball':
+        sb = conn
+        break
+print(str(sb.get('environment', 'staging')).strip().lower())
+print(str(sb.get('region', 'us')).strip().lower())
+"
+)
+SB_ENV="${SB_FIELDS[0]:-staging}"
+SB_REGION="${SB_FIELDS[1]:-us}"
+[ "$SB_ENV" = "production" ] || SB_ENV="staging"   # normalize anything else to staging
+
+# Auth host by (region, environment) — must match the connector + provider tables.
+case "${SB_REGION}:${SB_ENV}" in
+  us:production) AUTH_HOST="https://auth.smokeball.com" ;;
+  us:staging)    AUTH_HOST="https://datastaging-auth.smokeball.com" ;;
+  au:production) AUTH_HOST="https://auth.smokeball.com.au" ;;
+  au:staging)    AUTH_HOST="https://datastaging-auth.smokeball.com.au" ;;
+  uk:production) AUTH_HOST="https://auth.smokeball.co.uk" ;;
+  uk:staging)    AUTH_HOST="https://datastaging-auth.smokeball.co.uk" ;;
+  *) echo "FATAL: unknown region/environment ${SB_REGION}/${SB_ENV}" >&2; exit 1 ;;
+esac
+
+# Client id from the environment-matched operator-env name.
+if [ "$SB_ENV" = "production" ]; then
+  CLIENT_ID="${SMOKEBALL_PROD_CLIENT_ID:-}"
+  CLIENT_ID_SRC="SMOKEBALL_PROD_CLIENT_ID"
+else
+  CLIENT_ID="${SMOKEBALL_STAGING_CLIENT_ID:-}"
+  CLIENT_ID_SRC="SMOKEBALL_STAGING_CLIENT_ID"
+fi
+
+MISSING=()
+[ -n "${OAUTH_STATE_SIGNING_KEY:-}" ] || MISSING+=("OAUTH_STATE_SIGNING_KEY")
+[ -n "${PORTAL_BASE_URL:-}" ]         || MISSING+=("PORTAL_BASE_URL")
+[ -n "${CLIENT_ID}" ]                 || MISSING+=("${CLIENT_ID_SRC}")
+if [ "${#MISSING[@]}" -gt 0 ]; then
+  echo "FATAL: missing required env: ${MISSING[*]}" >&2
+  echo "       Run under: infisical run --env=prod --path=/ss -- bin/connect-smokeball.sh ${CUSTOMER_SLUG}" >&2
+  exit 2
+fi
+
+REDIRECT_URI="${PORTAL_BASE_URL%/}/api/operator/smokeball/connect-callback"
+PROVIDER="smokeball:${SB_REGION}:${SB_ENV}"
+REVIEWER_ID="${SMOKEBALL_CONNECT_REVIEWER_ID:-connect-script}"
+
+# Single node invocation: signs state (same HMAC scheme as src/lib/oauth/state.ts),
+# builds the authorize URL, prints only the URL. Scopes mirror
+# SMOKEBALL_OPERATOR_SCOPES in src/lib/oauth/providers/smokeball.ts (keep in sync).
+URL="$(
+  CUSTOMER_SLUG="$CUSTOMER_SLUG" \
+  PROVIDER="$PROVIDER" \
+  REVIEWER_ID="$REVIEWER_ID" \
+  CLIENT_ID="$CLIENT_ID" \
+  REDIRECT_URI="$REDIRECT_URI" \
+  AUTH_HOST="$AUTH_HOST" \
+  SIGNING_KEY="$OAUTH_STATE_SIGNING_KEY" \
+  node --input-type=module -e '
+    import { createHmac } from "node:crypto";
+
+    const customer_id = process.env.CUSTOMER_SLUG;
+    const provider = process.env.PROVIDER;
+    const reviewer_id = process.env.REVIEWER_ID;
+    const client_id = process.env.CLIENT_ID;
+    const redirect_uri = process.env.REDIRECT_URI;
+    const auth_host = process.env.AUTH_HOST;
+    const signingKeyB64 = process.env.SIGNING_KEY;
+
+    function b64UrlEncode(buf) {
+      return Buffer.from(buf).toString("base64")
+        .replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+    }
+
+    const exp = Math.floor(Date.now() / 1000) + 600; // 10-minute TTL
+    const nonce = crypto.randomUUID();
+    const payload = JSON.stringify({ v: 1, customer_id, provider, reviewer_id, nonce, exp });
+    const payloadB64 = b64UrlEncode(payload);
+    const keyBytes = Buffer.from(signingKeyB64, "base64");
+    const sigB64 = b64UrlEncode(createHmac("sha256", keyBytes).update(payloadB64).digest());
+    const state = `${payloadB64}.${sigB64}`;
+
+    const scopes = [
+      "matters/read", "contacts/read", "mattertypes/read", "stages/read",
+      "tasks/read", "staff/read", "roles/read", "documents/read",
+      "memos/read", "memos/write", "bankaccounts/read", "bankaccountbalances/read",
+      "billingconfiguration/read", "fees/read", "expenses/read",
+      "webhooks/read", "webhooks/write",
+    ];
+
+    const params = new URLSearchParams({
+      response_type: "code",
+      client_id,
+      redirect_uri,
+      scope: scopes.join(" "),
+      state,
+    });
+    process.stdout.write(`${auth_host}/oauth2/authorize?${params.toString()}\n`);
+  '
+)"
+
+[ -n "$URL" ] || { echo "FATAL: state-signing step produced no URL" >&2; exit 1; }
+
+cat <<EOF
+
+Smokeball connect — ${CUSTOMER_SLUG}
+  environment:   ${SB_ENV}  (region ${SB_REGION}, host ${AUTH_HOST})
+  redirect_uri:  ${REDIRECT_URI}
+  state TTL:     10 minutes
+
+Hand this URL to the firm. They sign into Smokeball + click Allow:
+
+${URL}
+
+EOF

--- a/operator/bin/provision-customer.sh
+++ b/operator/bin/provision-customer.sh
@@ -494,19 +494,76 @@ fi
 stage_secret_from_env GOOGLE_SERVICE_ACCOUNT_JSON "${GOOGLE_SERVICE_ACCOUNT_JSON:-}" "base64 service-account key (domain-wide delegation)"
 
 # ---------- Step 6b-smokeball: Smokeball connector creds (ADR 0053, name remap) --
-# mcp:smokeball reads env-agnostic SMOKEBALL_CLIENT_ID/SECRET/API_KEY and mints its
-# own Bearer (client_credentials). The values live in operator env under the
-# SMOKEBALL_STAGING_* names (SMD's Partner-Program STAGING app, Infisical /ss), so
-# this is a NAME REMAP the manifest-driven loop below can't do (it stages by the
-# runtime name). Seat-gated: the staging app key only lands on a Machine that
-# actually binds Smokeball. The connector + manifest + overlay registry all stay
-# env-agnostic; this per-seat block is the right home for environment-specific
-# credential sourcing. At go-live the real firm's seat sources its own prod app
-# creds here (a separate path), not these staging keys.
+# mcp:smokeball reads env-agnostic SMOKEBALL_CLIENT_ID/SECRET/API_KEY. The operator
+# env holds them under environment-specific names — SMOKEBALL_STAGING_* (SMD's own
+# Partner-Program STAGING app) and SMOKEBALL_PROD_* (a real firm's PRODUCTION app,
+# obtained at go-live) — so this is a NAME REMAP the manifest-driven loop below
+# can't do. The seat declares which environment it is via the smokeball connector
+# block in customer.yaml:
+#
+#   connectors:
+#     PracticeManagement:
+#       backend: mcp:smokeball
+#       environment: staging | production   # default staging; selects host pair + cred set
+#       auth_mode: client_credentials | authorization_code   # default client_credentials
+#       account_id: <id>                     # optional; multi-account URL prefix
+#
+# SMOKEBALL_ENVIRONMENT is a REQUIRED runtime secret (the overlay fail-closes the
+# connector if it is unset) so a prod seat can never silently default to staging.
+# The authorization_code refresh token is NOT staged here — it is obtained at the
+# connect step (operator/bin/connect-smokeball.sh) and set as SMOKEBALL_REFRESH_TOKEN
+# directly. A prod seat whose SMOKEBALL_PROD_* creds are not yet in the operator env
+# simply warns+skips → the connector is unwired this boot (boot-before-token), and
+# wires once the creds land.
 if grep -qE 'backend:[[:space:]]*mcp:smokeball' "${CUSTOMER_DIR}/customer.yaml" 2>/dev/null; then
-  stage_secret_from_env SMOKEBALL_CLIENT_ID     "${SMOKEBALL_STAGING_CLIENT_ID:-}"     "Smokeball OAuth client id (client_credentials; from SMOKEBALL_STAGING_CLIENT_ID)"
-  stage_secret_from_env SMOKEBALL_CLIENT_SECRET "${SMOKEBALL_STAGING_CLIENT_SECRET:-}" "Smokeball OAuth client secret (from SMOKEBALL_STAGING_CLIENT_SECRET)"
-  stage_secret_from_env SMOKEBALL_API_KEY       "${SMOKEBALL_STAGING_API_KEY:-}"       "Smokeball x-api-key per-request app key (from SMOKEBALL_STAGING_API_KEY)"
+  SB_PARSE_PY="
+import yaml
+with open('${CUSTOMER_YAML}') as f:
+    c = yaml.safe_load(f) or {}
+sb = {}
+for conn in (c.get('connectors') or {}).values():
+    if isinstance(conn, dict) and str(conn.get('backend', '')) == 'mcp:smokeball':
+        sb = conn
+        break
+print(str(sb.get('environment', 'staging')).strip().lower())
+print(str(sb.get('auth_mode', 'client_credentials')).strip().lower())
+print(str(sb.get('account_id') or '').strip())
+"
+  SB_FIELDS=()
+  while IFS= read -r _line; do SB_FIELDS+=("${_line}"); done \
+    < <(uv run --quiet --with pyyaml python3 -c "${SB_PARSE_PY}")
+  SB_ENV="${SB_FIELDS[0]:-staging}"
+  SB_AUTH_MODE="${SB_FIELDS[1]:-client_credentials}"
+  SB_ACCOUNT_ID="${SB_FIELDS[2]:-}"
+
+  if [ "${SB_ENV}" = "production" ]; then
+    _sb_cid="${SMOKEBALL_PROD_CLIENT_ID:-}"
+    _sb_sec="${SMOKEBALL_PROD_CLIENT_SECRET:-}"
+    _sb_key="${SMOKEBALL_PROD_API_KEY:-}"
+    _sb_src="SMOKEBALL_PROD"
+  else
+    SB_ENV="staging"  # normalize anything non-production to staging (fail-safe)
+    _sb_cid="${SMOKEBALL_STAGING_CLIENT_ID:-}"
+    _sb_sec="${SMOKEBALL_STAGING_CLIENT_SECRET:-}"
+    _sb_key="${SMOKEBALL_STAGING_API_KEY:-}"
+    _sb_src="SMOKEBALL_STAGING"
+  fi
+
+  log "Smokeball seat: environment=${SB_ENV} auth_mode=${SB_AUTH_MODE} (creds from ${_sb_src}_*)"
+  stage_secret_from_env SMOKEBALL_CLIENT_ID     "${_sb_cid}" "Smokeball OAuth client id (from ${_sb_src}_CLIENT_ID)"
+  stage_secret_from_env SMOKEBALL_CLIENT_SECRET "${_sb_sec}" "Smokeball OAuth client secret (from ${_sb_src}_CLIENT_SECRET)"
+  stage_secret_from_env SMOKEBALL_API_KEY       "${_sb_key}" "Smokeball x-api-key per-request app key (from ${_sb_src}_API_KEY)"
+  # Required per-seat — value is always present (default staging), never silently prod-as-staging.
+  stage_secret_from_env SMOKEBALL_ENVIRONMENT   "${SB_ENV}"  "Smokeball host environment (staging|production)"
+  # Optional per-seat. client_credentials is the connector default, so stage AUTH_MODE
+  # only when the firm-delegated grant is authored; account_id only when present.
+  if [ "${SB_AUTH_MODE}" = "authorization_code" ]; then
+    stage_secret_from_env SMOKEBALL_AUTH_MODE "authorization_code" "Smokeball grant: firm-delegated (refresh token set at the connect step)"
+  fi
+  if [ -n "${SB_ACCOUNT_ID}" ]; then
+    stage_secret_from_env SMOKEBALL_ACCOUNT_ID "${SB_ACCOUNT_ID}" "Smokeball multi-account URL prefix"
+  fi
+  unset SB_PARSE_PY SB_FIELDS SB_ENV SB_AUTH_MODE SB_ACCOUNT_ID _sb_cid _sb_sec _sb_key _sb_src
 fi
 
 # ---------- Step 6b-authored: author-built connector secrets (ADR 0053) ----------

--- a/operator/connectors/smokeball/smokeball_connector/client.py
+++ b/operator/connectors/smokeball/smokeball_connector/client.py
@@ -2,15 +2,29 @@
 
 Auth contract (confirmed against docs.smokeball.com, 2026-06-23, not assumed):
 
-- client_credentials grant → AWS Cognito token endpoint ``{auth_host}/oauth2/token``,
-  POST with ``Authorization: Basic base64(client_id:client_secret)`` and
-  ``Content-Type: application/x-www-form-urlencoded``, body
-  ``grant_type=client_credentials`` (+ ``client_id``). Response carries
-  ``access_token`` / ``expires_in`` / ``token_type: Bearer``.
+Two grants, selected by ``auth_mode`` (both mint a Bearer at the same Cognito
+endpoint ``{auth_host}/oauth2/token`` with ``Authorization: Basic
+base64(client_id:client_secret)`` and ``Content-Type:
+application/x-www-form-urlencoded``):
+
+- ``client_credentials`` (default) — body ``grant_type=client_credentials`` (+
+  ``client_id``). Server-to-server; no user consent. The path proven live against
+  our own staging tenant.
+- ``authorization_code`` — the firm-delegated grant. The user-consent round-trip
+  (authorize → code → first token) happens OUTSIDE this client (the connect flow);
+  this client receives the resulting ``refresh_token`` and mints access tokens with
+  body ``grant_type=refresh_token`` (+ ``client_id`` + ``refresh_token``). If the
+  refresh response rotates the refresh token, we hold the new one in memory.
+
+Both responses carry ``access_token`` / ``expires_in`` / ``token_type: Bearer``.
+
 - EVERY API request carries TWO headers: ``x-api-key`` (the Smokeball-issued
   client key, identifies the app) and ``Authorization: Bearer <token>``.
 - Region+environment select the host pair; the two MUST match (never cross
   US/AU/UK or prod/staging hosts).
+- ``account_id`` (optional) — when set, every API path is prefixed ``/{account_id}``
+  (the documented multi-account server-to-server shape; a single-firm seat usually
+  leaves it unset).
 
 This client is a FAITHFUL passthrough: read tools pass params straight through
 and return the raw JSON. It deliberately does NOT bake the still-unverified
@@ -42,6 +56,7 @@ _HOSTS: dict[tuple[str, str], tuple[str, str]] = {
 
 _TOKEN_SKEW_SECONDS = 60
 _MAX_ATTEMPTS = 4
+_AUTH_MODES = ("client_credentials", "authorization_code")
 
 
 def _clean(params: dict[str, Any] | None) -> dict[str, Any] | None:
@@ -66,6 +81,9 @@ class SmokeballClient:
         client_id: str,
         client_secret: str,
         api_key: str,
+        auth_mode: str = "client_credentials",
+        refresh_token: str | None = None,
+        account_id: str | None = None,
         timeout: float = 30.0,
     ) -> None:
         key = (region.lower(), environment.lower())
@@ -74,17 +92,38 @@ class SmokeballClient:
                 f"unknown region/environment {region!r}/{environment!r}; "
                 f"valid: {sorted(_HOSTS)}"
             )
+        if auth_mode not in _AUTH_MODES:
+            raise ValueError(f"unknown auth_mode {auth_mode!r}; valid: {_AUTH_MODES}")
+        if auth_mode == "authorization_code" and not refresh_token:
+            raise ValueError("auth_mode='authorization_code' requires a refresh_token")
         self.region = region.lower()
         self.environment = environment.lower()
         self.auth_host, self.api_host = _HOSTS[key]
+        self.auth_mode = auth_mode
         self._client_id = client_id
         self._client_secret = client_secret
         self._api_key = api_key
+        self._refresh_token = refresh_token
+        # Normalize the optional account prefix to a bare segment ("abc", not
+        # "/abc/") so request() can build "{api_host}/{account_id}{path}" cleanly.
+        self._account_id = account_id.strip("/") if account_id else None
         self._token: str | None = None
         self._token_deadline = 0.0
         self._http = httpx.Client(timeout=timeout)
 
     # ---- auth -------------------------------------------------------------
+    def _token_request_body(self) -> dict[str, str]:
+        """The grant-specific form body. client_credentials mints from the app's
+        own creds; authorization_code mints from the firm-delegated refresh token."""
+        if self.auth_mode == "authorization_code":
+            # _refresh_token is guaranteed non-None for this mode (ctor enforces it).
+            return {
+                "grant_type": "refresh_token",
+                "client_id": self._client_id,
+                "refresh_token": self._refresh_token or "",
+            }
+        return {"grant_type": "client_credentials", "client_id": self._client_id}
+
     def _mint_token(self) -> int:
         basic = base64.b64encode(f"{self._client_id}:{self._client_secret}".encode()).decode()
         try:
@@ -94,19 +133,26 @@ class SmokeballClient:
                     "Authorization": f"Basic {basic}",
                     "Content-Type": "application/x-www-form-urlencoded",
                 },
-                data={"grant_type": "client_credentials", "client_id": self._client_id},
+                data=self._token_request_body(),
             )
         except httpx.HTTPError as exc:
             raise SmokeballAuthError(f"token request to {self.auth_host} failed: {exc}") from exc
         if resp.status_code != 200:
             # Never include the response body verbatim — it can echo the grant.
             raise SmokeballAuthError(
-                f"token mint rejected with HTTP {resp.status_code} at {self.auth_host}/oauth2/token"
+                f"token mint ({self.auth_mode}) rejected with HTTP {resp.status_code} "
+                f"at {self.auth_host}/oauth2/token"
             )
         body = resp.json()
         token = body.get("access_token")
         if not token:
             raise SmokeballAuthError("token response had no access_token")
+        # Smokeball may rotate the refresh token on a refresh_token grant; if it
+        # returns a new one, hold it in memory so subsequent refreshes use the
+        # current token (the seeded Fly secret stays the cold-start fallback).
+        rotated = body.get("refresh_token")
+        if self.auth_mode == "authorization_code" and rotated:
+            self._refresh_token = rotated
         expires_in = int(body.get("expires_in", 3600))
         self._token = token
         self._token_deadline = time.monotonic() + max(expires_in - _TOKEN_SKEW_SECONDS, 0)
@@ -129,7 +175,8 @@ class SmokeballClient:
     ) -> Any:
         """Issue an authenticated request. Returns parsed JSON (or None for an
         empty body). Retries 429 with backoff and refreshes once on a 401."""
-        url = f"{self.api_host}{path}"
+        prefix = f"/{self._account_id}" if self._account_id else ""
+        url = f"{self.api_host}{prefix}{path}"
         refreshed = False
         last: httpx.Response | None = None
         for attempt in range(_MAX_ATTEMPTS):
@@ -159,10 +206,12 @@ class SmokeballClient:
 
     # ---- health -----------------------------------------------------------
     def auth_status(self) -> dict[str, Any]:
-        """Mint a token and report connectivity — never the token value."""
+        """Mint a token and report connectivity — never the token/refresh value."""
         expires_in = self._mint_token()
         return {
             "authenticated": True,
+            "auth_mode": self.auth_mode,
+            "account_scoped": self._account_id is not None,
             "region": self.region,
             "environment": self.environment,
             "api_host": self.api_host,

--- a/operator/connectors/smokeball/smokeball_connector/server.py
+++ b/operator/connectors/smokeball/smokeball_connector/server.py
@@ -33,12 +33,18 @@ _client: SmokeballClient | None = None
 def _get_client() -> SmokeballClient:
     global _client
     if _client is None:
+        # auth_mode/refresh_token/account_id are per-seat runtime selections, read
+        # via .get so an absent value never crashes the default client_credentials
+        # path (the manifest declares only the three required secrets).
         _client = SmokeballClient(
             region=os.environ.get("SMOKEBALL_REGION", "us"),
             environment=os.environ.get("SMOKEBALL_ENVIRONMENT", "staging"),
             client_id=os.environ["SMOKEBALL_CLIENT_ID"],
             client_secret=os.environ["SMOKEBALL_CLIENT_SECRET"],
             api_key=os.environ["SMOKEBALL_API_KEY"],
+            auth_mode=os.environ.get("SMOKEBALL_AUTH_MODE", "client_credentials"),
+            refresh_token=os.environ.get("SMOKEBALL_REFRESH_TOKEN") or None,
+            account_id=os.environ.get("SMOKEBALL_ACCOUNT_ID") or None,
         )
     return _client
 

--- a/operator/connectors/smokeball/tests/test_auth_modes.py
+++ b/operator/connectors/smokeball/tests/test_auth_modes.py
@@ -1,0 +1,162 @@
+"""Unit coverage for the two auth modes + the optional accountId URL prefix.
+
+No live Smokeball calls: an ``httpx.MockTransport`` (built into httpx, no extra
+dep) is injected into the client's HTTP engine so the real ``_mint_token`` /
+``request`` logic runs against scripted responses. The client_credentials path is
+deliberately re-asserted here so a regression in the auth-code branch can't
+silently change the proven default.
+"""
+
+from __future__ import annotations
+
+from urllib.parse import parse_qs
+
+import httpx
+import pytest
+
+from smokeball_connector.client import SmokeballClient, SmokeballAuthError
+
+
+def _mock_client(handler, **overrides) -> SmokeballClient:
+    kwargs = dict(
+        region="us",
+        environment="staging",
+        client_id="cid",
+        client_secret="sec",
+        api_key="apikey",
+    )
+    kwargs.update(overrides)
+    client = SmokeballClient(**kwargs)
+    client._http = httpx.Client(transport=httpx.MockTransport(handler))
+    return client
+
+
+def _token_handler(captured: list[httpx.Request], *, rotate: str | None = None):
+    """A handler that answers the token endpoint and echoes any API call as {ok}."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        if request.url.path.endswith("/oauth2/token"):
+            body: dict = {
+                "access_token": "zzz-access-secret",
+                "expires_in": 3600,
+                "token_type": "Bearer",
+            }
+            if rotate is not None:
+                body["refresh_token"] = rotate
+            return httpx.Response(200, json=body)
+        return httpx.Response(200, json={"ok": True, "path": request.url.path})
+
+    return handler
+
+
+# ---- grant selection ------------------------------------------------------
+def test_client_credentials_mint_body_is_unchanged() -> None:
+    captured: list[httpx.Request] = []
+    client = _mock_client(_token_handler(captured))
+    client.auth_status()
+    token_req = next(r for r in captured if r.url.path.endswith("/oauth2/token"))
+    form = parse_qs(token_req.content.decode())
+    assert form["grant_type"] == ["client_credentials"]
+    assert form["client_id"] == ["cid"]
+    assert "refresh_token" not in form
+
+
+def test_authorization_code_mints_via_refresh_token() -> None:
+    captured: list[httpx.Request] = []
+    client = _mock_client(
+        _token_handler(captured), auth_mode="authorization_code", refresh_token="rt-123"
+    )
+    client.auth_status()
+    token_req = next(r for r in captured if r.url.path.endswith("/oauth2/token"))
+    form = parse_qs(token_req.content.decode())
+    assert form["grant_type"] == ["refresh_token"]
+    assert form["refresh_token"] == ["rt-123"]
+    assert form["client_id"] == ["cid"]
+
+
+def test_authorization_code_requires_refresh_token() -> None:
+    with pytest.raises(ValueError, match="refresh_token"):
+        SmokeballClient(
+            region="us",
+            environment="staging",
+            client_id="cid",
+            client_secret="sec",
+            api_key="apikey",
+            auth_mode="authorization_code",
+        )
+
+
+def test_unknown_auth_mode_rejected() -> None:
+    with pytest.raises(ValueError, match="auth_mode"):
+        SmokeballClient(
+            region="us",
+            environment="staging",
+            client_id="cid",
+            client_secret="sec",
+            api_key="apikey",
+            auth_mode="implicit",
+        )
+
+
+def test_refresh_token_rotation_is_adopted() -> None:
+    captured: list[httpx.Request] = []
+    client = _mock_client(
+        _token_handler(captured, rotate="rt-NEW"),
+        auth_mode="authorization_code",
+        refresh_token="rt-OLD",
+    )
+    client.auth_status()
+    assert client._refresh_token == "rt-NEW"
+
+
+# ---- accountId prefix -----------------------------------------------------
+def test_no_account_id_means_no_prefix() -> None:
+    captured: list[httpx.Request] = []
+    client = _mock_client(_token_handler(captured))
+    client.get("/matters")
+    api_req = next(r for r in captured if r.url.path.endswith("/matters"))
+    assert api_req.url.path == "/matters"
+
+
+def test_account_id_prefixes_every_request() -> None:
+    captured: list[httpx.Request] = []
+    client = _mock_client(_token_handler(captured), account_id="acct-9")
+    client.get("/matters")
+    api_req = next(r for r in captured if r.url.path.endswith("/matters"))
+    assert api_req.url.path == "/acct-9/matters"
+
+
+def test_account_id_is_normalized_to_a_bare_segment() -> None:
+    captured: list[httpx.Request] = []
+    client = _mock_client(_token_handler(captured), account_id="/acct-9/")
+    client.get("/matters")
+    api_req = next(r for r in captured if r.url.path.endswith("/matters"))
+    assert api_req.url.path == "/acct-9/matters"
+
+
+# ---- auth_status surface (never leaks the token) --------------------------
+def test_auth_status_reports_mode_not_token() -> None:
+    captured: list[httpx.Request] = []
+    client = _mock_client(
+        _token_handler(captured),
+        auth_mode="authorization_code",
+        refresh_token="rt-123",
+        account_id="acct-9",
+    )
+    status = client.auth_status()
+    assert status["auth_mode"] == "authorization_code"
+    assert status["account_scoped"] is True
+    blob = repr(status)
+    assert "rt-123" not in blob and "zzz-access-secret" not in blob
+
+
+def test_mint_failure_does_not_echo_grant() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(401, json={"error": "invalid_grant", "secret_echo": "rt-123"})
+
+    client = _mock_client(handler, auth_mode="authorization_code", refresh_token="rt-123")
+    with pytest.raises(SmokeballAuthError) as exc:
+        client.auth_status()
+    assert "rt-123" not in str(exc.value)
+    assert "authorization_code" in str(exc.value)

--- a/operator/customers/ashton-price/customer.yaml
+++ b/operator/customers/ashton-price/customer.yaml
@@ -1,31 +1,36 @@
 schema_version: 1
 
-# pilot-smokeball — the Smokeball STAGING build instance for the law-firm Operator
-# (the Ashton & Price pilot prep). This is bound to OUR OWN Smokeball staging
-# tenant (Partner-Program credentials), NOT a real client's production data. At
-# go-live the real firm gets its own slug bound to its firm-sponsored prod app.
+# ashton-price — the PRODUCTION Operator for the Ashton & Price law-firm pilot
+# (ADR 0053). This is bound to A&P's REAL production Smokeball tenant via the
+# firm-delegated authorization_code grant, NOT our own staging tenant. The
+# rehearsal rig is the separate `pilot-smokeball` seat (our staging) — do NOT
+# conflate them: separate app, tenant, credentials, Fly app, slug.
 #
 # Validate:  npx tsx scripts/validate-customer-yaml.ts \
-#              operator/customers/pilot-smokeball/customer.yaml
+#              operator/customers/ashton-price/customer.yaml
 #
-# GATES (Track 0 / Captain): the mcp:smokeball connector is net-new (overlay) and
-# its token_ref below is seeded once SMD's Smokeball staging credential lands.
-# The persona name/voice are a PROPOSED default — the firm authors the final
-# identity and writing voice (ADR 0035, no imposed defaults).
+# OPEN ITEMS before provisioning (Captain to confirm — no fabricated values):
+#   - fly_region: set to `phx` as a placeholder; CONFIRM A&P's geography.
+#   - users: only the SMD principal (Scott) is authored. Add A&P's people
+#     (the partner + office manager) with their REAL names/emails once confirmed.
+#   - hermes_ref: pin to the OVERLAY_REF carrying the smokeball auth-code change
+#     (ss-console + overlay PRs) at provision time.
+#   - SMOKEBALL_PROD_* creds + the refresh token land at the connect step; until
+#     then the smokeball connector is unwired (boot-before-token), Machine healthy.
 
 # ---- IDENTITY ----
-customer_id: pilot-smokeball
-customer_name: 'Pilot Law (Smokeball Staging)'
+customer_id: ashton-price
+customer_name: 'Ashton & Price'
 vertical: law-firm
 addons: []
 practice_areas:
   - personal-injury-plaintiff
-fly_region: lax # Pacific — the pilot firm is California-based
+fly_region: phx # CONFIRM A&P geography (placeholder: SMD's Phoenix home market)
 
 # ---- RUNTIME ----
 model: claude-opus-4-8
-# Pin to the CURRENT overlay/hermes ref at provision time (matches OVERLAY_REF).
-# Placeholder mirrors demo-law; bump before reprovision.sh.
+# CONFIRM: bump to the OVERLAY_REF carrying the smokeball authorization_code +
+# per-seat-env change before reprovision.sh (matches pilot at provision time).
 hermes_ref: v2026.5.16@a91a57fa5a13d516c38b07a141a9ce8a3daabeb0
 
 machine:
@@ -33,19 +38,18 @@ machine:
   memory_mb: 1024
 
 # ---- HUMANS WITH PORTAL ACCESS ----
+# Only the SMD principal is authored. A&P's partner + office manager are added
+# with their real names/emails once confirmed (do not invent — CLAUDE.md).
 users:
   - email: scott@smd.services
     role: principal
     full_name: Scott Durgan
 
 # ---- PERSONAS ----
-# One coordinator persona. Name/title/voice are a PROPOSED default — the firm
-# authors the final identity and tunes the writing voice from real samples.
-# Every external-bound message stays draft_for_review (the law external-send
-# floor, ADR 0005, non-raisable). The two committed deliverables —
-# matter-memo-on-update (internal supervision memo) and matter-document-review
-# (surface-only, never drafts) — write only internally; draft_for_review here is
-# the conservative authored cap (it governs external send; internal writes pass).
+# One coordinator persona — the law spine + the two committed deliverables
+# (matter-memo-on-update, matter-document-review). Every external-bound message
+# stays draft_for_review (the law external-send floor, ADR 0005, non-raisable).
+# Name/voice are a PROPOSED default; the firm authors the final identity.
 personas:
   - slug: quinn
     status: active
@@ -117,8 +121,8 @@ personas:
         version: pending
         trust_ceiling: draft_for_review
         enabled: true
-    # The escalator runs on Hermes-native cron (ADR 0021 Stream B): pre_run.py
-    # decides whether a deadline needs the ladder, else writes SUPPRESSED_WAKE.
+    # The escalator runs on Hermes-native cron; pre_run.py decides whether a
+    # deadline needs the ladder, else writes SUPPRESSED_WAKE.
     cron:
       - skill: deadline-miss-escalator
         schedule: '0 7 * * *' # daily 0700 PT
@@ -131,35 +135,32 @@ personas:
 
 # ---- CONNECTORS ----
 connectors:
-  # System of record — the net-new mcp:smokeball server (Track A), bound to SMD's
-  # Smokeball STAGING tenant. token_ref is seeded once the staging credential
-  # lands (Partner Program). The matter.updated webhook drives the memo skill.
+  # System of record — A&P's PRODUCTION Smokeball, firm-delegated grant.
+  # environment: production selects the prod hosts (auth.smokeball.com /
+  # api.smokeball.com) AND sources SMOKEBALL_PROD_* creds at provision.
+  # auth_mode: authorization_code — the firm authorizes via login + Allow; the
+  # refresh token is set at the connect step (bin/connect-smokeball.sh).
   PracticeManagement:
     adapter: smokeball
     backend: mcp:smokeball
     enabled: true
-    environment: staging # our own STAGING tenant (default; explicit for clarity)
-    # auth_mode defaults to client_credentials (live-verified). The auth-code
-    # rehearsal (ADR 0053) flips this to authorization_code temporarily.
-    token_ref: 'infisical:/operator/pilot-smokeball/practice-management/smokeball-oauth'
-    webhook_url: 'https://hermes-pilot-smokeball.fly.dev/webhooks/smokeball'
+    environment: production
+    auth_mode: authorization_code
+    token_ref: 'infisical:/operator/ashton-price/practice-management/smokeball-oauth'
+    webhook_url: 'https://hermes-ashton-price.fly.dev/webhooks/smokeball'
 
-  # The Operator's OWN inbox (default-on, toggleable). Anyone can email it; the
-  # inbound webhook routes to the spine. AGENTMAIL_API_KEY is a Fly secret.
+  # The Operator's OWN inbox (default-on). AGENTMAIL_API_KEY is a Fly secret.
   Email:
     adapter: agentmail
     backend: mcp:agentmail
     enabled: true
-    webhook_url: 'https://hermes-pilot-smokeball.fly.dev/webhooks/agentmail'
+    webhook_url: 'https://hermes-ashton-price.fly.dev/webhooks/agentmail'
 
-  # NOTE: Calendar + DocumentStorage are added at provision once the firm's mail
-  # platform is confirmed (Google path shipped; M365 = Track E). Smokeball has no
-  # calendar API, so calendar always rides the mail binding. Documents ride the
-  # Smokeball Documents API (mcp:smokeball get_files_on_matter), not a separate
-  # store — pending the Track 0 doc-entitlement confirmation.
+  # NOTE: Calendar + DocumentStorage are added at provision once A&P's mail
+  # platform is confirmed. Smokeball has no calendar API, so calendar rides the
+  # mail binding. Documents ride the Smokeball Documents API (get_files_on_matter).
 
 # ---- WEBHOOK TRIGGERS ----
-# source must match a connector adapter that has a webhook_url above.
 webhook_triggers:
   # The flagship: a Smokeball matter change drives the internal supervision memo.
   - source: smokeball
@@ -192,13 +193,12 @@ escalation:
     - scott@smd.services
 
 # ---- VOICE LIBRARY ----
-# Empty until the firm supplies writing samples to tune the voice; ships with the
-# general voice meanwhile.
+# Empty until the firm supplies writing samples; ships with the general voice.
 voice_library:
-  samples_path: 'r2://vaults/pilot-smokeball/voice/samples/'
+  samples_path: 'r2://vaults/ashton-price/voice/samples/'
 
 # ---- MEMORY (per-customer isolation invariants; must match customer_id) ----
 memory:
-  d1_namespace: pilot-smokeball
-  r2_vault_path: 'vaults/pilot-smokeball/'
-  vectorize_index: 'hermes-pilot-smokeball-vault'
+  d1_namespace: ashton-price
+  r2_vault_path: 'vaults/ashton-price/'
+  vectorize_index: 'hermes-ashton-price-vault'

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -111,6 +111,19 @@ declare namespace Cloudflare {
     GOOGLE_CLIENT_ID?: string
     /** Google Cloud OAuth 2.0 client secret. */
     GOOGLE_CLIENT_SECRET?: string
+    // Smokeball OAuth app credentials, by environment — used only by the
+    // authorization_code connect callback to exchange a firm's code for a
+    // refresh token (ADR 0053). The connector on the Machine refreshes itself
+    // and never needs these on the Worker. Staging = SMD's own Partner-Program
+    // app; production = a real firm's private app (set when the firm shares it).
+    /** Smokeball STAGING app OAuth client id (firm-delegated code exchange). */
+    SMOKEBALL_STAGING_CLIENT_ID?: string
+    /** Smokeball STAGING app OAuth client secret. */
+    SMOKEBALL_STAGING_CLIENT_SECRET?: string
+    /** Smokeball PRODUCTION app OAuth client id. */
+    SMOKEBALL_PROD_CLIENT_ID?: string
+    /** Smokeball PRODUCTION app OAuth client secret. */
+    SMOKEBALL_PROD_CLIENT_SECRET?: string
     /**
      * 32-byte base64-encoded random key used to AES-GCM encrypt Google
      * refresh tokens at rest in the `integrations` table. Generate with

--- a/src/lib/oauth/providers/smokeball.ts
+++ b/src/lib/oauth/providers/smokeball.ts
@@ -1,0 +1,194 @@
+/**
+ * Smokeball OAuth — the firm-delegated (authorization_code) connect flow.
+ *
+ * Unlike the Google / Microsoft providers this is NOT registered in the generic
+ * `providers.ts` map, for two reasons that make Smokeball a dedicated flow:
+ *
+ *   1. Environment-specific hosts. The authorize + token endpoints differ by
+ *      region AND environment (staging vs production), and the client
+ *      credentials used to exchange the code likewise differ
+ *      (SMOKEBALL_STAGING_* vs SMOKEBALL_PROD_*). The generic `OAuthProvider`
+ *      interface assumes one static `token_url` + one credential pair, so
+ *      Smokeball is modeled as standalone host-aware functions.
+ *   2. The connecting user is the FIRM, not a portal user. The Smokeball connect
+ *      callback is authorized by the signed state alone (HMAC + short TTL +
+ *      nonce), NOT a Clerk session — the firm clicks an authorize link we hand
+ *      them and never logs into our portal. The generic portal callback is
+ *      Clerk-gated and stays untouched.
+ *
+ * Token shape on the Machine: the connector reads a PLAIN refresh token from
+ * `SMOKEBALL_REFRESH_TOKEN` (not a JSON blob), and mints/refreshes its own
+ * access tokens (grant_type=refresh_token). So the relay only needs to deliver
+ * the refresh token (see `relaySmokeballRefreshToken` in `../store.ts`).
+ *
+ * Secrets are never logged. Issuer error bodies are surfaced only as opaque
+ * status codes to the caller. Confirmed against docs.smokeball.com (2026-06-23):
+ * authorize `{auth_host}/oauth2/authorize`, token `{auth_host}/oauth2/token`,
+ * `Authorization: Basic base64(client_id:client_secret)`, access token 60 min,
+ * refresh token 30 days.
+ */
+
+import { env } from 'cloudflare:workers'
+
+import type { ProviderTokenResponse } from '../providers.js'
+
+export type SmokeballEnvironment = 'staging' | 'production'
+export type SmokeballRegion = 'us' | 'au' | 'uk'
+
+/**
+ * (region, environment) → auth host. Mirrors the connector's host table
+ * (operator/connectors/smokeball/.../client.py `_HOSTS`). The two MUST match —
+ * a token minted at a staging auth host is invalid against a production API
+ * host, and vice versa.
+ */
+const AUTH_HOSTS: Readonly<Record<string, string>> = Object.freeze({
+  'us:production': 'https://auth.smokeball.com',
+  'us:staging': 'https://datastaging-auth.smokeball.com',
+  'au:production': 'https://auth.smokeball.com.au',
+  'au:staging': 'https://datastaging-auth.smokeball.com.au',
+  'uk:production': 'https://auth.smokeball.co.uk',
+  'uk:staging': 'https://datastaging-auth.smokeball.co.uk',
+})
+
+/**
+ * Default minimal scope checklist for the phase-1 law-pack surface (the read
+ * tools + `create_memo` + webhook provisioning). The FIRM's app must grant at
+ * least these; a narrower grant means a successful-looking Allow followed by the
+ * Operator silently unable to read — so this is the list to confirm at app
+ * creation. Scope strings are Smokeball's `resource/action` form.
+ */
+export const SMOKEBALL_OPERATOR_SCOPES: readonly string[] = Object.freeze([
+  'matters/read',
+  'contacts/read',
+  'mattertypes/read',
+  'stages/read',
+  'tasks/read',
+  'staff/read',
+  'roles/read',
+  'documents/read',
+  'memos/read',
+  'memos/write', // create_memo — the one internal-log write the wedge uses
+  'bankaccounts/read',
+  'bankaccountbalances/read',
+  'billingconfiguration/read',
+  'fees/read',
+  'expenses/read',
+  'webhooks/read',
+  'webhooks/write', // create_webhook_subscription — drives matter.updated
+])
+
+function authHost(region: SmokeballRegion, environment: SmokeballEnvironment): string {
+  const host = AUTH_HOSTS[`${region}:${environment}`]
+  if (!host) {
+    throw new Error(`unknown Smokeball region/environment ${region}/${environment}`)
+  }
+  return host
+}
+
+/** The two env-specific credential pairs, by environment. Worker secrets. */
+function clientCreds(environment: SmokeballEnvironment): {
+  client_id: string | undefined
+  client_secret: string | undefined
+} {
+  if (environment === 'production') {
+    return {
+      client_id: env.SMOKEBALL_PROD_CLIENT_ID,
+      client_secret: env.SMOKEBALL_PROD_CLIENT_SECRET,
+    }
+  }
+  return {
+    client_id: env.SMOKEBALL_STAGING_CLIENT_ID,
+    client_secret: env.SMOKEBALL_STAGING_CLIENT_SECRET,
+  }
+}
+
+/**
+ * Build the Smokeball authorize URL. `state` MUST be the signed token from
+ * `src/lib/oauth/state.ts`. Smokeball returns a refresh token on the
+ * authorization_code grant by default (30-day), so no Google-style
+ * `access_type=offline` toggle is needed.
+ */
+export function buildSmokeballAuthorizeUrl(args: {
+  client_id: string
+  redirect_uri: string
+  state: string
+  region: SmokeballRegion
+  environment: SmokeballEnvironment
+  scopes?: readonly string[]
+}): string {
+  if (!args.client_id) throw new Error('client_id is required')
+  if (!args.redirect_uri) throw new Error('redirect_uri is required')
+  if (!args.state) throw new Error('state is required')
+  const scopes = args.scopes ?? SMOKEBALL_OPERATOR_SCOPES
+  if (scopes.length === 0) throw new Error('at least one scope is required')
+  const params = new URLSearchParams({
+    response_type: 'code',
+    client_id: args.client_id,
+    redirect_uri: args.redirect_uri,
+    scope: scopes.join(' '),
+    state: args.state,
+  })
+  return `${authHost(args.region, args.environment)}/oauth2/authorize?${params.toString()}`
+}
+
+interface RawTokenJson {
+  access_token?: unknown
+  refresh_token?: unknown
+  scope?: unknown
+  expires_in?: unknown
+}
+
+/**
+ * Exchange an authorization code for an access + refresh token at the
+ * environment-specific token endpoint. Reads the matching client credentials
+ * (SMOKEBALL_STAGING_* / SMOKEBALL_PROD_*) from Worker env. Throws on a missing
+ * credential or a non-2xx issuer response (status only, never the body, which
+ * can echo the grant).
+ */
+export async function exchangeSmokeballCode(args: {
+  code: string
+  redirect_uri: string
+  region: SmokeballRegion
+  environment: SmokeballEnvironment
+}): Promise<ProviderTokenResponse> {
+  const { client_id, client_secret } = clientCreds(args.environment)
+  if (!client_id || !client_secret) {
+    throw new Error(
+      `Smokeball ${args.environment} client credentials are not configured ` +
+        `(SMOKEBALL_${args.environment === 'production' ? 'PROD' : 'STAGING'}_CLIENT_ID / _CLIENT_SECRET).`
+    )
+  }
+  const basic = btoa(`${client_id}:${client_secret}`)
+  const response = await fetch(`${authHost(args.region, args.environment)}/oauth2/token`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Basic ${basic}`,
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: new URLSearchParams({
+      grant_type: 'authorization_code',
+      client_id,
+      code: args.code,
+      redirect_uri: args.redirect_uri,
+    }),
+  })
+  if (!response.ok) {
+    // Never include the body — it can echo the code/grant.
+    throw new Error(`Smokeball token exchange failed (${response.status})`)
+  }
+  const raw: RawTokenJson = await response.json()
+  if (typeof raw.access_token !== 'string' || raw.access_token.length === 0) {
+    throw new Error('Smokeball token exchange returned no access_token')
+  }
+  const expiresInSec = typeof raw.expires_in === 'number' ? raw.expires_in : 3600
+  const now = Date.now()
+  return {
+    access_token: raw.access_token,
+    refresh_token: typeof raw.refresh_token === 'string' ? raw.refresh_token : null,
+    scopes: typeof raw.scope === 'string' ? raw.scope : '',
+    expires_at: new Date(now + expiresInSec * 1000).toISOString(),
+    obtained_at: new Date(now).toISOString(),
+  }
+}
+
+export { AUTH_HOSTS }

--- a/src/lib/oauth/store.ts
+++ b/src/lib/oauth/store.ts
@@ -223,3 +223,55 @@ export function createNoOpTokenStore(): OAuthTokenStore {
 export function getDefaultTokenStore(): OAuthTokenStore {
   return env.FLY_API_TOKEN ? createFlySecretTokenStore() : createNoOpTokenStore()
 }
+
+export type RelaySmokeballResult =
+  | { ok: true }
+  | { ok: false; reason: 'unavailable' | 'unknown_customer' | 'network' }
+
+/**
+ * Relay a firm-delegated Smokeball REFRESH token to the customer's Machine.
+ *
+ * Unlike the Google relay (which writes a google-auth JSON blob to a volume
+ * file), the Smokeball connector reads a PLAIN `SMOKEBALL_REFRESH_TOKEN` env var
+ * and mints/refreshes its own access tokens. So this sets one Fly app secret and
+ * restarts the Machines — no JSON shaping, no volume file. `SMOKEBALL_AUTH_MODE`
+ * is already `authorization_code` from provision time (authored in customer.yaml),
+ * so the connector switches to the refresh grant on restart.
+ *
+ * The refresh token is base64'd for transport (Fly secret) and NEVER logged.
+ */
+export async function relaySmokeballRefreshToken(args: {
+  customer_id: string
+  refresh_token: string
+}): Promise<RelaySmokeballResult> {
+  if (!env.FLY_API_TOKEN) {
+    console.error('[oauth/store] smokeball relay unavailable: FLY_API_TOKEN not configured')
+    return { ok: false, reason: 'unavailable' }
+  }
+  if (!args.refresh_token) {
+    // A connect with no refresh token can't self-refresh — reject loudly rather
+    // than clobber a working token with a dead one.
+    console.error('[oauth/store] smokeball relay: empty refresh_token; refusing')
+    return { ok: false, reason: 'unavailable' }
+  }
+  const app = resolveCustomerFlyApp(args.customer_id)
+  if (!app) {
+    console.error(
+      `[oauth/store] smokeball relay: unknown customer_id=${args.customer_id}; refusing to target any app`
+    )
+    return { ok: false, reason: 'unknown_customer' }
+  }
+  const setResult = await setFlySecret(
+    app,
+    'SMOKEBALL_REFRESH_TOKEN',
+    base64Utf8(args.refresh_token)
+  )
+  if (!setResult.ok) {
+    return { ok: false, reason: setResult.reason === 'network' ? 'network' : 'unavailable' }
+  }
+  const restartResult = await restartFlyMachines(app)
+  if (!restartResult.ok) {
+    return { ok: false, reason: restartResult.reason === 'network' ? 'network' : 'unavailable' }
+  }
+  return { ok: true }
+}

--- a/src/lib/operator/fly-app-registry.ts
+++ b/src/lib/operator/fly-app-registry.ts
@@ -16,6 +16,10 @@
 
 const CUSTOMER_FLY_APPS: Readonly<Record<string, string>> = Object.freeze({
   smd: 'hermes-smd',
+  // Smokeball Operator seats (ADR 0053). pilot-smokeball = our own staging
+  // rehearsal rig; ashton-price = the production pilot firm.
+  'pilot-smokeball': 'hermes-pilot-smokeball',
+  'ashton-price': 'hermes-ashton-price',
 })
 
 /**

--- a/src/pages/api/operator/smokeball/connect-callback.ts
+++ b/src/pages/api/operator/smokeball/connect-callback.ts
@@ -1,0 +1,163 @@
+/**
+ * GET /api/operator/smokeball/connect-callback
+ *
+ * The hosted landing page for the Smokeball firm-delegated (authorization_code)
+ * connect flow (ADR 0053). The firm clicks an authorize link we hand them
+ * (built by `operator/bin/connect-smokeball.sh`), signs into Smokeball, clicks
+ * Allow, and Smokeball redirects HERE with `?code=…&state=…`.
+ *
+ * Authorization model — DELIBERATELY state-only, NOT Clerk-gated. The connecting
+ * party is the FIRM, who has no portal session. The signed `state`
+ * (HMAC-SHA256 + 10-min TTL + nonce, `src/lib/oauth/state.ts`) is the
+ * authorization: it proves WE issued this connect for this customer. A captured
+ * link is useless after 10 minutes, and the state cannot be forged without the
+ * signing key. (The Clerk-gated portal callback at
+ * `/portal/products/operator/oauth/[connector]/callback` is a separate surface
+ * and stays untouched.)
+ *
+ * The customer's environment+region travel inside the signed state's `provider`
+ * field as `smokeball:<region>:<environment>` (tamper-proof under the HMAC), so
+ * this endpoint selects the right Smokeball hosts and client credentials.
+ *
+ * Flow: verify state → exchange code at the env-specific token endpoint →
+ * relay the refresh token to the customer's Machine (Fly secret + restart) →
+ * render a plain "✓ Connected" page. No token material is logged or rendered;
+ * issuer error bodies stay server-side and collapse to a short reason.
+ */
+
+import type { APIRoute } from 'astro'
+
+import { verifyOAuthState } from '../../../../lib/oauth/state.js'
+import {
+  exchangeSmokeballCode,
+  type SmokeballEnvironment,
+  type SmokeballRegion,
+} from '../../../../lib/oauth/providers/smokeball.js'
+import { relaySmokeballRefreshToken } from '../../../../lib/oauth/store.js'
+import { emitAuditEvent } from '../../../../lib/oauth/audit.js'
+
+const VALID_REGIONS = new Set(['us', 'au', 'uk'])
+const VALID_ENVIRONMENTS = new Set(['staging', 'production'])
+
+function page(title: string, body: string, status: number): Response {
+  const html = `<!doctype html><html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${title}</title>
+<style>
+  body { font-family: system-ui, -apple-system, sans-serif; max-width: 32rem; margin: 4rem auto;
+         padding: 0 1.5rem; color: #1a1a2e; line-height: 1.5; }
+  .badge { font-size: 2.5rem; }
+  h1 { font-size: 1.4rem; margin: 0.5rem 0; }
+  p { color: #444; }
+</style></head><body>${body}</body></html>`
+  return new Response(html, {
+    status,
+    headers: { 'Content-Type': 'text/html; charset=utf-8' },
+  })
+}
+
+function connectedPage(): Response {
+  return page(
+    'Connected',
+    `<div class="badge">✓</div><h1>Smokeball connected</h1>
+     <p>Your Operator is now linked to your Smokeball account. You can close this window.</p>`,
+    200
+  )
+}
+
+function failedPage(reason: string): Response {
+  return page(
+    'Connection failed',
+    `<div class="badge">⚠️</div><h1>We couldn't finish connecting Smokeball</h1>
+     <p>Please close this window and let your SMD contact know
+        (reference: <code>${reason}</code>). You can safely try again.</p>`,
+    400
+  )
+}
+
+/** Parse `smokeball:<region>:<environment>` from the signed state's provider. */
+function parseSmokeballProvider(
+  provider: string
+): { region: SmokeballRegion; environment: SmokeballEnvironment } | null {
+  const parts = provider.split(':')
+  if (parts.length !== 3 || parts[0] !== 'smokeball') return null
+  const region = parts[1]
+  const environment = parts[2]
+  if (!VALID_REGIONS.has(region) || !VALID_ENVIRONMENTS.has(environment)) return null
+  return { region: region as SmokeballRegion, environment: environment as SmokeballEnvironment }
+}
+
+/** Emit a rejection audit row (no token material) and render the failure page. */
+async function reject(
+  reason: string,
+  ctx: {
+    customer_id: string | null
+    provider: string | null
+    reviewer_id: string | null
+    auditReason?: string
+  }
+): Promise<Response> {
+  await emitAuditEvent({
+    action: 'token-rejected',
+    customer_id: ctx.customer_id,
+    provider: ctx.provider,
+    reviewer_id: ctx.reviewer_id,
+    reason: ctx.auditReason ?? reason,
+  })
+  return failedPage(reason)
+}
+
+export const GET: APIRoute = async ({ request }) => {
+  const url = new URL(request.url)
+  const anon = { customer_id: null, provider: 'smokeball', reviewer_id: null }
+
+  const issuerError = url.searchParams.get('error')
+  if (issuerError) {
+    return reject('provider_error', { ...anon, auditReason: `provider_error:${issuerError}` })
+  }
+
+  const code = url.searchParams.get('code')
+  const state = url.searchParams.get('state')
+  if (!code || !state) return reject('missing_params', anon)
+
+  const stateResult = await verifyOAuthState(state)
+  if (!stateResult.ok) {
+    const reason = stateResult.error === 'expired' ? 'expired_state' : 'bad_state'
+    return reject(reason, { ...anon, auditReason: `${reason}:${stateResult.error}` })
+  }
+
+  const { customer_id, provider, reviewer_id } = stateResult.payload
+  const ctx = { customer_id, provider, reviewer_id }
+  const parsed = parseSmokeballProvider(provider)
+  if (!parsed) return reject('unknown_provider', ctx)
+
+  // The redirect_uri sent to the token endpoint MUST byte-match the one used in
+  // the authorize step — exactly this endpoint's own URL (origin + path), which
+  // is what we registered and what Smokeball just called.
+  const redirect_uri = `${url.origin}${url.pathname}`
+
+  let token
+  try {
+    token = await exchangeSmokeballCode({ code, redirect_uri, ...parsed })
+  } catch (err) {
+    // The exchange error message carries only a status code, never the body.
+    console.error(
+      `[smokeball/connect] exchange_failed customer=${customer_id} env=${parsed.environment}: ${
+        err instanceof Error ? err.message : 'unknown'
+      }`
+    )
+    return reject('exchange_failed', ctx)
+  }
+
+  if (!token.refresh_token) return reject('missing_refresh_token', ctx)
+
+  const relay = await relaySmokeballRefreshToken({
+    customer_id,
+    refresh_token: token.refresh_token,
+  })
+  if (!relay.ok)
+    return reject('relay_failed', { ...ctx, auditReason: `relay_failed:${relay.reason}` })
+
+  await emitAuditEvent({ action: 'token-issued', customer_id, provider, reviewer_id })
+  return connectedPage()
+}

--- a/tests/oauth-smokeball.test.ts
+++ b/tests/oauth-smokeball.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Coverage for the Smokeball firm-delegated connect flow:
+ *  - buildSmokeballAuthorizeUrl: env-specific host, required params, scope default
+ *  - exchangeSmokeballCode: env-matched creds, Basic auth, normalized token, and
+ *    that a non-2xx never leaks the issuer body
+ *  - relaySmokeballRefreshToken: sets SMOKEBALL_REFRESH_TOKEN + restarts, and the
+ *    unknown-customer / empty-token / no-FLY_API_TOKEN rejections
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { env as testEnv } from 'cloudflare:workers'
+
+import {
+  buildSmokeballAuthorizeUrl,
+  exchangeSmokeballCode,
+  SMOKEBALL_OPERATOR_SCOPES,
+} from '../src/lib/oauth/providers/smokeball'
+import { relaySmokeballRefreshToken } from '../src/lib/oauth/store'
+
+function clearEnv(): void {
+  for (const key of Object.keys(testEnv)) {
+    delete (testEnv as unknown as Record<string, unknown>)[key]
+  }
+}
+
+afterEach(() => {
+  clearEnv()
+  vi.restoreAllMocks()
+})
+
+describe('buildSmokeballAuthorizeUrl', () => {
+  it('targets the staging auth host with the required params', () => {
+    const url = new URL(
+      buildSmokeballAuthorizeUrl({
+        client_id: 'cid',
+        redirect_uri: 'https://portal.smd.services/api/operator/smokeball/connect-callback',
+        state: 'signed.state',
+        region: 'us',
+        environment: 'staging',
+      })
+    )
+    expect(url.origin).toBe('https://datastaging-auth.smokeball.com')
+    expect(url.pathname).toBe('/oauth2/authorize')
+    expect(url.searchParams.get('response_type')).toBe('code')
+    expect(url.searchParams.get('client_id')).toBe('cid')
+    expect(url.searchParams.get('state')).toBe('signed.state')
+    expect(url.searchParams.get('scope')).toBe(SMOKEBALL_OPERATOR_SCOPES.join(' '))
+  })
+
+  it('targets the production auth host', () => {
+    const url = new URL(
+      buildSmokeballAuthorizeUrl({
+        client_id: 'cid',
+        redirect_uri: 'https://x/cb',
+        state: 's',
+        region: 'us',
+        environment: 'production',
+      })
+    )
+    expect(url.origin).toBe('https://auth.smokeball.com')
+  })
+
+  it('rejects a missing client_id / redirect_uri / state', () => {
+    const base = {
+      client_id: 'cid',
+      redirect_uri: 'https://x/cb',
+      state: 's',
+      region: 'us' as const,
+      environment: 'staging' as const,
+    }
+    expect(() => buildSmokeballAuthorizeUrl({ ...base, client_id: '' })).toThrow(/client_id/)
+    expect(() => buildSmokeballAuthorizeUrl({ ...base, redirect_uri: '' })).toThrow(/redirect_uri/)
+    expect(() => buildSmokeballAuthorizeUrl({ ...base, state: '' })).toThrow(/state/)
+  })
+})
+
+describe('exchangeSmokeballCode', () => {
+  it('exchanges with Basic auth at the env-matched token endpoint and normalizes the token', async () => {
+    Object.assign(testEnv, {
+      SMOKEBALL_STAGING_CLIENT_ID: 'scid',
+      SMOKEBALL_STAGING_CLIENT_SECRET: 'ssecret',
+    })
+    let captured: { url: string; auth: string | null; body: string } | null = null
+    globalThis.fetch = vi.fn(async (url: string, init?: RequestInit) => {
+      const headers = new Headers(init?.headers)
+      captured = { url: String(url), auth: headers.get('Authorization'), body: String(init?.body) }
+      return new Response(
+        JSON.stringify({
+          access_token: 'AT',
+          refresh_token: 'RT',
+          scope: 'matters/read contacts/read',
+          expires_in: 3600,
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    }) as unknown as typeof fetch
+
+    const token = await exchangeSmokeballCode({
+      code: 'the-code',
+      redirect_uri: 'https://x/cb',
+      region: 'us',
+      environment: 'staging',
+    })
+
+    expect(captured!.url).toBe('https://datastaging-auth.smokeball.com/oauth2/token')
+    expect(captured!.auth).toBe(`Basic ${btoa('scid:ssecret')}`)
+    expect(captured!.body).toContain('grant_type=authorization_code')
+    expect(captured!.body).toContain('the-code')
+    expect(token.access_token).toBe('AT')
+    expect(token.refresh_token).toBe('RT')
+    expect(token.scopes).toBe('matters/read contacts/read')
+  })
+
+  it('uses the PROD credentials + host for a production seat', async () => {
+    Object.assign(testEnv, {
+      SMOKEBALL_PROD_CLIENT_ID: 'pcid',
+      SMOKEBALL_PROD_CLIENT_SECRET: 'psecret',
+    })
+    let url = ''
+    globalThis.fetch = vi.fn(async (u: string) => {
+      url = String(u)
+      return new Response(JSON.stringify({ access_token: 'AT', refresh_token: 'RT' }), {
+        status: 200,
+      })
+    }) as unknown as typeof fetch
+    await exchangeSmokeballCode({
+      code: 'c',
+      redirect_uri: 'https://x/cb',
+      region: 'us',
+      environment: 'production',
+    })
+    expect(url).toBe('https://auth.smokeball.com/oauth2/token')
+  })
+
+  it('throws when the env credentials are not configured', async () => {
+    await expect(
+      exchangeSmokeballCode({
+        code: 'c',
+        redirect_uri: 'https://x/cb',
+        region: 'us',
+        environment: 'staging',
+      })
+    ).rejects.toThrow(/not configured/)
+  })
+
+  it('throws on a non-2xx WITHOUT leaking the issuer body', async () => {
+    Object.assign(testEnv, {
+      SMOKEBALL_STAGING_CLIENT_ID: 'scid',
+      SMOKEBALL_STAGING_CLIENT_SECRET: 'ssecret',
+    })
+    globalThis.fetch = vi.fn(
+      async () => new Response('{"error":"invalid_grant","leak":"RT"}', { status: 400 })
+    )
+    await expect(
+      exchangeSmokeballCode({
+        code: 'c',
+        redirect_uri: 'https://x/cb',
+        region: 'us',
+        environment: 'staging',
+      })
+    ).rejects.toThrow(/^Smokeball token exchange failed \(400\)$/)
+  })
+})
+
+describe('relaySmokeballRefreshToken', () => {
+  beforeEach(() => {
+    Object.assign(testEnv, { FLY_API_TOKEN: 'fly-tok' })
+  })
+
+  it('sets the SMOKEBALL_REFRESH_TOKEN secret and restarts the machines', async () => {
+    const calls: string[] = []
+    globalThis.fetch = vi.fn(async (url: string, init?: RequestInit) => {
+      const u = String(url)
+      calls.push(u)
+      if (u.includes('graphql')) {
+        const body = String(init?.body)
+        // The secret name is set; the refresh token value is base64'd, never raw.
+        expect(body).toContain('SMOKEBALL_REFRESH_TOKEN')
+        expect(body).not.toContain('the-refresh-token')
+        return new Response(
+          JSON.stringify({ data: { setSecrets: { release: { id: 'r', version: 1 } } } }),
+          {
+            status: 200,
+          }
+        )
+      }
+      if (u.endsWith('/machines')) {
+        return new Response(JSON.stringify([{ id: 'm1' }]), { status: 200 })
+      }
+      return new Response('{}', { status: 200 }) // restart
+    }) as unknown as typeof fetch
+
+    const result = await relaySmokeballRefreshToken({
+      customer_id: 'pilot-smokeball',
+      refresh_token: 'the-refresh-token',
+    })
+    expect(result.ok).toBe(true)
+    expect(calls.some((c) => c.includes('graphql'))).toBe(true)
+    expect(calls.some((c) => c.endsWith('/machines/m1/restart'))).toBe(true)
+  })
+
+  it('refuses an unknown customer', async () => {
+    const result = await relaySmokeballRefreshToken({
+      customer_id: 'not-a-customer',
+      refresh_token: 'rt',
+    })
+    expect(result).toEqual({ ok: false, reason: 'unknown_customer' })
+  })
+
+  it('refuses an empty refresh token', async () => {
+    const result = await relaySmokeballRefreshToken({
+      customer_id: 'pilot-smokeball',
+      refresh_token: '',
+    })
+    expect(result.ok).toBe(false)
+  })
+
+  it('is unavailable without FLY_API_TOKEN', async () => {
+    clearEnv()
+    const result = await relaySmokeballRefreshToken({
+      customer_id: 'pilot-smokeball',
+      refresh_token: 'rt',
+    })
+    expect(result).toEqual({ ok: false, reason: 'unavailable' })
+  })
+})


### PR DESCRIPTION
## Why

Prep to authenticate the **Ashton & Price** production Operator to A&P's **production Smokeball** — a one-shot pilot. The shipped `mcp:smokeball` connector authenticates only via `client_credentials` (our own staging tenant). Connecting a real firm uses the **authorization_code** grant (the firm logs into Smokeball + clicks Allow). This PR builds that path end-to-end, additively, without disturbing the working client_credentials path.

Paired with overlay PR (per-seat env + optional auth-code vars).

## What

- **Connector** (`operator/connectors/smokeball/`): additive `auth_mode` / `refresh_token` / `account_id`. `authorization_code` mints from a refresh token (rotation adopted in-memory); optional `account_id` prefixes the request path (multi-account shape). `client_credentials` path byte-identical; `auth_status` never returns the token. Tool surface / `tool_classes` / `auth_model` / `required_secrets` **unchanged** (conformance green). +8 unit tests.
- **Connect flow** (firm-facing, Sign-in-with-Google-grade):
  - `src/lib/oauth/providers/smokeball.ts` — env/region-aware authorize-URL builder + `exchangeSmokeballCode` (Basic auth at the env-matched token endpoint; never leaks the issuer body) + `SMOKEBALL_OPERATOR_SCOPES` (the minimal scope checklist).
  - `src/pages/api/operator/smokeball/connect-callback.ts` — hosted landing. **State-only** authz (HMAC + 10-min TTL, *not* Clerk-gated, because the firm is not a portal user); environment+region travel tamper-proof inside the signed state's `provider` field. Verify → exchange → relay → "✓ Connected".
  - `store.ts` `relaySmokeballRefreshToken` — sets a plain `SMOKEBALL_REFRESH_TOKEN` Fly secret (base64, never logged) + restarts; the connector self-refreshes from it.
  - `bin/connect-smokeball.sh` — Captain-run initiate; prints the authorize URL (no secret touched, no email).
- **Provisioning** (`provision-customer.sh`): the seat declares `environment` / `auth_mode` / `account_id` on the smokeball connector; provisioning sets `SMOKEBALL_ENVIRONMENT` (required per-seat — a prod seat can never silently default to staging) and sources creds from `SMOKEBALL_STAGING_*` or `SMOKEBALL_PROD_*`.
- **Seats**: `operator/customers/ashton-price/customer.yaml` (NEW, production / authorization_code, strictly separate from the `pilot-smokeball` staging rig); `pilot-smokeball` gains an explicit `environment: staging` marker. `fly-app-registry` adds both seats.

## TEST vs PRODUCTION (strictly separate)

| | TEST (`pilot-smokeball`) | PROD (`ashton-price`) |
|---|---|---|
| Smokeball app / tenant | our staging app + tenant | A&P's prod private app + tenant |
| hosts | `datastaging-auth` / `stagingapi` | `auth` / `api.smokeball.com` |
| creds | `SMOKEBALL_STAGING_*` | `SMOKEBALL_PROD_*` |
| Fly app | `hermes-pilot-smokeball` | `hermes-ashton-price` |

## Verification

`npm run verify` green: typecheck ×2, format, lint (0 errors), build, vitest (3290 pass) + workers (9). Connector pytest (15) + operator-substrate conformance (env/block/runtime) green. `bin/*.sh` bash-3.2 + shellcheck clean.

## Prereqs to RUN (Captain-gated; not in this PR)

- Set `SMOKEBALL_STAGING_CLIENT_ID/SECRET` (and later `SMOKEBALL_PROD_*`) as **ss-web Worker secrets** (the callback exchanges the code).
- Register the callback redirect URI (`{PORTAL_BASE_URL}/api/operator/smokeball/connect-callback`) on the Smokeball app.
- Bump `OVERLAY_REF`/`hermes_ref` to the ref carrying the overlay change.
- A&P open items flagged in `ashton-price/customer.yaml` (region, firm users).

🤖 Generated with [Claude Code](https://claude.com/claude-code)