### PR TITLE
fix(operator): request documents/write in the Smokeball connect scope set

### DIFF
--- a/bin/connect-smokeball.sh
+++ b/bin/connect-smokeball.sh
@@ -148,6 +148,11 @@ URL="$(
     const scopes = [
       "matters/read", "contacts/read", "mattertypes/read", "stages/read",
       "tasks/read", "staff/read", "roles/read", "documents/read",
+      // documents/write authorizes the connector add_file (save-back) and
+      // delete_file (Smokeball "write" = mutate, covers create + delete). Without
+      // it the firm-delegated token is read-only on documents and every upload
+      // 403s: the gap that blocked the document round-trip on pilot-smokeball.
+      "documents/write",
       "memos/read", "memos/write", "bankaccounts/read", "bankaccountbalances/read",
       "billingconfiguration/read", "fees/read", "expenses/read",
       "webhooks/read", "webhooks/write",


### PR DESCRIPTION
## What

`bin/connect-smokeball.sh` requested 17 read-leaning scopes plus `memos/write` + `webhooks/write`, but **not `documents/write`**. So the firm-delegated (authorization_code) token the Operator authenticates with was **read-only on documents**, and the connector's `add_file` / `delete_file` (#1513) 403'd at the Smokeball API even though governance allowed them.

## Live evidence (pilot-smokeball, post-#1513 reprovision)

Driving the live Operator: `add_file` and `create_memo` both **403** at the Smokeball API; reads 200. `add_file` passed governance (internal_write autonomous) and reached the API — the rejection is the missing scope. (`crane_verify` vfy_01KW02SWW9WCK2ZHB0XGVZJG1X.)

## Fix

Add `documents/write` to the consent scope list. Smokeball `write` = mutate (covers create + delete), so this authorizes both `add_file` and `delete_file`. A **re-consent** mints a token carrying it.

bash-3.2 validated (the scope list lives inside a single-quoted `node -e` block — no apostrophes).

## Follow-up (operational, not code)

Re-run `connect-smokeball.sh pilot-smokeball` → firm clicks Allow → new token lands on the Machine → restart the connector to pick it up → re-test `add_file`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)