### PR TITLE
Refactor remaining page SQL readers

### DIFF
--- a/src/lib/admin/assessment-redirect.ts
+++ b/src/lib/admin/assessment-redirect.ts
@@ -1,0 +1,16 @@
+import { getMeeting } from '../db/meetings'
+
+export interface AssessmentRedirectTarget {
+  id: string
+  entity_id: string
+}
+
+export async function getAssessmentRedirectTarget(
+  db: D1Database,
+  orgId: string,
+  assessmentId: string
+): Promise<AssessmentRedirectTarget | null> {
+  const meeting = await getMeeting(db, orgId, assessmentId)
+  if (!meeting) return null
+  return { id: meeting.id, entity_id: meeting.entity_id }
+}

--- a/src/lib/admin/generator-readers.ts
+++ b/src/lib/admin/generator-readers.ts
@@ -1,0 +1,168 @@
+import type { PipelineId } from '../generators/types'
+
+export interface PipelineMetrics {
+  total_signals: number
+  last_7d: number
+  has_pain: number
+  has_vertical: number
+  has_area: number
+  has_employee_count: number
+  has_tier: number
+  latest_signal_at: string | null
+  top_vertical: string | null
+  top_vertical_count: number
+}
+
+export interface GeneratorSignalRow {
+  id: string
+  name: string
+  pain_score: number | null
+  tier: string | null
+  vertical: string | null
+  area: string | null
+  summary: string | null
+  created_at: string
+  context_id: string | null
+  context_metadata: string | null
+  context_content: string | null
+  context_source_ref: string | null
+}
+
+export interface GeneratorDayRow {
+  day: string
+  count: number
+}
+
+const ZERO_COUNTS: PipelineMetrics = {
+  total_signals: 0,
+  last_7d: 0,
+  has_pain: 0,
+  has_vertical: 0,
+  has_area: 0,
+  has_employee_count: 0,
+  has_tier: 0,
+  latest_signal_at: null,
+  top_vertical: null,
+  top_vertical_count: 0,
+}
+
+export async function loadPipelineMetrics(
+  db: D1Database,
+  orgId: string,
+  pipeline: PipelineId
+): Promise<PipelineMetrics> {
+  const [row, verticalRow] = await Promise.all([
+    fetchSignalCounts(db, orgId, pipeline),
+    fetchTopVertical(db, orgId, pipeline),
+  ])
+  const counts = row ? { ...row } : { ...ZERO_COUNTS }
+  counts.top_vertical = verticalRow ? verticalRow.vertical : null
+  counts.top_vertical_count = verticalRow ? verticalRow.count : 0
+  return counts
+}
+
+export async function loadAveragePainScore(
+  db: D1Database,
+  orgId: string,
+  pipeline: PipelineId
+): Promise<number | null> {
+  const row = await db
+    .prepare(
+      `SELECT AVG(pain_score) as avg
+       FROM entities
+       WHERE stage = 'signal' AND org_id = ? AND source_pipeline = ? AND pain_score IS NOT NULL`
+    )
+    .bind(orgId, pipeline)
+    .first<{ avg: number | null }>()
+  return row?.avg ?? null
+}
+
+export async function listGeneratorSignals(
+  db: D1Database,
+  orgId: string,
+  pipeline: PipelineId
+): Promise<GeneratorSignalRow[]> {
+  const signals = await db
+    .prepare(
+      `SELECT e.id, e.name, e.pain_score, e.tier, e.vertical, e.area, e.summary, e.created_at,
+              c.id as context_id, c.metadata as context_metadata, c.content as context_content,
+              c.source_ref as context_source_ref
+       FROM entities e
+       LEFT JOIN context c ON c.entity_id = e.id AND c.type = 'signal'
+       WHERE e.org_id = ? AND e.source_pipeline = ? AND e.stage = 'signal'
+       ORDER BY e.created_at DESC, c.created_at DESC
+       LIMIT 50`
+    )
+    .bind(orgId, pipeline)
+    .all<GeneratorSignalRow>()
+
+  const seen = new Set<string>()
+  const rows: GeneratorSignalRow[] = []
+  for (const row of signals.results ?? []) {
+    if (seen.has(row.id)) continue
+    seen.add(row.id)
+    rows.push(row)
+  }
+  return rows
+}
+
+export async function listGeneratorSignalDays(
+  db: D1Database,
+  orgId: string,
+  pipeline: PipelineId
+): Promise<GeneratorDayRow[]> {
+  const byDay = await db
+    .prepare(
+      `SELECT date(created_at) as day, COUNT(*) as count
+       FROM entities
+       WHERE org_id = ? AND source_pipeline = ? AND stage = 'signal'
+         AND created_at >= datetime('now', '-30 days')
+       GROUP BY day
+       ORDER BY day DESC`
+    )
+    .bind(orgId, pipeline)
+    .all<GeneratorDayRow>()
+  return byDay.results ?? []
+}
+
+async function fetchSignalCounts(
+  db: D1Database,
+  orgId: string,
+  pipeline: PipelineId
+): Promise<PipelineMetrics | null> {
+  return await db
+    .prepare(
+      `SELECT
+         COUNT(*) as total_signals,
+         SUM(CASE WHEN created_at >= datetime('now', '-7 days') THEN 1 ELSE 0 END) as last_7d,
+         SUM(CASE WHEN pain_score IS NOT NULL THEN 1 ELSE 0 END) as has_pain,
+         SUM(CASE WHEN vertical IS NOT NULL AND vertical != 'unknown' THEN 1 ELSE 0 END) as has_vertical,
+         SUM(CASE WHEN area IS NOT NULL THEN 1 ELSE 0 END) as has_area,
+         SUM(CASE WHEN employee_count IS NOT NULL THEN 1 ELSE 0 END) as has_employee_count,
+         SUM(CASE WHEN tier IS NOT NULL THEN 1 ELSE 0 END) as has_tier,
+         MAX(created_at) as latest_signal_at
+       FROM entities
+       WHERE stage = 'signal' AND org_id = ? AND source_pipeline = ?`
+    )
+    .bind(orgId, pipeline)
+    .first<PipelineMetrics>()
+}
+
+async function fetchTopVertical(
+  db: D1Database,
+  orgId: string,
+  pipeline: PipelineId
+): Promise<{ vertical: string; count: number } | null> {
+  return await db
+    .prepare(
+      `SELECT vertical, COUNT(*) as count
+       FROM entities
+       WHERE stage = 'signal' AND org_id = ? AND source_pipeline = ?
+         AND vertical IS NOT NULL AND vertical != 'unknown'
+       GROUP BY vertical
+       ORDER BY count DESC
+       LIMIT 1`
+    )
+    .bind(orgId, pipeline)
+    .first<{ vertical: string; count: number }>()
+}

