### PR TITLE
feat(operator): MCP issuance-policy axis — allowlist | open (ADR 0057 slice 2c)

### DIFF
--- a/operator/contracts/customer-yaml-blocks.yaml
+++ b/operator/contracts/customer-yaml-blocks.yaml
@@ -127,14 +127,17 @@ top_level:
     materializer: ss-console portal (console-side access control); not staged to the Machine
   mcp_connector:
     status: implemented
-    materializer: ss-console MCP endpoint (console-hosted Operator<->Claude connector; reads enabled/data_posture/access to authorize MCP tool calls) + WEBHOOK_SECRET_MCP staged by provision-customer.sh for the handoff route
+    materializer: ss-console MCP endpoint (console-hosted Operator<->Claude connector; reads enabled/data_posture/policy/allowed_domains/default_profile/ttl_days/access to authorize MCP tool calls) + WEBHOOK_SECRET_MCP staged by provision-customer.sh for the handoff route
     note: >-
       Operator <-> Claude MCP connector (Phase 1, console-mediated). Consumed
       console-side, not translated into Machine config.yaml — validated by
       src/lib/operator/customer-yaml/sections-mcp-connector.ts. The only Machine
       touch is the per-customer WEBHOOK_SECRET_MCP (handoff route) + the
-      webhook-router recognizing source="mcp". Fail-closed: absent/enabled:false
-      => no user reaches the Operator through Claude. See
+      webhook-router recognizing source="mcp". Issuance policy (ADR 0057 §3):
+      policy=allowlist (default, fail-closed) | open (verified firm-domain JIT,
+      requires allowed_domains + default_profile; auto-issue is slice 2e).
+      ttl_days bounds every grant (1..90, never infinite). Fail-closed:
+      absent/enabled:false => no user reaches the Operator through Claude. See
       docs/design/operator/03-mcp-server-exposure.md.
   relationship:
     status: implemented

