### PR TITLE
fix(marketing): frame the Operator as a worker with a job, not a request-response bot

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -114,9 +114,9 @@ const firmSchema = {
         <p
           class="mb-12 max-w-3xl text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]"
         >
-          A new kind of worker, built for your business and given a real role. It works across the
-          tools you already run and takes on the recurring connective work, so nothing falls
-          through. Not a person you hire, not a tool you buy.
+          A new kind of worker, built for your business and given a real role. It comes in knowing
+          that role: it carries the recurring connective work on its own, and takes on what you hand
+          it, so nothing falls through. Not a person you hire, not a tool you buy.
         </p>
 
         <div

--- a/src/pages/operator.astro
+++ b/src/pages/operator.astro
@@ -27,7 +27,7 @@ const productSchema = {
 const faqs = [
   {
     q: 'Is the Operator just a chatbot?',
-    a: 'No. A chatbot waits for someone to type a question and answers it. The Operator does the work. It reads the inquiry, pulls what matters from your systems, drafts the reply in your voice, books the next step, and logs it where your team can see. A chatbot is a conversation; the Operator is a worker that carries tasks to done across the tools you already run.',
+    a: 'No. A chatbot waits for someone to type a question and answers it. The Operator does not wait. Like any worker, it has standing work it does on its own, on a schedule, whether or not anyone messages it: watching for what is slipping, sending the recurring update, moving the work along. And when you do hand it something, it carries it to done, pulling what matters from your systems, drafting in your voice, booking the next step, and logging it where your team can see. A chatbot is a conversation; the Operator is a worker with a job.',
   },
   {
     q: 'Should we build our own AI agent or have one built and run for us?',
@@ -158,9 +158,10 @@ const industries = [
           </p>
           <p>
             Picture a remote worker from the future, sitting at a desk in your business today. A
-            computer, a phone, and access to the systems and processes you already run. You hand it
-            work the way you hand work to anyone on your team. You send the request, it does the
-            job, and it comes back with the result.
+            computer, a phone, and access to the systems and processes you already run. Like anyone
+            you would hire for the role, it comes in knowing the job. It has standing work it
+            carries on its own, on its own schedule, without waiting to be asked, and like anyone on
+            your team, you can hand it something new whenever you need to.
           </p>
           <p>
             It works from its own office, the way much of your team already does. The bookkeeper you


### PR DESCRIPTION
## Summary
The Operator copy leaned on reactive verbs — "you send the request, it does the job, and it comes back," "reads the inquiry," "drafts the reply" — which read as a chatbot that waits for input. A real worker doesn't wait: it comes in knowing the job, carries standing work on its own schedule unprompted, **and** takes what you hand it. Both modes — exactly what Crane already does (autonomous scheduled triage report + inbound reply).

- **`/operator` "A Worker, In Another Office":** replaced the send-request/comes-back line with standing-work-on-its-own + hand-it-something-new.
- **`/operator` "Is the Operator just a chatbot?" FAQ:** leads with "does not wait," names the standing/scheduled work, then the on-demand work. Feeds the FAQPage schema, so answer engines get the corrected framing too.
- **Home beat 4 "Meet The Operator":** "comes in knowing that role: carries the recurring work on its own, and takes on what you hand it."

No structural change, no new graphics, no dollar amounts, no em dashes. The firm-with-flagship guards and voice/fabrication guards still pass.

## Test plan
- [x] \`npm run verify\` passes (18 landing-page guards green, format clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)