### PR TITLE
feat(booking): alert the team when a guest booking email fails delivery (async webhook catch)

### DIFF
--- a/src/lib/email/booking-emails.ts
+++ b/src/lib/email/booking-emails.ts
@@ -9,7 +9,7 @@
 
 import { BRAND_NAME } from '../config/brand'
 import { sendEmail } from './resend'
-import type { SendResult, EmailAttachment } from './resend'
+import type { SendResult, EmailAttachment, EmailTag } from './resend'
 import {
   bookingConfirmationEmailHtml,
   bookingRescheduledEmailHtml,
@@ -25,6 +25,19 @@ import type {
 
 const NOTIFY_EMAIL = 'team@smd.services'
 
+/**
+ * Tag a guest booking email so the Resend webhook can recognize it on a
+ * delivery-failure event (suppressed/bounced/failed) and alert the team.
+ * `meeting_id` lets the webhook resolve the originating entity. Resend tag
+ * values are constrained to letters/numbers/underscores/dashes — the
+ * category slugs and UUID meeting ids used here satisfy that.
+ */
+function bookingEmailTags(category: string, meetingId?: string): EmailTag[] {
+  const tags: EmailTag[] = [{ name: 'category', value: category }]
+  if (meetingId) tags.push({ name: 'meeting_id', value: meetingId })
+  return tags
+}
+
 // ---------------------------------------------------------------------------
 // Confirmation (sent to guest after successful reserve)
 // ---------------------------------------------------------------------------
@@ -33,6 +46,8 @@ export interface SendBookingConfirmationInput extends BookingConfirmationEmailIn
   guestEmail: string
   /** ICS attachment, or null if ICS generation failed. */
   icsAttachment: EmailAttachment | null
+  /** Originating meeting/assessment id, tagged so the webhook can resolve the entity. */
+  meetingId?: string
 }
 
 export async function sendBookingConfirmation(
@@ -50,6 +65,7 @@ export async function sendBookingConfirmation(
     subject: `Confirmed: ${input.meetingLabel} with ${BRAND_NAME}`,
     html,
     ...(attachments.length > 0 ? { attachments } : {}),
+    tags: bookingEmailTags('booking_confirmation', input.meetingId),
   })
 }
 
@@ -61,6 +77,8 @@ export interface SendBookingRescheduleInput extends BookingRescheduledEmailInput
   guestEmail: string
   /** ICS attachment with bumped SEQUENCE, or null if ICS generation failed. */
   icsAttachment: EmailAttachment | null
+  /** Originating meeting/assessment id, tagged so the webhook can resolve the entity. */
+  meetingId?: string
 }
 
 export async function sendBookingReschedule(
@@ -78,6 +96,7 @@ export async function sendBookingReschedule(
     subject: `Rescheduled: ${input.meetingLabel} with ${BRAND_NAME}`,
     html,
     ...(attachments.length > 0 ? { attachments } : {}),
+    tags: bookingEmailTags('booking_reschedule', input.meetingId),
   })
 }
 
@@ -89,6 +108,8 @@ export interface SendBookingCancellationInput extends BookingCancelledEmailInput
   guestEmail: string
   /** ICS CANCEL attachment, or null if ICS generation failed. */
   icsAttachment: EmailAttachment | null
+  /** Originating meeting/assessment id, tagged so the webhook can resolve the entity. */
+  meetingId?: string
 }
 
 export async function sendBookingCancellation(
@@ -106,6 +127,7 @@ export async function sendBookingCancellation(
     subject: `Cancelled: Assessment call with ${BRAND_NAME}`,
     html,
     ...(attachments.length > 0 ? { attachments } : {}),
+    tags: bookingEmailTags('booking_cancellation', input.meetingId),
   })
 }
 

--- a/src/lib/email/resend.ts
+++ b/src/lib/email/resend.ts
@@ -38,12 +38,25 @@ export interface EmailAttachment {
   content_type?: string
 }
 
+/**
+ * Resend email tag. Tag name + value must match Resend's charset
+ * (ASCII letters, numbers, underscores, dashes) — values like a
+ * `category` slug or a UUID `meeting_id` satisfy this. Tags are echoed
+ * back on webhook events, which is how the webhook handler recognizes
+ * transactional booking emails.
+ */
+export interface EmailTag {
+  name: string
+  value: string
+}
+
 export interface EmailPayload {
   to: string
   subject: string
   html: string
   reply_to?: string
   attachments?: EmailAttachment[]
+  tags?: EmailTag[]
 }
 
 export interface SendResult {
@@ -87,6 +100,10 @@ export async function sendEmail(
       content: a.content,
       ...(a.content_type ? { content_type: a.content_type } : {}),
     }))
