### PR TITLE
fix(marketing): frame the mapped industry pack as a starting point, not a fixed mold

### DIFF
--- a/src/pages/industries.astro
+++ b/src/pages/industries.astro
@@ -32,7 +32,7 @@ const industries = [
 
 <Base
   title="Industries | SMD Services"
-  description="The Operator is built around how your business runs, not around an industry. For these, we have already mapped the seat it fills, the work it takes on, and the line it will not cross."
+  description="The Operator is built around how your business runs, not around an industry. For these, we have already mapped where it fits: a starting point to react to and shape, not the only way it can run."
 >
   <Nav />
   <main id="main" role="main">
@@ -54,8 +54,9 @@ const industries = [
         >
           The Operator is not built for an industry. It is built for your business. But the work
           that falls between your people and your systems takes a recognizable shape in each trade.
-          For these, we have already mapped the seat the Operator fills, the work it takes on, and
-          the line it will not cross. Find yours.
+          For these, we have already mapped where the Operator fits: the seat it fills, the work it
+          takes on, and the line it will not cross. That is a starting point to react to and shape
+          together, not the only way it can run. Find yours.
         </p>
       </div>
     </section>

--- a/src/pages/operator.astro
+++ b/src/pages/operator.astro
@@ -384,8 +384,10 @@ const industries = [
         <p
           class="mb-12 max-w-2xl text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]"
         >
-          The role is built around your operation. For these, we have already mapped the seat the
-          Operator fills, the work it takes on, and the line it does not cross. Find yours.
+          The role is built around your operation. For these, we have already mapped where the
+          Operator fits: the seat it fills, the work it takes on, and the line it does not cross.
+          That is a starting point to react to and shape together, not the only way it can run. Find
+          yours.
         </p>
 
         <div


### PR DESCRIPTION
## Summary
- The Industries copy read as if a mapped vertical was the only way the Operator could work. Reframed so it lands the intended nuance: we arrive with an informed read of the seat, the work, and the line, but it is a starting point to react to and shape together, not the only way it can run.
- Touches both surfaces that carry this copy: the `industries.astro` hero + meta description, and the `operator.astro` Industries section.
- Reinforces the collaborative-positioning law (CLAUDE.md 2 "collaborative, not diagnostic" / 7 "no claim to know the prospect's business"). No em dashes, no fenced terms.

## Test plan
- [x] `npm run verify` passes
- [x] `tests/forbidden-strings.test.ts` green (em-dash + style-marker guards)
- [ ] Visual check on the Industries hero and the Operator-page Industries section

🤖 Generated with [Claude Code](https://claude.com/claude-code)