--- a/src/lib/operator/customer-yaml/sections-mcp-connector.ts
+++ b/src/lib/operator/customer-yaml/sections-mcp-connector.ts
@@ -17,9 +17,13 @@
 import { isPlainObject } from './helpers'
 import {
   ACCEPTED_DATA_POSTURES,
+  ACCEPTED_MCP_POLICIES,
+  MCP_GRANT_TTL_DEFAULT_DAYS,
+  MCP_GRANT_TTL_MAX_DAYS,
   type DataPosture,
   type McpConnector,
   type McpConnectorAccess,
+  type McpIssuancePolicy,
   type Persona,
   type User,
   type ValidationError,
@@ -28,8 +32,14 @@ import {
 const MCP_CONNECTOR_DEFAULT: McpConnector = {
   enabled: false,
   data_posture: 'open',
+  policy: 'allowlist',
+  allowed_domains: [],
+  default_profile: null,
+  ttl_days: MCP_GRANT_TTL_DEFAULT_DAYS,
   access: [],
 }
+
+const DOMAIN_RE = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/
 
 function parseEnabled(raw: unknown, errors: ValidationError[]): boolean {
   if (raw === undefined || raw === null) return false
@@ -53,6 +63,88 @@ function parseDataPosture(raw: unknown, errors: ValidationError[]): DataPosture 
     return 'open'
   }
   return raw as DataPosture
+}
+
+function parsePolicy(raw: unknown, errors: ValidationError[]): McpIssuancePolicy {
+  if (raw === undefined || raw === null) return 'allowlist'
+  if (typeof raw !== 'string' || !ACCEPTED_MCP_POLICIES.includes(raw as McpIssuancePolicy)) {
+    errors.push({
+      code: 'EnumViolation',
+      path: 'mcp_connector.policy',
+      message: `mcp_connector.policy must be one of: ${ACCEPTED_MCP_POLICIES.join(', ')}`,
+    })
+    return 'allowlist'
+  }
+  return raw as McpIssuancePolicy
+}
+
+function parseAllowedDomains(raw: unknown, errors: ValidationError[]): string[] {
+  if (raw === undefined || raw === null) return []
+  if (!Array.isArray(raw)) {
+    errors.push({
+      code: 'TypeMismatch',
+      path: 'mcp_connector.allowed_domains',
+      message: 'mcp_connector.allowed_domains must be a list when present',
+    })
+    return []
+  }
+  const out: string[] = []
+  raw.forEach((entry, i) => {
+    const value = typeof entry === 'string' ? entry.trim().toLowerCase() : ''
+    if (!value || !DOMAIN_RE.test(value)) {
+      errors.push({
+        code: 'TypeMismatch',
+        path: `mcp_connector.allowed_domains[${i}]`,
+        message: `mcp_connector.allowed_domains[${i}] must be a bare email domain (e.g. firm.com)`,
+      })
+      return
+    }
+    out.push(value)
+  })
+  return out
+}
+
+function parseDefaultProfile(
+  raw: unknown,
+  activeProfiles: Set<string>,
+  errors: ValidationError[]
+): string | null {
+  if (raw === undefined || raw === null) return null
+  if (typeof raw !== 'string' || raw.trim() === '') {
+    errors.push({
+      code: 'TypeMismatch',
+      path: 'mcp_connector.default_profile',
+      message: 'mcp_connector.default_profile must be a non-empty string when present',
+    })
+    return null
+  }
+  if (!activeProfiles.has(raw)) {
+    errors.push({
+      code: 'EnumViolation',
+      path: 'mcp_connector.default_profile',
+      message: `mcp_connector.default_profile "${raw}" does not match any active persona slug`,
+    })
+    return null
+  }
+  return raw
+}
+
+function parseTtlDays(raw: unknown, errors: ValidationError[]): number {
+  if (raw === undefined || raw === null) return MCP_GRANT_TTL_DEFAULT_DAYS
+  if (
+    typeof raw !== 'number' ||
+    !Number.isInteger(raw) ||
+    raw < 1 ||
+    raw > MCP_GRANT_TTL_MAX_DAYS
+  ) {
+    errors.push({
+      code: 'TypeMismatch',
+      path: 'mcp_connector.ttl_days',
+      message: `mcp_connector.ttl_days must be an integer in [1, ${MCP_GRANT_TTL_MAX_DAYS}] (never infinite, ADR 0057)`,
+    })
+    return MCP_GRANT_TTL_DEFAULT_DAYS
+  }
+  return raw
 }
 
 interface AccessValidationContext {
@@ -220,9 +312,36 @@ export function checkMcpConnector(
   const authoredEmails = new Set(users.map((u) => u.email))
   const activeProfiles = new Set(personas.filter((p) => p.status === 'active').map((p) => p.slug))
 
+  const policy = parsePolicy(raw['policy'], errors)
+  const allowedDomains = parseAllowedDomains(raw['allowed_domains'], errors)
+  const defaultProfile = parseDefaultProfile(raw['default_profile'], activeProfiles, errors)
+
+  // Open-policy preconditions (ADR 0057 §3): a verified firm-domain identity is
+  // JIT-granted, so an open connector with no domain to match or no profile to
+  // mint into would either grant nothing or fail at runtime. Require both up front.
+  if (policy === 'open' && allowedDomains.length === 0) {
+    errors.push({
+      code: 'MissingField',
+      path: 'mcp_connector.allowed_domains',
+      message: "mcp_connector.allowed_domains must be non-empty when policy is 'open'",
+    })
+  }
+  if (policy === 'open' && defaultProfile === null) {
+    errors.push({
+      code: 'MissingField',
+      path: 'mcp_connector.default_profile',
+      message:
+        "mcp_connector.default_profile is required (and must be an active persona) when policy is 'open'",
+    })
+  }
+
   return {
     enabled: parseEnabled(raw['enabled'], errors),
     data_posture: parseDataPosture(raw['data_posture'], errors),
+    policy,
+    allowed_domains: allowedDomains,
+    default_profile: defaultProfile,
+    ttl_days: parseTtlDays(raw['ttl_days'], errors),
     access: parseAccess(raw['access'], authoredEmails, activeProfiles, errors),
   }
 }

--- a/src/lib/operator/customer-yaml/types.ts
+++ b/src/lib/operator/customer-yaml/types.ts
@@ -205,6 +205,22 @@ export type UserRole = (typeof ACCEPTED_USER_ROLES)[number]
 export const ACCEPTED_DATA_POSTURES = ['open', 'firm_only'] as const
 export type DataPosture = (typeof ACCEPTED_DATA_POSTURES)[number]
 
+/**
+ * Issuance policy for the Operator ⇄ Claude MCP connector (ADR 0057 §3) — who may
+ * connect, distinct from `data_posture` (where entitled data may land).
+ *   - `allowlist` (default, fail-closed): grants exist only for authored/seeded
+ *     principals. The pilot path.
+ *   - `open`: a verified firm-domain identity is JIT-granted on first connect.
+ *     The hardened auto-issue path is slice 2e; this enum + its validation seat
+ *     the axis now.
+ */
+export const ACCEPTED_MCP_POLICIES = ['allowlist', 'open'] as const
+export type McpIssuancePolicy = (typeof ACCEPTED_MCP_POLICIES)[number]
+
+/** Bounded-grant TTL invariant (ADR 0057): never null, never infinite. */
+export const MCP_GRANT_TTL_DEFAULT_DAYS = 30
+export const MCP_GRANT_TTL_MAX_DAYS = 90
+
 export const ACCEPTED_PERSONA_STATUSES = ['active', 'archived'] as const
 export type PersonaStatus = (typeof ACCEPTED_PERSONA_STATUSES)[number]
 
@@ -736,6 +752,28 @@ export interface McpConnectorAccess {
 export interface McpConnector {
   enabled: boolean
   data_posture: DataPosture
+  /**
+   * Issuance policy (ADR 0057 §3). `allowlist` (default) = only authored/seeded
+   * principals connect. `open` = JIT-grant a verified firm-domain identity on
+   * first connect (the auto-issue mechanism is slice 2e). When `open`,
+   * `allowed_domains` must be non-empty and `default_profile` must name an active
+   * persona.
+   */
+  policy: McpIssuancePolicy
+  /**
+   * Firm email domains eligible for an `open`-policy JIT grant (lowercased host,
+   * e.g. `ashtonprice.com`). Empty under `allowlist`. Per-customer domain rules
+   * live here, not in Clerk's instance-global allowlist.
+   */
+  allowed_domains: string[]
+  /** Persona an `open`-policy JIT grant runs as. Null under `allowlist`. */
+  default_profile: string | null
+  /**
+   * Per-client default grant TTL in days. Bounded `[1, {@link MCP_GRANT_TTL_MAX_DAYS}]`;
+   * defaults to {@link MCP_GRANT_TTL_DEFAULT_DAYS}. Drives `expires_at` (never
+   * null) and should match the Clerk session lifetime.
+   */
+  ttl_days: number
   access: McpConnectorAccess[]
 }
 

--- a/src/lib/portal/customer-config.ts
+++ b/src/lib/portal/customer-config.ts
@@ -28,6 +28,9 @@ import {
 } from '../operator/credential-custody'
 import {
   ACCEPTED_DATA_POSTURES,
+  ACCEPTED_MCP_POLICIES,
+  MCP_GRANT_TTL_DEFAULT_DAYS,
+  MCP_GRANT_TTL_MAX_DAYS,
   type McpConnector,
   type PersonaEntitlements,
   type SkillInitiation,
@@ -175,12 +178,46 @@ function parseJsonRequired<T>(value: string, column: string, entityId: string): 
 const MCP_CONNECTOR_FAIL_CLOSED: McpConnector = {
   enabled: false,
   data_posture: 'open',
+  policy: 'allowlist',
+  allowed_domains: [],
+  default_profile: null,
+  ttl_days: MCP_GRANT_TTL_DEFAULT_DAYS,
   access: [],
+}
+
+const DOMAIN_RE = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/
+
+/** Defensive parse of the projected allowed_domains (lowercased, valid hosts only). */
+function readAllowedDomains(raw: unknown): string[] {
+  if (!Array.isArray(raw)) return []
+  const out: string[] = []
+  for (const entry of raw) {
+    const value = typeof entry === 'string' ? entry.trim().toLowerCase() : ''
+    if (value && DOMAIN_RE.test(value)) out.push(value)
+  }
+  return out
+}
+
+/** Defensive parse of the projected ttl_days; out-of-range/garbage → default. */
+function readTtlDays(raw: unknown): number {
+  if (
+    typeof raw !== 'number' ||
+    !Number.isInteger(raw) ||
+    raw < 1 ||
+    raw > MCP_GRANT_TTL_MAX_DAYS
+  ) {
+    return MCP_GRANT_TTL_DEFAULT_DAYS
+  }
+  return raw
 }
 
 const mcpConnectorProjectionSchema = z.object({
   enabled: z.unknown().optional(),
   data_posture: z.unknown().optional(),
+  policy: z.unknown().optional(),
+  allowed_domains: z.unknown().optional(),
+  default_profile: z.unknown().optional(),
+  ttl_days: z.unknown().optional(),
   access: z.unknown().optional(),
 })
 
@@ -219,6 +256,11 @@ export function parseMcpConnector(json: string | null | undefined): McpConnector
   const parsed = mcpConnectorProjectionSchema.safeParse(raw)
   if (!parsed.success) return { ...MCP_CONNECTOR_FAIL_CLOSED, access: [] }
   const posture = z.enum(ACCEPTED_DATA_POSTURES).safeParse(parsed.data.data_posture)
+  const policy = z.enum(ACCEPTED_MCP_POLICIES).safeParse(parsed.data.policy)
+  const defaultProfile =
+    typeof parsed.data.default_profile === 'string' && parsed.data.default_profile.trim() !== ''
+      ? parsed.data.default_profile
+      : null
   const access = Array.isArray(parsed.data.access)
     ? parsed.data.access.flatMap((entry) => {
         const result = mcpConnectorAccessSchema.safeParse(entry)
@@ -228,6 +270,10 @@ export function parseMcpConnector(json: string | null | undefined): McpConnector
   return {
     enabled: parsed.data.enabled === true,
     data_posture: posture.success ? posture.data : 'open',
+    policy: policy.success ? policy.data : 'allowlist',
+    allowed_domains: readAllowedDomains(parsed.data.allowed_domains),
+    default_profile: defaultProfile,
+    ttl_days: readTtlDays(parsed.data.ttl_days),
     access,
   }
 }

--- a/tests/customer-config.test.ts
+++ b/tests/customer-config.test.ts
@@ -311,30 +311,28 @@ describe('mcp_connector projection column (migration 0071)', () => {
 })
 
 describe('parseMcpConnector (fail-closed, defensive)', () => {
-  it('null / undefined ⇒ disabled, empty access', () => {
-    expect(parseMcpConnector(null)).toEqual({ enabled: false, data_posture: 'open', access: [] })
-    expect(parseMcpConnector(undefined)).toEqual({
-      enabled: false,
-      data_posture: 'open',
-      access: [],
-    })
+  const FAIL_CLOSED = {
+    enabled: false,
+    data_posture: 'open',
+    policy: 'allowlist',
+    allowed_domains: [],
+    default_profile: null,
+    ttl_days: 30,
+    access: [],
+  }
+
+  it('null / undefined ⇒ disabled, allowlist, empty access', () => {
+    expect(parseMcpConnector(null)).toEqual(FAIL_CLOSED)
+    expect(parseMcpConnector(undefined)).toEqual(FAIL_CLOSED)
   })
 
   it('malformed JSON ⇒ fail-closed (never throws)', () => {
-    expect(parseMcpConnector('{not json')).toEqual({
-      enabled: false,
-      data_posture: 'open',
-      access: [],
-    })
+    expect(parseMcpConnector('{not json')).toEqual(FAIL_CLOSED)
   })
 
   it('a non-object value ⇒ fail-closed', () => {
-    expect(parseMcpConnector('"a string"')).toEqual({
-      enabled: false,
-      data_posture: 'open',
-      access: [],
-    })
-    expect(parseMcpConnector('42')).toEqual({ enabled: false, data_posture: 'open', access: [] })
+    expect(parseMcpConnector('"a string"')).toEqual(FAIL_CLOSED)
+    expect(parseMcpConnector('42')).toEqual(FAIL_CLOSED)
   })
 
   it('an unknown data_posture falls back to open; enabled requires literal true', () => {
@@ -360,6 +358,33 @@ describe('parseMcpConnector (fail-closed, defensive)', () => {
       })
     )
     expect(c.access).toEqual([{ email: 'good@firm.com', profile: 'crane' }])
+  })
+
+  it('surfaces a well-formed open policy (lowercased domains, profile, ttl)', () => {
+    const c = parseMcpConnector(
+      JSON.stringify({
+        enabled: true,
+        policy: 'open',
+        allowed_domains: ['Firm.com', 'bad domain', 'partners.firm.com'],
+        default_profile: 'marcus',
+        ttl_days: 14,
+        access: [],
+      })
+    )
+    expect(c.policy).toBe('open')
+    expect(c.allowed_domains).toEqual(['firm.com', 'partners.firm.com'])
+    expect(c.default_profile).toBe('marcus')
+    expect(c.ttl_days).toBe(14)
+  })
+
+  it('falls back policy/ttl defensively on garbage values', () => {
+    const c = parseMcpConnector(
+      JSON.stringify({ enabled: true, policy: 'everyone', ttl_days: 9999, access: [] })
+    )
+    expect(c.policy).toBe('allowlist')
+    expect(c.ttl_days).toBe(30)
+    expect(c.allowed_domains).toEqual([])
+    expect(c.default_profile).toBeNull()
   })
 })
 

--- a/tests/customer-yaml-validator.test.ts
+++ b/tests/customer-yaml-validator.test.ts
@@ -1424,10 +1424,132 @@ describe('validate — compliance_enabled (#895)', () => {
 // -----------------------------------------------------------------------------
 
 describe('validate — mcp_connector', () => {
-  it('defaults to disabled/open/empty when the block is omitted', () => {
+  it('defaults to disabled/allowlist/empty when the block is omitted', () => {
     const r = validate(validFixture())
     if (!r.ok) throw new Error(`expected ok; got: ${JSON.stringify(r.errors)}`)
-    expect(r.value.mcp_connector).toEqual({ enabled: false, data_posture: 'open', access: [] })
+    expect(r.value.mcp_connector).toEqual({
+      enabled: false,
+      data_posture: 'open',
+      policy: 'allowlist',
+      allowed_domains: [],
+      default_profile: null,
+      ttl_days: 30,
+      access: [],
+    })
+  })
+
+  it('defaults policy to allowlist (fail-closed) when enabled without a policy', () => {
+    const f = validFixture()
+    f['mcp_connector'] = {
+      enabled: true,
+      access: [{ email: 'partner@firm.com', profile: 'marcus' }],
+    }
+    const r = validate(f)
+    if (!r.ok) throw new Error(`expected ok; got: ${JSON.stringify(r.errors)}`)
+    expect(r.value.mcp_connector.policy).toBe('allowlist')
+  })
+
+  it('accepts an open policy with allowed_domains and an active default_profile', () => {
+    const f = validFixture()
+    f['mcp_connector'] = {
+      enabled: true,
+      policy: 'open',
+      allowed_domains: ['Firm.com', 'partners.firm.com'],
+      default_profile: 'marcus',
+      ttl_days: 7,
+      access: [],
+    }
+    const r = validate(f)
+    if (!r.ok) throw new Error(`expected ok; got: ${JSON.stringify(r.errors)}`)
+    expect(r.value.mcp_connector.policy).toBe('open')
+    expect(r.value.mcp_connector.allowed_domains).toEqual(['firm.com', 'partners.firm.com'])
+    expect(r.value.mcp_connector.default_profile).toBe('marcus')
+    expect(r.value.mcp_connector.ttl_days).toBe(7)
+  })
+
+  it('rejects an open policy with no allowed_domains', () => {
+    const f = validFixture()
+    f['mcp_connector'] = { enabled: true, policy: 'open', default_profile: 'marcus', access: [] }
+    const r = validate(f)
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(
+      r.errors.some((e) => e.path === 'mcp_connector.allowed_domains' && e.code === 'MissingField')
+    ).toBe(true)
+  })
+
+  it('rejects an open policy with no default_profile', () => {
+    const f = validFixture()
+    f['mcp_connector'] = {
+      enabled: true,
+      policy: 'open',
+      allowed_domains: ['firm.com'],
+      access: [],
+    }
+    const r = validate(f)
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(
+      r.errors.some((e) => e.path === 'mcp_connector.default_profile' && e.code === 'MissingField')
+    ).toBe(true)
+  })
+
+  it('rejects a default_profile that is not an active persona', () => {
+    const f = validFixture()
+    f['mcp_connector'] = {
+      enabled: true,
+      policy: 'open',
+      allowed_domains: ['firm.com'],
+      default_profile: 'ghost',
+      access: [],
+    }
+    const r = validate(f)
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(
+      r.errors.some((e) => e.path === 'mcp_connector.default_profile' && e.code === 'EnumViolation')
+    ).toBe(true)
+  })
+
+  it('rejects an unknown policy value', () => {
+    const f = validFixture()
+    f['mcp_connector'] = { enabled: true, policy: 'everyone', access: [] }
+    const r = validate(f)
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(
+      r.errors.some((e) => e.path === 'mcp_connector.policy' && e.code === 'EnumViolation')
+    ).toBe(true)
+  })
+
+  it('rejects a malformed allowed_domains entry', () => {
+    const f = validFixture()
+    f['mcp_connector'] = {
+      enabled: true,
+      policy: 'open',
+      allowed_domains: ['not a domain'],
+      default_profile: 'marcus',
+      access: [],
+    }
+    const r = validate(f)
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(
+      r.errors.some(
+        (e) => e.path === 'mcp_connector.allowed_domains[0]' && e.code === 'TypeMismatch'
+      )
+    ).toBe(true)
+  })
+
+  it('rejects a ttl_days above the 90-day ceiling (never infinite)', () => {
+    const f = validFixture()
+    f['mcp_connector'] = { enabled: true, ttl_days: 365, access: [] }
+    const r = validate(f)
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(
+      r.errors.some((e) => e.path === 'mcp_connector.ttl_days' && e.code === 'TypeMismatch')
+    ).toBe(true)
   })
 
   it('accepts an enabled connector binding an authored user to an active persona', () => {

--- a/tests/operator-mcp-endpoint.test.ts
+++ b/tests/operator-mcp-endpoint.test.ts
@@ -53,6 +53,10 @@ function customerFixture(over: Partial<ResolvedMcpCustomer> = {}): ResolvedMcpCu
     connector: {
       enabled: true,
       data_posture: 'open',
+      policy: 'allowlist',
+      allowed_domains: [],
+      default_profile: null,
+      ttl_days: 30,
       access: [{ email: 'pilot@example.com', profile: 'crane' }],
     },
     clerk: {
@@ -290,7 +294,15 @@ describe('validateMcpToken', () => {
       await validateMcpToken(
         'token',
         customerFixture({
-          connector: { enabled: false, data_posture: 'open', access: [] },
+          connector: {
+            enabled: false,
+            data_posture: 'open',
+            policy: 'allowlist',
+            allowed_domains: [],
+            default_profile: null,
+            ttl_days: 30,
+            access: [],
+          },
         }),
         claimsVerifier(claims())
       )


### PR DESCRIPTION
## What

Slice 2c of the Operator ⇄ Claude connector (ADR 0057). Seats the **issuance-policy axis** on `mcp_connector` — *who may connect* — kept deliberately distinct from the existing `data_posture` (*where entitled data may land*). The **pilot ships on `allowlist`**; the open-by-domain JIT auto-issue mechanism is hardened separately in slice 2e.

## New `mcp_connector` fields

- `policy: 'allowlist' (default, fail-closed) | 'open'`
- `allowed_domains: string[]` — bare email domains eligible for an open-policy JIT grant (lowercased, validated hosts)
- `default_profile: string | null` — persona an open-policy JIT grant runs as
- `ttl_days: number` — per-client default grant TTL, bounded `[1, 90]` (never infinite)

## Enforcement

- **Validator** (`sections-mcp-connector.ts`): fail-closed defaults; `policy:'open'` **requires** non-empty `allowed_domains` **and** a `default_profile` naming an active persona; `ttl_days` outside `[1,90]` is rejected.
- **Read path** (`customer-config.ts` `parseMcpConnector`): defensively surfaces the new fields for the runtime endpoint (2e reads them here), each with a fail-closed fallback. Projection write is automatic.
- Constants `MCP_GRANT_TTL_DEFAULT_DAYS`/`MAX` live in `customer-yaml/types.ts`. Contract-registry note updated; `test_customer_yaml_block_conformance.py` green.

## Verification

- Validator tests: default shape, open preconditions (missing domains / profile / non-active profile), bad policy / malformed domain / over-ceiling ttl.
- Read-path tests: open-policy round-trip (lowercased domains), defensive fallback on garbage.
- Full suite green (3285 passed), typecheck + lint clean, operator block-conformance pytest green.

## Sequencing

Independent of slice 2b (#1527) — disjoint files. The screening-attestation gate is **2d**; the hardened open-by-domain JIT (sticky revoke + verified-email pinning + exact domain match + grant cap) is **2e**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)