### PR TITLE
fix(seo): exclude admin/portal/auth/dev/flag-gated routes from sitemap

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,6 +3,7 @@ import cloudflare from '@astrojs/cloudflare'
 import tailwindcss from '@tailwindcss/vite'
 import sitemap from '@astrojs/sitemap'
 import clerk from '@clerk/astro'
+import { isPublicMarketingUrl } from './src/lib/seo/sitemap-filter.mjs'
 
 // SS uses its own session layer backed by the SESSIONS KV namespace (see
 // src/lib/auth/session.ts); we don't use Astro's built-in session API. Pin
@@ -28,7 +29,7 @@ export default defineConfig({
     imageService: 'passthrough',
   }),
   session: { driver: sessionDrivers.lruCache() },
-  integrations: [clerk(), sitemap()],
+  integrations: [clerk(), sitemap({ filter: isPublicMarketingUrl })],
   vite: {
     plugins: [tailwindcss()],
   },

--- a/src/lib/seo/sitemap-filter.mjs
+++ b/src/lib/seo/sitemap-filter.mjs
@@ -1,0 +1,38 @@
+/**
+ * Sitemap inclusion filter for @astrojs/sitemap (wired in astro.config.mjs).
+ *
+ * The integration enumerates every non-dynamic route in src/pages, including
+ * the admin console, client portal, auth, dev/design scaffolding, and
+ * flag-gated pages that 404 in production. Only the public marketing surface
+ * belongs in the sitemap; everything else wastes crawl budget and publishes
+ * internal route names.
+ *
+ * Plain .mjs (not .ts) so both the Astro config loader and vitest import it
+ * without a transform step.
+ */
+
+/** Path prefixes that must never appear in the public sitemap. */
+export const EXCLUDED_PATH_PREFIXES = [
+  '/admin',
+  '/portal',
+  '/auth',
+  '/api',
+  '/dev',
+  '/design-preview',
+  '/assessment', // flag-gated, 404 in prod (ENABLE_ASSESSMENT_PREVIEW)
+  '/patterns', // flag-gated, 404 in prod (ENABLE_PUBLIC_PATTERNS)
+  '/book/manage', // guest token surface, not a landing page
+  '/get-started', // post-booking only; cold visits 301 to /
+  '/404',
+]
+
+/**
+ * @param {string} page Absolute URL as passed by @astrojs/sitemap's filter().
+ * @returns {boolean} true when the URL belongs in the sitemap.
+ */
+export function isPublicMarketingUrl(page) {
+  const pathname = new URL(page).pathname
+  return !EXCLUDED_PATH_PREFIXES.some(
+    (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`)
+  )
+}

--- a/tests/sitemap-filter.test.ts
+++ b/tests/sitemap-filter.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest'
+import { isPublicMarketingUrl } from '../src/lib/seo/sitemap-filter.mjs'
+
+const SITE = 'https://smd.services'
+
+describe('sitemap filter (astro.config.mjs)', () => {
+  it('keeps the public marketing surface', () => {
+    const publicRoutes = [
+      '/',
+      '/about/',
+      '/book/',
+      '/contact/',
+      '/industries/',
+      '/operator/',
+      '/packs/law-firm/',
+      '/packs/home-services/',
+      '/privacy/',
+      '/terms/',
+    ]
+    for (const route of publicRoutes) {
+      expect(isPublicMarketingUrl(`${SITE}${route}`), route).toBe(true)
+    }
+  })
+
+  it('excludes back-office, auth, dev, and flag-gated routes', () => {
+    const privateRoutes = [
+      '/admin/',
+      '/admin/analytics/',
+      '/admin/operator/provision/',
+      '/portal/',
+      '/portal/products/operator/settings/users/',
+      '/auth/sign-in/',
+      '/api/booking/slots',
+      '/dev/portal-components/',
+      '/design-preview/portal-quotes-detail/',
+      '/assessment/',
+      '/assessment/report-preview/',
+      '/patterns/',
+      '/book/manage/',
+      '/get-started/',
+      '/404/',
+    ]
+    for (const route of privateRoutes) {
+      expect(isPublicMarketingUrl(`${SITE}${route}`), route).toBe(false)
+    }
+  })
+
+  it('does not over-match prefixes against similarly named public paths', () => {
+    // /book must survive the /book/manage exclusion.
+    expect(isPublicMarketingUrl(`${SITE}/book/`)).toBe(true)
+  })
+})


### PR DESCRIPTION
## Problem

The `@astrojs/sitemap` integration ran with no `filter`, so the live `sitemap-0.xml` published every non-dynamic route in `src/pages` — the full admin console (17 routes), client portal (14 routes), auth pages, `/dev/*`, `/design-preview/*`, and the flag-gated `/assessment` and `/patterns` pages that 404 in production. Verified live 2026-07-01. This wastes crawl budget, looks broken to crawlers (redirects/auth walls/404s), and publishes internal route names.

## Fix

- `src/lib/seo/sitemap-filter.mjs` — exclusion-prefix filter, plain `.mjs` so the Astro config loader and vitest both import it without a transform.
- `astro.config.mjs` — wire `sitemap({ filter: isPublicMarketingUrl })`.
- `tests/sitemap-filter.test.ts` — regression coverage: public surface kept, private/flag-gated routes excluded, `/book` survives the `/book/manage` prefix.

## Verification

Local `npm run build` → generated `dist/client/sitemap-0.xml` contains exactly the 20 public marketing URLs (`/`, `/about`, `/book`, `/contact`, `/industries`, `/operator`, 12 packs, `/privacy`, `/terms`). `npm run verify` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)