### PR TITLE
refactor(api): canonicalize jsonResponse to the shared helper + lint guard

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -160,6 +160,26 @@ export default tseslint.config(
     files: DEFAULT_EXPORT_ALLOW_PATTERNS,
     rules: { 'import-x/no-default-export': 'off' },
   },
+  // The API JSON helper must be imported from src/lib/api/helpers, never
+  // re-declared locally. Local copies drifted — several inverted the canonical
+  // (status, data) arg order, a latent copy-paste bug hazard (2026-06-30 code
+  // review). Scoped to src/ so the workers/* subprojects (separate tsconfig,
+  // cannot import the shared helper) are exempt; helpers.ts itself is ignored.
+  {
+    files: ['src/**/*.ts', 'src/**/*.tsx'],
+    ignores: ['src/lib/api/helpers.ts'],
+    rules: {
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector:
+            "FunctionDeclaration[id.name='jsonResponse'], VariableDeclarator[id.name='jsonResponse']",
+          message:
+            'Import jsonResponse from src/lib/api/helpers instead of re-declaring it — local copies drift (several inverted the canonical (status, data) arg order).',
+        },
+      ],
+    },
+  },
   // astro-eslint-parser does not support projectService; type-aware rules that
   // require a full TS program crash or produce false positives in .astro files.
   // Structural and type-safety rules still apply.

--- a/src/lib/operator/mcp/mcp-handler.ts
+++ b/src/lib/operator/mcp/mcp-handler.ts
@@ -17,6 +17,7 @@
  * for stateless servers).
  */
 
+import { jsonResponse } from '../../api/helpers'
 import { z } from 'zod'
 import { getTool, listToolDescriptors, type McpToolContext, type McpToolResult } from './tools'
 
