### PR TITLE
chore(operator): screening attestation for pilot-smokeball (ADR 0057 §4)

### DIFF
--- a/operator/customers/pilot-smokeball/customer.yaml
+++ b/operator/customers/pilot-smokeball/customer.yaml
@@ -181,6 +181,17 @@ personas:
       - google-workspace
       - himalaya
 
+# ---- SCREENING ATTESTATION (ADR 0057 §4) ----
+# Fail-closed precondition for ANY live inbound channel (the mcp_connector below
+# and scope.inbound_allow_from). Affirms that no active ethical screens / conflicts
+# at the firm would keep the Operator from acting on its inbound channels.
+# pilot-smokeball is SMD's own staging rig (no external client), so there is no
+# client conflict to screen.
+screening_attestation:
+  attested: true
+  attested_by: 'Scott Durgan'
+  attested_at: '2026-06-27T22:06:39Z'
+
 # ---- MCP CONNECTOR (Operator ⇄ Claude) ----
 # Rehearsal channel: lets us drive a real agent turn on this staging rig to prove
 # the firm-delegated Smokeball read end-to-end (Allow → token file → connector →


### PR DESCRIPTION
Adds the ADR 0057 §4 `screening_attestation` block to `pilot-smokeball/customer.yaml` (attested by Scott Durgan, our own staging rig — no external client/conflict).

**Why:** the ADR 0057 §4 validator on main fail-closes any live inbound channel without a named, dated no-active-screens attestation. `pilot-smokeball` triggers it via `mcp_connector.enabled` + `scope.inbound_allow_from`, so its reprovision was blocked — needed to bring the Smokeball webhook gate verifier live (overlay#115 + #1529/#1530).

Validated locally: `scripts/validate-customer-yaml.ts` → OK.

**Flag:** no other customer config carries this block yet, so the gate currently blocks reprovisions fleet-wide (incl. the live Machines) — a separate ADR 0057 backfill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)