### PR TITLE
feat(marketing): rebuild the law pack to the lifecycle altitude (template-of-record)

### DIFF
--- a/docs/marketing/pack-standard.md
+++ b/docs/marketing/pack-standard.md
@@ -1,0 +1,83 @@
+# Vertical Pack Standard: the bar a `/packs/<slug>` page must clear
+
+**Status:** Captain decision, 2026-06-29. Extracted from the A&P discovery-lifecycle
+response (the template-of-record) by building the law pack to its altitude first.
+Authority for all twelve packs. A pack that does not meet every rule below is not shippable.
+
+## Why this exists
+
+The twelve packs shipped breadth-first against no standard: every one led with the
+**front-desk / intake** layer ("The Intake Desk, Fully Staffed") and a verbatim §02
+("The Seat The Market Won't Fill") carrying an **unsourced labor-market claim**. That is
+the cookie-cutter, and it is a credibility leak. A real prospect (a litigation firm) was
+explicit: the **full lifecycle** of the core work is what they want, not _"someone to
+answer the phone."_ This standard makes that the bar.
+
+## The seven rules
+
+1. **Target the core operational lifecycle, not the front desk.** The pack pitches the
+   deep, recurring, high-stakes process a _skilled person_ runs in that trade (the
+   paralegal-level work, the caseload), not intake, reception, or "answer the phone."
+   The lifecycle walk (rule 4) is the centre of the page.
+
+2. **Name systems as generic categories, never brands.** "your case management system,"
+   not "Smokeball." "the tools your attorneys already use to draft," not "CoCounsel."
+   Each vertical has its own core system category and its own specialist tools.
+
+3. **Orchestrates, does not replace.** State plainly that the Operator works _inside_ the
+   core system and _alongside_ the specialist tools: it prepares their inputs, routes
+   their outputs, and does the work between and around them. It is the connective tissue,
+   not a replacement for any one system (ADR 0037).
+
+4. **Walk the lifecycle step by step.** The differentiator. One real stretch of the core
+   process, carried start to finish, each step in three lines:
+   **Operator does X · Your part · If it stalls.** This is what converts; it is also what
+   proves we understand the trade. Rendered by `PackLifecycle.astro`.
+
+5. **Every empirical claim is sourced, or it is cut.** No "the market won't fill it," no
+   "harder to find than a year ago," no statistic, without a real citation. The problem
+   section (§02) makes its case from the _shape of the work_, not from an unsupported
+   labor or market assertion.
+
+6. **Honest trust mechanics, not bravado.** Two non-negotiable beats: **the line**
+   (what stays with the licensed professional; the hard floors that are not settings) and
+   **what we prove first** (where accuracy is unproven, the Operator surfaces what it found
+   and asks rather than acting; we validate on your real work before relying on it). Plus
+   **quiet by design** (routine batched into one summary; pings only when a person is
+   genuinely needed). Because the lifecycle walk uses the selling voice, the truth is
+   carried by the section framing: the walk is declared illustrative ("the shape of the
+   work, not a fixed script") and paired with the fail-closed honesty ("surfaces what it
+   found and asks"). The kit-grammar guard enforces both phrases on every lifecycle pack.
+
+7. **One door, collaborative close.** Ends in the assessment: "we learn how you actually
+   run, find where the time goes, shape it to fit; if it is not the right fit we say so."
+   Single primary verb: **Start with an assessment.** Client is the hero.
+
+## Authenticity guardrails (the anti-cookie-cutter checks)
+
+Before a pack ships, an adversarial pass must answer NO to all of these:
+
+- Is §02 a noun-swap of another vertical's problem? (Could you paste it onto a different
+  trade and have it still read true? If yes, it is not specific enough.)
+- Is any empirical/market claim unsourced?
+- Does the lifecycle walk describe the _front desk_ instead of the _core work_?
+- Does the lifecycle read like a real process in _this_ trade, or a generic flow with the
+  nouns changed?
+- Are any brand names present where a category belongs?
+- Does any sentence promise behavior we have not validated, without the test-and-tune caveat?
+
+## Sourcing discipline
+
+Research-driven, **not interviews**. We are not talking to prospects. Real sources only:
+the existing `operator/verticals/<slug>/` substrate, cited industry/workflow facts, and
+the real (categorical) systems and steps of the trade. Never invent a lifecycle we do not
+understand; research it first. Build **one vertical at a time** behind a Captain gate,
+never a twelve-at-once run.
+
+## Provenance
+
+The template-of-record is the A&P discovery-lifecycle response. **Internal; de-identify;
+never publish the firm name, the person, the specific tool combination, or
+jurisdiction-specific specifics.** The _shape_ and _altitude_ are reusable; the engagement
+is not. See `project_pack_core_lifecycle_strategy` (memory), ADR 0037 (thesis), ADR 0038
+(delivery method).

