### PR TITLE
chore(deps): bump eslint-plugin-astro 1.7.0 -> 2.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "@types/react": "^19.2.17",
         "@venturecrane/crane-test-harness": "^0.1.0",
         "eslint": "^10.5.0",
-        "eslint-plugin-astro": "^1.6.0",
+        "eslint-plugin-astro": "^2.1.1",
         "eslint-plugin-import-x": "^4.17.0",
         "globals": "^17.7.0",
         "husky": "^9.1.0",
@@ -1829,38 +1829,6 @@
         "@tybys/wasm-util": "^0.10.0"
       }
     },
-    "node_modules/@nodelib/fs.scandir": {
-      "version": "2.1.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "2.0.5",
-        "run-parallel": "^1.1.9"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.stat": {
-      "version": "2.0.5",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.walk": {
-      "version": "1.2.8",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.scandir": "2.1.5",
-        "fastq": "^1.6.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/@opentelemetry/api": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
@@ -1877,11 +1845,13 @@
       "license": "MIT"
     },
     "node_modules/@pkgr/core": {
-      "version": "0.2.9",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.3.6.tgz",
+      "integrity": "sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+        "node": "^14.18.0 || >=16.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
@@ -2558,9 +2528,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2578,9 +2545,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2598,9 +2562,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2618,9 +2579,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3139,19 +3097,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
-      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@ungap/structured-clone": {
@@ -3881,29 +3826,37 @@
       }
     },
     "node_modules/astro-eslint-parser": {
-      "version": "1.4.0",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/astro-eslint-parser/-/astro-eslint-parser-2.1.0.tgz",
+      "integrity": "sha512-poUfd66bOTY59rQajtusj/+i6kaBc4pKXkBa2XHYjwBZyhWThS1sdlgxLrnmo7NQqLUpvhmEtkOONUBs9WIp9Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@astrojs/compiler": "^2.0.0 || ^3.0.0",
-        "@typescript-eslint/scope-manager": "^7.0.0 || ^8.0.0",
-        "@typescript-eslint/types": "^7.0.0 || ^8.0.0",
+        "@astrojs/compiler": "^4.0.0",
+        "@typescript-eslint/scope-manager": "^8.61.0",
+        "@typescript-eslint/types": "^8.61.0",
         "astrojs-compiler-sync": "^1.0.0",
         "debug": "^4.3.4",
-        "entities": "^7.0.0",
-        "eslint-scope": "^8.0.1",
-        "eslint-visitor-keys": "^4.0.0",
-        "espree": "^10.0.0",
-        "fast-glob": "^3.3.3",
-        "is-glob": "^4.0.3",
-        "semver": "^7.3.8"
+        "entities": "^8.0.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "semver": "^7.3.8",
+        "tinyglobby": "^0.2.17"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^22.22.3 || ^24.16.0 || >=26.3.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/ota-meshi"
       }
+    },
+    "node_modules/astro-eslint-parser/node_modules/@astrojs/compiler": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-4.0.0.tgz",
+      "integrity": "sha512-eouss7G8ygdZqHuke033VMcVw5HTZUu+PXd/h06DGDUg/jt5btPYPqh66ENWw/mU78rBrf/oeC4oqoBwMtDMNA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/astro/node_modules/@astrojs/compiler": {
       "version": "4.0.0",
@@ -3959,6 +3912,8 @@
     },
     "node_modules/astrojs-compiler-sync": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/astrojs-compiler-sync/-/astrojs-compiler-sync-1.1.1.tgz",
+      "integrity": "sha512-0mKvB9sDQRIZPsEJadw6OaFbGJ92cJPPR++ICca9XEyiUAZqgVuk25jNmzHPT0KF80rI94trSZrUR5iHFXGGOQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4024,17 +3979,6 @@
       },
       "engines": {
         "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/braces": {
-      "version": "3.0.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fill-range": "^7.1.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/ccount": {
@@ -4648,11 +4592,13 @@
       }
     },
     "node_modules/entities": {
-      "version": "7.0.1",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
-        "node": ">=0.12"
+        "node": ">=20.19.0"
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
@@ -4805,20 +4751,6 @@
         }
       }
     },
-    "node_modules/eslint-compat-utils": {
-      "version": "0.6.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^7.5.4"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "eslint": ">=6.0.0"
-      }
-    },
     "node_modules/eslint-import-context": {
       "version": "0.1.9",
       "resolved": "https://registry.npmjs.org/eslint-import-context/-/eslint-import-context-0.1.9.tgz",
@@ -4845,38 +4777,53 @@
       }
     },
     "node_modules/eslint-plugin-astro": {
-      "version": "1.7.0",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-astro/-/eslint-plugin-astro-2.1.1.tgz",
+      "integrity": "sha512-oZwtjIfBOxOJT09exeGLQWy5o8/ATxY8RSq0548VMd0q7FqIVxoA5a46fRjnVLrj3pd3aP3/zkrGTuYPPo+iSw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.2.0",
-        "@jridgewell/sourcemap-codec": "^1.4.14",
-        "@typescript-eslint/types": "^7.7.1 || ^8",
-        "astro-eslint-parser": "^1.3.0",
-        "eslint-compat-utils": "^0.6.0",
-        "globals": "^16.0.0",
-        "postcss": "^8.4.14",
-        "postcss-selector-parser": "^7.0.0"
+        "@eslint-community/eslint-utils": "^4.5.1",
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@typescript-eslint/types": "^8.61.0",
+        "astro-eslint-parser": "^2.0.0",
+        "espree": "^11.0.0",
+        "globals": "^17.0.0",
+        "parse5": "^8.0.0",
+        "postcss": "^8.5.3",
+        "postcss-selector-parser": "^7.1.0"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^22.22.3 || ^24.16.0 || >=26.3.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/ota-meshi"
       },
       "peerDependencies": {
-        "eslint": ">=8.57.0"
+        "@typescript-eslint/parser": ">=8.61.0",
+        "eslint": ">=10.0.0",
+        "eslint-plugin-jsx-a11y": ">=6.10.2"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/parser": {
+          "optional": true
+        },
+        "eslint-plugin-jsx-a11y": {
+          "optional": true
+        }
       }
     },
