### PR TITLE
docs: code review 2026-07-02 — full-codebase scorecard (Overall B, up from C)

### DIFF
--- a/docs/reviews/code-review-2026-07-02.md
+++ b/docs/reviews/code-review-2026-07-02.md
@@ -1,0 +1,150 @@
+# Code Review: SMD Services
+
+**Date:** 2026-07-02
+**Reviewer:** Claude Code (automated)
+**Scope:** Full codebase
+**Mode:** Full (Phase 1 — Claude-only)
+**Models Used:** Claude
+**Golden Path Tier:** 2
+
+## Summary
+
+**Overall: B** (improved from C on 2026-07-01).
+
+A healthy, disciplined codebase: near-zero `any` under strict TypeScript, parameterized SQL throughout, uniformly applied auth helpers on every sampled admin and portal route, a defense-in-depth webhook handler, strong test coverage of the money paths, and zero dependency vulnerabilities. The 2026-07-01 lead-gen retirement was executed cleanly on origin/main with no orphaned worker code. The grade improves to B because the recurring trust-boundary and security categories from prior reviews have largely resolved; what remains is structural (19 files over the 500-line ceiling, an inconsistent API response convention) and documentation debt (no API reference for the 85-file API surface, stale lead-gen references pending the deferred de-staling pass).
+
+Two findings from the review agent were orchestrator-verified before grading: the suspected stored-XSS in `renderSimpleMarkdown` is a **false positive** (input is HTML-escaped before markdown transforms), and the SignWell `verifyEventHash` uses a constant-time compare (verification `vfy_01KWJ84T75XZ20QW8BF1F5229N`).
+
+## Scorecard
+
+| Dimension | Grade | Trend |
+|-----------|-------|-------|
+| Architecture | C | stable |
+| Security | B | improved |
+| Code Quality | B | improved |
+| Testing | B | stable |
+| Dependencies | B | stable |
+| Documentation | C | stable |
+| Golden Path | B | stable |
+
+## Detailed Findings
+
+### 1. Architecture
+
+1. [HIGH] 19 tracked files exceed the repo's 500-line ceiling. Worst: `src/lib/operator/customer-yaml/types.ts` (949 lines, 77 exports), `src/lib/db/quotes.ts` (774 lines, 23 exported functions — quote CRUD + line items + status transitions in one DAL), `src/lib/db/entities.ts` (663), `src/lib/portal/operator/customer-yaml-editor.ts` (683). Recommendation: split the DALs by sub-domain (`quotes/crud.ts`, `quotes/line-items.ts`, `quotes/status.ts`); split `types.ts` by customer.yaml section (the `sections-personas.ts` sibling already establishes the pattern).
+2. [MEDIUM] `src/lib/sow/service-finalize.ts` — 589 lines across only 4 exports, implying functions far above the 75-line ceiling. Recommendation: decompose the finalize pipeline into named stages.
+3. [MEDIUM] `src/middleware.ts` (321 lines) accumulates four legacy-redirect concerns inline (`redirectLegacyAuthPaths`:135, `redirectLegacyOperatorPaths`:160, `redirectRetiredMarketingPaths`:197, admin-host redirect:116) alongside subdomain rewriting and auth resolution. Recommendation: extract redirect rules to a declarative table module (`src/lib/routing/legacy-redirects.ts`).
+4. [LOW] `src/pages/api/booking/reserve.ts` (512 lines) is a route handler carrying substantial business logic. Recommendation: move reservation domain logic into `src/lib/booking/`, keep the route as a thin adapter.
+5. [MEDIUM — process] The local checkout was 2 commits behind origin/main during review (missing #1610 and #1616, the lead-gen retirement PRs). All "orphaned worker" appearances on disk were staleness, not repo state. Recommendation: pull main current once the other live session's uncommitted work is safe to rebase around.
+6. [LOW] Positive: API surface layering is consistent — every sampled `src/pages/api/admin/**` route delegates auth to `requireAdminSession(locals)` and DB work to `src/lib/db/*`; portal routes uniformly use `getPortalClient`/`resolveOperatorAccess`. No route-level SQL found. The one admin route without the standard session guard (`src/pages/api/admin/fleet/health.ts:93`) is intentional: a machine-callable surface guarded by a dedicated bearer secret (`OPERATOR_HEALTH_READ_KEY`, constant-time compared).
+7. [MEDIUM] Inconsistent API response construction: shared `jsonResponse` helper exists (`src/lib/api/helpers.ts:33`) but only ~20 route files import it while ~39 hand-roll `new Response(JSON.stringify({ error: ... }))` — error body shape and content-type are not uniform. Recommendation: standardize on `jsonResponse`/`errorResponse`; lint against raw `new Response(JSON.stringify` under `src/pages/api/**`.
+8. [MEDIUM] `src/lib/assessment/prompts.ts:15-21` — the Astro build reaches three levels up into the repo-root Operator substrate via `?raw` imports (`../../../operator/assessment-eval/fixtures/...`, `../../../operator/skills/assessment-findings-draft/...`), hard-coupling the web build to the `operator/` directory layout; moving a fixture silently breaks `npm run build`. Recommendation: add indirection (tracked manifest/copy step or an `@operator/*` path alias).
+9. [LOW] `src/lib/sow/service-finalize.ts:27-33` — a `src/lib/**` service constructs HTTP `Response` objects, coupling the domain module to the transport layer. Recommendation: return a typed result; let the webhook route translate.
+10. [LOW] Three top-level "portal" locations: `src/portal/assessments/` (home of `extraction-schema.ts`, the observation-taxonomy source of truth cited in CLAUDE.md) sits outside `src/lib/`, distinct from `src/lib/portal/` and `src/pages/portal/`. Recommendation: relocate under `src/lib/` so there are two portal roots (services + pages), not three.
+
+**Grade: C.** Rationale: rubric places 3+ files over 500 lines at C; there are 19, plus a route-convention inconsistency. Layering discipline keeps it from sliding lower.
+
+### 2. Security
+
+1. [RESOLVED — FALSE POSITIVE] The review agent flagged `src/components/admin/EntityDossierSummary.astro:164` (`set:html={renderSimpleMarkdown(...)}`) as potential stored XSS. Orchestrator verification: `renderSimpleMarkdown` (`src/lib/admin/entity-detail-page.ts:125`) calls `escapeHtml` (escapes `& < > "`) as its first operation, before any markdown transforms. Not exploitable. Verification recorded: `vfy_01KWJ84T75XZ20QW8BF1F5229N`.
+2. [RESOLVED — VERIFIED SAFE] SignWell `verifyEventHash` (`src/pages/api/webhooks/signwell.ts:200-211`) uses a constant-time XOR comparison with length check. The agent's "confirm timing-safe compare" caveat is closed.
+3. [LOW] JSON-LD `set:html={JSON.stringify(schema)}` instances (`src/components/JsonLd.astro:44`, `src/pages/index.astro:44`, `src/pages/operator.astro:101-102`, pack components) — safe while schema content is authored, but `JSON.stringify` does not escape `</script>`; a future user-supplied value becomes script-context injection. Recommendation: escape `<` as `<` in a shared JsonLd helper.
+4. [LOW] `src/pages/api/health.ts` — unauthenticated endpoint discloses binding presence (`db`, `storage`, `sessions` booleans). Recommendation: return bare `{status:'ok'}` publicly; details only with an internal token.
+5. [LOW] Verified compliant: admin gating (`src/middleware.ts:41-72` — client-role sessions explicitly rejected on admin paths); 6/6 sampled admin routes and 4/4 sampled portal routes properly gated; all D1 access via `.prepare().bind()` (three dynamic fragments interpolate only internally-constructed `column = ?` lists); SignWell webhook fails closed with replay protection and zod-parses payload only after HMAC verification; public booking endpoint rate-limited per-IP via KV; no hardcoded secrets, gitleaks enforced pre-commit and in CI; no token/session logging found.
+6. [LOW] Recommendation (structural): add a repo-level guard test asserting every file under `src/pages/api/admin/**` imports `requireAdminSession`, making the auth convention mechanical.
+
+**Grade: B (improved).** Rationale: no medium+ findings survive verification; remaining items are 2 actionable lows on a strong, consistently applied posture.
+
+### 3. Code Quality
+
+1. [LOW] TypeScript strictness — `tsconfig.json` extends `astro/tsconfigs/strict`; `: any` appears 4 times and `as any` once across 629 TS files. Exemplary.
+2. [LOW] Error handling — zero empty catch blocks in first-party code.
+3. [RESOLVED QUESTION] Dead-worker wiring: on origin/main the lead-gen retirement is complete and clean — `workers/job-monitor`, `review-mining`, `enrichment-workflow`, `new-business`, `scan-workflow`, `social-listening` fully deleted including wrangler service bindings, env vars, and deploy/verify workflow steps. Only `workers/cost-anomaly` and `workers/cost-telemetry` remain, both Operator-scoped and intentionally kept. No orphaned worker code.
+4. [MEDIUM — RESOLVED same-day] `wrangler.toml:179` (origin/main) — secrets-rotation comment grepped out `NEW_BUSINESS_|JOB_MONITOR_|REVIEW_MINING_` prefixes for workers that no longer exist. **Fixed by #1619** (merged 2026-07-02, citing this review's §3.4).
+5. [MEDIUM] Function-length ceiling (75 lines) — `src/lib/sow/service-finalize.ts` and `src/pages/api/booking/reserve.ts` almost certainly contain functions well over the ceiling. Recommendation: decompose; consider eslint `max-lines-per-function` to make the ceiling mechanical.
+6. [LOW] Open carry-over: #1596 (validate webhook payloads narrow-after-cast post-HMAC) remains open; SignWell now zod-parses post-verification, but the issue's remaining scope (other webhook surfaces) should be closed out.
+7. [LOW] Policy compliance verified: no Pattern A/B fabricated-content strings outside guard-tested files; `waitUntil` used for heavy work in API files; no module-level mutable state in sampled Worker-path files.
+
+**Grade: B (improved).** Rationale: near-zero `any`, no swallowed errors, clean retirement execution; remaining items are stale comments and size ceilings (graded under Architecture).
+
+### 4. Testing
+
+1. [LOW] Vitest 4 via `getViteConfig` with a Clerk virtual-module stub (`vitest.config.ts:12-24`); 193 test files under `tests/` plus 13 colocated.
+2. [LOW] Critical-path coverage verified present: middleware, admin session, invoicing (including send-gate), milestones (including explicit cross-org isolation tests), SOW render/template/outbox, booking, SignWell handler (635-line test).
+3. [MEDIUM] No dedicated test for `src/lib/auth/admin-session-shim.ts` (`resolveAdminSessionFromClerk` — the admin gate's Clerk→legacy bridge). Recommendation: add unit tests covering non-admin role rejection, missing local user, and session synthesis.
+4. [MEDIUM] No test targeting `src/lib/sow/service-finalize.ts` (SOW tests cover render/template/outbox but not finalize). Recommendation: add finalize-path tests including missing-authored-data fail-closed behavior per the no-fabrication policy.
+5. [LOW] Policy-guard tests confirmed enforced: `tests/forbidden-strings.test.ts`, `tests/intake-questionnaire.test.ts`, `tests/handbook-integrity.test.ts`. (`tests/enrichment-prompt-contracts.test.ts` retired with the lead-gen machine on origin/main.)
+6. [LOW] Recommendation: replicate the cross-org regression-test pattern (`tests/admin/milestones.cross-org.test.ts`) for the other org-scoped DALs (quotes, invoices) if not already covered.
+
+**Grade: B (stable).** Rationale: broad, meaningful coverage of business-risk surfaces; two soft spots (admin-session shim, SOW finalize).
+
+### 5. Dependencies
+
+1. [LOW] `npm audit`: 0 vulnerabilities across 714 resolved packages. CI fails on high+ for root and workers.
+2. [MEDIUM] Outdated majors: `astro` 6.4.7 → 7.0.6 and `@astrojs/cloudflare` 13.5.2 → 14.1.1 (paired bumps). Adapter-major lag has bitten this repo before (v13 `Astro.locals.runtime` removal). Recommendation: schedule the migration as a deliberate PR.
+3. [LOW] `@venturecrane/tokens` pinned at `0.0.2-alpha.0`; `0.1.0` published. Bump when convenient.
+4. [LOW] `npm outdated` shows `eslint-plugin-astro` "latest 1.7.0" below installed 2.1.1 — registry dist-tag anomaly; ignore.
+5. [LOW] Runtime (workerd) compatibility verified: no `eval()`/`new Function()` in any production dependency; `ajv` present only via dev tooling, never bundled.
+6. [LOW] No unused dependencies: all 16 prod deps verified imported. `overrides` block pins `esbuild`/`ws`/`yaml`/`undici` — deliberate supply-chain hygiene.
+7. [LOW] npm warns `Unknown project config "min-release-age"` — this knob stops working in the next npm major. Migrate when upgrading npm.
+
+**Grade: B (stable).** Rationale: zero vulns and clean hygiene; one key dependency pair one major behind.
+
+### 6. Documentation
+
+1. [MEDIUM — RESOLVED same-day] `CLAUDE.md` cited `tests/enrichment-prompt-contracts.test.ts` (deleted on origin/main with #1610) — orchestrator-verified at review time. **Fixed by #1619** (merged 2026-07-02, citing this review's §6.1), which dropped the citation. The `src/portal/assessments/extraction-schema.ts` reference was verified fine (file still exists).
+2. [MEDIUM] Handbook (`docs/handbook/`) — integrity enforcement is in place, but the lead-gen retirement explicitly deferred handbook de-staling; pages describing the scrape-score-enrich machine are currently wrong. Recommendation: complete the deferred update; `npm run handbook:drift` will surface affected pages.
+3. [HIGH] No API documentation: no OpenAPI spec, no `docs/api/`. Orchestrator-counted on origin/main: 85 route files / 88 exported HTTP method handlers under `src/pages/api/**` (43 admin, 13 portal, 7 booking, 5 webhooks, rest misc), documented only via ad-hoc header comments. Tier 2 requires API docs. Recommendation: at minimum a maintained endpoint inventory (path, method, auth requirement, request/response shape), ideally gated by a route-manifest test.
+4. [RETRACTED] An earlier draft flagged "no main-DB schema documentation." **Wrong** — `docs/handbook/data-model.md` exists on origin/main (verified): a substantive narrative schema doc naming `migrations/` as source of truth, distinguishing console D1 from per-Operator-customer D1, and describing tables by group. Schema docs are COMPLIANT.
+5. [LOW] `README.md` (~95 lines) is solid for onboarding: purpose, stack, subdomain table, /etc/hosts setup, build commands, repo layout.
+
+**Grade: C (stable).** Rationale: exceptional internal doctrine (ADRs, 33-page merge-gated handbook, data-model.md, CLAUDE.md) but no API docs for a project with a large API surface, plus a known-stale CLAUDE.md reference.
+
+### 7. Golden Path Compliance (Tier 2)
+
+| Requirement | Status |
+|---|---|
+| Source control + CI (T1) | COMPLIANT — 11 workflows incl. verify, deploy, security, policy gates |
+| CLAUDE.md (T1) | COMPLIANT (staleness noted above) |
+| TypeScript + ESLint (T1) | COMPLIANT — strict preset; ESLint 10 flat config in CI + pre-commit |
+| No hardcoded secrets (T1) | COMPLIANT — gitleaks pre-commit + CI; grep sweep clean |
+| Error monitoring (T2) | COMPLIANT w/ caveat — Sentry wraps every request (`src/middleware.ts:7,318`) but no-ops without `SENTRY_DSN`; prod DSN presence needs one-time live verification |
+| Full CI/CD (T2) | COMPLIANT — audit (high+), gitleaks, Semgrep, typecheck, nosemgrep-suppression audit, aggregate gate, least-privilege permissions |
+| Branch protection (T2) | PARTIAL (unverifiable locally) — policy documented and operationally corroborated; snapshot `gh api .../branches/main/protection` into docs |
+| Uptime monitoring (T2) | PARTIAL — `/api/health` checks binding presence only (never queries D1; a wedged D1 still returns 200); healthchecks.io integration covers Operator machines, not smd.services. Add a `SELECT 1` probe + external monitor |
+| API docs (T2) | MISSING — see Documentation #3 |
+| Schema docs (T2) | COMPLIANT — `docs/handbook/data-model.md` (verified on origin/main; earlier "Operator-only" claim retracted) |
+| Deployment runbook (T2) | COMPLIANT — `docs/handbook/deployment-release.md` + CLAUDE.md deploy mechanics |
+
+**Grade: B (stable).** Rationale: all critical requirements met with unusually strong CI/security automation; gaps are the API-docs/schema-docs documentation items and a shallow health endpoint.
+
+## Model Convergence
+
+Single-model review (Phase 1) executed as a Claude agent fleet: one lead agent plus dimension teammates (arch-review, security-review, quality-review, testing-review, docs-goldenpath-review). Convergent across agents: the API-docs gap, the shallow `/api/health` endpoint, Sentry wired-but-DSN-unverified, and the size-ceiling violations. Two lead-agent claims were corrected by teammate + orchestrator verification: the "no main-DB schema doc" finding (retracted — `docs/handbook/data-model.md` exists) and the endpoint count (85 files / 88 handlers, not 100+). One teammate claim was corrected by orchestrator verification: CLAUDE.md staleness is real (line 88 cites the deleted enrichment-prompt-contracts test) despite the docs teammate's spot-checks passing. Codex review: skipped. Gemini review: skipped.
+
+## Trend Analysis
+
+Previous review: 2026-07-01 (Overall C, stable vs 2026-06-30).
+
+- **Security C → B:** prior trust-boundary findings resolved (#1597 architecture-polish closed; SignWell zod-parses post-HMAC); this review's only medium was orchestrator-verified as a false positive.
+- **Code Quality C → B:** the recurring "oversized files + trust-boundary casts" pair has narrowed — casts are down to 5 `any`-usages repo-wide and the dead lead-gen machine was removed cleanly rather than left to rot.
+- **Architecture C, Documentation C:** the same structural categories recur (size ceilings; handbook/CLAUDE.md drift — now with a concrete deferred de-staling task attached to the retirement PRs).
+- **Issue resolution:** 41/43 all-time `source:code-review` issues resolved. Open: #1596 (webhook narrow-after-cast — partially addressed), #765 (system prompt geography).
+
+## File Manifest
+
+~152,591 lines of TS/TSX/Astro/JS (~101,413 in `src/`). 629 `.ts`, 195 `.astro`, 491 `.md`, 142 `.py`, 105 `.sql` (migrations), 1 `.tsx`. Top-level: `src/` (588 files), `operator/` (485), `docs/` (229), `tests/` (197), `migrations/` (96), `workers/` (48 on stale local disk; 21 on origin/main after lead-gen retirement — cost-anomaly + cost-telemetry only), `.github/workflows/` (11).
+
+## Raw Model Outputs
+
+### Claude Review
+
+The findings above are the Claude review output, edited only for the two orchestrator verifications noted in Security (§2.1, §2.2) and re-grouped per dimension. The agent resolved its own highest-priority open question (dead-worker wiring post-retirement) against origin/main rather than the stale local checkout.
+
+### Codex Review
+
+Skipped (Phase 1 — Claude-only).
+
+### Gemini Review
+
+Skipped (Phase 1 — Claude-only).

--- a/docs/reviews/index.md
+++ b/docs/reviews/index.md
@@ -8,6 +8,7 @@ Code review records and platform audit reports for the SMD Services codebase.
 
 ## Files
 
+- [code-review-2026-07-02.md](./code-review-2026-07-02.md) - Full codebase code review (2026-07-02)
 - [code-review-2026-07-01.md](./code-review-2026-07-01.md) - Full codebase code review (2026-07-01)
 - [code-review-2026-06-30.md](./code-review-2026-06-30.md) - Full codebase code review (2026-06-30)
 - [code-review-2026-06-12.md](./code-review-2026-06-12.md) - Full codebase code review (2026-06-12)


### PR DESCRIPTION
Adds the 2026-07-02 full-codebase review report + index entry (docs-only).

## Highlights

- **Overall B**, improved from C on 2026-07-01. Security and Code Quality C→B; Architecture and Documentation hold at C.
- Flagged stored-XSS in `renderSimpleMarkdown` verified **false positive** (escapes before transforms); SignWell `verifyEventHash` constant-time compare confirmed.
- Lead-gen retirement (#1610/#1616) verified clean on origin/main — zero orphaned worker code.
- Two medium findings (CLAUDE.md stale test citation, wrangler.toml rotation comment) were fixed same-day by #1619 and are marked resolved in the report.
- Remaining highs: 19 files over the 500-line ceiling; no API endpoint inventory (85 routes / 88 handlers) — the last hard Tier 2 gap.

VCMS scorecard stored under tag `code-review` (note_01KWJ8591NXFY01N5HMJCK1BAJ). Cadence recorded (next due 2026-08-01).

🤖 Generated with [Claude Code](https://claude.com/claude-code)