### PR TITLE
fix(booking): make guest-email failures loud + end the reschedule dead-end

### DIFF
--- a/src/lib/booking/alerts.ts
+++ b/src/lib/booking/alerts.ts
@@ -17,7 +17,11 @@ import { BOOKING_CONFIG } from './config.js'
 // Types
 // ---------------------------------------------------------------------------
 
-export type BookingAlertKind = 'google_sync_error' | 'integration_invalid_grant' | 'freebusy_error'
+export type BookingAlertKind =
+  | 'google_sync_error'
+  | 'integration_invalid_grant'
+  | 'freebusy_error'
+  | 'guest_email_delivery_failed'
 
 export interface BookingAlertDetails {
   assessmentId?: string
@@ -74,6 +78,18 @@ const ALERT_DESCRIPTIONS: Record<
     action:
       'Check the Google Calendar integration status. If the error is transient (5xx), it may ' +
       'resolve on its own. If persistent, re-authorize the OAuth connection.',
+  },
+  guest_email_delivery_failed: {
+    title: 'Guest booking email could not be sent',
+    meaning:
+      'A booking action (confirmation, reschedule, or cancellation) succeeded, but the email to ' +
+      'the guest was rejected by the email provider at send time. The guest may not have received ' +
+      'the time, the video link, or the calendar invite. The booking itself is valid in the ' +
+      'calendar and the CRM.',
+    action:
+      'Contact the guest directly with the call time and the video link. Their email and booking ' +
+      'details are on the entity in admin. If this repeats, check the RESEND_API_KEY and the ' +
+      'Resend account status (sending limits, domain verification, suppression list).',
   },
 }
 

--- a/src/lib/email/templates.ts
+++ b/src/lib/email/templates.ts
@@ -385,7 +385,7 @@ export function bookingRescheduledEmailHtml(input: BookingRescheduledEmailInput)
 
       <p style="font-size:15px;color:#334155;margin:0 0 16px;">Hi ${guestName},</p>
       <p style="font-size:15px;color:#334155;margin:0 0 16px;">
-        Your assessment call for <strong>${businessName}</strong> has moved.
+        Your assessment call${businessName ? ` for <strong>${businessName}</strong>` : ''} has moved.
       </p>
 
       <div style="background:#f1f5f9;border-radius:6px;padding:16px;margin:0 0 16px;">
@@ -448,7 +448,7 @@ export function bookingCancelledEmailHtml(input: BookingCancelledEmailInput): st
 
       <p style="font-size:15px;color:#334155;margin:0 0 16px;">Hi ${guestName},</p>
       <p style="font-size:15px;color:#334155;margin:0 0 16px;">
-        Your assessment call for <strong>${businessName}</strong>
+        Your assessment call${businessName ? ` for <strong>${businessName}</strong>` : ''}
         scheduled for <strong>${slotLabel}</strong> has been cancelled.
       </p>
 

