### PR TITLE
chore(ci): harden GitHub Actions — pin to SHAs, drop unused secrets, add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+# Keeps the GitHub Actions pinned to commit SHAs current. Workflows pin every
+# `uses:` to a full-length commit SHA (supply-chain hardening; enforced by the
+# Semgrep github-actions-mutable-action-tag rule in security.yml). Dependabot
+# bumps the SHA and the trailing version comment when a new release ships, so
+# the pins stay both immutable and maintained. Dependabot PRs flow through
+# .github/workflows/dependabot-auto-merge.yml.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+    groups:
+      github-actions:
+        patterns:
+          - '*'
+    commit-message:
+      prefix: chore(actions)

--- a/.github/workflows/adr-0022-pi-prefix-gate.yml
+++ b/.github/workflows/adr-0022-pi-prefix-gate.yml
@@ -28,7 +28,7 @@ jobs:
     name: Block law-pi- prefix in active paths
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Install ripgrep
         run: |

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v3
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,10 +18,10 @@ jobs:
       packages: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Setup Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: '22'
           cache: 'npm'
@@ -38,7 +38,7 @@ jobs:
 
       # Dry-run catches wrangler config / binding errors before they hit prod.
       - name: Wrangler deploy (dry-run)
-        uses: cloudflare/wrangler-action@v4
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -47,14 +47,14 @@ jobs:
       # Migrations must be backward-compatible with the currently deployed
       # application. Apply them before publishing code that depends on them.
       - name: Run D1 migrations
-        uses: cloudflare/wrangler-action@v4
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: d1 migrations apply ss-console-db --remote
 
       - name: Deploy to Cloudflare Workers
-        uses: cloudflare/wrangler-action@v4
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -78,7 +78,7 @@ jobs:
         run: cd workers/job-monitor && npm ci
 
       - name: Deploy Job Monitor Worker
-        uses: cloudflare/wrangler-action@v4
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -89,7 +89,7 @@ jobs:
         run: cd workers/new-business && npm ci
 
       - name: Deploy New Business Worker
-        uses: cloudflare/wrangler-action@v4
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -100,7 +100,7 @@ jobs:
         run: cd workers/review-mining && npm ci
 
       - name: Deploy Review Mining Worker
-        uses: cloudflare/wrangler-action@v4
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -111,7 +111,7 @@ jobs:
         run: cd workers/social-listening && npm ci
 
       - name: Deploy Social Listening Worker
-        uses: cloudflare/wrangler-action@v4
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -127,7 +127,7 @@ jobs:
         run: cd workers/cost-anomaly && npm ci
 
       - name: Deploy Cost Anomaly Worker
-        uses: cloudflare/wrangler-action@v4
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -138,7 +138,7 @@ jobs:
         run: cd workers/cost-telemetry && npm ci
 
       - name: Deploy Cost Telemetry Worker
-        uses: cloudflare/wrangler-action@v4
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -149,7 +149,7 @@ jobs:
         run: cd workers/enrichment-workflow && npm ci
 
       - name: Deploy Enrichment Workflow Worker
-        uses: cloudflare/wrangler-action@v4
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/operator-substrate.yml
+++ b/.github/workflows/operator-substrate.yml
@@ -38,10 +38,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: '>=3.11'
 
@@ -105,7 +105,7 @@ jobs:
       # not a source-tree import. Per-connector venv = the same isolation the
       # image gets.
       - name: Set up uv (connector venvs)
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
 
       - name: Author-built connector conformance
         working-directory: operator/connectors

--- a/.github/workflows/regression-claim-origin.yml
+++ b/.github/workflows/regression-claim-origin.yml
@@ -9,6 +9,6 @@ jobs:
     if: |
       contains(github.event.issue.labels.*.name, 'regression') ||
       github.event.label.name == 'regression'
-    uses: venturecrane/crane-console/.github/workflows/regression-claim-origin-reusable.yml@main
+    uses: venturecrane/crane-console/.github/workflows/regression-claim-origin-reusable.yml@d95ef439383286f683ad5002bd2728d31c44b36b # main
     secrets:
       CRANE_RELAY_KEY: ${{ secrets.CRANE_RELAY_KEY }}

