### PR TITLE
feat(operator): MCP grant write side — admin issue/revoke + immutable audit (ADR 0057 slice 2b)

### DIFF
--- a/migrations/0076_operator_mcp_grant_audit.sql
+++ b/migrations/0076_operator_mcp_grant_audit.sql
@@ -1,0 +1,51 @@
+-- Operator ⇄ Claude MCP connector — grant lifecycle audit ledger (ADR 0057)
+-- ============================================================================
+-- The append-only, immutable record of every access-grant issue and revoke on
+-- the Claude connector. `mcp_issued_grants` (migration 0075) is the LIVE state
+-- and is mutated in place (re-issue overwrites the row, revoke flips a column),
+-- so the row itself is not an audit trail. This table is.
+--
+-- Every adminIssueGrant / revokeGrant (and, later, every JIT auto-issue) writes
+-- one row here capturing WHO acted (the SMD admin `actor`, or the system for a
+-- JIT mint), WHAT they did (`action`), for WHICH principal, with what TTL/expiry,
+-- and WHEN. A law firm's access record must be reconstructable from an immutable
+-- log even after the live grant row has been overwritten or deleted — this is
+-- that log. Rows are never updated or deleted.
+--
+-- Distinct from operator_mcp_audit (request-time auth/tool_call events, whose
+-- CHECK constraint is fixed to those two types) — grant lifecycle is a different
+-- shape (it carries an admin actor and a TTL), so it gets its own ledger.
+--
+-- ISOLATION: control-plane D1 (per ADR 0007/0009). `customer_slug` scopes every
+-- read; `entity_id` FK cascades with the entity.
+--
+-- Refers to: docs/adr/0057-operator-claude-connector-access-model.md
+-- ============================================================================
+
+CREATE TABLE operator_mcp_grant_audit (
+  id            INTEGER PRIMARY KEY AUTOINCREMENT,
+  entity_id     TEXT NOT NULL REFERENCES entities(id) ON DELETE CASCADE,
+  customer_slug TEXT NOT NULL,
+  -- 'issue' (admin or JIT mint) | 'revoke' (the explicit kill).
+  action        TEXT NOT NULL CHECK (action IN ('issue', 'revoke')),
+  -- The Clerk subject the grant authorizes (the grantee).
+  clerk_user_id TEXT NOT NULL,
+  email         TEXT NOT NULL,
+  profile       TEXT,
+  -- Bounded TTL the grant was issued with (issue events); NULL on revoke.
+  ttl_days      INTEGER,
+  -- The concrete expiry the grant resolved to (issue events); NULL on revoke.
+  expires_at    TEXT,
+  -- WHO performed the action: the SMD admin's email, or 'system:jit' for an
+  -- open-policy auto-issue (slice 2e). Never null — every grant change has an
+  -- accountable actor.
+  actor         TEXT NOT NULL,
+  reason        TEXT,
+  created_at    TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+
+CREATE INDEX idx_operator_mcp_grant_audit_customer_created
+  ON operator_mcp_grant_audit (customer_slug, created_at DESC);
+
+CREATE INDEX idx_operator_mcp_grant_audit_subject_created
+  ON operator_mcp_grant_audit (clerk_user_id, created_at DESC);

--- a/migrations/rollbacks/0076_operator_mcp_grant_audit_down.sql
+++ b/migrations/rollbacks/0076_operator_mcp_grant_audit_down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS operator_mcp_grant_audit;

--- a/src/lib/operator/mcp/grant-store.ts
+++ b/src/lib/operator/mcp/grant-store.ts
@@ -1,0 +1,189 @@
+import type { D1Database } from '@cloudflare/workers-types'
+
+/**
+ * Writer for the Operator ⇄ Claude MCP access-grant table (`mcp_issued_grants`,
+ * ADR 0057). Slice 2a shipped the live READ (loadMcpCustomer); this is the write
+ * side that makes the kill switch operable.
+ *
+ * Two issue paths exist by design and must stay distinct:
+ *   - adminIssueGrant — an SMD admin deliberately granting; MAY lift a prior
+ *     revocation (clears revoked_at).
+ *   - jitIssueGrant (slice 2e, open-by-domain) — auto-issue on first authenticated
+ *     firm-domain connect; MUST refuse if a revoked row exists (sticky revoke), so
+ *     a revoked user cannot re-mint their way back in.
+ *
+ * Every issue and revoke also writes one append-only row to
+ * operator_mcp_grant_audit. The live grant row is mutable state (re-issue
+ * overwrites it, revoke flips a column); the audit ledger is the immutable record
+ * of who changed access, for whom, when — a law-firm obligation.
+ */
+
+const NOW_SQL = "strftime('%Y-%m-%dT%H:%M:%fZ', 'now')"
+
+/** Bounded-TTL invariant (ADR 0057): never null, never infinite. */
+export const GRANT_TTL_DEFAULT_DAYS = 30
+export const GRANT_TTL_MAX_DAYS = 90
+
+/** Clamp an authored/submitted TTL into [1, GRANT_TTL_MAX_DAYS]; junk → default. */
+export function clampTtlDays(raw: number): number {
+  if (!Number.isFinite(raw) || raw < 1) return GRANT_TTL_DEFAULT_DAYS
+  return Math.min(Math.floor(raw), GRANT_TTL_MAX_DAYS)
+}
+
+export interface GrantAuditContext {
+  /** entities.id — for the audit FK + cascade. */
+  entityId: string
+  /** Who acted: an SMD admin email, or 'system:jit' for an open-policy mint. */
+  actor: string
+  reason: string | null
+}
+
+export interface IssueGrantInput {
+  customerSlug: string
+  clerkUserId: string
+  email: string
+  profile: string
+  ttlDays: number
+}
+
+export interface GrantListRow {
+  clerk_user_id: string
+  email: string
+  profile: string
+  issued_at: string
+  expires_at: string
+  revoked_at: string | null
+}
+
+/**
+ * Admin-issued grant. UPSERT on the (customer_slug, clerk_user_id) PK; refreshes
+ * issued_at and **clears revoked_at** — an admin re-granting deliberately lifts a
+ * prior revocation. Returns the concrete expiry the grant resolved to.
+ */
+export async function adminIssueGrant(
+  db: D1Database,
+  input: IssueGrantInput,
+  ctx: GrantAuditContext
+): Promise<{ expiresAt: string }> {
+  const ttlDays = clampTtlDays(input.ttlDays)
+  await db
+    .prepare(
+      'INSERT INTO mcp_issued_grants ' +
+        '(customer_slug, clerk_user_id, email, profile, expires_at, issued_at, revoked_at) ' +
+        `VALUES (?, ?, ?, ?, strftime('%Y-%m-%dT%H:%M:%fZ', 'now', ?), ${NOW_SQL}, NULL) ` +
+        'ON CONFLICT(customer_slug, clerk_user_id) DO UPDATE SET ' +
+        'email = excluded.email, profile = excluded.profile, ' +
+        'expires_at = excluded.expires_at, issued_at = excluded.issued_at, revoked_at = NULL'
+    )
+    .bind(input.customerSlug, input.clerkUserId, input.email, input.profile, `+${ttlDays} days`)
+    .run()
+  const row = await db
+    .prepare(
+      'SELECT expires_at FROM mcp_issued_grants WHERE customer_slug = ? AND clerk_user_id = ?'
+    )
+    .bind(input.customerSlug, input.clerkUserId)
+    .first<{ expires_at: string }>()
+  const expiresAt = row?.expires_at ?? ''
+  await recordGrantAudit(db, {
+    entityId: ctx.entityId,
+    customerSlug: input.customerSlug,
+    action: 'issue',
+    clerkUserId: input.clerkUserId,
+    email: input.email,
+    profile: input.profile,
+    ttlDays,
+    expiresAt,
+    actor: ctx.actor,
+    reason: ctx.reason,
+  })
+  return { expiresAt }
+}
+
+/**
+ * Revoke a grant: set revoked_at on the live (un-revoked) row. The next MCP
+ * request sees the principal vanish (loadMcpCustomer filters revoked_at IS NULL).
+ * Idempotent — re-revoking an already-revoked grant changes nothing and writes no
+ * audit row. Returns whether a live grant was actually killed.
+ */
+export async function revokeGrant(
+  db: D1Database,
+  input: { customerSlug: string; clerkUserId: string },
+  ctx: GrantAuditContext
+): Promise<{ changed: boolean; email: string | null; profile: string | null }> {
+  const existing = await db
+    .prepare(
+      'SELECT email, profile FROM mcp_issued_grants WHERE customer_slug = ? AND clerk_user_id = ?'
+    )
+    .bind(input.customerSlug, input.clerkUserId)
+    .first<{ email: string; profile: string }>()
+  const res = await db
+    .prepare(
+      `UPDATE mcp_issued_grants SET revoked_at = ${NOW_SQL} ` +
+        'WHERE customer_slug = ? AND clerk_user_id = ? AND revoked_at IS NULL'
+    )
+    .bind(input.customerSlug, input.clerkUserId)
+    .run()
+  const changed = (res.meta?.changes ?? 0) > 0
+  if (changed) {
+    await recordGrantAudit(db, {
+      entityId: ctx.entityId,
+      customerSlug: input.customerSlug,
+      action: 'revoke',
+      clerkUserId: input.clerkUserId,
+      email: existing?.email ?? '',
+      profile: existing?.profile ?? null,
+      ttlDays: null,
+      expiresAt: null,
+      actor: ctx.actor,
+      reason: ctx.reason,
+    })
+  }
+  return { changed, email: existing?.email ?? null, profile: existing?.profile ?? null }
+}
+
+/** All grants for a customer (incl. revoked/expired) for the admin view. */
+export async function listGrants(db: D1Database, customerSlug: string): Promise<GrantListRow[]> {
+  const res = await db
+    .prepare(
+      'SELECT clerk_user_id, email, profile, issued_at, expires_at, revoked_at ' +
+        'FROM mcp_issued_grants WHERE customer_slug = ? ORDER BY issued_at DESC'
+    )
+    .bind(customerSlug)
+    .all<GrantListRow>()
+  return res.results ?? []
+}
+
+interface GrantAuditRow {
+  entityId: string
+  customerSlug: string
+  action: 'issue' | 'revoke'
+  clerkUserId: string
+  email: string
+  profile: string | null
+  ttlDays: number | null
+  expiresAt: string | null
+  actor: string
+  reason: string | null
+}
+
+async function recordGrantAudit(db: D1Database, row: GrantAuditRow): Promise<void> {
+  await db
+    .prepare(
+      'INSERT INTO operator_mcp_grant_audit ' +
+        '(entity_id, customer_slug, action, clerk_user_id, email, profile, ttl_days, ' +
+        'expires_at, actor, reason) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
+    )
+    .bind(
+      row.entityId,
+      row.customerSlug,
+      row.action,
+      row.clerkUserId,
+      row.email,
+      row.profile,
+      row.ttlDays,
+      row.expiresAt,
+      row.actor,
+      row.reason
+    )
+    .run()
+}

--- a/src/pages/admin/operator/[customer]/connectors.astro
+++ b/src/pages/admin/operator/[customer]/connectors.astro
@@ -9,6 +9,11 @@ import {
 } from '../../../../lib/admin/connectors-view'
 import { getCustomerConfig } from '../../../../lib/portal/customer-config'
 import { isSecretTransportConfigured } from '../../../../lib/operator/credential-secret-transport'
+import {
+  listGrants,
+  GRANT_TTL_DEFAULT_DAYS,
+  GRANT_TTL_MAX_DAYS,
+} from '../../../../lib/operator/mcp/grant-store'
 import { env } from 'cloudflare:workers'
 
 /**
@@ -40,6 +45,27 @@ const connectors = config
   ? parseConnectorViews(config.connectors, config.credential_custody_default)
   : []
 const relayEnabled = isSecretTransportConfigured(env)
+
+// ADR 0057 — Claude connector access grants (the live kill switch).
+const grants = entityId ? await listGrants(env.DB, slug) : []
+const nowIso = new Date().toISOString()
+function grantState(g: { revoked_at: string | null; expires_at: string }): string {
+  if (g.revoked_at) return 'revoked'
+  return g.expires_at > nowIso ? 'active' : 'expired'
+}
+
+const GRANT_STATUS_MESSAGES: Record<string, { tone: 'ok' | 'warn'; text: string }> = {
+  grant_issued: { tone: 'ok', text: 'Grant issued. It applies on the next request.' },
+  grant_revoked: { tone: 'ok', text: 'Grant revoked. Access is cut on the next request.' },
+  grant_not_found: { tone: 'warn', text: 'No active grant to revoke for that subject.' },
+  invalid_action: { tone: 'warn', text: 'Unrecognized grant action.' },
+  invalid_subject: { tone: 'warn', text: 'A Clerk subject is required.' },
+  invalid_email: { tone: 'warn', text: 'A valid grantee email is required.' },
+  invalid_profile: { tone: 'warn', text: 'A persona profile is required.' },
+}
+const statusParam = Astro.url.searchParams.get('status')
+const grantBanner = statusParam ? (GRANT_STATUS_MESSAGES[statusParam] ?? null) : null
+const grantsAction = `/api/admin/operator/${encodeURIComponent(slug)}/mcp-grants`
 ---
 
 <AdminLayout
@@ -69,6 +95,18 @@ const relayEnabled = isSecretTransportConfigured(env)
         </div>
       ) : (
         <>
+          {grantBanner && (
+            <div
+              class={`rounded-[var(--ss-radius-card)] border p-3 text-sm ${
+                grantBanner.tone === 'ok'
+                  ? 'border-[color:var(--ss-color-border)] bg-[color:var(--ss-color-surface-muted)] text-[color:var(--ss-color-text-primary)]'
+                  : 'border-[color:var(--ss-color-border)] bg-white text-[color:var(--ss-color-text-secondary)]'
+              }`}
+            >
+              {grantBanner.text}
+            </div>
+          )}
+
           <header>
             <h2 class="text-xl font-semibold text-[color:var(--ss-color-text-primary)]">
               Connectors &amp; credentials — {slug}
@@ -139,6 +177,128 @@ const relayEnabled = isSecretTransportConfigured(env)
             OAuth re-consent execution ride the secret relay (ADR 0036); they light up here once it
             is configured.
           </p>
+
+          <section class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card">
+            <header class="mb-3">
+              <h3 class="text-lg font-semibold text-[color:var(--ss-color-text-primary)]">
+                Claude connector access (ADR 0057)
+              </h3>
+              <p class="text-sm text-[color:var(--ss-color-text-secondary)] mt-1">
+                Who may reach this Operator through their own Claude. The grant is the authoritative
+                authorization and is checked live on every request, so revoking cuts access on the
+                next call. Bounded by design: every grant expires (default {GRANT_TTL_DEFAULT_DAYS}{' '}
+                days, max {GRANT_TTL_MAX_DAYS}).
+              </p>
+            </header>
+
+            {grants.length === 0 ? (
+              <p class="text-sm text-[color:var(--ss-color-text-secondary)]">
+                No grants issued. Issue one below to authorize a firm user's Claude.
+              </p>
+            ) : (
+              <table class="w-full text-sm">
+                <thead>
+                  <tr class="text-left text-[color:var(--ss-color-text-secondary)]">
+                    <th class="py-1 pr-3 font-medium">Subject</th>
+                    <th class="py-1 pr-3 font-medium">Email</th>
+                    <th class="py-1 pr-3 font-medium">Profile</th>
+                    <th class="py-1 pr-3 font-medium">Expires</th>
+                    <th class="py-1 pr-3 font-medium">State</th>
+                    <th class="py-1 font-medium" />
+                  </tr>
+                </thead>
+                <tbody>
+                  {grants.map((g) => {
+                    const state = grantState(g)
+                    return (
+                      <tr class="border-t border-[color:var(--ss-color-border)] align-middle">
+                        <td class="py-1.5 pr-3 font-mono text-xs text-[color:var(--ss-color-text-primary)]">
+                          {g.clerk_user_id}
+                        </td>
+                        <td class="py-1.5 pr-3 text-[color:var(--ss-color-text-primary)]">
+                          {g.email}
+                        </td>
+                        <td class="py-1.5 pr-3 text-[color:var(--ss-color-text-primary)]">
+                          {g.profile}
+                        </td>
+                        <td class="py-1.5 pr-3 text-[color:var(--ss-color-text-secondary)]">
+                          {g.expires_at.slice(0, 10)}
+                        </td>
+                        <td class="py-1.5 pr-3 text-[color:var(--ss-color-text-secondary)]">
+                          {state}
+                        </td>
+                        <td class="py-1.5 text-right">
+                          {state === 'active' && (
+                            <form method="POST" action={grantsAction}>
+                              <input type="hidden" name="action" value="revoke" />
+                              <input type="hidden" name="clerk_user_id" value={g.clerk_user_id} />
+                              <button
+                                type="submit"
+                                class="text-xs text-[color:var(--ss-color-action)] hover:underline"
+                              >
+                                Revoke
+                              </button>
+                            </form>
+                          )}
+                        </td>
+                      </tr>
+                    )
+                  })}
+                </tbody>
+              </table>
+            )}
+
+            <form method="POST" action={grantsAction} class="mt-4 grid gap-2 sm:grid-cols-2">
+              <input type="hidden" name="action" value="issue" />
+              <label class="text-xs text-[color:var(--ss-color-text-secondary)]">
+                Clerk subject
+                <input
+                  name="clerk_user_id"
+                  required
+                  placeholder="user_..."
+                  class="mt-0.5 w-full rounded border border-[color:var(--ss-color-border)] px-2 py-1 text-sm font-mono"
+                />
+              </label>
+              <label class="text-xs text-[color:var(--ss-color-text-secondary)]">
+                Grantee email
+                <input
+                  name="email"
+                  type="email"
+                  required
+                  placeholder="person@firm.com"
+                  class="mt-0.5 w-full rounded border border-[color:var(--ss-color-border)] px-2 py-1 text-sm"
+                />
+              </label>
+              <label class="text-xs text-[color:var(--ss-color-text-secondary)]">
+                Profile
+                <input
+                  name="profile"
+                  required
+                  placeholder="persona slug"
+                  class="mt-0.5 w-full rounded border border-[color:var(--ss-color-border)] px-2 py-1 text-sm"
+                />
+              </label>
+              <label class="text-xs text-[color:var(--ss-color-text-secondary)]">
+                TTL (days, max {GRANT_TTL_MAX_DAYS})
+                <input
+                  name="ttl_days"
+                  type="number"
+                  min="1"
+                  max={GRANT_TTL_MAX_DAYS}
+                  placeholder={String(GRANT_TTL_DEFAULT_DAYS)}
+                  class="mt-0.5 w-full rounded border border-[color:var(--ss-color-border)] px-2 py-1 text-sm"
+                />
+              </label>
+              <div class="sm:col-span-2">
+                <button
+                  type="submit"
+                  class="rounded bg-[color:var(--ss-color-action)] px-3 py-1.5 text-sm font-medium text-white hover:opacity-90"
+                >
+                  Issue grant
+                </button>
+              </div>
+            </form>
+          </section>
         </>
       )
     }

--- a/src/pages/api/admin/operator/[customer]/mcp-grants.ts
+++ b/src/pages/api/admin/operator/[customer]/mcp-grants.ts
@@ -1,0 +1,122 @@
+/**
+ * POST /api/admin/operator/[customer]/mcp-grants
+ *
+ * SMD issues or revokes a Claude-connector access grant (ADR 0057). The grant
+ * table is the authoritative authorization layer and the kill switch, read live
+ * on every MCP request — so a revoke here cuts the principal on their next call.
+ *
+ * Form fields:
+ *   action        — 'issue' | 'revoke'
+ *   clerk_user_id — the Clerk subject the grant authorizes (required)
+ *   email         — the grantee's email           (issue only, required)
+ *   profile       — the persona the session runs as (issue only, required)
+ *   ttl_days      — bounded TTL, clamped to [1, 90]; default 30 (issue only)
+ *   reason        — optional free-text note for the audit ledger
+ *
+ * Every issue/revoke writes an immutable row to operator_mcp_grant_audit with the
+ * SMD actor. Status banner on the connectors page:
+ *   ?status=grant_issued | grant_revoked | grant_not_found | invalid_* | not_found
+ *
+ * Admin-only (middleware on /api/admin/* + explicit re-check).
+ */
+
+import type { APIContext, APIRoute } from 'astro'
+import { env } from 'cloudflare:workers'
+import { resolveEntityIdBySlug } from '../../../../../lib/admin/operator-overview'
+import {
+  adminIssueGrant,
+  clampTtlDays,
+  GRANT_TTL_DEFAULT_DAYS,
+  revokeGrant,
+} from '../../../../../lib/operator/mcp/grant-store'
+
+function redirectWithStatus(slug: string, status: string): Response {
+  const target = `/admin/operator/${encodeURIComponent(slug)}/connectors?status=${encodeURIComponent(status)}`
+  return new Response(null, { status: 303, headers: { Location: target } })
+}
+
+function jsonError(status: number, message: string): Response {
+  return new Response(JSON.stringify({ error: message }), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+function optionalString(raw: FormDataEntryValue | null): string | null {
+  return typeof raw === 'string' && raw.trim() !== '' ? raw.trim() : null
+}
+
+type ParsedForm =
+  | { action: 'revoke'; clerkUserId: string; reason: string | null }
+  | {
+      action: 'issue'
+      clerkUserId: string
+      email: string
+      profile: string
+      ttlDays: number
+      reason: string | null
+    }
+
+const EMAIL_RE = /^[^@\s]+@[^@\s]+\.[^@\s]+$/
+
+/** Parse + validate without casting. Returns a status string on error. */
+function parseForm(form: FormData): { error: string } | { parsed: ParsedForm } {
+  const action = optionalString(form.get('action'))
+  const clerkUserId = optionalString(form.get('clerk_user_id'))
+  const reason = optionalString(form.get('reason'))
+  if (!clerkUserId) return { error: 'invalid_subject' }
+
+  if (action === 'revoke') {
+    return { parsed: { action: 'revoke', clerkUserId, reason } }
+  }
+  if (action !== 'issue') return { error: 'invalid_action' }
+
+  const email = optionalString(form.get('email'))
+  if (!email || !EMAIL_RE.test(email)) return { error: 'invalid_email' }
+  const profile = optionalString(form.get('profile'))
+  if (!profile) return { error: 'invalid_profile' }
+
+  const rawTtl = optionalString(form.get('ttl_days'))
+  const ttlDays = rawTtl === null ? GRANT_TTL_DEFAULT_DAYS : clampTtlDays(Number(rawTtl))
+
+  return { parsed: { action: 'issue', clerkUserId, email, profile, ttlDays, reason } }
+}
+
+async function handlePost(ctx: APIContext): Promise<Response> {
+  const session = ctx.locals.session
+  if (!session || session.role !== 'admin') return jsonError(401, 'Unauthorized')
+
+  const slug = ctx.params.customer ?? ''
+  const entityId = await resolveEntityIdBySlug(env.DB, slug)
+  if (!entityId) return redirectWithStatus(slug, 'not_found')
+
+  const result = parseForm(await ctx.request.formData())
+  if ('error' in result) return redirectWithStatus(slug, result.error)
+  const parsed = result.parsed
+
+  const auditCtx = { entityId, actor: session.email, reason: parsed.reason }
+
+  if (parsed.action === 'issue') {
+    await adminIssueGrant(
+      env.DB,
+      {
+        customerSlug: slug,
+        clerkUserId: parsed.clerkUserId,
+        email: parsed.email,
+        profile: parsed.profile,
+        ttlDays: parsed.ttlDays,
+      },
+      auditCtx
+    )
+    return redirectWithStatus(slug, 'grant_issued')
+  }
+
+  const { changed } = await revokeGrant(
+    env.DB,
+    { customerSlug: slug, clerkUserId: parsed.clerkUserId },
+    auditCtx
+  )
+  return redirectWithStatus(slug, changed ? 'grant_revoked' : 'grant_not_found')
+}
+
+export const POST: APIRoute = (ctx) => handlePost(ctx)

--- a/tests/operator-mcp-grant-store.test.ts
+++ b/tests/operator-mcp-grant-store.test.ts
@@ -1,0 +1,241 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  createTestD1,
+  discoverNumericMigrations,
+  runMigrations,
+} from '@venturecrane/crane-test-harness'
+import type { D1Database } from '@cloudflare/workers-types'
+import { resolve } from 'node:path'
+import { ORG_ID } from '../src/lib/constants'
+import { loadMcpCustomer } from '../src/lib/operator/mcp/customer-resolution'
+import {
+  adminIssueGrant,
+  clampTtlDays,
+  GRANT_TTL_DEFAULT_DAYS,
+  GRANT_TTL_MAX_DAYS,
+  listGrants,
+  revokeGrant,
+} from '../src/lib/operator/mcp/grant-store'
+
+const migrationsDir = resolve(process.cwd(), 'migrations')
+const SLUG = 'smd'
+const ENTITY_ID = 'entity-grant-test'
+const ISSUER = 'https://clerk.smd.services'
+const RESOURCE_URI = 'https://smd.services/api/operator/smd/mcp'
+const ACTOR = 'admin@smd.services'
+
+async function freshDb(): Promise<D1Database> {
+  const db = createTestD1()
+  await runMigrations(db, { files: discoverNumericMigrations(migrationsDir) })
+  return db
+}
+
+async function seed(db: D1Database): Promise<void> {
+  await db
+    .prepare('INSERT INTO entities (id, org_id, name, slug, clerk_org_id) VALUES (?, ?, ?, ?, ?)')
+    .bind(ENTITY_ID, ORG_ID, 'Grant Test', SLUG, null)
+    .run()
+  await db
+    .prepare(
+      'INSERT INTO customer_configs ' +
+        '(entity_id, org_id, customer_slug, schema_version, personas_json, mcp_connector_json, ' +
+        'git_sha, synced_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)'
+    )
+    .bind(
+      ENTITY_ID,
+      ORG_ID,
+      SLUG,
+      '1',
+      '[]',
+      JSON.stringify({ enabled: true, data_posture: 'open', access: [] }),
+      'test-sha',
+      '2026-06-27T00:00:00Z'
+    )
+    .run()
+  await db
+    .prepare(
+      'INSERT INTO mcp_clerk_bindings (entity_id, customer_slug, issuer, resource_uri) ' +
+        'VALUES (?, ?, ?, ?)'
+    )
+    .bind(ENTITY_ID, SLUG, ISSUER, RESOURCE_URI)
+    .run()
+}
+
+const issueCtx = { entityId: ENTITY_ID, actor: ACTOR, reason: null }
+
+async function auditRows(db: D1Database) {
+  const res = await db
+    .prepare(
+      'SELECT action, clerk_user_id, email, profile, ttl_days, expires_at, actor, reason ' +
+        'FROM operator_mcp_grant_audit WHERE customer_slug = ? ORDER BY id ASC'
+    )
+    .bind(SLUG)
+    .all()
+  return res.results ?? []
+}
+
+describe('grant-store TTL clamping', () => {
+  it('clamps junk and out-of-range TTLs into [1, max], default on garbage', () => {
+    expect(clampTtlDays(45)).toBe(45)
+    expect(clampTtlDays(200)).toBe(GRANT_TTL_MAX_DAYS)
+    expect(clampTtlDays(0)).toBe(GRANT_TTL_DEFAULT_DAYS)
+    expect(clampTtlDays(-5)).toBe(GRANT_TTL_DEFAULT_DAYS)
+    expect(clampTtlDays(Number.NaN)).toBe(GRANT_TTL_DEFAULT_DAYS)
+    expect(clampTtlDays(12.9)).toBe(12)
+  })
+})
+
+describe('grant-store write side (ADR 0057)', () => {
+  let db: D1Database
+  beforeEach(async () => {
+    db = await freshDb()
+    await seed(db)
+  })
+
+  it('admin-issues a live grant that loadMcpCustomer authorizes', async () => {
+    const { expiresAt } = await adminIssueGrant(
+      db,
+      {
+        customerSlug: SLUG,
+        clerkUserId: 'user_a',
+        email: 'a@firm.com',
+        profile: 'quinn',
+        ttlDays: 30,
+      },
+      issueCtx
+    )
+    expect(expiresAt > new Date().toISOString()).toBe(true)
+
+    const customer = await loadMcpCustomer(db, SLUG)
+    expect(customer?.principals).toContainEqual({
+      localUserId: 'user_a',
+      clerkUserId: 'user_a',
+      email: 'a@firm.com',
+      profile: 'quinn',
+    })
+
+    const audit = await auditRows(db)
+    expect(audit).toHaveLength(1)
+    expect(audit[0]).toMatchObject({
+      action: 'issue',
+      clerk_user_id: 'user_a',
+      email: 'a@firm.com',
+      profile: 'quinn',
+      ttl_days: 30,
+      actor: ACTOR,
+    })
+    expect((audit[0] as { expires_at: string }).expires_at).toBe(expiresAt)
+  })
+
+  it('clamps an over-ceiling TTL at issue time', async () => {
+    await adminIssueGrant(
+      db,
+      {
+        customerSlug: SLUG,
+        clerkUserId: 'user_b',
+        email: 'b@firm.com',
+        profile: 'quinn',
+        ttlDays: 999,
+      },
+      issueCtx
+    )
+    const audit = await auditRows(db)
+    expect((audit[0] as { ttl_days: number }).ttl_days).toBe(GRANT_TTL_MAX_DAYS)
+  })
+
+  it('revokes a grant so loadMcpCustomer drops it, and audits the revoke', async () => {
+    await adminIssueGrant(
+      db,
+      {
+        customerSlug: SLUG,
+        clerkUserId: 'user_a',
+        email: 'a@firm.com',
+        profile: 'quinn',
+        ttlDays: 30,
+      },
+      issueCtx
+    )
+    const res = await revokeGrant(db, { customerSlug: SLUG, clerkUserId: 'user_a' }, issueCtx)
+    expect(res.changed).toBe(true)
+
+    const customer = await loadMcpCustomer(db, SLUG)
+    expect(customer?.principals.find((p) => p.clerkUserId === 'user_a')).toBeUndefined()
+
+    const audit = await auditRows(db)
+    expect(audit.map((r) => (r as { action: string }).action)).toEqual(['issue', 'revoke'])
+  })
+
+  it('is idempotent on a missing or already-revoked grant (no audit row)', async () => {
+    const missing = await revokeGrant(db, { customerSlug: SLUG, clerkUserId: 'nope' }, issueCtx)
+    expect(missing.changed).toBe(false)
+
+    await adminIssueGrant(
+      db,
+      {
+        customerSlug: SLUG,
+        clerkUserId: 'user_a',
+        email: 'a@firm.com',
+        profile: 'quinn',
+        ttlDays: 30,
+      },
+      issueCtx
+    )
+    await revokeGrant(db, { customerSlug: SLUG, clerkUserId: 'user_a' }, issueCtx)
+    const second = await revokeGrant(db, { customerSlug: SLUG, clerkUserId: 'user_a' }, issueCtx)
+    expect(second.changed).toBe(false)
+
+    const audit = await auditRows(db)
+    expect(audit.map((r) => (r as { action: string }).action)).toEqual(['issue', 'revoke'])
+  })
+
+  it('admin re-issue lifts a revocation (clears revoked_at) and re-authorizes', async () => {
+    await adminIssueGrant(
+      db,
+      {
+        customerSlug: SLUG,
+        clerkUserId: 'user_a',
+        email: 'a@firm.com',
+        profile: 'quinn',
+        ttlDays: 30,
+      },
+      issueCtx
+    )
+    await revokeGrant(db, { customerSlug: SLUG, clerkUserId: 'user_a' }, issueCtx)
+    await adminIssueGrant(
+      db,
+      {
+        customerSlug: SLUG,
+        clerkUserId: 'user_a',
+        email: 'a@firm.com',
+        profile: 'quinn',
+        ttlDays: 30,
+      },
+      issueCtx
+    )
+
+    const customer = await loadMcpCustomer(db, SLUG)
+    expect(customer?.principals.find((p) => p.clerkUserId === 'user_a')).toBeDefined()
+
+    const grants = await listGrants(db, SLUG)
+    expect(grants).toHaveLength(1)
+    expect(grants[0]?.revoked_at).toBeNull()
+  })
+
+  it('lists all grants including revoked, newest first', async () => {
+    await adminIssueGrant(
+      db,
+      {
+        customerSlug: SLUG,
+        clerkUserId: 'user_a',
+        email: 'a@firm.com',
+        profile: 'quinn',
+        ttlDays: 30,
+      },
+      issueCtx
+    )
+    await revokeGrant(db, { customerSlug: SLUG, clerkUserId: 'user_a' }, issueCtx)
+    const grants = await listGrants(db, SLUG)
+    expect(grants).toHaveLength(1)
+    expect(grants[0]?.revoked_at).not.toBeNull()
+  })
+})


### PR DESCRIPTION
## What

Slice 2b of the Operator ⇄ Claude connector (ADR 0057). Slice 2a (#1525) shipped the live **read** of `mcp_issued_grants` — the kill switch — but nothing wrote it. This adds the write side that makes the kill switch operable.

## Changes

- **`grant-store.ts`** — the single writer:
  - `adminIssueGrant` (UPSERT; **clears `revoked_at`** — an admin re-grant deliberately lifts a revocation)
  - `revokeGrant` (sets `revoked_at`; idempotent — no-op + no audit on an already-dead grant)
  - `listGrants`
  - A separate `jitIssueGrant` with **sticky-revoke** semantics is reserved for slice 2e (open-by-domain), per the /critique finding that auto-issue must never resurrect a revoked grant.
- **TTL bounded by invariant** (ADR 0057): default 30 days, hard ceiling **90** (never infinite). `clampTtlDays` enforces `[1, 90]`.
- **migration 0076 `operator_mcp_grant_audit`** — append-only ledger. The live grant row is mutable state (re-issue overwrites, revoke flips a column); this ledger is the immutable record of *who* changed access, for *whom*, *when* — a law-firm obligation. Separate table because `operator_mcp_audit`'s `CHECK` pins `event_type` to `auth`/`tool_call`.
- **admin route** `POST /api/admin/operator/[customer]/mcp-grants` — issue/revoke, admin-guarded, records the SMD actor, redirects to the connectors page with a status banner.
- **`connectors.astro`** — grants panel (list + per-row revoke + issue form) + status banner.

## Verification

- `tests/operator-mcp-grant-store.test.ts` (7 tests): TTL clamp; issue → `loadMcpCustomer` authorizes; revoke → principal drops + audited; idempotent re-revoke (no audit row); admin re-issue lifts revocation; `listGrants`.
- Full suite green (3282 passed), typecheck + lint clean.

## Not in this slice

`ttl_days`/`policy`/`allowed_domains` authored fields land in **2c** (issuance-policy axis); the screening-attestation gate in **2d**; the hardened open-by-domain JIT (sticky revoke + verified-email pinning + domain match + cap) in **2e**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)