### PR TITLE
Refactor portal home data loading

### DIFF
--- a/src/lib/portal/home.test.ts
+++ b/src/lib/portal/home.test.ts
@@ -1,0 +1,201 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  createTestD1,
+  discoverNumericMigrations,
+  runMigrations,
+} from '@venturecrane/crane-test-harness'
+import { resolve } from 'path'
+import type { D1Database } from '@cloudflare/workers-types'
+import { loadPortalHomeDashboard } from './home'
+
+const migrationsDir = resolve(process.cwd(), 'migrations')
+
+const ORG_A = 'portal-home-org-a'
+const ORG_B = 'portal-home-org-b'
+const ENTITY_A = 'portal-home-entity-a'
+const ENTITY_B = 'portal-home-entity-b'
+const QUOTE_A = 'portal-home-quote-a'
+const QUOTE_B = 'portal-home-quote-b'
+const ENGAGEMENT_A = 'portal-home-engagement-a'
+const ENGAGEMENT_B = 'portal-home-engagement-b'
+
+describe('loadPortalHomeDashboard', () => {
+  let db: D1Database
+
+  beforeEach(async () => {
+    db = createTestD1()
+    await runMigrations(db, { files: discoverNumericMigrations(migrationsDir) })
+    await seedBaseRows(db)
+  })
+
+  it('loads the active engagement dashboard scoped to the caller org and entity', async () => {
+    await addInvoice(db, 'invoice-a-paid', ORG_A, ENTITY_A, ENGAGEMENT_A, 'paid', '2026-07-04')
+    await addInvoice(db, 'invoice-b-sent', ORG_B, ENTITY_B, ENGAGEMENT_B, 'sent', '2026-07-01')
+    await addMilestone(db, 'milestone-a', ORG_A, ENGAGEMENT_A, 'completed', '2026-07-03T12:00:00Z')
+    await addMilestone(db, 'milestone-b', ORG_B, ENGAGEMENT_B, 'completed', '2026-07-04T12:00:00Z')
+
+    const dashboard = await loadPortalHomeDashboard(db, ORG_A, ENTITY_A)
+
+    expect(dashboard.activeEngagement?.id).toBe(ENGAGEMENT_A)
+    expect(dashboard.invoices.map((invoice) => invoice.id)).toEqual(['invoice-a-paid'])
+    expect(dashboard.quotes.map((quote) => quote.id)).toEqual([QUOTE_A])
+    expect(dashboard.completedMilestones.map((milestone) => milestone.id)).toEqual(['milestone-a'])
+  })
+
+  it('selects the earliest due sent or overdue active-engagement invoice', async () => {
+    await addInvoice(db, 'invoice-null-due', ORG_A, ENTITY_A, ENGAGEMENT_A, 'sent', null)
+    await addInvoice(
+      db,
+      'invoice-paid-earlier',
+      ORG_A,
+      ENTITY_A,
+      ENGAGEMENT_A,
+      'paid',
+      '2026-07-01'
+    )
+    await addInvoice(db, 'invoice-later', ORG_A, ENTITY_A, ENGAGEMENT_A, 'sent', '2026-07-10')
+    await addInvoice(db, 'invoice-earliest', ORG_A, ENTITY_A, ENGAGEMENT_A, 'overdue', '2026-07-02')
+    await addCompletedEngagement(db, 'inactive-engagement')
+    await addInvoice(
+      db,
+      'invoice-other-engagement',
+      ORG_A,
+      ENTITY_A,
+      'inactive-engagement',
+      'sent',
+      '2026-06-01'
+    )
+
+    const dashboard = await loadPortalHomeDashboard(db, ORG_A, ENTITY_A)
+
+    expect(dashboard.pendingInvoice?.id).toBe('invoice-earliest')
+    expect(dashboard.invoices.map((invoice) => invoice.id)).not.toContain(
+      'invoice-other-engagement'
+    )
+  })
+
+  it('returns quotes but no engagement artifacts when the entity has no active engagement', async () => {
+    await db
+      .prepare("UPDATE engagements SET status = 'completed' WHERE id = ? AND org_id = ?")
+      .bind(ENGAGEMENT_A, ORG_A)
+      .run()
+
+    const dashboard = await loadPortalHomeDashboard(db, ORG_A, ENTITY_A)
+
+    expect(dashboard.activeEngagement).toBeNull()
+    expect(dashboard.pendingInvoice).toBeNull()
+    expect(dashboard.invoices).toEqual([])
+    expect(dashboard.completedMilestones).toEqual([])
+    expect(dashboard.quotes.map((quote) => quote.id)).toEqual([QUOTE_A])
+  })
+})
+
+async function seedBaseRows(db: D1Database): Promise<void> {
+  for (const [orgId, name] of [
+    [ORG_A, 'Portal Home Org A'],
+    [ORG_B, 'Portal Home Org B'],
+  ]) {
+    await db
+      .prepare('INSERT INTO organizations (id, name, slug) VALUES (?, ?, ?)')
+      .bind(orgId, name, orgId)
+      .run()
+  }
+
+  for (const [entityId, orgId, name] of [
+    [ENTITY_A, ORG_A, 'Portal Home Entity A'],
+    [ENTITY_B, ORG_B, 'Portal Home Entity B'],
+  ]) {
+    await db
+      .prepare('INSERT INTO entities (id, org_id, name, slug) VALUES (?, ?, ?, ?)')
+      .bind(entityId, orgId, name, entityId)
+      .run()
+  }
+
+  await seedQuoteAndEngagement(db, ORG_A, ENTITY_A, QUOTE_A, ENGAGEMENT_A)
+  await seedQuoteAndEngagement(db, ORG_B, ENTITY_B, QUOTE_B, ENGAGEMENT_B)
+}
+
+async function seedQuoteAndEngagement(
+  db: D1Database,
+  orgId: string,
+  entityId: string,
+  quoteId: string,
+  engagementId: string
+): Promise<void> {
+  const assessmentId = `${quoteId}-assessment`
+  await db
+    .prepare('INSERT INTO assessments (id, org_id, entity_id, status) VALUES (?, ?, ?, ?)')
+    .bind(assessmentId, orgId, entityId, 'completed')
+    .run()
+
+  await db
+    .prepare(
+      `INSERT INTO quotes (id, org_id, entity_id, assessment_id, line_items, total_hours, rate, total_price, status, sent_at, updated_at)
+       VALUES (?, ?, ?, ?, '[]', 10, 200, 2000, 'sent', '2026-07-01T10:00:00Z', '2026-07-01T10:00:00Z')`
+    )
+    .bind(quoteId, orgId, entityId, assessmentId)
+    .run()
+
+  await db
+    .prepare(
+      `INSERT INTO engagements (id, org_id, entity_id, quote_id, status, consultant_name, next_touchpoint_label, created_at)
+       VALUES (?, ?, ?, ?, 'active', 'Ada Lovelace', 'Friday check-in', '2026-07-01T11:00:00Z')`
+    )
+    .bind(engagementId, orgId, entityId, quoteId)
+    .run()
+}
+
+async function addInvoice(
+  db: D1Database,
+  id: string,
+  orgId: string,
+  entityId: string,
+  engagementId: string,
+  status: string,
+  dueDate: string | null
+): Promise<void> {
+  await db
+    .prepare(
+      `INSERT INTO invoices (id, org_id, entity_id, engagement_id, type, amount, status, due_date, sent_at, paid_at, created_at)
+       VALUES (?, ?, ?, ?, 'deposit', 500, ?, ?, ?, ?, ?)`
+    )
+    .bind(
+      id,
+      orgId,
+      entityId,
+      engagementId,
+      status,
+      dueDate,
+      status === 'sent' || status === 'overdue' ? '2026-07-01T12:00:00Z' : null,
+      status === 'paid' ? '2026-07-02T12:00:00Z' : null,
+      `2026-07-01T12:00:${id.length}Z`
+    )
+    .run()
+}
+
+async function addCompletedEngagement(db: D1Database, engagementId: string): Promise<void> {
+  await db
+    .prepare(
+      `INSERT INTO engagements (id, org_id, entity_id, quote_id, status, created_at)
+       VALUES (?, ?, ?, ?, 'completed', '2026-06-01T12:00:00Z')`
+    )
+    .bind(engagementId, ORG_A, ENTITY_A, QUOTE_A)
+    .run()
+}
+
+async function addMilestone(
+  db: D1Database,
+  id: string,
+  orgId: string,
+  engagementId: string,
+  status: string,
+  completedAt: string | null
+): Promise<void> {
+  await db
+    .prepare(
+      `INSERT INTO milestones (id, engagement_id, org_id, name, status, completed_at, sort_order)
+       VALUES (?, ?, ?, ?, ?, ?, 1)`
+    )
+    .bind(id, engagementId, orgId, `Milestone ${id}`, status, completedAt)
+    .run()
+}

