### PR TITLE
docs(operator): reconcile MCP connector docs to ADR 0057 + shipped slices 2a–2d

### DIFF
--- a/docs/adr/0057-operator-claude-connector-access-model.md
+++ b/docs/adr/0057-operator-claude-connector-access-model.md
@@ -56,6 +56,21 @@ When EMA supports Microsoft Entra / M365 (Okta-only at writing), identity and of
 - **Implementation surface shrinks to what is ours**: a grant table + live authorization (this ADR's first build), Clerk configuration + a revoke route, a JIT issuance gate, and a `customer.yaml` policy field. No hand-rolled OAuth server, no ticket-threading seam.
 - The already-shipped email channel (roster `scope.inbound_allow_from`, [ADR 0055](0055-operator-is-an-employee.md)) is unchanged; the screening attestation gate applies to it too.
 
+### Implementation status (slices 2a–2d shipped 2026-06-27)
+
+- **2a** — `mcp_issued_grants` table + live-read merge into principal resolution (the kill switch's read side).
+- **2b** — admin grant lifecycle (`adminIssueGrant` clears a revocation; `revokeGrant`; `listGrants`) + immutable `operator_mcp_grant_audit` ledger (the mutable grant row is state; the ledger is the record of who changed access, for whom, when). TTL bounded `[1, 90]`, never infinite. Admin route + connectors-page panel.
+- **2c** — `mcp_connector.policy` axis (`allowlist` default / `open`), `allowed_domains`, `default_profile`, `ttl_days`, kept distinct from `data_posture`. Validator requires domains + an active `default_profile` for `open`. Pilot ships on `allowlist`.
+- **2d** — screening attestation: authoring gate (validator, both channels, CI-blocking) + a runtime **freshness** gate (`isAttestationFresh`, 90-day window) that takes an enabled connector dark when the attestation is missing or stale. Projected to `customer_configs`; surfaced in the admin panel.
+
+**Enforcement points (where each property lives):**
+
+- **Sticky revoke** — the explicit-revoke kill is instant (live-read filters `revoked_at`). The open-policy JIT path (slice 2e) MUST refuse to re-issue a `revoked_at` grant, so a revoked user cannot auto-mint their way back; only an admin re-issue lifts a revocation.
+- **JIT at the route egress** — open-by-domain minting and the verified-primary-email + exact-host-domain checks live in the route (`handleMcpPost`), where the DB handle and the verified email are available; `validateMcpToken` stays pure.
+- **Attestation at validation + runtime** — the structural "enabled ⇒ attested" gate is pure/CI-blocking; the time-based freshness gate runs with a clock at the endpoint (and is surfaced in admin).
+
+**Offboarding-backstop reframe (open).** The passive-lapse story holds only if Clerk's refresh-token absolute expiry ≤ the grant TTL; this must be verified empirically. Until verified, the grant `expires_at` + explicit admin revoke is the authoritative backstop, and mailbox-kill passive lapse is secondary. The email in-flow factor uses **OTP code** (not magic link) to keep verification in Claude's OAuth browser — an implementation refinement of "email-link," same mailbox-possession identity.
+
 ## What this does not decide
 
 - **The EMA/IdP cutover** — adopted when EMA supports Entra/M365; not built now.

--- a/docs/design/operator/03-mcp-server-exposure.md
+++ b/docs/design/operator/03-mcp-server-exposure.md
@@ -1,9 +1,17 @@
 # 03 — Operator ⇄ Claude MCP Connector (Operator-as-MCP-Server)
 
-**Status:** Implemented foundation (rev 5, 2026-06-15), activation-gated on Clerk issuing an RFC 8707 resource-bound token. Phase-1 hosting is console-mediated. Clerk authenticates and issues tokens; Operator owns principal, profile, tool, and action authorization.
-**Author:** design pass, no implementation
-**Companion docs:** [00-foundations.md](00-foundations.md), [01-admin-portal.md](01-admin-portal.md), [02-client-portal.md](02-client-portal.md)
-**Primary ADRs:** [0007](../../adr/0007-per-customer-machine-isolation.md) · [0010](../../adr/0010-per-customer-oauth-token-storage.md) · [0011](../../adr/0011-multi-persona-per-customer.md) · [0015](../../adr/0015-hermes-fork-vs-upstream.md) · [0020](../../adr/0020-connector-strategy.md) · [0035](../../adr/0035-no-imposed-entitlement-defaults.md) · [0043](../../adr/0043-operator-runtime-read-path.md) · [0045](../../adr/0045-mediated-connector-capability-broker.md) · [0005](../../adr/0005-external-send-identity.md) · [0037](../../adr/0037-operator-thesis.md)
+**Status:** Implemented (rev 6, 2026-06-27). The access model is locked by **[ADR 0057](../../adr/0057-operator-claude-connector-access-model.md)** and the connector surface shipped across slices 2a–2d (grant table + live kill switch, admin grant lifecycle + immutable audit, issuance-policy axis, screening-attestation gate). Phase-1 hosting is console-mediated. Clerk authenticates; the Operator's grant table authorizes.
+**Author:** design pass (rev 1–5) + implementation (ADR 0057, slices 2a–2d)
+**Companion docs:** [00-foundations.md](00-foundations.md), [01-admin-portal.md](01-admin-portal.md), [02-client-portal.md](02-client-portal.md), [mcp-clerk-setup.md](mcp-clerk-setup.md)
+**Primary ADRs:** **[0057](../../adr/0057-operator-claude-connector-access-model.md) (the access model — authoritative)** · [0007](../../adr/0007-per-customer-machine-isolation.md) · [0010](../../adr/0010-per-customer-oauth-token-storage.md) · [0011](../../adr/0011-multi-persona-per-customer.md) · [0015](../../adr/0015-hermes-fork-vs-upstream.md) · [0020](../../adr/0020-connector-strategy.md) · [0035](../../adr/0035-no-imposed-entitlement-defaults.md) · [0043](../../adr/0043-operator-runtime-read-path.md) · [0045](../../adr/0045-mediated-connector-capability-broker.md) · [0005](../../adr/0005-external-send-identity.md) · [0037](../../adr/0037-operator-thesis.md)
+
+> **Reconciliation with ADR 0057 (read this first).** This doc's §4 (access model) and §5 (authentication) were the rev-1 design pass. Where they differ from ADR 0057, **ADR 0057 governs.** What it locked and shipped:
+>
+> - **Login = Clerk per-user OAuth, mailbox-possession sign-in to the firm address** (email OTP code preferred over magic link, so the verification stays in Claude's OAuth browser; see [mcp-clerk-setup.md](mcp-clerk-setup.md)). Email possession is the identity, so offboarding rides the firm mailbox.
+> - **Authorization = SMD's `mcp_issued_grants` grant table, read live per request** — the authoritative allowance and the **instant kill switch** (revoke cuts on the next call). Bounded: `ttl_days` ∈ [1, 90], never infinite. Admin issue/revoke + an append-only `operator_mcp_grant_audit` ledger (slice 2b).
+> - **Issuance policy is firm-authored** (`mcp_connector.policy`): `allowlist` (default, fail-closed — the pilot path) or `open` (verified firm-domain JIT). The hardened open-by-domain auto-issue is **slice 2e** (sticky revoke, verified-primary-email pinning, exact-host domain match, per-customer grant cap, shorter TTL); **not in the pilot path.**
+> - **Screening attestation (ADR 0057 §4) is a fail-closed precondition** to any enabled inbound channel (this connector AND `scope.inbound_allow_from`): authoring gate in the validator + a runtime **freshness** gate (90-day window) that takes an enabled connector dark when the attestation is missing or stale (slice 2d).
+> - **The "activation-gated on an RFC 8707 `aud`" status below is superseded.** Clerk's MCP/DCR tokens omit a resource-bound `aud` (verified in #1398), so isolation rests on exact `iss` + the customer-scoped subject/grant check; a present `aud` is still enforced. The connector is **not** blocked on Clerk shipping resource indicators.
 
 ---
 

--- a/docs/design/operator/mcp-clerk-setup.md
+++ b/docs/design/operator/mcp-clerk-setup.md
@@ -1,8 +1,16 @@
 # Clerk setup for the Operator MCP connector
 
-**Status:** activation-gated. The console is deployed as a strict OAuth Resource
-Server, but a customer remains dark until Clerk issues an access token bound to
-that customer's canonical MCP resource.
+**Status:** access model locked by [ADR 0057](../../adr/0057-operator-claude-connector-access-model.md); console shipped (slices 2a–2d). The console is a strict OAuth Resource Server. Per-customer activation needs (1) a Clerk binding row, (2) an authored `mcp_connector` policy, (3) a fresh screening attestation, and (4) the live token-triple verify.
+
+## Authoritative model (ADR 0057)
+
+**Clerk proves who knocks; the Operator's grant table decides whether to open.** Clerk authenticates a firm user by **mailbox possession** and issues the token; SMD's `mcp_issued_grants` table is the live authorization and instant kill switch. Two decisions from ADR 0057 + the build:
+
+- **One dedicated operator-fleet Clerk instance for external firms**, not one per firm. Isolation rests on the grant table (the authoritative per-request gate), so a single instance authenticating any firm-domain mailbox is sufficient; the per-customer Clerk app was belt-and-suspenders from before the grant table existed. Customer-zero (`smd`) may stay on `clerk.smd.services`; external firms share the fleet instance. (If a regulated client demands structural token isolation, a dedicated per-client instance remains the escape hatch — mirrors the on-Machine-sidecar posture in 03 §2.3.)
+- **Email OTP code, not magic link, for the in-flow factor.** A magic link clicked from a mail client often opens a _different_ browser than Claude Desktop's OAuth tab, breaking the PKCE/state binding; a 6-digit code typed back into the same tab never leaves the originating browser. Same mailbox-possession identity ADR 0057 intends — an implementation refinement of its "email-link" wording.
+- **Set the Clerk session lifetime to the grant `ttl_days`** so re-auth is forced at the same cadence the grant expires.
+
+> **Open verification (offboarding backstop).** The passive-lapse offboarding story ("kill the mailbox → re-auth fails → access lapses within TTL") holds only if Clerk's **refresh-token absolute expiry ≤ the grant TTL**. This must be confirmed empirically (`crane_verify`) before relying on passive lapse. If Clerk rotates refresh tokens indefinitely, the grant `expires_at` + explicit admin revoke is the real backstop, and passive mailbox-kill is secondary.
 
 ## Responsibility split
 
@@ -70,14 +78,26 @@ Migration 0072 requires one canonical resource URI per customer:
 
 `resource_uri` is mandatory. `client_id` does not replace audience validation.
 
-## 3. Provision the stable principal
+## 3. Author the connector + attestation, then issue grants
 
-The authored connector remains readable:
+The authored connector (slices 2c/2d add `policy` / `allowed_domains` /
+`default_profile` / `ttl_days`, distinct from `data_posture`):
 
 ```yaml
+# REQUIRED before any enabled inbound channel — real legal data, never placeholder.
+screening_attestation:
+  attested: true
+  attested_by: SMD Services (Scott Durgan, Principal)
+  attested_at: 2026-06-27T00:00:00.000Z
+
 mcp_connector:
   enabled: true
-  data_posture: open
+  data_posture: open # where entitled data may land (personal vs firm Claude)
+  policy: allowlist # who may connect: allowlist (default, pilot) | open
+  # open-policy only (slice 2e auto-issue):
+  # allowed_domains: [firm.com]
+  # default_profile: crane
+  ttl_days: 30 # per-client grant TTL, bounded [1, 90], never infinite
   access:
     - email: scott@smd.services
       profile: crane
@@ -92,6 +112,15 @@ those accounts carry different emails. The singular `clerk_subject` remains
 supported for one-account bindings. When both are omitted, the connector falls
 back to that local user's `users.clerk_user_id`. If none is present, it fails
 closed.
+
+**Grants are the live authorization (ADR 0057).** Authored `access[]` entries
+seat static principals; the dynamic layer + kill switch is `mcp_issued_grants`,
+issued/revoked from the admin connectors page
+(`POST /api/admin/operator/<slug>/mcp-grants`, slice 2b) and recorded immutably in
+`operator_mcp_grant_audit`. Revoking cuts access on the next request. Under
+`policy: open`, a verified firm-domain identity is JIT-granted on first connect
+(slice 2e). The connector also stays dark unless `screening_attestation` is
+present and fresh (within 90 days).
 
 When `entities.clerk_org_id` is populated, the token must also carry that exact
 `org_id`. A non-empty token audience must exactly include the MCP resource URI.


### PR DESCRIPTION
## Summary

Reconciles the Operator ⇄ Claude connector docs to the now-locked access model (ADR 0057) and the shipped implementation (slices 2a–2d, all merged).

- **`03-mcp-server-exposure.md` → rev 6:** ADR 0057 is authoritative for login/authz; adds a reconciliation banner (mailbox-possession login, grant-table kill switch, allowlist/open policy, attestation gate). The "activation-gated on an RFC 8707 `aud`" status is marked **superseded** — Clerk's MCP/DCR tokens omit a resource-bound `aud` (#1398), so isolation rests on exact `iss` + the customer-scoped subject/grant check; the connector is not blocked on Clerk.
- **`mcp-clerk-setup.md`:** dedicated operator-fleet Clerk instance (not per-firm); **email OTP not magic link** (keeps verification in Claude's OAuth browser); session lifetime = grant TTL; refresh-token-expiry verification flagged as an open backstop dependency; provisioning example updated with `policy` / `ttl_days` / `screening_attestation` + the grant-issuance step.
- **ADR 0057 Consequences:** implementation status (2a–2d), enforcement points (sticky revoke, JIT-at-route-egress, attestation-at-validation+runtime), and the offboarding-backstop reframe.

## Test plan

- [x] Docs-only; no code paths touched. Markdown formatted (prettier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)