### PR TITLE
Refactor portal detail data loading

### DIFF
--- a/src/lib/portal/detail-readers.test.ts
+++ b/src/lib/portal/detail-readers.test.ts
@@ -1,0 +1,168 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  createTestD1,
+  discoverNumericMigrations,
+  runMigrations,
+} from '@venturecrane/crane-test-harness'
+import { resolve } from 'path'
+import type { D1Database } from '@cloudflare/workers-types'
+import { loadPortalInvoiceDetail } from './invoice-detail'
+import { loadPortalQuoteDetail } from './quote-detail'
+
+const migrationsDir = resolve(process.cwd(), 'migrations')
+
+const ORG_A = 'portal-detail-org-a'
+const ORG_B = 'portal-detail-org-b'
+const ENTITY_A = 'portal-detail-entity-a'
+const ENTITY_B = 'portal-detail-entity-b'
+const ASSESSMENT_A = 'portal-detail-assessment-a'
+const ASSESSMENT_B = 'portal-detail-assessment-b'
+const QUOTE_A = 'portal-detail-quote-a'
+const QUOTE_A2 = 'portal-detail-quote-a2'
+const QUOTE_B = 'portal-detail-quote-b'
+const ENGAGEMENT_A = 'portal-detail-engagement-a'
+const ENGAGEMENT_B = 'portal-detail-engagement-b'
+const INVOICE_A = 'portal-detail-invoice-a'
+const INVOICE_B = 'portal-detail-invoice-b'
+
+describe('portal detail readers', () => {
+  let db: D1Database
+
+  beforeEach(async () => {
+    db = createTestD1()
+    await runMigrations(db, { files: discoverNumericMigrations(migrationsDir) })
+    await seedRows(db)
+  })
+
+  it('loads invoice detail rows through org and entity scope', async () => {
+    const detail = await loadPortalInvoiceDetail(db, ORG_A, ENTITY_A, INVOICE_A)
+
+    expect(detail?.invoice.id).toBe(INVOICE_A)
+    expect(detail?.lineItems.map((item) => item.description)).toEqual(['Deposit'])
+    expect(detail?.engagement?.id).toBe(ENGAGEMENT_A)
+    expect(detail?.engagement?.consultant_name).toBe('Ada Lovelace')
+  })
+
+  it('returns null for invoice detail outside the caller org or entity', async () => {
+    await expect(loadPortalInvoiceDetail(db, ORG_A, ENTITY_B, INVOICE_B)).resolves.toBeNull()
+    await expect(loadPortalInvoiceDetail(db, ORG_B, ENTITY_A, INVOICE_A)).resolves.toBeNull()
+  })
+
+  it('loads quote detail rows through org and entity scope', async () => {
+    const detail = await loadPortalQuoteDetail(db, ORG_A, ENTITY_A, QUOTE_A)
+
+    expect(detail?.quote.id).toBe(QUOTE_A)
+    expect(detail?.engagement?.id).toBe(ENGAGEMENT_A)
+    expect(detail?.engagement?.next_touchpoint_label).toBe('Friday check-in')
+    expect(detail?.superseding?.id).toBe(QUOTE_A2)
+    expect(detail?.sowState.downloadableRevision).toBeNull()
+  })
+
+  it('returns null for quote detail outside the caller org or entity', async () => {
+    await expect(loadPortalQuoteDetail(db, ORG_A, ENTITY_B, QUOTE_B)).resolves.toBeNull()
+    await expect(loadPortalQuoteDetail(db, ORG_B, ENTITY_A, QUOTE_A)).resolves.toBeNull()
+  })
+})
+
+async function seedRows(db: D1Database): Promise<void> {
+  await seedOrgAndEntity(db, ORG_A, ENTITY_A, 'A')
+  await seedOrgAndEntity(db, ORG_B, ENTITY_B, 'B')
+  await seedQuote(db, ORG_A, ENTITY_A, ASSESSMENT_A, QUOTE_A, 1, null)
+  await seedQuote(db, ORG_A, ENTITY_A, ASSESSMENT_A, QUOTE_A2, 2, QUOTE_A)
+  await seedQuote(db, ORG_B, ENTITY_B, ASSESSMENT_B, QUOTE_B, 1, null)
+  await seedEngagement(db, ORG_A, ENTITY_A, QUOTE_A, ENGAGEMENT_A)
+  await seedEngagement(db, ORG_B, ENTITY_B, QUOTE_B, ENGAGEMENT_B)
+  await seedInvoice(db, ORG_A, ENTITY_A, ENGAGEMENT_A, INVOICE_A)
+  await seedInvoice(db, ORG_B, ENTITY_B, ENGAGEMENT_B, INVOICE_B)
+}
+
+async function seedOrgAndEntity(
+  db: D1Database,
+  orgId: string,
+  entityId: string,
+  suffix: string
+): Promise<void> {
+  await db
+    .prepare('INSERT INTO organizations (id, name, slug) VALUES (?, ?, ?)')
+    .bind(orgId, `Portal Detail Org ${suffix}`, orgId)
+    .run()
+
+  await db
+    .prepare('INSERT INTO entities (id, org_id, name, slug) VALUES (?, ?, ?, ?)')
+    .bind(entityId, orgId, `Portal Detail Entity ${suffix}`, entityId)
+    .run()
+}
+
+async function seedQuote(
+  db: D1Database,
+  orgId: string,
+  entityId: string,
+  assessmentId: string,
+  quoteId: string,
+  version: number,
+  parentQuoteId: string | null
+): Promise<void> {
+  if (version === 1) {
+    await db
+      .prepare('INSERT INTO assessments (id, org_id, entity_id, status) VALUES (?, ?, ?, ?)')
+      .bind(assessmentId, orgId, entityId, 'completed')
+      .run()
+  }
+
+  await db
+    .prepare(
+      `INSERT INTO quotes (
+         id, org_id, entity_id, assessment_id, version, parent_quote_id,
+         line_items, total_hours, rate, total_price, deposit_pct, status, sent_at, updated_at
+       )
+       VALUES (?, ?, ?, ?, ?, ?, '[]', 12, 200, 2400, 0.5, 'sent', '2026-07-01T10:00:00Z', '2026-07-01T10:00:00Z')`
+    )
+    .bind(quoteId, orgId, entityId, assessmentId, version, parentQuoteId)
+    .run()
+}
+
+async function seedEngagement(
+  db: D1Database,
+  orgId: string,
+  entityId: string,
+  quoteId: string,
+  engagementId: string
+): Promise<void> {
+  await db
+    .prepare(
+      `INSERT INTO engagements (
+         id, org_id, entity_id, quote_id, status, consultant_name, consultant_phone,
+         next_touchpoint_label, created_at
+       )
+       VALUES (?, ?, ?, ?, 'active', 'Ada Lovelace', '555-0100', 'Friday check-in', '2026-07-01T11:00:00Z')`
+    )
+    .bind(engagementId, orgId, entityId, quoteId)
+    .run()
+}
+
+async function seedInvoice(
+  db: D1Database,
+  orgId: string,
+  entityId: string,
+  engagementId: string,
+  invoiceId: string
+): Promise<void> {
+  await db
+    .prepare(
+      `INSERT INTO invoices (
+         id, org_id, entity_id, engagement_id, type, amount, description, status, due_date,
+         sent_at, stripe_hosted_url, created_at, updated_at
+       )
+       VALUES (?, ?, ?, ?, 'deposit', 500, 'Deposit', 'sent', '2026-07-15', '2026-07-01T12:00:00Z', 'https://pay.example/invoice', '2026-07-01T12:00:00Z', '2026-07-01T12:00:00Z')`
+    )
+    .bind(invoiceId, orgId, entityId, engagementId)
+    .run()
+
+  await db
+    .prepare(
+      `INSERT INTO invoice_line_items (id, invoice_id, description, amount_cents, sort_order, created_at)
+       VALUES (?, ?, 'Deposit', 50000, 1, '2026-07-01T12:01:00Z')`
+    )
+    .bind(`${invoiceId}-line-1`, invoiceId)
+    .run()
+}

