### PR TITLE
chore(operator): pilot-smokeball test seat — autonomous internal_write + destructive ceilings

### DIFF
--- a/operator/customers/pilot-smokeball/customer.yaml
+++ b/operator/customers/pilot-smokeball/customer.yaml
@@ -213,8 +213,18 @@ scope:
   # External send (to anyone OUTSIDE the roster / a chosen recipient) is drafted,
   # never autonomous. Recipient-locked replies to rostered senders are governed by
   # the roster above, not by this ceiling (ADR 0055 §3).
+  #
+  # This is SMD's own STAGING TEST seat (not a client). The Operator manages its
+  # own sample matters for testing, so it gets full document-write autonomy here:
+  #   - internal_write (add_file save-back, create_memo, drafts) -> autonomous
+  #   - destructive   (delete_file)                              -> autonomous
+  # destructive stays taint-gated regardless of this ceiling, so an untrusted-fed
+  # turn can NEVER trigger a delete. A real client seat authors its own posture
+  # (a firm would typically leave destructive refused/draft).
   action_ceilings:
     external_send: draft_for_review
+    internal_write: autonomous
+    destructive: autonomous
 
 # ---- ESCALATION ----
 escalation:


### PR DESCRIPTION
Authorizes the document round-trip writes from #1513 on SMD's own **staging test seat** so the Operator can manage its own sample matters during testing.

- `internal_write` (add_file save-back, create_memo, drafts) → **autonomous**
- `destructive` (delete_file) → **autonomous**

`destructive` stays **taint-gated** regardless of this ceiling — an untrusted-fed turn can never trigger a delete. `external_send` stays `draft_for_review` (law floor, ADR 0005). This autonomy is scoped to our test seat only; a real client seat (e.g. ashton-price) authors its own posture and would typically leave `destructive` refused/draft.

Validated: YAML parse + `bin/tests/test_customer_yaml_block_conformance.py` (4 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)