### PR TITLE
feat(marketing): finalize copy — drop draft hedges, tighten hero close

### DIFF
--- a/src/components/ConsultingPath.astro
+++ b/src/components/ConsultingPath.astro
@@ -4,8 +4,6 @@
 // now lives on /consulting and points the other direction). One paragraph, one
 // secondary link. The consulting argument itself is not re-run here; it lives
 // on /consulting.
-//
-// DRAFT COPY — directional placeholder for the Captain's voice pass.
 import CtaButton from './CtaButton.astro'
 ---
 

--- a/src/components/OperatorHero.astro
+++ b/src/components/OperatorHero.astro
@@ -3,9 +3,6 @@
 // words (concrete, cross-vertical, not the bare abstraction the prior hero used),
 // then the gap as the why, the managed worker as the fill, and the door. No
 // diagram; composition and type carry it. Plainspoken: cream/ink/orange, zero radius.
-//
-// DRAFT COPY: directional for the Captain's voice pass. The mechanism (named
-// micro-symptoms + a route to the vertical) is locked; exact words are the pass.
 import CtaButton from './CtaButton.astro'
 ---
 
@@ -29,7 +26,7 @@ import CtaButton from './CtaButton.astro'
       class="mt-8 max-w-2xl font-['Archivo'] text-xl leading-relaxed text-[color:var(--ss-color-text-secondary)]"
     >
       It falls into the gap between your people and your software. The Operator is a new kind of
-      worker that fills that gap, built around how you run and managed by us.
+      worker that fills that gap. We build it around how you run, and we run it for you.
     </p>
     <div class="mt-9 flex flex-col items-start gap-4 sm:flex-row sm:items-center sm:gap-7">
       <CtaButton href="/book?interest=operator" data-ev="home-operator-hero-cta">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -9,9 +9,7 @@ export const prerender = false
 // and one door. It is NOT the manifesto: the full category argument is gone, the
 // mechanism lives on /operator, the comparison Q&A lives on /why, vertical
 // recognition lives on the packs. Each idea is argued in exactly one place.
-//
-// DRAFT COPY in the inline sections is directional, for the Captain's voice pass.
-// Structure, IA, and CTA wiring are final.
+// Copy, structure, IA, and CTA wiring are final.
 import Base from '../layouts/Base.astro'
 import Nav from '../components/Nav.astro'
 import OperatorHero from '../components/OperatorHero.astro'

--- a/src/pages/why.astro
+++ b/src/pages/why.astro
@@ -7,8 +7,6 @@ export const prerender = false
 // Operator to the alternatives: a chatbot, building your own, a hire, doing nothing.
 // Each H2 is a question; the same questions/answers are emitted as FAQPage JSON-LD
 // (one artifact). Answer-shaped: a direct answer first, then the expansion.
-//
-// DRAFT COPY - directional for the Captain's voice pass. Structure is final.
 import Base from '../layouts/Base.astro'
 import Nav from '../components/Nav.astro'
 import Footer from '../components/Footer.astro'


### PR DESCRIPTION
## Summary
Follow-up to #1541. Makes the marketing copy final rather than draft.

- Removes the "DRAFT COPY / for the Captain's voice pass" hedge comments from `OperatorHero`, `index`, `why`, and `ConsultingPath`.
- Tightens the home hero close to end on the managed promise: "We build it around how you run, and we run it for you."

## Test plan
- [ ] `npm run verify` passes (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)