### PR TITLE
docs(handbook): de-stale lead-gen retirement (§6.2)

### DIFF
--- a/docs/handbook/admin-console.md
+++ b/docs/handbook/admin-console.md
@@ -34,7 +34,7 @@ The information architecture is flow-ordered (acquire, serve, deliver, get paid,
 | **Operator** | `/admin/operator` | The Operator fleet cockpit - roster and per-customer drill-ins. |
 | **Analytics** | `/admin/analytics` | Business-intelligence views, rendered server-side. |
 | **Playbook** | `/admin/playbook` | This handbook. |
-| **Settings** | `/admin/settings` | The configuration hub: lead generators, follow-ups, pipeline tuning, Google connect. |
+| **Settings** | `/admin/settings` | The configuration hub: follow-ups and Google connect. |
 
 `assessments` and `engagements` also live under `src/pages/admin/` and are reached from within the flow (a lead's meeting, a client's engagement) rather than from a dedicated top-nav tab.
 
@@ -150,10 +150,10 @@ All per-customer runtime detail comes through the read seam in `src/lib/operator
 
 `/admin/settings` is the configuration hub. It links to:
 
-- **Lead generators** (`/admin/generators`) - the four ingestion pipelines (New Business, Job Monitor, Review Mining, Social Listening), each with a card showing signal volume, fill rates for the key fields, last-run status, and an enabled flag. The detail page (`generators/[type]`) carries the per-pipeline configuration form (target verticals, geos, search or discovery queries, geo center and radius for review mining) and a run-now button that invokes the ingestion worker. The pipelines qualify and score signals with models matched to the source; social listening is context-only and creates no entity.
 - **Follow-ups** (`/admin/follow-ups`) - the cadence working list, tabbed Upcoming / Overdue / Completed with a type filter.
-- **Pipeline settings** (`/admin/settings/pipelines`) - the tunable per-pipeline parameters, each validated against bounds twice (in the form and in the data layer), with an immutable audit trail of every change (old value, new value, actor, time). Changes take effect on the next cron run without a deploy.
 - **Google connect** (`/admin/settings/google-connect`) - the Google Calendar OAuth connection used for booking, showing the connected account or a connect button.
+
+The **Lead generators** surface (`/admin/generators`) and the **Pipeline settings** page (`/admin/settings/pipelines`) were removed with the automated lead-gen retirement on 2026-07-01 (PRs #1610/#1616). Lead generation is now hand-personalized outreach (ADR 0059), not a configurable ingestion pipeline.
 
 ## Patterns that hold across the console
 

--- a/docs/handbook/admin-console.md
+++ b/docs/handbook/admin-console.md
@@ -67,19 +67,18 @@ Bulk select and bulk actions are offered only on the `signal`, `prospect`, and `
 
 ### Lead detail (`/admin/entities/[id]`)
 
-The decision surface for one business. It shows an identity strip (name, stage, tier, pain score out of ten, vertical, area), an enrichment summary (pain observations, address, when it was generated, and which enrichment module produced it), a contacts panel, and a deduplicated timeline of context entries (signals, notes, outreach, observations) with an inline add-note form. A right-hand decision rail carries the stage-appropriate actions and surfaces missing-data warnings (no pain score, no contacts) and stale-outreach-draft warnings.
+The decision surface for one business. It shows an identity strip (name, stage, tier, pain score out of ten, vertical, area), an enrichment summary rendered from any enrichment data left on legacy entity rows (pain observations, address, when it was generated), a contacts panel, and a deduplicated timeline of context entries (signals, notes, outreach, observations) with an inline add-note form. A right-hand decision rail carries the stage-appropriate actions and surfaces missing-data warnings (no pain score, no contacts) and stale-outreach-draft warnings.
 
 The actions on the rail each hit an endpoint under `src/pages/api/admin/entities/[id]/`:
 
-- **Promote** (`promote`) - moves signal to prospect, dispatches enrichment, and schedules the follow-up cadence.
-- **Re-enrich** (`dossier`) - runs the reviews-and-news enrichment mode in the background.
+- **Promote** (`promote`) - moves signal to prospect and schedules the follow-up cadence.
 - **Send booking link** (`send-booking-link`) - creates a meeting, transitions prospect to meetings, and sends the booking email.
 - **Draft quote** (`quotes`) - creates an empty draft quote shell (preconditions: not already engaged, no open quote, a prior meeting exists).
 - **Add note** (`context`) - appends a note to the timeline.
 - **Stage change** (`stage`) - transitions stage against a valid-transition table, optionally recording a lost reason and detail.
 - **Merge** (`merge`) - folds a duplicate entity into this one.
 
-Enrichment itself is a background pipeline; the per-module retry and full-run endpoints live under `entities/[id]/enrichment/`. The enrichment model and what it may infer are bounded by the extractive prompt-contract policy in `/admin/playbook/security-trust`.
+The automated enrichment pipeline that used to populate the enrichment summary (the `entities/[id]/enrichment/` and `dossier` endpoints, the Re-enrich action) was retired with the lead-gen machine on 2026-07-01 (PRs #1610/#1616); only enrichment data already stored on legacy rows still renders.
 
 ### Meeting detail (`/admin/entities/[id]/meetings/[meetingId]`)
 

--- a/docs/handbook/architecture-map.md
+++ b/docs/handbook/architecture-map.md
@@ -40,17 +40,16 @@ Every request to `smd.services`, `admin.smd.services`, or `portal.smd.services` 
    - **D1** (binding `DB`, database `ss-console-db`) - all structured business data. See `/admin/playbook/data-model`.
    - **R2** - three buckets: `STORAGE` (documents, transcripts, SOWs), `CONSULTANT_PHOTOS` (public consultant images), and `CUSTOMER_CONFIG` (the authoritative live Operator config and voice vaults, `smd-customer-config`).
    - **KV** - `SESSIONS` (session storage) and `BOOKING_CACHE` (booking rate-limit plus the public-assessment turn/cost ceiling).
-   - **Service binding** - `ENRICHMENT_WORKFLOW_SERVICE` dispatches entity enrichment to a separate Worker (see below).
 
 All bindings are declared in `wrangler.toml`. The canonical outbound origins (`APP_BASE_URL`, `ADMIN_BASE_URL`, `PORTAL_BASE_URL`) are built from env vars, never from the inbound request host (`src/lib/config/app-url.ts`).
 
-## Background Workers (lead-gen and cost)
+## Background Workers (Operator cost)
 
-Some work does not belong in the request path. Five tracked sibling Workers live under `workers/` and run on their own schedules or service bindings:
+Some work does not belong in the request path. Two sibling Workers live under `workers/`:
 
-- **Lead generation** - `job-monitor` and `review-mining`. These are the tracked pipelines behind the admin Generators surface; their endpoints are declared as env vars in `wrangler.toml` and invoked Bearer-authed with `LEAD_INGEST_API_KEY`.
-- **Enrichment** - `enrichment-workflow` runs Cloudflare Workflows orchestration for entity enrichment, reached via the `ENRICHMENT_WORKFLOW_SERVICE` service binding. It exists because the legacy in-request `ctx.waitUntil(enrichEntity(...))` path was being killed by the post-response CPU budget on ingest batches (`wrangler.toml`, `[[services]]` note; issue #631).
 - **Cost** - `cost-telemetry` and `cost-anomaly` handle Operator cost ingest and anomaly detection.
+
+The automated lead-gen pipelines (`job-monitor`, `review-mining`, `enrichment-workflow`, `new-business`, `scan-workflow`, `social-listening`) that used to live here, along with the `ENRICHMENT_WORKFLOW_SERVICE` service binding and the `LEAD_INGEST_API_KEY` ingest path, were retired root-and-branch on 2026-07-01 (PRs #1610/#1616). The cost workers are all that remain.
 
 ## The Operator plane
 
@@ -79,4 +78,4 @@ Across all of SMD's ventures sits the **crane MCP** server - the enterprise cont
 
 ## External services at a glance
 
-The console plane depends on Cloudflare (Workers, D1, R2, KV), Clerk (identity), Anthropic (LLM), and a billing and document stack (Stripe, SignWell, Resend) plus the lead-gen data providers. The Operator plane adds Fly.io (Machines) and Google Workspace (managed-mailbox OAuth). The full inventory, what each is for, and where its credentials live is at `/admin/playbook/integrations-tooling`. The repository layout that implements all of the above is at `/admin/playbook/repository-map`.
+The console plane depends on Cloudflare (Workers, D1, R2, KV), Clerk (identity), Anthropic (LLM), and a billing and document stack (Stripe, SignWell, Resend). The Operator plane adds Fly.io (Machines) and Google Workspace (managed-mailbox OAuth). The full inventory, what each is for, and where its credentials live is at `/admin/playbook/integrations-tooling`. The repository layout that implements all of the above is at `/admin/playbook/repository-map`.

--- a/docs/handbook/customer-lifecycle.md
+++ b/docs/handbook/customer-lifecycle.md
@@ -26,9 +26,9 @@ This page walks the row from first contact to handoff. For the business meaning 
 
 ## 1. Lead capture - stage `signal`
 
-A lead enters as a `signal`. Lead-generation pipelines feed this stage automatically; the entity list filters by `source_pipeline` across `review_mining`, `job_monitor`, `new_business`, and `social_listening` (`src/pages/admin/entities/index.astro`). Each signal carries the evidence that produced it (a latest pipeline signal context entry plus a last-activity timestamp), surfaced inline on the Signal tab so the operator can judge it without clicking through.
+A lead enters as a `signal`. The automated lead-generation pipelines that used to feed this stage were retired 2026-07-01 (PRs #1610/#1616); current lead generation is hand-personalized outreach (ADR 0059). The entity list still filters by `source_pipeline` across `review_mining`, `job_monitor`, `new_business`, and `social_listening` (`src/pages/admin/entities/index.astro`) for signals already in the system. Each signal carries the evidence that produced it (a latest signal context entry plus a last-activity timestamp), surfaced inline on the Signal tab so the operator can judge it without clicking through.
 
-- **Surface:** `/admin/entities?stage=signal` (the Leads "Signal" tab). Pipelines are managed from `/admin/generators`.
+- **Surface:** `/admin/entities?stage=signal` (the Leads "Signal" tab).
 - **Data objects:** `entities` row (stage `signal`), `context` entries (the signal evidence).
 
 A signal that is not worth pursuing is dismissed. One that is gets promoted to `prospect`.

--- a/docs/handbook/customer-lifecycle.md
+++ b/docs/handbook/customer-lifecycle.md
@@ -2,7 +2,7 @@
 title: Customer Lifecycle
 section: operations
 order: 7
-summary: The end-to-end walk of a business through the system - lead to enrichment to assessment to quote to signing to delivery to billing to handoff - and which admin surface and data object owns each step
+summary: The end-to-end walk of a business through the system - lead to outreach to assessment to quote to signing to delivery to billing to handoff - and which admin surface and data object owns each step
 sources:
   - label: Entity stages & transitions (src/lib/db/entities.ts)
     href: https://github.com/venturecrane/ss-console/blob/main/src/lib/db/entities.ts
@@ -33,14 +33,9 @@ A lead enters as a `signal`. The automated lead-generation pipelines that used t
 
 A signal that is not worth pursuing is dismissed. One that is gets promoted to `prospect`.
 
-## 2. Enrichment
+## 2. Enrichment (retired)
 
-Before or during outreach, a prospect is enriched - public-data gathering that builds a dossier (`src/lib/enrichment/`): website analysis, reviews, tech stack, news, Google Places, and related sources synthesized into a profile. Enrichment is extractive and evidence-bound; it gathers what is publicly observable, not inferred private conditions about the owner (an enforced policy - see CLAUDE.md fabrication guardrails).
-
-- **Surface:** the entity detail page at `/admin/entities/[id]`.
-- **Data objects:** `entities` row plus enrichment `context` entries and the dossier.
-
-> TODO(why): Enrichment runs as a workflow under src/lib/enrichment/ (dispatch.ts, workflow.ts, synthesis.ts), but I did not trace the exact trigger - whether enrichment fires automatically on promotion to prospect, on demand from the detail page, or as a scheduled pipeline step. Looked in src/lib/enrichment/dispatch.ts and the entity list/detail pages; did not read the dispatch trigger wiring.
+The automated public-data enrichment step (dossier building via `src/lib/enrichment/`: website analysis, reviews, tech stack, news, Google Places) was part of the scrape-score-enrich lead-gen machine, retired 2026-07-01 (PRs #1610/#1616). `src/lib/enrichment/`, the `/admin/entities/[id]/enrichment/` and `dossier` endpoints, and the Re-enrich action are gone. The lead detail page still renders any enrichment data left on legacy entity rows, but no new enrichment runs. A prospect now moves from signal straight into outreach.
 
 ## 3. Prospect and outreach - stage `prospect`
 

--- a/docs/handbook/deployment-release.md
+++ b/docs/handbook/deployment-release.md
@@ -48,11 +48,12 @@ The deploy steps run in this order, and the order matters:
    Migrations apply before the code that depends on them and must be
    backward-compatible with the currently deployed app.
 4. **Deploy to Cloudflare Workers** (`wrangler deploy`) - the main `ss-web` Worker.
-5. **Deploy the sub-workers** - job-monitor, review-mining, cost-anomaly,
-   cost-telemetry, enrichment-workflow - each from its own directory.
-   (Between the root deploy and the sub-worker deploys the
+5. **Deploy the sub-workers** - cost-anomaly and cost-telemetry - each from its
+   own directory. (Between the root deploy and the sub-worker deploys the
    pipeline removes `.wrangler/`, because the root deploy writes a deploy-config
-   file that makes the sub-workers' `wrangler deploy` ambiguous.)
+   file that makes the sub-workers' `wrangler deploy` ambiguous.) These two
+   Operator-cost workers are all that remain under `workers/`; the lead-gen
+   pipelines were retired 2026-07-01 (PRs #1610/#1616).
 
 **Secrets.** On Workers, secrets persist across `wrangler deploy` runs - unlike
 the Pages era, there is no post-deploy sync step and no risk of a deploy wiping
@@ -60,7 +61,7 @@ dashboard-set secrets. Rotate them out of band from Infisical:
 
 ```bash
 infisical export --env=prod --path=/ss --format=dotenv \
-  | grep -vE '^(APP_|ADMIN_|PORTAL_|MEETING_|NEW_BUSINESS_|JOB_MONITOR_|REVIEW_MINING_|PUBLIC_)' \
+  | grep -vE '^(APP_|ADMIN_|PORTAL_|MEETING_|PUBLIC_)' \
   | npx wrangler secret bulk
 ```
 

--- a/docs/handbook/integrations-tooling.md
+++ b/docs/handbook/integrations-tooling.md
@@ -55,16 +55,9 @@ This is the inventory of external services the platform touches and what each is
 | **Google Calendar OAuth** | The booking system (the Calendly replacement): availability and event creation. | `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` / `BOOKING_ENCRYPTION_KEY` in `wrangler.toml`; `src/lib/booking/google-calendar.ts`. |
 | **Google Workspace (managed mailbox)** | On the Operator plane, the operator manages a principal's mailbox via per-operation domain-wide-delegation, with the workspace broker as the authorization boundary. OAuth tokens live on the customer's Machine volume, not the console. | `operator/workspace_broker/`; ADR 0010. See `/admin/playbook/connectors-channels`. |
 
-## Lead-generation data providers
+## Lead-generation data providers (retired)
 
-The four lead-gen Workers under `workers/` call external data sources, configured by env in `wrangler.toml`:
-
-- **Google Places** (`GOOGLE_PLACES_API_KEY`) - business profile enrichment.
-- **Outscraper** (`OUTSCRAPER_API_KEY`) - business profile and email enrichment.
-- **SerpAPI** (`SERPAPI_API_KEY`) - Google Search for news and press enrichment.
-- **Proxycurl** (`PROXYCURL_API_KEY`) - LinkedIn company data (optional, Tier 4 dossier).
-
-These feed the admin Generators surface; the generator Worker endpoints are themselves declared as env URLs (`NEW_BUSINESS_WORKER_URL` and siblings) and Bearer-authed with `LEAD_INGEST_API_KEY`.
+The automated lead-gen pipelines that called external data sources (Google Places, Outscraper, SerpAPI, Proxycurl) were retired root-and-branch on 2026-07-01 (PRs #1610/#1616): the Workers, the `NEW_BUSINESS_WORKER_URL`-style env URLs, the `LEAD_INGEST_API_KEY` ingest path, and the admin Generators surface are all gone. Some provider API keys (`GOOGLE_PLACES_API_KEY`, `OUTSCRAPER_API_KEY`, `SERPAPI_API_KEY`) may still linger in the Infisical vault and on the Worker; they are now unused. Current lead generation is hand-personalized outreach from the Captain's mailbox (ADR 0059), not an ingestion pipeline.
 
 ## Operator-plane and enterprise tooling
 

--- a/docs/handbook/integrations-tooling.md
+++ b/docs/handbook/integrations-tooling.md
@@ -36,7 +36,7 @@ This is the inventory of external services the platform touches and what each is
 
 | Service | Used for | Grounded in |
 |---|---|---|
-| **Anthropic (Claude)** | The LLM behind outreach generation, website analysis, the dossier, and the live assessment. The Operator plane also runs on Claude via the per-Machine Anthropic key. | `ANTHROPIC_API_KEY` in `wrangler.toml` secrets; `src/lib/claude/*`, `src/lib/llm/models.ts`. Default to the latest, most capable Claude models. |
+| **Anthropic (Claude)** | The LLM behind the live assessment and assessment-to-quote flow (`src/lib/claude/*`). The Operator plane also runs on Claude via the per-Machine Anthropic key. | `ANTHROPIC_API_KEY` in `wrangler.toml` secrets; `src/lib/claude/*`, `src/lib/llm/models.ts`. Default to the latest, most capable Claude models. |
 | **ElevenLabs** | Voice. Used by the public assessment voice flow (`@elevenlabs/client`) and in the Operator explainer video pipeline. | `@elevenlabs/client` in `package.json`; `src/lib/claude/assessment-llm.ts`, `src/scripts/assessment-voice.ts`. |
 
 ## Billing, documents, and email

--- a/docs/handbook/repository-map.md
+++ b/docs/handbook/repository-map.md
@@ -20,9 +20,9 @@ The repo is `venturecrane/ss-console`. From the root:
 |---|---|
 | `src/` | The Astro SSR application - marketing, admin, portal, API, and all the business logic in `src/lib/`. The bulk of the console plane. |
 | `operator/` | The Operator plane's authored content and tooling: vertical skill bodies, the safety substrate, capability adapters, connectors, per-customer `customer.yaml` files, the workspace broker, provisioning scripts. Python and YAML, not the Worker. |
-| `workers/` | Five sibling Cloudflare Workers run outside the request path: the tracked lead-gen pipelines (`job-monitor`, `review-mining`), `enrichment-workflow`, and `cost-telemetry` / `cost-anomaly`. |
+| `workers/` | Two sibling Cloudflare Workers run outside the request path: `cost-telemetry` and `cost-anomaly` (Operator cost ingest + anomaly detection). The lead-gen pipelines that used to live here were retired 2026-07-01 (PRs #1610/#1616). |
 | `migrations/` | D1 schema migrations for the console database `ss-console-db`, numbered `0001_*` upward (68 forward migrations plus a `rollbacks/` directory). Applied with `wrangler d1 migrations apply`. See `/admin/playbook/data-model`. |
-| `tests/` | Vitest suites, including the policy-enforcing tests cited in CLAUDE.md (`forbidden-strings.test.ts`, `enrichment-prompt-contracts.test.ts`, `intake-questionnaire.test.ts`). |
+| `tests/` | Vitest suites, including the policy-enforcing tests cited in CLAUDE.md (`forbidden-strings.test.ts`, `intake-questionnaire.test.ts`). |
 | `docs/` | All venture documentation: `adr/` (decision records), `handbook/` (this manual), plus `design/`, `runbooks/`, `specs/`, `security/`, and more. The full map is at `/admin/playbook/docs-map`. |
 | `.github/` | CI workflows, including the fabrication and scope merge gates (`scope-deferred-todo.yml`, `unmet-ac-on-close.yml`). See `/admin/playbook/deployment-release`. |
 | `scripts/` | One-off and operational TypeScript / shell scripts (data backfills, customer-config projection, migration verification). |
@@ -42,7 +42,6 @@ src/
   styles/           global.css (Tailwind v4)
   pages/            all routes (see below)
   lib/              all business logic (see below)
-  lead-gen/         lead-generation prompts + schemas (used by workers/)
   portal/           assessment logic shared with the public assessment flow
   scripts/          in-app scripts
 ```
@@ -51,8 +50,8 @@ src/
 
 `src/pages/` holds every route. Which host serves which is decided by `src/middleware.ts` (subdomain rewrite), not by directory separation - the admin and portal trees live here and the subdomain prepends their prefix.
 
-- **Marketing** (`smd.services`) - top-level `.astro` files: `index.astro`, `operator.astro`, `consulting.astro`, `why.astro`, `contact.astro`, `book.astro`, `assessment.astro`, `privacy.astro`, `terms.astro`, plus `packs/`. Note the retired lead-magnet routes (`get-started.astro`, `assessment`, the old `/scan` family) - several 301 to home per the Outside View retirement; treat them as legacy, not live surfaces.
-- **Admin** (`admin.smd.services` to `/admin/*`) - `src/pages/admin/`: `entities` (Leads), `clients`, `services`, `billing`, `operator`, `analytics`, `settings`, plus `assessments`, `engagements`, `follow-ups`, `generators`. Full surface map at `/admin/playbook/admin-console`.
+- **Marketing** (`smd.services`) - top-level `.astro` files: `index.astro`, `operator.astro`, `contact.astro`, `book.astro`, `assessment.astro`, `privacy.astro`, `terms.astro`, plus `packs/`. The `consulting`, `why`, and `/scan` / `/scorecard` lead-magnet routes were removed and now 301 to home (the marketing consolidation + Outside View retirement); the redirect rules live in `src/lib/routing/legacy-redirects.ts`. Treat those paths as legacy, not live surfaces.
+- **Admin** (`admin.smd.services` to `/admin/*`) - `src/pages/admin/`: `entities` (Leads), `clients`, `services`, `billing`, `operator`, `analytics`, `settings`, plus `assessments`, `engagements`, `follow-ups`. (The `generators` surface was removed with the lead-gen retirement.) Full surface map at `/admin/playbook/admin-console`.
 - **Portal** (`portal.smd.services` to `/portal/*`) - `src/pages/portal/`: `quotes`, `engagement`, `documents`, `invoices`, `products`. See `/admin/playbook/client-portal`.
 - **API** (`src/pages/api/`) - JSON and webhook endpoints: `admin/` (admin mutations and fleet reads), `operator/[customer]/`, `portal/`, `auth/`, `oauth/`, `booking/`, `assessment/`, `intake/`, `webhooks/` (`stripe`, `signwell`, `resend`, `sentry`, `healthchecks`), plus `contact.ts`, `events.ts`, `health.ts`, `mcp.ts`.
 
@@ -68,14 +67,12 @@ src/
 | `auth/` | Identity: Clerk bridge, the admin-session shim, legacy magic-link sessions, machine and API keys, health read key. |
 | `booking/` | The Calendly-replacement booking system: availability, holds, Google Calendar sync, ICS generation, intake questionnaire, encryption, rate limiting. |
 | `category.ts` | The single Operator category constant ("Managed Operator"). |
-| `claude/` | LLM-backed business flows: assessment, assessment-to-quote, extraction, outreach generation. |
+| `claude/` | LLM-backed business flows: assessment, assessment-to-quote, extraction. |
 | `config/` | Canonical app URLs (`app-url.ts`), brand and firm-contact constants. |
-| `db/` | D1 data access, one file per domain (entities, engagements, contacts, assessments, analytics, enrichment-runs, and more). The query layer over `ss-console-db`. |
+| `db/` | D1 data access, one file per domain (entities, engagements, contacts, assessments, analytics, quotes, invoices, milestones, and more). The query layer over `ss-console-db`. |
 | `email/` | Resend transactional email, templates, booking and follow-up emails. |
-| `enrichment/` | Entity enrichment: Google Places, dossier, deep-website, LinkedIn, competitors, dispatch. |
 | `entities/` | Entity domain logic: slug, recompute, meeting substate, list sort. |
 | `follow-ups/` | The follow-up cadence scheduler. |
-| `generators/` | Lead-generator types and validation (the admin Generators surface). |
 | `llm/` | Model id constants (`models.ts`). |
 | `oauth/` | OAuth provider plumbing for the console's own integrations: state, store, audit, providers. |
 | `observability/` | Sentry wiring (`sentry.ts`), no-op when `SENTRY_DSN` is unset. |

--- a/docs/handbook/security-trust.md
+++ b/docs/handbook/security-trust.md
@@ -53,7 +53,6 @@ The policy is not enforced by vigilance alone; it is wired into CI and into test
 | Mechanism | What it does |
 |---|---|
 | `tests/forbidden-strings.test.ts` | Regression guard: the historical Pattern A/B phrases, the user-facing style-marker checks (em dash, "coming soon"), and portal registry guardrails must not appear in shipped source. |
-| `tests/enrichment-prompt-contracts.test.ts` | Source-level checks that the dossier, review-analysis, and deep-website enrichment prompts stay extractive. |
 | `tests/intake-questionnaire.test.ts` | Shared-surface regression coverage for the canonical intake questionnaire. |
 | `.github/workflows/scope-deferred-todo.yml` | Merge gate: blocks a PR that defers an acceptance criterion via a TODO without the `scope-deferred` label. |
 | `.github/workflows/unmet-ac-on-close.yml` | Issue-close gate: reopens an issue closed with unchecked acceptance criteria. |


### PR DESCRIPTION
Code review 2026-07-02 §6.2. The lead-gen retirement (PRs #1610/#1616) explicitly deferred the handbook update, so several pages still described the retired scrape-score-enrich machine as live.

Rewritten against **verified current repo state**: only `cost-anomaly` + `cost-telemetry` remain under `workers/`; the admin Generators surface, `src/lead-gen`, `src/lib/enrichment`, `src/lib/generators`, the `enrichment-runs` DAL, and the lead-gen wrangler bindings are all gone; `extraction-schema.ts` and the two-layer taxonomy doctrine remain.

| Page | Change |
|---|---|
| architecture-map | Background Workers = two cost workers only; dropped `ENRICHMENT_WORKFLOW_SERVICE` binding + lead-gen from external services |
| integrations-tooling | lead-gen data-providers section marked retired (keys linger but unused) |
| admin-console | removed Generators + Pipeline-settings; Settings = follow-ups + Google connect |
| repository-map | two-worker count; dropped `src/lead-gen`, `src/lib/enrichment`, `src/lib/generators`, the dead `enrichment-prompt-contracts` citation, removed marketing/admin routes |
| deployment-release | sub-worker deploy list = cost-anomaly + cost-telemetry; trimmed dead secret prefixes |
| customer-lifecycle | signal stage no longer claims automated pipeline feed |
| security-trust | removed dead `enrichment-prompt-contracts` test row |

Left intentionally: the two-layer taxonomy doctrine in glossary/business-model (tracks the still-current CLAUDE.md / ADR 0001 and the extant `extraction-schema.ts`) and historical/archive mentions.

`handbook-integrity` green; no em dashes introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)