### PR TITLE
feat(operator): provision Smokeball webhook gate secrets

### DIFF
--- a/operator/bin/provision-customer.sh
+++ b/operator/bin/provision-customer.sh
@@ -578,6 +578,28 @@ print(str(sb.get('account_id') or '').strip())
   if [ -n "${SB_ACCOUNT_ID}" ]; then
     stage_secret_from_env SMOKEBALL_ACCOUNT_ID "${SB_ACCOUNT_ID}" "Smokeball multi-account URL prefix"
   fi
+  # Smokeball webhook ingress (overlay webhook-gate). Staged only when the seat
+  # declares a smokeball webhook_url — otherwise these are unused. Two secrets:
+  #   WEBHOOK_SECRET_SMOKEBALL — the HMAC key the gate verifies with. It MUST equal
+  #     the `key` set on the Smokeball subscription. Smokeball uses it as RAW UTF-8
+  #     bytes, so it is staged byte-identical (printf '%s', no whsec_/base64/newline
+  #     transform — unlike the Svix secret). Per-customer
+  #     WEBHOOK_SECRET_SMOKEBALL__<CUSTOMER_ID>, else the global.
+  #   WEBHOOK_SMOKEBALL_CLIENT_ID — OUR Smokeball API ClientId, fed into the signed
+  #     string {Timestamp}|{RequestId}|{ClientId} (Smokeball never sends it). It is
+  #     the same client id the connector authenticates with (SMOKEBALL_CLIENT_ID ==
+  #     ${_sb_cid}); a per-customer override exists only for the rare case the signing
+  #     ClientId differs in byte form from the OAuth client id (confirm vs a real
+  #     delivery). Without these the smokeball route fail-closes (gate 401).
+  if grep -qE 'webhook_url:.*/webhooks/smokeball' "${CUSTOMER_DIR}/customer.yaml" 2>/dev/null; then
+    _SB_WH_KEY="WEBHOOK_SECRET_SMOKEBALL__$(printf '%s' "${CUSTOMER_ID}" | tr '[:lower:]-' '[:upper:]_' | tr -cd 'A-Z0-9_')"
+    _SB_WH_SECRET="${!_SB_WH_KEY:-${WEBHOOK_SECRET_SMOKEBALL:-}}"
+    stage_secret_from_env WEBHOOK_SECRET_SMOKEBALL "${_SB_WH_SECRET}" "Smokeball webhook HMAC key == subscription key, raw bytes (per-customer ${_SB_WH_KEY}, else global)"
+    _SB_WH_CID_KEY="WEBHOOK_SMOKEBALL_CLIENT_ID__$(printf '%s' "${CUSTOMER_ID}" | tr '[:lower:]-' '[:upper:]_' | tr -cd 'A-Z0-9_')"
+    _SB_WH_CID="${!_SB_WH_CID_KEY:-${_sb_cid}}"
+    stage_secret_from_env WEBHOOK_SMOKEBALL_CLIENT_ID "${_SB_WH_CID}" "Smokeball API ClientId fed into the webhook HMAC (per-customer ${_SB_WH_CID_KEY}, else = SMOKEBALL_CLIENT_ID)"
+    unset _SB_WH_KEY _SB_WH_SECRET _SB_WH_CID_KEY _SB_WH_CID
+  fi
   unset SB_PARSE_PY SB_FIELDS SB_ENV SB_AUTH_MODE SB_ACCOUNT_ID _sb_cid _sb_sec _sb_key _sb_src
 fi
 


### PR DESCRIPTION
## What

Stages the two secrets the overlay webhook gate needs to verify Smokeball deliveries — the provisioning half of the Smokeball gate verifier (pairs with **hermes-smd-overlay#115**). Staged for any seat whose `customer.yaml` declares a smokeball `webhook_url`.

- **`WEBHOOK_SECRET_SMOKEBALL`** — the HMAC key the gate verifies with, which **must equal the `key`** set on the Smokeball subscription. Smokeball uses it as **raw UTF-8 bytes**, so it is staged **byte-identical** (`printf '%s'`, no `whsec_`/base64/trailing-newline transform — unlike the Svix secret). Per-customer `WEBHOOK_SECRET_SMOKEBALL__<CUSTOMER_ID>`, else the global.
- **`WEBHOOK_SMOKEBALL_CLIENT_ID`** — **our** Smokeball API ClientId, fed into the signed string `{Timestamp}|{RequestId}|{ClientId}` (Smokeball never delivers it). Defaults to the same client id the connector authenticates with (`SMOKEBALL_CLIENT_ID`), with a per-customer override for the rare case the signing ClientId differs in byte form from the OAuth client id.

Without these the smokeball route fail-closes (gate `401`). `translate.py`'s webhook materializer needs **no change** — it maps `adapter -> WEBHOOK_SECRET_SMOKEBALL` generically and emits the route once the secret exists (confirm on first reprovision).

## Order of operations

This is necessary-but-not-sufficient. End-to-end: (1) overlay verifier #115 merges + `OVERLAY_REF` bump, (2) this provisioning, (3) set the actual `WEBHOOK_SECRET_SMOKEBALL__*` value in the operator env (= the subscription key), (4) Captain-authorized reprovision of `pilot-smokeball`, (5) the `matter-memo-on-update` handler skill (re-fetches from the connector — follow-on), (6) register the subscription. **This change does not enable autonomous action on a real firm.**

## Tests

Operator-substrate suite green (363 passed); `bash -n` clean. The change is an isolated bash file in `operator/`; CI runs the full `npm verify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)