### PR TITLE
chore(claude): remove dead apple-notes MCP allow-rule

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,8 +12,7 @@
       "Grep",
       "Task",
       "NotebookEdit",
-      "mcp__crane__*",
-      "mcp__apple-notes__*"
+      "mcp__crane__*"
     ]
   }
 }


### PR DESCRIPTION
## What

Removes the `mcp__apple-notes__*` permission allow-rule from `.claude/settings.json`.

## Why

It's the **only** reference to apple-notes anywhere in the repo (`git grep` confirms), and no apple-notes MCP server is configured. A vestigial permission grant for a server that no longer exists — should have been removed when the integration was dropped.

## Scope

One line. No behavior change for any live tooling. Surfaced during `/doctor` cleanup of this branch's settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)