### PR TITLE
feat(operator): hardened open-by-domain JIT grant (ADR 0057 slice 2e)

### DIFF
--- a/docs/adr/0057-operator-claude-connector-access-model.md
+++ b/docs/adr/0057-operator-claude-connector-access-model.md
@@ -56,12 +56,13 @@ When EMA supports Microsoft Entra / M365 (Okta-only at writing), identity and of
 - **Implementation surface shrinks to what is ours**: a grant table + live authorization (this ADR's first build), Clerk configuration + a revoke route, a JIT issuance gate, and a `customer.yaml` policy field. No hand-rolled OAuth server, no ticket-threading seam.
 - The already-shipped email channel (roster `scope.inbound_allow_from`, [ADR 0055](0055-operator-is-an-employee.md)) is unchanged; the screening attestation gate applies to it too.
 
-### Implementation status (slices 2a–2d shipped 2026-06-27)
+### Implementation status (slices 2a–2e shipped 2026-06-27)
 
 - **2a** — `mcp_issued_grants` table + live-read merge into principal resolution (the kill switch's read side).
 - **2b** — admin grant lifecycle (`adminIssueGrant` clears a revocation; `revokeGrant`; `listGrants`) + immutable `operator_mcp_grant_audit` ledger (the mutable grant row is state; the ledger is the record of who changed access, for whom, when). TTL bounded `[1, 90]`, never infinite. Admin route + connectors-page panel.
 - **2c** — `mcp_connector.policy` axis (`allowlist` default / `open`), `allowed_domains`, `default_profile`, `ttl_days`, kept distinct from `data_posture`. Validator requires domains + an active `default_profile` for `open`. Pilot ships on `allowlist`.
 - **2d** — screening attestation: authoring gate (validator, both channels, CI-blocking) + a runtime **freshness** gate (`isAttestationFresh`, 90-day window) that takes an enabled connector dark when the attestation is missing or stale. Projected to `customer_configs`; surfaced in the admin panel.
+- **2e** — hardened open-by-domain JIT (firm opt-in; not the pilot path). On `policy: open`, a genuine token whose subject is not yet granted is auto-granted **only** when: the verified **primary** email's flag is true, its exact host is in `allowed_domains` (single-`@`, lowercased, no implicit subdomain), no `revoked_at` row exists for the subject (**sticky revoke** — only an admin re-issue lifts a revocation), and the per-customer active-grant **cap** (`MCP_OPEN_GRANT_CAP`) is not reached. Open grants carry a shorter TTL (`min(ttl_days, MCP_OPEN_GRANT_TTL_DAYS=7)`). Minting + refusals (`jit_revoked` / `jit_cap_exceeded`) are audited.
 
 **Enforcement points (where each property lives):**
 
@@ -70,6 +71,8 @@ When EMA supports Microsoft Entra / M365 (Okta-only at writing), identity and of
 - **Attestation at validation + runtime** — the structural "enabled ⇒ attested" gate is pure/CI-blocking; the time-based freshness gate runs with a clock at the endpoint (and is surfaced in admin).
 
 **Offboarding-backstop reframe (open).** The passive-lapse story holds only if Clerk's refresh-token absolute expiry ≤ the grant TTL; this must be verified empirically. Until verified, the grant `expires_at` + explicit admin revoke is the authoritative backstop, and mailbox-kill passive lapse is secondary. The email in-flow factor uses **OTP code** (not magic link) to keep verification in Claude's OAuth browser — an implementation refinement of "email-link," same mailbox-possession identity.
+
+**Open-by-domain structural-guard finding (2e research).** Under the shared fleet Clerk instance with DCR, **no token claim structurally binds a token to one customer**: Clerk omits a resource-bound `aud` for the MCP/DCR path (#1398), and custom session claims are instance-global (JWT templates), not per-OAuth-app/entry, so they cannot encode the customer the user signed in for. A structural per-customer claim would require per-customer Clerk instances (the heavy onboarding we rejected). Therefore open-by-domain cross-tenant isolation rests on the **compensating controls** — verified primary email + exact firm-domain match + sticky revoke + the per-customer cap + short TTL + the grant table as the authoritative per-request gate — not a structural token barrier. The no-`aud` cross-customer test (a token valid for X presented to Y → 401 because X's subject is absent from Y's grant set) is the guard that proves this holds, and it is exercised for both `allowlist` and `open` policies.
 
 ## What this does not decide
 

--- a/src/lib/operator/mcp/grant-store.ts
+++ b/src/lib/operator/mcp/grant-store.ts
@@ -24,6 +24,21 @@ const NOW_SQL = "strftime('%Y-%m-%dT%H:%M:%fZ', 'now')"
 export const GRANT_TTL_DEFAULT_DAYS = 30
 export const GRANT_TTL_MAX_DAYS = 90
 
+/**
+ * Open-by-domain JIT (slice 2e) carries a SHORTER ceiling than admin-issued
+ * grants: no human approves each auto-mint, so the standing-access window is
+ * tighter. The route grants min(connector.ttl_days, this).
+ */
+export const MCP_OPEN_GRANT_TTL_DAYS = 7
+
+/**
+ * Per-customer active-grant ceiling for open-by-domain auto-issue. A compromised
+ * firm mailbox shouldn't fan out unbounded grants; at the cap, JIT refuses (the
+ * breach is audited) until grants lapse or an admin intervenes. Admin issuance is
+ * not capped (a human is in the loop).
+ */
+export const MCP_OPEN_GRANT_CAP = 50
+
 /** Clamp an authored/submitted TTL into [1, GRANT_TTL_MAX_DAYS]; junk → default. */
 export function clampTtlDays(raw: number): number {
   if (!Number.isFinite(raw) || raw < 1) return GRANT_TTL_DEFAULT_DAYS
@@ -151,6 +166,79 @@ export async function listGrants(db: D1Database, customerSlug: string): Promise<
     .bind(customerSlug)
     .all<GrantListRow>()
   return res.results ?? []
+}
+
+/** Count live (un-revoked, un-expired) grants for the open-policy cap. */
+export async function countActiveGrants(db: D1Database, customerSlug: string): Promise<number> {
+  const row = await db
+    .prepare(
+      'SELECT COUNT(*) AS n FROM mcp_issued_grants ' +
+        `WHERE customer_slug = ? AND revoked_at IS NULL AND expires_at > ${NOW_SQL}`
+    )
+    .bind(customerSlug)
+    .first<{ n: number }>()
+  return row?.n ?? 0
+}
+
+export type JitResult =
+  | { issued: true; expiresAt: string }
+  | { issued: false; reason: 'revoked' | 'cap_exceeded' }
+
+/**
+ * Open-by-domain JIT mint (slice 2e). STICKY REVOKE: refuses if a revoked grant
+ * already exists for the subject — a revoked user cannot auto-mint their way back
+ * (only adminIssueGrant lifts a revocation). Refuses at the per-customer cap.
+ * Unlike adminIssueGrant, it never clears revoked_at (the refuse-on-revoked check
+ * guarantees any row it upserts is already un-revoked).
+ */
+export async function jitIssueGrant(
+  db: D1Database,
+  input: IssueGrantInput,
+  ctx: GrantAuditContext
+): Promise<JitResult> {
+  const existing = await db
+    .prepare(
+      'SELECT revoked_at FROM mcp_issued_grants WHERE customer_slug = ? AND clerk_user_id = ?'
+    )
+    .bind(input.customerSlug, input.clerkUserId)
+    .first<{ revoked_at: string | null }>()
+  if (existing && existing.revoked_at !== null) return { issued: false, reason: 'revoked' }
+  if ((await countActiveGrants(db, input.customerSlug)) >= MCP_OPEN_GRANT_CAP) {
+    return { issued: false, reason: 'cap_exceeded' }
+  }
+
+  const ttlDays = clampTtlDays(input.ttlDays)
+  await db
+    .prepare(
+      'INSERT INTO mcp_issued_grants ' +
+        '(customer_slug, clerk_user_id, email, profile, expires_at, issued_at, revoked_at) ' +
+        `VALUES (?, ?, ?, ?, strftime('%Y-%m-%dT%H:%M:%fZ', 'now', ?), ${NOW_SQL}, NULL) ` +
+        'ON CONFLICT(customer_slug, clerk_user_id) DO UPDATE SET ' +
+        'email = excluded.email, profile = excluded.profile, ' +
+        'expires_at = excluded.expires_at, issued_at = excluded.issued_at'
+    )
+    .bind(input.customerSlug, input.clerkUserId, input.email, input.profile, `+${ttlDays} days`)
+    .run()
+  const row = await db
+    .prepare(
+      'SELECT expires_at FROM mcp_issued_grants WHERE customer_slug = ? AND clerk_user_id = ?'
+    )
+    .bind(input.customerSlug, input.clerkUserId)
+    .first<{ expires_at: string }>()
+  const expiresAt = row?.expires_at ?? ''
+  await recordGrantAudit(db, {
+    entityId: ctx.entityId,
+    customerSlug: input.customerSlug,
+    action: 'issue',
+    clerkUserId: input.clerkUserId,
+    email: input.email,
+    profile: input.profile,
+    ttlDays,
+    expiresAt,
+    actor: ctx.actor,
+    reason: ctx.reason,
+  })
+  return { issued: true, expiresAt }
 }
 
 interface GrantAuditRow {

--- a/src/lib/operator/mcp/jit-grant.ts
+++ b/src/lib/operator/mcp/jit-grant.ts
@@ -1,0 +1,29 @@
+/**
+ * Pure email-domain matching for the open-by-domain JIT gate (slice 2e, ADR 0057).
+ *
+ * The strictness here IS the isolation control: under `policy: open`, a verified
+ * firm-domain identity is auto-granted, so a sloppy domain check would admit
+ * outsiders. Match the full host after the LAST `@`, lowercased, single-`@` only,
+ * and exact membership (no implicit subdomain match — a firm authors `mail.firm.com`
+ * explicitly if it wants it). `allowed_domains` arrive already lowercased + shape-
+ * validated from the validator / projection read.
+ */
+
+/** Lowercased host after a single `@`, or null for a malformed address. */
+export function extractEmailDomain(email: string): string | null {
+  const at = email.indexOf('@')
+  if (at < 1) return null
+  // Reject more than one '@' (quoted local parts, junk) — fail closed.
+  if (email.indexOf('@', at + 1) !== -1) return null
+  const domain = email
+    .slice(at + 1)
+    .trim()
+    .toLowerCase()
+  return domain.length > 0 ? domain : null
+}
+
+/** Exact-host membership test for an open-policy JIT grant. */
+export function domainAllowed(email: string, allowedDomains: readonly string[]): boolean {
+  const domain = extractEmailDomain(email)
+  return domain !== null && allowedDomains.includes(domain)
+}

--- a/src/lib/operator/mcp/mcp-route.ts
+++ b/src/lib/operator/mcp/mcp-route.ts
@@ -5,6 +5,8 @@ import { isAttestationFresh } from '../customer-yaml/sections-screening-attestat
 import { buildMcpMetadataPath, type ResolvedMcpCustomer } from './customer-resolution'
 import { dispatchMcpRequest, getMcpToolName, parseMcpBody } from './mcp-handler'
 import { recordMcpAudit } from './mcp-audit'
+import { jitIssueGrant, MCP_OPEN_GRANT_TTL_DAYS } from './grant-store'
+import { domainAllowed } from './jit-grant'
 import { buildWwwAuthenticate } from './oauth-metadata'
 import {
   extractBearerToken,
@@ -80,6 +82,68 @@ function unauthorized(
   })
 }
 
+/**
+ * Open-by-domain JIT decision (slice 2e). Given the `identity_not_authored`
+ * failure, returns: an `ok` auth when a grant was minted, a `jit_*` failure when
+ * minting was refused (sticky-revoke or cap — audited as a deny by the caller), or
+ * `null` when JIT does not apply (so the original `identity_not_authored` stands).
+ * All hardening lives here: open policy only, verified PRIMARY email, exact
+ * firm-domain match, sticky revoke + cap (in jitIssueGrant), shorter open TTL.
+ */
+async function attemptOpenPolicyJit(
+  deps: McpRouteDependencies,
+  failure: Extract<McpAuthResult, { ok: false }>
+): Promise<McpAuthResult | null> {
+  const c = deps.customer.connector
+  const { email, subject } = failure
+  if (
+    c.policy !== 'open' ||
+    c.default_profile === null ||
+    !subject ||
+    !email ||
+    failure.emailVerified !== true ||
+    !domainAllowed(email, c.allowed_domains)
+  ) {
+    return null
+  }
+  const result = await jitIssueGrant(
+    deps.db,
+    {
+      customerSlug: deps.customer.customerId,
+      clerkUserId: subject,
+      email,
+      profile: c.default_profile,
+      ttlDays: Math.min(c.ttl_days, MCP_OPEN_GRANT_TTL_DAYS),
+    },
+    {
+      entityId: deps.customer.entityId,
+      actor: 'system:jit',
+      reason: 'open-policy firm-domain match',
+    }
+  )
+  if (!result.issued) {
+    return {
+      ok: false,
+      reason: result.reason === 'revoked' ? 'jit_revoked' : 'jit_cap_exceeded',
+      detail:
+        result.reason === 'revoked'
+          ? 'a revoked grant exists for this subject; admin re-issue required'
+          : 'open-policy grant cap reached for this customer',
+      subject,
+      tokenAudience: failure.tokenAudience,
+    }
+  }
+  return {
+    ok: true,
+    customer: deps.customer,
+    subject,
+    tokenAudience: failure.tokenAudience ?? [],
+    localUserId: subject,
+    email,
+    profile: c.default_profile,
+  }
+}
+
 export async function handleMcpPost(
   request: Request,
   url: URL,
@@ -118,7 +182,14 @@ export async function handleMcpPost(
   }
 
   const token = extractBearerToken(request.headers.get('authorization'))
-  const auth = await validateMcpToken(token, deps.customer, deps.verifier)
+  let auth = await validateMcpToken(token, deps.customer, deps.verifier)
+  // Open-by-domain JIT (slice 2e): a genuine, verified firm-domain user who is not
+  // yet granted is auto-granted on first connect under `policy: open`. Only this
+  // exact failure is eligible; everything else stays denied.
+  if (!auth.ok && auth.reason === 'identity_not_authored') {
+    const jitted = await attemptOpenPolicyJit(deps, auth)
+    if (jitted) auth = jitted
+  }
   await recordAuth(deps, auth, auth.ok ? 'allow' : 'deny')
   if (!auth.ok) {
     return unauthorized(

--- a/src/lib/operator/mcp/token-validation.ts
+++ b/src/lib/operator/mcp/token-validation.ts
@@ -8,6 +8,7 @@ const verifiedClaimsSchema = z.object({
   aud: z.union([z.string().min(1), z.array(z.string().min(1)).min(1)]).optional(),
   org_id: z.string().min(1).optional(),
   email: z.email().optional(),
+  email_verified: z.boolean().optional(),
 })
 
 export type McpAuthFailureReason =
@@ -20,6 +21,9 @@ export type McpAuthFailureReason =
   | 'connector_disabled'
   | 'identity_not_authored'
   | 'organization_mismatch'
+  // Open-by-domain JIT refusals (slice 2e), surfaced by the route, not token validation.
+  | 'jit_revoked'
+  | 'jit_cap_exceeded'
 
 export type McpAuthResult =
   | {
@@ -37,6 +41,15 @@ export type McpAuthResult =
       detail: string
       subject?: string
       tokenAudience?: string[]
+      /**
+       * The verified primary email + its verified flag from the token, surfaced
+       * ONLY on `identity_not_authored` so the route can decide an open-policy JIT
+       * grant (slice 2e). The PRIMARY email is the trust anchor — under shared
+       * Clerk a user can attach a secondary verified address, but the token always
+       * carries their primary, so an outsider cannot JIT into a firm by adding one.
+       */
+      email?: string
+      emailVerified?: boolean
     }
 
 export type McpTokenVerifier = (token: string, customer: ResolvedMcpCustomer) => Promise<unknown>
@@ -147,6 +160,8 @@ export async function validateMcpToken(
       detail: 'Clerk subject is not authorized for this Operator',
       subject: claims.sub,
       tokenAudience: normalizeAudience(claims.aud),
+      email: claims.email,
+      emailVerified: claims.email_verified === true,
     }
   }
 

--- a/tests/operator-mcp-endpoint.test.ts
+++ b/tests/operator-mcp-endpoint.test.ts
@@ -675,6 +675,113 @@ describe('MCP route authorization and audit', () => {
       },
     ])
   })
+
+  // --- Open-by-domain JIT (slice 2e) ---
+  const STATUS_BODY =
+    '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"operator_status"}}'
+  const okRead = (): Promise<RuntimeReadResult> =>
+    Promise.resolve({ ok: true, kind: 'audit_log', data: { entries: [], cursor: null } })
+  const openCustomer = (): ResolvedMcpCustomer => ({
+    ...customer,
+    connector: {
+      ...customer.connector,
+      policy: 'open',
+      allowed_domains: ['firm.com'],
+      default_profile: 'crane',
+      ttl_days: 7,
+    },
+    principals: [], // the caller is a not-yet-authored newcomer
+  })
+  const postAs = (cust: ResolvedMcpCustomer, claimsOver: Record<string, unknown>) =>
+    handleMcpPost(
+      new Request(RESOURCE_URI, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer t' },
+        body: STATUS_BODY,
+      }),
+      new URL(RESOURCE_URI),
+      { db, customer: cust, verifier: claimsVerifier(claims(claimsOver)), readRuntime: okRead }
+    )
+  const grantFor = (clerkUserId: string) =>
+    db
+      .prepare('SELECT clerk_user_id, profile FROM mcp_issued_grants WHERE clerk_user_id = ?')
+      .bind(clerkUserId)
+      .first()
+
+  it('open policy: JIT-grants a verified firm-domain newcomer and serves the call', async () => {
+    const res = await postAs(openCustomer(), {
+      sub: 'user_new',
+      email: 'new@firm.com',
+      email_verified: true,
+    })
+    expect(res.status).toBe(200)
+    expect(await grantFor('user_new')).toMatchObject({
+      clerk_user_id: 'user_new',
+      profile: 'crane',
+    })
+  })
+
+  it('open policy: denies a non-matching domain and mints nothing', async () => {
+    const res = await postAs(openCustomer(), {
+      sub: 'user_evil',
+      email: 'evil@notfirm.com',
+      email_verified: true,
+    })
+    expect(res.status).toBe(401)
+    expect(await grantFor('user_evil')).toBeNull()
+  })
+
+  it('open policy: denies an unverified primary email', async () => {
+    const res = await postAs(openCustomer(), {
+      sub: 'user_unv',
+      email: 'unv@firm.com',
+      email_verified: false,
+    })
+    expect(res.status).toBe(401)
+    expect(await grantFor('user_unv')).toBeNull()
+  })
+
+  it('allowlist policy: never JITs, even on a matching domain', async () => {
+    const allowlist: ResolvedMcpCustomer = {
+      ...customer,
+      connector: { ...customer.connector, policy: 'allowlist' },
+      principals: [],
+    }
+    const res = await postAs(allowlist, {
+      sub: 'user_al',
+      email: 'al@firm.com',
+      email_verified: true,
+    })
+    expect(res.status).toBe(401)
+    expect(await grantFor('user_al')).toBeNull()
+  })
+
+  it('open policy: STICKY REVOKE — a revoked subject is denied, not re-minted', async () => {
+    await db
+      .prepare(
+        'INSERT INTO mcp_issued_grants (customer_slug, clerk_user_id, email, profile, expires_at, revoked_at) ' +
+          'VALUES (?, ?, ?, ?, ?, ?)'
+      )
+      .bind(
+        'smd',
+        'user_rev',
+        'user_rev@firm.com',
+        'crane',
+        '2999-01-01T00:00:00.000Z',
+        '2026-06-01T00:00:00.000Z'
+      )
+      .run()
+    const res = await postAs(openCustomer(), {
+      sub: 'user_rev',
+      email: 'user_rev@firm.com',
+      email_verified: true,
+    })
+    expect(res.status).toBe(401)
+    const audit = await db
+      .prepare("SELECT reason FROM operator_mcp_audit WHERE decision = 'deny' ORDER BY id DESC")
+      .first<{ reason: string }>()
+    expect(audit?.reason).toBe('jit_revoked')
+  })
 })
 
 const unreachableRead = (): Promise<RuntimeReadResult> =>