--- a/src/lib/portal/home.ts
+++ b/src/lib/portal/home.ts
@@ -1,0 +1,167 @@
+/**
+ * Portal home data reader.
+ *
+ * Keeps the portal landing page out of raw SQL while preserving its home-only
+ * rules: one current engagement, active-engagement invoices, recent proposals,
+ * and completed milestone timeline entries.
+ */
+
+import { getActiveEngagementForEntities, type Engagement } from '../db/engagements'
+import { listInvoices, type Invoice } from '../db/invoices'
+import { listMilestones, type Milestone } from '../db/milestones'
+import { listQuotes, type Quote } from '../db/quotes'
+
+export type PortalHomeEngagement = Pick<
+  Engagement,
+  | 'id'
+  | 'status'
+  | 'scope_summary'
+  | 'start_date'
+  | 'estimated_end'
+  | 'consultant_name'
+  | 'consultant_phone'
+  | 'next_touchpoint_at'
+  | 'next_touchpoint_label'
+>
+
+export type PortalHomeInvoice = Pick<
+  Invoice,
+  'id' | 'amount' | 'status' | 'due_date' | 'sent_at' | 'paid_at'
+>
+
+export type PortalHomeQuote = Pick<Quote, 'id' | 'status' | 'sent_at' | 'accepted_at'>
+
+export type PortalHomeMilestone = Pick<Milestone, 'id' | 'name' | 'completed_at'>
+
+export interface PortalHomeDashboard {
+  activeEngagement: PortalHomeEngagement | null
+  pendingInvoice: PortalHomeInvoice | null
+  invoices: PortalHomeInvoice[]
+  quotes: PortalHomeQuote[]
+  completedMilestones: PortalHomeMilestone[]
+}
+
+const PORTAL_HOME_ENGAGEMENT_STATUSES = new Set(['scheduled', 'active', 'handoff', 'safety_net'])
+
+export async function loadPortalHomeDashboard(
+  db: D1Database,
+  orgId: string,
+  entityId: string
+): Promise<PortalHomeDashboard> {
+  const [activeEngagement, quotes] = await Promise.all([
+    loadActiveEngagement(db, orgId, entityId),
+    loadPortalHomeQuotes(db, orgId, entityId),
+  ])
+
+  if (!activeEngagement) {
+    return {
+      activeEngagement: null,
+      pendingInvoice: null,
+      invoices: [],
+      quotes,
+      completedMilestones: [],
+    }
+  }
+
+  const [invoices, completedMilestones] = await Promise.all([
+    loadPortalHomeInvoices(db, orgId, entityId, activeEngagement.id),
+    loadCompletedMilestones(db, orgId, activeEngagement.id),
+  ])
+
+  return {
+    activeEngagement,
+    pendingInvoice: selectPendingInvoice(invoices),
+    invoices,
+    quotes,
+    completedMilestones,
+  }
+}
+
+async function loadActiveEngagement(
+  db: D1Database,
+  orgId: string,
+  entityId: string
+): Promise<PortalHomeEngagement | null> {
+  const rows = await getActiveEngagementForEntities(db, orgId, [entityId])
+  const engagement = rows.get(entityId)
+  if (!engagement || !PORTAL_HOME_ENGAGEMENT_STATUSES.has(engagement.status)) {
+    return null
+  }
+  return {
+    id: engagement.id,
+    status: engagement.status,
+    scope_summary: engagement.scope_summary,
+    start_date: engagement.start_date,
+    estimated_end: engagement.estimated_end,
+    consultant_name: engagement.consultant_name,
+    consultant_phone: engagement.consultant_phone,
+    next_touchpoint_at: engagement.next_touchpoint_at,
+    next_touchpoint_label: engagement.next_touchpoint_label,
+  }
+}
+
+async function loadPortalHomeInvoices(
+  db: D1Database,
+  orgId: string,
+  entityId: string,
+  engagementId: string
+): Promise<PortalHomeInvoice[]> {
+  const invoices = await listInvoices(db, orgId, { entityId, engagementId })
+  return invoices
+    .filter((invoice) => invoice.status !== 'void')
+    .map((invoice) => ({
+      id: invoice.id,
+      amount: invoice.amount,
+      status: invoice.status,
+      due_date: invoice.due_date,
+      sent_at: invoice.sent_at,
+      paid_at: invoice.paid_at,
+    }))
+}
+
+async function loadPortalHomeQuotes(
+  db: D1Database,
+  orgId: string,
+  entityId: string
+): Promise<PortalHomeQuote[]> {
+  const quotes = await listQuotes(db, orgId, entityId)
+  return quotes.slice(0, 5).map((quote) => ({
+    id: quote.id,
+    status: quote.status,
+    sent_at: quote.sent_at,
+    accepted_at: quote.accepted_at,
+  }))
+}
+
+async function loadCompletedMilestones(
+  db: D1Database,
+  orgId: string,
+  engagementId: string
+): Promise<PortalHomeMilestone[]> {
+  const milestones = await listMilestones(db, orgId, engagementId)
+  return milestones
+    .filter((milestone) => milestone.status === 'completed' && milestone.completed_at !== null)
+    .sort((a, b) => {
+      if (!a.completed_at || !b.completed_at) return 0
+      return a.completed_at < b.completed_at ? 1 : -1
+    })
+    .slice(0, 5)
+    .map((milestone) => ({
+      id: milestone.id,
+      name: milestone.name,
+      completed_at: milestone.completed_at,
+    }))
+}
+
+function selectPendingInvoice(invoices: PortalHomeInvoice[]): PortalHomeInvoice | null {
+  const pending = invoices.filter(
+    (invoice) => invoice.status === 'sent' || invoice.status === 'overdue'
+  )
+  pending.sort((a, b) => {
+    if (a.due_date && b.due_date) return a.due_date < b.due_date ? -1 : 1
+    if (a.due_date) return -1
+    if (b.due_date) return 1
+    return 0
+  })
+  return pending[0] ?? null
+}

