### PR TITLE
feat(marketing): anchor the positioning spine to stop the rebuild churn

### DIFF
--- a/.design/marketing-ux-brief.md
+++ b/.design/marketing-ux-brief.md
@@ -1,113 +1,36 @@
-# Marketing — UX Brief (Modern Institutional)
+# Marketing — UX Brief (SUPERSEDED)
 
-_First-pass brief, authored 2026-04-19 alongside the identity sweep. Scope: the `smd.services` apex (public) surfaces — homepage, booking flow, get-started, scorecard, contact, 404, and the sign-in pages. Every surface inherits the Modern Institutional identity committed in `.design/DESIGN.md`._
-
-## Context
-
-Marketing is the first thing a prospective client sees. They're reading it on a laptop between jobs or on a phone in a truck cab. They're deciding whether to book a call, not whether to read about a framework. Copy + clarity first; chrome second.
-
-SMD Services sells scope-based consulting engagements to growing, owner-led businesses. Positioning: collaborative guide, not diagnostic expert. Marketing must read like the firm it belongs to — calm, direct, substance over polish, evidence over reassurance.
-
-## Scope
-
-| #   | Path                   | Archetype      | Purpose                                                           |
-| --- | ---------------------- | -------------- | ----------------------------------------------------------------- |
-| 1   | `/`                    | marketing-home | Positioning, what-we-do, who-we-help, case snippets, primary CTA. |
-| 2   | `/book`                | booking-wizard | Multi-step booking flow for the paid assessment call.             |
-| 3   | `/book/manage/[token]` | booking-manage | Reschedule / cancel a scheduled assessment via secure link.       |
-| 4   | `/get-started`         | conversion     | Intake form — name, business, rough context before a call.        |
-| 5   | `/scorecard`           | lead-magnet    | Operations scorecard quiz / results flow for top-of-funnel leads. |
-| 6   | `/contact`             | static         | Minimal contact page — email + direct booking link.               |
-| 7   | `/404`                 | error          | Clear message, link back to home.                                 |
-| 8   | `/auth/login`          | gate           | Admin sign-in (magic link).                                       |
-| 9   | `/auth/portal-login`   | gate           | Client-portal sign-in (magic link on the portal subdomain).       |
-| 10  | `/auth/verify`         | gate           | Magic-link verification landing.                                  |
-
-## Visit modes
-
-- **Cold visitor** — first touch via ad, referral, or search. Needs to answer "what does this firm do and should I talk to them?" in the first 10 seconds above the fold.
-- **Returning prospect** — came back after an initial touch. Needs a clear path to book or start.
-- **Book-ready prospect** — email/referral told them to book directly. Lands on `/book` from a deep link.
-- **Researcher** — assistant, spouse, accountant vetting on behalf of the buyer. Needs proof of concreteness and named humans (Scott).
-- **Client** — already engaged; arrived from a stale bookmark or email. Should find their way to `portal.smd.services` without confusion.
-
-## Identity inheritance
-
-All identity rules from `.design/DESIGN.md` apply. Summary of what marketing gets automatically from the token cutover in #455:
-
-- Crimson Pro display, Crimson Pro body, IBM Plex Mono for any data readouts
-- Warm near-white `#F9F7F1` background, graphite ink, navy primary
-- 0 radii on cards, buttons, pills
-- Flat — no elevation, no shadows
-- Motion minimal (120ms color transitions)
-
-## Identity chrome conventions (marketing interpretations)
-
-- **Global nav.** `Nav.astro` is the marketing site chrome — firm name left, primary CTA right (Book assessment). Sticky on scroll. Matches portal masthead tone: restrained, not marketing-heavy.
-- **Hero.** Oversized Crimson Pro headline, one-line tagline in Crimson Pro, single CTA. No rotator, no gradient text, no animated keyword reveal. The headline does the work.
-- **Section labels.** Same as portal: mono-caps eyebrow above each major section (`WHAT WE DO`, `WHO WE HELP`, `HOW IT WORKS`, `PRICING`). Hairline-underlined.
-- **Cards.** 0 radius, hairline border, flat. Used sparingly — marketing prefers typographic hierarchy over boxed content.
-- **Booking / form flow.** Steps numbered visually (`1`, `2`, `3`), 2px rounded squares filled with the current step's primary or neutral tone. No progress bars.
-- **Buttons.** Primary CTA is navy filled. Secondary CTAs are ghost buttons with `--color-border` outline. No gradient, no drop-shadow, no elevation-on-hover.
-- **Footer.** Minimal — copyright, privacy, terms, contact email, portal sign-in link. Typographic, hairline-separated, no decoration.
-
-## Anti-patterns (marketing-specific, additional to identity list)
-
-- Hero video autoplay or background video loops.
-- Parallax scroll, scroll-driven reveals, "as you scroll" animations.
-- Gradient-text headlines, text shadows, text-with-outline treatments.
-- Testimonial carousels with autoplay.
-- Trust-badge rows ("As seen in…") unless the logos are real and earned.
-- Countdown timers or urgency ticker scripts.
-- Email-gated content ("enter your email to read the rest"). Marketing is the read; intake comes after the read.
-- Stock photography of business owners with laptops.
-- Numerical claims without specifics ("10x your operations" — no).
-- Live chat widgets in the bottom-right corner.
-
-## Copy tone
-
-Voice is the same as everywhere else — guide persona, collaborative, evidence over reassurance, no em dashes, no AI filler. Marketing copy is a bit looser than admin but still calm and direct.
-
-Principles (from `CLAUDE.md` §Tone & Positioning Standard):
-
-- Objectives over problems. ("We start by understanding where you're trying to go.")
-- Collaborative, not diagnostic. ("We work alongside you.")
-- No fixed timeframes. ("We start with a conversation" beats "1-hour call".)
-- No published dollar amounts.
-- "Solution" not "systems" in positioning. ("System" is fine when literal.)
-- Always "we" / "our team."
-
-Landing-page samples (already in production, kept as tone reference):
-
-- Hero: "Operational consulting for growing businesses. Figure out what's in the way. Build the right solution together."
-- What we do: "Process design. Custom tools. Systems that talk to each other. AI when AI is the right answer — and nowhere it isn't."
-- Who we help: "Owner-led businesses where the operational load has outgrown the systems holding it together."
-- CTA: "Book a conversation."
-
-## Success criteria
-
-- Every marketing page renders in Crimson Pro + Crimson Pro + IBM Plex Mono with no Inter / Plus Jakarta fallback (except via system fallback chain).
-- Palette reads warm — no cool slate or indigo anywhere.
-- All buttons render as 2px rectangles (navy primary, neutral ghost, error red).
-- Booking wizard step indicators render as filled 2px squares with numbered labels, not circles.
-- No shadows, gradients, glow effects, or motion beyond 120ms color transitions.
-- Homepage above-the-fold answers "what does this firm do" without scrolling.
-- Desktop and mobile renders both clean at 390px and 1280px.
-
-## Open follow-ups
-
-- **Email templates** (`src/lib/email/templates.ts`, `src/lib/email/follow-up-templates.ts`, `src/lib/booking/alerts.ts`) still reference `Inter,Arial,sans-serif` inline. Email clients strip custom fonts aggressively; a safe swap to `'Crimson Pro',Helvetica Neue,Arial,sans-serif` is low-risk but not yet done. Do in a dedicated email-audit pass.
-- **PDF templates** (`src/lib/pdf/sow-template.tsx`, `src/lib/pdf/scorecard-template.tsx`, `src/lib/sow/service.ts`) register fonts via React-PDF; not swept. Changing requires visual regression check because SOW PDFs are client-signed contract documents. Separate PR with before/after renders before merge.
-- **Nav mobile menu** currently a single-level dropdown. If more marketing sections ship, reconsider.
-- **`/scorecard` results page** has a lead-gen email gate. Kept as-is for now (the gate IS the conversion mechanism) — flagged against the anti-pattern only so it's an explicit exception.
-- **Marketing primitive extraction.** Shared components (`Hero`, `Pricing`, `ProblemCards`, `WhoWeHelp`, `HowItWorks`, `FinalCta`, `Footer`, `Nav`) are already componentized in `src/components/`. No new extraction needed.
-
-## Approver
-
-Scott Durgan. Marketing reviewed via dev server at `localhost:4321/` (or staging Vercel build after merge).
+> **Stale. Do not build from this file.** This was the first-pass brief authored 2026-04-19 for the **pre-Operator consulting site** (Crimson Pro serif, deep-navy accent, "Book a conversation," the scorecard quiz). The venture pivoted to the **Operator** and the site moved to the "Plainspoken Sign Shop" identity. Almost every concrete instruction below (fonts, palette, page list, CTA copy) is now wrong.
+>
+> **For positioning, narrative, per-surface jobs, and the conversion model →** `docs/marketing/positioning-spine.md` (the living source of truth).
+>
+> **For the live visual identity →** read `src/styles/global.css` (the `--ss-color-*` tokens and `@theme` mapping) and the design-system package. Note: `.design/DESIGN.md` and `.design/theme.css` are **also stale** — they still describe the retired navy/Crimson-Pro "Modern Institutional" identity and are flagged for reconciliation in `positioning-spine.md` §6.
 
 ---
 
