### PR TITLE
fix(marketing): make "a guide, not a vendor" land at the firm level, not via the Operator

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -249,8 +249,8 @@ const firmSchema = {
             businesses that never had access to it.
           </p>
           <p>
-            We do not sell you something and leave. The Operator is a managed service, and the field
-            keeps changing, so we stay with you and keep it current. A guide for new ground.
+            We do not sell you something and leave. This is new ground, and it keeps shifting, so we
+            stay in it with you as it does. A vendor hands you a thing and moves on. A guide stays.
           </p>
           <p>
             <a


### PR DESCRIPTION
## Summary
Home beat 7 ("Who Runs It / A Guide, Not A Vendor") justified "we stay with you" with *"The Operator is a managed service"* — which:
- drops the Operator into a section that's about **Scott and the firm**, with no setup, and
- quietly concedes the vendor framing the heading just denied (we *did* sell you a thing; it's just managed).

"We stay with you" is a firm-level truth, not an Operator feature. Reframed so it lands on its own: the ground is new and keeps shifting, so we stay; a vendor hands off and moves on, a guide stays. The managed-service fact already lives prominently on `/operator`, so nothing is lost.

Same class of fix as the chatbot framing — removing a claim that assumes context it never established.

## Test plan
- [x] \`npm run verify\` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)