### PR TITLE
fix(marketing): standardize on left alignment (heroes + mid-page CTAs)

### DIFF
--- a/src/components/packs/PackHero.astro
+++ b/src/components/packs/PackHero.astro
@@ -13,7 +13,7 @@ const { slug } = Astro.props
 ---
 
 <section class="relative overflow-hidden bg-[color:var(--ss-color-background)] px-6 pt-24 pb-32">
-  <div class="mx-auto max-w-5xl text-center">
+  <div class="mx-auto max-w-5xl">
     <p
       class="mb-6 font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--ss-color-text-secondary)]"
     >
@@ -24,9 +24,7 @@ const { slug } = Astro.props
     >
       <slot name="heading" />
     </h1>
-    <p
-      class="mx-auto mb-8 max-w-2xl text-xl leading-relaxed text-[color:var(--ss-color-text-secondary)]"
-    >
+    <p class="mb-8 max-w-2xl text-xl leading-relaxed text-[color:var(--ss-color-text-secondary)]">
       <slot name="lede" />
     </p>
     <CtaButton href={`/book?interest=${slug}`} data-ev={`${slug}-hero-cta`}

--- a/src/components/packs/PackSectionCta.astro
+++ b/src/components/packs/PackSectionCta.astro
@@ -1,5 +1,5 @@
 ---
-// The centered mid-page CTA row at the end of § 06.
+// The left-aligned mid-page CTA row at the end of a section.
 import CtaButton from '../CtaButton.astro'
 
 interface Props {
@@ -9,7 +9,7 @@ interface Props {
 const { slug } = Astro.props
 ---
 
-<div class="text-center">
+<div>
   <CtaButton variant="secondary" href={`/book?interest=${slug}`} data-ev={`${slug}-section-cta`}
     >Start with an assessment</CtaButton
   >

--- a/src/pages/operator.astro
+++ b/src/pages/operator.astro
@@ -105,7 +105,7 @@ const industries = [
     <section
       class="relative overflow-hidden bg-[color:var(--ss-color-background)] px-6 pt-24 pb-32"
     >
-      <div class="mx-auto max-w-5xl text-center">
+      <div class="mx-auto max-w-5xl">
         <p
           class="mb-6 font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--ss-color-text-secondary)]"
         >
@@ -117,7 +117,7 @@ const industries = [
           Hire Once.
         </h1>
         <p
-          class="mx-auto mb-12 max-w-2xl text-xl leading-relaxed text-[color:var(--ss-color-text-secondary)]"
+          class="mb-12 max-w-2xl text-xl leading-relaxed text-[color:var(--ss-color-text-secondary)]"
         >
           A dedicated worker for your business, in its own office and plugged into your systems. It
           takes on the recurring work, learns how you run, and everything it learns stays yours.
@@ -244,7 +244,7 @@ const industries = [
             builds is yours to keep, and it is not locked inside our system.
           </p>
         </div>
-        <div class="text-center">
+        <div>
           <CtaButton
             variant="secondary"
             href="/book?interest=operator"


### PR DESCRIPTION
## Summary
The site jumped between left and centered: the home, industries, and about heroes were left-aligned, but the **operator hero and all 12 pack heroes were centered**. Standardize on left, matching the home page.

- **operator.astro** — hero → left; the mid-page "One Operator, One Memory" CTA row → left.
- **PackHero.astro** — hero → left (fixes all 12 pack heroes in one place).
- **PackSectionCta.astro** — mid-page CTA row → left.

The dark closing CTA bands ("It Starts With An Assessment") **stay centered** on every page — which is what the home page itself does (Captain decision) — the one deliberate centered focal moment per page. No copy changes.

## Test plan
- [x] \`npm run verify\` passes
- [x] Confirmed only the 5 closing CTA bands remain centered; all heroes and mid-page CTAs are left

🤖 Generated with [Claude Code](https://claude.com/claude-code)