-## Appendix: Token map
+## Current identity quick facts (so this file no longer misleads)
 
-Marketing inherits every token from `.design/DESIGN.md` unchanged. No marketing-specific tokens.
+The live marketing site, as shipped:
+
+- **Type:** Archivo / Archivo Black (brutalist uppercase display), Archivo Narrow, JetBrains Mono (eyebrow labels). **Not** Crimson Pro / Public Sans.
+- **Palette:** warm cream background, graphite/ink text, a **single burnt-orange accent**. **Not** the deep-navy single accent.
+- **Shape:** zero radius, flat, hairline + heavy (3px) rules. No shadows, no gradients, no glow.
+- **Motion:** minimal; `prefers-reduced-motion` respected.
+- **Tokens:** `--ss-color-*` via `src/styles/global.css`.
+
+## Marketing anti-patterns (still valid, identity-independent)
+
+These survive the pivot and remain in force:
+
+- Hero video autoplay or background video loops; parallax / scroll-driven reveals.
+- Gradient-text headlines, text shadows, text-with-outline.
+- Testimonial carousels with autoplay; trust-badge "As seen in…" rows unless real and earned.
+- Countdown timers / urgency tickers; live chat widgets.
+- Email-gated content (the marketing _is_ the read; intake comes after).
+- Stock photography of business owners with laptops; mascots.
+- Numerical hype without specifics ("10x your operations").
+- A second contact form standing as a peer conversion door (one front door — the assessment).
+
+## Approver
+
+Scott Durgan.

