### PR TITLE
feat(operator): mcp:smokeball document round-trip writes — add_file + delete_file (ADR 0053)

### DIFF
--- a/operator/connectors/smokeball/manifest.toml
+++ b/operator/connectors/smokeball/manifest.toml
@@ -12,9 +12,10 @@
 #
 # tool_classes is the conformance ORACLE: every entry must agree with the
 # hand-authored overlay map (shared/action_classes.py) under the runtime name
-# mcp_smokeball_<tool>. The phase-1 surface is the reads + create_memo. The
-# trust-account fund-movement tools are NEVER exposed here and are hard-BANNED at
-# the overlay.
+# mcp_smokeball_<tool>. The surface is the reads + create_memo (internal_write) +
+# the document round-trip writes add_file (internal_write) and delete_file
+# (destructive, taint-gated). The trust-account fund-movement tools are NEVER
+# exposed here and are hard-BANNED at the overlay.
 [connector]
 name = "smokeball"
 capability = "PracticeManagement"
@@ -56,6 +57,8 @@ get_relationships_on_matter = "read"
 get_files_on_matter = "read"
 get_file = "read"
 get_download_url = "read"
+add_file = "internal_write"
+delete_file = "destructive"
 get_memos_on_matter = "read"
 get_bank_accounts = "read"
 get_matter_balances = "read"

--- a/operator/connectors/smokeball/smokeball_connector/client.py
+++ b/operator/connectors/smokeball/smokeball_connector/client.py
@@ -73,6 +73,11 @@ class SmokeballAuthError(RuntimeError):
     clear refusal rather than a raw 4xx."""
 
 
+class SmokeballWriteError(RuntimeError):
+    """A document write (upload/delete) failed — the metadata POST returned no
+    upload URL, or the presigned PUT was rejected. Surfaced as a clear refusal."""
+
+
 class SmokeballClient:
     def __init__(
         self,
@@ -228,6 +233,61 @@ class SmokeballClient:
 
     def get(self, path: str, **params: Any) -> Any:
         return self.request("GET", path, params=params)
+
+    # ---- document writes --------------------------------------------------
+    def add_file(
+        self,
+        matter_id: str,
+        file_name: str,
+        data: bytes,
+        *,
+        folder_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Upload a file to a matter via Smokeball's documented two-stage flow:
+
+        1. ``POST /matters/{id}/documents/files`` with the metadata returns a
+           presigned ``uploadUrl`` + ``fileId`` (HTTP 202).
+        2. ``PUT`` the raw bytes to that URL with an **empty** ``Content-Type``
+           (an S3 presigned-PUT requirement Smokeball calls out explicitly — a
+           non-empty value breaks the signature → 403).
+
+        Materialization is asynchronous: the file becomes readable once the
+        firm's document worker ingests it, so callers that need to confirm should
+        poll ``get_file``. Returns the ``fileId`` (and echoes the request)."""
+        body: dict[str, Any] = {"fileName": file_name}
+        if folder_id is not None:
+            body["folderId"] = folder_id
+        info = self.request("POST", f"/matters/{matter_id}/documents/files", json=body)
+        if not isinstance(info, dict) or not info.get("uploadUrl"):
+            raise SmokeballWriteError(
+                "add_file: metadata POST did not return an uploadUrl "
+                f"(matter {matter_id!r}, file {file_name!r})"
+            )
+        self._put_presigned(info["uploadUrl"], data)
+        return {
+            "fileId": info.get("fileId"),
+            "matterId": matter_id,
+            "fileName": file_name,
+            "uploaded": True,
+        }
+
+    def _put_presigned(self, url: str, data: bytes) -> None:
+        """PUT raw bytes to a presigned S3 upload URL. The URL is pre-authenticated
+        by its signature, so we send NO ``x-api-key``/``Authorization`` and an
+        EMPTY ``Content-Type`` (the header is not part of the signed request)."""
+        try:
+            resp = self._http.put(url, content=data, headers={"Content-Type": ""})
+        except httpx.HTTPError as exc:
+            raise SmokeballWriteError(f"presigned upload PUT failed: {exc}") from exc
+        if resp.status_code >= 400:
+            raise SmokeballWriteError(
+                f"presigned upload PUT rejected with HTTP {resp.status_code}"
+            )
+
+    def delete_file(self, matter_id: str, file_id: str) -> Any:
+        """Delete a file from a matter (``DELETE /matters/{id}/documents/files/{fileId}``,
+        async — returns the tracking Link). DESTRUCTIVE at the overlay."""
+        return self.request("DELETE", f"/matters/{matter_id}/documents/files/{file_id}")
 
     # ---- health -----------------------------------------------------------
     def auth_status(self) -> dict[str, Any]:

