### PR TITLE
fix(operator): provision /run/smd-mcp so Machine-hosted /mcp returns answers in-band

### DIFF
--- a/operator/customers/pilot-smokeball/customer.yaml
+++ b/operator/customers/pilot-smokeball/customer.yaml
@@ -129,6 +129,24 @@ personas:
       - google-workspace
       - himalaya
 
+# ---- MCP CONNECTOR (Operator ⇄ Claude) ----
+# Rehearsal channel: lets us drive a real agent turn on this staging rig to prove
+# the firm-delegated Smokeball read end-to-end (Allow → token file → connector →
+# list_matters). translate.py emits the core /webhooks/mcp route ONLY when this
+# block is enabled AND WEBHOOK_SECRET_MCP is set (fail-closed). Clerk is NOT
+# configured on the staging Machine, so /mcp auth falls to the transitional stub
+# bearer (SMD_MCP_STUB_TOKEN); the access[] entry below is the production shape
+# (Clerk-gated) and is inert until Clerk env is materialized.
+mcp_connector:
+  enabled: true
+  data_posture: open
+  access:
+    - email: scott@smd.services
+      profile: quinn
+      clerk_subjects:
+        - user_3EEs0aMBRgu6PRxBa4g5YhHjggD
+        - user_3E1RPGrTMxkSqciXMTyybUNSJWu
+
 # ---- CONNECTORS ----
 connectors:
   # System of record — the net-new mcp:smokeball server (Track A), bound to SMD's

--- a/operator/templates/entrypoint.sh
+++ b/operator/templates/entrypoint.sh
@@ -269,6 +269,21 @@ else
   log "Root config applier NOT launched (R2 config creds absent, or config_applier not in this overlay)"
 fi
 
+# MCP channel cross-process result/thread store (shared/mcp_result_store.py +
+# shared/mcp_thread_store.py). The webhook gate (:8643) and the agent's result-sink
+# plugin (inside the Hermes gateway) BOTH read/write here to hand a synchronous
+# /mcp answer back to the caller; the default path is /run/smd-mcp. /run is a
+# root-owned tmpfs, so the unprivileged hermes processes cannot mkdir it themselves
+# (Permission denied → the answer never lands and the gate's 55s poll always times
+# out; first surfaced on the Machine-hosted /mcp path, hermes-pilot-smokeball
+# 2026-06-24). Create it hermes-owned now, while still root — both processes run as
+# hermes (the exec-drop below), so a single hermes-owned 0700 dir serves both.
+# tmpfs is correct: results are short-lived and scoped to one in-flight request.
+MCP_STORE_DIR="/run/smd-mcp"
+mkdir -p "${MCP_STORE_DIR}"
+chown hermes:hermes "${MCP_STORE_DIR}"
+chmod 0700 "${MCP_STORE_DIR}"
+
 exec setpriv \
   --reuid=hermes \
   --regid=hermes \


### PR DESCRIPTION
## What

The Machine-hosted MCP channel (Claude-as-a-channel, ADR 0054 firm-delegated connect) returns a **synchronous** answer by handing it across processes through a shared result store at `/run/smd-mcp` (`shared/mcp_result_store.py` + `mcp_thread_store.py`). `/run` is a root-owned tmpfs, and **both** the webhook gate (`:8643`) and the agent's result-sink plugin run unprivileged as `hermes` — so neither can `mkdir /run/smd-mcp` (`Permission denied`). The agent answered every turn correctly, but the result never landed, so the gate's 55s long-poll always timed out and every `/mcp` call returned *"did not return a result in time."*

`hermes-pilot-smokeball` is the **first Machine to exercise the Machine-hosted `/mcp` path**, so the gap surfaced now — and it applies to every customer Machine, including `ashton-price`.

## Fix

Create `/run/smd-mcp` hermes-owned (`0700`) in `operator/templates/entrypoint.sh` while still root, before the exec-drop to `hermes` — mirroring the existing `/run/smd-audit` bind-dir pattern. Both consumers are `hermes`, so one hermes-owned dir serves both. tmpfs is correct: results are short-lived and scoped to a single in-flight request.

Also flips `mcp_connector.enabled` on the **`pilot-smokeball` staging seat** so this path is exercisable on our own gear. Clerk is unconfigured on staging, so `/mcp` auth falls to the transitional stub bearer; the `access[]` entry is the inert production (Clerk-gated) shape.

## Proof (live, end-to-end on hermes-pilot-smokeball, after this change)

A `/mcp` `ask_operator` turn returns **in-band in 6–14s**:
- `PONG` no-tool turn → `PONG` (10.4s) — confirms the store fix
- Smokeball `list_matters` (13.9s) → real staging matter **PI-2026-0001 — Johnson, Marcus (vs. Reyes, Daniel)**
- raw Smokeball matter **GUID `54bc1371-…`** (5.7s) — unfabricable; only a live API read returns it

This is the full ADR 0054 chain: firm Allow → refresh-token file on the Machine → connector mints an auth-code token → `list_matters` against staging → answer in-band. `vfy_01KVXG46X6W1SFKZVZVEC4R7H8`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)