--- a/src/lib/admin/meeting-detail.ts
+++ b/src/lib/admin/meeting-detail.ts
@@ -1,0 +1,25 @@
+import { getMeetingScheduleByMeetingId, type MeetingSchedule } from '../booking/meeting-schedule'
+import { getScheduleByAssessmentId, type AssessmentSchedule } from '../booking/schedule'
+
+export type AdminMeetingSchedule = Pick<
+  MeetingSchedule | AssessmentSchedule,
+  | 'slot_start_utc'
+  | 'slot_end_utc'
+  | 'timezone'
+  | 'guest_timezone'
+  | 'guest_name'
+  | 'guest_email'
+  | 'google_meet_url'
+  | 'google_event_link'
+>
+
+export async function loadAdminMeetingSchedule(
+  db: D1Database,
+  orgId: string,
+  meetingId: string
+): Promise<AdminMeetingSchedule | null> {
+  return (
+    (await getMeetingScheduleByMeetingId(db, orgId, meetingId)) ??
+    (await getScheduleByAssessmentId(db, orgId, meetingId))
+  )
+}

--- a/src/lib/auth/magic-link-users.ts
+++ b/src/lib/auth/magic-link-users.ts
@@ -1,0 +1,26 @@
+export interface MagicLinkClientUser {
+  id: string
+  org_id: string
+  email: string
+  name: string
+  role: string
+  entity_id: string | null
+}
+
+export async function getMagicLinkClientUser(
+  db: D1Database,
+  orgId: string,
+  userId: string
+): Promise<MagicLinkClientUser | null> {
+  return await db
+    .prepare(`SELECT * FROM users WHERE id = ? AND org_id = ? AND role = 'client'`)
+    .bind(userId, orgId)
+    .first<MagicLinkClientUser>()
+}
+
+export async function recordUserLogin(db: D1Database, userId: string): Promise<void> {
+  await db
+    .prepare(`UPDATE users SET last_login_at = datetime('now') WHERE id = ?`)
+    .bind(userId)
+    .run()
+}

--- a/src/lib/db/follow-ups.ts
+++ b/src/lib/db/follow-ups.ts
@@ -65,6 +65,11 @@ export interface FollowUpFilters {
   overdue?: boolean
 }
 