--- a/src/components/packs/PackClosing.astro
+++ b/src/components/packs/PackClosing.astro
@@ -63,7 +63,7 @@ const faqSchema = {
     <h2
       class="mb-6 font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-white"
     >
-      Start The Conversation.
+      It Starts With An Assessment.
     </h2>
     <p class="mx-auto mb-6 max-w-2xl text-lg text-[color:var(--ss-color-text-muted)]">
       <slot name="pitch" />

--- a/src/components/packs/PackLifecycle.astro
+++ b/src/components/packs/PackLifecycle.astro
@@ -1,0 +1,70 @@
+---
+// The lifecycle walk: the center of a pack page and the differentiator over the
+// retired intake-desk framing. One real stretch of the vertical's core process,
+// carried start to finish, each step in three lines: what the Operator does, the
+// person's part, and what happens if a step stalls. This shape is the standard
+// (docs/marketing/pack-standard.md, rule 4), sourced from the A&P discovery-
+// lifecycle template-of-record.
+//
+// Truthfulness: the steps describe the work in the established selling voice, but
+// the section that hosts this component MUST frame it as illustrative ("the shape
+// of the work, not a fixed script") and pair it with the fail-closed test-and-tune
+// honesty ("surfaces what it found and asks"). The kit-grammar guard enforces both.
+interface Step {
+  title: string
+  operator: string
+  your: string
+  stalls?: string
+}
+
+interface Props {
+  steps: Step[]
+}
+
+const { steps } = Astro.props
+
+const rows = (step: Step): { label: string; tone: 'primary' | 'secondary'; text: string }[] => {
+  const out: { label: string; tone: 'primary' | 'secondary'; text: string }[] = [
+    { label: 'Operator', tone: 'primary', text: step.operator },
+    { label: 'Your part', tone: 'secondary', text: step.your },
+  ]
+  if (step.stalls) out.push({ label: 'If it stalls', tone: 'secondary', text: step.stalls })
+  return out
+}
+---
+
+<ol class="border-t-[3px] border-[color:var(--ss-color-text-primary)]">
+  {
+    steps.map((step, i) => (
+      <li class="grid grid-cols-[2.5rem_1fr] gap-x-5 gap-y-4 border-b-[3px] border-[color:var(--ss-color-text-primary)] py-8 md:grid-cols-[4rem_1fr] md:gap-x-8">
+        <span class="font-['Archivo'] text-2xl md:text-4xl font-black tabular-nums leading-none text-[color:var(--ss-color-primary)]">
+          {String(i + 1).padStart(2, '0')}
+        </span>
+        <div class="space-y-5">
+          <h3 class="font-['Archivo'] text-xl md:text-2xl font-black uppercase tracking-[-0.01em] text-[color:var(--ss-color-text-primary)]">
+            {step.title}
+          </h3>
+          <dl class="space-y-3">
+            {rows(step).map((r) => (
+              <div class="grid grid-cols-1 gap-1 sm:grid-cols-[7.5rem_1fr] sm:gap-4">
+                <dt
+                  class:list={[
+                    "font-['Archivo_Narrow'] text-xs font-semibold uppercase tracking-[0.12em]",
+                    r.tone === 'primary'
+                      ? 'text-[color:var(--ss-color-primary)]'
+                      : 'text-[color:var(--ss-color-text-secondary)]',
+                  ]}
+                >
+                  {r.label}
+                </dt>
+                <dd class="text-base leading-relaxed text-[color:var(--ss-color-text-secondary)]">
+                  {r.text}
+                </dd>
+              </div>
+            ))}
+          </dl>
+        </div>
+      </li>
+    ))
+  }
+</ol>

--- a/src/pages/packs/law-firm.astro
+++ b/src/pages/packs/law-firm.astro
@@ -1,24 +1,23 @@
 ---
 export const prerender = false
 
-import PackCardGrid from '../../components/packs/PackCardGrid.astro'
 import PackClosing from '../../components/packs/PackClosing.astro'
 import PackEyebrow from '../../components/packs/PackEyebrow.astro'
 import PackHeading from '../../components/packs/PackHeading.astro'
 import PackHero from '../../components/packs/PackHero.astro'
 import PackIntro from '../../components/packs/PackIntro.astro'
 import PackLayout from '../../components/packs/PackLayout.astro'
+import PackLifecycle from '../../components/packs/PackLifecycle.astro'
 import PackProse from '../../components/packs/PackProse.astro'
 import PackSection from '../../components/packs/PackSection.astro'
 import PackSectionCta from '../../components/packs/PackSectionCta.astro'
-import { shapeZoneTitles } from '../../lib/operator-packs/shared'
 
 const productSchema = {
   '@context': 'https://schema.org',
   '@type': 'Product',
   name: 'Operator for Law Firms',
   description:
-    'The Operator is a worker you hire, not software you buy. The law-firm pack is its head start: a starting point shaped around intake and matter coordination, which we configure with you and you customize to your firm. The law stays with your lawyers; you set the line.',
+    'The Operator is a worker you hire, not software you buy. It works inside your case management system and alongside the tools your attorneys use to draft, carrying a matter through its life: the deadlines, the documents, the follow-ups, and the chase. Every piece of work goes to an attorney to review; the Operator never sends to another party and never signs on its own.',
   brand: { '@type': 'Brand', name: 'SMD Services' },
   offers: {
     '@type': 'Offer',
@@ -27,188 +26,205 @@ const productSchema = {
   },
 }
 
-// Section 03: the starting templates in the pack, grouped in plain language. Sourced
-// from operator/verticals/law-firm/vertical.yaml (the intake, matter-motion,
-// routine, and proactive skill families). These are templates we configure, not
-// a finished, running product.
-const packTemplates = [
+// Section 04: the lifecycle walk. One real stretch of a matter (responding to
+// discovery) carried start to finish, each step in the standard's three-line shape
+// (Operator does / your part / if it stalls). De-identified and brand-generic:
+// general civil-litigation process, not the jurisdiction- or tool-specific specifics
+// of the internal template-of-record. The section framing (illustrative + the
+// fail-closed honesty in section 07) carries the truthfulness, per the kit-grammar guard.
+const lifecycleSteps = [
   {
-    title: 'Intake and conflicts',
-    body: 'A new inquiry captured and routed wherever it lands, the matter details gathered, the conflict check captured and sent to a person to clear, the consult booked.',
+    title: 'Discovery is served',
+    operator:
+      'Spots the served document in the matter, identifies the type, reads the service date and method, and tells the responsible attorney it arrived.',
+    your: 'Nothing, unless it asks you to confirm.',
+    stalls: 'Re-flags if it goes unacknowledged.',
   },
   {
-    title: 'Keeping matters moving',
-    body: 'The engagement letter chased toward signature, status updates drafted, documents logged as they arrive, the quiet matter nudged, the dates you have authored tracked.',
+    title: 'The response deadline',
+    operator:
+      'Computes the response deadline and the downstream dates, calendars them, and emails the attorney a one-click confirm.',
+    your: 'Confirm, or correct the date.',
+    stalls: 'Reminds before the date.',
   },
   {
-    title: 'The routine back-and-forth',
-    body: 'The status question that gets the same answer every time, the receipt of a document, the scheduling. Drafts go to a reviewer until you trust a kind of message on its own.',
+    title: 'Drafting the response',
+    operator:
+      'Gathers the served request and the supporting documents into the place your drafting tool draws from, then sends a ready-to-go nudge with the link.',
+    your: 'Generate the draft in your tool.',
+    stalls: 'Follows up if the draft has not landed back in the matter.',
   },
   {
-    title: 'Proactive touches',
-    body: 'The internal matter digest assembled, referral sources thanked, your practice-management system kept in sync.',
-  },
-]
-
-// Section 05: the three customization zones. Titles are shared (shapeZoneTitles); the
-// body under each is law-specific.
-const zones = [
-  {
-    title: shapeZoneTitles.prebuilt,
-    body: 'The starting templates above, shaped around an intake and matter desk and ready to configure. You are not building from a blank page.',
+    title: 'Client verification',
+    operator:
+      'Drafts the verification request and sends the attorney an approve-and-send button. Once approved, it sends, then tracks the signature.',
+    your: 'Approve, and the client signs.',
+    stalls: 'Chases the client for the signature, and tells you only if it stalls.',
   },
   {
-    title: shapeZoneTitles.connected,
-    body: 'Wired into your own accounts: Clio, your email and calendar, your documents. It works inside the tools you already run.',
+    title: "The other side's responses",
+    operator:
+      'Reviews them for gaps (boilerplate objections, non-answers, missing verifications), drafts the meet-and-confer letter, and sends it for review with the deadline noted.',
+    your: 'Review, send, or edit.',
+    stalls: 'Reminds as the deadline nears.',
   },
   {
-    title: shapeZoneTitles.yours,
-    body: 'Your voice, your intake questions, the way you run a matter, and where the line sits. You decide what runs on its own and what waits for a person. You are the expert in your firm; you shape it from there.',
-  },
-]
-
-const roleLenses = [
-  {
-    title: 'New-client intake',
-    body: 'A new inquiry lands, wherever it comes from. The Operator captures the details that matter, drafts the first reply in your voice, and offers times for the consult. The person who used to drop or slow that first response is no longer the bottleneck, and the legal advice waits for a lawyer.',
+    title: 'Motion to compel, if needed',
+    operator:
+      'Assembles the supporting pieces, including the item-by-item statement courts require.',
+    your: 'The attorney finalizes and files.',
+    stalls: 'Reminds before the deadline.',
   },
   {
-    title: 'Keeping matters moving',
-    body: 'The engagement letter that sits unsigned, the matter that goes quiet, the document you are waiting on. The Operator watches the work in flight, chases what stalled, and drafts the follow-up, with everything logged in your practice-management system.',
+    title: 'The record',
+    operator: 'Keeps a running case timeline and chronology as records and events arrive.',
+    your: 'Use it for the work ahead: demands, mediation, valuation.',
   },
   {
-    title: 'The routine back-and-forth',
-    body: 'The status questions answered the same way every time, the consult scheduling, the receipt of a document. Drafts go to a reviewer on your team until you trust the Operator to handle a kind of message on its own.',
+    title: 'What needs you',
+    operator: 'Sends one short summary of what needs attention: due soon, unsigned, deadline near.',
+    your: 'React to the few items.',
+    stalls: 'Re-surfaces anything missed.',
   },
 ]
 ---
 
 <PackLayout
   title="Operator for Law Firms | SMD Services"
-  description="The law-firm pack is the Operator's head start: a starting point shaped around intake and matter coordination, which we configure with you and you customize to your firm. The law stays with your lawyers. You set the line."
+  description="A worker you hire, not software you buy. The Operator works inside your case management system and alongside your drafting tools, carrying a matter through its life so nothing slips. Every piece of work goes to an attorney. It starts with an assessment."
   schema={productSchema}
 >
-  <!-- § 01 Hero -->
+  <!-- 01 Hero -->
   <PackHero slug="law-firm">
-    <Fragment slot="heading">The Intake Desk, Fully Staffed.</Fragment>
+    <Fragment slot="heading">The Matter, Carried End To End.</Fragment>
     <Fragment slot="lede">
-      The Operator is a worker you hire, not software you buy. This is its law-firm head start: a
-      starting point already shaped around intake and matter coordination, so you are not building
-      from a blank page. You make it yours from there.
+      The Operator is a worker you hire, not software you buy. It works inside your case management
+      system and alongside the tools your attorneys already use to draft, carrying a matter through
+      its life: the deadlines, the documents, the follow-ups, the chase, so your team does not have
+      to hold it all in their heads. Every piece of work goes to an attorney to review. It never
+      sends to another party, and it never signs on its own.
     </Fragment>
   </PackHero>
 
-  <!-- § 02 The seat the market won't fill -->
+  <!-- 02 The problem -->
   <PackSection bg="white">
     <PackEyebrow>The Problem</PackEyebrow>
-    <PackHeading variant="prose">The Seat The Market Won't Fill.</PackHeading>
+    <PackHeading variant="prose">Every Open Matter, At Once.</PackHeading>
     <PackProse>
       <p>
-        Intake and matter coordination is one of the hardest seats to keep filled. Legal leaders say
-        skilled support is harder to find than it was a year ago, and the assistant or paralegal you
-        train is the one a bigger firm hires away. The work does not wait while the seat sits open.
-        The call that does not get returned and the engagement that does not get chased are the
-        matter itself, gone.
+        The hard part of a practice is not answering the phone. It is carrying every open matter at
+        once: the response deadline on a served discovery request, the document that has not come
+        back, the other side's answers that need a closer read, the matter that has gone quiet, the
+        signature still outstanding.
       </p>
       <p>
-        An Operator fills that seat. It works at full speed, all the time, and what it learns about
-        how your firm runs, your practice areas, your intake questions, your voice, stays with the
-        firm instead of leaving with the person who had it.
+        Each one is small. Together they are a caseload, and they live in your people's heads, where
+        things slip. When a deadline is missed or a response stalls, that is not an inconvenience.
+        In a matter, it is the matter itself, at risk.
       </p>
     </PackProse>
   </PackSection>
 
-  <!-- § 03 What the pack starts you with -->
+  <!-- 03 What the Operator does -->
   <PackSection bg="background">
-    <PackEyebrow>What You Get</PackEyebrow>
-    <PackHeading variant="grid">What The Pack Starts You With.</PackHeading>
-    <PackIntro>
-      You do not start from a blank page. The law-firm pack comes shaped around the work an intake
-      and matter desk runs, as starting templates we configure with you:
-    </PackIntro>
-    <PackCardGrid items={packTemplates} cols={2} card="templates" />
-    <PackIntro after>
-      These plug into Clio and your email and calendar. The templates are the head start. How they
-      run is yours to shape.
-    </PackIntro>
-  </PackSection>
-
-  <!-- § 04 From the start -->
-  <PackSection bg="white">
-    <PackEyebrow>Day One</PackEyebrow>
-    <PackHeading variant="prose">From The Start.</PackHeading>
+    <PackEyebrow>What It Does</PackEyebrow>
+    <PackHeading variant="prose">An Always-On Member Of The Team.</PackHeading>
     <PackProse>
       <p>
-        Before it starts, we sit down with you and the people who run intake, and we shape the
-        templates around how your firm actually operates, so it begins ready, not green.
+        The Operator is an always-on team member that works inside your case management system and
+        alongside the tools your attorneys already use to draft. Its job is to carry the process so
+        your people do not have to hold it in their heads: it watches every matter, knows every
+        deadline, prepares the documents, and chases what is outstanding.
       </p>
       <p>
-        From there the work moves the way it always did. A new inquiry comes in and gets a first
-        reply in your voice with times for the consult. The engagement letter gets chased toward
-        signature. The routine status question gets answered, the document that arrives gets logged,
-        the matter that has gone quiet gets a nudge. It is all logged in Clio as it happens, and it
-        keeps getting sharper from your team's corrections.
+        When it needs a person to do their part, it comes to them with everything already prepared,
+        so their part is usually a single reply or a one-click confirm. If a step does not get done,
+        it follows up rather than letting it slip. Every piece of work product goes to an attorney
+        to review and finalize. It never sends anything to another party, and it never signs on its
+        own.
+      </p>
+      <p>
+        It does not replace your drafting tools. Those are the engines that produce the document.
+        The Operator prepares their inputs, routes their outputs, and does the work between and
+        around them.
       </p>
     </PackProse>
   </PackSection>
 
-  <!-- § 05 Yours to shape -->
-  <PackSection bg="background">
-    <PackEyebrow>Your Way</PackEyebrow>
-    <PackHeading variant="grid">Yours To Shape.</PackHeading>
+  <!-- 04 The lifecycle, step by step -->
+  <PackSection bg="white">
+    <PackEyebrow>The Lifecycle</PackEyebrow>
+    <PackHeading variant="grid">One Matter, Step By Step.</PackHeading>
     <PackIntro>
-      We are not the experts in how your firm runs. You are. So the pack is a starting point in
-      three parts, and the third is the biggest.
+      Here is one stretch of a matter's life, responding to discovery, carried start to finish. This
+      is the shape of the work, not a fixed script; we build it around how your firm actually runs.
     </PackIntro>
-    <PackCardGrid items={zones} cols={3} card="zones" />
+    <PackLifecycle steps={lifecycleSteps} />
   </PackSection>
 
-  <!-- § 06 The line -->
-  <PackSection bg="white">
-    <PackEyebrow>The Boundary</PackEyebrow>
-    <PackHeading variant="prose">The Line.</PackHeading>
-    <PackProse spaced>
+  <!-- 05 How it connects -->
+  <PackSection bg="background">
+    <PackEyebrow>How It Connects</PackEyebrow>
+    <PackHeading variant="prose">Through The Systems You Already Run.</PackHeading>
+    <PackProse>
       <p>
-        The Operator does coordination and brings the law to a lawyer. Legal advice, the strategy,
-        the judgment about a matter, drafting legal substance, those stay with your attorneys. Not
-        because the software could not write a clear sentence, but because the license is the point:
-        practicing law takes a licensed attorney, and a trained but unlicensed paralegal could not
-        give that advice either.
+        The Operator hands off to your drafting tools the way those tools already connect to your
+        case management system. It places the request and the supporting documents where the draft
+        is generated, and when the finished draft lands back in the matter, it picks it up there,
+        files it, and routes it to an attorney to review. Nothing has to be emailed around or
+        re-uploaded by hand.
       </p>
       <p>
-        Some lines are not settings anyone can move. A conflict check is captured and routed to a
-        person to clear; the Operator never clears it itself. Trust balances are read-only: it can
-        report them, and it never moves money. Anything that leaves the firm goes to a reviewer on
-        your team until you decide otherwise. Every action it takes is logged where you can see it.
-      </p>
-      <p>
-        Beyond those floors, you govern where the line sits, and you can move it as you learn what
-        the Operator is good at. Your client files stay private, including from us. The Operator
-        works in your firm's own walled-off environment, on your own accounts. We can see that it is
-        running and the record of what it did, but the contents of your matters and messages stay
-        yours, and so do the configuration, the logs, and the off switch.
+        It works on your own accounts, inside the systems you already pay for. It is the connective
+        tissue between them, not another system to learn.
       </p>
     </PackProse>
     <PackSectionCta slug="law-firm" />
   </PackSection>
 
-  <!-- § 07 Where it fits -->
-  <PackSection bg="background">
-    <PackEyebrow>The Role</PackEyebrow>
-    <PackHeading variant="grid">Where It Fits.</PackHeading>
-    <PackIntro>
-      A few shapes the seat can take. We build it around how your firm runs, so these are starting
-      points, not a menu.
-    </PackIntro>
-    <PackCardGrid items={roleLenses} cols={3} card="lenses" />
+  <!-- 06 Quiet by design -->
+  <PackSection bg="white">
+    <PackEyebrow>Quiet By Design</PackEyebrow>
+    <PackHeading variant="prose">It Takes Load Off. It Does Not Add It.</PackHeading>
+    <PackProse>
+      <p>
+        The Operator is built to reduce the noise, not add to it. Routine items are gathered into a
+        single short summary rather than a stream of notifications, and it reaches out directly only
+        when something genuinely needs a person. The goal is that your team feels work coming off
+        their plate, not one more thing pinging them.
+      </p>
+    </PackProse>
   </PackSection>
 
-  <!-- § 08 Start with an assessment -->
+  <!-- 07 The line, and what we prove first -->
+  <PackSection bg="background">
+    <PackEyebrow>The Line</PackEyebrow>
+    <PackHeading variant="prose">The Lawyer's Work Stays The Lawyer's.</PackHeading>
+    <PackProse spaced>
+      <p>
+        The Operator does the coordination and brings the law to a lawyer. The legal judgment stays
+        with your attorneys: the strategy, the call on a matter, the substance of an argument. Some
+        lines are not settings anyone moves. A conflict check is captured and routed to a person to
+        clear. Trust balances are read-only, reported but never moved. Anything that leaves the firm
+        goes to an attorney first. Every action it takes is logged where you can see it.
+      </p>
+      <p>
+        And we are honest about what we prove before we rely on it. The parts that depend on reading
+        your documents and matching your firm's rules, like a deadline read off a served document or
+        a gap in an opposing response, we validate on your real matters first. Where accuracy is not
+        yet proven, the Operator surfaces what it found and asks, rather than acting on its own. It
+        earns more autonomy only as it proves accurate on your work. Your files stay private,
+        including from us, and the configuration, the logs, and the off switch stay with you.
+      </p>
+    </PackProse>
+  </PackSection>
+
+  <!-- 08 Close -->
   <PackClosing slug="law-firm">
     <Fragment slot="pitch">
-      It starts with a conversation. We learn how your firm runs, find the intake and coordination
-      work that is eating your team's time, and start from the pack, customizing it to your firm. If
-      it is not a fit, we will tell you.
+      We learn how your firm actually runs a matter, find where the time goes and where things slip,
+      and shape the Operator to fit: what it watches, how much it does on its own, where a person
+      stays in the loop. If it is not the right fit, we will tell you.
     </Fragment>
   </PackClosing>
 </PackLayout>

--- a/tests/landing-page.test.ts
+++ b/tests/landing-page.test.ts
@@ -183,6 +183,34 @@ describe('marketing structure: firm-with-flagship (locked)', () => {
     }
   })
 
+  it('the packs carry the same single verb (CTA in shared components, no retired verb anywhere)', () => {
+    // The pack CTA text lives in the shared pack components, so presence is asserted
+    // there once; the retired verb must appear on neither the components nor any pack page.
+    const packCtaComponents = [
+      'src/components/packs/PackHero.astro',
+      'src/components/packs/PackClosing.astro',
+      'src/components/packs/PackSectionCta.astro',
+    ]
+    for (const comp of packCtaComponents) {
+      const c = flat(readFileSync(resolve(comp), 'utf-8'))
+      expect(c, `"start with an assessment" missing from ${comp}`).toContain(
+        'start with an assessment'
+      )
+      expect(c, `retired verb "start the conversation" present in ${comp}`).not.toContain(
+        'start the conversation'
+      )
+    }
+    const packPages = readdirSync(resolve('src/pages/packs'))
+      .filter((n) => n.endsWith('.astro'))
+      .map((n) => `src/pages/packs/${n}`)
+    for (const page of packPages) {
+      const c = flat(readFileSync(resolve(page), 'utf-8'))
+      expect(c, `retired verb "start the conversation" present in ${page}`).not.toContain(
+        'start the conversation'
+      )
+    }
+  })
+
   it('the retired marketing pages are gone (not live routes)', () => {
     for (const p of [
       'src/pages/why.astro',

--- a/tests/operator-pack-kit-grammar.test.ts
+++ b/tests/operator-pack-kit-grammar.test.ts
@@ -2,17 +2,24 @@ import { describe, it, expect } from 'vitest'
 import { readFileSync, readdirSync } from 'fs'
 import { resolve, join } from 'path'
 
-// The vertical pack pages each have a "What The Pack Starts You With" section
-// driven by a `packTemplates` array. Those entries describe the STARTING
-// TEMPLATES the pack ships with — work the Operator is configured to start
-// from, NOT a finished, running product. The distinction is a truthfulness P0:
-// the pack config is largely aspirational (only Clio is runtime-live, and there
-// are no customers yet), so the kit must read as "templates we configure," never
-// as a delivered capability. This guard enforces that grammar mechanically.
+// Truthfulness P0: the pack config is largely aspirational (only one connector is
+// runtime-live, and there are no customers yet), so a pack must never read as a
+// delivered, running capability. Two pack generations carry this truth differently,
+// and during the one-at-a-time migration to the lifecycle standard both must stay
+// enforced:
 //
-// Scope: ONLY the `packTemplates` array literal. The role-lens narratives and
-// the day-one section legitimately use the established selling voice
-// ("captures / drafts / chases"); this guard does not touch those.
+//   - Lifecycle standard (docs/marketing/pack-standard.md): the pack walks the
+//     vertical's core process via <PackLifecycle>. The walk uses the established
+//     selling voice, so the truth is carried by the SECTION FRAMING instead: the
+//     walk is declared illustrative ("the shape of the work, not a fixed script")
+//     and paired with the fail-closed honesty ("surfaces what it found and asks").
+//     Both phrases are required.
+//
+//   - Legacy "What The Pack Starts You With" (the 11 not-yet-migrated): a
+//     `packTemplates` array framed as "starting templates we configure with you,"
+//     with no finished-capability verbs bound to a template.
+//
+// A pack is detected as lifecycle-standard by its use of <PackLifecycle>.
 
 const packsDir = resolve('src/pages/packs')
 
@@ -36,19 +43,37 @@ describe('Operator pack kit grammar (truthfulness)', () => {
   for (const file of packFiles()) {
     const rel = file.slice(file.indexOf('src/'))
     const src = readFileSync(file, 'utf-8')
+    const flat = src.replace(/\s+/g, ' ')
+    const isLifecyclePack = src.includes('<PackLifecycle')
 
-    it(`${rel} frames the kit as starting templates, not a capability`, () => {
-      // The truthful framing must be present on every pack page.
-      expect(src).toContain('starting templates we configure with you')
-    })
+    if (isLifecyclePack) {
+      it(`${rel} frames the lifecycle walk as illustrative, not a delivered capability`, () => {
+        expect(
+          flat,
+          `lifecycle pack ${rel} must declare the walk illustrative ("the shape of the work, not a fixed script")`
+        ).toContain('the shape of the work, not a fixed script')
+      })
 
-    it(`${rel} packTemplates use no finished-capability verbs`, () => {
-      const literal = packTemplatesLiteral(src)
-      expect(literal, 'packTemplates array not found').not.toBeNull()
-      expect(
-        CAPABILITY_VERBS.test(literal as string),
-        `packTemplates binds a finished-capability verb (handles/manages/automates/does) to a template in ${rel}`
-      ).toBe(false)
-    })
+      it(`${rel} carries the fail-closed test-and-tune honesty`, () => {
+        expect(
+          flat,
+          `lifecycle pack ${rel} must carry the fail-closed honesty ("surfaces what it found and asks")`
+        ).toContain('surfaces what it found and asks')
+      })
+    } else {
+      it(`${rel} frames the kit as starting templates, not a capability`, () => {
+        // The truthful framing must be present on every legacy pack page.
+        expect(src).toContain('starting templates we configure with you')
+      })
+
+      it(`${rel} packTemplates use no finished-capability verbs`, () => {
+        const literal = packTemplatesLiteral(src)
+        expect(literal, 'packTemplates array not found').not.toBeNull()
+        expect(
+          CAPABILITY_VERBS.test(literal as string),
+          `packTemplates binds a finished-capability verb (handles/manages/automates/does) to a template in ${rel}`
+        ).toBe(false)
+      })
+    }
   }
 })


### PR DESCRIPTION
## Summary
The 12 packs shipped breadth-first against no standard — every one led with the front-desk/intake layer ("The Intake Desk, Fully Staffed") plus a verbatim §02 ("The Seat The Market Won't Fill") carrying an **unsourced labor-market claim**. A real prospect (a litigation firm) was explicit: the **full lifecycle** of the core work is what they want — "not someone to answer the phone."

This rebuilds **law** — the only vertical with real research behind it — to that altitude, as the **template-of-record** every other vertical follows, one at a time.

- **`law-firm.astro`** re-pitched from the intake desk up to the matter lifecycle: new hero ("The Matter, Carried End To End"), §02 ("Every Open Matter, At Once" — no market claim), and the centrepiece **§04 lifecycle walk** (responding to discovery, step by step: *Operator does / Your part / If it stalls*). Adds connective-tissue ("orchestrates, does not replace"), "quiet by design," and the honest **"what we prove first"** trust beat. De-identified and brand-generic — general civil-litigation process, no firm/person/tool names, no jurisdiction or PI specifics (those stay internal).
- **`PackLifecycle.astro`** — new reusable lifecycle-walk component (every future pack uses it).
- **`PackClosing.astro`** — retire "Start The Conversation." → "It Starts With An Assessment." across all 12 packs.
- **`docs/marketing/pack-standard.md`** — the written standard extracted from this build: the bar every pack must clear.
- **Tests** — kit-grammar truthfulness guard now enforces the lifecycle standard's illustrative-framing + fail-closed honesty on lifecycle packs, while keeping the legacy templates check on the 11 not-yet-migrated; single-verb guard extended to the pack CTA components + every pack page.

No graphics, no dollar amounts, no em dashes. The template-of-record (A&P discovery response) stays internal.

## Test plan
- [x] \`npm run verify\` passes (3322 tests; new + legacy truthfulness guards both green)
- [x] Adversarial guardrail sweep: no brand names, no jurisdiction/PI specifics, no unsourced claim, lifecycle (not front-desk)

🤖 Generated with [Claude Code](https://claude.com/claude-code)