--- a/tests/operator-mcp-grant-store.test.ts
+++ b/tests/operator-mcp-grant-store.test.ts
@@ -11,9 +11,12 @@ import { loadMcpCustomer } from '../src/lib/operator/mcp/customer-resolution'
 import {
   adminIssueGrant,
   clampTtlDays,
+  countActiveGrants,
   GRANT_TTL_DEFAULT_DAYS,
   GRANT_TTL_MAX_DAYS,
+  jitIssueGrant,
   listGrants,
+  MCP_OPEN_GRANT_CAP,
   revokeGrant,
 } from '../src/lib/operator/mcp/grant-store'
 
@@ -237,5 +240,86 @@ describe('grant-store write side (ADR 0057)', () => {
     const grants = await listGrants(db, SLUG)
     expect(grants).toHaveLength(1)
     expect(grants[0]?.revoked_at).not.toBeNull()
+  })
+})
+
+describe('jitIssueGrant — open-by-domain (slice 2e)', () => {
+  let db: D1Database
+  const jitCtx = { entityId: ENTITY_ID, actor: 'system:jit', reason: 'open-policy' }
+  beforeEach(async () => {
+    db = await freshDb()
+    await seed(db)
+  })
+
+  const jit = (clerkUserId: string, ttlDays = 7) =>
+    jitIssueGrant(
+      db,
+      {
+        customerSlug: SLUG,
+        clerkUserId,
+        email: `${clerkUserId}@firm.com`,
+        profile: 'quinn',
+        ttlDays,
+      },
+      jitCtx
+    )
+
+  it('mints a grant and authorizes the subject', async () => {
+    const res = await jit('user_jit')
+    expect(res).toMatchObject({ issued: true })
+    const customer = await loadMcpCustomer(db, SLUG)
+    expect(customer?.principals.find((p) => p.clerkUserId === 'user_jit')).toBeDefined()
+    const audit = await auditRows(db)
+    expect(audit).toHaveLength(1)
+    expect(audit[0]).toMatchObject({ action: 'issue', actor: 'system:jit' })
+  })
+
+  it('STICKY REVOKE: refuses to re-mint a revoked subject (no audit, no resurrection)', async () => {
+    await adminIssueGrant(
+      db,
+      {
+        customerSlug: SLUG,
+        clerkUserId: 'user_x',
+        email: 'user_x@firm.com',
+        profile: 'quinn',
+        ttlDays: 7,
+      },
+      issueCtx
+    )
+    await revokeGrant(db, { customerSlug: SLUG, clerkUserId: 'user_x' }, issueCtx)
+    const res = await jit('user_x')
+    expect(res).toEqual({ issued: false, reason: 'revoked' })
+    const customer = await loadMcpCustomer(db, SLUG)
+    expect(customer?.principals.find((p) => p.clerkUserId === 'user_x')).toBeUndefined()
+  })
+
+  it('re-mints over an expired (not revoked) grant', async () => {
+    await db
+      .prepare(
+        'INSERT INTO mcp_issued_grants (customer_slug, clerk_user_id, email, profile, expires_at, revoked_at) ' +
+          'VALUES (?, ?, ?, ?, ?, ?)'
+      )
+      .bind(SLUG, 'user_exp', 'user_exp@firm.com', 'quinn', '2000-01-01T00:00:00.000Z', null)
+      .run()
+    const res = await jit('user_exp')
+    expect(res).toMatchObject({ issued: true })
+    const customer = await loadMcpCustomer(db, SLUG)
+    expect(customer?.principals.find((p) => p.clerkUserId === 'user_exp')).toBeDefined()
+  })
+
+  it('refuses at the per-customer cap', async () => {
+    const far = '2999-01-01T00:00:00.000Z'
+    const stmts = Array.from({ length: MCP_OPEN_GRANT_CAP }, (_, i) =>
+      db
+        .prepare(
+          'INSERT INTO mcp_issued_grants (customer_slug, clerk_user_id, email, profile, expires_at, revoked_at) ' +
+            'VALUES (?, ?, ?, ?, ?, ?)'
+        )
+        .bind(SLUG, `cap_${i}`, `cap_${i}@firm.com`, 'quinn', far, null)
+    )
+    await db.batch(stmts)
+    expect(await countActiveGrants(db, SLUG)).toBe(MCP_OPEN_GRANT_CAP)
+    const res = await jit('user_overflow')
+    expect(res).toEqual({ issued: false, reason: 'cap_exceeded' })
   })
 })