@@ -49,18 +50,11 @@ const JSON_RPC = {
 } as const
 
 function rpcResult(id: JsonRpcRequest['id'], result: unknown): Response {
-  return jsonResponse({ jsonrpc: '2.0', id: id ?? null, result }, 200)
+  return jsonResponse(200, { jsonrpc: '2.0', id: id ?? null, result })
 }
 
 function rpcError(id: JsonRpcRequest['id'], code: number, message: string): Response {
-  return jsonResponse({ jsonrpc: '2.0', id: id ?? null, error: { code, message } }, 200)
-}
-
-function jsonResponse(body: unknown, status: number): Response {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: { 'Content-Type': 'application/json' },
-  })
+  return jsonResponse(200, { jsonrpc: '2.0', id: id ?? null, error: { code, message } })
 }
 
 /**

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,3 +1,4 @@
+import { jsonResponse } from './lib/api/helpers'
 import { defineMiddleware, sequence } from 'astro:middleware'
 import type { APIContext, MiddlewareNext } from 'astro'
 import { clerkMiddleware } from '@clerk/astro/server'
@@ -222,24 +223,17 @@ function handleLegacyRedirects(
   return redirectRetiredMarketingPaths(context, pathname)
 }
 
-function jsonResponse(body: object, status: number): Response {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: { 'Content-Type': 'application/json' },
-  })
-}
-
 function enforceAdminAuth(context: APIContext, isAdminApiRoute: boolean): Response | null {
   const auth = context.locals.auth()
   if (!auth.userId) {
     return isAdminApiRoute
-      ? jsonResponse({ error: 'Unauthorized' }, 401)
+      ? jsonResponse(401, { error: 'Unauthorized' })
       : context.redirect('/auth/sign-in')
   }
   // Clerk user signed in but no admin row in D1 (or role != 'admin').
   // Treat as forbidden — they're authenticated but lack admin clearance.
   if (!context.locals.session || context.locals.session.role !== 'admin') {
-    return isAdminApiRoute ? jsonResponse({ error: 'Forbidden' }, 403) : context.redirect('/portal')
+    return isAdminApiRoute ? jsonResponse(403, { error: 'Forbidden' }) : context.redirect('/portal')
   }
   return null
 }
@@ -260,7 +254,7 @@ function enforcePortalAuth(context: APIContext, isPortalApiRoute: boolean): Resp
   if (context.locals.session?.role === 'client') return null
 
   return isPortalApiRoute
-    ? jsonResponse({ error: 'Unauthorized' }, 401)
+    ? jsonResponse(401, { error: 'Unauthorized' })
     : context.redirect('/auth/sign-in')
 }
 

--- a/src/pages/api/admin/assessments/[id]/live-notes.ts
+++ b/src/pages/api/admin/assessments/[id]/live-notes.ts
@@ -1,3 +1,4 @@
+import { jsonResponse } from '../../../../../lib/api/helpers'
 import type { APIRoute } from 'astro'
 import { getAssessment, updateAssessment } from '../../../../../lib/db/assessments'
 import { env } from 'cloudflare:workers'
@@ -43,11 +44,4 @@ export const PUT: APIRoute = async ({ request, locals, params }) => {
     console.error('[api/admin/assessments/[id]/live-notes] Error:', err)
     return jsonResponse(500, { error: 'Internal server error' })
   }
-}
-
-function jsonResponse(status: number, data: unknown): Response {
-  return new Response(JSON.stringify(data), {
-    status,
-    headers: { 'Content-Type': 'application/json' },
-  })
 }

--- a/src/pages/api/admin/enrichment/backfill.ts
+++ b/src/pages/api/admin/enrichment/backfill.ts
@@ -1,3 +1,4 @@
+import { jsonResponse } from '../../../../lib/api/helpers'
 import type { APIContext, APIRoute } from 'astro'
 import { dispatchEnrichmentWorkflow } from '../../../../lib/enrichment/dispatch'
 import { env } from 'cloudflare:workers'
@@ -119,10 +120,3 @@ async function handlePost({ request, locals }: APIContext): Promise<Response> {
 }
 
 export const POST: APIRoute = (ctx) => handlePost(ctx)
-
-function jsonResponse(status: number, body: unknown): Response {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: { 'Content-Type': 'application/json' },
-  })
-}

--- a/src/pages/api/admin/entities/[id]/context.ts
+++ b/src/pages/api/admin/entities/[id]/context.ts
@@ -1,3 +1,4 @@
+import { jsonResponse } from '../../../../../lib/api/helpers'
 import type { APIRoute } from 'astro'
 import { appendContext, listContext, type ContextType } from '../../../../../lib/db/context'
 import { getEntity } from '../../../../../lib/db/entities'
@@ -71,11 +72,4 @@ export const POST: APIRoute = async ({ params, request, locals, redirect }) => {
     console.error('[api/admin/entities/context] POST Error:', err)
     return redirect(`/admin/entities/${entityId}?error=server`, 302)
   }
-}
-
-function jsonResponse(status: number, data: unknown): Response {
-  return new Response(JSON.stringify(data), {
-    status,
-    headers: { 'Content-Type': 'application/json' },
-  })
 }

--- a/src/pages/api/admin/entities/[id]/meetings/[meetingId]/live-notes.ts
+++ b/src/pages/api/admin/entities/[id]/meetings/[meetingId]/live-notes.ts
@@ -1,3 +1,4 @@
+import { jsonResponse } from '../../../../../../../lib/api/helpers'
 import type { APIRoute } from 'astro'
 import { getMeeting, updateMeeting } from '../../../../../../../lib/db/meetings'
 import { env } from 'cloudflare:workers'
@@ -47,11 +48,4 @@ export const PUT: APIRoute = async ({ request, locals, params }) => {
     console.error('[api/admin/entities/[id]/meetings/[meetingId]/live-notes] Error:', err)
     return jsonResponse(500, { error: 'Internal server error' })
   }
-}
-
-function jsonResponse(status: number, data: unknown): Response {
-  return new Response(JSON.stringify(data), {
-    status,
-    headers: { 'Content-Type': 'application/json' },
-  })
 }

--- a/src/pages/api/admin/entities/[id]/send-booking-link.ts
+++ b/src/pages/api/admin/entities/[id]/send-booking-link.ts
@@ -1,3 +1,4 @@
+import { jsonResponse } from '../../../../../lib/api/helpers'
 import type { APIContext, APIRoute } from 'astro'
 import { getEntity, transitionStage } from '../../../../../lib/db/entities'
 import { createMeetingWithLegacyAssessment } from '../../../../../lib/db/meetings'
@@ -118,13 +119,6 @@ function buildMailtoUrl(params: { to: string | null; subject: string; body: stri
     body: params.body,
   })
   return `mailto:${encodeURIComponent(address)}?${query.toString()}`
-}
-
-function jsonResponse(status: number, data: unknown): Response {
-  return new Response(JSON.stringify(data), {
-    status,
-    headers: { 'Content-Type': 'application/json' },
-  })
 }
 
 async function parseRequestBody(request: Request): Promise<Record<string, unknown> | Response> {

--- a/src/pages/api/admin/entities/bulk.ts
+++ b/src/pages/api/admin/entities/bulk.ts
@@ -1,3 +1,4 @@
+import { jsonResponse } from '../../../../lib/api/helpers'
 import type { APIContext, APIRoute } from 'astro'
 import { env } from 'cloudflare:workers'
 import {
@@ -33,18 +34,18 @@ import { isLostReasonCode } from '../../../../lib/db/lost-reasons'
 async function handlePost({ request, locals }: APIContext): Promise<Response> {
   const session = locals.session
   if (!session || session.role !== 'admin') {
-    return jsonResponse({ error: 'Unauthorized' }, 401)
+    return jsonResponse(401, { error: 'Unauthorized' })
   }
 
   let body: unknown
   try {
     body = await request.json()
   } catch {
-    return jsonResponse({ error: 'Invalid JSON body' }, 400)
+    return jsonResponse(400, { error: 'Invalid JSON body' })
   }
 
   if (!body || typeof body !== 'object') {
-    return jsonResponse({ error: 'Invalid body' }, 400)
+    return jsonResponse(400, { error: 'Invalid body' })
   }
 
   const { ids, action, reason, reasonDetail } = body as {
@@ -55,15 +56,15 @@ async function handlePost({ request, locals }: APIContext): Promise<Response> {
   }
 
   if (!Array.isArray(ids) || ids.length === 0) {
-    return jsonResponse({ error: 'ids must be a non-empty array' }, 400)
+    return jsonResponse(400, { error: 'ids must be a non-empty array' })
   }
   if (!ids.every((id) => typeof id === 'string' && id.length > 0)) {
-    return jsonResponse({ error: 'ids must be strings' }, 400)
+    return jsonResponse(400, { error: 'ids must be strings' })
   }
   // Cap batch size to keep the request bounded. Picked to match a full
   // screen of signals without requiring pagination scroll gymnastics.
   if (ids.length > 200) {
-    return jsonResponse({ error: 'batch size capped at 200 ids' }, 400)
+    return jsonResponse(400, { error: 'batch size capped at 200 ids' })
   }
 
   const stringIds = ids as string[]
@@ -77,11 +78,11 @@ async function handlePost({ request, locals }: APIContext): Promise<Response> {
       return handleExport(session.orgId, stringIds)
     }
 
-    return jsonResponse({ error: `Unknown action: ${String(action)}` }, 400)
+    return jsonResponse(400, { error: `Unknown action: ${String(action)}` })
   } catch (err) {
     console.error('[api/admin/entities/bulk] Error:', err)
     const message = err instanceof Error ? err.message : 'server error'
-    return jsonResponse({ error: message }, 500)
+    return jsonResponse(500, { error: message })
   }
 }
 
@@ -92,13 +93,10 @@ async function handleDismiss(
   reasonDetail: unknown
 ): Promise<Response> {
   if (!isLostReasonCode(reason)) {
-    return jsonResponse(
-      {
-        error:
-          'reason must be one of the canonical lost-reason values (see src/lib/db/lost-reasons.ts)',
-      },
-      400
-    )
+    return jsonResponse(400, {
+      error:
+        'reason must be one of the canonical lost-reason values (see src/lib/db/lost-reasons.ts)',
+    })
   }
   const detail =
     typeof reasonDetail === 'string' && reasonDetail.trim() ? reasonDetail.trim() : null
@@ -107,7 +105,7 @@ async function handleDismiss(
     reason,
     detail,
   })
-  return jsonResponse(result, result.failed.length === 0 ? 200 : 207)
+  return jsonResponse(result.failed.length === 0 ? 200 : 207, result)
 }
 
 async function handleExport(orgId: string, ids: string[]): Promise<Response> {
@@ -124,13 +122,6 @@ async function handleExport(orgId: string, ids: string[]): Promise<Response> {
 }
 
 export const POST: APIRoute = (ctx) => handlePost(ctx)
-
-function jsonResponse(body: unknown, status: number): Response {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: { 'Content-Type': 'application/json' },
-  })
-}
 
 function csvEscape(value: string | null | undefined): string {
   if (value == null) return ''

--- a/src/pages/api/admin/operator/costs/anomalies/[action].ts
+++ b/src/pages/api/admin/operator/costs/anomalies/[action].ts
@@ -14,6 +14,7 @@
  * explicit role check here for defense in depth).
  */
 