--- a/src/pages/portal/index.astro
+++ b/src/pages/portal/index.astro
@@ -3,6 +3,13 @@ import '../../styles/global.css'
 import { BRAND_NAME } from '../../lib/config/brand'
 import { getPortalClient } from '../../lib/portal/session'
 import { getProductSubscription } from '../../lib/portal/product-access'
+import {
+  loadPortalHomeDashboard,
+  type PortalHomeEngagement,
+  type PortalHomeInvoice,
+  type PortalHomeMilestone,
+  type PortalHomeQuote,
+} from '../../lib/portal/home'
 import PortalHeader from '../../components/portal/PortalHeader.astro'
 import PortalTabs from '../../components/portal/PortalTabs.astro'
 import SkipToMain from '../../components/SkipToMain.astro'
@@ -35,105 +42,22 @@ const operatorActive = operatorSubscription !== null
 
 const { client } = portalData
 
-interface EngagementRow {
-  id: string
-  status: string
-  scope_summary: string | null
-  start_date: string | null
-  estimated_end: string | null
-  consultant_name: string | null
-  consultant_phone: string | null
-  next_touchpoint_at: string | null
-  next_touchpoint_label: string | null
-}
-
-interface InvoiceRow {
-  id: string
-  amount: number
-  status: string
-  due_date: string | null
-  sent_at: string | null
-  paid_at: string | null
-}
-
-interface QuoteRow {
-  id: string
-  status: string
-  sent_at: string | null
-  accepted_at: string | null
-}
-
-interface MilestoneRow {
-  id: string
-  name: string
-  completed_at: string | null
-}
-
-let activeEngagement: EngagementRow | null = null
-let pendingInvoice: InvoiceRow | null = null
-let invoices: InvoiceRow[] = []
-let quotes: QuoteRow[] = []
-let completedMilestones: MilestoneRow[] = []
+let activeEngagement: PortalHomeEngagement | null = null
+let pendingInvoice: PortalHomeInvoice | null = null
+let invoices: PortalHomeInvoice[] = []
+let quotes: PortalHomeQuote[] = []
+let completedMilestones: PortalHomeMilestone[] = []
 // When a DB read fails we render a single error state rather than a partial
 // dashboard. The header's contact icons are the persistent contact affordance.
 let dashboardError = false
 
 try {
-  activeEngagement = await env.DB.prepare(
-    `SELECT id, status, scope_summary, start_date, estimated_end,
-            consultant_name, consultant_phone,
-            next_touchpoint_at, next_touchpoint_label
-       FROM engagements
-      WHERE entity_id = ? AND org_id = ? AND status IN ('scheduled', 'active', 'handoff', 'safety_net')
-      ORDER BY created_at DESC
-      LIMIT 1`
-  )
-    .bind(client.id, portalData.user.org_id)
-    .first<EngagementRow>()
-
-  if (activeEngagement) {
-    const invoiceResult = await env.DB.prepare(
-      `SELECT id, amount, status, due_date, sent_at, paid_at
-         FROM invoices
-        WHERE engagement_id = ? AND org_id = ? AND status != 'void'
-        ORDER BY created_at DESC`
-    )
-      .bind(activeEngagement.id, portalData.user.org_id)
-      .all<InvoiceRow>()
-    invoices = invoiceResult.results ?? []
-
-    // Next pending invoice: earliest-due among sent/overdue (null due_date last).
-    const pending = invoices.filter((i) => i.status === 'sent' || i.status === 'overdue')
-    pending.sort((a, b) => {
-      if (a.due_date && b.due_date) return a.due_date < b.due_date ? -1 : 1
-      if (a.due_date) return -1
-      if (b.due_date) return 1
-      return 0
-    })
-    pendingInvoice = pending[0] ?? null
-
-    const milestoneResult = await env.DB.prepare(
-      `SELECT id, name, completed_at
-         FROM milestones
-        WHERE engagement_id = ? AND org_id = ? AND status = 'completed' AND completed_at IS NOT NULL
-        ORDER BY completed_at DESC
-        LIMIT 5`
-    )
-      .bind(activeEngagement.id, portalData.user.org_id)
-      .all<MilestoneRow>()
-    completedMilestones = milestoneResult.results ?? []
-  }
-
-  const quoteResult = await env.DB.prepare(
-    `SELECT id, status, sent_at, accepted_at
-       FROM quotes
-      WHERE entity_id = ? AND org_id = ?
-      ORDER BY updated_at DESC
-      LIMIT 5`
-  )
-    .bind(client.id, portalData.user.org_id)
-    .all<QuoteRow>()
-  quotes = quoteResult.results ?? []
+  const dashboard = await loadPortalHomeDashboard(env.DB, portalData.user.org_id, client.id)
+  activeEngagement = dashboard.activeEngagement
+  pendingInvoice = dashboard.pendingInvoice
+  invoices = dashboard.invoices
+  quotes = dashboard.quotes
+  completedMilestones = dashboard.completedMilestones
 } catch (err) {
   console.error('portal/index: data fetch failure', err)
   dashboardError = true

--- a/tests/portal-quotes.test.ts
+++ b/tests/portal-quotes.test.ts
@@ -95,6 +95,7 @@ describe('portal quotes: session helper', () => {
 
 describe('portal quotes: dashboard', () => {
   const source = () => readFileSync(resolve('src/pages/portal/index.astro'), 'utf-8')
+  const homeSource = () => readFileSync(resolve('src/lib/portal/home.ts'), 'utf-8')
 
   it('portal dashboard exists', () => {
     expect(existsSync(resolve('src/pages/portal/index.astro'))).toBe(true)
@@ -113,9 +114,9 @@ describe('portal quotes: dashboard', () => {
 
   it('loads quotes scoped to the signed-in entity', () => {
     const code = source()
-    // New design inlines the query (needs richer columns than listQuotesForEntity exposes).
-    expect(code).toContain('FROM quotes')
-    expect(code).toContain('entity_id = ?')
+    const homeCode = homeSource()
+    expect(code).toContain('loadPortalHomeDashboard(env.DB, portalData.user.org_id, client.id)')
+    expect(homeCode).toContain('listQuotes(db, orgId, entityId)')
   })
 
   it('resolves client via getPortalClient', () => {


### PR DESCRIPTION
## Summary
- move `/portal` dashboard DB reads into `src/lib/portal/home.ts`
- keep the page focused on rendering and timeline assembly
- add D1-backed coverage for org/entity scoping, active-engagement invoice scope, pending invoice ordering, and no-active-engagement state
- update the stale portal quote source test to assert the new reader boundary

## Verification
- `npm run test -- src/lib/portal/home.test.ts`
- `npm run test -- tests/portal-quotes.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run verify`
- pre-push `npm run verify`

Refs #1597