--- a/src/pages/api/booking/confirmation-emails.ts
+++ b/src/pages/api/booking/confirmation-emails.ts
@@ -1,0 +1,146 @@
+/**
+ * Booking confirmation + admin-notification emails for POST /api/booking/reserve.
+ *
+ * Extracted from reserve.ts to keep that handler under the file-size ceiling
+ * and to isolate the email orchestration. Both sends go through the shared
+ * booking-email wrappers (which return a SendResult), and the guest send is
+ * result-checked: a Resend rejection returns { success: false } rather than
+ * throwing, so an ignored result would silently swallow a guest who never
+ * received their confirmation. A failed guest send is routed to the booking
+ * alert system (entity timeline + team email) so it is visible, not lost.
+ */
+
+import { env } from 'cloudflare:workers'
+import { BOOKING_CONFIG } from '../../../lib/booking/config'
+import { buildIcs, icsToBase64 } from '../../../lib/booking/ics'
+import { buildAdminUrl } from '../../../lib/config/app-url'
+import { recordBookingError } from '../../../lib/booking/alerts'
+import {
+  sendBookingConfirmation,
+  sendBookingAdminNotification,
+} from '../../../lib/email/booking-emails'
+import { formatSlotLabelLong } from './reserve-helpers'
+
+/** Narrow structural views of the reserve handler's validated input + commit result. */
+export interface ConfirmationEmailInput {
+  name: string
+  email: string
+  businessName: string
+  slotStartUtc: string
+  guestTimezone: string | null
+}
+
+export interface ConfirmationEmailDbResult {
+  scheduleId: string
+  entityId: string
+  intakeLines: string[]
+}
+
+export interface SendConfirmationArgs {
+  input: ConfirmationEmailInput
+  dbResult: ConfirmationEmailDbResult
+  googleMeetUrl: string
+  manageUrl: string
+}
+
+function buildConfirmationIcs(
+  args: SendConfirmationArgs
+): { filename: string; content: string; content_type: string } | null {
+  const { input, dbResult, googleMeetUrl, manageUrl } = args
+  try {
+    const icsResult = buildIcs({
+      scheduleId: dbResult.scheduleId,
+      sequence: 0,
+      method: 'REQUEST',
+      startUtc: input.slotStartUtc,
+      durationMinutes: BOOKING_CONFIG.slot_minutes,
+      title: `${BOOKING_CONFIG.meeting_label} — SMD Services`,
+      description: `Assessment call with SMD Services for ${input.businessName}.\n\nManage your booking: ${manageUrl}`,
+      location: googleMeetUrl,
+      organizerName: BOOKING_CONFIG.consultant.name,
+      organizerEmail: BOOKING_CONFIG.consultant.email,
+      guestName: input.name,
+      guestEmail: input.email,
+    })
+    return {
+      filename: 'invite.ics',
+      content: icsToBase64(icsResult.ics),
+      content_type: icsResult.contentType,
+    }
+  } catch (icsErr) {
+    console.error('[api/booking/reserve] ICS generation failed:', icsErr)
+    return null
+  }
+}
+
+async function alertGuestEmailFailure(
+  details: { entityId: string; scheduleId: string },
+  message: string
+): Promise<void> {
+  try {
+    await recordBookingError(env.DB, env.RESEND_API_KEY, 'guest_email_delivery_failed', {
+      entityId: details.entityId,
+      scheduleId: details.scheduleId,
+      message,
+    })
+  } catch (alertErr) {
+    console.error('[api/booking/reserve] Failed to record guest email alert:', alertErr)
+  }
+}
+
+export async function sendConfirmationEmails(args: SendConfirmationArgs): Promise<void> {
+  const { input, dbResult, googleMeetUrl, manageUrl } = args
+  const { name, email, businessName, slotStartUtc, guestTimezone } = input
+  const { scheduleId, intakeLines, entityId } = dbResult
+
+  const displayTz = guestTimezone || BOOKING_CONFIG.consultant.timezone
+  const slotLabel = formatSlotLabelLong(slotStartUtc, displayTz)
+  const consultantTzLabel = formatSlotLabelLong(slotStartUtc, BOOKING_CONFIG.consultant.timezone)
+  const icsAttachment = buildConfirmationIcs(args)
+
+  try {
+    const guestResult = await sendBookingConfirmation(env.RESEND_API_KEY, {
+      guestName: name,
+      businessName,
+      slotLabel,
+      meetUrl: googleMeetUrl,
+      manageUrl,
+      meetingLabel: BOOKING_CONFIG.meeting_label,
+      guestEmail: email,
+      icsAttachment,
+    })
+    if (!guestResult.success) {
+      console.error('[api/booking/reserve] Confirmation email NOT sent:', guestResult.error)
+      await alertGuestEmailFailure(
+        { entityId, scheduleId },
+        `Confirmation email to ${email} was rejected: ${guestResult.error ?? 'unknown error'}`
+      )
+    }
+  } catch (emailErr) {
+    console.error('[api/booking/reserve] Confirmation email failed:', emailErr)
+    await alertGuestEmailFailure(
+      { entityId, scheduleId },
+      `Confirmation email to ${email} threw: ${
+        emailErr instanceof Error ? emailErr.message : String(emailErr)
+      }`
+    )
+  }
+
+  try {
+    const adminResult = await sendBookingAdminNotification(env.RESEND_API_KEY, {
+      guestName: name,
+      guestEmail: email,
+      businessName,
+      slotLabel: consultantTzLabel,
+      intakeLines,
+      entityAdminUrl: buildAdminUrl(env, `/admin/entities/${entityId}`),
+      replyTo: email,
+      subjectSlotLabel: consultantTzLabel,
+    })
+    if (!adminResult.success) {
+      console.error('[api/booking/reserve] Admin notification NOT sent:', adminResult.error)
+    }
+  } catch (emailErr) {
+    console.error('[api/booking/reserve] Admin notification email failed:', emailErr)
+  }
+}