--- a/docs/marketing/positioning-spine.md
+++ b/docs/marketing/positioning-spine.md
@@ -1,0 +1,116 @@
+# Marketing Positioning Spine — Source of Truth
+
+_Status: **LIVING / LOCKED.** This is the single authority for marketing-site positioning, the per-surface narrative, and the copy spine. If a marketing PR disagrees with this file, this file wins. A locked item in §2 and §4 is not re-litigated inside a build PR; it is changed only by a recorded Captain decision appended to §6._
+
+_Authored 2026-06-29. Promotes the M2 diagnosis (`SMD-marketing-M2-diagnosis.md`, with the Captain decisions LOCKED 2026-06-27) into the repo so the next builder is checked against it instead of re-deriving positioning from the code. Supersedes `.design/marketing-ux-brief.md` for everything about message, narrative, and conversion. That brief predates the Operator pivot and is retained only as a stale historical artifact (see §7)._
+
+---
+
+## Why this file exists
+
+The marketing site went in circles. In one ~8-hour window on 2026-06-27/28 four PRs shipped (#1534, #1538, #1541, #1543), and #1541 **rejected and rebuilt** #1538 — reversing decisions that were already locked: it deleted the greenlit gap visual motif, flipped `/why` from the conviction piece to a pure FAQ, and swung the home hero from the gap to named symptoms. None of those reversals were wrong on the merits. The problem is that **nothing held the line**, so each pass swung the pendulum and re-decided the core.
+
+Two structural causes, both addressed here:
+
+1. **No living source of truth in the repo.** The real spec lived on a Desktop file; the repo's marketing brief was stale. Every agent re-derived positioning from the code and its own taste. → _This file is now the in-repo authority._
+2. **The locks were prose, not guardrails.** `forbidden-strings` catches banned phrases, but nothing asserted "the home hero leads symptom→gap" or "/why earns belief." A rebuild could silently reverse a Captain-locked decision and still pass `npm run verify`. → _The load-bearing locks are now encoded as guard tests (see §5)._
+
+---
+
+## 1. The flag (locked)
+
+SMD owns one quadrant the entire competitor field has left empty: **the gap between capable people and capable software.** Everyone else leads with a _role_ (BDR, CX, SDR) and a mascot. SMD names a _category_.
+
+> Capable people and capable software are **both genuinely good**. The problem is structural and universal: between even the best people and the best systems there is a **gap** where work falls through — the handoff between systems, the step that is everyone's job and no one's, the follow-up that slips. Today it is bridged by hand. **The Operator is a new kind of worker that fills the space in between.** It is a **managed** service: we build it around how you run, and we run it for you, as the field keeps moving. (Grounded in ADR 0037 Tenets 1 + 2. Category name locked as "Managed Operator" — see `src/lib/category.ts`.)
+
+**Voice laws (non-negotiable, enforced in `tests/forbidden-strings.test.ts` and `tests/landing-page.test.ts`):**
+
+- **Never disparage people or software.** Both are capable. The enemy is the gap and the teaching-tax, not either resource. No "off the shelf," no AI-vs-human comparison table, no "the role you keep meaning to fill" accusation.
+- **"Managed" is load-bearing.** We do not sell-and-leave. "A guide in this wilderness, here to see you to your destination." Give it prominent placement as a top differentiator.
+- Transience ("it won't walk out the door") is **one quiet closing factor**, never the theme.
+- "Substrate" stays internal doctrine; on the page it is "a new kind of worker."
+- No em dashes. No published dollar amounts. No first-person "I" outside the test-excluded `About.astro`. No "from day one."
+
+---
+
+## 2. The narrative synthesis (locked — this ends the abstraction-vs-symptom fight)
+
+Every prior pass oscillated between leading with **the gap** (abstraction) and leading with **a named symptom** (the leak). Both instincts are right; they are not alternatives, they **nest**. The canonical order, on the home and reused everywhere the full argument is made:
+
+> **1. Hook the symptom (the leak)** — a nameable leak in the buyer's own words: _the follow-up nobody sent, the handoff that stalled, the work that's everyone's job and no one's._
+> **2. Name the gap** — that leak is not a people failure or a software failure. It falls into **the gap between your people and your software.**
+> **3. The worker that fills it** — the Operator is a new kind of worker that fills that gap, across the tools you already run.
+> **4. Managed by us, the guide** — you set the limits; we build it around how you run and we run it for you.
+
+**Resolution of the specific reversals:**
+
+- **Home hero: symptom-led, gap-resolved.** Lead the hero with the concrete leak (step 1), resolve to the gap in the very next beat (step 2). This keeps #1541's instinct and ends the swing. _Do not_ revert the hero to a bare gap abstraction with no symptom hook, and _do not_ strip the gap resolution so it becomes a generic pain list.
+- **`/why`: the FAQ is kept, plus one conviction beat.** #1541's comparison/answer-engine FAQ (with `FAQPage` schema) is good SEO and stays. But `/why` must still **earn belief**: it carries one short conviction beat that states the gap (step 2) and the guide (step 4) respectfully, so a skeptic or a referral source doing diligence leaves convinced, not just informed.
+- **`/operator`: bridge from the gap, then go to mechanism.** `/operator` assumes the sale and opens at the machine — but it must **bridge from the home's gap framing** in its first "what it is" beat rather than introducing a disconnected fresh metaphor. The buyer arriving from the home should feel one continuous argument.
+
+---
+
+## 3. Per-surface jobs (locked)
+
+Each idea is argued in exactly one place. The distinctness test: a visitor who reads all four core pages should find `/why` changes _what they believe_, `/operator` _what they picture_, the home makes them _act_, `/consulting` catches the one-in-five with a bounded need.
+
+| Surface           | Job                                                                                                                                                    | Carries                                                                                                             | Must NOT do                                                                             |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| **`/` home**      | The spine. Make a visitor believe a new category exists and move them to one conversation. Surface one forwardable definition for the referral source. | Symptom→gap→worker→managed (the §2 nesting), light; the industry router; the consulting second door; About; one CTA | Re-run the full manifesto; lead with hire-cost; expose §-number seams                   |
+| **`/why`**        | Earn belief for the skeptic and the referrer doing diligence; double as the answer-engine surface. End forwardably.                                    | The comparison FAQ + `FAQPage` schema **and** one conviction beat (gap + guide)                                     | Describe the mechanism; restate pricing mechanics; become a pure FAQ with no conviction |
+| **`/operator`**   | The mechanism — how the worker works, for someone already sold. Bridge from the gap, then assume the sale.                                             | One gap-bridge beat, then: what you get, the memory, the leash, the guide, where-it-fits, verticals                 | Re-argue the category from scratch; open on a disconnected new metaphor                 |
+| **`/consulting`** | The honest second door — bounded scoped work. _"Not everything is a seat."_                                                                            | Objectives-first consulting spine, clearly subordinate                                                              | Compete with the Operator CTA at equal weight; bleed Operator language in               |
+| **`/packs/*`**    | Recognition by vertical; self-contained warm-arrival surface (referred buyers deep-link here).                                                         | Role-specificity, the line/boundary, one conversation, at the home's craft bar                                      | Read generic; drop the per-vertical specificity                                         |
+| **`/ai`**         | Single-funnel AI-house capability/SEO surface. SMD is an AI house, owned not downplayed, still solution-first.                                         | Confident AI capability framing draining to one conversation                                                        | Double-pitch the Operator; live in a foreign visual era                                 |
+
+**Conversion model (locked):** one primary verb site-wide, **"Start the conversation"** → `/book?interest=<source>`, attribution always preserved. One lower-weight secondary, **"Read the argument"** → `/why`. Everything else is navigation, never a third co-equal CTA. The **assessment is the single front door**; consulting is an _outcome_ of the assessment, not a competing door (Captain decision #3). Refuse the SaaS reflexes: no signup/trial, no pricing table, no second contact form as a peer door.
+
+---
+
+## 4. Captain decisions — LOCKED 2026-06-27
+
+Carried verbatim from the M2 diagnosis. These are settled. Reopen only via §6.
+
+1. **Palette:** keep & tighten the warm "sign-shop" system. No dark/editorial pivot.
+2. **Industries/packs:** promote packs to a real Industries index (warm vertical arrivals get a real door). Packs reach toward the depth of the Ashton & Price litigation-lifecycle review — the recognizable _shape_ of the carrying work per vertical; generalized marketing, never client-contracted promises.
+3. **Conversion model:** the **assessment is the single front door.** Outcomes range from a recommendation to a single engagement to the Operator (the flagship outcome). "The right solution for the situation." Consulting is an outcome of the assessment, not a competing door. The site leads Operator-forward; the ask is always the assessment/conversation.
+4. **`/ai`:** rebuild into the design system as a confident capability surface. SMD is an AI house — owned, not downplayed. Still solution-first.
+5. **Managed service / guide promise (core message):** the Operator is a **managed** service — "a guide in this wilderness, here to see you to your destination." We don't sell-and-leave; we run it and guide as the field changes. "Managed" is load-bearing and gets prominent placement as a top differentiator.
+6. **Gap visual motif:** greenlit, **but prove it small on 2–3 static references before committing the rebuild** (visual-thinker calibration). See §6 — currently unbuilt.
+
+---
+
+## 5. What is enforced in CI
+
+The load-bearing locks are guard tests in `tests/landing-page.test.ts` (`describe('locked positioning spine')`). They fail the build if a future pass silently reverses a lock:
+
+- **Home hero is symptom-led and gap-resolved** — `OperatorHero.astro` carries both the named symptom and the gap resolution.
+- **The home surfaces the forwardable "fills the gap" definition.**
+- **`/operator` bridges from the gap** — it references the gap framing, not only a standalone "remote worker" metaphor.
+- **`/why` keeps the FAQ _and_ carries a conviction beat** — `FAQPage` schema present **and** the gap-conviction line present.
+- **Single primary verb** — the spine surfaces all use "Start the conversation."
+
+Plus the pre-existing guards that remain in force: no dollar amounts (`landing-page.test.ts`), retired-villain and banned phrases (`forbidden-strings.test.ts`), the eyebrow-system guard (`operator-section-badges.test.ts`), and the firm-voice "no first-person I" scan.
+
+---
+
+## 6. Open / deferred — the deliberate next steps
+
+These are tracked here so they are not lost and not silently executed inside an unrelated rebuild.
+
+- **Gap visual motif (decision #6).** Greenlit, built in #1538, deleted in #1541, **currently at zero.** This is the single biggest differentiation lever and the highest-craft/highest-risk piece. Per the Captain's own calibration rule it must be **proven small on 2–3 static reference artifacts before any rebuild commits to it.** Do not rebuild it as a side effect of a copy pass, and do not leave it permanently dropped by default. It gets its own de-risked effort and a recorded go/no-go.
+- **Design-system docs are stale (newly surfaced 2026-06-29).** `.design/DESIGN.md` and `.design/theme.css` describe a retired "Modern Institutional" identity — navy `#2C5282`, Crimson Pro / Public Sans, `--color-*` tokens. The **live** site is the "Plainspoken Sign Shop" — burnt-orange accent, cream/ink, Archivo Black + JetBrains Mono, `--ss-color-*` tokens defined via `src/styles/global.css` and the design-system package. `global.css` itself still points its token documentation at the stale `DESIGN.md`. An agent that "follows the design system" today builds the wrong thing. **Reconcile the design docs to the live system in a dedicated pass** (out of scope for the positioning anchor that created this file).
+- **Remaining M2 cohesion items not yet verified done:** `/consulting` weight (full subordinate page vs. thin door — Captain open decision #3 in M2 §6), category-vs-product reconciling line on the home (M2 #17), CaseStudies taxonomy two-layer cleanup (M2 #19). Check each against §3 before closing.
+
+---
+
+## 7. Superseded / stale artifacts
+
+- **`.design/marketing-ux-brief.md`** — first-pass brief from 2026-04-19, written for the pre-Operator **consulting** site (Crimson Pro, navy, "Book a conversation," the scorecard quiz). Superseded by this file for all positioning, narrative, and conversion. Its identity/anti-pattern notes are also stale (see the design-system bullet in §6). Replaced with a pointer header.
+- **`.design/DESIGN.md`, `.design/theme.css`** — stale "Modern Institutional" identity; see §6.
+
+---
+
+## Change control
+
+A lock in §2, §3, or §4 changes only by a Captain decision recorded as a dated entry appended here, followed by updating the guard tests in the same PR. A build PR that needs to deviate stops and gets the decision first. That is the whole point of this file: the argument is sound, so the site should stop moving except by intent.

--- a/src/lib/category.ts
+++ b/src/lib/category.ts
@@ -2,9 +2,10 @@
 //
 // The Operator-forward marketing site coins and owns a category. The name is a
 // durable brand decision and the riskiest, least-load-bearing element of the
-// positioning: the villain (the cost of the hire) and the old-way/new-way
-// framing carry the conversion weight, not the name. Keeping the name here means
-// a substitution is a one-line change, not a copy sweep across every surface.
+// positioning: the spine (the gap between capable people and capable software, and
+// the managed worker that fills it) carries the conviction weight, not the name. See
+// docs/marketing/positioning-spine.md. Keeping the name here means a substitution is
+// a one-line change, not a copy sweep across every surface.
 //
 // Locked by Captain 2026-06-12: "Managed Operator".
 export const CATEGORY_NAME = 'Managed Operator'

--- a/src/pages/operator.astro
+++ b/src/pages/operator.astro
@@ -116,6 +116,10 @@ const industries = [
         </h2>
         <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
           <p>
+            You have seen where the work falls through, the gap between your people and your
+            software. This is the worker that fills it. Here is how it works.
+          </p>
+          <p>
             Picture a remote worker from the future, sitting at a desk in your business today. A
             computer, a phone, and access to the systems and processes you already run. You hand it
             work the way you hand work to anyone on your team. You send the request, it does the

--- a/src/pages/why.astro
+++ b/src/pages/why.astro
@@ -1,12 +1,13 @@
 ---
 export const prerender = false
 
-// /why is the COMPARISON / answer-engine surface (demoted from the old manifesto).
-// It does not re-argue that the gap exists (that is the home's job). It answers the
-// decision questions a researcher or an AI answer-engine asks when comparing the
-// Operator to the alternatives: a chatbot, building your own, a hire, doing nothing.
-// Each H2 is a question; the same questions/answers are emitted as FAQPage JSON-LD
-// (one artifact). Answer-shaped: a direct answer first, then the expansion.
+// /why earns belief AND doubles as the answer-engine surface. Per the locked spine
+// (docs/marketing/positioning-spine.md §2/§3) it carries one conviction beat (the gap,
+// stated respectfully, plus the guide) so a skeptic or a referral source doing diligence
+// leaves convinced, then answers the decision questions a researcher or an AI answer-engine
+// asks when comparing the Operator to the alternatives: a chatbot, building your own, a
+// hire, doing nothing. Each H2 is a question; the same questions/answers are emitted as
+// FAQPage JSON-LD (one artifact). It does not describe the mechanism (that is /operator).
 import Base from '../layouts/Base.astro'
 import Nav from '../components/Nav.astro'
 import Footer from '../components/Footer.astro'
@@ -73,6 +74,36 @@ const faqSchema = {
           You have options for the work that falls between your people and your software. Here is
           how a managed Operator compares to each of them, in plain terms.
         </p>
+      </div>
+    </section>
+
+    <!-- Conviction beat: /why earns belief, it is not only a comparison FAQ. States
+         the gap (respectfully) and the guide. Locked in docs/marketing/positioning-spine.md §2. -->
+    <section class="bg-white px-6 py-20">
+      <div class="mx-auto max-w-5xl">
+        <p
+          class="mb-5 font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--ss-color-text-secondary)]"
+        >
+          Why It's Different
+        </p>
+        <h2
+          class="mb-8 max-w-3xl font-['Archivo'] text-3xl md:text-4xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
+        >
+          The Work Lives In The Space Between.
+        </h2>
+        <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
+          <p>
+            Your people are capable and your software is capable. No single tool was ever built to
+            do the work between your tools, the handoffs and the follow-through that touch four
+            systems and belong to none of them. That work has always come down to a person holding
+            it together by hand.
+          </p>
+          <p>
+            The Operator is the first worker built for exactly that space, and it does not work
+            alone. We build it around how you run, we run it for you, and we keep it current as the
+            field changes. A guide for new ground, not software we hand you and walk away from.
+          </p>
+        </div>
       </div>
     </section>
 

--- a/tests/landing-page.test.ts
+++ b/tests/landing-page.test.ts
@@ -171,6 +171,65 @@ describe('operator-forward home integrity', () => {
   })
 })
 
+describe('locked positioning spine', () => {
+  // Encodes the locks in docs/marketing/positioning-spine.md so a future rebuild
+  // cannot silently reverse a Captain-locked decision and still pass `npm run verify`.
+  // The marketing site went in circles (#1534/#1538/#1541/#1543) because the locks
+  // were prose, not guardrails. These are the load-bearing ones.
+  // Prettier wraps prose across lines, so phrase assertions normalize runs of
+  // whitespace to a single space (and lowercase) before matching.
+  const flat = (s: string) => s.replace(/\s+/g, ' ').toLowerCase()
+  const operatorHero = flat(readComponent('OperatorHero.astro'))
+  const home = flat(readFileSync(resolve('src/pages/index.astro'), 'utf-8'))
+  const whyRaw = readFileSync(resolve('src/pages/why.astro'), 'utf-8')
+  const why = flat(whyRaw)
+  const operator = flat(readFileSync(resolve('src/pages/operator.astro'), 'utf-8'))
+
+  it('home hero is symptom-led: it names a concrete leak', () => {
+    // The §2 nesting step 1 — hook the symptom in the buyer's words, not a bare
+    // abstraction. Do not revert the hero to a context-free gap statement.
+    expect(operatorHero).toContain("everyone's job and no one's")
+  })
+
+  it('home hero resolves the symptom to the gap', () => {
+    // §2 nesting step 2 — the named leak resolves to the gap. Do not strip this so
+    // the hero becomes a generic pain list with no category.
+    expect(operatorHero).toContain('the gap between your people and your software')
+  })
+
+  it('home surfaces the forwardable "fills the gap" definition', () => {
+    expect(home).toContain('fills the gap')
+  })
+
+  it('/operator bridges from the gap rather than opening on a disconnected metaphor', () => {
+    // /operator must tie back to the home's framing before going to mechanism.
+    expect(operator).toContain('the gap between your people and your software')
+  })
+
+  it('/why keeps the comparison FAQ', () => {
+    expect(whyRaw).toContain('FAQPage')
+  })
+
+  it('/why also carries the conviction beat (it is not a pure FAQ)', () => {
+    // /why must still earn belief — the gap, stated respectfully. Locked synthesis:
+    // keep #1541's FAQ AND restore one conviction beat.
+    expect(why).toContain('no single tool was ever built to do the work between')
+  })
+
+  it('single primary verb across the spine surfaces', () => {
+    for (const [label, content] of [
+      ['OperatorHero.astro', operatorHero],
+      ['index.astro', home],
+      ['operator.astro', operator],
+      ['why.astro', why],
+    ] as const) {
+      expect(content, `"Start the conversation" missing from ${label}`).toContain(
+        'start the conversation'
+      )
+    }
+  })
+})
+
 describe('JSON-LD schema', () => {
   it('JsonLd.astro contains LocalBusiness type', () => {
     const content = readComponent('JsonLd.astro')


### PR DESCRIPTION
## Why

The marketing site has been going in circles. In one ~8-hour window (Jun 27–28) four PRs shipped — **#1534, #1538, #1541, #1543** — and **#1541 rejected and rebuilt #1538**, reversing decisions that were already locked: it deleted the greenlit gap visual motif, flipped `/why` from the conviction piece to a pure FAQ, and swung the home hero from the gap to named symptoms.

None of those reversals were wrong on the merits. The problem is **nothing held the line.** Two structural causes:

1. **No living source of truth in the repo.** The real spec (the M2 diagnosis) lived on a Desktop file; the repo's marketing brief was stale (still described the pre-Operator consulting site). Every pass re-derived positioning from the code + its own taste.
2. **The locks were prose, not guardrails.** `forbidden-strings` catches banned phrases, but nothing asserted "the home hero leads symptom→gap" or "/why earns belief." A rebuild could silently reverse a Captain-locked decision and still pass `npm run verify`.

This PR is the **anchor, not another rebuild.**

## What

- **`docs/marketing/positioning-spine.md`** (new) — the in-repo source of truth. Ports the M2 diagnosis + the Captain decisions **LOCKED 2026-06-27**, and writes down the narrative synthesis that ends the abstraction-vs-symptom fight: **symptom (the leak) → the gap → the worker that fills it → managed/guide.** Records the deferred **gap-visual-motif** decision (greenlit, built in #1538, deleted in #1541, currently at zero — prove small first) and the newly surfaced **stale design-system docs** as explicit open items.
- **`.design/marketing-ux-brief.md`** — retired. Replaced with a corrected pointer to the spine doc + current identity facts (it still described Crimson Pro / navy / "Book a conversation").
- **`tests/landing-page.test.ts`** — **7 guard tests** encode the load-bearing locks so a future pass can't silently reverse them: home hero symptom-led + gap-resolved, home's forwardable "fills the gap" definition, `/operator` bridges to the gap, `/why` keeps the FAQ **and** carries a conviction beat, single primary verb across the spine.
- **Minimal copy fixes** to satisfy the locked spec (no rebuild): `/operator` now bridges from the gap before its mechanism metaphor; `/why` regains one conviction beat alongside the comparison FAQ.
- **`src/lib/category.ts`** — corrected the source-of-truth comment, which still narrated the retired "cost of the hire" villain.

## Out of scope (tracked in the spec §6)

- The **gap visual motif** rebuild — deferred per the Captain's own "prove small on 2–3 static refs first" rule.
- Reconciling the **stale `.design/DESIGN.md` / `theme.css`** (navy/Crimson-Pro) to the live "Plainspoken Sign Shop" system — same staleness disease, design side; its own pass.

## Test plan

- [x] `npm run verify` green — **3349 passed, 2 skipped**; typecheck, lint, format, build all clean.
- [x] 7 new guard tests pass and fail correctly when a lock is reversed (verified by line-wrap iteration during authoring).
- [ ] Captain read of `positioning-spine.md` — confirm the locked synthesis is the one you want before it becomes the authority the next builder is checked against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)