-    "node_modules/eslint-plugin-astro/node_modules/globals": {
-      "version": "16.5.0",
+    "node_modules/eslint-plugin-astro/node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
       "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": ">=18"
+      "dependencies": {
+        "entities": "^8.0.0"
       },
       "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/eslint-plugin-import-x": {
@@ -4917,32 +4864,6 @@
       }
     },
     "node_modules/eslint-scope": {
-      "version": "8.4.0",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "esrecurse": "^4.3.0",
-        "estraverse": "^5.2.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint-visitor-keys": {
-      "version": "4.2.1",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint/node_modules/eslint-scope": {
       "version": "9.1.2",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
       "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
@@ -4961,7 +4882,7 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/eslint/node_modules/eslint-visitor-keys": {
+    "node_modules/eslint-visitor-keys": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
       "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
@@ -4974,7 +4895,7 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/eslint/node_modules/espree": {
+    "node_modules/espree": {
       "version": "11.2.0",
       "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
       "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
@@ -4987,22 +4908,6 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/espree": {
-      "version": "10.4.0",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "acorn": "^8.15.0",
-        "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^4.2.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -5088,32 +4993,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/fast-glob": {
-      "version": "3.3.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.2",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.8"
-      },
-      "engines": {
-        "node": ">=8.6.0"
-      }
-    },
-    "node_modules/fast-glob/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -5173,14 +5052,6 @@
         "fast-string-width": "^1.1.0"
       }
     },
-    "node_modules/fastq": {
-      "version": "1.20.1",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "reusify": "^1.0.4"
-      }
-    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "license": "MIT",
@@ -5205,17 +5076,6 @@
       },
       "engines": {
         "node": ">=16.0.0"
-      }
-    },
-    "node_modules/fill-range": {
-      "version": "7.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "to-regex-range": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/find-up": {
@@ -5717,14 +5577,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is-number": {
-      "version": "7.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12.0"
       }
     },
     "node_modules/is-plain-obj": {
@@ -6556,14 +6408,6 @@
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "license": "CC0-1.0"
     },
-    "node_modules/merge2": {
-      "version": "1.4.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/micromark": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
@@ -7127,29 +6971,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/micromatch": {
-      "version": "4.0.8",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "braces": "^3.0.3",
-        "picomatch": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
-    },
-    "node_modules/micromatch/node_modules/picomatch": {
-      "version": "2.3.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/mimic-function": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
@@ -7693,25 +7514,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/queue-microtask": {
-      "version": "1.2.3",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/radix3": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/radix3/-/radix3-1.1.2.tgz",
@@ -8017,15 +7819,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/reusify": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "iojs": ">=1.0.0",
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/rfdc": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
@@ -8073,28 +7866,6 @@
         "@rollup/rollup-win32-x64-gnu": "4.60.1",
         "@rollup/rollup-win32-x64-msvc": "4.60.1",
         "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/run-parallel": {
-      "version": "1.2.0",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/runes2": {
@@ -8462,11 +8233,13 @@
       }
     },
     "node_modules/synckit": {
-      "version": "0.11.12",
+      "version": "0.11.13",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.13.tgz",
+      "integrity": "sha512-eNRKgb3z66Yp3D2CixVujOUvXLFUTij/zVnV8KRyvFdQwpz7I5DS8UfRkTeLzb64u+dkzDSdelE24izu+zSSUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pkgr/core": "^0.2.9"
+        "@pkgr/core": "^0.3.6"
       },
       "engines": {
         "node": "^14.18.0 || >=16.0.0"
@@ -8530,7 +8303,9 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.16",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -8551,17 +8326,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/to-regex-range": {
-      "version": "5.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-number": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=8.0"
       }
     },
     "node_modules/toposort": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@types/react": "^19.2.17",
     "@venturecrane/crane-test-harness": "^0.1.0",
     "eslint": "^10.5.0",
-    "eslint-plugin-astro": "^1.6.0",
+    "eslint-plugin-astro": "^2.1.1",
     "eslint-plugin-import-x": "^4.17.0",
     "globals": "^17.7.0",
     "husky": "^9.1.0",


### PR DESCRIPTION
## What

Bumps `eslint-plugin-astro` 1.7.0 → 2.1.1 (dev-only lint tooling).

## Why now

Dependabot's #1592 for this bump was **closed** earlier today because `eslint-plugin-astro@2` couldn't resolve against the tree:
- peer `@typescript-eslint/parser >=8.61.0` — tree had 8.59.2
- peer `eslint >=10.0.0`

Both peers are **now satisfied** after today's Dependabot merges:
- `typescript-eslint@8.62` (bundles parser 8.62) — via the npm-minor-patch group (#1589)
- `eslint@^10.5.0` — already present

So the previously-blocking ERESOLVE is gone.

## Verification

- Clean `npm install` — no ERESOLVE, 0 vulnerabilities
- `npm run verify` exits 0: typecheck 0 errors, prettier clean, lint 0 errors (20 pre-existing `no-unsafe-*` warnings, unchanged), 18/18 tests

## Not included

Astro 6→7 (Dependabot #1591, also closed) remains blocked: `@clerk/astro@3.4.11` (latest) declares `peerDependencies.astro = ^4|^5|^6` — no astro 7. Deferred until Clerk publishes astro-7 support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)