--- a/tests/operator-mcp-jit-grant.test.ts
+++ b/tests/operator-mcp-jit-grant.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { extractEmailDomain, domainAllowed } from '../src/lib/operator/mcp/jit-grant'
+
+describe('extractEmailDomain', () => {
+  it('returns the lowercased host after a single @', () => {
+    expect(extractEmailDomain('Bob@Firm.com')).toBe('firm.com')
+    expect(extractEmailDomain('a.b+tag@partners.firm.com')).toBe('partners.firm.com')
+  })
+
+  it('fails closed on malformed addresses', () => {
+    expect(extractEmailDomain('no-at-sign')).toBeNull()
+    expect(extractEmailDomain('@firm.com')).toBeNull() // empty local part
+    expect(extractEmailDomain('a@b@firm.com')).toBeNull() // more than one @
+    expect(extractEmailDomain('bob@')).toBeNull() // empty domain
+  })
+})
+
+describe('domainAllowed (exact host, no implicit subdomain)', () => {
+  const allowed = ['firm.com', 'partners.firm.com']
+
+  it('admits an exact firm-domain match', () => {
+    expect(domainAllowed('bob@firm.com', allowed)).toBe(true)
+    expect(domainAllowed('BOB@Firm.com', allowed)).toBe(true)
+    expect(domainAllowed('p@partners.firm.com', allowed)).toBe(true)
+  })
+
+  it('rejects look-alikes, unauthored subdomains, and malformed addresses', () => {
+    expect(domainAllowed('evil@notfirm.com', allowed)).toBe(false)
+    expect(domainAllowed('evil@firm.com.attacker.net', allowed)).toBe(false)
+    expect(domainAllowed('x@mail.firm.com', allowed)).toBe(false) // subdomain not authored
+    expect(domainAllowed('x@a@firm.com', allowed)).toBe(false) // double @
+    expect(domainAllowed('junk', allowed)).toBe(false)
+  })
+})


