### PR TITLE
feat(operator): log Smokeball granted scopes on mint (flag-free readout)

### DIFF
--- a/operator/connectors/smokeball/manifest.toml
+++ b/operator/connectors/smokeball/manifest.toml
@@ -25,12 +25,6 @@ description = "Smokeball practice-management API connector (law wedge system of 
 [connector.env_static]
 SMOKEBALL_REGION = "us"
 SMOKEBALL_ENVIRONMENT = "staging"
-# TEMPORARY DIAGNOSTIC (remove after the pilot-smokeball write-403 root-cause run):
-# arms server._boot_diagnose() so the connector logs its granted token scopes at
-# boot (scope-only; no write — SMOKEBALL_DIAGNOSE_WRITE is intentionally NOT set).
-# env_static is the only in-repo channel that reaches the broker-curated connector
-# env. Revert this line once the granted-scope readout is captured.
-SMOKEBALL_BOOT_DIAGNOSE = "1"
 
 [[connector.required_secrets]]
 runtime_env = "SMOKEBALL_CLIENT_ID"

--- a/operator/connectors/smokeball/smokeball_connector/client.py
+++ b/operator/connectors/smokeball/smokeball_connector/client.py
@@ -149,6 +149,7 @@ class SmokeballClient:
         self._account_id = account_id.strip("/") if account_id else None
         self._token: str | None = None
         self._token_deadline = 0.0
+        self._scopes_logged = False
         self._http = httpx.Client(timeout=timeout)
 
     # ---- auth -------------------------------------------------------------
@@ -197,6 +198,25 @@ class SmokeballClient:
         expires_in = int(body.get("expires_in", 3600))
         self._token = token
         self._token_deadline = time.monotonic() + max(expires_in - _TOKEN_SKEW_SECONDS, 0)
+        # Operability: log the granted scopes once per process on first successful
+        # auth. The connector mints on the first tool call of any agent turn (e.g.
+        # the inbox router's get_contacts/list_matters), so this surfaces the live
+        # token's actual grant without an agent ever calling auth_status — the only
+        # reliable readout, since no env flag reaches the broker-curated connector
+        # env and no enabled skill writes. Scopes are not secret; the token never is.
+        if not self._scopes_logged:
+            self._scopes_logged = True
+            try:
+                import sys
+
+                print(
+                    f"[smokeball] authenticated mode={self.auth_mode} "
+                    f"granted_scopes={self._decode_token_scopes()}",
+                    file=sys.stderr,
+                    flush=True,
+                )
+            except Exception:  # noqa: BLE001 - logging must never break auth
+                pass
         return expires_in
 
     def _persist_refresh_token(self, token: str) -> None:

--- a/operator/connectors/smokeball/tests/test_auth_modes.py
+++ b/operator/connectors/smokeball/tests/test_auth_modes.py
@@ -193,6 +193,21 @@ def test_auth_status_granted_scopes_empty_for_opaque_token() -> None:
     assert client.auth_status()["granted_scopes"] == []
 
 
+def test_mint_logs_granted_scopes_once(capsys) -> None:
+    jwt = _make_jwt({"scope": "documents/read documents/write matters/read"})
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"access_token": jwt, "expires_in": 3600, "token_type": "Bearer"})
+
+    client = _mock_client(handler, auth_mode="authorization_code", refresh_token="rt-1")
+    client._mint_token()
+    client._mint_token()  # second mint must NOT re-log
+    err = capsys.readouterr().err
+    assert err.count("[smokeball] authenticated") == 1
+    assert "documents/write" in err
+    assert jwt not in err  # the token itself is never logged
+
+
 # ---- ADR 0054: durable refresh-token file (read + rotation persist) --------
 def test_authorization_code_persists_rotated_token_to_file(tmp_path) -> None:
     token_file = tmp_path / "refresh_token"


### PR DESCRIPTION
Replaces the dead env_static boot-flag (the broker injects only an overlay-known allowlist, not manifest env_static, so the flag never reached the connector) with a flag-free readout: the client logs its granted token scopes (decoded JWT scope claim; token never logged) once per process on first mint. Mints happen on every agent read turn (proven: the inbox router's get_contacts/list_matters), so this surfaces the live firm-delegated token's actual grant — the verified path to whether it carries `documents/write` (the write-403 root cause). 34 connector tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)