+import { jsonResponse } from '../../../../../../lib/api/helpers'
 import type { APIContext, APIRoute } from 'astro'
 import { env } from 'cloudflare:workers'
 import { acknowledgeAlert, snoozeAlert } from '../../../../../../lib/admin/cost-anomaly'
@@ -25,13 +26,6 @@ interface AlertIdentity {
   entity_id: string
   alert_date: string
   driver: string
-}
-
-function jsonResponse(body: unknown, status: number): Response {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: { 'Content-Type': 'application/json' },
-  })
 }
 
 function parseIdentity(body: unknown): AlertIdentity | { error: string } {
@@ -57,24 +51,24 @@ function parseIdentity(body: unknown): AlertIdentity | { error: string } {
 async function handlePost(ctx: APIContext): Promise<Response> {
   const session = ctx.locals.session
   if (!session || session.role !== 'admin') {
-    return jsonResponse({ error: 'Unauthorized' }, 401)
+    return jsonResponse(401, { error: 'Unauthorized' })
   }
 
   const action = ctx.params.action
   if (action !== 'snooze' && action !== 'acknowledge') {
-    return jsonResponse({ error: `unknown action: ${action}` }, 404)
+    return jsonResponse(404, { error: `unknown action: ${action}` })
   }
 
   let body: unknown
   try {
     body = await ctx.request.json()
   } catch {
-    return jsonResponse({ error: 'invalid JSON body' }, 400)
+    return jsonResponse(400, { error: 'invalid JSON body' })
   }
 
   const parsed = parseIdentity(body)
   if ('error' in parsed) {
-    return jsonResponse({ error: parsed.error }, 400)
+    return jsonResponse(400, { error: parsed.error })
   }
 
   if (action === 'snooze') {
@@ -85,17 +79,16 @@ async function handlePost(ctx: APIContext): Promise<Response> {
     } else if (typeof snoozed_until === 'string' && ISO_RE.test(snoozed_until)) {
       snoozedIso = snoozed_until
     } else {
-      return jsonResponse(
-        { error: 'snoozed_until must be ISO 8601 UTC (e.g. 2026-05-30T00:00:00Z) or null' },
-        400
-      )
+      return jsonResponse(400, {
+        error: 'snoozed_until must be ISO 8601 UTC (e.g. 2026-05-30T00:00:00Z) or null',
+      })
     }
     await snoozeAlert(env.DB, parsed, snoozedIso)
-    return jsonResponse({ ok: true, action: 'snooze', snoozed_until: snoozedIso }, 200)
+    return jsonResponse(200, { ok: true, action: 'snooze', snoozed_until: snoozedIso })
   }
 
   await acknowledgeAlert(env.DB, parsed, session.userId)
-  return jsonResponse({ ok: true, action: 'acknowledge' }, 200)
+  return jsonResponse(200, { ok: true, action: 'acknowledge' })
 }
 
 export const POST: APIRoute = (ctx) => handlePost(ctx)

--- a/src/pages/api/admin/operator/costs/export.ts
+++ b/src/pages/api/admin/operator/costs/export.ts
@@ -16,6 +16,7 @@
  * 400 rather than silently widening the query.
  */
 
+import { jsonResponse } from '../../../../../lib/api/helpers'
 import type { APIContext, APIRoute } from 'astro'
 import { env } from 'cloudflare:workers'
 import {
@@ -30,35 +31,35 @@ const DATE_RE = /^\d{4}-\d{2}-\d{2}$/
 async function handleGet({ request, locals }: APIContext): Promise<Response> {
   const session = locals.session
   if (!session || session.role !== 'admin') {
-    return jsonResponse({ error: 'Unauthorized' }, 401)
+    return jsonResponse(401, { error: 'Unauthorized' })
   }
 
   const url = new URL(request.url)
   const customerSlug = url.searchParams.get('customer_slug')
   if (!customerSlug) {
-    return jsonResponse({ error: 'customer_slug query param is required' }, 400)
+    return jsonResponse(400, { error: 'customer_slug query param is required' })
   }
 
   const defaults = defaultWindow()
   const start = url.searchParams.get('start') ?? defaults.start
   const end = url.searchParams.get('end') ?? defaults.end
   if (!DATE_RE.test(start) || !DATE_RE.test(end)) {
-    return jsonResponse({ error: 'start and end must be YYYY-MM-DD' }, 400)
+    return jsonResponse(400, { error: 'start and end must be YYYY-MM-DD' })
   }
   if (start >= end) {
-    return jsonResponse({ error: 'start must be before end' }, 400)
+    return jsonResponse(400, { error: 'start must be before end' })
   }
 
   const customers = await listCostCustomers(env.DB)
   const customer = customers.find((c) => c.customer_slug === customerSlug)
   if (!customer) {
-    return jsonResponse({ error: 'customer not found' }, 404)
+    return jsonResponse(404, { error: 'customer not found' })
   }
   if (!customer.per_customer_d1_database_id) {
-    return jsonResponse({ error: 'customer has no per-customer D1 database configured' }, 409)
+    return jsonResponse(409, { error: 'customer has no per-customer D1 database configured' })
   }
   if (!env.CF_ACCOUNT_ID || !env.CF_D1_API_TOKEN) {
-    return jsonResponse({ error: 'CF_ACCOUNT_ID / CF_D1_API_TOKEN not configured' }, 503)
+    return jsonResponse(503, { error: 'CF_ACCOUNT_ID / CF_D1_API_TOKEN not configured' })
   }
 
   const result = await fetchCustomerCostRows(
@@ -68,7 +69,7 @@ async function handleGet({ request, locals }: APIContext): Promise<Response> {
     end
   )
   if (result.error) {
-    return jsonResponse({ error: result.error }, 502)
+    return jsonResponse(502, { error: result.error })
   }
 
   const csv = rowsToCsv(customerSlug, result.rows)
@@ -80,13 +81,6 @@ async function handleGet({ request, locals }: APIContext): Promise<Response> {
       'Content-Disposition': `attachment; filename="${filename}"`,
       'Cache-Control': 'no-store',
     },
-  })
-}
-
-function jsonResponse(body: unknown, status: number): Response {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: { 'Content-Type': 'application/json' },
   })
 }
 

