### PR TITLE
fix(marketing): mobile header overflow + stray menu logo focus ring

### DIFF
--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -37,8 +37,11 @@ const bookHref = `/book?interest=${bookInterest}`
           </a>
         ))
       }
+      <!-- Persistent CTA is desktop-only. On mobile it would crowd the bar and
+           push the Menu button off-screen; the CTA still lives in the mobile
+           menu's bottom bar and in every page hero. -->
       <a
-        class="inline-flex items-center whitespace-nowrap min-h-11 border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-primary)] hover:bg-[color:var(--ss-color-primary-hover)] active:bg-[color:var(--ss-color-primary-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2 px-3 md:px-5 py-2 font-['Archivo'] font-bold uppercase tracking-[0.08em] text-white text-xs md:text-sm transition-colors"
+        class="hidden md:inline-flex items-center whitespace-nowrap min-h-11 border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-primary)] hover:bg-[color:var(--ss-color-primary-hover)] active:bg-[color:var(--ss-color-primary-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2 px-3 md:px-5 py-2 font-['Archivo'] font-bold uppercase tracking-[0.08em] text-white text-xs md:text-sm transition-colors"
         href={bookHref}
         data-ev="nav-book">Start with an assessment</a
       >
@@ -70,9 +73,14 @@ const bookHref = `/book?interest=${bookInterest}`
          Brand on the left, Close on the right. -->
     <div class="flex h-14 flex-none items-center justify-between px-4 border-b-[3px] border-white">
       <SmdLogo inverse data-nav-link />
+      <!-- autofocus directs the dialog's initial focus here on open. Without it,
+           showModal() focuses the first focusable descendant (the logo link),
+           leaving a stray focus ring around the brand that reads as a different
+           logo. Close is the correct, conventional initial focus target. -->
       <button
         type="button"
         aria-label="Close menu"
+        autofocus
         data-nav-close
         class="inline-flex items-center justify-center min-w-11 min-h-11 px-3 border-[3px] border-white bg-transparent font-['Archivo_Narrow'] text-xs font-bold uppercase tracking-[0.14em] text-white cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--ss-color-surface-inverse)]"
       >


### PR DESCRIPTION
## What

Fixes two mobile-only bugs in the shared `Nav.astro` header, reported from an iPhone 17 Pro Max and reproduced at 375px/430px against the live build. **Rebased onto current `main`** (the #1548 rebuild) — the rebuild's copy ("Start with an assessment") and 3-link nav (Operator / Industries / About) are preserved untouched; this PR's diff is *only* the two fixes.

### 1. Header overflow — global, blocking 🔴
On mobile the persistent **"Start with an assessment"** CTA rendered alongside the Menu button. The nowrap CTA + Menu + logo overflowed the viewport by **84–99px**, pushing the **Menu button off-screen** — the menu was unreachable (the original report).

**Fix:** the CTA is now desktop-only (`hidden md:inline-flex`). It still lives in the mobile menu's bottom bar and in every page hero, so no conversion path is lost. The mobile bar is now `logo + Menu`.

### 2. "Different logo" on the menu overlay — cosmetic 🟠
The orange box the logo appeared to gain on the dark menu was the **keyboard focus ring**: `dialog.showModal()` auto-focuses the first focusable descendant (the inverse logo link), and iOS renders its `focus-visible` ring.

**Fix:** `autofocus` on the **Close** button so initial focus lands on the correct dismiss control. The two logos are the same lockup; only the wordmark color differs by surface — intentional, not accidental.

## Mobile review

Ran an automated horizontal-overflow sweep across **all core pages + 12 vertical packs at 375px and 430px** against current `main`:

| Area | Result |
|---|---|
| Shared header | overflowed every page → **fixed** |
| Menu overlay logo | stray focus ring → **fixed** |
| Page body (heroes, sections, all 12 packs) | no overflow — responsive |
| Tap targets (nav / CTA / menu items) | all >=44px |

The body of the site is responsive everywhere; the only structural mobile bug was the shared header (which is why it affected every page).

## Verification
- Post-fix sweep: **zero** horizontal overflow at 375/430 across all rendered pages.
- Dialog initial focus now lands on **"Close menu"**, not the logo.
- `npm run verify` green — **3,323 tests** pass. CTA copy and 3-link nav unchanged.

> Correction note: an earlier revision of this PR was accidentally branched off a stale local `main` and would have reverted #1548's copy/nav. Force-pushed onto current `origin/main`; diff is now strictly the two fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