--- a/src/lib/portal/invoice-detail.ts
+++ b/src/lib/portal/invoice-detail.ts
@@ -1,0 +1,62 @@
+/**
+ * Portal invoice detail reader.
+ *
+ * Keeps the deep-link invoice page out of raw SQL while preserving the portal
+ * access rule: invoice first resolves through entity + org scope, then related
+ * detail rows are loaded from that scoped invoice.
+ */
+
+import {
+  getInvoiceForEntity,
+  listLineItemsForInvoice,
+  type Invoice,
+  type InvoiceLineItem,
+} from '../db/invoices'
+
+export interface PortalInvoiceEngagement {
+  id: string
+  consultant_name: string | null
+  consultant_phone: string | null
+}
+
+export interface PortalInvoiceDetail {
+  invoice: Invoice
+  lineItems: InvoiceLineItem[]
+  engagement: PortalInvoiceEngagement | null
+}
+
+export async function loadPortalInvoiceDetail(
+  db: D1Database,
+  orgId: string,
+  entityId: string,
+  invoiceId: string
+): Promise<PortalInvoiceDetail | null> {
+  const invoice = await getInvoiceForEntity(db, orgId, entityId, invoiceId)
+  if (!invoice) return null
+
+  const [lineItems, engagement] = await Promise.all([
+    listLineItemsForInvoice(db, invoice.id),
+    loadInvoiceEngagement(db, orgId, invoice.engagement_id),
+  ])
+
+  return { invoice, lineItems, engagement }
+}
+
+async function loadInvoiceEngagement(
+  db: D1Database,
+  orgId: string,
+  engagementId: string | null
+): Promise<PortalInvoiceEngagement | null> {
+  if (!engagementId) return null
+
+  const row = await db
+    .prepare(
+      `SELECT id, consultant_name, consultant_phone
+       FROM engagements
+       WHERE id = ? AND org_id = ?`
+    )
+    .bind(engagementId, orgId)
+    .first<PortalInvoiceEngagement>()
+
+  return row ?? null
+}