### PR DESCRIPTION
## What

Final slice of the Operator ⇄ Claude connector (ADR 0057). Under `policy: open` (a firm opt-in, **not** the pilot path), a genuine token whose subject is not yet granted is auto-granted on first connect — behind every hardening control surfaced by the `/critique`:

- **Sticky revoke** — `jitIssueGrant` refuses if a `revoked_at` row exists for the subject. A revoked user cannot auto-mint their way back; only `adminIssueGrant` lifts a revocation.
- **Verified PRIMARY email only** — mints against `token.email` with `email_verified === true`. Under shared Clerk one human = one subject across firms and can attach a secondary firm address, but the token carries their **primary**, so an outsider can't JIT in by adding one.
- **Exact firm-domain match** (`jit-grant.ts`) — lowercased host after a single `@`, exact membership, no implicit subdomain. Rejects look-alikes / multi-`@`.
- **Per-customer cap** (`MCP_OPEN_GRANT_CAP`) + **shorter TTL** (`min(ttl_days, 7)`). Refusals audited (`jit_revoked` / `jit_cap_exceeded`); mints recorded in the grant ledger as actor `system:jit`.

The JIT decision lives at the route egress (`handleMcpPost`); `validateMcpToken` stays pure and only surfaces the verified email on `identity_not_authored`.

## Structural-guard finding (the plan's research item)

Shared Clerk + DCR exposes **no per-customer token claim** (no resource `aud`; custom claims are instance-global), so open-policy cross-tenant isolation rests on the compensating controls + the grant table, not a structural token barrier. The no-`aud` cross-customer test proves it for both policies. Recorded in ADR 0057.

## Verification

- Domain matching (exact / subdomain / multi-`@` / look-alike); `jitIssueGrant` (mint / sticky-revoke / expired-remint / cap); endpoint (open mint → 200, non-match → 401, unverified → 401, allowlist → no JIT, sticky-revoke → `jit_revoked`).
- Full suite green (**3315**), typecheck + lint clean.

## Sequencing

Completes 2a–2e. The pilot still ships on `allowlist`; `open` activates only when a firm authors `policy: open` + `allowed_domains` + `default_profile`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)