### PR TITLE
refactor(middleware): declarative legacy-redirect table (§1.3)

### DIFF
--- a/src/lib/routing/legacy-redirects.ts
+++ b/src/lib/routing/legacy-redirects.ts
@@ -1,0 +1,172 @@
+/**
+ * Declarative table of the console's legacy 301 redirects, extracted from
+ * src/middleware.ts (code review 2026-07-02 §1.3). Each rule is a predicate plus
+ * a target builder; the middleware evaluates a rule list in order and issues the
+ * first match. Keeping the rules here as data (rather than inline `if` ladders in
+ * the request handler) makes the redirect surface auditable in one place and
+ * keeps the middleware focused on rewrite + auth.
+ *
+ * Two lists exist because the rules fire at two different points in the pipeline:
+ *
+ *   PRE_REWRITE_REDIRECTS  run BEFORE the subdomain rewrite (the rewrite
+ *                          terminates the chain, so the product-rename redirect
+ *                          must precede it to catch subdomain-relative forms).
+ *   POST_REWRITE_REDIRECTS run AFTER the rewrite (host canonicalization, legacy
+ *                          auth paths, and retired marketing surfaces).
+ *
+ * IMPORTANT: the SOURCES of every rule are the OLD paths. Do not "modernize" a
+ * source path to its target — that turns the rule into a self-redirect loop.
+ *
+ * Each rule's `location` is returned to `context.redirect(location, status)`
+ * verbatim, so the absolute-vs-relative form of each target is preserved exactly
+ * as it was inline (absolute URLs where the host or query must be carried;
+ * relative paths otherwise).
+ */
+
+export interface RedirectContext {
+  readonly hostname: string
+  readonly pathname: string
+  readonly url: URL
+}
+
+export interface RedirectRule {
+  readonly label: string
+  match(ctx: RedirectContext): boolean
+  location(ctx: RedirectContext): string
+  readonly status: 301
+}
+
+export interface RedirectOutcome {
+  readonly location: string
+  readonly status: 301
+}
+
+/** pathname === base, or pathname is a descendant path of base. */
+function isPathOrDescendant(pathname: string, base: string): boolean {
+  return pathname === base || pathname.startsWith(`${base}/`)
+}
+
+/**
+ * Product renamed "AI Employee" → "Operator" (ADR 0034). Permanent redirects
+ * from the pre-rename `/ai-employee` URLs to `/operator`, covering the marketing,
+ * portal, and admin surfaces plus their subdomain-relative forms. All matches use
+ * the same first-occurrence path substitution, so they collapse into one rule.
+ */
+const OPERATOR_RENAME: RedirectRule = {
+  label: 'operator-rename',
+  match: ({ pathname }) =>
+    isPathOrDescendant(pathname, '/ai-employee') ||
+    isPathOrDescendant(pathname, '/portal/products/ai-employee') ||
+    isPathOrDescendant(pathname, '/products/ai-employee') ||
+    isPathOrDescendant(pathname, '/admin/ai-employee'),
+  location: ({ pathname }) => pathname.replace('/ai-employee', '/operator'),
+  status: 301,
+}
+
+/**
+ * Marketing `/admin/*` on the apex host canonicalizes to the admin subdomain, so
+ * old bookmarks keep working. Absolute target (host change).
+ */
+const ADMIN_HOST_CANONICALIZE: RedirectRule = {
+  label: 'admin-host-canonicalize',
+  match: ({ hostname, pathname }) =>
+    hostname === 'smd.services' && (pathname === '/admin' || pathname.startsWith('/admin/')),
+  location: ({ url }) => {
+    const next = new URL(url)
+    next.hostname = 'admin.smd.services'
+    return next.toString()
+  },
+  status: 301,
+}
+
+/** Old dual-auth-era paths → the unified Clerk sign-in/up. Query preserved. */
+const LEGACY_AUTH_PATHS: Record<string, string> = {
+  '/auth/login': '/auth/sign-in',
+  '/auth/portal-sign-in': '/auth/sign-in',
+  '/auth/portal-sign-up': '/auth/sign-up',
+  '/auth/portal-login': '/auth/sign-in',
+}
+
+const LEGACY_AUTH: RedirectRule = {
+  label: 'legacy-auth-paths',
+  match: ({ pathname }) => pathname in LEGACY_AUTH_PATHS,
+  location: ({ pathname, url }) => {
+    const next = new URL(url)
+    next.pathname = LEGACY_AUTH_PATHS[pathname]
+    // Preserve query string (status=signed_out, etc.).
+    return next.toString()
+  },
+  status: 301,
+}
+
+/** Post-booking thanks page moved onto /get-started. */
+const BOOK_THANKS: RedirectRule = {
+  label: 'book-thanks',
+  match: ({ pathname }) => isPathOrDescendant(pathname, '/book/thanks'),
+  location: () => '/get-started?booked=1',
+  status: 301,
+}
+
+// Retired marketing routes → the surviving surface that absorbed them (marketing
+// consolidation 2026-06-29 + earlier lead-magnet retirements). /contact is NOT
+// retired (Captain decision 2026-06-30). SOURCES are the retired paths.
+const RETIRED_MARKETING_TO_HOME_EXACT = new Set(['/scan', '/consulting', '/ai'])
+const RETIRED_MARKETING_TO_HOME_PREFIX = ['/scorecard', '/outside-view', '/consulting/', '/ai/']
+
+const RETIRED_MARKETING_EXACT: RedirectRule = {
+  label: 'retired-marketing-exact',
+  match: ({ pathname }) => RETIRED_MARKETING_TO_HOME_EXACT.has(pathname),
+  location: () => '/',
+  status: 301,
+}
+
+const RETIRED_MARKETING_PREFIX: RedirectRule = {
+  label: 'retired-marketing-prefix',
+  match: ({ pathname }) =>
+    RETIRED_MARKETING_TO_HOME_PREFIX.some(
+      (p) => pathname === p.replace(/\/$/, '') || pathname.startsWith(p)
+    ),
+  location: () => '/',
+  status: 301,
+}
+
+const RETIRED_WHY: RedirectRule = {
+  label: 'retired-why',
+  match: ({ pathname }) => isPathOrDescendant(pathname, '/why'),
+  location: () => '/operator#compare',
+  status: 301,
+}
+
+const RETIRED_GET_STARTED: RedirectRule = {
+  label: 'retired-get-started',
+  match: ({ pathname, url }) => pathname === '/get-started' && !url.searchParams.has('booked'),
+  location: () => '/',
+  status: 301,
+}
+
+/** Redirects that must run BEFORE the subdomain rewrite terminates the chain. */
+export const PRE_REWRITE_REDIRECTS: readonly RedirectRule[] = [OPERATOR_RENAME]
+
+/** Redirects that run AFTER the subdomain rewrite. Order is significant. */
+export const POST_REWRITE_REDIRECTS: readonly RedirectRule[] = [
+  ADMIN_HOST_CANONICALIZE,
+  LEGACY_AUTH,
+  BOOK_THANKS,
+  RETIRED_MARKETING_EXACT,
+  RETIRED_MARKETING_PREFIX,
+  RETIRED_WHY,
+  RETIRED_GET_STARTED,
+]
+
+/** Return the first matching rule's outcome, or null if none match. */
+export function firstRedirect(
+  rules: readonly RedirectRule[],
+  ctx: RedirectContext
+): RedirectOutcome | null {
+  for (const rule of rules) {
+    if (rule.match(ctx)) {
+      return { location: rule.location(ctx), status: rule.status }
+    }
+  }
+  return null
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -5,6 +5,11 @@ import { clerkMiddleware } from '@clerk/astro/server'
 import { resolveAdminSessionFromClerk } from './lib/auth/admin-session-shim'
 import { parseSessionToken, validateSession, renewSession } from './lib/auth/session'
 import { withSentryRequestHandler } from './lib/observability/sentry'
+import {
+  PRE_REWRITE_REDIRECTS,
+  POST_REWRITE_REDIRECTS,
+  firstRedirect,
+} from './lib/routing/legacy-redirects'
 import { env } from 'cloudflare:workers'
 
 /**
@@ -113,116 +118,6 @@ function handleSubdomainRewrite(
   return null
 }
 
-function redirectToAdminHost(
-  context: APIContext,
-  hostname: string,
-  pathname: string
-): Response | null {
-  if (hostname !== 'smd.services') return null
-  if (pathname === '/admin' || pathname.startsWith('/admin/')) {
-    const newUrl = new URL(context.url)
-    newUrl.hostname = 'admin.smd.services'
-    return context.redirect(newUrl.toString(), 301)
-  }
-  return null
-}
-
-/**
- * Legacy auth-path 301 redirects. Old URLs from the dual-auth era keep
- * working so external links (Clerk invitation emails, bookmarks, prior
- * code review docs) don't break.
- */
-function redirectLegacyAuthPaths(context: APIContext, pathname: string): Response | null {
-  const target = legacyAuthRedirectTarget(pathname)
-  if (!target) return null
-  const newUrl = new URL(context.url)
-  newUrl.pathname = target
-  // Preserve query string (status=signed_out, etc.)
-  return context.redirect(newUrl.toString(), 301)
-}
-
-function legacyAuthRedirectTarget(pathname: string): string | null {
-  if (pathname === '/auth/login') return '/auth/sign-in'
-  if (pathname === '/auth/portal-sign-in') return '/auth/sign-in'
-  if (pathname === '/auth/portal-sign-up') return '/auth/sign-up'
-  if (pathname === '/auth/portal-login') return '/auth/sign-in'
-  return null
-}
-
-/**
- * Product renamed "AI Employee" → "Operator" (ADR 0034). Permanent (301)
- * redirects from the pre-rename `/ai-employee` URLs to `/operator` so old
- * bookmarks and indexed links keep working. Runs before the subdomain rewrite,
- * so it must handle both the canonical paths and the subdomain-relative forms
- * the rewrite would prepend. The SOURCES are the legacy `/ai-employee` paths —
- * do not rename them to `/operator` (that would self-redirect into a loop).
- */
-function redirectLegacyOperatorPaths(
-  context: APIContext,
-  hostname: string,
-  pathname: string
-): Response | null {
-  // Marketing product page: smd.services/ai-employee → /operator.
-  // Also covers admin.smd.services/ai-employee (rewrites to /admin/operator
-  // after the redirect lands on the operator path).
-  if (pathname === '/ai-employee' || pathname.startsWith('/ai-employee/'))
-    return context.redirect(pathname.replace('/ai-employee', '/operator'), 301)
-
-  // Portal product surface: canonical (/portal/products/ai-employee) and the
-  // portal-subdomain-relative form (/products/ai-employee).
-  for (const oldPath of ['/portal/products/ai-employee', '/products/ai-employee']) {
-    if (pathname === oldPath || pathname.startsWith(`${oldPath}/`))
-      return context.redirect(pathname.replace('/ai-employee', '/operator'), 301)
-  }
-
-  // Admin surface: canonical /admin/ai-employee (the admin-subdomain-relative
-  // /ai-employee form is already handled by the marketing rule above).
-  if (pathname === '/admin/ai-employee' || pathname.startsWith('/admin/ai-employee/'))
-    return context.redirect(pathname.replace('/ai-employee', '/operator'), 301)
-
-  return null
-}
-
-// Retired marketing routes → 301 to the surviving surface that absorbed them.
-// Marketing consolidated 2026-06-29 (firm-with-flagship structure, 5 page types):
-// the comparison argument moved onto /operator; firm breadth onto the home + the
-// assessment; the /ai toe-dip page is retired now that the firm is all-in on AI.
-// Also folds the older lead-magnet retirements (/scan, /scorecard, /outside-view,
-// the cold /get-started). The SOURCES here are the retired paths — do not rename
-// them (that would self-redirect).
-//
-// NOTE: /contact is NOT retired. Captain decision 2026-06-30 restored it as the
-// quiet general-inquiry channel (a real form, not a published email). See
-// docs/marketing/positioning-spine.md change-control log.
-function redirectRetiredMarketingPaths(context: APIContext, pathname: string): Response | null {
-  const exactToHome = new Set(['/scan', '/consulting', '/ai'])
-  if (exactToHome.has(pathname)) return context.redirect('/', 301)
-
-  const prefixToHome = ['/scorecard', '/outside-view', '/consulting/', '/ai/']
-  if (prefixToHome.some((p) => pathname === p.replace(/\/$/, '') || pathname.startsWith(p)))
-    return context.redirect('/', 301)
-
-  if (pathname === '/why' || pathname.startsWith('/why/'))
-    return context.redirect('/operator#compare', 301)
-  if (pathname === '/get-started' && !context.url.searchParams.has('booked'))
-    return context.redirect('/', 301)
-  return null
-}
-
-function handleLegacyRedirects(
-  context: APIContext,
-  hostname: string,
-  pathname: string
-): Response | null {
-  const adminRedirect = redirectToAdminHost(context, hostname, pathname)
-  if (adminRedirect) return adminRedirect
-  const authRedirect = redirectLegacyAuthPaths(context, pathname)
-  if (authRedirect) return authRedirect
-  if (pathname === '/book/thanks' || pathname.startsWith('/book/thanks/'))
-    return context.redirect('/get-started?booked=1', 301)
-  return redirectRetiredMarketingPaths(context, pathname)
-}
-
 function enforceAdminAuth(context: APIContext, isAdminApiRoute: boolean): Response | null {
   const auth = context.locals.auth()
   if (!auth.userId) {
@@ -284,17 +179,21 @@ function enforceAuth(context: APIContext, pathname: string): Response | null {
 async function handleRequest(context: APIContext, next: NextFn): Promise<Response> {
   const { pathname } = context.url
   const hostname = context.url.hostname
+  const redirectCtx = { hostname, pathname, url: context.url }
 
-  // Product renamed "Operator" → "Operator" (ADR 0034). 301 old paths
-  // before the subdomain rewrite, since the rewrite terminates the chain.
-  const operatorRename = redirectLegacyOperatorPaths(context, hostname, pathname)
-  if (operatorRename) return operatorRename
+  // Legacy redirects that must run BEFORE the subdomain rewrite terminates the
+  // chain (the /ai-employee → /operator product rename, ADR 0034). Rule table
+  // lives in src/lib/routing/legacy-redirects.ts.
+  const preRewrite = firstRedirect(PRE_REWRITE_REDIRECTS, redirectCtx)
+  if (preRewrite) return context.redirect(preRewrite.location, preRewrite.status)
 
   const subdomainRewrite = handleSubdomainRewrite(context, hostname, pathname)
   if (subdomainRewrite) return subdomainRewrite
 
-  const legacyRedirect = handleLegacyRedirects(context, hostname, pathname)
-  if (legacyRedirect) return legacyRedirect
+  // Legacy redirects that run after the rewrite (admin-host canonicalization,
+  // legacy auth paths, retired marketing surfaces).
+  const postRewrite = firstRedirect(POST_REWRITE_REDIRECTS, redirectCtx)
+  if (postRewrite) return context.redirect(postRewrite.location, postRewrite.status)
 
   context.locals.session = null
   await resolveAdminSession(context, pathname)

--- a/tests/landing-page.test.ts
+++ b/tests/landing-page.test.ts
@@ -260,9 +260,15 @@ describe('marketing structure: firm-with-flagship (locked)', () => {
     expect(footer, 'footer must not publish a mailto address').not.toContain('mailto:')
   })
 
-  it('the contact route is NOT 301-redirected away in middleware', () => {
+  it('the contact route is NOT 301-redirected away', () => {
+    // Redirect logic lives in the legacy-redirect table now; assert /contact is
+    // absent from both it and the middleware so the guard is not vacuous.
     const mw = readFileSync(resolve('src/middleware.ts'), 'utf-8')
-    expect(mw, 'middleware must not redirect /contact').not.toContain("pathname === '/contact'")
+    const redirects = readFileSync(resolve('src/lib/routing/legacy-redirects.ts'), 'utf-8')
+    expect(mw, 'middleware must not redirect /contact').not.toContain("'/contact'")
+    expect(redirects, 'legacy-redirect table must not redirect /contact').not.toContain(
+      "'/contact'"
+    )
   })
 
   it('nav does not link the retired pages', () => {
@@ -270,12 +276,16 @@ describe('marketing structure: firm-with-flagship (locked)', () => {
     expect(nav).not.toContain("href: '/consulting'")
   })
 
-  it('the retired routes 301 in middleware (bookmarks keep working)', () => {
-    const mw = readFileSync(resolve('src/middleware.ts'), 'utf-8')
+  it('the retired routes 301 via the legacy-redirect table (bookmarks keep working)', () => {
+    // The redirect rules were extracted from middleware.ts into a declarative
+    // table (code review 2026-07-02 §1.3). Retired routes now live there.
+    const redirects = readFileSync(resolve('src/lib/routing/legacy-redirects.ts'), 'utf-8')
     for (const route of ["'/why'", "'/consulting'", "'/ai'"]) {
-      expect(mw, `middleware should reference retired route ${route}`).toContain(route)
+      expect(redirects, `legacy-redirect table should reference retired route ${route}`).toContain(
+        route
+      )
     }
-    expect(mw).toContain('/operator#compare')
+    expect(redirects).toContain('/operator#compare')
   })
 })
 

--- a/tests/middleware-behavior.test.ts
+++ b/tests/middleware-behavior.test.ts
@@ -279,6 +279,53 @@ describe('middleware runtime: behavior', () => {
     })
   })
 
+  // ---- Extracted legacy-redirect table (src/lib/routing/legacy-redirects) --
+  // Behavioral coverage of the redirect rules moved out of middleware.ts (code
+  // review 2026-07-02 §1.3). Drives the real onRequest so the extraction is
+  // proven behavior-preserving, not just structurally present.
+  describe('legacy redirects (rule table)', () => {
+    it('301s the /ai-employee product rename to /operator (before subdomain rewrite)', async () => {
+      const { res } = await invoke({ url: 'https://smd.services/ai-employee/pricing' })
+      expect(res.status).toBe(301)
+      expect(res.headers.get('Location')).toBe('/operator/pricing')
+    })
+
+    it('301s a portal-relative /products/ai-employee path to /products/operator', async () => {
+      const { res } = await invoke({ url: 'https://smd.services/products/ai-employee' })
+      expect(res.status).toBe(301)
+      expect(res.headers.get('Location')).toBe('/products/operator')
+    })
+
+    it('301s a legacy auth path to the unified sign-in, preserving the query', async () => {
+      const { res } = await invoke({ url: 'https://smd.services/auth/login?status=signed_out' })
+      expect(res.status).toBe(301)
+      const loc = new URL(res.headers.get('Location')!)
+      expect(loc.pathname).toBe('/auth/sign-in')
+      expect(loc.searchParams.get('status')).toBe('signed_out')
+    })
+
+    it('301s a retired marketing route (/scan) to home', async () => {
+      const { res } = await invoke({ url: 'https://smd.services/scan' })
+      expect(res.status).toBe(301)
+      expect(res.headers.get('Location')).toBe('/')
+    })
+
+    it('301s /why to /operator#compare', async () => {
+      const { res } = await invoke({ url: 'https://smd.services/why' })
+      expect(res.status).toBe(301)
+      expect(res.headers.get('Location')).toBe('/operator#compare')
+    })
+
+    it('301s bare /get-started to home but leaves /get-started?booked=1 alone', async () => {
+      const retired = await invoke({ url: 'https://smd.services/get-started' })
+      expect(retired.res.status).toBe(301)
+      expect(retired.res.headers.get('Location')).toBe('/')
+
+      const booked = await invoke({ url: 'https://smd.services/get-started?booked=1' })
+      expect(booked.res.status).not.toBe(301)
+    })
+  })
+
   // ---- Admin auth enforcement -------------------------------------------
   describe('admin auth enforcement', () => {
     it('redirects an unauthenticated admin PAGE request to /auth/sign-in', async () => {

--- a/tests/middleware.test.ts
+++ b/tests/middleware.test.ts
@@ -49,50 +49,47 @@ describe('middleware: admin subdomain rewrite', () => {
   })
 })
 
-describe('middleware: legacy apex redirects', () => {
-  const source = () => readFileSync(resolve('src/middleware.ts'), 'utf-8')
+describe('legacy redirects: apex + auth rules (src/lib/routing/legacy-redirects.ts)', () => {
+  // The redirect rule table was extracted from middleware.ts (code review
+  // 2026-07-02 §1.3). These source guards follow the logic to its new home and
+  // keep asserting the invariants that matter (loop safety, apex admin
+  // canonicalization, legacy auth targets, permanent status).
+  const source = () => readFileSync(resolve('src/lib/routing/legacy-redirects.ts'), 'utf-8')
 
-  it('uses strict hostname inequality guard for the apex admin redirect', () => {
-    // CRITICAL: startsWith/endsWith would also match admin.smd.services and loop.
-    // The guard uses `if (hostname !== 'smd.services') return null` form.
+  it('uses strict hostname equality for the apex admin redirect (no endsWith/startsWith loop)', () => {
+    // CRITICAL: startsWith/endsWith on the host would also match
+    // admin.smd.services and loop. The rule matches on strict equality.
     const code = source()
-    expect(code).toContain("hostname !== 'smd.services'")
+    expect(code).toContain("hostname === 'smd.services'")
+    expect(code).not.toContain("hostname.endsWith('smd.services')")
+    expect(code).not.toContain("hostname.startsWith('smd.services')")
   })
 
   it('redirects apex /admin/* to admin subdomain', () => {
     const code = source()
-    expect(code).toMatch(
-      /hostname\s*!==\s*'smd\.services'[\s\S]*?pathname\.startsWith\('\/admin\/'\)/
-    )
-    expect(code).toContain("newUrl.hostname = 'admin.smd.services'")
+    expect(code).toMatch(/pathname\.startsWith\('\/admin\/'\)/)
+    expect(code).toContain("next.hostname = 'admin.smd.services'")
   })
 
-  it('301s legacy auth paths to unified /auth/sign-in', () => {
+  it('301s legacy auth paths to unified /auth/sign-in|sign-up', () => {
     const code = source()
-    // The unified-auth migration replaced the old /auth/login admin host
-    // redirect with same-host 301s that funnel all legacy auth URLs to
-    // the new /auth/sign-in entry point.
-    expect(code).toMatch(/pathname\s*===\s*'\/auth\/login'\s*\)\s*return\s*'\/auth\/sign-in'/)
-    expect(code).toMatch(
-      /pathname\s*===\s*'\/auth\/portal-sign-in'\s*\)\s*return\s*'\/auth\/sign-in'/
-    )
-    expect(code).toMatch(
-      /pathname\s*===\s*'\/auth\/portal-sign-up'\s*\)\s*return\s*'\/auth\/sign-up'/
-    )
-    expect(code).toMatch(
-      /pathname\s*===\s*'\/auth\/portal-login'\s*\)\s*return\s*'\/auth\/sign-in'/
-    )
+    // The unified-auth migration funnels all legacy auth URLs to the new
+    // /auth/sign-in (and /auth/sign-up) entry points.
+    expect(code).toMatch(/'\/auth\/login':\s*'\/auth\/sign-in'/)
+    expect(code).toMatch(/'\/auth\/portal-sign-in':\s*'\/auth\/sign-in'/)
+    expect(code).toMatch(/'\/auth\/portal-sign-up':\s*'\/auth\/sign-up'/)
+    expect(code).toMatch(/'\/auth\/portal-login':\s*'\/auth\/sign-in'/)
   })
 
-  it('uses 301 for backwards-compat redirects', () => {
+  it('every legacy redirect is permanent (301, never 302/307)', () => {
     const code = source()
-    expect(code).toMatch(/context\.redirect\(newUrl\.toString\(\),\s*301\)/)
+    expect(code).toMatch(/status:\s*301/)
+    expect(code).not.toMatch(/status:\s*30[27]/)
   })
 
-  it('does NOT redirect admin.smd.services to itself (no loop)', () => {
-    // The guard hostname !== 'smd.services' is strict inequality, not endsWith.
-    const code = source()
-    expect(code).not.toContain("hostname.endsWith('smd.services')")
+  it('the middleware issues the redirect through context.redirect with the rule status', () => {
+    const mw = readFileSync(resolve('src/middleware.ts'), 'utf-8')
+    expect(mw).toMatch(/context\.redirect\(\s*\w+\.location,\s*\w+\.status\s*\)/)
   })
 })
 


### PR DESCRIPTION
Code review 2026-07-02 §1.3. `src/middleware.ts` accumulated four legacy-redirect concerns inline alongside subdomain rewriting and auth resolution. This extracts the rule logic into `src/lib/routing/legacy-redirects.ts` as a declarative table.

### What moved
- `redirectToAdminHost`, `redirectLegacyAuthPaths` (+ `legacyAuthRedirectTarget`), `redirectLegacyOperatorPaths`, `redirectRetiredMarketingPaths`, and the inline `/book/thanks` rule → rule objects in the new module.
- Middleware now calls `firstRedirect(PRE_REWRITE_REDIRECTS, ctx)` before the subdomain rewrite and `firstRedirect(POST_REWRITE_REDIRECTS, ctx)` after, then issues `context.redirect(outcome.location, outcome.status)`.

### Behavior preserved exactly
- **Ordering:** the `/ai-employee → /operator` rename still fires *before* the subdomain rewrite (which terminates the chain); admin-host, legacy-auth, book/thanks, and retired-marketing still fire *after*, in the same evaluation order.
- **Target form:** each rule returns its original location string verbatim, so host-changing and query-preserving redirects stay byte-identical.
- **Loop safety:** the apex-admin rule keeps strict `hostname === 'smd.services'` equality (never `startsWith`/`endsWith`).

### Tests
- Source-text guards in `middleware.test.ts` and `landing-page.test.ts` repointed to the module where the logic now lives (and the `/contact` guard strengthened so it isn't vacuous).
- **Added 6 behavioral tests** to `middleware-behavior.test.ts` driving the real `onRequest` through the rename, legacy-auth (query preserved), and retired-marketing rules — proving the extraction is behavior-preserving, not just structurally present.

`npm run verify` green (typecheck, workers typecheck, format, lint, build, 3129 tests + workers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)