### PR TITLE
Refactor admin session guard

### DIFF
--- a/src/lib/auth/admin-session.ts
+++ b/src/lib/auth/admin-session.ts
@@ -1,0 +1,28 @@
+export interface AdminSession {
+  userId: string
+  orgId: string
+  role: 'admin'
+  email: string
+  expiresAt: string
+}
+
+export type RequireAdminSessionResult =
+  | { ok: true; session: AdminSession }
+  | { ok: false; response: Response }
+
+export function requireAdminSession(
+  locals: Pick<App.Locals, 'session'>
+): RequireAdminSessionResult {
+  const session = locals.session
+  if (!session || session.role !== 'admin') {
+    return { ok: false, response: adminUnauthorizedResponse() }
+  }
+  return { ok: true, session: { ...session, role: 'admin' } }
+}
+
+export function adminUnauthorizedResponse(): Response {
+  return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+    status: 401,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}

--- a/src/pages/api/admin/assessments/[id].ts
+++ b/src/pages/api/admin/assessments/[id].ts
@@ -8,6 +8,7 @@ import type { AssessmentStatus } from '../../../../lib/db/assessments'
 import { uploadTranscript, getTranscript } from '../../../../lib/storage/r2'
 import { extractAssessment } from '../../../../lib/claude/extract'
 import { env } from 'cloudflare:workers'
+import { requireAdminSession } from '../../../../lib/auth/admin-session'
 
 type Redirect = APIContext['redirect']
 
