### PR TITLE
fix(marketing): reframe About heading so the founder bio reads right

### DIFF
--- a/src/components/About.astro
+++ b/src/components/About.astro
@@ -6,12 +6,12 @@
       <p
         class="mb-4 font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--ss-color-text-secondary)]"
       >
-        The Guide
+        Scott Durgan
       </p>
       <h2
         class="font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
       >
-        Who We Are
+        At The Core Of The Firm
       </h2>
     </div>
     <div class="flex flex-col gap-10 sm:flex-row sm:items-start">

--- a/tests/landing-page.test.ts
+++ b/tests/landing-page.test.ts
@@ -85,8 +85,8 @@ describe('content integrity', () => {
 describe('voice standard', () => {
   // About.astro is intentionally excluded: SMD is positioned as a practitioner
   // firm (lawyer / doctor / craftsman model) where the founder *is* the firm.
-  // §07 Who We Are uses Scott's first-person voice; the rest of the page stays
-  // in firm-level "we" voice. See CLAUDE.md "Voice standard" practitioner-firm
+  // The About founder bio uses Scott's first-person voice; the rest of the page
+  // stays in firm-level "we" voice. See CLAUDE.md "Voice standard" practitioner-firm
   // exception.
   const marketingComponents = ['OperatorHero.astro']
 


### PR DESCRIPTION
## Summary
The About founder section read **"WHO WE ARE"** and then dropped straight into *"I've been building software since the '90s."* The plural heading collided with the first-person bio — and the bio never named the person it belonged to.

- Eyebrow: "The Guide" → **"Scott Durgan"** (names the individual; also removes the mild "guide" redundancy with the page hero "A Guide, Not A Vendor").
- Heading: "Who We Are" → **"At The Core Of The Firm"** — frames the individual the firm is built around, so the handoff into "I" is sensible.
- Updated a stale test comment that referenced the renamed heading.

First-person stays confined to About.astro per the practitioner-firm voice exception; no structural change.

## Test plan
- [x] \`npm run verify\` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)