+export interface FollowUpEntityName {
+  id: string
+  name: string
+}
+
 export interface CreateFollowUpData {
   entity_id: string
   engagement_id?: string | null
@@ -112,6 +117,24 @@ export async function listFollowUps(
     .bind(...params)
     .all<FollowUp>()
   return result.results
+}
+
+export async function listFollowUpEntityNames(
+  db: D1Database,
+  orgId: string,
+  entityIds: readonly string[]
+): Promise<Record<string, string>> {
+  const validIds = [...new Set(entityIds.filter(Boolean))].slice(0, 500)
+  if (validIds.length === 0) return {}
+
+  const placeholders = validIds.map(() => '?').join(', ')
+  const sql = 'SELECT id, name FROM entities WHERE id IN (' + placeholders + ') AND org_id = ?'
+  const rows = await db
+    .prepare(sql)
+    .bind(...validIds, orgId)
+    .all<FollowUpEntityName>()
+
+  return Object.fromEntries((rows.results ?? []).map((row) => [row.id, row.name]))
 }
 
 /**

--- a/src/pages/admin/assessments/[id].astro
+++ b/src/pages/admin/assessments/[id].astro
@@ -15,19 +15,13 @@
  * New admin UI routes all flow through the meeting page.
  */
 
+import { getAssessmentRedirectTarget } from '../../../lib/admin/assessment-redirect'
 import { env } from 'cloudflare:workers'
 
 const session = Astro.locals.session!
 const assessmentId = Astro.params.id!
 
-// The meetings table backfill (migration 0025) preserved IDs, so the same
-// ID lookup works. If nothing matches (e.g. an unmigrated pre-0010 row),
-// fall back to the entities list.
-const meeting = await env.DB.prepare(
-  'SELECT id, entity_id FROM meetings WHERE id = ? AND org_id = ?'
-)
-  .bind(assessmentId, session.orgId)
-  .first<{ id: string; entity_id: string }>()
+const meeting = await getAssessmentRedirectTarget(env.DB, session.orgId, assessmentId)
 
 if (!meeting) {
   return Astro.redirect('/admin/entities?error=not_found', 301)

--- a/src/pages/admin/entities/[id]/meetings/[meetingId].astro
+++ b/src/pages/admin/entities/[id]/meetings/[meetingId].astro
@@ -5,6 +5,7 @@ import { getMeeting } from '../../../../../lib/db/meetings'
 import { getEntity, ENTITY_STAGES } from '../../../../../lib/db/entities'
 import type { EntityStage } from '../../../../../lib/db/entities'
 import { listContext } from '../../../../../lib/db/context'
+import { loadAdminMeetingSchedule } from '../../../../../lib/admin/meeting-detail'
 import { env } from 'cloudflare:workers'
 
 /**
@@ -35,33 +36,7 @@ if (meeting.entity_id !== entityId) {
 const entity = await getEntity(env.DB, session.orgId, meeting.entity_id)
 if (!entity) return Astro.redirect('/admin/entities?error=entity_not_found')
 
-// Load the booking schedule sidecar. Prefer the new meeting_schedule table;
-// fall back to assessment_schedule during the monitoring window for rows
-// created before the meetings backfill.
-interface ScheduleRow {
-  slot_start_utc: string
-  slot_end_utc: string
-  timezone: string
-  guest_timezone: string | null
-  guest_name: string
-  guest_email: string
-  google_meet_url: string | null
-  google_event_link: string | null
-}
-
-let schedule = await env.DB.prepare(
-  'SELECT * FROM meeting_schedule WHERE meeting_id = ? AND org_id = ?'
-)
-  .bind(meetingId, session.orgId)
-  .first<ScheduleRow>()
-
-if (!schedule) {
-  schedule = await env.DB.prepare(
-    'SELECT * FROM assessment_schedule WHERE assessment_id = ? AND org_id = ?'
-  )
-    .bind(meetingId, session.orgId)
-    .first<ScheduleRow>()
-}
+const schedule = await loadAdminMeetingSchedule(env.DB, session.orgId, meetingId)
 
 // Load entity context timeline
 const contextEntries = await listContext(env.DB, entity.id)

--- a/src/pages/admin/follow-ups/index.astro
+++ b/src/pages/admin/follow-ups/index.astro
@@ -1,7 +1,7 @@
 ---
 import AdminLayout from '../../../layouts/AdminLayout.astro'
 import FollowUpList from '../../../components/admin/FollowUpList.astro'
-import { listFollowUps, FOLLOW_UP_TYPES } from '../../../lib/db/follow-ups'
+import { listFollowUps, listFollowUpEntityNames, FOLLOW_UP_TYPES } from '../../../lib/db/follow-ups'
 import type { FollowUpType } from '../../../lib/db/follow-ups'
 import { env } from 'cloudflare:workers'
 
@@ -33,28 +33,9 @@ const [upcoming, overdue, completed] = await Promise.all([
   }),
 ])
 
-// Look up client names for follow-ups
 const allFollowUps = [...upcoming, ...overdue, ...completed]
 const clientIds = [...new Set(allFollowUps.map((f) => f.entity_id))]
-
-interface EntityRow {
-  id: string
-  name: string
-}
-
-const clientMap: Record<string, string> = {}
-const validIds = clientIds.filter(Boolean).slice(0, 500)
-if (validIds.length > 0) {
-  const placeholders = validIds.map(() => '?').join(', ')
-  const rows = await env.DB.prepare(
-    `SELECT id, name FROM entities WHERE id IN (${placeholders}) AND org_id = ?`
-  )
-    .bind(...validIds, session.orgId)
-    .all<EntityRow>()
-  for (const row of rows.results) {
-    clientMap[row.id] = row.name
-  }
-}
+const clientMap = await listFollowUpEntityNames(env.DB, session.orgId, clientIds)
 
 const success = Astro.url.searchParams.get('saved')
 const activeItems =

--- a/src/pages/admin/generators/[type].astro
+++ b/src/pages/admin/generators/[type].astro
@@ -4,6 +4,7 @@ import GeneratorConfigForm from '../../../components/admin/GeneratorConfigForm.a
 import GeneratorSignalsList from '../../../components/admin/GeneratorSignalsList.astro'
 import { getGeneratorConfig, upsertGeneratorConfig } from '../../../lib/db/generators'
 import { PIPELINE_IDS, PIPELINE_LABELS, type PipelineId } from '../../../lib/generators/types'
+import { listGeneratorSignalDays, listGeneratorSignals } from '../../../lib/admin/generator-readers'
 import { env } from 'cloudflare:workers'
 
 /**
@@ -130,60 +131,8 @@ function buildConfigFromForm(pipeline: PipelineId, form: FormData): unknown {
 // ---------------------------------------------------------------------------
 
 const configRow = await getGeneratorConfig(env.DB, session.orgId, type)
-
-interface SignalRow {
-  id: string
-  name: string
-  pain_score: number | null
-  tier: string | null
-  vertical: string | null
-  area: string | null
-  summary: string | null
-  created_at: string
-  context_id: string | null
-  context_metadata: string | null
-  context_content: string | null
-  context_source_ref: string | null
-}
-
-const signals = await env.DB.prepare(
-  `SELECT e.id, e.name, e.pain_score, e.tier, e.vertical, e.area, e.summary, e.created_at,
-          c.id as context_id, c.metadata as context_metadata, c.content as context_content,
-          c.source_ref as context_source_ref
-   FROM entities e
-   LEFT JOIN context c ON c.entity_id = e.id AND c.type = 'signal'
-   WHERE e.org_id = ? AND e.source_pipeline = ? AND e.stage = 'signal'
-   ORDER BY e.created_at DESC, c.created_at DESC
-   LIMIT 50`
-)
-  .bind(session.orgId, type)
-  .all<SignalRow>()
-
-const seen = new Set<string>()
-const signalRows: SignalRow[] = []
-for (const row of signals.results ?? []) {
-  if (seen.has(row.id)) continue
-  seen.add(row.id)
-  signalRows.push(row)
-}
-
-interface DayRow {
-  day: string
-  count: number
-}
-
-const byDay = await env.DB.prepare(
-  `SELECT date(created_at) as day, COUNT(*) as count
-   FROM entities
-   WHERE org_id = ? AND source_pipeline = ? AND stage = 'signal'
-     AND created_at >= datetime('now', '-30 days')
-   GROUP BY day
-   ORDER BY day DESC`
-)
-  .bind(session.orgId, type)
-  .all<DayRow>()
-
-const daysWithData = byDay.results ?? []
+const signalRows = await listGeneratorSignals(env.DB, session.orgId, type)
+const daysWithData = await listGeneratorSignalDays(env.DB, session.orgId, type)
 const maxDayCount = Math.max(1, ...daysWithData.map((d) => d.count))
 
 // ---------------------------------------------------------------------------

--- a/src/pages/admin/generators/index.astro
+++ b/src/pages/admin/generators/index.astro
@@ -3,6 +3,11 @@ import AdminLayout from '../../../layouts/AdminLayout.astro'
 import GeneratorPipelineCard from '../../../components/admin/GeneratorPipelineCard.astro'
 import { listGeneratorConfigs } from '../../../lib/db/generators'
 import type { PipelineId } from '../../../lib/generators/types'
+import {
+  loadAveragePainScore,
+  loadPipelineMetrics,
+  type PipelineMetrics,
+} from '../../../lib/admin/generator-readers'
 import { env } from 'cloudflare:workers'
 
 /**
@@ -38,99 +43,19 @@ const PIPELINES: PipelineDef[] = [
 const configRows = await listGeneratorConfigs(env.DB, session.orgId)
 const configByPipeline = Object.fromEntries(configRows.map((r) => [r.pipeline, r]))
 
-interface PipelineMetrics {
-  total_signals: number
-  last_7d: number
-  has_pain: number
-  has_vertical: number
-  has_area: number
-  has_employee_count: number
-  has_tier: number
-  latest_signal_at: string | null
-  top_vertical: string | null
-  top_vertical_count: number
-}
-
-async function fetchSignalCounts(orgId: string, pipeline: string) {
-  return env.DB.prepare(
-    `SELECT
-       COUNT(*) as total_signals,
-       SUM(CASE WHEN created_at >= datetime('now', '-7 days') THEN 1 ELSE 0 END) as last_7d,
-       SUM(CASE WHEN pain_score IS NOT NULL THEN 1 ELSE 0 END) as has_pain,
-       SUM(CASE WHEN vertical IS NOT NULL AND vertical != 'unknown' THEN 1 ELSE 0 END) as has_vertical,
-       SUM(CASE WHEN area IS NOT NULL THEN 1 ELSE 0 END) as has_area,
-       SUM(CASE WHEN employee_count IS NOT NULL THEN 1 ELSE 0 END) as has_employee_count,
-       SUM(CASE WHEN tier IS NOT NULL THEN 1 ELSE 0 END) as has_tier,
-       MAX(created_at) as latest_signal_at
-     FROM entities
-     WHERE stage = 'signal' AND org_id = ? AND source_pipeline = ?`
-  )
-    .bind(orgId, pipeline)
-    .first<PipelineMetrics>()
-}
-
-async function fetchTopVertical(orgId: string, pipeline: string) {
-  return env.DB.prepare(
-    `SELECT vertical, COUNT(*) as count
-     FROM entities
-     WHERE stage = 'signal' AND org_id = ? AND source_pipeline = ?
-       AND vertical IS NOT NULL AND vertical != 'unknown'
-     GROUP BY vertical
-     ORDER BY count DESC
-     LIMIT 1`
-  )
-    .bind(orgId, pipeline)
-    .first<{ vertical: string; count: number }>()
-}
-
-const ZERO_COUNTS: PipelineMetrics = {
-  total_signals: 0,
-  last_7d: 0,
-  has_pain: 0,
-  has_vertical: 0,
-  has_area: 0,
-  has_employee_count: 0,
-  has_tier: 0,
-  latest_signal_at: null,
-  top_vertical: null,
-  top_vertical_count: 0,
-}
-
-function mergeMetrics(
-  row: PipelineMetrics | null,
-  verticalRow: { vertical: string; count: number } | null
-): PipelineMetrics {
-  const counts = row ? { ...row } : { ...ZERO_COUNTS }
-  counts.top_vertical = verticalRow ? verticalRow.vertical : null
-  counts.top_vertical_count = verticalRow ? verticalRow.count : 0
-  return counts
-}
-
 async function getPipelineMetrics(pipeline: string): Promise<PipelineMetrics> {
-  const [row, verticalRow] = await Promise.all([
-    fetchSignalCounts(session.orgId, pipeline),
-    fetchTopVertical(session.orgId, pipeline),
-  ])
-  return mergeMetrics(row, verticalRow)
+  return loadPipelineMetrics(env.DB, session.orgId, pipeline as PipelineId)
 }
 
 const metrics = await Promise.all(
   PIPELINES.map(async (p) => ({ pipeline: p, metrics: await getPipelineMetrics(p.id) }))
 )
 
-async function avgPainScore(pipeline: string): Promise<number | null> {
-  const row = await env.DB.prepare(
-    `SELECT AVG(pain_score) as avg
-     FROM entities
-     WHERE stage = 'signal' AND org_id = ? AND source_pipeline = ? AND pain_score IS NOT NULL`
-  )
-    .bind(session.orgId, pipeline)
-    .first<{ avg: number | null }>()
-  return row?.avg ?? null
-}
-
 const painAvgs = await Promise.all(
-  PIPELINES.map(async (p) => ({ pipeline: p.id, avg: await avgPainScore(p.id) }))
+  PIPELINES.map(async (p) => ({
+    pipeline: p.id,
+    avg: await loadAveragePainScore(env.DB, session.orgId, p.id),
+  }))
 )
 const painByPipeline = Object.fromEntries(painAvgs.map((a) => [a.pipeline, a.avg]))
 

--- a/src/pages/auth/verify.astro
+++ b/src/pages/auth/verify.astro
@@ -2,6 +2,7 @@
 import '../../styles/global.css'
 import { verifyMagicLink } from '../../lib/auth/magic-link'
 import { asUserRole, createSession, buildSessionCookie } from '../../lib/auth/session'
+import { getMagicLinkClientUser, recordUserLogin } from '../../lib/auth/magic-link-users'
 import { getPortalBaseUrl } from '../../lib/config/app-url'
 import { env } from 'cloudflare:workers'
 
@@ -34,31 +35,13 @@ if (!verified) {
   return Astro.redirect('/auth/sign-in?error=invalid')
 }
 
-// Look up the bound portal user by id + org. Email alone is not globally
-// unique across organizations.
-interface UserRow {
-  id: string
-  org_id: string
-  email: string
-  name: string
-  role: string
-  entity_id: string | null
-}
-
-const user = await env.DB.prepare(
-  `SELECT * FROM users WHERE id = ? AND org_id = ? AND role = 'client'`
-)
-  .bind(verified.userId, verified.orgId)
-  .first<UserRow>()
+const user = await getMagicLinkClientUser(env.DB, verified.orgId, verified.userId)
 
 if (!user) {
   return Astro.redirect('/auth/sign-in?error=no_account')
 }
 
-// Update last_login_at
-await env.DB.prepare(`UPDATE users SET last_login_at = datetime('now') WHERE id = ?`)
-  .bind(user.id)
-  .run()
+await recordUserLogin(env.DB, user.id)
 
 const sessionToken = await createSession(env.DB, env.SESSIONS, {
   id: user.id,

--- a/src/pages/portal/products/operator/settings/users.astro
+++ b/src/pages/portal/products/operator/settings/users.astro
@@ -5,6 +5,7 @@ import { getPortalClient } from '../../../../../lib/portal/session'
 import { getProductSubscription, listProductRoles } from '../../../../../lib/portal/product-access'
 import { listClerkOrgParticipants } from '../../../../../lib/portal/clerk-org-members'
 import { isPeopleAccessOperable } from '../../../../../lib/portal/operator/people-access-gate'
+import { loadTeamRoster, formatLastLogin } from '../../../../../lib/portal/operator/team-read'
 import PortalHeader from '../../../../../components/portal/PortalHeader.astro'
 import PortalTabs from '../../../../../components/portal/PortalTabs.astro'
 import PortalPageHead from '../../../../../components/portal/PortalPageHead.astro'
@@ -91,77 +92,9 @@ if (!(await isPeopleAccessOperable(env.DB, client.id))) {
   return Astro.redirect('/portal/products/operator/team')
 }
 
-// Aggregate roles per user. A single user can hold multiple roles
-// (e.g., principal AND compliance); we group rows here so the UI
-// renders one row per person with a comma-joined role list.
-interface MemberRow {
-  id: string
-  email: string
-  name: string
-  last_login_at: string | null
-  earliest_granted_at: string
-  roles: string[]
-}
-
-const memberRowsRaw = await env.DB.prepare(
-  `SELECT u.id           AS id,
-          u.email        AS email,
-          u.name         AS name,
-          u.last_login_at AS last_login_at,
-          pr.role         AS role,
-          pr.granted_at   AS granted_at
-     FROM product_roles pr
-     JOIN users u ON u.id = pr.user_id
-    WHERE pr.entity_id = ?
-      AND pr.org_id = ?
-      AND pr.product_slug = ?
-      AND pr.revoked_at IS NULL
-    ORDER BY u.name, pr.granted_at ASC`
-)
-  .bind(client.id, orgId, PRODUCT_SLUG)
-  .all<{
-    id: string
-    email: string
-    name: string
-    last_login_at: string | null
-    role: string
-    granted_at: string
-  }>()
-
-const memberMap = new Map<string, MemberRow>()
-for (const row of memberRowsRaw.results ?? []) {
-  const existing = memberMap.get(row.id)
-  if (existing) {
-    existing.roles.push(row.role)
-    if (row.granted_at < existing.earliest_granted_at) {
-      existing.earliest_granted_at = row.granted_at
-    }
-  } else {
-    memberMap.set(row.id, {
-      id: row.id,
-      email: row.email,
-      name: row.name,
-      last_login_at: row.last_login_at,
-      earliest_granted_at: row.granted_at,
-      roles: [row.role],
-    })
-  }
-}
-const members = Array.from(memberMap.values())
-
-const ROLE_ORDER: Record<string, number> = { principal: 0, staff: 1, compliance: 2 }
-for (const m of members) {
-  m.roles.sort((a, b) => (ROLE_ORDER[a] ?? 99) - (ROLE_ORDER[b] ?? 99))
-}
+const { members } = await loadTeamRoster(env.DB, client.id, orgId)
 
 const ALL_ROLES = ['principal', 'staff', 'compliance'] as const
-
-function formatLastLogin(iso: string | null): string {
-  if (!iso) return 'Never'
-  const d = new Date(iso)
-  if (Number.isNaN(d.getTime())) return 'Never'
-  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
-}
 
 function formatInviteDate(iso: string | null): string {
   if (!iso) return ''
@@ -327,7 +260,7 @@ const banner = status ? (STATUS_BANNERS[status] ?? null) : null
                           {m.email}
                         </span>
                         <span class="text-xs text-[color:var(--ss-color-text-muted)]">
-                          Last login: {formatLastLogin(m.last_login_at)}
+                          Last login: {formatLastLogin(m.lastLoginAt)}
                         </span>
                       </div>
 

--- a/tests/follow-ups.test.ts
+++ b/tests/follow-ups.test.ts
@@ -263,7 +263,7 @@ describe('follow-ups: dashboard page', () => {
   it('displays client name for each follow-up', () => {
     const code = source()
     expect(code).toContain('clientMap')
-    expect(code).toContain('row.name')
+    expect(code).toContain('listFollowUpEntityNames')
   })
 
   it('displays follow-up type label', () => {

--- a/tests/page-sql-readers.test.ts
+++ b/tests/page-sql-readers.test.ts
@@ -1,0 +1,217 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  createTestD1,
+  discoverNumericMigrations,
+  runMigrations,
+} from '@venturecrane/crane-test-harness'
+import type { D1Database } from '@cloudflare/workers-types'
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import {
+  listGeneratorSignalDays,
+  listGeneratorSignals,
+  loadAveragePainScore,
+  loadPipelineMetrics,
+} from '../src/lib/admin/generator-readers'
+import { getMagicLinkClientUser, recordUserLogin } from '../src/lib/auth/magic-link-users'
+import { listFollowUpEntityNames } from '../src/lib/db/follow-ups'
+import { appendContextRaw } from '../src/lib/db/context'
+
+const migrationsDir = resolve(process.cwd(), 'migrations')
+const ORG_ID = 'page-reader-org'
+const OTHER_ORG_ID = 'page-reader-other-org'
+
+describe('page SQL boundary', () => {
+  it('keeps raw D1 prepares out of Astro page frontmatter', () => {
+    const offenders = astroPages(resolve(process.cwd(), 'src/pages')).filter((file) =>
+      readFileSync(file, 'utf8').includes('env.DB.prepare')
+    )
+
+    expect(offenders).toEqual([])
+  })
+})
+
+describe('page reader helpers', () => {
+  let db: D1Database
+
+  beforeEach(async () => {
+    db = createTestD1()
+    await runMigrations(db, { files: discoverNumericMigrations(migrationsDir) })
+    await seedOrgs(db)
+  })
+
+  it('loads generator dashboard metrics through org and pipeline scope', async () => {
+    await seedSignalEntity(db, ORG_ID, 'signal-a', 'Alpha', 'review_mining', {
+      painScore: 8,
+      vertical: 'legal',
+      area: 'Phoenix',
+      employeeCount: 12,
+      tier: 'hot',
+      createdAt: new Date().toISOString(),
+    })
+    await seedSignalEntity(db, ORG_ID, 'signal-b', 'Beta', 'review_mining', {
+      painScore: null,
+      vertical: 'legal',
+      area: null,
+      employeeCount: null,
+      tier: null,
+      createdAt: new Date().toISOString(),
+    })
+    await seedSignalEntity(db, OTHER_ORG_ID, 'signal-c', 'Other', 'review_mining', {
+      painScore: 10,
+      vertical: 'medical',
+      area: 'Tucson',
+      employeeCount: 20,
+      tier: 'warm',
+      createdAt: new Date().toISOString(),
+    })
+
+    const metrics = await loadPipelineMetrics(db, ORG_ID, 'review_mining')
+    const avg = await loadAveragePainScore(db, ORG_ID, 'review_mining')
+
+    expect(metrics.total_signals).toBe(2)
+    expect(metrics.has_pain).toBe(1)
+    expect(metrics.top_vertical).toBe('legal')
+    expect(metrics.top_vertical_count).toBe(2)
+    expect(avg).toBe(8)
+  })
+
+  it('loads generator detail rows and deduplicates joined signal context', async () => {
+    await seedSignalEntity(db, ORG_ID, 'signal-a', 'Alpha', 'job_monitor', {
+      painScore: 5,
+      vertical: 'logistics',
+      area: 'Mesa',
+      employeeCount: 30,
+      tier: 'cool',
+      createdAt: '2026-07-01T10:00:00.000Z',
+    })
+    await appendContextRaw(db, ORG_ID, {
+      entity_id: 'signal-a',
+      type: 'signal',
+      content: 'older context',
+      source: 'job_monitor',
+      created_at: '2026-07-01T10:01:00.000Z',
+    })
+    await appendContextRaw(db, ORG_ID, {
+      entity_id: 'signal-a',
+      type: 'signal',
+      content: 'newer context',
+      source: 'job_monitor',
+      created_at: '2026-07-01T10:02:00.000Z',
+    })
+
+    const signals = await listGeneratorSignals(db, ORG_ID, 'job_monitor')
+    const days = await listGeneratorSignalDays(db, ORG_ID, 'job_monitor')
+
+    expect(signals).toHaveLength(1)
+    expect(signals[0]?.context_content).toBe('newer context')
+    expect(days).toEqual([{ day: '2026-07-01', count: 1 }])
+  })
+
+  it('loads follow-up entity names through org scope', async () => {
+    await seedEntity(db, ORG_ID, 'entity-a', 'A Client')
+    await seedEntity(db, OTHER_ORG_ID, 'entity-b', 'Other Client')
+
+    const names = await listFollowUpEntityNames(db, ORG_ID, ['entity-a', 'entity-b'])
+
+    expect(names).toEqual({ 'entity-a': 'A Client' })
+  })
+
+  it('loads magic-link client users and records last login', async () => {
+    await seedEntity(db, ORG_ID, 'entity-a', 'A Client')
+    await db
+      .prepare(
+        `INSERT INTO users (id, org_id, email, name, role, entity_id)
+         VALUES ('user-a', ?, 'client@example.com', 'Client User', 'client', 'entity-a')`
+      )
+      .bind(ORG_ID)
+      .run()
+
+    const user = await getMagicLinkClientUser(db, ORG_ID, 'user-a')
+    await recordUserLogin(db, 'user-a')
+    const row = await db
+      .prepare('SELECT last_login_at FROM users WHERE id = ?')
+      .bind('user-a')
+      .first<{ last_login_at: string | null }>()
+
+    expect(user?.email).toBe('client@example.com')
+    expect(row?.last_login_at).toBeTruthy()
+    await expect(getMagicLinkClientUser(db, OTHER_ORG_ID, 'user-a')).resolves.toBeNull()
+  })
+})
+
+function astroPages(dir: string): string[] {
+  const files: string[] = []
+  for (const entry of readdirSync(dir)) {
+    const path = join(dir, entry)
+    if (statSync(path).isDirectory()) {
+      files.push(...astroPages(path))
+    } else if (path.endsWith('.astro')) {
+      files.push(path)
+    }
+  }
+  return files
+}
+
+async function seedOrgs(db: D1Database): Promise<void> {
+  await db
+    .prepare('INSERT INTO organizations (id, name, slug) VALUES (?, ?, ?)')
+    .bind(ORG_ID, 'Page Reader Org', ORG_ID)
+    .run()
+  await db
+    .prepare('INSERT INTO organizations (id, name, slug) VALUES (?, ?, ?)')
+    .bind(OTHER_ORG_ID, 'Page Reader Other Org', OTHER_ORG_ID)
+    .run()
+}
+
+async function seedEntity(
+  db: D1Database,
+  orgId: string,
+  entityId: string,
+  name: string
+): Promise<void> {
+  await db
+    .prepare('INSERT INTO entities (id, org_id, name, slug) VALUES (?, ?, ?, ?)')
+    .bind(entityId, orgId, name, entityId)
+    .run()
+}
+
+async function seedSignalEntity(
+  db: D1Database,
+  orgId: string,
+  entityId: string,
+  name: string,
+  pipeline: string,
+  data: {
+    painScore: number | null
+    vertical: string | null
+    area: string | null
+    employeeCount: number | null
+    tier: string | null
+    createdAt: string
+  }
+): Promise<void> {
+  await db
+    .prepare(
+      `INSERT INTO entities (
+         id, org_id, name, slug, stage, source_pipeline, pain_score, vertical,
+         area, employee_count, tier, created_at, updated_at
+       )
+       VALUES (?, ?, ?, ?, 'signal', ?, ?, ?, ?, ?, ?, ?, ?)`
+    )
+    .bind(
+      entityId,
+      orgId,
+      name,
+      entityId,
+      pipeline,
+      data.painScore,
+      data.vertical,
+      data.area,
+      data.employeeCount,
+      data.tier,
+      data.createdAt,
+      data.createdAt
+    )
+    .run()
+}


### PR DESCRIPTION
Refs #1597

Summary:
- Move remaining Astro page-level D1 reads into named reader helpers for generators, meeting schedule fallback, assessment redirects, magic-link users, follow-up entity names, and Operator team roster reuse.
- Add a page SQL boundary test that fails if Astro pages reintroduce env.DB.prepare.
- Add D1-backed coverage for generator metrics/details, follow-up entity-name scoping, and magic-link user lookup/login updates.

Verification:
- npm run test -- tests/page-sql-readers.test.ts tests/follow-ups.test.ts tests/magic-link.test.ts tests/operator-team.test.ts
- npm run typecheck
- npm run lint
- npm run format:check
- npm run build
- npm run verify