### PR TITLE
fix(marketing): continuity pass — five "asserted without setup" defects across the spine

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -29,14 +29,13 @@ import CtaButton from '../components/CtaButton.astro'
         <h1
           class="mb-8 font-['Archivo'] text-5xl md:text-7xl font-black uppercase leading-[0.95] tracking-[-0.03em] text-[color:var(--ss-color-text-primary)]"
         >
-          A Guide, Not A Vendor.
+          Enterprise Discipline, For Small Business.
         </h1>
         <p
           class="max-w-2xl font-['Archivo'] text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]"
         >
           We are a software and AI solutions firm for small businesses. We do not sell you something
-          and leave. We build the right solution, we run it, and we stay with you as the field keeps
-          changing.
+          and leave; we build the right solution and stay with you as the ground keeps shifting.
         </p>
       </div>
     </section>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -244,8 +244,8 @@ const firmSchema = {
         </h2>
         <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
           <p>
-            Behind SMD is Scott Durgan, who spent two decades building enterprise software for
-            Fortune 500 and Fortune 100 companies. The same operational discipline, now for
+            Behind SMD Services is Scott Durgan, who spent two decades building enterprise software
+            for Fortune 500 and Fortune 100 companies. The same operational discipline, now for
             businesses that never had access to it.
           </p>
           <p>

--- a/src/pages/operator.astro
+++ b/src/pages/operator.astro
@@ -138,7 +138,7 @@ const industries = [
       </div>
     </section>
 
-    <!-- A worker, in another office (opens at the machine; the comparison vs a hire lives on /why) -->
+    <!-- A worker, in another office. Opens at the concrete picture; the hire comparison lives in #compare below. -->
     <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-5xl">
         <p
@@ -153,8 +153,8 @@ const industries = [
         </h2>
         <div class="space-y-8 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
           <p>
-            You have seen where the work falls through, the gap between your people and your
-            software. This is the worker that fills it. Here is how it works.
+            There is a gap in most businesses, between your people and your software, where the
+            connective work falls through. This is the worker that fills it. Here is how it works.
           </p>
           <p>
             Picture a remote worker from the future, sitting at a desk in your business today. A


### PR DESCRIPTION
## Summary
A cold-visitor read of home → `/operator` → `/about` surfaced the same defect class as the chatbot and guide-not-vendor fixes: claims that assume context they never establish.

1. **Home→About was a dead end.** Home beat 7 and the About hero shared the identical eyebrow + headline ("Who Runs It / A Guide, Not A Vendor"). Clicking "More about us" landed on an identically-titled section. About hero now carries the credibility line it exists to make: **"Enterprise Discipline, For Small Business."**
2. **About hero over-claimed.** "we build the right solution, we run it" implied universal managed running, against the firm's own solution-first stance (some outcomes are a one-time recommendation). Softened to "we build the right solution and stay with you as the ground keeps shifting."
3. **`/operator` assumed you came from home.** Opened with "You have seen where the work falls through" — a cold SEO/ad lander hasn't. Now states the gap instead of presuming it.
4. **Firm name:** "Behind SMD is Scott Durgan" → "Behind SMD Services is Scott Durgan."
5. **Stale code comment** pointed at the deleted `/why` page; corrected to the live `#compare` block.

No structural change, no graphics, no dollar amounts, no em dashes. Guards green.

## Test plan
- [x] \`npm run verify\` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)