### PR TITLE
docs: de-stale lead-gen references in CLAUDE.md + wrangler.toml

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,7 +85,6 @@ Any information displayed to a client (timelines, schedules, deliverables, prici
 **Tests linked to this policy**
 
 - `tests/forbidden-strings.test.ts` - historical Pattern A/B phrases, user-facing style-marker checks, and portal registry guardrails
-- `tests/enrichment-prompt-contracts.test.ts` - source-level prompt-contract checks for dossier, review-analysis, and deep-website
 - `tests/intake-questionnaire.test.ts` - shared-surface regression coverage for the canonical intake questionnaire
 
 ## Tone & Positioning Standard

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -176,5 +176,5 @@ name = "ss-web-staging"
 #
 # Bulk-load from Infisical:
 #   infisical export --env=prod --path=/ss --format=dotenv \
-#     | grep -vE '^(APP_|ADMIN_|PORTAL_|MEETING_|NEW_BUSINESS_|JOB_MONITOR_|REVIEW_MINING_|PUBLIC_)' \
+#     | grep -vE '^(APP_|ADMIN_|PORTAL_|MEETING_|PUBLIC_)' \
 #     | npx wrangler secret bulk


### PR DESCRIPTION
Code review 2026-07-02 findings §6.1 (Documentation) and §3.4 (Code Quality).

- **CLAUDE.md** — removes the citation to `tests/enrichment-prompt-contracts.test.ts`, which was deleted with the lead-gen retirement (#1610). The two surviving policy tests (`forbidden-strings`, `intake-questionnaire`) stay listed.
- **wrangler.toml** — trims the dead `NEW_BUSINESS_` / `JOB_MONITOR_` / `REVIEW_MINING_` worker secret prefixes from the Infisical bulk-load rotation comment. Those workers no longer exist on `main`.

Pure documentation/comment change — no behavior, no source, no tests touched. Handbook pages that also cite the retired lead-gen machine are handled in a separate handbook de-staling PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)