### PR TITLE
test: admin-session shim + cross-org quotes/invoices DAL coverage (§4.3, §4.6)

### DIFF
--- a/tests/admin-session-shim.test.ts
+++ b/tests/admin-session-shim.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Unit tests for the admin session shim (code review 2026-07-02 §4.3).
+ *
+ * resolveAdminSessionFromClerk is the admin gate's Clerk→legacy bridge: the
+ * middleware calls it on every admin path to turn a Clerk user_id into the
+ * SessionData shape 73 call sites read. It had no dedicated test. These cover
+ * the security-relevant branches: non-admin rejection, missing local user,
+ * session synthesis, the KV cache path, and the corrupt-cache fall-through
+ * (issue #834 — a bad cache entry must never 500 an authenticated request).
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import {
+  createTestD1,
+  runMigrations,
+  discoverNumericMigrations,
+  installWorkerdPolyfills,
+} from '@venturecrane/crane-test-harness'
+import { resolve } from 'path'
+import type { D1Database } from '@cloudflare/workers-types'
+// KVNamespace is referenced via the ambient global (from the versioned
+// @cloudflare/workers-types in tsconfig) so it is the SAME nominal type the
+// shim's signature uses — importing the non-versioned index causes a ts(2345)
+// identity mismatch when passing the fake KV straight into the function.
+import {
+  resolveAdminSessionFromClerk,
+  invalidateAdminSessionCache,
+} from '../src/lib/auth/admin-session-shim'
+
+installWorkerdPolyfills()
+
+const migrationsDir = resolve(process.cwd(), 'migrations')
+
+const ORG_ID = 'org-1'
+const ADMIN_CLERK = 'user_admin_clerk'
+const CLIENT_CLERK = 'user_client_clerk'
+const cacheKey = (clerkId: string) => `admin-session:${clerkId}`
+
+function createMemoryKv(): { kv: KVNamespace; store: Map<string, string> } {
+  const store = new Map<string, string>()
+  const kv = {
+    get: vi.fn(async (key: string) => store.get(key) ?? null),
+    put: vi.fn(async (key: string, value: string) => {
+      store.set(key, value)
+    }),
+    delete: vi.fn(async (key: string) => {
+      store.delete(key)
+    }),
+    list: vi.fn(),
+    getWithMetadata: vi.fn(),
+  } as unknown as KVNamespace
+  return { kv, store }
+}
+
+describe('resolveAdminSessionFromClerk', () => {
+  let db: D1Database
+
+  beforeEach(async () => {
+    db = createTestD1()
+    await runMigrations(db, { files: discoverNumericMigrations(migrationsDir) })
+    await db
+      .prepare('INSERT INTO organizations (id, name, slug) VALUES (?, ?, ?)')
+      .bind(ORG_ID, 'Org', 'org')
+      .run()
+    await db
+      .prepare(
+        `INSERT INTO users (id, org_id, email, name, role, clerk_user_id)
+         VALUES (?, ?, ?, ?, 'admin', ?)`
+      )
+      .bind('u-admin', ORG_ID, 'admin@smd.services', 'Admin', ADMIN_CLERK)
+      .run()
+    await db
+      .prepare(
+        `INSERT INTO users (id, org_id, email, name, role, clerk_user_id)
+         VALUES (?, ?, ?, ?, 'client', ?)`
+      )
+      .bind('u-client', ORG_ID, 'client@example.com', 'Client', CLIENT_CLERK)
+      .run()
+  })
+
+  it('synthesizes SessionData for an admin Clerk user', async () => {
+    const { kv } = createMemoryKv()
+    const session = await resolveAdminSessionFromClerk(ADMIN_CLERK, db, kv)
+    expect(session).not.toBeNull()
+    expect(session).toMatchObject({
+      userId: 'u-admin',
+      orgId: ORG_ID,
+      role: 'admin',
+      email: 'admin@smd.services',
+    })
+    // expiresAt is a forward-dated ISO string (Clerk owns real expiry).
+    expect(new Date(session!.expiresAt).getTime()).toBeGreaterThan(Date.now())
+  })
+
+  it('returns null when the Clerk user has no local users row', async () => {
+    const { kv } = createMemoryKv()
+    expect(await resolveAdminSessionFromClerk('user_nobody', db, kv)).toBeNull()
+  })
+
+  it('returns null when the local user exists but is not an admin', async () => {
+    const { kv } = createMemoryKv()
+    // The client user is real, but the SELECT gates on role = 'admin'.
+    expect(await resolveAdminSessionFromClerk(CLIENT_CLERK, db, kv)).toBeNull()
+  })
+
+  it('caches the resolved session and serves the second call from KV', async () => {
+    const { kv, store } = createMemoryKv()
+    const first = await resolveAdminSessionFromClerk(ADMIN_CLERK, db, kv)
+    expect(first).not.toBeNull()
+    expect(store.has(cacheKey(ADMIN_CLERK))).toBe(true)
+
+    // Remove the DB row; a cache hit must still resolve (proves KV was used).
+    await db.prepare('DELETE FROM users WHERE clerk_user_id = ?').bind(ADMIN_CLERK).run()
+    const second = await resolveAdminSessionFromClerk(ADMIN_CLERK, db, kv)
+    expect(second).toMatchObject({ userId: 'u-admin', role: 'admin' })
+  })
+
+  it('falls through to D1 and repopulates when the cache entry is corrupt (#834)', async () => {
+    const { kv, store } = createMemoryKv()
+    store.set(cacheKey(ADMIN_CLERK), '{ not-valid-json')
+    const session = await resolveAdminSessionFromClerk(ADMIN_CLERK, db, kv)
+    expect(session).toMatchObject({ userId: 'u-admin', role: 'admin' })
+    // Corrupt entry was replaced with a valid one.
+    const cached = store.get(cacheKey(ADMIN_CLERK))
+    expect(cached).toBeTruthy()
+    expect(JSON.parse(cached!).role).toBe('admin')
+  })
+
+  it('treats a non-admin cache entry as corrupt and falls through to D1', async () => {
+    const { kv, store } = createMemoryKv()
+    // A cache value whose role is not 'admin' must never be trusted.
+    store.set(
+      cacheKey(ADMIN_CLERK),
+      JSON.stringify({
+        userId: 'attacker',
+        orgId: ORG_ID,
+        email: 'x@x',
+        role: 'client',
+        expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      })
+    )
+    const session = await resolveAdminSessionFromClerk(ADMIN_CLERK, db, kv)
+    expect(session).toMatchObject({ userId: 'u-admin', role: 'admin' })
+  })
+
+  it('invalidateAdminSessionCache deletes the cached entry', async () => {
+    const { kv, store } = createMemoryKv()
+    await resolveAdminSessionFromClerk(ADMIN_CLERK, db, kv)
+    expect(store.has(cacheKey(ADMIN_CLERK))).toBe(true)
+    await invalidateAdminSessionCache(ADMIN_CLERK, kv)
+    expect(store.has(cacheKey(ADMIN_CLERK))).toBe(false)
+  })
+})

--- a/tests/db-cross-org.test.ts
+++ b/tests/db-cross-org.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Cross-org isolation regression tests for the quotes and invoices DALs
+ * (code review 2026-07-02 §4.6). Mirrors tests/admin/milestones.cross-org.test.ts,
+ * but at the DAL layer: every org-scoped read/mutate must refuse a row that
+ * belongs to another org.
+ *
+ * The invariant: getQuote / updateQuote / updateQuoteStatus (and the invoice
+ * equivalents) take orgId and add `AND org_id = ?` to their queries. A call made
+ * with org A's id against org B's row must return null and leave org B's row
+ * untouched — the money-path analogue of the milestones #399 fix.
+ *
+ * Seeding is raw SQL (SQLite FK enforcement is off in the harness), matching the
+ * proven milestones cross-org seed.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  createTestD1,
+  runMigrations,
+  discoverNumericMigrations,
+  installWorkerdPolyfills,
+} from '@venturecrane/crane-test-harness'
+import { resolve } from 'path'
+import type { D1Database } from '@cloudflare/workers-types'
+import { getQuote, updateQuote, updateQuoteStatus } from '../src/lib/db/quotes'
+import { getInvoice, updateInvoice, updateInvoiceStatus } from '../src/lib/db/invoices'
+
+installWorkerdPolyfills()
+
+const migrationsDir = resolve(process.cwd(), 'migrations')
+
+const ORG_A = 'org-a'
+const ORG_B = 'org-b'
+const QUOTE_A = 'quote-a'
+const QUOTE_B = 'quote-b'
+const INVOICE_A = 'invoice-a'
+const INVOICE_B = 'invoice-b'
+
+describe('quotes/invoices DAL — cross-org isolation', () => {
+  let db: D1Database
+
+  beforeEach(async () => {
+    db = createTestD1()
+    await runMigrations(db, { files: discoverNumericMigrations(migrationsDir) })
+
+    for (const [id, name, slug] of [
+      [ORG_A, 'Org A', 'org-a'],
+      [ORG_B, 'Org B', 'org-b'],
+    ]) {
+      await db
+        .prepare('INSERT INTO organizations (id, name, slug) VALUES (?, ?, ?)')
+        .bind(id, name, slug)
+        .run()
+    }
+
+    // entities + assessments are FK targets of quotes; seed one pair per org.
+    for (const [orgId, suffix] of [
+      [ORG_A, 'a'],
+      [ORG_B, 'b'],
+    ]) {
+      await db
+        .prepare('INSERT INTO entities (id, org_id, name, slug) VALUES (?, ?, ?, ?)')
+        .bind(`entity-${suffix}`, orgId, `Entity ${suffix}`, `entity-${suffix}`)
+        .run()
+      await db
+        .prepare(
+          `INSERT INTO assessments (id, org_id, entity_id, status) VALUES (?, ?, ?, 'completed')`
+        )
+        .bind(`assessment-${suffix}`, orgId, `entity-${suffix}`)
+        .run()
+    }
+
+    // One quote per org.
+    for (const [id, orgId, suffix] of [
+      [QUOTE_A, ORG_A, 'a'],
+      [QUOTE_B, ORG_B, 'b'],
+    ]) {
+      await db
+        .prepare(
+          `INSERT INTO quotes (id, org_id, entity_id, assessment_id, line_items, total_hours, rate, total_price, status)
+           VALUES (?, ?, ?, ?, '[]', 10, 175, 1750, 'draft')`
+        )
+        .bind(id, orgId, `entity-${suffix}`, `assessment-${suffix}`)
+        .run()
+    }
+
+    // One invoice per org (columns per createInvoice()).
+    for (const [id, orgId, suffix] of [
+      [INVOICE_A, ORG_A, 'a'],
+      [INVOICE_B, ORG_B, 'b'],
+    ]) {
+      await db
+        .prepare(
+          `INSERT INTO invoices (id, org_id, entity_id, engagement_id, type, amount, description, status, due_date, created_at, updated_at)
+           VALUES (?, ?, ?, NULL, 'deposit', 1000, 'Deposit ${suffix}', 'draft', NULL, datetime('now'), datetime('now'))`
+        )
+        .bind(id, orgId, `entity-${suffix}`)
+        .run()
+    }
+  })
+
+  // ---- quotes ------------------------------------------------------------
+  it('getQuote returns the row for the owning org', async () => {
+    expect(await getQuote(db, ORG_A, QUOTE_A)).not.toBeNull()
+  })
+
+  it('getQuote refuses a quote owned by another org', async () => {
+    expect(await getQuote(db, ORG_A, QUOTE_B)).toBeNull()
+  })
+
+  it('updateQuote refuses a cross-org quote and leaves it untouched', async () => {
+    const result = await updateQuote(db, ORG_A, QUOTE_B, { rate: 999 })
+    expect(result).toBeNull()
+    const row = await db
+      .prepare('SELECT rate FROM quotes WHERE id = ?')
+      .bind(QUOTE_B)
+      .first<{ rate: number }>()
+    expect(row?.rate).toBe(175)
+  })
+
+  it('updateQuoteStatus refuses a cross-org quote and leaves it untouched', async () => {
+    const result = await updateQuoteStatus(db, ORG_A, QUOTE_B, 'accepted')
+    expect(result).toBeNull()
+    const row = await db
+      .prepare('SELECT status FROM quotes WHERE id = ?')
+      .bind(QUOTE_B)
+      .first<{ status: string }>()
+    expect(row?.status).toBe('draft')
+  })
+
+  // ---- invoices ----------------------------------------------------------
+  it('getInvoice returns the row for the owning org', async () => {
+    expect(await getInvoice(db, ORG_A, INVOICE_A)).not.toBeNull()
+  })
+
+  it('getInvoice refuses an invoice owned by another org', async () => {
+    expect(await getInvoice(db, ORG_A, INVOICE_B)).toBeNull()
+  })
+
+  it('updateInvoice refuses a cross-org invoice and leaves it untouched', async () => {
+    const result = await updateInvoice(db, ORG_A, INVOICE_B, { amount: 999 })
+    expect(result).toBeNull()
+    const row = await db
+      .prepare('SELECT amount FROM invoices WHERE id = ?')
+      .bind(INVOICE_B)
+      .first<{ amount: number }>()
+    expect(row?.amount).toBe(1000)
+  })
+
+  it('updateInvoiceStatus refuses a cross-org invoice and leaves it untouched', async () => {
+    const result = await updateInvoiceStatus(db, ORG_A, INVOICE_B, 'sent')
+    expect(result).toBeNull()
+    const row = await db
+      .prepare('SELECT status FROM invoices WHERE id = ?')
+      .bind(INVOICE_B)
+      .first<{ status: string }>()
+    expect(row?.status).toBe('draft')
+  })
+})


### PR DESCRIPTION
Code review 2026-07-02 — the two Testing soft spots (§4.3, §4.6). Test-only, no source change.

### §4.3 — admin-session shim
`tests/admin-session-shim.test.ts` unit-tests `resolveAdminSessionFromClerk`, the admin gate's Clerk→legacy `SessionData` bridge that had no dedicated test. Covers:
- admin session synthesis (userId/orgId/role/email + forward-dated expiresAt)
- **missing local user** → null
- **non-admin role rejection** (the `role = 'admin'` SELECT gate) → null
- KV cache path: second call served from cache after the DB row is deleted
- corrupt-cache fall-through to D1 and repopulation (#834 — a bad cache entry must never 500 an authenticated request)
- a non-admin cache entry treated as corrupt

### §4.6 — cross-org DAL isolation
`tests/db-cross-org.test.ts` replicates the milestones cross-org regression pattern (#399) at the DAL layer for the money paths. For both quotes and invoices, `get*` / `update*` / `update*Status` must refuse a row owned by another org (return null, leave it untouched) and succeed for the owning org.

`npm run verify` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)