--- a/src/pages/api/booking/manage/[token]/cancel.ts
+++ b/src/pages/api/booking/manage/[token]/cancel.ts
@@ -18,6 +18,7 @@ import { buildIcs, icsToBase64 } from '../../../../../lib/booking/ics'
 import { BOOKING_CONFIG } from '../../../../../lib/booking/config'
 import { sendBookingCancellation } from '../../../../../lib/email/booking-emails'
 import { sendEmail } from '../../../../../lib/email/resend'
+import { recordBookingError } from '../../../../../lib/booking/alerts'
 import { formatInTimeZone } from 'date-fns-tz'
 import { env } from 'cloudflare:workers'
 
@@ -116,8 +117,20 @@ async function sendCancellationEmails(
 ): Promise<void> {
   const icsAttachment = buildIcsAttachment(schedule)
 
+  async function alertGuestEmailFailure(message: string): Promise<void> {
+    try {
+      await recordBookingError(env.DB, env.RESEND_API_KEY, 'guest_email_delivery_failed', {
+        assessmentId: schedule.assessment_id,
+        scheduleId: schedule.id,
+        message,
+      })
+    } catch (alertErr) {
+      console.error('[api/booking/manage/cancel] Failed to record guest email alert:', alertErr)
+    }
+  }
+
   try {
-    await sendBookingCancellation(env.RESEND_API_KEY, {
+    const guestResult = await sendBookingCancellation(env.RESEND_API_KEY, {
       guestName: schedule.guest_name,
       guestEmail: schedule.guest_email,
       businessName: '',
@@ -125,17 +138,31 @@ async function sendCancellationEmails(
       rebookUrl: 'https://smd.services/book',
       icsAttachment,
     })
+    if (!guestResult.success) {
+      console.error('[api/booking/manage/cancel] Cancellation email NOT sent:', guestResult.error)
+      await alertGuestEmailFailure(
+        `Cancellation email to ${schedule.guest_email} was rejected: ${guestResult.error ?? 'unknown error'}`
+      )
+    }
   } catch (emailErr) {
     console.error('[api/booking/manage/cancel] Cancellation email failed:', emailErr)
+    await alertGuestEmailFailure(
+      `Cancellation email to ${schedule.guest_email} threw: ${
+        emailErr instanceof Error ? emailErr.message : String(emailErr)
+      }`
+    )
   }
 
   try {
-    await sendEmail(env.RESEND_API_KEY, {
+    const adminResult = await sendEmail(env.RESEND_API_KEY, {
       to: NOTIFY_EMAIL,
       reply_to: schedule.guest_email,
       subject: `Cancelled: ${schedule.guest_name} — ${slotLabel}`,
       html: `<p><strong>${escapeHtml(schedule.guest_name)}</strong> cancelled their assessment call scheduled for <strong>${escapeHtml(slotLabel)}</strong>.</p>${reason ? `<p>Reason: ${escapeHtml(reason)}</p>` : ''}`,
     })
+    if (!adminResult.success) {
+      console.error('[api/booking/manage/cancel] Admin notification NOT sent:', adminResult.error)
+    }
   } catch (emailErr) {
     console.error('[api/booking/manage/cancel] Admin notification failed:', emailErr)
   }

--- a/src/pages/api/booking/manage/[token]/reschedule.ts
+++ b/src/pages/api/booking/manage/[token]/reschedule.ts
@@ -21,6 +21,7 @@ import { updateMeeting } from '../../../../../lib/db/meetings'
 import { buildIcs, icsToBase64 } from '../../../../../lib/booking/ics'
 import { sendBookingReschedule } from '../../../../../lib/email/booking-emails'
 import { sendEmail } from '../../../../../lib/email/resend'
+import { recordBookingError } from '../../../../../lib/booking/alerts'
 import { requireAppBaseUrl } from '../../../../../lib/config/app-url'
 import { formatInTimeZone } from 'date-fns-tz'
 import { env } from 'cloudflare:workers'
@@ -186,8 +187,20 @@ async function sendRescheduleEmails(
 ): Promise<void> {
   const icsAttachment = buildRescheduleIcs(schedule, newSlotStartUtc, manageUrl)
 
+  async function alertGuestEmailFailure(message: string): Promise<void> {
+    try {
+      await recordBookingError(env.DB, env.RESEND_API_KEY, 'guest_email_delivery_failed', {
+        assessmentId: schedule.assessment_id,
+        scheduleId: schedule.id,
+        message,
+      })
+    } catch (alertErr) {
+      console.error('[api/booking/manage/reschedule] Failed to record guest email alert:', alertErr)
+    }
+  }
+
   try {
-    await sendBookingReschedule(env.RESEND_API_KEY, {
+    const guestResult = await sendBookingReschedule(env.RESEND_API_KEY, {
       guestName: schedule.guest_name,
       guestEmail: schedule.guest_email,
       businessName: '',
@@ -198,8 +211,19 @@ async function sendRescheduleEmails(
       meetingLabel: BOOKING_CONFIG.meeting_label,
       icsAttachment,
     })
+    if (!guestResult.success) {
+      console.error('[api/booking/manage/reschedule] Reschedule email NOT sent:', guestResult.error)
+      await alertGuestEmailFailure(
+        `Reschedule email to ${schedule.guest_email} was rejected: ${guestResult.error ?? 'unknown error'}`
+      )
+    }
   } catch (emailErr) {
     console.error('[api/booking/manage/reschedule] Reschedule email failed:', emailErr)
+    await alertGuestEmailFailure(
+      `Reschedule email to ${schedule.guest_email} threw: ${
+        emailErr instanceof Error ? emailErr.message : String(emailErr)
+      }`
+    )
   }
 
   try {
@@ -208,12 +232,18 @@ async function sendRescheduleEmails(
       BOOKING_CONFIG.consultant.timezone,
       "EEEE, MMMM d 'at' h:mm a (zzz)"
     )
-    await sendEmail(env.RESEND_API_KEY, {
+    const adminResult = await sendEmail(env.RESEND_API_KEY, {
       to: NOTIFY_EMAIL,
       reply_to: schedule.guest_email,
       subject: `Rescheduled: ${schedule.guest_name} — ${adminNewLabel}`,
       html: `<p><strong>${escapeHtml(schedule.guest_name)}</strong> rescheduled their assessment call.</p><p>Old: ${escapeHtml(oldSlotLabel)}</p><p>New: <strong>${escapeHtml(newSlotLabel)}</strong></p>`,
     })
+    if (!adminResult.success) {
+      console.error(
+        '[api/booking/manage/reschedule] Admin notification NOT sent:',
+        adminResult.error
+      )
+    }
   } catch (emailErr) {
     console.error('[api/booking/manage/reschedule] Admin notification failed:', emailErr)
   }

--- a/src/pages/api/booking/reserve.ts
+++ b/src/pages/api/booking/reserve.ts
@@ -8,7 +8,6 @@ import {
   hashManageToken,
   computeManageTokenExpiry,
 } from '../../../lib/booking/tokens'
-import { buildIcs, icsToBase64 } from '../../../lib/booking/ics'
 import { processIntakeSubmission, type PreSeededIntake } from '../../../lib/booking/intake-core'
 import { rollbackFailedBooking } from '../../../lib/booking/rollback'
 import { createScheduleStatement, updateScheduleGoogleSync } from '../../../lib/booking/schedule'
@@ -19,12 +18,8 @@ import {
 } from '../../../lib/booking/meeting-schedule'
 import { getIntegration, getGoogleAccessToken } from '../../../lib/db/integrations'
 import { transitionStage } from '../../../lib/db/entities'
-import { sendEmail } from '../../../lib/email/resend'
-import {
-  bookingConfirmationEmailHtml,
-  bookingAdminNotificationEmailHtml,
-} from '../../../lib/email/templates'
-import { requireAppBaseUrl, buildAdminUrl } from '../../../lib/config/app-url'
+import { sendConfirmationEmails } from './confirmation-emails'
+import { requireAppBaseUrl } from '../../../lib/config/app-url'
 import { env } from 'cloudflare:workers'
 import {
   createGoogleCalendarEvent,
@@ -37,7 +32,6 @@ import {
 } from './reserve-helpers'
 
 const FALLBACK_EMAIL = 'team@smd.services'
-const NOTIFY_EMAIL = 'team@smd.services'
 
 /**
  * POST /api/booking/reserve
@@ -408,86 +402,6 @@ async function syncGoogleCalendarAndPromote(args: GoogleSyncArgs): Promise<strin
         message: `Please email ${FALLBACK_EMAIL} to schedule your call.`,
       },
     })
-  }
-}
-
-interface SendConfirmationArgs {
-  input: ValidatedInput
-  dbResult: DbCommitResult
-  googleMeetUrl: string
-  manageUrl: string
-}
-
-async function sendConfirmationEmails(args: SendConfirmationArgs): Promise<void> {
-  const { input, dbResult, googleMeetUrl, manageUrl } = args
-  const { name, email, businessName, slotStartUtc, guestTimezone } = input
-  const { scheduleId, intakeLines, entityId } = dbResult
-
-  const displayTz = guestTimezone || BOOKING_CONFIG.consultant.timezone
-  const slotLabel = formatSlotLabelLong(slotStartUtc, displayTz)
-  const consultantTzLabel = formatSlotLabelLong(slotStartUtc, BOOKING_CONFIG.consultant.timezone)
-
-  let icsAttachment: { filename: string; content: string; content_type: string } | null = null
-  try {
-    const icsResult = buildIcs({
-      scheduleId,
-      sequence: 0,
-      method: 'REQUEST',
-      startUtc: slotStartUtc,
-      durationMinutes: BOOKING_CONFIG.slot_minutes,
-      title: `${BOOKING_CONFIG.meeting_label} — SMD Services`,
-      description: `Assessment call with SMD Services for ${businessName}.\n\nManage your booking: ${manageUrl}`,
-      location: googleMeetUrl,
-      organizerName: BOOKING_CONFIG.consultant.name,
-      organizerEmail: BOOKING_CONFIG.consultant.email,
-      guestName: name,
-      guestEmail: email,
-    })
-    icsAttachment = {
-      filename: 'invite.ics',
-      content: icsToBase64(icsResult.ics),
-      content_type: icsResult.contentType,
-    }
-  } catch (icsErr) {
-    console.error('[api/booking/reserve] ICS generation failed:', icsErr)
-  }
-
-  try {
-    const confirmationHtml = bookingConfirmationEmailHtml({
-      guestName: name,
-      businessName,
-      slotLabel,
-      meetUrl: googleMeetUrl,
-      manageUrl,
-      meetingLabel: BOOKING_CONFIG.meeting_label,
-    })
-    await sendEmail(env.RESEND_API_KEY, {
-      to: email,
-      subject: `Confirmed: ${BOOKING_CONFIG.meeting_label} with SMD Services`,
-      html: confirmationHtml,
-      ...(icsAttachment ? { attachments: [icsAttachment] } : {}),
-    })
-  } catch (emailErr) {
-    console.error('[api/booking/reserve] Confirmation email failed:', emailErr)
-  }
-
-  try {
-    const adminHtml = bookingAdminNotificationEmailHtml({
-      guestName: name,
-      guestEmail: email,
-      businessName,
-      slotLabel: consultantTzLabel,
-      intakeLines,
-      entityAdminUrl: buildAdminUrl(env, `/admin/entities/${entityId}`),
-    })
-    await sendEmail(env.RESEND_API_KEY, {
-      to: NOTIFY_EMAIL,
-      reply_to: email,
-      subject: `New booking: ${businessName} — ${consultantTzLabel}`,
-      html: adminHtml,
-    })
-  } catch (emailErr) {
-    console.error('[api/booking/reserve] Admin notification email failed:', emailErr)
   }
 }
 

--- a/src/pages/book/manage/[token].astro
+++ b/src/pages/book/manage/[token].astro
@@ -52,6 +52,7 @@ import SlotPicker from '../../../components/booking/SlotPicker.astro'
             <p class="ss-eyebrow">Confirmed</p>
             <h1 id="details-slot" class="ss-headline-sm"></h1>
             <p id="details-meeting-label" class="ss-lede mt-row"></p>
+            <p id="details-notice" class="ss-notice mt-row" hidden></p>
           </header>
 
           <dl class="ss-detail-list">
@@ -227,6 +228,15 @@ import SlotPicker from '../../../components/booking/SlotPicker.astro'
 
     // ---------- Reschedule ----------
 
+    function resetRescheduleForm() {
+      currentSlot = null
+      document.getElementById('reschedule-selected').hidden = true
+      const confirmBtn = document.getElementById('reschedule-confirm-btn')
+      confirmBtn.disabled = true
+      confirmBtn.textContent = 'Confirm new time'
+      document.getElementById('reschedule-error').hidden = true
+    }
+
     document.getElementById('details-reschedule-btn').addEventListener('click', function () {
       if (!bookingData) return
       document.getElementById('reschedule-current').textContent = bookingData.slot_label
@@ -242,12 +252,7 @@ import SlotPicker from '../../../components/booking/SlotPicker.astro'
     })
 
     document.getElementById('reschedule-back-btn').addEventListener('click', function () {
-      currentSlot = null
-      document.getElementById('reschedule-selected').hidden = true
-      const confirmBtn = document.getElementById('reschedule-confirm-btn')
-      confirmBtn.disabled = true
-      confirmBtn.textContent = 'Confirm new time'
-      document.getElementById('reschedule-error').hidden = true
+      resetRescheduleForm()
       setState('details')
     })
 
@@ -304,12 +309,20 @@ import SlotPicker from '../../../components/booking/SlotPicker.astro'
         })
         const data = await res.json()
         if (data.ok) {
-          showResult(
-            'Rescheduled',
-            'Your call has been moved.',
-            'It is now on ' + data.slot_label + '. We sent a calendar update.',
-            { hideCta: true }
-          )
+          // Return to the details view showing the new time, with Reschedule
+          // and Cancel still available — the manage token stays valid across a
+          // reschedule, so this is not a terminal state. A re-reschedule must
+          // refetch availability (the slot just taken is now busy), so clear
+          // the fetched flag.
+          bookingData.slot_label = data.slot_label
+          document.getElementById('details-slot').textContent = data.slot_label
+          const notice = document.getElementById('details-notice')
+          notice.textContent =
+            'Rescheduled. Your call is now on ' + data.slot_label + '. We sent a calendar update.'
+          notice.hidden = false
+          resetRescheduleForm()
+          slotsFetched = false
+          setState('details')
           return
         }
         setError(
@@ -399,6 +412,15 @@ import SlotPicker from '../../../components/booking/SlotPicker.astro'
       margin: 0;
       font-size: 1rem;
       color: var(--ss-color-text-primary);
+    }
+    .ss-notice {
+      margin: 0.75rem 0 0;
+      padding: 0.75rem 1rem;
+      border-radius: 6px;
+      background: var(--ss-color-surface-muted);
+      border-left: 3px solid var(--ss-color-success);
+      color: var(--ss-color-text-secondary);
+      font-size: 0.95rem;
     }
   </style>
 </Base>

--- a/tests/booking/alerts.test.ts
+++ b/tests/booking/alerts.test.ts
@@ -17,11 +17,12 @@ describe('booking alerts: exports', () => {
     expect(source()).toContain('export async function recordBookingError')
   })
 
-  it('exports BookingAlertKind type with all three error kinds', () => {
+  it('exports BookingAlertKind type with all error kinds', () => {
     const code = source()
     expect(code).toContain("'google_sync_error'")
     expect(code).toContain("'integration_invalid_grant'")
     expect(code).toContain("'freebusy_error'")
+    expect(code).toContain("'guest_email_delivery_failed'")
   })
 
   it('exports BookingAlertDetails interface', () => {
@@ -108,12 +109,13 @@ describe('booking alerts: email', () => {
 })
 
 describe('booking alerts: alert descriptions', () => {
-  it('has descriptions for all three alert kinds', () => {
+  it('has descriptions for all alert kinds', () => {
     const code = source()
     // Verify each kind has a title, meaning, and action entry
     expect(code).toContain('google_sync_error: {')
     expect(code).toContain('integration_invalid_grant: {')
     expect(code).toContain('freebusy_error: {')
+    expect(code).toContain('guest_email_delivery_failed: {')
   })
 
   it('google_sync_error mentions calendar out of sync', () => {
@@ -126,5 +128,9 @@ describe('booking alerts: alert descriptions', () => {
 
   it('freebusy_error mentions double-bookings risk', () => {
     expect(source()).toContain('double-bookings')
+  })
+
+  it('guest_email_delivery_failed tells the team to contact the guest directly', () => {
+    expect(source()).toContain('Contact the guest directly')
   })
 })

--- a/tests/booking/email-failure-visibility.test.ts
+++ b/tests/booking/email-failure-visibility.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+
+/**
+ * Regression guard: guest booking emails must not be sent fire-and-forget.
+ *
+ * `sendEmail` returns { success: false } on a Resend rejection (e.g. the
+ * recipient is on the suppression list) rather than throwing. The original
+ * handlers awaited the send but discarded the result, so a guest who never
+ * received their confirmation / reschedule / cancellation email was
+ * completely invisible — the booking still returned success.
+ *
+ * These structural checks lock in that each handler inspects the send result
+ * and routes a failure to recordBookingError('guest_email_delivery_failed'),
+ * which writes an entity-timeline alert row and emails the team to follow up.
+ *
+ * See: missing-guest-email incident 2026-06-30 (scott@smd.services suppressed).
+ */
+
+// The reserve handler delegates its guest-confirmation send to
+// confirmation-emails.ts; the manage handlers keep their send logic inline.
+const confirmationSrc = readFileSync(
+  resolve('src/pages/api/booking/confirmation-emails.ts'),
+  'utf-8'
+)
+const rescheduleSrc = readFileSync(
+  resolve('src/pages/api/booking/manage/[token]/reschedule.ts'),
+  'utf-8'
+)
+const cancelSrc = readFileSync(resolve('src/pages/api/booking/manage/[token]/cancel.ts'), 'utf-8')
+
+const HANDLERS: Array<{ name: string; code: string }> = [
+  { name: 'confirmation-emails.ts', code: confirmationSrc },
+  { name: 'reschedule.ts', code: rescheduleSrc },
+  { name: 'cancel.ts', code: cancelSrc },
+]
+
+describe('booking guest-email failure visibility', () => {
+  for (const { name, code } of HANDLERS) {
+    describe(name, () => {
+      it('imports the booking alert recorder', () => {
+        expect(code).toContain('recordBookingError')
+      })
+
+      it('inspects the guest send result instead of discarding it', () => {
+        // A captured result whose .success is checked — not a bare `await send(...)`.
+        expect(code).toMatch(/Result\.success/)
+      })
+
+      it('routes a guest-email failure to the guest_email_delivery_failed alert', () => {
+        expect(code).toContain("'guest_email_delivery_failed'")
+      })
+    })
+  }
+})

--- a/tests/booking/email-templates-businessname.test.ts
+++ b/tests/booking/email-templates-businessname.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest'
+import {
+  bookingRescheduledEmailHtml,
+  bookingCancelledEmailHtml,
+} from '../../src/lib/email/templates'
+
+/**
+ * The reschedule and cancel handlers do not have the business name on the
+ * schedule row, so they pass businessName: ''. The templates must drop the
+ * "for <business>" clause cleanly rather than render a dangling
+ * "Your assessment call for  has moved." (observed in a live Resend preview
+ * on 2026-06-30). When a business name IS present, it still renders.
+ */
+
+const rescheduleBase = {
+  guestName: 'Scott Durgan',
+  oldSlotLabel: 'Wednesday, July 1 at 11:00 AM (MST)',
+  newSlotLabel: 'Wednesday, July 1 at 12:30 PM (MST)',
+  meetUrl: 'https://zoom.us/j/4284801619',
+  manageUrl: 'https://smd.services/book/manage?token=abc',
+  meetingLabel: '30-minute intro call',
+}
+
+const cancelBase = {
+  guestName: 'Scott Durgan',
+  slotLabel: 'Wednesday, July 1 at 11:00 AM (MST)',
+  rebookUrl: 'https://smd.services/book',
+}
+
+describe('booking email templates: empty business name renders cleanly', () => {
+  it('reschedule with empty businessName has no dangling "for" clause', () => {
+    const html = bookingRescheduledEmailHtml({ ...rescheduleBase, businessName: '' })
+    expect(html).toContain('Your assessment call has moved.')
+    expect(html).not.toMatch(/for\s*<\/strong>/)
+    expect(html).not.toMatch(/call\s+for\s+has moved/)
+  })
+
+  it('reschedule with a businessName still renders the clause', () => {
+    const html = bookingRescheduledEmailHtml({ ...rescheduleBase, businessName: 'Acme LLC' })
+    expect(html).toContain('for <strong>Acme LLC</strong>')
+  })
+
+  it('cancel with empty businessName has no dangling "for" clause', () => {
+    const html = bookingCancelledEmailHtml({ ...cancelBase, businessName: '' })
+    expect(html).not.toMatch(/for\s*<\/strong>/)
+    expect(html).not.toMatch(/call\s+for\s+scheduled/)
+    expect(html).toContain('Your assessment call')
+    expect(html).toContain('has been cancelled.')
+  })
+
+  it('cancel with a businessName still renders the clause', () => {
+    const html = bookingCancelledEmailHtml({ ...cancelBase, businessName: 'Acme LLC' })
+    expect(html).toContain('for <strong>Acme LLC</strong>')
+  })
+})

--- a/tests/canonical-app-url.test.ts
+++ b/tests/canonical-app-url.test.ts
@@ -349,7 +349,9 @@ describe('canonical app-url: outbound admin URLs use buildAdminUrl', () => {
   })
 
   it('booking admin notification email uses buildAdminUrl', () => {
-    const source = readFileSync(resolve('src/pages/api/booking/reserve.ts'), 'utf-8')
+    // The booking admin notification is composed in confirmation-emails.ts,
+    // which reserve.ts delegates to.
+    const source = readFileSync(resolve('src/pages/api/booking/confirmation-emails.ts'), 'utf-8')
     expect(source).toContain('buildAdminUrl')
     expect(source).not.toMatch(/\$\{appBaseUrl\}\/admin\//)
   })


### PR DESCRIPTION
## Why

A live test booking on 2026-06-30 (booking as SMD itself, with one reschedule) surfaced two real defects. The customer received **no** confirmation, reschedule, or cancellation email, and the reschedule flow dead-ended.

**Root cause of the missing emails (confirmed from live Resend logs):** every team@ (admin) email delivered; both guest emails to `scott@smd.services` came back `last_event: suppressed`. The address is on Resend's suppression list (from a prior bounce/spam-mark). The code never surfaced this because the guest `sendEmail` result was discarded — `sendEmail` returns `{ success: false }` on a Resend rejection rather than throwing, so the booking reported success while the guest got silence.

## What this PR does

1. **Make guest-email failures visible.** `reserve` (via the new `confirmation-emails.ts`), `reschedule`, and `cancel` now check the send result and route a failure to `recordBookingError('guest_email_delivery_failed')`, which writes an `alert` row on the entity timeline **and** emails the team to follow up by hand. (`recordBookingError` already existed and was tested but had **zero call sites** — this is its first consumer.)

2. **End the reschedule dead-end.** A successful guest reschedule landed on a terminal result screen with the only action button hidden, even though the manage token stays valid across a reschedule. It now returns to the booking **details** view showing the new time, with Reschedule and Cancel still available, and refetches availability on a subsequent reschedule (the just-taken slot is now busy).

3. **Refactor.** Extracts the reserve confirmation/admin email orchestration into `confirmation-emails.ts` (reserve.ts was over the 500-line ceiling) and routes it through the existing `booking-emails.ts` wrappers instead of duplicating inline HTML + `sendEmail`.

## Important limitation (and the follow-on)

Resend suppression is **asynchronous** — the send API returns `200`, and the address is marked `suppressed` as a later `last_event`. So the synchronous result check in this PR catches send-time failures (auth, payload, rate-limit, outage) but **not** suppression/bounce. Catching those needs the Resend `email.suppressed` / `email.bounced` / `email.failed` webhooks (which exist), plus tagging booking emails so the webhook handler can recognize them. Filed as a follow-on.

## Operational action required (not code)

`scott@smd.services` must be removed from Resend's suppression list (Resend dashboard → the suppressed email → "Remove from suppression list"; there is no public API for this). Until then, guest emails to that address keep getting suppressed.

## Tests

- `tests/booking/email-failure-visibility.test.ts` (new) — regression guard that each handler checks the send result and routes to the alert (locks the swallowed-result bug shut).
- `tests/booking/alerts.test.ts` — extended for the new `guest_email_delivery_failed` alert kind.
- `tests/canonical-app-url.test.ts` — updated for the extracted module.
- `npm run verify` green (typecheck, lint, format, full test suite, build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)