### PR TITLE
fix(marketing): neutral firm-level assessment front door (no Operator presumption)

### DIFF
--- a/src/components/CtaButton.astro
+++ b/src/components/CtaButton.astro
@@ -6,9 +6,11 @@ interface Props {
   /** Explicit destination. Wins over `interest`. */
   href?: string
   /**
-   * Assessment intent slug. When `href` is omitted, the button links to
-   * /book?interest=<interest> (defaulting to the flagship product). Lets a
-   * CTA carry attribution without hand-writing the /book URL.
+   * Assessment intent slug. When `href` is omitted and `interest` is set,
+   * the button links to /book?interest=<interest> and the prospect sees an
+   * "Inquiring about …" chip. Pass it only from a solution-specific surface
+   * (the /operator page, a vertical pack). With neither `href` nor `interest`
+   * the button links to a neutral /book — the objectives-first front door.
    */
   interest?: string
   class?: string
@@ -23,7 +25,7 @@ const {
   'data-ev': dataEv,
 } = Astro.props
 
-// Precedence: explicit href > interest-built /book href > default /book href.
+// Precedence: explicit href > interest-built /book href > neutral /book.
 const resolvedHref = href ?? bookHref(interest)
 
 const base =

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -42,7 +42,7 @@ import { bookHref } from '../lib/booking/config'
       <a href="/operator" class="hover:text-white" data-ev="footer-operator">Operator</a>
       <a href="/industries" class="hover:text-white" data-ev="footer-industries">Industries</a>
       <a href="/about" class="hover:text-white" data-ev="footer-about">About</a>
-      <a href={bookHref('operator')} class="hover:text-white" data-ev="footer-assessment"
+      <a href={bookHref()} class="hover:text-white" data-ev="footer-assessment"
         >Start with an assessment</a
       >
       <a href="/contact" class="hover:text-white" data-ev="footer-contact">Contact</a>

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -1,6 +1,6 @@
 ---
 import SmdLogo from './SmdLogo.astro'
-import { bookHref, DEFAULT_BOOK_INTEREST } from '../lib/booking/config'
+import { bookHref } from '../lib/booking/config'
 
 const navLinks = [
   { href: '/operator', label: 'Operator' },
@@ -8,12 +8,18 @@ const navLinks = [
   { href: '/about', label: 'About' },
 ]
 
-// The persistent CTA inherits the page's context so a vertical arrival keeps its
-// attribution instead of being clobbered with `operator`. Pack pages carry their
-// slug; everything else defaults to operator. The single front door is the assessment.
+// The persistent CTA carries an interest only from a surface that is genuinely
+// about that solution, so the assessment chip never presumes one: a pack page
+// keeps its vertical slug, the /operator page keeps `operator`, and every
+// firm-level page starts the assessment neutral. The single front door is the
+// assessment regardless.
 const path = Astro.url.pathname
 const packMatch = path.match(/^\/packs\/([^/]+)\/?$/)
-const bookUrl = bookHref(packMatch ? packMatch[1] : DEFAULT_BOOK_INTEREST)
+const bookUrl = packMatch
+  ? bookHref(packMatch[1])
+  : path === '/operator'
+    ? bookHref('operator')
+    : bookHref()
 ---
 
 <header

--- a/src/components/OperatorHero.astro
+++ b/src/components/OperatorHero.astro
@@ -30,7 +30,7 @@ import CtaButton from './CtaButton.astro'
       walk out the door. It starts with an assessment.
     </p>
     <div class="mt-9 flex flex-col items-start gap-4 sm:flex-row sm:items-center sm:gap-7">
-      <CtaButton interest="operator" data-ev="home-hero-cta"> Start with an assessment </CtaButton>
+      <CtaButton data-ev="home-hero-cta"> Start with an assessment </CtaButton>
       <a
         href="/operator"
         data-ev="home-hero-operator"

--- a/src/lib/booking/config.ts
+++ b/src/lib/booking/config.ts
@@ -128,14 +128,15 @@ export function interestLabel(slug?: string | null): string | null {
   return INTEREST_LABELS[slug] ?? slug
 }
 
-/** Contextless marketing surfaces default to the flagship product. */
-export const DEFAULT_BOOK_INTEREST = 'operator'
-
 /**
- * Builds a /book href that always carries an interest, so no CTA silently
- * drops attribution. Does NOT validate — the allow-list is enforced at
- * /book and /api/intake/send.
+ * Builds a /book href. Pass an `interest` only from a surface that is
+ * genuinely about that solution (the /operator page or a vertical pack) so
+ * the prospect sees an "Inquiring about …" chip. Firm-level surfaces
+ * (homepage, about, contact, footer, the nav on generic pages) call this
+ * with no argument: the assessment is the objectives-first front door and
+ * must not presume a solution before the conversation. Does NOT validate —
+ * the allow-list is enforced at /book and /api/intake/send.
  */
-export function bookHref(interest: string = DEFAULT_BOOK_INTEREST): string {
-  return `/book?interest=${interest}`
+export function bookHref(interest?: string): string {
+  return interest ? `/book?interest=${interest}` : '/book'
 }

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -59,7 +59,7 @@ import CtaButton from '../components/CtaButton.astro'
           We learn how your business runs, find what is costing you the most time, and recommend the
           right solution. If an Operator is not the fit, we say so.
         </p>
-        <CtaButton variant="outline-white" interest="operator" data-ev="about-final-cta"
+        <CtaButton variant="outline-white" data-ev="about-final-cta"
           >Start with an assessment</CtaButton
         >
       </div>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -32,7 +32,7 @@ import { bookHref } from '../lib/booking/config'
         <header class="mb-stack">
           <h1 class="ss-headline">Contact</h1>
           <p class="ss-subhead">
-            Looking to start an engagement? <a href={bookHref('operator')} class="ss-quiet-link"
+            Looking to start an engagement? <a href={bookHref()} class="ss-quiet-link"
               >Start with an assessment</a
             >, our front door. For anything else, a partnership, a question, press, or another way
             to work together, send a note below.

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -284,7 +284,7 @@ const firmSchema = {
           recommend the right solution. If an Operator is not the fit, we say so. You walk away with
           a clear recommendation either way.
         </p>
-        <CtaButton variant="outline-white" interest="operator" data-ev="home-final-cta"
+        <CtaButton variant="outline-white" data-ev="home-final-cta"
           >Start with an assessment</CtaButton
         >
       </div>

--- a/src/pages/industries.astro
+++ b/src/pages/industries.astro
@@ -113,7 +113,7 @@ const industries = [
           your business runs on systems and people, there is a gap between them, and that is the
           work the Operator takes on. Tell us how you run, and we will find it.
         </p>
-        <CtaButton variant="outline-white" interest="operator" data-ev="industries-cta"
+        <CtaButton variant="outline-white" data-ev="industries-cta"
           >Start with an assessment</CtaButton
         >
       </div>

--- a/tests/booking-interest-parity.test.ts
+++ b/tests/booking-interest-parity.test.ts
@@ -18,7 +18,6 @@ import {
   ALLOWED_INTERESTS,
   interestLabel,
   bookHref,
-  DEFAULT_BOOK_INTEREST,
 } from '../src/lib/booking/config'
 
 describe('interest label ↔ allow-list parity', () => {
@@ -61,14 +60,15 @@ describe('interestLabel() behavior', () => {
 })
 
 describe('bookHref() route contract', () => {
-  it('builds /book?interest=<slug>', () => {
+  it('builds /book?interest=<slug> when a solution-specific interest is given', () => {
     expect(bookHref('operator')).toBe('/book?interest=operator')
     expect(bookHref('med-spa')).toBe('/book?interest=med-spa')
   })
 
-  it('defaults to the flagship interest when none is given', () => {
-    expect(DEFAULT_BOOK_INTEREST).toBe('operator')
-    expect(bookHref()).toBe('/book?interest=operator')
+  it('returns a neutral /book (no interest) for the firm-level front door', () => {
+    // Firm-level surfaces start the assessment without presuming a solution.
+    expect(bookHref()).toBe('/book')
+    expect(bookHref(undefined)).toBe('/book')
   })
 })
 

--- a/tests/landing-page.test.ts
+++ b/tests/landing-page.test.ts
@@ -157,11 +157,16 @@ describe('marketing structure: firm-with-flagship (locked)', () => {
     expect(home).toContain('not every problem needs an operator')
   })
 
-  it('the assessment is the one front door (primary CTA routes to /book)', () => {
-    // The home final CTA declares its intent via the shared CtaButton `interest`
-    // prop, which resolves to /book?interest=operator through bookHref() (the
-    // route contract itself is asserted centrally in booking-interest-parity).
-    expect(home).toContain('interest="operator"')
+  it('the homepage assessment entry is the neutral front door (presumes no solution)', () => {
+    // Firm-level surfaces start the assessment with no `interest`, so the chip
+    // never presumes an Operator before the objectives-first conversation. The
+    // CTA's presence + verb are guarded by the single-verb spine test below;
+    // here we lock that the homepage carries no product attribution. The
+    // /operator page and the vertical packs keep their interest on purpose
+    // (route contract asserted centrally in booking-interest-parity).
+    expect(home).toContain('data-ev="home-final-cta"')
+    expect(home, 'home CTA must not presume a solution').not.toContain('interest=')
+    expect(operatorHero, 'home hero CTA must not presume a solution').not.toContain('interest=')
   })
 
   it('/operator absorbs the comparison as the answer-engine surface', () => {
@@ -243,12 +248,10 @@ describe('marketing structure: firm-with-flagship (locked)', () => {
     // Honors the "do not publish the email" intent: no mailto on the page.
     expect(contact, 'contact page must not publish a mailto address').not.toContain('mailto:')
     // Routes engagement-seekers to the real front door via the shared helper
-    // (bookHref builds /book?interest=operator — asserted centrally in
+    // (bookHref() builds the neutral /book — asserted centrally in
     // booking-interest-parity). Guards the actual CTA, not an incidental
     // "/book" mention in a comment.
-    expect(contact, 'contact page must point to the assessment front door').toContain(
-      "bookHref('operator')"
-    )
+    expect(contact, 'contact page must point to the assessment front door').toContain('bookHref()')
   })
 
   it('the footer links to /contact and does not publish a raw email address', () => {


### PR DESCRIPTION
## Problem

Every "Start with an assessment" CTA injected an `interest`, so the `/book` chip always presumed a solution — **"Inquiring about Operator"** — even from the homepage, before any objectives conversation. That contradicts the firm's own positioning: *the assessment finds the right solution; if an Operator isn't the fit, we say so* ("not every problem needs an Operator").

## Change

Carry an interest **only** from a surface genuinely about that solution — the `/operator` page (operator) and the 12 vertical pack pages (their vertical). **Every firm-level surface now starts the assessment neutral** (plain `/book`, no chip).

- `bookHref(interest?)` returns a neutral `/book` when no interest is given; removed `DEFAULT_BOOK_INTEREST` (the contextless operator default is gone).
- **Neutral now:** homepage hero + final CTA, About, Contact, footer, and the Industries "don't see yours" CTA.
- **Nav** persistent CTA: pack route keeps its slug, `/operator` keeps operator, every other (firm-level) page is neutral.
- **Unchanged (still attributed):** `/operator` page CTAs and the 12 pack CTAs.
- **Guards:** `landing-page` now asserts the homepage assessment entry presumes no solution (hero + final CTA carry no `interest`); `booking-interest-parity` asserts `bookHref() === '/book'`.

Follow-up to #1569 (which fixed the silent vertical chip). Scope confirmed with Captain: all firm-level surfaces neutral, attribution kept only on the Operator page and vertical packs.

## Verification

- `npm run verify` green.
- Post-deploy: `/book` (from homepage/about/contact/footer) → no chip; `/book?interest=med-spa` (pack) → "Operator for Med Spas"; `/book?interest=operator` (/operator page) → "Operator".

🤖 Generated with [Claude Code](https://claude.com/claude-code)