--- a/.github/workflows/scope-deferred-todo.yml
+++ b/.github/workflows/scope-deferred-todo.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Inspect PR diff for TODO(#NNN) introductions
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             const SOURCE_EXTS = /\.(ts|tsx|js|jsx|astro|mjs|cjs|svelte|vue|py|go|rs|java|kt)$/i;

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -31,10 +31,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Setup Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: '22'
           cache: 'npm'
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
 
@@ -111,10 +111,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Setup Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: '22'
           cache: 'npm'
@@ -138,7 +138,7 @@ jobs:
       # .github/workflows/dependabot-auto-merge.yml when safe).
       image: returntocorp/semgrep:1.157.0
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Run Semgrep
         # POSIX-compatible shell script — the returntocorp/semgrep container
         # uses Alpine ash, not bash, so ${PIPESTATUS[n]} is unavailable.
@@ -177,7 +177,7 @@ jobs:
     name: nosemgrep Justification Audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Require substantive justification on every nosemgrep
         # Every `// nosemgrep` annotation must be followed by ` — ` or `: ` and
         # at least 20 characters of justification prose. Without this audit,

--- a/.github/workflows/tick-acs-on-merge.yml
+++ b/.github/workflows/tick-acs-on-merge.yml
@@ -9,8 +9,7 @@ on:
 
 jobs:
   tick:
-    uses: venturecrane/crane-console/.github/workflows/tick-acs-on-merge-reusable.yml@tick-acs-v1
-    secrets: inherit
+    uses: venturecrane/crane-console/.github/workflows/tick-acs-on-merge-reusable.yml@986b07602f11909ead8ba17818a2c9ac5c24bc96 # tick-acs-v1
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/ui-drift-audit.yml
+++ b/.github/workflows/ui-drift-audit.yml
@@ -32,14 +32,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Sync canonical skills from crane-console
         # The audit script lives in crane-console/.agents/skills/ui-drift-audit/.
         # Locally, the launcher (crane-console/packages/crane-mcp/src/cli/launch-lib.ts:1185
         # syncVentureSkills) mirrors it on every `crane <venture>` launch. CI has no
         # launcher, so we sparse-clone canon and stage the script into the expected path.
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           repository: venturecrane/crane-console
           sparse-checkout: |
@@ -54,7 +54,7 @@ jobs:
           rm -rf .crane-canon
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: '>=3.11'
 
@@ -111,13 +111,13 @@ jobs:
 
       - name: Comment on PR
         if: github.event_name == 'pull_request'
-        uses: marocchino/sticky-pull-request-comment@v3
+        uses: marocchino/sticky-pull-request-comment@d4d6b0936434b21bc8345ad45a440c5f7d2c40ff # v3
         with:
           header: ui-drift-audit
           path: comment.md
 
       - name: Upload audit JSON
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: ui-drift-audit
           path: audit.json

--- a/.github/workflows/unmet-ac-on-close.yml
+++ b/.github/workflows/unmet-ac-on-close.yml
@@ -9,7 +9,6 @@ on:
 
 jobs:
   check:
-    uses: venturecrane/crane-console/.github/workflows/unmet-ac-on-close-reusable.yml@tick-acs-v1
-    secrets: inherit
+    uses: venturecrane/crane-console/.github/workflows/unmet-ac-on-close-reusable.yml@986b07602f11909ead8ba17818a2c9ac5c24bc96 # tick-acs-v1
     permissions:
       issues: write

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -21,10 +21,10 @@ jobs:
       packages: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Setup Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: '22'
           cache: 'npm'

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,6 @@
 @venturecrane:registry=https://npm.pkg.github.com
 //npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}
+# Supply-chain cooldown: never install a package version published in the last 7 days
+# (npm >= 11.10.0; silently ignored by older npm, so inert on the Node 22 toolchain today).
+# Pairs with the Dependabot cooldown in .github/dependabot.yml.
+min-release-age=7


### PR DESCRIPTION
## Summary
CI's Semgrep security gate (`p/security-audit`) went red repo-wide on **35 findings in the workflow files** after they landed on main, blocking every PR (including the in-flight pack work). Fixed properly, **not suppressed** — zero nosemgrep bypasses:

- **Pin every `uses:` to a full-length commit SHA** with a trailing version comment (`github-actions-mutable-action-tag`; OpenSSF/GitHub supply-chain hardening). Covers all third-party actions and the three first-party `venturecrane/crane-console` reusable workflows.
- **Remove `secrets: inherit`** from the AC-tick caller stubs. Their reusable workflows declare no `secrets:` and use only the `GITHUB_TOKEN` from the caller's `permissions:` block — so inheriting secrets passed credentials they never consume. Removed, not enumerated.
- **Add `.github/dependabot.yml`** (github-actions ecosystem, weekly, grouped, 7-day cooldown) so the SHA pins stay current going forward instead of freezing. Flows through the existing `dependabot-auto-merge` workflow.

Verified locally with the exact CI Semgrep config: **0 findings on `.github/`**.

## Note (out of scope)
A newer Semgrep registry locally surfaces 5 pre-existing findings elsewhere (4 false-positive "open redirect" on same-page `location.pathname` reloads in admin code; 1 `.npmrc` release-age). CI's current ruleset does not flag them (the failing run showed only the 35 github-actions findings). Flagging for a separate pass if CI rules later drift.

## Test plan
- [x] Local Semgrep (`p/security-audit p/owasp-top-ten p/typescript p/javascript`) → 0 findings on `.github/`
- [x] `secrets: inherit` removal verified against the reusable workflows' `workflow_call` contracts (no `secrets:` declared)

🤖 Generated with [Claude Code](https://claude.com/claude-code)