### PR TITLE
fix(marketing): restore /contact form + lock the decision so reworks stop reaping it

### DIFF
--- a/docs/marketing/positioning-spine.md
+++ b/docs/marketing/positioning-spine.md
@@ -6,7 +6,7 @@
 >
 > - **The frame is the firm.** SMD is a software and AI solutions firm for small businesses. The **Operator is the flagship within it**, not the whole company. The **assessment is the one front door**; it leads to a recommendation, a project, or an Operator. "We specialize in AI and will tell you when it isn't the answer."
 > - **The site is 5 page types, not ~13:** Home (firm's face, flagship-forward, 8 beats — firm wraps flagship), `/operator` (the flagship deep page, now absorbing the comparison FAQ), `/industries` + 12 packs (recognition / the proof substitute), `/book` (the assessment front door), `/about` (Scott = the proof). Legal in the footer.
-> - **Killed (folded + 301-redirected):** `/why` → `/operator#compare`; `/consulting` → `/`; `/ai` → `/` (retired toe-dip from the abandoned AI-cautious posture); `/contact` → `/book` (booking + a footer email is the contact).
+> - **Killed (folded + 301-redirected):** `/why` → `/operator#compare`; `/consulting` → `/`; `/ai` → `/` (retired toe-dip from the abandoned AI-cautious posture); ~~`/contact` → `/book` (booking + a footer email is the contact)~~ **[REVERSED 2026-06-30 — see Change control. `/contact` is restored as the quiet general-inquiry channel; the footer email is removed.]**
 > - **Win on clarity, substance, credibility — never graphics** (the gap visual motif is killed; rejected twice). Credibility with no proof = recognition-by-trade (packs) + architecture transparency (your accounts / your authority / your memory) + solution-first honesty + Scott's pedigree + owner-does-the-math ROI.
 > - **Guards are now stable invariants** (firm descriptor in the hero, Operator named as flagship above the fold, single assessment CTA, retired routes gone + 301'd), not brittle section-order, in `tests/landing-page.test.ts`.
 >
@@ -126,3 +126,11 @@ These are tracked here so they are not lost and not silently executed inside an 
 ## Change control
 
 A lock in §2, §3, or §4 changes only by a Captain decision recorded as a dated entry appended here, followed by updating the guard tests in the same PR. A build PR that needs to deviate stops and gets the decision first. That is the whole point of this file: the argument is sound, so the site should stop moving except by intent.
+
+### Decision log
+
+**2026-06-30 — `/contact` restored as the quiet general-inquiry channel.** Amends §3's "no second contact form as a peer door" lock and reverses the 2026-06-29 superseding-block call that killed `/contact` in favor of "booking + a footer email."
+
+- **Why.** The contact form exists so anyone who wants to reach the firm for a reason that is _not_ booking an assessment — a partnership, a vendor question, press, or another way to work together — has a channel, **without us publishing an email address on the site**. The 2026-06-29 consolidation replaced the form with a published `mailto:team@smd.services` in the footer, which is the exact thing the form was meant to avoid. That was the defect, surfaced because the form kept getting reaped on every rebuild while the intent behind it was never recorded here.
+- **What stays locked.** The assessment at `/book` is and remains the **single primary front door.** `/contact` is **not** a peer door: it is footer-linked only, never in the nav and never a hero CTA, and the page itself routes engagement-seekers to the assessment. This satisfies the spirit of the §3 "no second contact form as a peer door" lock — the prohibition is on a _co-equal_ door, not on a quiet lower-weight channel.
+- **What changed in the same PR (per change-control).** Page `src/pages/contact.astro` restored (wired to the surviving `src/pages/api/contact.ts` Resend endpoint, which never left). Footer `mailto` replaced with a `Contact` link. Middleware `/contact` 301 removed. Guard tests in `tests/landing-page.test.ts` **inverted** — they now assert the page exists, posts to `/api/contact`, publishes no `mailto`, and is not redirected away. So a future rebuild reading this spine keeps the form instead of reaping it.

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -26,9 +26,11 @@
 
     <div class="h-px bg-[color:rgba(245,240,227,0.16)]"></div>
 
-    <!-- Region 2: Site map + reach. The surviving marketing surfaces, and a direct
-         email — the booking is the front door, the email is the quieter way to reach
-         us (there is no separate contact page). -->
+    <!-- Region 2: Site map + reach. The surviving marketing surfaces, and a quiet
+         Contact link. The booking is the front door; /contact is the lower-weight
+         general-inquiry channel (partnerships, press, vendors, other) so we reach
+         a real form instead of publishing an email address on the page. -->
+
     <nav
       aria-label="Site"
       class="py-6 md:py-7 flex flex-wrap gap-x-6 gap-y-2 font-['Archivo_Narrow'] text-xs uppercase tracking-[0.12em] text-[color:var(--ss-color-text-muted)]"
@@ -39,9 +41,7 @@
       <a href="/book?interest=operator" class="hover:text-white" data-ev="footer-assessment"
         >Start with an assessment</a
       >
-      <a href="mailto:team@smd.services" class="hover:text-white" data-ev="footer-email"
-        >team@smd.services</a
-      >
+      <a href="/contact" class="hover:text-white" data-ev="footer-contact">Contact</a>
     </nav>
 
     <div class="h-px bg-[color:rgba(245,240,227,0.16)]"></div>

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -185,10 +185,14 @@ function redirectLegacyOperatorPaths(
 // Retired marketing routes → 301 to the surviving surface that absorbed them.
 // Marketing consolidated 2026-06-29 (firm-with-flagship structure, 5 page types):
 // the comparison argument moved onto /operator; firm breadth onto the home + the
-// assessment; contact is the booking + a footer email; the /ai toe-dip page is
-// retired now that the firm is all-in on AI. Also folds the older lead-magnet
-// retirements (/scan, /scorecard, /outside-view, the cold /get-started). The SOURCES
-// here are the retired paths — do not rename them (that would self-redirect).
+// assessment; the /ai toe-dip page is retired now that the firm is all-in on AI.
+// Also folds the older lead-magnet retirements (/scan, /scorecard, /outside-view,
+// the cold /get-started). The SOURCES here are the retired paths — do not rename
+// them (that would self-redirect).
+//
+// NOTE: /contact is NOT retired. Captain decision 2026-06-30 restored it as the
+// quiet general-inquiry channel (a real form, not a published email). See
+// docs/marketing/positioning-spine.md change-control log.
 function redirectRetiredMarketingPaths(context: APIContext, pathname: string): Response | null {
   const exactToHome = new Set(['/scan', '/consulting', '/ai'])
   if (exactToHome.has(pathname)) return context.redirect('/', 301)
@@ -199,8 +203,6 @@ function redirectRetiredMarketingPaths(context: APIContext, pathname: string): R
 
   if (pathname === '/why' || pathname.startsWith('/why/'))
     return context.redirect('/operator#compare', 301)
-  if (pathname === '/contact' || pathname.startsWith('/contact/'))
-    return context.redirect('/book?interest=operator', 301)
   if (pathname === '/get-started' && !context.url.searchParams.has('booked'))
     return context.redirect('/', 301)
   return null

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -1,0 +1,186 @@
+---
+export const prerender = false
+
+// /contact — the quiet general-inquiry channel.
+//
+// Restored 2026-06-30 (Captain decision, recorded in
+// docs/marketing/positioning-spine.md change-control log). The assessment at
+// /book is and remains the single primary front door; this page is NOT a peer
+// door to it. It exists so partners, vendors, press, and anyone who wants to
+// work together in some other way has a way to reach the firm WITHOUT us
+// publishing an email address on the site. Linked from the footer only, never
+// the nav or a hero CTA, so it stays a lower-weight channel by construction.
+//
+// The backend (src/pages/api/contact.ts: Resend notification to
+// team@smd.services, honeypot, rate-limit, XSS hardening) never left when the
+// page was deleted in #1548; this page wires the form back to it. Guarded by
+// tests/landing-page.test.ts so a future rebuild cannot silently reap it again.
+import Base from '../layouts/Base.astro'
+import Nav from '../components/Nav.astro'
+import Footer from '../components/Footer.astro'
+---
+
+<Base
+  title="Contact | SMD Services"
+  description="Reach SMD Services about a partnership, a question, or another way to work together. To start an engagement, begin with an assessment."
+>
+  <Nav />
+  <main id="main" role="main" class="ss-book-main">
+    <section class="ss-book-section">
+      <div class="ss-book-frame">
+        <header class="mb-stack">
+          <h1 class="ss-headline">Contact</h1>
+          <p class="ss-subhead">
+            Looking to start an engagement? <a href="/book?interest=operator" class="ss-quiet-link"
+              >Start with an assessment</a
+            >, our front door. For anything else, a partnership, a question, press, or another way
+            to work together, send a note below.
+          </p>
+        </header>
+
+        <div id="form-status" class="ss-form-status" aria-live="polite"></div>
+
+        <form id="contact-form" class="ss-form" novalidate>
+          <div class="ss-field">
+            <label for="name" class="ss-field-label">Name</label>
+            <input
+              id="name"
+              name="name"
+              type="text"
+              required
+              maxlength="200"
+              autocomplete="name"
+              class="ss-input"
+            />
+          </div>
+
+          <div class="ss-field">
+            <label for="email" class="ss-field-label">Email</label>
+            <input
+              id="email"
+              name="email"
+              type="email"
+              required
+              maxlength="254"
+              autocomplete="email"
+              class="ss-input"
+            />
+          </div>
+
+          <div class="ss-field">
+            <label for="message" class="ss-field-label">Message</label>
+            <div class="ss-textarea-wrap">
+              <textarea
+                id="message"
+                name="message"
+                rows="6"
+                required
+                maxlength="5000"
+                class="ss-textarea"></textarea>
+            </div>
+          </div>
+
+          <!-- Honeypot. Hidden from real users; bots fill it and are silently rejected. -->
+          <div class="ss-honeypot" aria-hidden="true">
+            <label for="website">Website</label>
+            <input type="text" id="website" name="website" tabindex="-1" autocomplete="off" />
+          </div>
+
+          <div class="ss-form-actions">
+            <button
+              type="submit"
+              id="contact-submit-btn"
+              data-ev="contact-submit"
+              class="ss-primary">Send message</button
+            >
+          </div>
+        </form>
+      </div>
+    </section>
+  </main>
+  <Footer />
+
+  <script is:inline>
+    const form = document.getElementById('contact-form')
+    if (form) {
+      form.addEventListener('submit', async function (e) {
+        e.preventDefault()
+        const status = document.getElementById('form-status')
+        const button = document.getElementById('contact-submit-btn')
+
+        button.disabled = true
+        button.textContent = 'Sending...'
+        status.replaceChildren()
+
+        const data = {
+          name: form.elements.namedItem('name').value,
+          email: form.elements.namedItem('email').value,
+          message: form.elements.namedItem('message').value,
+          website: form.elements.namedItem('website').value,
+        }
+
+        // Build the banner with safe DOM construction. `content` is a plain
+        // string set via textContent, never parsed as HTML. Response field
+        // values (validation messages, body.error) are server-controlled but
+        // flow into this sink as untrusted text, so they go through textContent.
+        function setBanner(variant, content) {
+          const banner = document.createElement('div')
+          banner.className = 'ss-banner ss-banner-' + variant
+          banner.textContent = content
+          status.replaceChildren(banner)
+        }
+
+        try {
+          const res = await fetch('/api/contact', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(data),
+          })
+
+          if (res.ok) {
+            setBanner('success', 'Message sent.')
+            form.reset()
+            form.style.display = 'none'
+            return
+          }
+          const body = await res.json()
+          if (res.status === 400 && body.fields) {
+            const msgs = Object.values(body.fields).join('. ')
+            setBanner('error', msgs)
+          } else if (res.status === 429) {
+            setBanner('error', 'Too many messages from this network. Please try again later.')
+          } else {
+            throw new Error(body.error || 'Request failed')
+          }
+        } catch {
+          // Intentionally no published email in the failure path. The whole
+          // point of this channel is to not publish an address; the recourse
+          // is to retry. Resend + the rate limiter make hard failures rare.
+          setBanner('error', 'Something went wrong. Please try again in a moment.')
+        } finally {
+          button.disabled = false
+          button.textContent = 'Send message'
+        }
+      })
+    }
+  </script>
+
+  <style>
+    .ss-form-status:empty {
+      display: none;
+    }
+    .ss-form-status {
+      margin-bottom: 1.5rem;
+    }
+    .ss-subhead {
+      margin-top: 0.75rem;
+      max-width: 42ch;
+      color: var(--ss-color-text-secondary);
+      line-height: 1.6;
+    }
+    .ss-honeypot {
+      position: absolute;
+      left: -9999px;
+    }
+  </style>
+</Base>

--- a/tests/landing-page.test.ts
+++ b/tests/landing-page.test.ts
@@ -212,14 +212,46 @@ describe('marketing structure: firm-with-flagship (locked)', () => {
   })
 
   it('the retired marketing pages are gone (not live routes)', () => {
-    for (const p of [
-      'src/pages/why.astro',
-      'src/pages/consulting.astro',
-      'src/pages/ai.astro',
-      'src/pages/contact.astro',
-    ]) {
+    for (const p of ['src/pages/why.astro', 'src/pages/consulting.astro', 'src/pages/ai.astro']) {
       expect(existsSync(resolve(p)), `${p} should be removed (folded + redirected)`).toBe(false)
     }
+  })
+
+  // /contact is NOT retired. Captain decision 2026-06-30 restored it as the
+  // quiet general-inquiry channel (a real form, not a published email address),
+  // recorded in docs/marketing/positioning-spine.md. The assessment at /book
+  // stays the single primary front door; /contact is a lower-weight channel
+  // (footer-linked, never nav or a hero CTA). This guard inverts the prior
+  // "retired" assertions so a future rebuild that reads the spine cannot
+  // silently reap the form again.
+  it('the contact form is restored and wired to its backend (quiet channel, not a peer door)', () => {
+    const page = resolve('src/pages/contact.astro')
+    expect(existsSync(page), 'src/pages/contact.astro should exist (restored 2026-06-30)').toBe(
+      true
+    )
+    const contact = readFileSync(page, 'utf-8')
+    // Posts to the surviving Resend-backed endpoint.
+    expect(contact, 'contact page must POST to /api/contact').toContain('/api/contact')
+    // The backend endpoint itself must be present.
+    expect(
+      existsSync(resolve('src/pages/api/contact.ts')),
+      'the /api/contact endpoint must exist'
+    ).toBe(true)
+    // Honors the "do not publish the email" intent: no mailto on the page.
+    expect(contact, 'contact page must not publish a mailto address').not.toContain('mailto:')
+    // Routes engagement-seekers to the real front door.
+    expect(contact, 'contact page must point to the assessment front door').toContain('/book')
+  })
+
+  it('the footer links to /contact and does not publish a raw email address', () => {
+    const footer = readComponent('Footer.astro')
+    expect(footer, 'footer must link to /contact').toContain('href="/contact"')
+    expect(footer, 'footer must not publish a mailto address').not.toContain('mailto:')
+  })
+
+  it('the contact route is NOT 301-redirected away in middleware', () => {
+    const mw = readFileSync(resolve('src/middleware.ts'), 'utf-8')
+    expect(mw, 'middleware must not redirect /contact').not.toContain("pathname === '/contact'")
   })
 
   it('nav does not link the retired pages', () => {
@@ -229,7 +261,7 @@ describe('marketing structure: firm-with-flagship (locked)', () => {
 
   it('the retired routes 301 in middleware (bookmarks keep working)', () => {
     const mw = readFileSync(resolve('src/middleware.ts'), 'utf-8')
-    for (const route of ["'/why'", "'/consulting'", "'/ai'", "'/contact'"]) {
+    for (const route of ["'/why'", "'/consulting'", "'/ai'"]) {
       expect(mw, `middleware should reference retired route ${route}`).toContain(route)
     }
     expect(mw).toContain('/operator#compare')


### PR DESCRIPTION
## Why

The marketing site kept losing its contact form on every rework. It wasn't accidental — it was a **recorded, test-enforced decision** quietly working against the intent.

PR #1548 (firm-with-flagship rebuild, 2026-06-29) killed `/contact` in favor of *"booking + a footer email,"* and three mechanisms re-asserted that on every subsequent pass:

1. **`positioning-spine.md`** (the marketing source of truth) listed `/contact` under *"Killed (folded + 301-redirected)"* — every rebuild re-derives the site from this doc.
2. **Middleware** 301-redirected `/contact` → `/book`.
3. **`tests/landing-page.test.ts`** *asserted `contact.astro` must NOT exist* — so any re-add failed `npm run verify` and the next agent deleted it again.

The **intent** behind the form — a quiet channel for partners, vendors, press, and anyone who wants to work together in some way other than booking an assessment, **without publishing an email address on the site** — was never recorded. So each pass reaped it. Worse, the replacement published `mailto:team@smd.services` in the footer: the exact thing the form existed to avoid.

The backend never left: `src/pages/api/contact.ts` (Resend → team@smd.services, honeypot, rate-limit, XSS hardening) is fully intact. This wires the form back to it.

## What changed (one PR, per the spine's change-control process)

- **Restored `src/pages/contact.astro`** — modeled on the live `book.astro` form chrome. General-inquiry copy that routes engagement-seekers to the assessment. No published email anywhere on the page (the failure path retries rather than expose an address). No em dashes, no banned outbound-promise phrases.
- **Footer** — replaced the published `mailto` with a quiet **Contact** link to `/contact`.
- **Middleware** — dropped the `/contact` 301.
- **Guard tests INVERTED** — now assert `contact.astro` exists, posts to `/api/contact`, publishes no `mailto`, footer links it, and `/contact` is not redirected. **This is the mechanism that keeps it for the future.**
- **`positioning-spine.md`** — recorded Captain decision (2026-06-30) amending the §3 *"no second contact form as a peer door"* lock. The assessment stays the **single primary front door**; `/contact` is a lower-weight channel (footer-only, never nav or a hero CTA), satisfying the spirit of that lock.

## Verification

- `npm run verify` green: **3326 passed, 2 skipped** + workers. Typecheck, lint, build, format all pass.
- Local SSR render is blocked in-worktree by a missing Clerk publishable key (affects **all** pages equally — home/about/book all 500 the same way). **Visual confirmation will come from the Cloudflare preview deploy on this PR.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)