--- a/src/lib/portal/quote-detail.ts
+++ b/src/lib/portal/quote-detail.ts
@@ -1,0 +1,85 @@
+/**
+ * Portal quote detail reader.
+ *
+ * Moves quote-detail D1 lookups out of the Astro frontmatter and keeps every
+ * related read scoped by the signed-in portal client entity and org.
+ */
+
+import { getQuoteForEntity, type Quote } from '../db/quotes'
+import { getSOWStateForQuote, type SOWState } from '../sow/service'
+
+export interface PortalQuoteEngagement {
+  id: string
+  consultant_name: string | null
+  consultant_phone: string | null
+  next_touchpoint_label: string | null
+}
+
+export interface PortalSupersedingQuote {
+  id: string
+}
+
+export interface PortalQuoteDetail {
+  quote: Quote
+  sowState: SOWState
+  engagement: PortalQuoteEngagement | null
+  superseding: PortalSupersedingQuote | null
+}
+
+export async function loadPortalQuoteDetail(
+  db: D1Database,
+  orgId: string,
+  entityId: string,
+  quoteId: string
+): Promise<PortalQuoteDetail | null> {
+  const quote = await getQuoteForEntity(db, orgId, entityId, quoteId)
+  if (!quote) return null
+
+  const [sowState, engagement, superseding] = await Promise.all([
+    getSOWStateForQuote(db, orgId, quote.id),
+    loadQuoteEngagement(db, orgId, quote.id),
+    loadSupersedingQuote(db, orgId, entityId, quote),
+  ])
+
+  return { quote, sowState, engagement, superseding }
+}
+
+async function loadQuoteEngagement(
+  db: D1Database,
+  orgId: string,
+  quoteId: string
+): Promise<PortalQuoteEngagement | null> {
+  const row = await db
+    .prepare(
+      `SELECT id, consultant_name, consultant_phone, next_touchpoint_label
+       FROM engagements
+       WHERE quote_id = ? AND org_id = ?
+       ORDER BY created_at DESC
+       LIMIT 1`
+    )
+    .bind(quoteId, orgId)
+    .first<PortalQuoteEngagement>()
+
+  return row ?? null
+}
+
+async function loadSupersedingQuote(
+  db: D1Database,
+  orgId: string,
+  entityId: string,
+  quote: Pick<Quote, 'id' | 'assessment_id' | 'version'>
+): Promise<PortalSupersedingQuote | null> {
+  const row = await db
+    .prepare(
+      `SELECT id FROM quotes
+       WHERE (parent_quote_id = ? OR (assessment_id = ? AND version > ? AND status IN ('sent', 'accepted')))
+         AND entity_id = ?
+         AND org_id = ?
+       ORDER BY version DESC
+       LIMIT 1`
+    )
+    .bind(quote.id, quote.assessment_id, quote.version, entityId, orgId)
+    .first<PortalSupersedingQuote>()
+
+  return row ?? null
+}

--- a/src/pages/portal/invoices/[id].astro
+++ b/src/pages/portal/invoices/[id].astro
@@ -3,7 +3,7 @@ import '../../../styles/global.css'
 import { BRAND_NAME } from '../../../lib/config/brand'
 import { getPortalClient } from '../../../lib/portal/session'
 import { getProductSubscription } from '../../../lib/portal/product-access'