@@ -120,13 +121,9 @@ async function handleGeneralUpdate({
  * Protected by auth middleware (requires admin role).
  */
 async function handlePost({ request, locals, redirect, params }: APIContext): Promise<Response> {
-  const session = locals.session
-  if (!session || session.role !== 'admin') {
-    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
-      status: 401,
-      headers: { 'Content-Type': 'application/json' },
-    })
-  }
+  const auth = requireAdminSession(locals)
+  if (!auth.ok) return auth.response
+  const { session } = auth
 
   const assessmentId = params.id
   if (!assessmentId) {

--- a/src/pages/api/admin/assessments/[id]/complete.ts
+++ b/src/pages/api/admin/assessments/[id]/complete.ts
@@ -9,6 +9,7 @@ import { appendContext } from '../../../../../lib/db/context'
 import { createQuote, type LineItem } from '../../../../../lib/db/quotes'
 import { uploadTranscript } from '../../../../../lib/storage/r2'
 import { env } from 'cloudflare:workers'
+import { requireAdminSession } from '../../../../../lib/auth/admin-session'
 
 /** Default hourly rate at launch (per Decision Stack #16, evolved). */
 const DEFAULT_RATE = 175
@@ -121,13 +122,9 @@ async function handleDisqualified(
 }
 
 async function handlePost({ request, locals, redirect, params }: APIContext): Promise<Response> {
-  const session = locals.session
-  if (!session || session.role !== 'admin') {
-    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
-      status: 401,
-      headers: { 'Content-Type': 'application/json' },
-    })
-  }
+  const auth = requireAdminSession(locals)
+  if (!auth.ok) return auth.response
+  const { session } = auth
 
   const assessmentId = params.id
   if (!assessmentId) {

--- a/src/pages/api/admin/assessments/[id]/live-notes.ts
+++ b/src/pages/api/admin/assessments/[id]/live-notes.ts
@@ -2,6 +2,7 @@ import { jsonResponse } from '../../../../../lib/api/helpers'
 import type { APIRoute } from 'astro'
 import { getAssessment, updateAssessment } from '../../../../../lib/db/assessments'
 import { env } from 'cloudflare:workers'
+import { requireAdminSession } from '../../../../../lib/auth/admin-session'
 
 /**
  * PUT /api/admin/assessments/:id/live-notes
@@ -12,10 +13,9 @@ import { env } from 'cloudflare:workers'
  * Protected by auth middleware (requires admin role).
  */
 export const PUT: APIRoute = async ({ request, locals, params }) => {
-  const session = locals.session
-  if (!session || session.role !== 'admin') {
-    return jsonResponse(401, { error: 'Unauthorized' })
-  }
+  const auth = requireAdminSession(locals)
+  if (!auth.ok) return auth.response
+  const { session } = auth
 
   const assessmentId = params.id
   if (!assessmentId) {

--- a/src/pages/api/admin/assessments/[id]/transcript.ts
+++ b/src/pages/api/admin/assessments/[id]/transcript.ts
@@ -2,6 +2,7 @@ import type { APIRoute } from 'astro'
 import { getAssessment } from '../../../../../lib/db/assessments'
 import { getTranscript } from '../../../../../lib/storage/r2'
 import { env } from 'cloudflare:workers'
+import { requireAdminSession } from '../../../../../lib/auth/admin-session'
 
 /**
  * GET /api/admin/assessments/:id/transcript
@@ -11,13 +12,9 @@ import { env } from 'cloudflare:workers'
  * Protected by auth middleware (requires admin role).
  */
 export const GET: APIRoute = async ({ locals, params }) => {
-  const session = locals.session
-  if (!session || session.role !== 'admin') {
-    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
-      status: 401,
-      headers: { 'Content-Type': 'application/json' },
-    })
-  }
+  const auth = requireAdminSession(locals)
+  if (!auth.ok) return auth.response
+  const { session } = auth
 
   const assessmentId = params.id
   if (!assessmentId) {

--- a/src/pages/api/admin/assessments/index.ts
+++ b/src/pages/api/admin/assessments/index.ts
@@ -1,6 +1,7 @@
 import type { APIRoute } from 'astro'
 import { createAssessment } from '../../../../lib/db/assessments'
 import { env } from 'cloudflare:workers'
+import { requireAdminSession } from '../../../../lib/auth/admin-session'
 
 /**
  * POST /api/admin/assessments
@@ -14,13 +15,9 @@ import { env } from 'cloudflare:workers'
  *   - scheduled_at
  */
 export const POST: APIRoute = async ({ request, locals, redirect }) => {
-  const session = locals.session
-  if (!session || session.role !== 'admin') {
-    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
-      status: 401,
-      headers: { 'Content-Type': 'application/json' },
-    })
-  }
+  const auth = requireAdminSession(locals)
+  if (!auth.ok) return auth.response
+  const { session } = auth
 
   try {
     const formData = await request.formData()

--- a/src/pages/api/admin/clients/[id]/operator-price.ts
+++ b/src/pages/api/admin/clients/[id]/operator-price.ts
@@ -1,6 +1,7 @@
 import type { APIContext, APIRoute } from 'astro'
 import { setOperatorPrice } from '../../../../../lib/db/services'
 import { env } from 'cloudflare:workers'
+import { requireAdminSession } from '../../../../../lib/auth/admin-session'
 
 /**
  * POST /api/admin/clients/[id]/operator-price
@@ -23,13 +24,9 @@ function parsePrice(
 }
 
 async function handlePost({ request, locals, params, redirect }: APIContext): Promise<Response> {
-  const session = locals.session
-  if (!session || session.role !== 'admin') {
-    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
-      status: 401,
-      headers: { 'Content-Type': 'application/json' },
-    })
-  }
+  const auth = requireAdminSession(locals)
+  if (!auth.ok) return auth.response
+  const { session } = auth
 
   const entityId = params.id
   if (!entityId) return redirect('/admin/clients?error=missing', 302)

--- a/src/pages/api/admin/contacts/[id].ts
+++ b/src/pages/api/admin/contacts/[id].ts
@@ -1,6 +1,7 @@
 import type { APIRoute } from 'astro'
 import { getContact, updateContact, deleteContact } from '../../../../lib/db/contacts'
 import { env } from 'cloudflare:workers'
+import { requireAdminSession } from '../../../../lib/auth/admin-session'
 
 /**
  * POST /api/admin/contacts/:id
@@ -15,13 +16,9 @@ import { env } from 'cloudflare:workers'
  *   - _method: "DELETE"
  */
 export const POST: APIRoute = async ({ request, locals, redirect, params }) => {
-  const session = locals.session
-  if (!session || session.role !== 'admin') {
-    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
-      status: 401,
-      headers: { 'Content-Type': 'application/json' },
-    })
-  }
+  const auth = requireAdminSession(locals)
+  if (!auth.ok) return auth.response
+  const { session } = auth
 
   const contactId = params.id
   if (!contactId) {

--- a/src/pages/api/admin/engagements/[id].ts
+++ b/src/pages/api/admin/engagements/[id].ts
@@ -7,6 +7,7 @@ import {
 import type { EngagementStatus } from '../../../../lib/db/engagements'
 import { getSignalById } from '../../../../lib/db/signal-attribution'
 import { env } from 'cloudflare:workers'
+import { requireAdminSession } from '../../../../lib/auth/admin-session'
 
 /**
  * POST /api/admin/engagements/:id
@@ -60,13 +61,9 @@ async function resolveSignalEdit(
 }
 
 async function handlePost({ request, locals, redirect, params }: APIContext): Promise<Response> {
-  const session = locals.session
-  if (!session || session.role !== 'admin') {
-    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
-      status: 401,
-      headers: { 'Content-Type': 'application/json' },
-    })
-  }
+  const auth = requireAdminSession(locals)
+  if (!auth.ok) return auth.response
+  const { session } = auth
 
   const engagementId = params.id
   if (!engagementId) {

--- a/src/pages/api/admin/engagements/[id]/consultant-photo.ts
+++ b/src/pages/api/admin/engagements/[id]/consultant-photo.ts
@@ -1,6 +1,7 @@
 import type { APIContext, APIRoute } from 'astro'
 import { getEngagement, updateEngagement } from '../../../../../lib/db/engagements'
 import { env } from 'cloudflare:workers'
+import { requireAdminSession } from '../../../../../lib/auth/admin-session'
 
 /**
  * Consultant photo upload endpoint.
@@ -51,13 +52,9 @@ function validatePhotoFile(file: FormDataEntryValue | null): Response | File {
 }
 
 async function handlePost({ request, locals, params }: APIContext): Promise<Response> {
-  const session = locals.session
-  if (!session || session.role !== 'admin') {
-    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
-      status: 401,
-      headers: { 'Content-Type': 'application/json' },
-    })
-  }
+  const auth = requireAdminSession(locals)
+  if (!auth.ok) return auth.response
+  const { session } = auth
 
   const engagementId = params.id
   if (!engagementId) {
@@ -104,13 +101,9 @@ async function handlePost({ request, locals, params }: APIContext): Promise<Resp
 export const POST: APIRoute = (ctx) => handlePost(ctx)
 
 async function handleDelete({ locals, params }: APIContext): Promise<Response> {
-  const session = locals.session
-  if (!session || session.role !== 'admin') {
-    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
-      status: 401,
-      headers: { 'Content-Type': 'application/json' },
-    })
-  }
+  const auth = requireAdminSession(locals)
+  if (!auth.ok) return auth.response
+  const { session } = auth
 
   const engagementId = params.id
   if (!engagementId) {

--- a/src/pages/api/admin/engagements/[id]/contacts.ts
+++ b/src/pages/api/admin/engagements/[id]/contacts.ts
@@ -11,6 +11,7 @@ import {
 import type { EngagementContactRole } from '../../../../../lib/db/engagement-contacts'
 import { appendContext } from '../../../../../lib/db/context'
 import { env } from 'cloudflare:workers'
+import { requireAdminSession } from '../../../../../lib/auth/admin-session'
 
 /**
  * POST /api/admin/engagements/:id/contacts
@@ -170,13 +171,9 @@ async function handleAdd({
 }
 
 async function handlePost({ request, locals, redirect, params }: APIContext): Promise<Response> {
-  const session = locals.session
-  if (!session || session.role !== 'admin') {
-    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
-      status: 401,
-      headers: { 'Content-Type': 'application/json' },
-    })
-  }
+  const auth = requireAdminSession(locals)
+  if (!auth.ok) return auth.response
+  const { session } = auth
 
   const engagementId = params.id
   if (!engagementId) {

--- a/src/pages/api/admin/engagements/[id]/deliverables.ts
+++ b/src/pages/api/admin/engagements/[id]/deliverables.ts
@@ -2,15 +2,12 @@ import type { APIRoute } from 'astro'
 import { getEngagement } from '../../../../../lib/db/engagements'
 import { listDocuments } from '../../../../../lib/storage/r2'
 import { env } from 'cloudflare:workers'
+import { requireAdminSession } from '../../../../../lib/auth/admin-session'
 
 export const POST: APIRoute = async ({ request, locals, params }) => {
-  const session = locals.session
-  if (!session || session.role !== 'admin') {
-    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
-      status: 401,
-      headers: { 'Content-Type': 'application/json' },
-    })
-  }
+  const auth = requireAdminSession(locals)
+  if (!auth.ok) return auth.response
+  const { session } = auth
   const engagementId = params.id
   if (!engagementId) {
     return new Response(JSON.stringify({ error: 'Engagement ID required' }), {
@@ -55,13 +52,9 @@ export const POST: APIRoute = async ({ request, locals, params }) => {
 }
 
 export const GET: APIRoute = async ({ locals, params }) => {
-  const session = locals.session
-  if (!session || session.role !== 'admin') {
-    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
-      status: 401,
-      headers: { 'Content-Type': 'application/json' },
-    })
-  }
+  const auth = requireAdminSession(locals)
+  if (!auth.ok) return auth.response
+  const { session } = auth
   const engagementId = params.id
   if (!engagementId) {
     return new Response(JSON.stringify({ error: 'Engagement ID required' }), {

--- a/src/pages/api/admin/engagements/[id]/deliverables/[...key].ts
+++ b/src/pages/api/admin/engagements/[id]/deliverables/[...key].ts
@@ -2,15 +2,12 @@ import type { APIRoute } from 'astro'
 import { getEngagement } from '../../../../../../lib/db/engagements'
 import { streamDocument } from '../../../../../../lib/storage/r2'
 import { env } from 'cloudflare:workers'
+import { requireAdminSession } from '../../../../../../lib/auth/admin-session'
 
 export const GET: APIRoute = async ({ locals, params }) => {
-  const session = locals.session
-  if (!session || session.role !== 'admin') {
-    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
-      status: 401,
-      headers: { 'Content-Type': 'application/json' },
-    })
-  }
+  const auth = requireAdminSession(locals)
+  if (!auth.ok) return auth.response
+  const { session } = auth
   const engagementId = params.id
   const keyPath = params.key
   if (!engagementId || !keyPath) {

--- a/src/pages/api/admin/engagements/[id]/milestones.ts
+++ b/src/pages/api/admin/engagements/[id]/milestones.ts
@@ -10,6 +10,7 @@ import {
 } from '../../../../../lib/db/milestones'
 import type { MilestoneStatus } from '../../../../../lib/db/milestones'
 import { env } from 'cloudflare:workers'
+import { requireAdminSession } from '../../../../../lib/auth/admin-session'
 
 /**
  * POST /api/admin/engagements/:id/milestones
@@ -170,13 +171,9 @@ async function handleCreate(
 }
 
 async function handlePost({ request, locals, redirect, params }: APIContext): Promise<Response> {
-  const session = locals.session
-  if (!session || session.role !== 'admin') {
-    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
-      status: 401,
-      headers: { 'Content-Type': 'application/json' },
-    })
-  }
+  const auth = requireAdminSession(locals)
+  if (!auth.ok) return auth.response
+  const { session } = auth
 
   const engagementId = params.id
   if (!engagementId) {

--- a/src/pages/api/admin/engagements/[id]/parking-lot.ts
+++ b/src/pages/api/admin/engagements/[id]/parking-lot.ts
@@ -10,6 +10,7 @@ import {
 import type { Disposition } from '../../../../../lib/db/parking-lot'
 import { appendContext } from '../../../../../lib/db/context'
 import { env } from 'cloudflare:workers'
+import { requireAdminSession } from '../../../../../lib/auth/admin-session'
 
 /**
  * POST /api/admin/engagements/:id/parking-lot
@@ -177,13 +178,9 @@ async function handleCreate(
 }
 
 async function handlePost({ request, locals, redirect, params }: APIContext): Promise<Response> {
-  const session = locals.session
-  if (!session || session.role !== 'admin') {
-    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
-      status: 401,
-      headers: { 'Content-Type': 'application/json' },
-    })
-  }
+  const auth = requireAdminSession(locals)
+  if (!auth.ok) return auth.response
+  const { session } = auth
 
   const engagementId = params.id
   if (!engagementId) {

--- a/src/pages/api/admin/engagements/index.ts
+++ b/src/pages/api/admin/engagements/index.ts
@@ -4,6 +4,7 @@ import { createMilestone } from '../../../../lib/db/milestones'
 import { getSignalById } from '../../../../lib/db/signal-attribution'
 import { env } from 'cloudflare:workers'
 import type { D1Database } from '@cloudflare/workers-types'
+import { requireAdminSession } from '../../../../lib/auth/admin-session'
 
 /**
  * POST /api/admin/engagements
@@ -70,13 +71,9 @@ async function createFormMilestones(
 }
 
 async function handlePost({ request, locals, redirect }: APIContext): Promise<Response> {
-  const session = locals.session
-  if (!session || session.role !== 'admin') {
-    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
-      status: 401,
-      headers: { 'Content-Type': 'application/json' },
-    })
-  }
+  const auth = requireAdminSession(locals)
+  if (!auth.ok) return auth.response
+  const { session } = auth
 
   try {
     const formData = await request.formData()

--- a/src/pages/api/admin/enrichment/backfill.ts
+++ b/src/pages/api/admin/enrichment/backfill.ts
@@ -2,6 +2,7 @@ import { jsonResponse } from '../../../../lib/api/helpers'
 import type { APIContext, APIRoute } from 'astro'
 import { dispatchEnrichmentWorkflow } from '../../../../lib/enrichment/dispatch'
 import { env } from 'cloudflare:workers'
+import { requireAdminSession } from '../../../../lib/auth/admin-session'
 
 /**
  * POST /api/admin/enrichment/backfill (#631)
@@ -83,10 +84,9 @@ async function dispatchSlice(
 }
 
 async function handlePost({ request, locals }: APIContext): Promise<Response> {
-  const session = locals.session
-  if (!session || session.role !== 'admin') {
-    return jsonResponse(401, { error: 'Unauthorized' })
-  }
+  const auth = requireAdminSession(locals)
+  if (!auth.ok) return auth.response
+  const { session } = auth
 
   let body: BackfillBody
   try {

--- a/src/pages/api/admin/entities/[id]/contacts.ts
+++ b/src/pages/api/admin/entities/[id]/contacts.ts
@@ -2,6 +2,7 @@ import type { APIRoute } from 'astro'
 import { getEntity } from '../../../../../lib/db/entities'
 import { createContact } from '../../../../../lib/db/contacts'
 import { env } from 'cloudflare:workers'
+import { requireAdminSession } from '../../../../../lib/auth/admin-session'
 
 /**
  * POST /api/admin/entities/:id/contacts
@@ -19,13 +20,9 @@ import { env } from 'cloudflare:workers'
  *     distinct from per-engagement role assignment)
  */
 export const POST: APIRoute = async ({ request, locals, redirect, params }) => {
-  const session = locals.session
-  if (!session || session.role !== 'admin') {
-    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
-      status: 401,
-      headers: { 'Content-Type': 'application/json' },
-    })
-  }
+  const auth = requireAdminSession(locals)
+  if (!auth.ok) return auth.response
+  const { session } = auth
 
   const entityId = params.id
   if (!entityId) {

--- a/src/pages/api/admin/entities/[id]/context.ts
+++ b/src/pages/api/admin/entities/[id]/context.ts
@@ -3,6 +3,7 @@ import type { APIRoute } from 'astro'
 import { appendContext, listContext, type ContextType } from '../../../../../lib/db/context'
 import { getEntity } from '../../../../../lib/db/entities'
 import { env } from 'cloudflare:workers'
+import { requireAdminSession } from '../../../../../lib/auth/admin-session'
 
 /**
  * GET /api/admin/entities/[id]/context
@@ -13,10 +14,9 @@ import { env } from 'cloudflare:workers'
  */
 
 export const GET: APIRoute = async ({ params, locals }) => {
-  const session = locals.session
-  if (!session || session.role !== 'admin') {
-    return jsonResponse(401, { error: 'Unauthorized' })
-  }
+  const auth = requireAdminSession(locals)
+  if (!auth.ok) return auth.response
+  const { session } = auth
 
   const entityId = params.id
   if (!entityId) {
@@ -38,13 +38,9 @@ export const GET: APIRoute = async ({ params, locals }) => {
 }
 
 export const POST: APIRoute = async ({ params, request, locals, redirect }) => {
-  const session = locals.session
-  if (!session || session.role !== 'admin') {
-    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
-      status: 401,
-      headers: { 'Content-Type': 'application/json' },
-    })
-  }
+  const auth = requireAdminSession(locals)
+  if (!auth.ok) return auth.response
+  const { session } = auth
 
   const entityId = params.id
   if (!entityId) {

--- a/src/pages/api/admin/entities/[id]/dismiss.ts
+++ b/src/pages/api/admin/entities/[id]/dismiss.ts
@@ -2,6 +2,7 @@ import type { APIContext, APIRoute } from 'astro'
 import { getEntity, transitionStage } from '../../../../../lib/db/entities'
 import { isLostReasonCode } from '../../../../../lib/db/lost-reasons'
 import { env } from 'cloudflare:workers'
+import { requireAdminSession } from '../../../../../lib/auth/admin-session'
 
 /**
  * POST /api/admin/entities/[id]/dismiss
@@ -36,13 +37,9 @@ function parseDismissForm(formData: FormData): {
 }
 
 async function handlePost({ params, request, locals, redirect }: APIContext): Promise<Response> {
-  const session = locals.session
-  if (!session || session.role !== 'admin') {
-    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
-      status: 401,
-      headers: { 'Content-Type': 'application/json' },
-    })
-  }
+  const auth = requireAdminSession(locals)
+  if (!auth.ok) return auth.response
+  const { session } = auth
 
   const entityId = params.id
   if (!entityId) return redirect('/admin/entities?error=missing', 302)

--- a/src/pages/api/admin/entities/[id]/dossier.ts
+++ b/src/pages/api/admin/entities/[id]/dossier.ts
@@ -1,6 +1,7 @@
 import type { APIRoute } from 'astro'
 import { dispatchEnrichmentWorkflow } from '../../../../../lib/enrichment/dispatch'
 import { env } from 'cloudflare:workers'
+import { requireAdminSession } from '../../../../../lib/auth/admin-session'
 
 /**
  * POST /api/admin/entities/[id]/dossier
@@ -22,13 +23,9 @@ import { env } from 'cloudflare:workers'
  * issue #471. This endpoint backs the "Re-enrich" toolbar action.
  */
 export const POST: APIRoute = ({ params, locals, redirect }) => {
-  const session = locals.session
-  if (!session || session.role !== 'admin') {
-    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
-      status: 401,
-      headers: { 'Content-Type': 'application/json' },
-    })
-  }
+  const auth = requireAdminSession(locals)
+  if (!auth.ok) return auth.response
+  const { session } = auth
 
   const entityId = params.id
   if (!entityId) return redirect('/admin/entities?error=missing', 302)

--- a/src/pages/api/admin/entities/[id]/enrichment/[module]/retry.ts
+++ b/src/pages/api/admin/entities/[id]/enrichment/[module]/retry.ts
@@ -2,6 +2,7 @@ import type { APIRoute } from 'astro'
 import { runSingleModule } from '../../../../../../../lib/enrichment'
 import { isModuleId } from '../../../../../../../lib/enrichment/modules'
 import { env } from 'cloudflare:workers'
+import { requireAdminSession } from '../../../../../../../lib/auth/admin-session'
 
 /**
  * POST /api/admin/entities/[id]/enrichment/[module]/retry
@@ -12,13 +13,9 @@ import { env } from 'cloudflare:workers'
  * cron-triggered run.
  */
 export const POST: APIRoute = async ({ params, locals, redirect }) => {
-  const session = locals.session
-  if (!session || session.role !== 'admin') {
-    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
-      status: 401,
-      headers: { 'Content-Type': 'application/json' },
-    })
-  }
+  const auth = requireAdminSession(locals)
+  if (!auth.ok) return auth.response
+  const { session } = auth
 
   const entityId = params.id
   const moduleParam = params.module

--- a/src/pages/api/admin/entities/[id]/enrichment/run-full.ts
+++ b/src/pages/api/admin/entities/[id]/enrichment/run-full.ts
@@ -1,6 +1,7 @@
 import type { APIRoute } from 'astro'
 import { dispatchEnrichmentWorkflow } from '../../../../../../lib/enrichment/dispatch'
 import { env } from 'cloudflare:workers'
+import { requireAdminSession } from '../../../../../../lib/auth/admin-session'
 
 /**
  * POST /api/admin/entities/[id]/enrichment/run-full
@@ -26,13 +27,9 @@ import { env } from 'cloudflare:workers'
  * accept that re-clicking on an already-succeeded entity short-circuits.
  */
 export const POST: APIRoute = ({ params, locals, redirect }) => {
-  const session = locals.session
-  if (!session || session.role !== 'admin') {
-    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
-      status: 401,
-      headers: { 'Content-Type': 'application/json' },
-    })
-  }
+  const auth = requireAdminSession(locals)
+  if (!auth.ok) return auth.response
+  const { session } = auth
 
   const entityId = params.id
   if (!entityId) return redirect('/admin/entities?error=missing', 302)

--- a/src/pages/api/admin/entities/[id]/meetings/[meetingId]/complete.ts
+++ b/src/pages/api/admin/entities/[id]/meetings/[meetingId]/complete.ts
@@ -7,6 +7,7 @@ import {
 import { getEntity, transitionStage, type EntityStage } from '../../../../../../../lib/db/entities'
 import { appendContext } from '../../../../../../../lib/db/context'
 import { env } from 'cloudflare:workers'
+import { requireAdminSession } from '../../../../../../../lib/auth/admin-session'
 
 /**
  * POST /api/admin/entities/:id/meetings/:meetingId/complete
@@ -63,13 +64,9 @@ function parseFormData(formData: FormData): {
 }
 
 async function handlePost({ request, locals, redirect, params }: APIContext): Promise<Response> {
-  const session = locals.session
-  if (!session || session.role !== 'admin') {
-    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
-      status: 401,
-      headers: { 'Content-Type': 'application/json' },
-    })
-  }
+  const auth = requireAdminSession(locals)
+  if (!auth.ok) return auth.response
+  const { session } = auth
 
   const entityId = params.id
   const meetingId = params.meetingId

--- a/src/pages/api/admin/entities/[id]/meetings/[meetingId]/draft-quote.ts
+++ b/src/pages/api/admin/entities/[id]/meetings/[meetingId]/draft-quote.ts
@@ -3,6 +3,7 @@ import { getMeeting } from '../../../../../../../lib/db/meetings'
 import { getEntity, transitionStage } from '../../../../../../../lib/db/entities'
 import { createQuote, type LineItem } from '../../../../../../../lib/db/quotes'
 import { env } from 'cloudflare:workers'
+import { requireAdminSession } from '../../../../../../../lib/auth/admin-session'
 
 /** Default hourly rate at launch (per Decision Stack #16, evolved). */
 const DEFAULT_RATE = 175
@@ -24,13 +25,9 @@ const DEFAULT_RATE = 175
  * Protected by auth middleware (requires admin role).
  */
 export const POST: APIRoute = async ({ locals, redirect, params }) => {
-  const session = locals.session
-  if (!session || session.role !== 'admin') {
-    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
-      status: 401,
-      headers: { 'Content-Type': 'application/json' },
-    })
-  }
+  const auth = requireAdminSession(locals)
+  if (!auth.ok) return auth.response
+  const { session } = auth
 
   const entityId = params.id
   const meetingId = params.meetingId

--- a/src/pages/api/admin/entities/[id]/meetings/[meetingId]/live-notes.ts
+++ b/src/pages/api/admin/entities/[id]/meetings/[meetingId]/live-notes.ts
@@ -2,6 +2,7 @@ import { jsonResponse } from '../../../../../../../lib/api/helpers'
 import type { APIRoute } from 'astro'
 import { getMeeting, updateMeeting } from '../../../../../../../lib/db/meetings'
 import { env } from 'cloudflare:workers'
+import { requireAdminSession } from '../../../../../../../lib/auth/admin-session'
 
 /**
  * PUT /api/admin/entities/:id/meetings/:meetingId/live-notes
@@ -12,10 +13,9 @@ import { env } from 'cloudflare:workers'
  * Protected by auth middleware (requires admin role).
  */
 export const PUT: APIRoute = async ({ request, locals, params }) => {
-  const session = locals.session
-  if (!session || session.role !== 'admin') {
-    return jsonResponse(401, { error: 'Unauthorized' })
-  }
+  const auth = requireAdminSession(locals)
+  if (!auth.ok) return auth.response
+  const { session } = auth
 
   const entityId = params.id
   const meetingId = params.meetingId

--- a/src/pages/api/admin/entities/[id]/merge.ts
+++ b/src/pages/api/admin/entities/[id]/merge.ts
@@ -1,6 +1,7 @@
 import type { APIRoute } from 'astro'
 import { mergeEntities } from '../../../../../lib/db/entities-extra'
 import { env } from 'cloudflare:workers'
+import { requireAdminSession } from '../../../../../lib/auth/admin-session'
 
 /**
  * POST /api/admin/entities/[id]/merge
@@ -12,13 +13,9 @@ import { env } from 'cloudflare:workers'
  * URL param: [id] — the entity to merge INTO (will be kept).
  */
 export const POST: APIRoute = async ({ params, request, locals, redirect }) => {
-  const session = locals.session
-  if (!session || session.role !== 'admin') {
-    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
-      status: 401,
-      headers: { 'Content-Type': 'application/json' },
-    })
-  }
+  const auth = requireAdminSession(locals)
+  if (!auth.ok) return auth.response
+  const { session } = auth
 
   const targetId = params.id
   if (!targetId) {

--- a/src/pages/api/admin/entities/[id]/outreach-draft/discard.ts
+++ b/src/pages/api/admin/entities/[id]/outreach-draft/discard.ts
@@ -1,5 +1,6 @@
 import type { APIContext, APIRoute } from 'astro'
 import { env } from 'cloudflare:workers'
+import { requireAdminSession } from '../../../../../../lib/auth/admin-session'
 
 interface OutreachDraftRow {
   id: string
@@ -17,13 +18,9 @@ function parseMetadata(raw: string | null): Record<string, unknown> {
 }
 
 async function handlePost({ params, locals, redirect }: APIContext): Promise<Response> {
-  const session = locals.session
-  if (!session || session.role !== 'admin') {
-    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
-      status: 401,
-      headers: { 'Content-Type': 'application/json' },
-    })
-  }
+  const auth = requireAdminSession(locals)
+  if (!auth.ok) return auth.response
+  const { session } = auth
 
   const entityId = params.id
   if (!entityId) return redirect('/admin/entities?error=missing', 302)

--- a/src/pages/api/admin/entities/[id]/promote.ts
+++ b/src/pages/api/admin/entities/[id]/promote.ts
@@ -3,6 +3,7 @@ import { getEntity, transitionStage } from '../../../../../lib/db/entities'
 import { dispatchEnrichmentWorkflow } from '../../../../../lib/enrichment/dispatch'
 import { scheduleProspectCadence } from '../../../../../lib/follow-ups/scheduler'
 import { env } from 'cloudflare:workers'
+import { requireAdminSession } from '../../../../../lib/auth/admin-session'
 
 /**
  * POST /api/admin/entities/[id]/promote
@@ -20,13 +21,9 @@ import { env } from 'cloudflare:workers'
  * the original Error 1101 incident.
  */
 export const POST: APIRoute = async ({ params, locals, redirect }) => {
-  const session = locals.session
-  if (!session || session.role !== 'admin') {
-    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
-      status: 401,
-      headers: { 'Content-Type': 'application/json' },
-    })
-  }
+  const auth = requireAdminSession(locals)
+  if (!auth.ok) return auth.response
+  const { session } = auth
 
   const entityId = params.id
   if (!entityId) {

--- a/src/pages/api/admin/entities/[id]/quotes.ts
+++ b/src/pages/api/admin/entities/[id]/quotes.ts
@@ -3,6 +3,7 @@ import { getEntity } from '../../../../../lib/db/entities'
 import { listAssessments } from '../../../../../lib/db/assessments'
 import { createQuote, getQuote, hasOpenQuoteForEntity } from '../../../../../lib/db/quotes'
 import { env } from 'cloudflare:workers'
+import { requireAdminSession } from '../../../../../lib/auth/admin-session'
 
 /**
  * POST /api/admin/entities/[id]/quotes
@@ -39,13 +40,9 @@ const ELIGIBLE_STAGES = ['signal', 'prospect', 'meetings', 'proposing']
 const DEFAULT_RATE = 175
 
 export const POST: APIRoute = async ({ params, request, locals, redirect }) => {
-  const session = locals.session
-  if (!session || session.role !== 'admin') {
-    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
-      status: 401,
-      headers: { 'Content-Type': 'application/json' },
-    })
-  }
+  const auth = requireAdminSession(locals)
+  if (!auth.ok) return auth.response
+  const { session } = auth
 
   const entityId = params.id
   if (!entityId) {

--- a/src/pages/api/admin/entities/[id]/reply-log.ts
+++ b/src/pages/api/admin/entities/[id]/reply-log.ts
@@ -2,6 +2,7 @@ import type { APIRoute } from 'astro'
 import { appendContext } from '../../../../../lib/db/context'
 import { getEntity } from '../../../../../lib/db/entities'
 import { env } from 'cloudflare:workers'
+import { requireAdminSession } from '../../../../../lib/auth/admin-session'
 
 /**
  * POST /api/admin/entities/[id]/reply-log
@@ -26,13 +27,9 @@ export const REPLY_NEXT_ACTIONS = [
 export type ReplyNextAction = (typeof REPLY_NEXT_ACTIONS)[number]
 
 export const POST: APIRoute = async ({ params, request, locals, redirect }) => {
-  const session = locals.session
-  if (!session || session.role !== 'admin') {
-    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
-      status: 401,
-      headers: { 'Content-Type': 'application/json' },
-    })
-  }
+  const auth = requireAdminSession(locals)
+  if (!auth.ok) return auth.response
+  const { session } = auth
 
   const entityId = params.id
   if (!entityId) {

--- a/src/pages/api/admin/entities/[id]/send-booking-link.ts
+++ b/src/pages/api/admin/entities/[id]/send-booking-link.ts
@@ -13,6 +13,7 @@ import { requireAppBaseUrl } from '../../../../../lib/config/app-url'
 import { sendOutreachEmail } from '../../../../../lib/email/resend'
 import { bookingLinkInviteEmailHtml } from '../../../../../lib/email/templates'
 import { env } from 'cloudflare:workers'
+import { requireAdminSession } from '../../../../../lib/auth/admin-session'
 
 /**
  * POST /api/admin/entities/[id]/send-booking-link
@@ -354,8 +355,9 @@ function parseMeetingType(raw: unknown): string | null {
 }
 
 async function handlePost({ params, request, locals }: APIContext): Promise<Response> {
-  const session = locals.session
-  if (!session || session.role !== 'admin') return jsonResponse(401, { error: 'Unauthorized' })
+  const auth = requireAdminSession(locals)
+  if (!auth.ok) return auth.response
+  const { session } = auth
   const entityId = params.id
   if (!entityId) return jsonResponse(400, { error: 'missing_entity_id' })
 

--- a/src/pages/api/admin/entities/[id]/stage.ts
+++ b/src/pages/api/admin/entities/[id]/stage.ts
@@ -7,6 +7,7 @@ import {
 } from '../../../../../lib/db/entities'
 import { isLostReasonCode } from '../../../../../lib/db/lost-reasons'
 import { env } from 'cloudflare:workers'
+import { requireAdminSession } from '../../../../../lib/auth/admin-session'
 
 /**
  * POST /api/admin/entities/[id]/stage
@@ -42,13 +43,9 @@ function resolveLostOptions(
 }
 
 async function handlePost({ params, request, locals, redirect }: APIContext): Promise<Response> {
-  const session = locals.session
-  if (!session || session.role !== 'admin') {
-    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
-      status: 401,
-      headers: { 'Content-Type': 'application/json' },
-    })
-  }
+  const auth = requireAdminSession(locals)
+  if (!auth.ok) return auth.response
+  const { session } = auth
 
   const entityId = params.id
   if (!entityId) return redirect('/admin/entities?error=missing', 302)

--- a/src/pages/api/admin/entities/bulk.ts
+++ b/src/pages/api/admin/entities/bulk.ts
@@ -7,6 +7,7 @@ import {
   type BulkActionResult,
 } from '../../../../lib/db/entities-bulk'
 import { isLostReasonCode } from '../../../../lib/db/lost-reasons'
+import { requireAdminSession } from '../../../../lib/auth/admin-session'
 
 /**
  * POST /api/admin/entities/bulk
@@ -32,10 +33,9 @@ import { isLostReasonCode } from '../../../../lib/db/lost-reasons'
  * Admin-only. Org-scoped. Validates every id belongs to the session org.
  */
 async function handlePost({ request, locals }: APIContext): Promise<Response> {
-  const session = locals.session
-  if (!session || session.role !== 'admin') {
-    return jsonResponse(401, { error: 'Unauthorized' })
-  }
+  const auth = requireAdminSession(locals)
+  if (!auth.ok) return auth.response
+  const { session } = auth
 
   let body: unknown
   try {

--- a/src/pages/api/admin/follow-ups/[id].ts
+++ b/src/pages/api/admin/follow-ups/[id].ts
@@ -5,6 +5,7 @@ import { getFollowUpTemplate } from '../../../../lib/email/follow-up-templates'
 import type { FollowUpEmailData } from '../../../../lib/email/follow-up-templates'
 import { sendEmail } from '../../../../lib/email/resend'
 import { env } from 'cloudflare:workers'
+import { requireAdminSession } from '../../../../lib/auth/admin-session'
 
 interface EntityRow {
   id: string
@@ -65,13 +66,9 @@ async function handleSendEmail(
 }
 
 async function handlePost({ request, locals, redirect, params }: APIContext): Promise<Response> {
-  const session = locals.session
-  if (!session || session.role !== 'admin') {
-    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
-      status: 401,
-      headers: { 'Content-Type': 'application/json' },
-    })
-  }
+  const auth = requireAdminSession(locals)
+  if (!auth.ok) return auth.response
+  const { session } = auth
 
   const followUpId = params.id
   if (!followUpId) {

--- a/src/pages/api/admin/invoices/[id].ts
+++ b/src/pages/api/admin/invoices/[id].ts
@@ -9,6 +9,7 @@ import {
 import { sendEmail } from '../../../../lib/email/resend'
 import { invoiceSentEmailHtml } from '../../../../lib/email/templates'
 import { env } from 'cloudflare:workers'
+import { requireAdminSession } from '../../../../lib/auth/admin-session'
 
 /**
  * POST /api/admin/invoices/:id
@@ -179,13 +180,9 @@ async function handleMarkPaid(
 }
 
 async function handlePost({ request, locals, redirect, params }: APIContext): Promise<Response> {
-  const session = locals.session
-  if (!session || session.role !== 'admin') {
-    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
-      status: 401,
-      headers: { 'Content-Type': 'application/json' },
-    })
-  }
+  const auth = requireAdminSession(locals)
+  if (!auth.ok) return auth.response
+  const { session } = auth
 
   const invoiceId = params.id
   if (!invoiceId) {

--- a/src/pages/api/admin/invoices/index.ts
+++ b/src/pages/api/admin/invoices/index.ts
@@ -2,6 +2,7 @@ import type { APIContext, APIRoute } from 'astro'
 import { createInvoice } from '../../../../lib/db/invoices'
 import type { InvoiceType } from '../../../../lib/db/invoices'
 import { env } from 'cloudflare:workers'
+import { requireAdminSession } from '../../../../lib/auth/admin-session'
 
 const VALID_TYPES: InvoiceType[] = ['deposit', 'completion', 'milestone', 'assessment', 'retainer']
 
@@ -39,13 +40,9 @@ function parseInvoiceForm(
 }
 
 async function handlePost({ request, locals, redirect }: APIContext): Promise<Response> {
-  const session = locals.session
-  if (!session || session.role !== 'admin') {
-    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
-      status: 401,
-      headers: { 'Content-Type': 'application/json' },
-    })
-  }
+  const auth = requireAdminSession(locals)
+  if (!auth.ok) return auth.response
+  const { session } = auth
 
   try {
     const formData = await request.formData()

--- a/src/pages/api/admin/operator/[customer]/authority.ts
+++ b/src/pages/api/admin/operator/[customer]/authority.ts
@@ -30,22 +30,17 @@ import {
 } from '../../../../../lib/admin/authority-write'
 import { getCustomerConfig } from '../../../../../lib/portal/customer-config'
 import { resolveDomainAuthority, isSwitchableDomain } from '../../../../../lib/operator/authority'
+import { requireAdminSession } from '../../../../../lib/auth/admin-session'
 
 function redirectWithStatus(slug: string, status: string): Response {
   const target = `/admin/operator/${encodeURIComponent(slug)}/authority?status=${encodeURIComponent(status)}`
   return new Response(null, { status: 303, headers: { Location: target } })
 }
 
-function jsonError(status: number, message: string): Response {
-  return new Response(JSON.stringify({ error: message }), {
-    status,
-    headers: { 'Content-Type': 'application/json' },
-  })
-}
-
 async function handlePost(ctx: APIContext): Promise<Response> {
-  const session = ctx.locals.session
-  if (!session || session.role !== 'admin') return jsonError(401, 'Unauthorized')
+  const auth = requireAdminSession(ctx.locals)
+  if (!auth.ok) return auth.response
+  const { session } = auth
 
   const slug = ctx.params.customer ?? ''
   const entityId = await resolveEntityIdBySlug(env.DB, slug)

--- a/src/pages/api/admin/operator/[customer]/governance.ts
+++ b/src/pages/api/admin/operator/[customer]/governance.ts
@@ -34,17 +34,11 @@ import {
   ACCEPTED_ACTION_CLASSES,
   type ActionClass,
 } from '../../../../../lib/operator/customer-yaml/types'
+import { requireAdminSession } from '../../../../../lib/auth/admin-session'
 
 function redirectWithStatus(slug: string, status: string): Response {
   const target = `/admin/operator/${encodeURIComponent(slug)}/governance?status=${encodeURIComponent(status)}`
   return new Response(null, { status: 303, headers: { Location: target } })
-}
-
-function jsonError(status: number, message: string): Response {
-  return new Response(JSON.stringify({ error: message }), {
-    status,
-    headers: { 'Content-Type': 'application/json' },
-  })
 }
 
 function optionalString(raw: FormDataEntryValue | null): string | null {
@@ -86,8 +80,9 @@ function parseForm(form: FormData): { error: string } | { parsed: ParsedForm } {
 }
 
 async function handlePost(ctx: APIContext): Promise<Response> {
-  const session = ctx.locals.session
-  if (!session || session.role !== 'admin') return jsonError(401, 'Unauthorized')
+  const auth = requireAdminSession(ctx.locals)
+  if (!auth.ok) return auth.response
+  const { session } = auth
 
   const slug = ctx.params.customer ?? ''
   const entityId = await resolveEntityIdBySlug(env.DB, slug)

--- a/src/pages/api/admin/operator/[customer]/mcp-grants.ts
+++ b/src/pages/api/admin/operator/[customer]/mcp-grants.ts
@@ -29,17 +29,11 @@ import {
   GRANT_TTL_DEFAULT_DAYS,
   revokeGrant,
 } from '../../../../../lib/operator/mcp/grant-store'
+import { requireAdminSession } from '../../../../../lib/auth/admin-session'
 
 function redirectWithStatus(slug: string, status: string): Response {
   const target = `/admin/operator/${encodeURIComponent(slug)}/connectors?status=${encodeURIComponent(status)}`
   return new Response(null, { status: 303, headers: { Location: target } })
-}
-
-function jsonError(status: number, message: string): Response {
-  return new Response(JSON.stringify({ error: message }), {
-    status,
-    headers: { 'Content-Type': 'application/json' },
-  })
 }
 
 function optionalString(raw: FormDataEntryValue | null): string | null {
@@ -83,8 +77,9 @@ function parseForm(form: FormData): { error: string } | { parsed: ParsedForm } {
 }
 
 async function handlePost(ctx: APIContext): Promise<Response> {
-  const session = ctx.locals.session
-  if (!session || session.role !== 'admin') return jsonError(401, 'Unauthorized')
+  const auth = requireAdminSession(ctx.locals)
+  if (!auth.ok) return auth.response
+  const { session } = auth
 
   const slug = ctx.params.customer ?? ''
   const entityId = await resolveEntityIdBySlug(env.DB, slug)

--- a/src/pages/api/admin/operator/costs/anomalies/[action].ts
+++ b/src/pages/api/admin/operator/costs/anomalies/[action].ts
@@ -18,6 +18,7 @@ import { jsonResponse } from '../../../../../../lib/api/helpers'
 import type { APIContext, APIRoute } from 'astro'
 import { env } from 'cloudflare:workers'
 import { acknowledgeAlert, snoozeAlert } from '../../../../../../lib/admin/cost-anomaly'
+import { requireAdminSession } from '../../../../../../lib/auth/admin-session'
 
 const DATE_RE = /^\d{4}-\d{2}-\d{2}$/
 const ISO_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?Z$/
@@ -49,10 +50,9 @@ function parseIdentity(body: unknown): AlertIdentity | { error: string } {
 }
 
 async function handlePost(ctx: APIContext): Promise<Response> {
-  const session = ctx.locals.session
-  if (!session || session.role !== 'admin') {
-    return jsonResponse(401, { error: 'Unauthorized' })
-  }
+  const auth = requireAdminSession(ctx.locals)
+  if (!auth.ok) return auth.response
+  const { session } = auth
 
   const action = ctx.params.action
   if (action !== 'snooze' && action !== 'acknowledge') {

--- a/src/pages/api/admin/operator/costs/export.ts
+++ b/src/pages/api/admin/operator/costs/export.ts
@@ -25,14 +25,13 @@ import {
   listCostCustomers,
   rowsToCsv,
 } from '../../../../../lib/admin/cost-query'
+import { requireAdminSession } from '../../../../../lib/auth/admin-session'
 
 const DATE_RE = /^\d{4}-\d{2}-\d{2}$/
 
 async function handleGet({ request, locals }: APIContext): Promise<Response> {
-  const session = locals.session
-  if (!session || session.role !== 'admin') {
-    return jsonResponse(401, { error: 'Unauthorized' })
-  }
+  const auth = requireAdminSession(locals)
+  if (!auth.ok) return auth.response
 
   const url = new URL(request.url)
   const customerSlug = url.searchParams.get('customer_slug')

--- a/src/pages/api/admin/operator/requests/[action].ts
+++ b/src/pages/api/admin/operator/requests/[action].ts
@@ -22,6 +22,7 @@ import type { APIContext, APIRoute } from 'astro'
 import { env } from 'cloudflare:workers'
 import { updateChangeRequestStatus } from '../../../../../lib/portal/operator/change-request'
 import { actionToStatus } from '../../../../../lib/admin/change-request-inbox'
+import { requireAdminSession } from '../../../../../lib/auth/admin-session'
 
 const MAX_NOTE_LENGTH = 4000
 
@@ -46,10 +47,9 @@ function parseBody(body: unknown): ParsedBody | { error: string } {
 }
 
 async function handlePost(ctx: APIContext): Promise<Response> {
-  const session = ctx.locals.session
-  if (!session || session.role !== 'admin') {
-    return jsonResponse(401, { error: 'Unauthorized' })
-  }
+  const auth = requireAdminSession(ctx.locals)
+  if (!auth.ok) return auth.response
+  const { session } = auth
 
   const status = actionToStatus(ctx.params.action ?? '')
   if (status === null) {

--- a/src/pages/api/admin/quotes/[id].ts
+++ b/src/pages/api/admin/quotes/[id].ts
@@ -13,6 +13,7 @@ import { getSignalById } from '../../../../lib/db/signal-attribution'
 import type { SOWTemplateProps } from '../../../../lib/pdf/sow-template'
 import { createSOWRevisionForQuote } from '../../../../lib/sow/service'
 import { env } from 'cloudflare:workers'
+import { requireAdminSession } from '../../../../lib/auth/admin-session'
 
 /**
  * POST /api/admin/quotes/:id
@@ -266,13 +267,9 @@ async function handleStatusAction(
 }
 
 async function handlePost({ request, locals, redirect, params }: APIContext): Promise<Response> {
-  const session = locals.session
-  if (!session || session.role !== 'admin') {
-    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
-      status: 401,
-      headers: { 'Content-Type': 'application/json' },
-    })
-  }
+  const auth = requireAdminSession(locals)
+  if (!auth.ok) return auth.response
+  const { session } = auth
 
   const quoteId = params.id
   if (!quoteId) {

--- a/src/pages/api/admin/quotes/[id]/sign.ts
+++ b/src/pages/api/admin/quotes/[id]/sign.ts
@@ -5,6 +5,7 @@ import { getContact } from '../../../../../lib/db/contacts'
 import { scheduleProposalCadence } from '../../../../../lib/follow-ups/scheduler'
 import { authorizeAndSendSOW } from '../../../../../lib/sow/service'
 import { env } from 'cloudflare:workers'
+import { requireAdminSession } from '../../../../../lib/auth/admin-session'
 
 /**
  * POST /api/admin/quotes/:id/sign
@@ -84,13 +85,9 @@ async function validateSignPreconditions(
 }
 
 async function handlePost({ request, locals, redirect, params }: APIContext): Promise<Response> {
-  const session = locals.session
-  if (!session || session.role !== 'admin') {
-    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
-      status: 401,
-      headers: { 'Content-Type': 'application/json' },
-    })
-  }
+  const auth = requireAdminSession(locals)
+  if (!auth.ok) return auth.response
+  const { session } = auth
 
   const quoteId = params.id
   if (!quoteId) {

--- a/src/pages/api/admin/quotes/index.ts
+++ b/src/pages/api/admin/quotes/index.ts
@@ -2,6 +2,7 @@ import type { APIContext, APIRoute } from 'astro'
 import { createQuote, parseLineItems } from '../../../../lib/db/quotes'
 import type { LineItem } from '../../../../lib/db/quotes'
 import { env } from 'cloudflare:workers'
+import { requireAdminSession } from '../../../../lib/auth/admin-session'
 
 /**
  * POST /api/admin/quotes
@@ -60,13 +61,9 @@ function parseQuoteForm(redirect: Redirect, formData: FormData): ParsedQuoteForm
 }
 
 async function handlePost({ request, locals, redirect }: APIContext): Promise<Response> {
-  const session = locals.session
-  if (!session || session.role !== 'admin') {
-    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
-      status: 401,
-      headers: { 'Content-Type': 'application/json' },
-    })
-  }
+  const auth = requireAdminSession(locals)
+  if (!auth.ok) return auth.response
+  const { session } = auth
 
   try {
     const formData = await request.formData()

--- a/src/pages/api/admin/resend-invitation.ts
+++ b/src/pages/api/admin/resend-invitation.ts
@@ -4,6 +4,7 @@ import { requirePortalBaseUrl } from '../../../lib/config/app-url'
 import { sendEmail } from '../../../lib/email/resend'
 import { buildMagicLinkUrl, portalInvitationEmailHtml } from '../../../lib/email/templates'
 import { env } from 'cloudflare:workers'
+import { requireAdminSession } from '../../../lib/auth/admin-session'
 
 interface UserRow {
   id: string
@@ -67,10 +68,9 @@ async function maybeUpdateEmail(
 async function handlePost({ request, locals }: APIContext): Promise<Response> {
   // Verify admin session (middleware already checks /admin/* routes,
   // but this is under /api/admin/* so we verify explicitly)
-  const session = locals.session
-  if (!session || session.role !== 'admin') {
-    return jsonError(401, 'Unauthorized')
-  }
+  const auth = requireAdminSession(locals)
+  if (!auth.ok) return auth.response
+  const { session } = auth
 
   try {
     const body: { userId?: unknown; email?: unknown } = await request.json()

--- a/src/pages/api/admin/time-entries/[id].ts
+++ b/src/pages/api/admin/time-entries/[id].ts
@@ -2,6 +2,7 @@ import type { APIContext, APIRoute } from 'astro'
 import { getTimeEntry, updateTimeEntry, deleteTimeEntry } from '../../../../lib/db/time-entries'
 import { getEngagement } from '../../../../lib/db/engagements'
 import { env } from 'cloudflare:workers'
+import { requireAdminSession } from '../../../../lib/auth/admin-session'
 
 /**
  * POST /api/admin/time-entries/:id
@@ -45,13 +46,9 @@ function buildUpdateFields(formData: FormData) {
 }
 
 async function handlePost({ request, locals, redirect, params }: APIContext): Promise<Response> {
-  const session = locals.session
-  if (!session || session.role !== 'admin') {
-    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
-      status: 401,
-      headers: { 'Content-Type': 'application/json' },
-    })
-  }
+  const auth = requireAdminSession(locals)
+  if (!auth.ok) return auth.response
+  const { session } = auth
 
   const entryId = params.id
   if (!entryId) {

--- a/src/pages/api/admin/time-entries/index.ts
+++ b/src/pages/api/admin/time-entries/index.ts
@@ -2,6 +2,7 @@ import type { APIContext, APIRoute } from 'astro'
 import { getEngagement } from '../../../../lib/db/engagements'
 import { createTimeEntry } from '../../../../lib/db/time-entries'
 import { env } from 'cloudflare:workers'
+import { requireAdminSession } from '../../../../lib/auth/admin-session'
 
 /**
  * POST /api/admin/time-entries
@@ -58,13 +59,9 @@ function validateTimeForm(
 }
 
 async function handlePost({ request, locals, redirect }: APIContext): Promise<Response> {
-  const session = locals.session
-  if (!session || session.role !== 'admin') {
-    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
-      status: 401,
-      headers: { 'Content-Type': 'application/json' },
-    })
-  }
+  const auth = requireAdminSession(locals)
+  if (!auth.ok) return auth.response
+  const { session } = auth
 
   try {
     const formData = await request.formData()

--- a/tests/admin-session-helper.test.ts
+++ b/tests/admin-session-helper.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest'
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join, relative, resolve } from 'node:path'
+import { requireAdminSession } from '../src/lib/auth/admin-session'
+
+function makeLocals(session: App.Locals['session']): Pick<App.Locals, 'session'> {
+  return { session }
+}
+
+function adminApiFiles(dir = resolve('src/pages/api/admin')): string[] {
+  return readdirSync(dir).flatMap((entry) => {
+    const file = join(dir, entry)
+    if (statSync(file).isDirectory()) {
+      return adminApiFiles(file)
+    }
+    return file.endsWith('.ts') ? [file] : []
+  })
+}
+
+describe('auth: admin session helper', () => {
+  it('returns a JSON 401 for unauthenticated requests', async () => {
+    const result = requireAdminSession(makeLocals(null))
+
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('expected unauthorized result')
+    expect(result.response.status).toBe(401)
+    expect(result.response.headers.get('Content-Type')).toBe('application/json')
+    await expect(result.response.json()).resolves.toEqual({ error: 'Unauthorized' })
+  })
+
+  it('returns a JSON 401 for non-admin requests', async () => {
+    const result = requireAdminSession(
+      makeLocals({
+        userId: 'client-user',
+        orgId: 'client-org',
+        role: 'client',
+        email: 'client@example.com',
+        expiresAt: '2026-07-08T00:00:00.000Z',
+      })
+    )
+
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('expected unauthorized result')
+    expect(result.response.status).toBe(401)
+    await expect(result.response.json()).resolves.toEqual({ error: 'Unauthorized' })
+  })
+
+  it('narrows admin sessions for route handlers', () => {
+    const result = requireAdminSession(
+      makeLocals({
+        userId: 'admin-user',
+        orgId: 'admin-org',
+        role: 'admin',
+        email: 'admin@example.com',
+        expiresAt: '2026-07-08T00:00:00.000Z',
+      })
+    )
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) throw new Error('expected admin session')
+    expect(result.session).toEqual({
+      userId: 'admin-user',
+      orgId: 'admin-org',
+      role: 'admin',
+      email: 'admin@example.com',
+      expiresAt: '2026-07-08T00:00:00.000Z',
+    })
+  })
+
+  it('keeps admin API routes on the shared guard', () => {
+    const offenders = adminApiFiles()
+      .map((file) => ({
+        file,
+        source: readFileSync(file, 'utf-8'),
+      }))
+      .filter(({ source }) => {
+        return (
+          source.includes('const session = locals.session') ||
+          source.includes('const session = ctx.locals.session') ||
+          source.includes("session.role !== 'admin'")
+        )
+      })
+      .map(({ file }) => relative(process.cwd(), file))
+
+    expect(offenders).toEqual([])
+  })
+})

--- a/tests/assessments.test.ts
+++ b/tests/assessments.test.ts
@@ -193,8 +193,8 @@ describe('assessments: API routes', () => {
   it('endpoints verify admin session', () => {
     const createCode = readFileSync(resolve('src/pages/api/admin/assessments/index.ts'), 'utf-8')
     const updateCode = readFileSync(resolve('src/pages/api/admin/assessments/[id].ts'), 'utf-8')
-    expect(createCode).toContain("session.role !== 'admin'")
-    expect(updateCode).toContain("session.role !== 'admin'")
+    expect(createCode).toContain('requireAdminSession')
+    expect(updateCode).toContain('requireAdminSession')
   })
 
   it('transcript endpoint verifies admin session', () => {
@@ -202,7 +202,7 @@ describe('assessments: API routes', () => {
       resolve('src/pages/api/admin/assessments/[id]/transcript.ts'),
       'utf-8'
     )
-    expect(code).toContain("session.role !== 'admin'")
+    expect(code).toContain('requireAdminSession')
   })
 
   it('transcript endpoint returns file as download', () => {

--- a/tests/engagements.test.ts
+++ b/tests/engagements.test.ts
@@ -235,8 +235,8 @@ describe('engagements: API routes', () => {
       resolve('src/pages/api/admin/engagements/[id]/milestones.ts'),
       'utf-8'
     )
-    expect(createCode).toContain("session.role !== 'admin'")
-    expect(updateCode).toContain("session.role !== 'admin'")
-    expect(milestonesCode).toContain("session.role !== 'admin'")
+    expect(createCode).toContain('requireAdminSession')
+    expect(updateCode).toContain('requireAdminSession')
+    expect(milestonesCode).toContain('requireAdminSession')
   })
 })

--- a/tests/entities-bulk.test.ts
+++ b/tests/entities-bulk.test.ts
@@ -92,7 +92,7 @@ describe('api/admin/entities/bulk: endpoint', () => {
   })
 
   it('requires admin role', () => {
-    expect(source()).toContain("session.role !== 'admin'")
+    expect(source()).toContain('requireAdminSession')
   })
 
   it('rejects empty id arrays', () => {

--- a/tests/follow-ups.test.ts
+++ b/tests/follow-ups.test.ts
@@ -340,7 +340,7 @@ describe('follow-ups: API route', () => {
   })
 
   it('verifies admin session', () => {
-    expect(source()).toContain("session.role !== 'admin'")
+    expect(source()).toContain('requireAdminSession')
   })
 
   it('scopes follow-up lookup to org', () => {

--- a/tests/invoices.test.ts
+++ b/tests/invoices.test.ts
@@ -200,7 +200,7 @@ describe('invoices: admin API routes', () => {
     })
 
     it('verifies admin session', () => {
-      expect(source()).toContain("session.role !== 'admin'")
+      expect(source()).toContain('requireAdminSession')
     })
 
     it('validates invoice type', () => {
@@ -224,7 +224,7 @@ describe('invoices: admin API routes', () => {
     })
 
     it('verifies admin session', () => {
-      expect(source()).toContain("session.role !== 'admin'")
+      expect(source()).toContain('requireAdminSession')
     })
 
     it('handles send action — creates in Stripe and sends', () => {

--- a/tests/parking-lot.test.ts
+++ b/tests/parking-lot.test.ts
@@ -112,8 +112,7 @@ describe('parking-lot: API endpoint', () => {
 
   it('rejects non-admin sessions with 401', () => {
     const code = source()
-    expect(code).toContain("session.role !== 'admin'")
-    expect(code).toContain('status: 401')
+    expect(code).toContain('requireAdminSession')
   })
 
   it('validates engagement ownership via getEngagement', () => {

--- a/tests/quotes.test.ts
+++ b/tests/quotes.test.ts
@@ -266,8 +266,8 @@ describe('quotes: API routes', () => {
   it('endpoints verify admin session', () => {
     const createCode = readFileSync(resolve('src/pages/api/admin/quotes/index.ts'), 'utf-8')
     const updateCode = readFileSync(resolve('src/pages/api/admin/quotes/[id].ts'), 'utf-8')
-    expect(createCode).toContain("session.role !== 'admin'")
-    expect(updateCode).toContain("session.role !== 'admin'")
+    expect(createCode).toContain('requireAdminSession')
+    expect(updateCode).toContain('requireAdminSession')
   })
 })
 
@@ -317,7 +317,7 @@ describe('quotes: repeat-quote flow (#472)', () => {
   })
 
   it('new-quote endpoint requires admin session', () => {
-    expect(apiSource()).toContain("session.role !== 'admin'")
+    expect(apiSource()).toContain('requireAdminSession')
   })
 
   it('new-quote endpoint gates on stage (signal through proposing)', () => {

--- a/tests/reply-log.test.ts
+++ b/tests/reply-log.test.ts
@@ -73,7 +73,7 @@ describe('reply-log endpoint: context entry shape', () => {
 describe('reply-log endpoint: auth and validation', () => {
   it('rejects non-admin sessions', () => {
     const code = endpoint()
-    expect(code).toContain("session.role !== 'admin'")
+    expect(code).toContain('requireAdminSession')
   })
 
   it('validates sentiment against allowed list', () => {

--- a/tests/signwell.test.ts
+++ b/tests/signwell.test.ts
@@ -270,7 +270,7 @@ describe('signwell: webhook route', () => {
 
   it('does NOT use auth middleware (webhooks are unauthenticated)', () => {
     const code = source()
-    expect(code).not.toContain("session.role !== 'admin'")
+    expect(code).not.toContain('requireAdminSession')
     expect(code).not.toContain('locals.session')
   })
 
@@ -294,7 +294,7 @@ describe('signwell: send-for-signature route', () => {
 
   it('verifies admin session', () => {
     const code = source()
-    expect(code).toContain("session.role !== 'admin'")
+    expect(code).toContain('requireAdminSession')
   })
 
   it('checks quote status is draft or sent', () => {

--- a/tests/time-entries.test.ts
+++ b/tests/time-entries.test.ts
@@ -182,7 +182,7 @@ describe('time-entries: API routes', () => {
   it('endpoints verify admin session', () => {
     const createCode = readFileSync(resolve('src/pages/api/admin/time-entries/index.ts'), 'utf-8')
     const updateCode = readFileSync(resolve('src/pages/api/admin/time-entries/[id].ts'), 'utf-8')
-    expect(createCode).toContain("session.role !== 'admin'")
-    expect(updateCode).toContain("session.role !== 'admin'")
+    expect(createCode).toContain('requireAdminSession')
+    expect(updateCode).toContain('requireAdminSession')
   })
 })


### PR DESCRIPTION
## Summary
- Add a shared requireAdminSession helper for admin API routes
- Migrate duplicated admin role checks across admin API endpoints
- Update source-level tests and add helper regression coverage

Refs #1597

## Verification
- npm run verify
- pre-push npm run verify