### PR TITLE
chore: remove verified dead exports

### DIFF
--- a/src/lib/db/entities.ts
+++ b/src/lib/db/entities.ts
@@ -62,7 +62,6 @@ export type EntityTier = 'hot' | 'warm' | 'cool' | 'cold'
 export type EntityVertical = 'home_services' | 'professional_services' | 'contractor_trades' | 'retail_salon' | 'restaurant_food' | 'other'
 
 type StageLabel = { value: EntityStage; label: string }
-type TierLabel = { value: EntityTier; label: string }
 type VerticalLabel = { value: EntityVertical; label: string }
 // prettier-ignore
 export const ENTITY_STAGES: StageLabel[] = [
@@ -70,11 +69,6 @@ export const ENTITY_STAGES: StageLabel[] = [
   { value: 'meetings', label: 'Meetings' }, { value: 'proposing', label: 'Proposing' },
   { value: 'engaged', label: 'Engaged' }, { value: 'delivered', label: 'Delivered' },
   { value: 'ongoing', label: 'Ongoing' }, { value: 'lost', label: 'Lost' },
-]
-// prettier-ignore
-export const ENTITY_TIERS: TierLabel[] = [
-  { value: 'hot', label: 'Hot' }, { value: 'warm', label: 'Warm' },
-  { value: 'cool', label: 'Cool' }, { value: 'cold', label: 'Cold' },
 ]
 // prettier-ignore
 export const ENTITY_VERTICALS: VerticalLabel[] = [

--- a/src/lib/db/meetings.ts
+++ b/src/lib/db/meetings.ts
@@ -43,14 +43,6 @@ export interface Meeting {
 
 export type MeetingStatus = 'scheduled' | 'completed' | 'disqualified' | 'converted' | 'cancelled'
 
-export const MEETING_STATUSES: { value: MeetingStatus; label: string }[] = [
-  { value: 'scheduled', label: 'Scheduled' },
-  { value: 'completed', label: 'Completed' },
-  { value: 'cancelled', label: 'Cancelled' },
-  { value: 'disqualified', label: 'Disqualified' },
-  { value: 'converted', label: 'Converted' },
-]
-
 /**
  * Valid status transitions enforced at the application layer. Mirrors the
  * legacy assessment state machine; the CHECK constraint on meetings.status

--- a/src/lib/db/services.ts
+++ b/src/lib/db/services.ts
@@ -53,13 +53,6 @@ export type ServiceType = 'consulting' | 'operator'
 export type ServiceCadence = 'one_time' | 'recurring'
 export type ServiceStatus = 'proposed' | 'active' | 'completed' | 'churned'
 
-export const SERVICE_STATUSES: { value: ServiceStatus; label: string }[] = [
-  { value: 'proposed', label: 'Proposed' },
-  { value: 'active', label: 'Active' },
-  { value: 'completed', label: 'Completed' },
-  { value: 'churned', label: 'Churned' },
-]
-
 /**
  * Commercial-lifecycle transitions — deliberately coarser than the delivery
  * lifecycle on the child (engagement/subscription). `engagements.status` and

--- a/src/lib/sow/store.ts
+++ b/src/lib/sow/store.ts
@@ -133,15 +133,6 @@ export interface OutboxJob {
   updated_at: string
 }
 
-export interface CreateOutboxJobData {
-  org_id: string
-  signature_request_id: string
-  type: OutboxJobType
-  dedupe_key: string
-  payload_json: string
-  available_at: string
-}
-
 export async function getSOWRevision(
   db: D1Database,
   orgId: string,
@@ -408,44 +399,6 @@ export async function getOpenSignatureRequestForQuote(
       .bind(orgId, quoteId)
       .first<SignatureRequest>()) ?? null
   )
-}
-
-export async function createOutboxJob(
-  db: D1Database,
-  data: CreateOutboxJobData
-): Promise<OutboxJob> {
-  const id = crypto.randomUUID()
-  const now = new Date().toISOString()
-
-  await db
-    .prepare(
-      `INSERT INTO outbox_jobs (
-        id, org_id, signature_request_id, type, status, dedupe_key,
-        payload_json, available_at, created_at, updated_at
-      ) VALUES (?, ?, ?, ?, 'pending', ?, ?, ?, ?, ?)`
-    )
-    .bind(
-      id,
-      data.org_id,
-      data.signature_request_id,
-      data.type,
-      data.dedupe_key,
-      data.payload_json,
-      data.available_at,
-      now,
-      now
-    )
-    .run()
-
-  const job = await db
-    .prepare('SELECT * FROM outbox_jobs WHERE id = ? AND org_id = ?')
-    .bind(id, data.org_id)
-    .first<OutboxJob>()
-
-  if (!job) {
-    throw new Error('Failed to retrieve created outbox job')
-  }
-  return job
 }
 
 export async function listOutboxJobsForSignatureRequest(


### PR DESCRIPTION
## What

Removes four exports confirmed to have **zero references** anywhere in `src/`, `tests/`, or `workers/` (finding Code Quality #3, `docs/reviews/code-review-2026-06-30.md`).

The review's original 8-item list included 5 that **are** consumed by tests (`createEntity`, `getDocument`, `distinctAuditActions`, `ASSESSMENT_OPENING_MESSAGE`, `INVOICE_STATUSES`) — the /critique pass caught that and those were kept. Only the genuinely-dead four are removed here:

- `ENTITY_TIERS` (`db/entities.ts`) + its now-orphaned private `TierLabel` type
- `MEETING_STATUSES` (`db/meetings.ts`)
- `SERVICE_STATUSES` (`db/services.ts`)
- `createOutboxJob` (`sow/store.ts`) + its now-orphaned `CreateOutboxJobData` interface — outbox rows are inserted via raw SQL in `service-finalize.ts`, so this helper was never wired in

`EntityTier` and `OutboxJobType` are used elsewhere and retained.

## Deferred

The recurrence gate (`knip` in CI) is deferred to its own change: it needs a committed baseline + entry globs (`tests/**`, `workers/*`) since the codebase has ~190 exported-but-internal-only symbols that would otherwise flood the gate.

## Verify

`npm run verify` green (0 errors; no new warnings introduced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)