--- a/src/pages/api/admin/operator/requests/[action].ts
+++ b/src/pages/api/admin/operator/requests/[action].ts
@@ -17,19 +17,13 @@
  * by middleware on /api/admin/* and re-checked here.
  */
 
+import { jsonResponse } from '../../../../../lib/api/helpers'
 import type { APIContext, APIRoute } from 'astro'
 import { env } from 'cloudflare:workers'
 import { updateChangeRequestStatus } from '../../../../../lib/portal/operator/change-request'
 import { actionToStatus } from '../../../../../lib/admin/change-request-inbox'
 
 const MAX_NOTE_LENGTH = 4000
-
-function jsonResponse(body: unknown, status: number): Response {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: { 'Content-Type': 'application/json' },
-  })
-}
 
 interface ParsedBody {
   id: number
@@ -54,23 +48,23 @@ function parseBody(body: unknown): ParsedBody | { error: string } {
 async function handlePost(ctx: APIContext): Promise<Response> {
   const session = ctx.locals.session
   if (!session || session.role !== 'admin') {
-    return jsonResponse({ error: 'Unauthorized' }, 401)
+    return jsonResponse(401, { error: 'Unauthorized' })
   }
 
   const status = actionToStatus(ctx.params.action ?? '')
   if (status === null) {
-    return jsonResponse({ error: `unknown action: ${ctx.params.action}` }, 404)
+    return jsonResponse(404, { error: `unknown action: ${ctx.params.action}` })
   }
 
   let body: unknown
   try {
     body = await ctx.request.json()
   } catch {
-    return jsonResponse({ error: 'invalid JSON body' }, 400)
+    return jsonResponse(400, { error: 'invalid JSON body' })
   }
 
   const parsed = parseBody(body)
-  if ('error' in parsed) return jsonResponse({ error: parsed.error }, 400)
+  if ('error' in parsed) return jsonResponse(400, { error: parsed.error })
 
   const updated = await updateChangeRequestStatus(env.DB, {
     id: parsed.id,
@@ -78,8 +72,8 @@ async function handlePost(ctx: APIContext): Promise<Response> {
     resolved_by_email: session.email,
     resolution_note: parsed.resolution_note,
   })
-  if (!updated) return jsonResponse({ error: 'change request not found' }, 404)
-  return jsonResponse({ ok: true, id: parsed.id, status }, 200)
+  if (!updated) return jsonResponse(404, { error: 'change request not found' })
+  return jsonResponse(200, { ok: true, id: parsed.id, status })
 }
 
 export const POST: APIRoute = (ctx) => handlePost(ctx)

--- a/src/pages/api/booking/manage/[token].ts
+++ b/src/pages/api/booking/manage/[token].ts
@@ -1,3 +1,4 @@
+import { jsonResponse } from '../../../../lib/api/helpers'
 import type { APIRoute } from 'astro'
 import { hashManageToken } from '../../../../lib/booking/tokens'
 import { getScheduleByManageToken, isManageTokenExpired } from '../../../../lib/booking/schedule'
@@ -66,11 +67,4 @@ export const GET: APIRoute = async ({ params }) => {
     console.error('[api/booking/manage] Error:', err)
     return jsonResponse(500, { error: 'Internal server error' })
   }
-}
-
-function jsonResponse(status: number, data: unknown): Response {
-  return new Response(JSON.stringify(data), {
-    status,
-    headers: { 'Content-Type': 'application/json' },
-  })
 }

--- a/src/pages/api/booking/manage/[token]/cancel.ts
+++ b/src/pages/api/booking/manage/[token]/cancel.ts
@@ -1,3 +1,4 @@
+import { jsonResponse } from '../../../../../lib/api/helpers'
 import type { APIContext, APIRoute } from 'astro'
 import { ORG_ID } from '../../../../../lib/constants'
 import { hashManageToken } from '../../../../../lib/booking/tokens'
@@ -43,13 +44,6 @@ function escapeHtml(str: string): string {
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;')
-}
-
-function jsonResponse(status: number, data: unknown): Response {
-  return new Response(JSON.stringify(data), {
-    status,
-    headers: { 'Content-Type': 'application/json' },
-  })
 }
 
 type Schedule = NonNullable<Awaited<ReturnType<typeof getScheduleByManageToken>>>

--- a/src/pages/api/booking/manage/[token]/reschedule.ts
+++ b/src/pages/api/booking/manage/[token]/reschedule.ts
@@ -1,3 +1,4 @@
+import { jsonResponse } from '../../../../../lib/api/helpers'
 import type { APIContext, APIRoute } from 'astro'
 import { ORG_ID } from '../../../../../lib/constants'
 import { hashManageToken, computeManageTokenExpiry } from '../../../../../lib/booking/tokens'
@@ -48,13 +49,6 @@ function escapeHtml(str: string): string {
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;')
-}
-
-function jsonResponse(status: number, data: unknown): Response {
-  return new Response(JSON.stringify(data), {
-    status,
-    headers: { 'Content-Type': 'application/json' },
-  })
 }
 
 type Schedule = NonNullable<Awaited<ReturnType<typeof getScheduleByManageToken>>>

--- a/src/pages/api/booking/slots.ts
+++ b/src/pages/api/booking/slots.ts
@@ -1,3 +1,4 @@
+import { jsonResponse } from '../../../lib/api/helpers'
 import type { APIRoute } from 'astro'
 import { ORG_ID } from '../../../lib/constants'
 import { BOOKING_CONFIG } from '../../../lib/booking/config'
@@ -156,11 +157,4 @@ function buildGoogleBusyFetcher(
       clearTimeout(timeout)
     }
   }
-}
-
-function jsonResponse(status: number, data: unknown): Response {
-  return new Response(JSON.stringify(data), {
-    status,
-    headers: { 'Content-Type': 'application/json' },
-  })
 }