-import { getInvoiceForEntity, listLineItemsForInvoice } from '../../../lib/db/invoices'
+import { loadPortalInvoiceDetail } from '../../../lib/portal/invoice-detail'
 import PortalHeader from '../../../components/portal/PortalHeader.astro'
 import PortalTabs from '../../../components/portal/PortalTabs.astro'
 import PortalPageHead from '../../../components/portal/PortalPageHead.astro'
@@ -48,10 +48,17 @@ const operatorActive = operatorSubscription !== null
 
 const { client } = portalData
 
-const invoice = await getInvoiceForEntity(env.DB, portalData.user.org_id, client.id, invoiceId)
-if (!invoice) {
+const invoiceDetail = await loadPortalInvoiceDetail(
+  env.DB,
+  portalData.user.org_id,
+  client.id,
+  invoiceId
+)
+if (!invoiceDetail) {
   return Astro.redirect('/portal')
 }
+
+const { invoice, lineItems, engagement } = invoiceDetail
 
 // Line items drive the "What's included" section. We never fabricate
 // invoice content — no generic placeholder rows, no borrow from
@@ -60,24 +67,6 @@ if (!invoice) {
 // renders no breakdown; the Total line still renders. Admin send-gate
 // should prevent this state reaching a client, but the page degrades
 // cleanly if it does.
-const lineItems = await listLineItemsForInvoice(env.DB, invoice.id)
-
-// Load engagement for scope fallback + consultant attribution.
-interface EngagementRow {
-  id: string
-  scope_summary: string | null
-  consultant_name: string | null
-  consultant_phone: string | null
-}
-
-const engagement = invoice.engagement_id
-  ? await env.DB.prepare(
-      `SELECT id, scope_summary, consultant_name, consultant_phone
-       FROM engagements WHERE id = ? AND org_id = ?`
-    )
-      .bind(invoice.engagement_id, portalData.user.org_id)
-      .first<EngagementRow>()
-  : null
 
 // Money — invoices.amount is dollars (REAL); convert to cents for display.
 const amountCents = Math.round(invoice.amount * 100)

--- a/src/pages/portal/quotes/[id].astro
+++ b/src/pages/portal/quotes/[id].astro
@@ -9,9 +9,9 @@ import QuoteProposalSections from '../../../components/portal/QuoteProposalSecti
 import { BRAND_NAME } from '../../../lib/config/brand'
 import { getPortalClient } from '../../../lib/portal/session'
 import { getProductSubscription } from '../../../lib/portal/product-access'
-import { getQuoteForEntity, parseSchedule, parseDeliverables } from '../../../lib/db/quotes'
+import { parseSchedule, parseDeliverables } from '../../../lib/db/quotes'
 import type { ScheduleRow, DeliverableRow } from '../../../lib/db/quotes'
-import { getSOWStateForQuote } from '../../../lib/sow/service'
+import { loadPortalQuoteDetail } from '../../../lib/portal/quote-detail'
 import { resolveProposalState } from '../../../lib/portal/states'
 import { formatShortDate } from '../../../lib/portal/formatters'
 import { env } from 'cloudflare:workers'
@@ -49,12 +49,12 @@ const operatorActive = operatorSubscription !== null
 const { client } = portalData
 const orgId = portalData.user.org_id
 
-const quote = await getQuoteForEntity(env.DB, orgId, client.id, quoteId)
-if (!quote) {
+const quoteDetail = await loadPortalQuoteDetail(env.DB, orgId, client.id, quoteId)
+if (!quoteDetail) {
   return Astro.redirect('/portal/quotes')
 }
 
-const sowState = await getSOWStateForQuote(env.DB, orgId, quote.id)
+const { quote, sowState, engagement, superseding } = quoteDetail
 const activeSignatureRequest = sowState.openSignatureRequest
 const downloadableRevision = sowState.downloadableRevision
 
@@ -83,47 +83,12 @@ const engagementTitle = deliverables[0]?.title ?? 'Engagement'
 // yet attached to an engagement render a blank attribution block per #377
 // — no hardcoded fallback identity.
 
-// Pull engagement for consultant metadata + scope_summary so the signed-state
-// "what happens next" copy is concrete. The engagement row joins by quote_id
-// when one exists. A draft or just-signed quote may not yet have one, in
-// which case we render the generic kickoff fallback.
-interface EngagementLookupRow {
-  id: string
-  scope_summary: string | null
-  consultant_name: string | null
-  consultant_phone: string | null
-  next_touchpoint_label: string | null
-}
-
-const engagement = await env.DB.prepare(
-  `SELECT id, scope_summary, consultant_name, consultant_phone, next_touchpoint_label
-     FROM engagements
-    WHERE quote_id = ? AND org_id = ?
-    ORDER BY created_at DESC
-    LIMIT 1`
-)
-  .bind(quote.id, orgId)
-  .first<EngagementLookupRow>()
-
 const consultantName = engagement?.consultant_name ?? null
 const consultantFirst = consultantName ? consultantName.split(/\s+/)[0] || consultantName : null
 
 // Superseded: a newer quote on the same engagement / parent chain. We look
 // up a child quote whose parent_quote_id points at this one OR (fallback) a
 // sibling version for the same assessment.
-interface SupersedingRow {
-  id: string
-}
-const superseding = await env.DB.prepare(
-  `SELECT id FROM quotes
-    WHERE (parent_quote_id = ? OR (assessment_id = ? AND version > ? AND status IN ('sent', 'accepted')))
-      AND entity_id = ?
-      AND org_id = ?
-    ORDER BY version DESC
-    LIMIT 1`
-)
-  .bind(quote.id, quote.assessment_id, quote.version, client.id, orgId)
-  .first<SupersedingRow>()
 
 // Build the concrete "what happens next" string for signed quotes. Render
 // authored copy verbatim — do not synthesize client-facing commitments from

--- a/tests/invoices.test.ts
+++ b/tests/invoices.test.ts
@@ -139,7 +139,10 @@ describe('invoices: portal view', () => {
 })
 
 describe('invoices: portal detail view', () => {
-  const source = () => readFileSync(resolve('src/pages/portal/invoices/[id].astro'), 'utf-8')
+  const source = () =>
+    readFileSync(resolve('src/pages/portal/invoices/[id].astro'), 'utf-8') +
+    '\n' +
+    readFileSync(resolve('src/lib/portal/invoice-detail.ts'), 'utf-8')
 
   it('portal invoice detail page exists', () => {
     expect(existsSync(resolve('src/pages/portal/invoices/[id].astro'))).toBe(true)
@@ -170,6 +173,13 @@ describe('invoices: portal detail view', () => {
     expect(code).not.toContain('Engagement work')
     expect(code).not.toContain('displayLineItems')
     expect(code).not.toMatch(/scope_summary\s*\?\?/)
+  })
+
+  it('loads invoice detail through the portal reader', () => {
+    const code = source()
+    expect(code).toContain('loadPortalInvoiceDetail')
+    expect(code).toContain('getInvoiceForEntity')
+    expect(code).toContain('listLineItemsForInvoice')
   })
 })
 

--- a/tests/portal-quotes.test.ts
+++ b/tests/portal-quotes.test.ts
@@ -259,14 +259,18 @@ describe('portal quotes: quote detail page', () => {
   const source = () =>
     readFileSync(resolve('src/pages/portal/quotes/[id].astro'), 'utf-8') +
     '\n' +
-    readFileSync(resolve('src/components/portal/QuoteProposalSections.astro'), 'utf-8')
+    readFileSync(resolve('src/components/portal/QuoteProposalSections.astro'), 'utf-8') +
+    '\n' +
+    readFileSync(resolve('src/lib/portal/quote-detail.ts'), 'utf-8')
 
   it('quote detail page exists', () => {
     expect(existsSync(resolve('src/pages/portal/quotes/[id].astro'))).toBe(true)
   })
 
   it('loads quote via getQuoteForEntity', () => {
-    expect(source()).toContain('getQuoteForEntity')
+    const code = source()
+    expect(code).toContain('loadPortalQuoteDetail')
+    expect(code).toContain('getQuoteForEntity')
   })
 
   it('resolves client via getPortalClient', () => {


### PR DESCRIPTION
Refs #1597

Summary:
- Move portal invoice detail reads into src/lib/portal/invoice-detail.ts.
- Move portal quote detail reads into src/lib/portal/quote-detail.ts.
- Add D1-backed coverage for org/entity scoping, line items, engagement rows, and superseding quote rows.
- Update portal invoice and quote source-contract tests to cover the new loaders.

Verification:
- npm run test -- src/lib/portal/detail-readers.test.ts
- npm run test -- tests/invoices.test.ts tests/portal-quotes.test.ts
- npm run typecheck
- npm run lint
- npm run verify