--- a/operator/connectors/smokeball/smokeball_connector/server.py
+++ b/operator/connectors/smokeball/smokeball_connector/server.py
@@ -1,10 +1,13 @@
 """The mcp:smokeball tool surface — Smokeball-native names over the real REST API.
 
-Phase-1 scope (per operator/verticals/law-firm/smokeball-surface.md): the read
-surface + ``create_memo`` (the one internal-log write the wedge uses). Gated
-writes (create_matter/patch_matter/create_task/...) are a phase-2 cut; the
-trust-account fund-movement tools (create_transaction/protect_funds/
-unprotect_funds) are NEVER implemented here and are hard-BANNED at the overlay.
+Scope (per operator/verticals/law-firm/smokeball-surface.md): the read surface,
+``create_memo`` (the internal-log write the wedge uses), and the document
+round-trip writes ``add_file`` (INTERNAL_WRITE) + ``delete_file`` (DESTRUCTIVE) —
+the upload half lets the agent save its work product back to a matter (read ->
+work -> save). Other gated writes (create_matter/patch_matter/create_task/...)
+remain a later cut; the trust-account fund-movement tools (create_transaction/
+protect_funds/unprotect_funds) are NEVER implemented here and are hard-BANNED at
+the overlay.
 
 Paths and query params are taken from the live OpenAPI spec
 (docs.smokeball.com/openapi.json, 2026-06-23), which corrected several guesses in
@@ -18,6 +21,7 @@ The client is built LAZILY on first tool call, so the tool surface introspects
 
 from __future__ import annotations
 
+import base64
 import os
 from typing import Any
 
@@ -240,6 +244,41 @@ def get_file(matter_id: str, file_id: str) -> Any:
 def get_download_url(matter_id: str, file_id: str) -> Any:
     """Get a download URL/stream reference for a file."""
     return _get_client().get(f"/matters/{matter_id}/documents/files/{file_id}/download")
+
+
+@server.tool()
+def add_file(
+    matter_id: str,
+    file_name: str,
+    content_base64: str,
+    folder_id: str | None = None,
+) -> Any:
+    """Upload a document to a matter. ``content_base64`` is the file's raw bytes
+    base64-encoded (any file type); ``folder_id`` is optional (root if omitted).
+    Runs Smokeball's two-stage upload (metadata POST -> presigned S3 PUT);
+    materialization is asynchronous, so the file may take a moment to appear in
+    ``get_files_on_matter``. Returns the new ``fileId``.
+
+    Classified INTERNAL_WRITE at the overlay: this is the agent saving its own
+    work product into the firm's record — the save-back half of the read ->
+    work -> save document round-trip — never an external send."""
+    try:
+        data = base64.b64decode(content_base64, validate=True)
+    except (ValueError, TypeError) as exc:
+        raise ValueError(f"content_base64 is not valid base64: {exc}") from exc
+    return _get_client().add_file(matter_id, file_name, data, folder_id=folder_id)
+
+
+@server.tool()
+def delete_file(matter_id: str, file_id: str) -> Any:
+    """Delete a file from a matter (needs matter_id + file_id — files live under
+    their matter). Irreversible loss of a document.
+
+    Classified DESTRUCTIVE at the overlay: it is taint-gated (an untrusted-fed
+    turn can never trigger it autonomously) and requires an authored
+    ``destructive`` ceiling on the seat — fail-closed otherwise. Returns the
+    async tracking link."""
+    return _get_client().delete_file(matter_id, file_id)
 
 
 # ---- Memos ----------------------------------------------------------------

--- a/operator/connectors/smokeball/tests/test_conformance.py
+++ b/operator/connectors/smokeball/tests/test_conformance.py
@@ -38,6 +38,8 @@ EXPECTED_TOOLS = {
     "get_files_on_matter",
     "get_file",
     "get_download_url",
+    "add_file",
+    "delete_file",
     "get_memos_on_matter",
     "get_bank_accounts",
     "get_matter_balances",
@@ -79,16 +81,22 @@ def test_conformance_every_tool_classified() -> None:
     runtime_map = conformance.run_all(server, _manifest())
     # Trust-account fund-movement tools are never exposed here.
     assert not any("transaction" in k or "protect" in k for k in runtime_map)
-    # The one write is an internal write under its runtime name; reads are reads.
+    # Writes carry their classes under the runtime name; reads are reads.
     assert runtime_map[runtime_tool_name("smokeball", "create_memo")] == "internal_write"
+    assert runtime_map[runtime_tool_name("smokeball", "add_file")] == "internal_write"
+    assert runtime_map[runtime_tool_name("smokeball", "delete_file")] == "destructive"
     assert runtime_map[runtime_tool_name("smokeball", "get_matter_balances")] == "read"
     assert runtime_map[runtime_tool_name("smokeball", "list_matters")] == "read"
 
 
-def test_only_create_memo_is_a_write() -> None:
+def test_write_surface_is_memo_and_document_round_trip() -> None:
     m = _manifest()
-    writes = {t for t, c in m.tool_classes.items() if c != "read"}
-    assert writes == {"create_memo"}
+    writes = {t: c for t, c in m.tool_classes.items() if c != "read"}
+    assert writes == {
+        "create_memo": "internal_write",
+        "add_file": "internal_write",
+        "delete_file": "destructive",
+    }
 
 
 @pytest.mark.skipif(_SCRIPT is None, reason="smokeball-mcp console-script not on PATH")

--- a/operator/connectors/smokeball/tests/test_document_writes.py
+++ b/operator/connectors/smokeball/tests/test_document_writes.py
@@ -1,0 +1,123 @@
+"""Unit coverage for the document round-trip writes (add_file / delete_file).
+
+No live Smokeball calls: an ``httpx.MockTransport`` is injected so the real
+two-stage upload logic runs against scripted responses. These lock the contract
+that bit the original seeding effort — the second-stage PUT must go to the
+presigned URL with an EMPTY ``Content-Type`` and NO ``x-api-key``/``Authorization``
+(those would break the S3 signature)."""
+
+from __future__ import annotations
+
+import base64
+
+import httpx
+import pytest
+
+from smokeball_connector.client import SmokeballClient, SmokeballWriteError
+
+_UPLOAD_URL = "https://s3.example.com/apiuploads/abc-123?X-Amz-Signature=deadbeef"
+
+
+def _mock_client(handler, **overrides) -> SmokeballClient:
+    kwargs = dict(region="us", environment="staging", client_id="cid", client_secret="sec", api_key="apikey")
+    kwargs.update(overrides)
+    client = SmokeballClient(**kwargs)
+    client._http = httpx.Client(transport=httpx.MockTransport(handler))
+    return client
+
+
+def _handler(captured: list[httpx.Request], *, no_upload_url: bool = False):
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        path = request.url.path
+        if path.endswith("/oauth2/token"):
+            return httpx.Response(200, json={"access_token": "tok", "expires_in": 3600, "token_type": "Bearer"})
+        if request.method == "POST" and path.endswith("/documents/files"):
+            body = {"fileId": "file-9"}
+            if not no_upload_url:
+                body["uploadUrl"] = _UPLOAD_URL
+            return httpx.Response(202, json=body)
+        if str(request.url) == _UPLOAD_URL:  # the presigned S3 PUT
+            return httpx.Response(200)
+        if request.method == "DELETE":
+            return httpx.Response(202, json={"href": "/tracking/del-1"})
+        return httpx.Response(200, json={"ok": True})
+
+    return handler
+
+
+def test_add_file_two_stage_metadata_then_presigned_put() -> None:
+    captured: list[httpx.Request] = []
+    client = _mock_client(_handler(captured))
+    raw = b"%PDF-1.4 fake pdf bytes"
+    result = client.add_file("m-1", "Demand Letter.pdf", raw)
+
+    assert result == {"fileId": "file-9", "matterId": "m-1", "fileName": "Demand Letter.pdf", "uploaded": True}
+
+    post = next(r for r in captured if r.method == "POST" and r.url.path.endswith("/documents/files"))
+    assert post.url.path == "/matters/m-1/documents/files"
+    import json as _json
+    assert _json.loads(post.content) == {"fileName": "Demand Letter.pdf"}
+    # the metadata call IS authenticated
+    assert post.headers.get("x-api-key") == "apikey"
+    assert post.headers.get("authorization") == "Bearer tok"
+
+    put = next(r for r in captured if r.method == "PUT")
+    assert str(put.url) == _UPLOAD_URL
+    assert put.content == raw
+    # the presigned PUT must carry an EMPTY content-type and NO app/bearer auth
+    assert put.headers.get("content-type") == ""
+    assert "x-api-key" not in put.headers
+    assert "authorization" not in put.headers
+
+
+def test_add_file_includes_folder_id_when_given() -> None:
+    captured: list[httpx.Request] = []
+    client = _mock_client(_handler(captured))
+    client.add_file("m-1", "x.txt", b"hi", folder_id="folder-7")
+    post = next(r for r in captured if r.method == "POST" and r.url.path.endswith("/documents/files"))
+    import json as _json
+    assert _json.loads(post.content) == {"fileName": "x.txt", "folderId": "folder-7"}
+
+
+def test_add_file_raises_when_no_upload_url() -> None:
+    captured: list[httpx.Request] = []
+    client = _mock_client(_handler(captured, no_upload_url=True))
+    with pytest.raises(SmokeballWriteError, match="uploadUrl"):
+        client.add_file("m-1", "x.txt", b"hi")
+    # the presigned PUT must NOT have been attempted
+    assert not any(r.method == "PUT" for r in captured)
+
+
+def test_delete_file_targets_the_matter_scoped_path() -> None:
+    captured: list[httpx.Request] = []
+    client = _mock_client(_handler(captured))
+    client.delete_file("m-1", "file-9")
+    dele = next(r for r in captured if r.method == "DELETE")
+    assert dele.url.path == "/matters/m-1/documents/files/file-9"
+    assert dele.headers.get("x-api-key") == "apikey"  # API call IS authenticated
+
+
+def test_server_add_file_rejects_bad_base64(monkeypatch) -> None:
+    from smokeball_connector import server
+
+    # never reaches the network: bad base64 is refused before the client is built
+    with pytest.raises(ValueError, match="base64"):
+        server.add_file("m-1", "x.txt", "not!!base64!!")
+
+
+def test_server_add_file_decodes_base64_and_delegates(monkeypatch) -> None:
+    from smokeball_connector import server
+
+    seen: dict = {}
+
+    class _FakeClient:
+        def add_file(self, matter_id, file_name, data, *, folder_id=None):
+            seen.update(matter_id=matter_id, file_name=file_name, data=data, folder_id=folder_id)
+            return {"fileId": "f-1", "uploaded": True}
+
+    monkeypatch.setattr(server, "_get_client", lambda: _FakeClient())
+    payload = base64.b64encode(b"hello bytes").decode()
+    out = server.add_file("m-2", "note.txt", payload, folder_id="fld-1")
+    assert out == {"fileId": "f-1", "uploaded": True}
+    assert seen == {"matter_id": "m-2", "file_name": "note.txt", "data": b"hello bytes", "folder_id": "fld-1"}


### PR DESCRIPTION
## What

Adds the document-write half of the **read → work → save** round-trip to the `mcp:smokeball` connector. Until now the connector was reads + `create_memo` only; the Operator could not save its own work product back to a matter (the workflow: retrieve matter docs → user works with/modifies → save the result back).

- **`add_file(matter_id, file_name, content_base64, folder_id=None)`** — Smokeball's two-stage upload: `POST /matters/{id}/documents/files` → `202 {fileId, uploadUrl}`, then `PUT` raw bytes to the presigned URL with an **empty `Content-Type`** (the S3-signature quirk the original seeding effort hit). `content_base64` so any file type works. Classified **INTERNAL_WRITE**.
- **`delete_file(matter_id, file_id)`** — `DELETE /matters/{id}/documents/files/{fileId}`. Classified **DESTRUCTIVE**: taint-gated (an untrusted-fed turn can never trigger it) and fail-closed unless the seat authors a `destructive` ceiling.

## Grounding

Contracts verified against the live Smokeball Documents API docs (`docs.smokeball.com/api-reference/files/*`, `/docs/api-docs/...files-folders`). `crane_verify`: `vfy_01KVYNE98KA49H8XNSESXA3NBV`.

## Governance — no overlay change needed

The overlay action-class map (`shared/action_classes.py`) **already** classifies both runtime names (`mcp_smokeball_add_file` = internal_write, `mcp_smokeball_delete_file` = destructive), authored ahead of the connector. The boot-smoke `connector-classification-probe` (manifest ⊆ map) stays green.

## Tests

- `manifest.toml` `tool_classes` + conformance assertions updated.
- New `tests/test_document_writes.py` locks the two-stage flow: empty `Content-Type`, **no** `x-api-key`/`Authorization` on the presigned PUT, `folderId` passthrough, the no-`uploadUrl` failure path, the matter-scoped delete path, and base64 decode/rejection at the server layer.
- **24 connector tests pass** (`uv venv` + `_sdk` + connector, per the operator-substrate CI pattern).

## Not in this PR (follow-up, gated)

Per-seat entitlement (`pilot-smokeball` `destructive` ceiling), reprovision, and the live Operator-driven seed/cleanup of the staging Johnson matter land in the gated next step — that's where the seams get verified on the real runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)