--- a/src/pages/api/contact.ts
+++ b/src/pages/api/contact.ts
@@ -1,3 +1,4 @@
+import { jsonResponse } from '../../lib/api/helpers'
 import type { APIContext, APIRoute } from 'astro'
 import { sendEmail } from '../../lib/email/resend'
 import { rateLimitByIp } from '../../lib/booking/rate-limit'
@@ -38,13 +39,6 @@ function escapeHtml(str: string): string {
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;')
-}
-
-function jsonResponse(status: number, data: unknown): Response {
-  return new Response(JSON.stringify(data), {
-    status,
-    headers: { 'Content-Type': 'application/json' },
-  })
 }
 
 function validateContactBody(body: Record<string, unknown>):

--- a/src/pages/api/internal/heartbeat.ts
+++ b/src/pages/api/internal/heartbeat.ts
@@ -32,6 +32,7 @@
  * authoritative red signal.
  */
 
+import { jsonResponse } from '../../../lib/api/helpers'
 import type { APIRoute } from 'astro'
 import { env } from 'cloudflare:workers'
 import { verifyMachineRequest } from '../../../lib/auth/machine-key'
@@ -50,18 +51,18 @@ interface HeartbeatBody {
 export const POST: APIRoute = async ({ request }) => {
   const auth = await verifyMachineRequest(request, env.MACHINE_HEARTBEAT_KEY, env.DB)
   if (!auth.ok) {
-    return jsonResponse({ error: 'unauthorized' }, 401)
+    return jsonResponse(401, { error: 'unauthorized' })
   }
 
   let body: HeartbeatBody
   try {
     body = await request.json<HeartbeatBody>()
   } catch {
-    return jsonResponse({ error: 'invalid_json' }, 400)
+    return jsonResponse(400, { error: 'invalid_json' })
   }
 
   if (typeof body.heartbeat_ts !== 'string' || body.heartbeat_ts.length === 0) {
-    return jsonResponse({ error: 'missing_heartbeat_ts' }, 400)
+    return jsonResponse(400, { error: 'missing_heartbeat_ts' })
   }
 
   const heartbeatStatus = deriveStatus(
@@ -96,7 +97,7 @@ export const POST: APIRoute = async ({ request }) => {
     )
     .run()
 
-  return jsonResponse({ ok: true, heartbeat_status: heartbeatStatus }, 200)
+  return jsonResponse(200, { ok: true, heartbeat_status: heartbeatStatus })
 }
 
 function deriveStatus(
@@ -110,11 +111,4 @@ function deriveStatus(
   if (ageSec < 2 * periodSec) return 'green'
   if (ageSec < graceMin * 60) return 'yellow'
   return 'red'
-}
-
-function jsonResponse(body: unknown, status: number): Response {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: { 'Content-Type': 'application/json' },
-  })
 }

--- a/src/pages/api/webhooks/healthchecks.ts
+++ b/src/pages/api/webhooks/healthchecks.ts
@@ -36,6 +36,7 @@
  * naturally. We don't try to be clever here.
  */
 
+import { jsonResponse } from '../../../lib/api/helpers'
 import type { APIRoute } from 'astro'
 import { env } from 'cloudflare:workers'
 
@@ -50,24 +51,24 @@ export const POST: APIRoute = async ({ request }) => {
   const expected = env.HEALTHCHECKS_WEBHOOK_SECRET
   if (!expected) {
     console.error('[webhook/healthchecks] HEALTHCHECKS_WEBHOOK_SECRET not configured')
-    return jsonResponse({ error: 'server_misconfigured' }, 500)
+    return jsonResponse(500, { error: 'server_misconfigured' })
   }
 
   if (!bearerMatches(request, expected)) {
-    return jsonResponse({ error: 'unauthorized' }, 401)
+    return jsonResponse(401, { error: 'unauthorized' })
   }
 
   let payload: HealthchecksWebhookPayload
   try {
     payload = await request.json<HealthchecksWebhookPayload>()
   } catch {
-    return jsonResponse({ error: 'invalid_json' }, 400)
+    return jsonResponse(400, { error: 'invalid_json' })
   }
 
   const tenant = payload.tenant?.trim()
   const status = payload.status
   if (!tenant || (status !== 'up' && status !== 'down')) {
-    return jsonResponse({ error: 'missing_tenant_or_status' }, 400)
+    return jsonResponse(400, { error: 'missing_tenant_or_status' })
   }
 
   const entityRow = await env.DB.prepare(
@@ -76,7 +77,7 @@ export const POST: APIRoute = async ({ request }) => {
     .bind(tenant)
     .first<{ entity_id: string }>()
   if (!entityRow) {
-    return jsonResponse({ error: 'unknown_tenant' }, 404)
+    return jsonResponse(404, { error: 'unknown_tenant' })
   }
 
   const summary =
@@ -109,7 +110,7 @@ export const POST: APIRoute = async ({ request }) => {
       .run()
   }
 
-  return jsonResponse({ ok: true, source: 'healthchecks', tenant, status }, 200)
+  return jsonResponse(200, { ok: true, source: 'healthchecks', tenant, status })
 }
 
 function bearerMatches(request: Request, expected: string): boolean {
@@ -122,11 +123,4 @@ function bearerMatches(request: Request, expected: string): boolean {
     mismatch |= provided.charCodeAt(i) ^ expected.charCodeAt(i)
   }
   return mismatch === 0
-}
-
-function jsonResponse(body: unknown, status: number): Response {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: { 'Content-Type': 'application/json' },
-  })
 }

--- a/src/pages/api/webhooks/sentry.ts
+++ b/src/pages/api/webhooks/sentry.ts
@@ -27,6 +27,7 @@
  * is rejected (400) rather than misattributed.
  */
 
+import { jsonResponse } from '../../../lib/api/helpers'
 import type { APIRoute } from 'astro'
 import { env } from 'cloudflare:workers'
 
@@ -44,7 +45,7 @@ export const POST: APIRoute = async ({ request }) => {
   const secret = env.SENTRY_WEBHOOK_SECRET
   if (!secret) {
     console.error('[webhook/sentry] SENTRY_WEBHOOK_SECRET not configured')
-    return jsonResponse({ error: 'server_misconfigured' }, 500)
+    return jsonResponse(500, { error: 'server_misconfigured' })
   }
 
   const rawBody = await request.text()
@@ -52,12 +53,12 @@ export const POST: APIRoute = async ({ request }) => {
   const timestampHeader = request.headers.get('sentry-hook-timestamp') ?? ''
 
   if (!signatureHeader) {
-    return jsonResponse({ error: 'missing_signature' }, 401)
+    return jsonResponse(401, { error: 'missing_signature' })
   }
 
   if (!(await verifyHmac(rawBody, signatureHeader, secret))) {
     console.error('[webhook/sentry] invalid signature')
-    return jsonResponse({ error: 'invalid_signature' }, 401)
+    return jsonResponse(401, { error: 'invalid_signature' })
   }
 
   const timestampSec = Number(timestampHeader)
@@ -65,7 +66,7 @@ export const POST: APIRoute = async ({ request }) => {
     const ageSec = Math.floor(Date.now() / 1000) - timestampSec
     if (ageSec > MAX_WEBHOOK_AGE_SECONDS) {
       console.error(`[webhook/sentry] stale webhook (age ${ageSec}s)`)
-      return jsonResponse({ error: 'stale' }, 401)
+      return jsonResponse(401, { error: 'stale' })
     }
   }
 
@@ -73,13 +74,13 @@ export const POST: APIRoute = async ({ request }) => {
   try {
     payload = JSON.parse(rawBody) as SentryWebhookPayload
   } catch {
-    return jsonResponse({ error: 'invalid_json' }, 400)
+    return jsonResponse(400, { error: 'invalid_json' })
   }
 
   const tenant = extractTenantTag(payload)
   if (!tenant) {
     console.warn('[webhook/sentry] payload missing tenant tag; rejected')
-    return jsonResponse({ error: 'missing_tenant_tag' }, 400)
+    return jsonResponse(400, { error: 'missing_tenant_tag' })
   }
 
   const entityRow = await env.DB.prepare(
@@ -89,7 +90,7 @@ export const POST: APIRoute = async ({ request }) => {
     .first<{ entity_id: string }>()
   if (!entityRow) {
     console.warn(`[webhook/sentry] tenant ${tenant} not found in customer_configs`)
-    return jsonResponse({ error: 'unknown_tenant' }, 404)
+    return jsonResponse(404, { error: 'unknown_tenant' })
   }
 
   const summary = buildSummary(payload)
@@ -109,7 +110,7 @@ export const POST: APIRoute = async ({ request }) => {
     .bind(entityRow.entity_id, tenant, alertDate, summary, rawBody)
     .run()
 
-  return jsonResponse({ ok: true, source: 'sentry', tenant }, 200)
+  return jsonResponse(200, { ok: true, source: 'sentry', tenant })
 }
 
 function extractTenantTag(payload: SentryWebhookPayload): string | null {
@@ -151,11 +152,4 @@ async function verifyHmac(rawBody: string, signatureHex: string, secret: string)
     mismatch |= digest.charCodeAt(i) ^ signatureHex.charCodeAt(i)
   }
   return mismatch === 0
-}
-
-function jsonResponse(body: unknown, status: number): Response {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: { 'Content-Type': 'application/json' },
-  })
 }


### PR DESCRIPTION
## What

Closes finding **Architecture #1** (`docs/reviews/code-review-2026-06-30.md`): 19 route/lib files each carried a private `jsonResponse` copy, and **9 inverted the argument order** — `(body, status)` instead of the shared helper's `(status, data)`. Each file was internally consistent, but the divergence is a latent copy-paste bug hazard (incl. the review-flagged `entities/bulk.ts` and `webhooks/sentry.ts`).

## Changes

- Deleted all 19 local defs; every file now imports `jsonResponse` from `src/lib/api/helpers` (canonical `(status, data)`).
- Flipped all **54 call sites** in the 9 inverted files to `(status, data)`. **TypeScript verified every flip** — the canonical first param is `number`, so any missed call site is a compile error; 0 type errors after the pass.
- Added an ESLint `no-restricted-syntax` guard (scoped to `src/`; `helpers.ts` and `workers/*` exempt) that blocks re-declaring `jsonResponse` locally, so the divergence can't recur. Verified it fires on a probe.

## Method note

The mechanical removal + import-insertion and the arg-flip were done with a string/paren/template-aware script, dry-run and eyeballed (all 54 flips reviewed) before applying, then validated by `npm run verify` (0 type errors, full suite green).

## Deferred

Webhook payload runtime validation (narrow-after-cast; same review, MED) is filed separately (#TBD) to keep this a cohesive canonicalization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)