+  }
+
+  if (payload.tags?.length) {
+    apiPayload.tags = payload.tags.map((t) => ({ name: t.name, value: t.value }))
   }
 
   const response = await fetch(RESEND_API_URL, {

--- a/src/lib/webhooks/booking-email-failure.ts
+++ b/src/lib/webhooks/booking-email-failure.ts
@@ -1,0 +1,125 @@
+/**
+ * Booking-email delivery-failure alerting from Resend webhooks.
+ *
+ * Transactional booking emails (confirmation / reschedule / cancellation) are
+ * sent with a `category` tag (booking_*) and a `meeting_id` tag. When Resend
+ * reports that one of them did NOT reach the guest — `email.suppressed`
+ * (recipient on the account suppression list), `email.bounced`,
+ * `email.complained`, or `email.failed` — this records a booking alert so the
+ * team finds out and can contact the guest by hand. This is the asynchronous
+ * counterpart to the synchronous send-result check in the booking handlers:
+ * suppression is reported as a later webhook event, not at send time.
+ *
+ * Why a separate path from the outreach handler: booking emails go through the
+ * plain send path and have no `outreach_events` 'sent' row, so the outreach
+ * attribution join cannot see them. The originating entity is instead resolved
+ * from the `meeting_id` tag.
+ */
+
+import { recordBookingError } from '../booking/alerts'
+import { getMeeting } from '../db/meetings'
+import { ORG_ID } from '../constants'
+import type { ResendWebhookPayload } from './resend-handler'
+
+/** Resend event types that mean the guest did not receive the email. */
+const FAILURE_EVENT_TYPES = new Set([
+  'email.bounced',
+  'email.complained',
+  'email.suppressed',
+  'email.failed',
+])
+
+const BOOKING_CATEGORY_PREFIX = 'booking_'
+
+export interface ParsedBookingEmailFailure {
+  /** Resend event type, e.g. 'email.suppressed'. */
+  eventType: string
+  /** The booking_* category tag. */
+  category: string
+  /** Originating meeting/assessment id from the meeting_id tag, if present. */
+  meetingId: string | null
+  /** Recipient address, if present. */
+  recipient: string | null
+  /** Human-readable failure reason from the event-specific detail block. */
+  reason: string
+}
+
+function failureReason(data: ResendWebhookPayload['data']): string {
+  return (
+    data?.suppressed?.message ??
+    data?.bounce?.message ??
+    data?.failed?.reason ??
+    'no reason provided'
+  )
+}
+
+/**
+ * Pure detection: returns failure details when the payload is a delivery
+ * failure for a tagged booking email, else null. No I/O — unit-testable.
+ */
+export function parseBookingEmailFailure(
+  payload: ResendWebhookPayload
+): ParsedBookingEmailFailure | null {
+  if (!FAILURE_EVENT_TYPES.has(payload.type)) return null
+
+  const data = payload.data
+  const tags = data?.tags
+  const category = tags?.category
+  if (!category) return null
+  if (!category.startsWith(BOOKING_CATEGORY_PREFIX)) return null
+
+  return {
+    eventType: payload.type,
+    category,
+    meetingId: tags?.meeting_id ?? null,
+    recipient: data?.to?.[0] ?? null,
+    reason: failureReason(data),
+  }
+}
+
+export interface BookingEmailFailureResult {
+  handled: boolean
+  entityId?: string | null
+}
+
+/**
+ * Detect + record a booking-email delivery failure. Resolves the originating
+ * entity from the meeting_id tag (so the alert lands on the prospect's
+ * timeline) and routes to recordBookingError, which writes a context alert
+ * row and emails the team (rate-limited). Best-effort: never throws.
+ */
+export async function handleBookingEmailDeliveryFailure(
+  db: D1Database,
+  resendApiKey: string | undefined,
+  payload: ResendWebhookPayload
+): Promise<BookingEmailFailureResult> {
+  const failure = parseBookingEmailFailure(payload)
+  if (!failure) return { handled: false }
+
+  let entityId: string | undefined
+  if (failure.meetingId) {
+    try {
+      const meeting = await getMeeting(db, ORG_ID, failure.meetingId)
+      entityId = meeting?.entity_id
+    } catch (err) {
+      console.error('[webhook/resend] booking-failure: meeting lookup failed:', err)
+    }
+  }
+
+  const recipient = failure.recipient ?? 'unknown recipient'
+  const message =
+    `Booking ${failure.category} email to ${recipient} was not delivered ` +
+    `(${failure.eventType}): ${failure.reason}`
+
+  try {
+    await recordBookingError(db, resendApiKey, 'guest_email_delivery_failed', {
+      entityId,
+      assessmentId: failure.meetingId ?? undefined,
+      message,
+    })
+  } catch (err) {
+    console.error('[webhook/resend] booking-failure: recordBookingError failed:', err)
+  }
+
+  return { handled: true, entityId: entityId ?? null }
+}

--- a/src/lib/webhooks/resend-handler.ts
+++ b/src/lib/webhooks/resend-handler.ts
@@ -26,6 +26,14 @@ export interface ResendWebhookPayload {
     to?: string[]
     from?: string
     subject?: string
+    /** Tags echoed from the send, flattened to an object by Resend. */
+    tags?: Record<string, string>
+    /** Present on email.bounced. */
+    bounce?: { message?: string; type?: string; subType?: string }
+    /** Present on email.suppressed. */
+    suppressed?: { message?: string; type?: string }
+    /** Present on email.failed. */
+    failed?: { reason?: string }
     [key: string]: unknown
   }
   [key: string]: unknown

--- a/src/pages/api/booking/confirmation-emails.ts
+++ b/src/pages/api/booking/confirmation-emails.ts
@@ -33,6 +33,7 @@ export interface ConfirmationEmailInput {
 export interface ConfirmationEmailDbResult {
   scheduleId: string
   entityId: string
+  meetingId: string
   intakeLines: string[]
 }
 
@@ -91,7 +92,7 @@ async function alertGuestEmailFailure(
 export async function sendConfirmationEmails(args: SendConfirmationArgs): Promise<void> {
   const { input, dbResult, googleMeetUrl, manageUrl } = args
   const { name, email, businessName, slotStartUtc, guestTimezone } = input
-  const { scheduleId, intakeLines, entityId } = dbResult
+  const { scheduleId, intakeLines, entityId, meetingId } = dbResult
 
   const displayTz = guestTimezone || BOOKING_CONFIG.consultant.timezone
   const slotLabel = formatSlotLabelLong(slotStartUtc, displayTz)
@@ -108,6 +109,7 @@ export async function sendConfirmationEmails(args: SendConfirmationArgs): Promis
       meetingLabel: BOOKING_CONFIG.meeting_label,
       guestEmail: email,
       icsAttachment,
+      meetingId,
     })
     if (!guestResult.success) {
       console.error('[api/booking/reserve] Confirmation email NOT sent:', guestResult.error)

--- a/src/pages/api/booking/manage/[token]/cancel.ts
+++ b/src/pages/api/booking/manage/[token]/cancel.ts
@@ -137,6 +137,7 @@ async function sendCancellationEmails(
       slotLabel,
       rebookUrl: 'https://smd.services/book',
       icsAttachment,
+      meetingId: schedule.assessment_id,
     })
     if (!guestResult.success) {
       console.error('[api/booking/manage/cancel] Cancellation email NOT sent:', guestResult.error)

--- a/src/pages/api/booking/manage/[token]/reschedule.ts
+++ b/src/pages/api/booking/manage/[token]/reschedule.ts
@@ -210,6 +210,7 @@ async function sendRescheduleEmails(
       manageUrl,
       meetingLabel: BOOKING_CONFIG.meeting_label,
       icsAttachment,
+      meetingId: schedule.assessment_id,
     })
     if (!guestResult.success) {
       console.error('[api/booking/manage/reschedule] Reschedule email NOT sent:', guestResult.error)

--- a/src/pages/api/webhooks/resend.ts
+++ b/src/pages/api/webhooks/resend.ts
@@ -1,6 +1,7 @@
 import type { APIContext, APIRoute } from 'astro'
 import { env } from 'cloudflare:workers'
 import { handleResendEvent, type ResendWebhookPayload } from '../../../lib/webhooks/resend-handler'
+import { handleBookingEmailDeliveryFailure } from '../../../lib/webhooks/booking-email-failure'
 
 /**
  * POST /api/webhooks/resend
@@ -112,12 +113,20 @@ async function handlePost({ request }: APIContext): Promise<Response> {
       payload,
       fallbackOrgId: DEFAULT_ORG_ID,
     })
+    // Independently, alert the team if this event is a delivery failure for a
+    // transactional booking email (suppressed/bounced/failed). Best-effort.
+    const bookingFailure = await handleBookingEmailDeliveryFailure(
+      env.DB,
+      env.RESEND_API_KEY,
+      payload
+    )
     return new Response(
       JSON.stringify({
         ok: true,
         recorded: result.recorded,
         ...(result.reason ? { reason: result.reason } : {}),
         ...(result.eventType ? { event_type: result.eventType } : {}),
+        ...(bookingFailure.handled ? { booking_alert: true } : {}),
       }),
       { status: 200, headers: { 'Content-Type': 'application/json' } }
     )

--- a/tests/resend-webhook.test.ts
+++ b/tests/resend-webhook.test.ts
@@ -23,6 +23,7 @@ import { env as testEnv } from 'cloudflare:workers'
 
 import { POST } from '../src/pages/api/webhooks/resend'
 import { recordEvent } from '../src/lib/db/outreach-events'
+import { ORG_ID as SMD_ORG_ID } from '../src/lib/constants'
 
 const migrationsDir = resolve(process.cwd(), 'migrations')
 
@@ -252,5 +253,61 @@ describe('POST /api/webhooks/resend', () => {
     })
     const res = await callRoute(req)
     expect(res.status).toBe(200)
+  })
+
+  it('records a booking alert on a suppressed booking email, resolving the entity', async () => {
+    // The booking-failure path uses the real SMD ORG_ID constant (not the
+    // test-local org), so seed the org + entity + meeting under it.
+    // The SMD org may already be seeded by migrations; tolerate either.
+    await db
+      .prepare(
+        `INSERT OR IGNORE INTO organizations (id, name, slug, created_at, updated_at)
+         VALUES (?, 'SMD', 'smd-services', datetime('now'), datetime('now'))`
+      )
+      .bind(SMD_ORG_ID)
+      .run()
+    await db
+      .prepare(
+        `INSERT INTO entities (id, org_id, name, slug, stage, stage_changed_at, created_at, updated_at)
+         VALUES ('ent-booking-1', ?, 'Prospect Biz', 'prospect-biz', 'meetings', datetime('now'), datetime('now'), datetime('now'))`
+      )
+      .bind(SMD_ORG_ID)
+      .run()
+    await db
+      .prepare(
+        `INSERT INTO meetings (id, org_id, entity_id, meeting_type, status, created_at)
+         VALUES ('mtg-booking-1', ?, 'ent-booking-1', 'assessment', 'scheduled', datetime('now'))`
+      )
+      .bind(SMD_ORG_ID)
+      .run()
+
+    const body = JSON.stringify({
+      type: 'email.suppressed',
+      data: {
+        email_id: 'm-supp-1',
+        to: ['scott@smd.services'],
+        subject: 'Confirmed: 30-minute intro call with SMD Services',
+        tags: { category: 'booking_confirmation', meeting_id: 'mtg-booking-1' },
+        suppressed: {
+          message: 'Recipient is on the suppression list',
+          type: 'OnAccountSuppressionList',
+        },
+      },
+    })
+
+    const res = await callRoute(makeRequest({ body }))
+    expect(res.status).toBe(200)
+    const json = await res.json<{ booking_alert?: boolean }>()
+    expect(json.booking_alert).toBe(true)
+
+    const row = await db
+      .prepare(
+        `SELECT entity_id, content, json_extract(metadata, '$.kind') AS kind
+         FROM context WHERE entity_id = 'ent-booking-1' AND type = 'alert'`
+      )
+      .first<{ entity_id: string; content: string; kind: string }>()
+    expect(row).toBeTruthy()
+    expect(row?.kind).toBe('guest_email_delivery_failed')
+    expect(row?.content).toContain('scott@smd.services')
   })
 })

--- a/tests/webhooks/booking-email-failure.test.ts
+++ b/tests/webhooks/booking-email-failure.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { parseBookingEmailFailure } from '../../src/lib/webhooks/booking-email-failure'
+import type { ResendWebhookPayload } from '../../src/lib/webhooks/resend-handler'
+
+/**
+ * Unit coverage for the pure booking-email failure detector + a structural
+ * guard that the booking-email wrappers tag their sends (so the webhook can
+ * recognize them). The DB-touching orchestration is exercised end-to-end in
+ * tests/resend-webhook.test.ts.
+ */
+
+describe('parseBookingEmailFailure', () => {
+  it('returns null for a non-failure event', () => {
+    const payload: ResendWebhookPayload = {
+      type: 'email.delivered',
+      data: { tags: { category: 'booking_confirmation' } },
+    }
+    expect(parseBookingEmailFailure(payload)).toBeNull()
+  })
+
+  it('returns null for a failure event whose category is not a booking email', () => {
+    const payload: ResendWebhookPayload = {
+      type: 'email.suppressed',
+      data: { tags: { category: 'outreach' } },
+    }
+    expect(parseBookingEmailFailure(payload)).toBeNull()
+  })
+
+  it('returns null for a failure event with no tags', () => {
+    const payload: ResendWebhookPayload = { type: 'email.bounced', data: {} }
+    expect(parseBookingEmailFailure(payload)).toBeNull()
+  })
+
+  it('parses a suppressed booking confirmation, preferring suppressed.message', () => {
+    const payload: ResendWebhookPayload = {
+      type: 'email.suppressed',
+      data: {
+        to: ['scott@smd.services'],
+        tags: { category: 'booking_confirmation', meeting_id: 'mtg-1' },
+        suppressed: { message: 'on the suppression list', type: 'OnAccountSuppressionList' },
+      },
+    }
+    expect(parseBookingEmailFailure(payload)).toMatchObject({
+      eventType: 'email.suppressed',
+      category: 'booking_confirmation',
+      meetingId: 'mtg-1',
+      recipient: 'scott@smd.services',
+      reason: 'on the suppression list',
+    })
+  })
+
+  it('parses a bounced booking reschedule, using bounce.message', () => {
+    const payload: ResendWebhookPayload = {
+      type: 'email.bounced',
+      data: {
+        to: ['a@b.com'],
+        tags: { category: 'booking_reschedule', meeting_id: 'mtg-2' },
+        bounce: { message: 'mailbox does not exist', type: 'Permanent' },
+      },
+    }
+    expect(parseBookingEmailFailure(payload)).toMatchObject({
+      category: 'booking_reschedule',
+      meetingId: 'mtg-2',
+      reason: 'mailbox does not exist',
+    })
+  })
+
+  it('falls back to a default reason and null meetingId when detail is absent', () => {
+    const payload: ResendWebhookPayload = {
+      type: 'email.failed',
+      data: { tags: { category: 'booking_cancellation' } },
+    }
+    const parsed = parseBookingEmailFailure(payload)
+    expect(parsed?.reason).toBe('no reason provided')
+    expect(parsed?.meetingId).toBeNull()
+    expect(parsed?.recipient).toBeNull()
+  })
+})
+
+describe('booking-email wrappers tag their sends', () => {
+  const src = readFileSync(resolve('src/lib/email/booking-emails.ts'), 'utf-8')
+
+  it('tags confirmation, reschedule, and cancellation with a booking category', () => {
+    expect(src).toContain("'booking_confirmation'")
+    expect(src).toContain("'booking_reschedule'")
+    expect(src).toContain("'booking_cancellation'")
+  })
+
+  it('includes a meeting_id tag so the webhook can resolve the entity', () => {
+    expect(src).toContain("name: 'meeting_id'")
+  })
+})


### PR DESCRIPTION
Closes #1566. The durable counterpart to #1565.

## Why

#1565 made the booking handlers check the **synchronous** send result. But the failure that actually bit us — `scott@smd.services` on Resend's suppression list — is **asynchronous**: the send API returns `200`, and the address is marked `suppressed` as a *later* webhook event. The sync check can't see it. This PR catches it.

## What

1. **Tag guest booking emails.** Confirmation / reschedule / cancellation sends now carry a `category` tag (`booking_confirmation` / `booking_reschedule` / `booking_cancellation`) and a `meeting_id` tag. Adds `tags` support to `sendEmail`/`EmailPayload`.
2. **Alert on delivery failure.** A new webhook path detects `email.suppressed` / `email.bounced` / `email.complained` / `email.failed` for a tagged booking email, resolves the originating entity from the `meeting_id` tag (`getMeeting`), and routes to `recordBookingError('guest_email_delivery_failed')` — an alert row on the **prospect's entity timeline** plus a rate-limited team email.

This runs independently of the existing outreach-attribution handler, which can't see booking emails (they go through the plain send path and have no `outreach_events` 'sent' row).

## ⚠️ Required operational step (not code)

For these alerts to fire in production, the **Resend dashboard webhook must be subscribed to `email.suppressed` and `email.failed`** (and `email.bounced` / `email.complained` if not already). Webhooks → the endpoint → enable those event types. The signature verification + handler are already in place.

Tag values are constrained to letters/numbers/underscores/dashes; the category slugs and UUID meeting ids used here satisfy that.

## Tests

- `tests/webhooks/booking-email-failure.test.ts` — pure `parseBookingEmailFailure` unit coverage + a structural guard that the wrappers tag their sends.
- `tests/resend-webhook.test.ts` — end-to-end signed-webhook test: a suppressed `booking_confirmation` event produces an alert row scoped to the resolved entity.
- `npm run verify` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)