### PR TITLE
refactor(api): standardize responses on jsonResponse/errorResponse + lint gate (§1.7)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -180,6 +180,30 @@ export default tseslint.config(
       ],
     },
   },
+  // API routes must build JSON responses through the shared helpers so error
+  // body shape and Content-Type stay uniform (code review 2026-07-02 §1.7).
+  // This block overrides the src/** no-restricted-syntax config for API files,
+  // so it re-declares the jsonResponse-redeclaration guard above.
+  {
+    files: ['src/pages/api/**/*.ts'],
+    rules: {
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector:
+            "FunctionDeclaration[id.name='jsonResponse'], VariableDeclarator[id.name='jsonResponse']",
+          message:
+            'Import jsonResponse from src/lib/api/helpers instead of re-declaring it — local copies drift (several inverted the canonical (status, data) arg order).',
+        },
+        {
+          selector:
+            "NewExpression[callee.name='Response'] CallExpression[callee.object.name='JSON'][callee.property.name='stringify']",
+          message:
+            'Use jsonResponse(status, data) or errorResponse(status, message) from src/lib/api/helpers instead of new Response(JSON.stringify(...)) — keeps API error and JSON bodies and their Content-Type uniform (code review 2026-07-02 §1.7). If you genuinely need extra headers, build on the helper and set them, or add a scoped eslint-disable with a reason.',
+        },
+      ],
+    },
+  },
   // astro-eslint-parser does not support projectService; type-aware rules that
   // require a full TS program crash or produce false positives in .astro files.
   // Structural and type-safety rules still apply.

--- a/src/lib/api/helpers.ts
+++ b/src/lib/api/helpers.ts
@@ -36,3 +36,12 @@ export function jsonResponse(status: number, data: unknown): Response {
     headers: { 'Content-Type': 'application/json' },
   })
 }
+
+/**
+ * Standard error response: a JSON body of `{ error: message }` at the given
+ * status. The single canonical shape for API-route error bodies, so error
+ * responses across `src/pages/api/**` are uniform (code review 2026-07-02 §1.7).
+ */
+export function errorResponse(status: number, message: string): Response {
+  return jsonResponse(status, { error: message })
+}

--- a/src/pages/api/admin/assessments/[id].ts
+++ b/src/pages/api/admin/assessments/[id].ts
@@ -9,6 +9,7 @@ import { uploadTranscript, getTranscript } from '../../../../lib/storage/r2'
 import { extractAssessment } from '../../../../lib/claude/extract'
 import { env } from 'cloudflare:workers'
 import { requireAdminSession } from '../../../../lib/auth/admin-session'
+import { errorResponse } from '../../../../lib/api/helpers'
 
 type Redirect = APIContext['redirect']
 
@@ -127,10 +128,7 @@ async function handlePost({ request, locals, redirect, params }: APIContext): Pr
 
   const assessmentId = params.id
   if (!assessmentId) {
-    return new Response(JSON.stringify({ error: 'Assessment ID required' }), {
-      status: 400,
-      headers: { 'Content-Type': 'application/json' },
-    })
+    return errorResponse(400, 'Assessment ID required')
   }
 
   try {

--- a/src/pages/api/admin/assessments/[id]/complete.ts
+++ b/src/pages/api/admin/assessments/[id]/complete.ts
@@ -10,6 +10,7 @@ import { createQuote, type LineItem } from '../../../../../lib/db/quotes'
 import { uploadTranscript } from '../../../../../lib/storage/r2'
 import { env } from 'cloudflare:workers'
 import { requireAdminSession } from '../../../../../lib/auth/admin-session'
+import { errorResponse } from '../../../../../lib/api/helpers'
 
 /** Default hourly rate at launch (per Decision Stack #16, evolved). */
 const DEFAULT_RATE = 175
@@ -128,10 +129,7 @@ async function handlePost({ request, locals, redirect, params }: APIContext): Pr
 
   const assessmentId = params.id
   if (!assessmentId) {
-    return new Response(JSON.stringify({ error: 'Assessment ID required' }), {
-      status: 400,
-      headers: { 'Content-Type': 'application/json' },
-    })
+    return errorResponse(400, 'Assessment ID required')
   }
 
   try {

--- a/src/pages/api/admin/assessments/[id]/transcript.ts
+++ b/src/pages/api/admin/assessments/[id]/transcript.ts
@@ -3,6 +3,7 @@ import { getAssessment } from '../../../../../lib/db/assessments'
 import { getTranscript } from '../../../../../lib/storage/r2'
 import { env } from 'cloudflare:workers'
 import { requireAdminSession } from '../../../../../lib/auth/admin-session'
+import { errorResponse } from '../../../../../lib/api/helpers'
 
 /**
  * GET /api/admin/assessments/:id/transcript
@@ -18,26 +19,17 @@ export const GET: APIRoute = async ({ locals, params }) => {
 
   const assessmentId = params.id
   if (!assessmentId) {
-    return new Response(JSON.stringify({ error: 'Assessment ID required' }), {
-      status: 400,
-      headers: { 'Content-Type': 'application/json' },
-    })
+    return errorResponse(400, 'Assessment ID required')
   }
 
   const assessment = await getAssessment(env.DB, session.orgId, assessmentId)
   if (!assessment || !assessment.transcript_path) {
-    return new Response(JSON.stringify({ error: 'Transcript not found' }), {
-      status: 404,
-      headers: { 'Content-Type': 'application/json' },
-    })
+    return errorResponse(404, 'Transcript not found')
   }
 
   const object = await getTranscript(env.STORAGE, assessment.transcript_path)
   if (!object) {
-    return new Response(JSON.stringify({ error: 'Transcript file not found in storage' }), {
-      status: 404,
-      headers: { 'Content-Type': 'application/json' },
-    })
+    return errorResponse(404, 'Transcript file not found in storage')
   }
 
   const originalName = object.customMetadata?.originalName ?? 'transcript.txt'

--- a/src/pages/api/admin/contacts/[id].ts
+++ b/src/pages/api/admin/contacts/[id].ts
@@ -2,6 +2,7 @@ import type { APIRoute } from 'astro'
 import { getContact, updateContact, deleteContact } from '../../../../lib/db/contacts'
 import { env } from 'cloudflare:workers'
 import { requireAdminSession } from '../../../../lib/auth/admin-session'
+import { errorResponse } from '../../../../lib/api/helpers'
 
 /**
  * POST /api/admin/contacts/:id
@@ -22,10 +23,7 @@ export const POST: APIRoute = async ({ request, locals, redirect, params }) => {
 
   const contactId = params.id
   if (!contactId) {
-    return new Response(JSON.stringify({ error: 'Contact ID required' }), {
-      status: 400,
-      headers: { 'Content-Type': 'application/json' },
-    })
+    return errorResponse(400, 'Contact ID required')
   }
 
   try {

--- a/src/pages/api/admin/engagements/[id].ts
+++ b/src/pages/api/admin/engagements/[id].ts
@@ -8,6 +8,7 @@ import type { EngagementStatus } from '../../../../lib/db/engagements'
 import { getSignalById } from '../../../../lib/db/signal-attribution'
 import { env } from 'cloudflare:workers'
 import { requireAdminSession } from '../../../../lib/auth/admin-session'
+import { errorResponse } from '../../../../lib/api/helpers'
 
 /**
  * POST /api/admin/engagements/:id
@@ -67,10 +68,7 @@ async function handlePost({ request, locals, redirect, params }: APIContext): Pr
 
   const engagementId = params.id
   if (!engagementId) {
-    return new Response(JSON.stringify({ error: 'Engagement ID required' }), {
-      status: 400,
-      headers: { 'Content-Type': 'application/json' },
-    })
+    return errorResponse(400, 'Engagement ID required')
   }
 
   try {

--- a/src/pages/api/admin/engagements/[id]/consultant-photo.ts
+++ b/src/pages/api/admin/engagements/[id]/consultant-photo.ts
@@ -2,6 +2,7 @@ import type { APIContext, APIRoute } from 'astro'
 import { getEngagement, updateEngagement } from '../../../../../lib/db/engagements'
 import { env } from 'cloudflare:workers'
 import { requireAdminSession } from '../../../../../lib/auth/admin-session'
+import { errorResponse, jsonResponse } from '../../../../../lib/api/helpers'
 
 /**
  * Consultant photo upload endpoint.
@@ -29,10 +30,7 @@ function extensionFor(mime: string): string {
 }
 
 function json(status: number, body: unknown): Response {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: { 'Content-Type': 'application/json' },
-  })
+  return jsonResponse(status, body)
 }
 
 function validatePhotoFile(file: FormDataEntryValue | null): Response | File {
@@ -58,10 +56,7 @@ async function handlePost({ request, locals, params }: APIContext): Promise<Resp
 
   const engagementId = params.id
   if (!engagementId) {
-    return new Response(JSON.stringify({ error: 'Engagement ID required' }), {
-      status: 400,
-      headers: { 'Content-Type': 'application/json' },
-    })
+    return errorResponse(400, 'Engagement ID required')
   }
 
   try {
@@ -107,19 +102,13 @@ async function handleDelete({ locals, params }: APIContext): Promise<Response> {
 
   const engagementId = params.id
   if (!engagementId) {
-    return new Response(JSON.stringify({ error: 'Engagement ID required' }), {
-      status: 400,
-      headers: { 'Content-Type': 'application/json' },
-    })
+    return errorResponse(400, 'Engagement ID required')
   }
 
   try {
     const engagement = await getEngagement(env.DB, session.orgId, engagementId)
     if (!engagement) {
-      return new Response(JSON.stringify({ error: 'Engagement not found' }), {
-        status: 404,
-        headers: { 'Content-Type': 'application/json' },
-      })
+      return errorResponse(404, 'Engagement not found')
     }
 
     const currentUrl = engagement.consultant_photo_url
@@ -145,16 +134,10 @@ async function handleDelete({ locals, params }: APIContext): Promise<Response> {
       consultant_photo_url: null,
     })
 
-    return new Response(JSON.stringify({ ok: true }), {
-      status: 200,
-      headers: { 'Content-Type': 'application/json' },
-    })
+    return jsonResponse(200, { ok: true })
   } catch (err) {
     console.error('[api/admin/engagements/[id]/consultant-photo] Delete error:', err)
-    return new Response(JSON.stringify({ error: 'Internal server error' }), {
-      status: 500,
-      headers: { 'Content-Type': 'application/json' },
-    })
+    return errorResponse(500, 'Internal server error')
   }
 }
 

--- a/src/pages/api/admin/engagements/[id]/contacts.ts
+++ b/src/pages/api/admin/engagements/[id]/contacts.ts
@@ -12,6 +12,7 @@ import type { EngagementContactRole } from '../../../../../lib/db/engagement-con
 import { appendContext } from '../../../../../lib/db/context'
 import { env } from 'cloudflare:workers'
 import { requireAdminSession } from '../../../../../lib/auth/admin-session'
+import { errorResponse } from '../../../../../lib/api/helpers'
 
 /**
  * POST /api/admin/engagements/:id/contacts
@@ -177,10 +178,7 @@ async function handlePost({ request, locals, redirect, params }: APIContext): Pr
 
   const engagementId = params.id
   if (!engagementId) {
-    return new Response(JSON.stringify({ error: 'Engagement ID required' }), {
-      status: 400,
-      headers: { 'Content-Type': 'application/json' },
-    })
+    return errorResponse(400, 'Engagement ID required')
   }
 
   try {

--- a/src/pages/api/admin/engagements/[id]/deliverables.ts
+++ b/src/pages/api/admin/engagements/[id]/deliverables.ts
@@ -3,6 +3,7 @@ import { getEngagement } from '../../../../../lib/db/engagements'
 import { listDocuments } from '../../../../../lib/storage/r2'
 import { env } from 'cloudflare:workers'
 import { requireAdminSession } from '../../../../../lib/auth/admin-session'
+import { errorResponse, jsonResponse } from '../../../../../lib/api/helpers'
 
 export const POST: APIRoute = async ({ request, locals, params }) => {
   const auth = requireAdminSession(locals)
@@ -10,26 +11,17 @@ export const POST: APIRoute = async ({ request, locals, params }) => {
   const { session } = auth
   const engagementId = params.id
   if (!engagementId) {
-    return new Response(JSON.stringify({ error: 'Engagement ID required' }), {
-      status: 400,
-      headers: { 'Content-Type': 'application/json' },
-    })
+    return errorResponse(400, 'Engagement ID required')
   }
   try {
     const engagement = await getEngagement(env.DB, session.orgId, engagementId)
     if (!engagement) {
-      return new Response(JSON.stringify({ error: 'Engagement not found' }), {
-        status: 404,
-        headers: { 'Content-Type': 'application/json' },
-      })
+      return errorResponse(404, 'Engagement not found')
     }
     const formData = await request.formData()
     const file = formData.get('file')
     if (!file || !(file instanceof File)) {
-      return new Response(JSON.stringify({ error: 'File required' }), {
-        status: 400,
-        headers: { 'Content-Type': 'application/json' },
-      })
+      return errorResponse(400, 'File required')
     }
     const safeName = file.name.replace(/[^a-zA-Z0-9._-]/g, '_')
     const key = `${session.orgId}/engagements/${engagementId}/docs/${safeName}`
@@ -38,16 +30,10 @@ export const POST: APIRoute = async ({ request, locals, params }) => {
       httpMetadata: { contentType: file.type || 'application/octet-stream' },
       customMetadata: { originalName: file.name, uploadedAt: new Date().toISOString() },
     })
-    return new Response(JSON.stringify({ key, name: safeName }), {
-      status: 201,
-      headers: { 'Content-Type': 'application/json' },
-    })
+    return jsonResponse(201, { key, name: safeName })
   } catch (err) {
     console.error('[api/admin/engagements/[id]/deliverables] Upload error:', err)
-    return new Response(JSON.stringify({ error: 'Internal server error' }), {
-      status: 500,
-      headers: { 'Content-Type': 'application/json' },
-    })
+    return errorResponse(500, 'Internal server error')
   }
 }
 
@@ -57,18 +43,12 @@ export const GET: APIRoute = async ({ locals, params }) => {
   const { session } = auth
   const engagementId = params.id
   if (!engagementId) {
-    return new Response(JSON.stringify({ error: 'Engagement ID required' }), {
-      status: 400,
-      headers: { 'Content-Type': 'application/json' },
-    })
+    return errorResponse(400, 'Engagement ID required')
   }
   try {
     const engagement = await getEngagement(env.DB, session.orgId, engagementId)
     if (!engagement) {
-      return new Response(JSON.stringify({ error: 'Engagement not found' }), {
-        status: 404,
-        headers: { 'Content-Type': 'application/json' },
-      })
+      return errorResponse(404, 'Engagement not found')
     }
     const prefix = `${session.orgId}/engagements/${engagementId}/docs/`
     const objects = await listDocuments(env.STORAGE, prefix)
@@ -78,15 +58,9 @@ export const GET: APIRoute = async ({ locals, params }) => {
       size: obj.size,
       uploaded: obj.uploaded.toISOString(),
     }))
-    return new Response(JSON.stringify({ files }), {
-      status: 200,
-      headers: { 'Content-Type': 'application/json' },
-    })
+    return jsonResponse(200, { files })
   } catch (err) {
     console.error('[api/admin/engagements/[id]/deliverables] List error:', err)
-    return new Response(JSON.stringify({ error: 'Internal server error' }), {
-      status: 500,
-      headers: { 'Content-Type': 'application/json' },
-    })
+    return errorResponse(500, 'Internal server error')
   }
 }

--- a/src/pages/api/admin/engagements/[id]/deliverables/[...key].ts
+++ b/src/pages/api/admin/engagements/[id]/deliverables/[...key].ts
@@ -3,6 +3,7 @@ import { getEngagement } from '../../../../../../lib/db/engagements'
 import { streamDocument } from '../../../../../../lib/storage/r2'
 import { env } from 'cloudflare:workers'
 import { requireAdminSession } from '../../../../../../lib/auth/admin-session'
+import { errorResponse } from '../../../../../../lib/api/helpers'
 
 export const GET: APIRoute = async ({ locals, params }) => {
   const auth = requireAdminSession(locals)
@@ -11,26 +12,17 @@ export const GET: APIRoute = async ({ locals, params }) => {
   const engagementId = params.id
   const keyPath = params.key
   if (!engagementId || !keyPath) {
-    return new Response(JSON.stringify({ error: 'Missing parameters' }), {
-      status: 400,
-      headers: { 'Content-Type': 'application/json' },
-    })
+    return errorResponse(400, 'Missing parameters')
   }
   try {
     const engagement = await getEngagement(env.DB, session.orgId, engagementId)
     if (!engagement) {
-      return new Response(JSON.stringify({ error: 'Engagement not found' }), {
-        status: 404,
-        headers: { 'Content-Type': 'application/json' },
-      })
+      return errorResponse(404, 'Engagement not found')
     }
     const fullKey = `${session.orgId}/engagements/${engagementId}/docs/${keyPath}`
     const obj = await streamDocument(env.STORAGE, fullKey)
     if (!obj) {
-      return new Response(JSON.stringify({ error: 'File not found' }), {
-        status: 404,
-        headers: { 'Content-Type': 'application/json' },
-      })
+      return errorResponse(404, 'File not found')
     }
     const filename = keyPath.split('/').pop() ?? 'download'
     const contentType = obj.httpMetadata?.contentType ?? 'application/octet-stream'
@@ -43,9 +35,6 @@ export const GET: APIRoute = async ({ locals, params }) => {
     })
   } catch (err) {
     console.error('[api/admin/engagements/[id]/deliverables/[...key]] Stream error:', err)
-    return new Response(JSON.stringify({ error: 'Internal server error' }), {
-      status: 500,
-      headers: { 'Content-Type': 'application/json' },
-    })
+    return errorResponse(500, 'Internal server error')
   }
 }

--- a/src/pages/api/admin/engagements/[id]/milestones.ts
+++ b/src/pages/api/admin/engagements/[id]/milestones.ts
@@ -11,6 +11,7 @@ import {
 import type { MilestoneStatus } from '../../../../../lib/db/milestones'
 import { env } from 'cloudflare:workers'
 import { requireAdminSession } from '../../../../../lib/auth/admin-session'
+import { errorResponse } from '../../../../../lib/api/helpers'
 
 /**
  * POST /api/admin/engagements/:id/milestones
@@ -177,10 +178,7 @@ async function handlePost({ request, locals, redirect, params }: APIContext): Pr
 
   const engagementId = params.id
   if (!engagementId) {
-    return new Response(JSON.stringify({ error: 'Engagement ID required' }), {
-      status: 400,
-      headers: { 'Content-Type': 'application/json' },
-    })
+    return errorResponse(400, 'Engagement ID required')
   }
 
   try {

--- a/src/pages/api/admin/engagements/[id]/parking-lot.ts
+++ b/src/pages/api/admin/engagements/[id]/parking-lot.ts
@@ -11,6 +11,7 @@ import type { Disposition } from '../../../../../lib/db/parking-lot'
 import { appendContext } from '../../../../../lib/db/context'
 import { env } from 'cloudflare:workers'
 import { requireAdminSession } from '../../../../../lib/auth/admin-session'
+import { errorResponse } from '../../../../../lib/api/helpers'
 
 /**
  * POST /api/admin/engagements/:id/parking-lot
@@ -184,10 +185,7 @@ async function handlePost({ request, locals, redirect, params }: APIContext): Pr
 
   const engagementId = params.id
   if (!engagementId) {
-    return new Response(JSON.stringify({ error: 'Engagement ID required' }), {
-      status: 400,
-      headers: { 'Content-Type': 'application/json' },
-    })
+    return errorResponse(400, 'Engagement ID required')
   }
 
   try {

--- a/src/pages/api/admin/entities/[id]/contacts.ts
+++ b/src/pages/api/admin/entities/[id]/contacts.ts
@@ -3,6 +3,7 @@ import { getEntity } from '../../../../../lib/db/entities'
 import { createContact } from '../../../../../lib/db/contacts'
 import { env } from 'cloudflare:workers'
 import { requireAdminSession } from '../../../../../lib/auth/admin-session'
+import { errorResponse } from '../../../../../lib/api/helpers'
 
 /**
  * POST /api/admin/entities/:id/contacts
@@ -26,10 +27,7 @@ export const POST: APIRoute = async ({ request, locals, redirect, params }) => {
 
   const entityId = params.id
   if (!entityId) {
-    return new Response(JSON.stringify({ error: 'Entity ID required' }), {
-      status: 400,
-      headers: { 'Content-Type': 'application/json' },
-    })
+    return errorResponse(400, 'Entity ID required')
   }
 
   try {

--- a/src/pages/api/admin/fleet/health.ts
+++ b/src/pages/api/admin/fleet/health.ts
@@ -46,6 +46,7 @@
  */
 
 import type { APIRoute } from 'astro'
+import { jsonResponse } from '../../../../lib/api/helpers'
 import { env } from 'cloudflare:workers'
 import { verifyHealthReadKey } from '../../../../lib/auth/health-read-key'
 
@@ -72,10 +73,7 @@ interface HealthRow {
 }
 
 function json(body: unknown, status: number): Response {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: { 'Content-Type': 'application/json' },
-  })
+  return jsonResponse(status, body)
 }
 
 const VALID_STATUSES = new Set(['green', 'yellow', 'red', 'unknown'])

--- a/src/pages/api/admin/follow-ups/[id].ts
+++ b/src/pages/api/admin/follow-ups/[id].ts
@@ -6,6 +6,7 @@ import type { FollowUpEmailData } from '../../../../lib/email/follow-up-template
 import { sendEmail } from '../../../../lib/email/resend'
 import { env } from 'cloudflare:workers'
 import { requireAdminSession } from '../../../../lib/auth/admin-session'
+import { errorResponse } from '../../../../lib/api/helpers'
 
 interface EntityRow {
   id: string
@@ -72,10 +73,7 @@ async function handlePost({ request, locals, redirect, params }: APIContext): Pr
 
   const followUpId = params.id
   if (!followUpId) {
-    return new Response(JSON.stringify({ error: 'Follow-up ID required' }), {
-      status: 400,
-      headers: { 'Content-Type': 'application/json' },
-    })
+    return errorResponse(400, 'Follow-up ID required')
   }
 
   try {

--- a/src/pages/api/admin/invoices/[id].ts
+++ b/src/pages/api/admin/invoices/[id].ts
@@ -10,6 +10,7 @@ import { sendEmail } from '../../../../lib/email/resend'
 import { invoiceSentEmailHtml } from '../../../../lib/email/templates'
 import { env } from 'cloudflare:workers'
 import { requireAdminSession } from '../../../../lib/auth/admin-session'
+import { errorResponse } from '../../../../lib/api/helpers'
 
 /**
  * POST /api/admin/invoices/:id
@@ -186,10 +187,7 @@ async function handlePost({ request, locals, redirect, params }: APIContext): Pr
 
   const invoiceId = params.id
   if (!invoiceId) {
-    return new Response(JSON.stringify({ error: 'Invoice ID required' }), {
-      status: 400,
-      headers: { 'Content-Type': 'application/json' },
-    })
+    return errorResponse(400, 'Invoice ID required')
   }
 
   try {

--- a/src/pages/api/admin/quotes/[id].ts
+++ b/src/pages/api/admin/quotes/[id].ts
@@ -14,6 +14,7 @@ import type { SOWTemplateProps } from '../../../../lib/pdf/sow-template'
 import { createSOWRevisionForQuote } from '../../../../lib/sow/service'
 import { env } from 'cloudflare:workers'
 import { requireAdminSession } from '../../../../lib/auth/admin-session'
+import { errorResponse } from '../../../../lib/api/helpers'
 
 /**
  * POST /api/admin/quotes/:id
@@ -273,10 +274,7 @@ async function handlePost({ request, locals, redirect, params }: APIContext): Pr
 
   const quoteId = params.id
   if (!quoteId) {
-    return new Response(JSON.stringify({ error: 'Quote ID required' }), {
-      status: 400,
-      headers: { 'Content-Type': 'application/json' },
-    })
+    return errorResponse(400, 'Quote ID required')
   }
 
   try {

--- a/src/pages/api/admin/quotes/[id]/sign.ts
+++ b/src/pages/api/admin/quotes/[id]/sign.ts
@@ -6,6 +6,7 @@ import { scheduleProposalCadence } from '../../../../../lib/follow-ups/scheduler
 import { authorizeAndSendSOW } from '../../../../../lib/sow/service'
 import { env } from 'cloudflare:workers'
 import { requireAdminSession } from '../../../../../lib/auth/admin-session'
+import { errorResponse } from '../../../../../lib/api/helpers'
 
 /**
  * POST /api/admin/quotes/:id/sign
@@ -91,10 +92,7 @@ async function handlePost({ request, locals, redirect, params }: APIContext): Pr
 
   const quoteId = params.id
   if (!quoteId) {
-    return new Response(JSON.stringify({ error: 'Quote ID required' }), {
-      status: 400,
-      headers: { 'Content-Type': 'application/json' },
-    })
+    return errorResponse(400, 'Quote ID required')
   }
 
   // Verify SignWell API key is configured

--- a/src/pages/api/admin/resend-invitation.ts
+++ b/src/pages/api/admin/resend-invitation.ts
@@ -5,6 +5,7 @@ import { sendEmail } from '../../../lib/email/resend'
 import { buildMagicLinkUrl, portalInvitationEmailHtml } from '../../../lib/email/templates'
 import { env } from 'cloudflare:workers'
 import { requireAdminSession } from '../../../lib/auth/admin-session'
+import { errorResponse, jsonResponse } from '../../../lib/api/helpers'
 
 interface UserRow {
   id: string
@@ -31,10 +32,7 @@ interface UserRow {
  * This supports the OQ-010 flow where admin corrects a bounced email.
  */
 function jsonError(status: number, message: string): Response {
-  return new Response(JSON.stringify({ error: message }), {
-    status,
-    headers: { 'Content-Type': 'application/json' },
-  })
+  return errorResponse(status, message)
 }
 
 async function maybeUpdateEmail(
@@ -126,17 +124,11 @@ async function handlePost({ request, locals }: APIContext): Promise<Response> {
       return jsonError(502, 'Failed to send email')
     }
 
-    return new Response(
-      JSON.stringify({
-        success: true,
-        emailId: result.id,
-        sentTo: targetEmail,
-      }),
-      {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      }
-    )
+    return jsonResponse(200, {
+      success: true,
+      emailId: result.id,
+      sentTo: targetEmail,
+    })
   } catch (err) {
     console.error('[resend-invitation] Error:', err)
     return jsonError(500, 'Internal server error')

--- a/src/pages/api/admin/time-entries/[id].ts
+++ b/src/pages/api/admin/time-entries/[id].ts
@@ -3,6 +3,7 @@ import { getTimeEntry, updateTimeEntry, deleteTimeEntry } from '../../../../lib/
 import { getEngagement } from '../../../../lib/db/engagements'
 import { env } from 'cloudflare:workers'
 import { requireAdminSession } from '../../../../lib/auth/admin-session'
+import { errorResponse } from '../../../../lib/api/helpers'
 
 /**
  * POST /api/admin/time-entries/:id
@@ -52,10 +53,7 @@ async function handlePost({ request, locals, redirect, params }: APIContext): Pr
 
   const entryId = params.id
   if (!entryId) {
-    return new Response(JSON.stringify({ error: 'Time entry ID required' }), {
-      status: 400,
-      headers: { 'Content-Type': 'application/json' },
-    })
+    return errorResponse(400, 'Time entry ID required')
   }
 
   try {

--- a/src/pages/api/assessment/findings.ts
+++ b/src/pages/api/assessment/findings.ts
@@ -13,16 +13,14 @@ import type { APIContext, APIRoute } from 'astro'
 import { env } from 'cloudflare:workers'
 import { draftFindings, type Turn } from '../../../lib/claude/assessment'
 import { rateLimitByIp } from '../../../lib/booking/rate-limit'
+import { jsonResponse } from '../../../lib/api/helpers'
 
 const RATE_LIMIT_PER_HOUR = 40
 const MAX_TURNS = 60
 const MAX_TURN_CHARS = 4000
 
 function json(status: number, body: unknown): Response {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: { 'content-type': 'application/json' },
-  })
+  return jsonResponse(status, body)
 }
 
 function parseTurns(body: unknown): Turn[] | null {

--- a/src/pages/api/assessment/llm.ts
+++ b/src/pages/api/assessment/llm.ts
@@ -29,12 +29,10 @@ import {
   streamInterviewerCompletion,
   type OpenAIChatMessage,
 } from '../../../lib/claude/assessment-llm'
+import { jsonResponse } from '../../../lib/api/helpers'
 
 function json(status: number, body: unknown): Response {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: { 'content-type': 'application/json' },
-  })
+  return jsonResponse(status, body)
 }
 
 /** Normalize OpenAI content, which may arrive as a string OR an array of parts (ElevenLabs/OpenAI multimodal). */

--- a/src/pages/api/assessment/turn.ts
+++ b/src/pages/api/assessment/turn.ts
@@ -34,6 +34,7 @@ import {
   issueAssessmentSession,
   verifyAssessmentSession,
 } from '../../../lib/assessment/session'
+import { jsonResponse } from '../../../lib/api/helpers'
 
 const RATE_LIMIT_PER_HOUR = 200
 const MAX_TURNS = 60
@@ -47,10 +48,7 @@ export interface ParsedTurnRequest {
 }
 
 function json(status: number, body: unknown): Response {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: { 'content-type': 'application/json' },
-  })
+  return jsonResponse(status, body)
 }
 
 /** Narrow one array element into a `Turn`, or null if it is not a valid turn. */

--- a/src/pages/api/assessment/voice-token.ts
+++ b/src/pages/api/assessment/voice-token.ts
@@ -9,15 +9,13 @@
 import type { APIContext, APIRoute } from 'astro'
 import { env } from 'cloudflare:workers'
 import { rateLimitByIp } from '../../../lib/booking/rate-limit'
+import { jsonResponse } from '../../../lib/api/helpers'
 
 const RATE_LIMIT_PER_HOUR = 60
 const SIGNED_URL_ENDPOINT = 'https://api.elevenlabs.io/v1/convai/conversation/get-signed-url'
 
 function json(status: number, body: unknown): Response {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: { 'content-type': 'application/json' },
-  })
+  return jsonResponse(status, body)
 }
 
 export const GET: APIRoute = async ({ clientAddress }: APIContext) => {

--- a/src/pages/api/events.ts
+++ b/src/pages/api/events.ts
@@ -1,5 +1,6 @@
 import type { APIContext, APIRoute } from 'astro'
 import { env } from 'cloudflare:workers'
+import { errorResponse } from '../../lib/api/helpers'
 
 /**
  * POST /api/events
@@ -113,18 +114,12 @@ async function handlePost({ request }: APIContext): Promise<Response> {
   try {
     body = await request.json()
   } catch {
-    return new Response(JSON.stringify({ error: 'Invalid JSON' }), {
-      status: 400,
-      headers: { 'Content-Type': 'application/json' },
-    })
+    return errorResponse(400, 'Invalid JSON')
   }
 
   const rawEvents = Array.isArray(body.events) ? body.events : null
   if (!rawEvents || rawEvents.length === 0) {
-    return new Response(JSON.stringify({ error: 'events array required' }), {
-      status: 400,
-      headers: { 'Content-Type': 'application/json' },
-    })
+    return errorResponse(400, 'events array required')
   }
 
   const { sessionId, needSetCookie } = resolveSessionId(request, body)
@@ -162,10 +157,7 @@ async function handlePost({ request }: APIContext): Promise<Response> {
     await persistEventRows(rows, eventCtx)
   } catch (err) {
     console.error('[api/events] D1 insert failed:', err)
-    return new Response(JSON.stringify({ error: 'Failed to persist events' }), {
-      status: 500,
-      headers: { 'Content-Type': 'application/json' },
-    })
+    return errorResponse(500, 'Failed to persist events')
   }
 
   return buildResponse(204, cookieSidOrNull, request)

--- a/src/pages/api/health.ts
+++ b/src/pages/api/health.ts
@@ -1,6 +1,7 @@
 import type { APIRoute } from 'astro'
 import { env } from 'cloudflare:workers'
 import { constantTimeEqual } from '../../lib/auth/constant-time'
+import { jsonResponse } from '../../lib/api/helpers'
 
 /**
  * Health check endpoint. GET /api/health
@@ -46,8 +47,5 @@ export const GET: APIRoute = async ({ request }) => {
     body.timestamp = new Date().toISOString()
   }
 
-  return new Response(JSON.stringify(body), {
-    status: dbOk ? 200 : 503,
-    headers: { 'Content-Type': 'application/json' },
-  })
+  return jsonResponse(dbOk ? 200 : 503, body)
 }

--- a/src/pages/api/internal/runtime-summary.ts
+++ b/src/pages/api/internal/runtime-summary.ts
@@ -25,6 +25,7 @@ import type { APIRoute } from 'astro'
 import { env } from 'cloudflare:workers'
 import { verifyMachineRequest } from '../../../lib/auth/machine-key'
 import type { SummaryStatus } from '../../../lib/admin/runtime-summary'
+import { jsonResponse } from '../../../lib/api/helpers'
 
 const STATUSES: ReadonlySet<string> = new Set(['green', 'yellow', 'red', 'unknown'])
 
@@ -37,10 +38,7 @@ interface SummaryBody {
 }
 
 function json(body: unknown, status: number): Response {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: { 'Content-Type': 'application/json' },
-  })
+  return jsonResponse(status, body)
 }
 
 function nonNegInt(v: unknown): number | null {

--- a/src/pages/api/mcp.ts
+++ b/src/pages/api/mcp.ts
@@ -1,10 +1,8 @@
 import type { APIRoute } from 'astro'
+import { jsonResponse } from '../../lib/api/helpers'
 
 const gone = (): Response =>
-  new Response(JSON.stringify({ error: 'gone', detail: 'use the customer-specific MCP URL' }), {
-    status: 410,
-    headers: { 'Content-Type': 'application/json' },
-  })
+  jsonResponse(410, { error: 'gone', detail: 'use the customer-specific MCP URL' })
 
 export const POST: APIRoute = gone
 export const GET: APIRoute = gone

--- a/src/pages/api/portal/consultants/photo/[...key].ts
+++ b/src/pages/api/portal/consultants/photo/[...key].ts
@@ -2,6 +2,7 @@ import type { APIRoute } from 'astro'
 import { listEngagements } from '../../../../../lib/db/engagements'
 import { getPortalClient } from '../../../../../lib/portal/session'
 import { env } from 'cloudflare:workers'
+import { jsonResponse } from '../../../../../lib/api/helpers'
 
 /**
  * GET /api/portal/consultants/photo/:key
@@ -29,10 +30,7 @@ const CONTENT_TYPES: Record<string, string> = {
 }
 
 function jsonError(status: number, error: string): Response {
-  return new Response(JSON.stringify({ error }), {
-    status,
-    headers: { 'Content-Type': 'application/json' },
-  })
+  return jsonResponse(status, { error })
 }
 
 function getContentType(key: string, objectContentType?: string): string {

--- a/src/pages/api/portal/documents/[...key].ts
+++ b/src/pages/api/portal/documents/[...key].ts
@@ -3,6 +3,7 @@ import { streamDocument } from '../../../../lib/storage/r2'
 import { listEngagements } from '../../../../lib/db/engagements'
 import { getPortalClient } from '../../../../lib/portal/session'
 import { env } from 'cloudflare:workers'
+import { errorResponse } from '../../../../lib/api/helpers'
 
 /**
  * GET /api/portal/documents/:key
@@ -42,25 +43,16 @@ function getContentType(key: string): string {
 export const GET: APIRoute = async ({ locals, params }) => {
   const key = params.key
   if (!key) {
-    return new Response(JSON.stringify({ error: 'Document key required' }), {
-      status: 400,
-      headers: { 'Content-Type': 'application/json' },
-    })
+    return errorResponse(400, 'Document key required')
   }
 
   // Resolve client entity via Clerk identity bridge
   const portalData = await getPortalClient(env.DB, locals)
   if (!portalData) {
-    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
-      status: 401,
-      headers: { 'Content-Type': 'application/json' },
-    })
+    return errorResponse(401, 'Unauthorized')
   }
   if (!portalData.client) {
-    return new Response(JSON.stringify({ error: 'Forbidden' }), {
-      status: 403,
-      headers: { 'Content-Type': 'application/json' },
-    })
+    return errorResponse(403, 'Forbidden')
   }
 
   // Path traversal protection: key must be scoped to this org.
@@ -70,18 +62,12 @@ export const GET: APIRoute = async ({ locals, params }) => {
   const orgPrefix = `${portalData.user.org_id}/`
   const orgsScopedPrefix = `orgs/${portalData.user.org_id}/`
   if (!key.startsWith(orgPrefix) && !key.startsWith(orgsScopedPrefix)) {
-    return new Response(JSON.stringify({ error: 'Forbidden' }), {
-      status: 403,
-      headers: { 'Content-Type': 'application/json' },
-    })
+    return errorResponse(403, 'Forbidden')
   }
 
   // Reject path traversal attempts
   if (key.includes('..') || key.includes('//')) {
-    return new Response(JSON.stringify({ error: 'Forbidden' }), {
-      status: 403,
-      headers: { 'Content-Type': 'application/json' },
-    })
+    return errorResponse(403, 'Forbidden')
   }
 
   // Verify the key belongs to this client's engagement
@@ -100,19 +86,13 @@ export const GET: APIRoute = async ({ locals, params }) => {
   )
 
   if (!isEngagementDoc && !isQuoteDoc) {
-    return new Response(JSON.stringify({ error: 'Forbidden' }), {
-      status: 403,
-      headers: { 'Content-Type': 'application/json' },
-    })
+    return errorResponse(403, 'Forbidden')
   }
 
   // Stream the document from R2
   const object = await streamDocument(env.STORAGE, key)
   if (!object) {
-    return new Response(JSON.stringify({ error: 'Not found' }), {
-      status: 404,
-      headers: { 'Content-Type': 'application/json' },
-    })
+    return errorResponse(404, 'Not found')
   }
 
   const contentType = getContentType(key)

--- a/src/pages/api/portal/operator/promotion-cards/[skill]/dismiss.ts
+++ b/src/pages/api/portal/operator/promotion-cards/[skill]/dismiss.ts
@@ -1,6 +1,7 @@
 import type { APIRoute } from 'astro'
 import { resolveOperatorAccess } from '../../../../../../lib/portal/operator-access'
 import { env } from 'cloudflare:workers'
+import { errorResponse } from '../../../../../../lib/api/helpers'
 
 /**
  * POST /api/portal/operator/promotion-cards/[skill]/dismiss
@@ -63,10 +64,7 @@ function resolveReturnTarget(raw: FormDataEntryValue | null): string {
 }
 
 function jsonError(status: number, message: string): Response {
-  return new Response(JSON.stringify({ error: message }), {
-    status,
-    headers: { 'Content-Type': 'application/json' },
-  })
+  return errorResponse(status, message)
 }
 
 export const POST: APIRoute = async ({ params, request, locals }) => {

--- a/src/pages/api/portal/operator/settings/connector-reconsent.ts
+++ b/src/pages/api/portal/operator/settings/connector-reconsent.ts
@@ -1,6 +1,7 @@
 import type { APIRoute } from 'astro'
 import { resolveOperatorAccess } from '../../../../../lib/portal/operator-access'
 import { env } from 'cloudflare:workers'
+import { errorResponse } from '../../../../../lib/api/helpers'
 
 /**
  * POST /api/portal/operator/settings/connector-reconsent
@@ -36,10 +37,7 @@ function redirectWithStatus(status: string): Response {
 }
 
 function jsonError(status: number, message: string): Response {
-  return new Response(JSON.stringify({ error: message }), {
-    status,
-    headers: { 'Content-Type': 'application/json' },
-  })
+  return errorResponse(status, message)
 }
 
 export const POST: APIRoute = async ({ locals, request }) => {

--- a/src/pages/api/portal/operator/settings/skill-toggle.ts
+++ b/src/pages/api/portal/operator/settings/skill-toggle.ts
@@ -3,6 +3,7 @@ import { resolveOperatorAccess } from '../../../../../lib/portal/operator-access
 import { getCustomerConfig } from '../../../../../lib/portal/customer-config'
 import { applySkillToggle } from '../../../../../lib/portal/operator/config-governance'
 import { env } from 'cloudflare:workers'
+import { errorResponse } from '../../../../../lib/api/helpers'
 
 /**
  * POST /api/portal/operator/settings/skill-toggle
@@ -29,10 +30,7 @@ function redirectWithStatus(status: string): Response {
 }
 
 function jsonError(status: number, message: string): Response {
-  return new Response(JSON.stringify({ error: message }), {
-    status,
-    headers: { 'Content-Type': 'application/json' },
-  })
+  return errorResponse(status, message)
 }
 
 export const POST: APIRoute = async ({ locals, request }) => {

--- a/src/pages/api/portal/operator/settings/trust-ceiling.ts
+++ b/src/pages/api/portal/operator/settings/trust-ceiling.ts
@@ -1,4 +1,5 @@
 import type { APIRoute } from 'astro'
+import { errorResponse } from '../../../../../lib/api/helpers'
 
 /**
  * Retired scalar trust-ceiling endpoint.
@@ -7,8 +8,4 @@ import type { APIRoute } from 'astro'
  * This legacy endpoint no longer records changes because doing so would create
  * audit rows the runtime cannot enforce.
  */
-export const POST: APIRoute = () =>
-  new Response(JSON.stringify({ error: 'Scalar trust ceiling is retired' }), {
-    status: 410,
-    headers: { 'Content-Type': 'application/json' },
-  })
+export const POST: APIRoute = () => errorResponse(410, 'Scalar trust ceiling is retired')

--- a/src/pages/api/portal/operator/settings/voice-samples.ts
+++ b/src/pages/api/portal/operator/settings/voice-samples.ts
@@ -1,6 +1,7 @@
 import type { APIRoute } from 'astro'
 import { resolveOperatorAccess } from '../../../../../lib/portal/operator-access'
 import { env } from 'cloudflare:workers'
+import { errorResponse } from '../../../../../lib/api/helpers'
 
 /**
  * POST /api/portal/operator/settings/voice-samples
@@ -40,10 +41,7 @@ function redirectWithStatus(status: string): Response {
 }
 
 function jsonError(status: number, message: string): Response {
-  return new Response(JSON.stringify({ error: message }), {
-    status,
-    headers: { 'Content-Type': 'application/json' },
-  })
+  return errorResponse(status, message)
 }
 
 export const POST: APIRoute = async ({ locals, request }) => {

--- a/src/pages/api/portal/products/operator/invitations.ts
+++ b/src/pages/api/portal/products/operator/invitations.ts
@@ -10,6 +10,7 @@ import {
 } from '../../../../../lib/portal/operator/rbac-audit'
 import { isPeopleAccessOperable } from '../../../../../lib/portal/operator/people-access-gate'
 import { env } from 'cloudflare:workers'
+import { errorResponse } from '../../../../../lib/api/helpers'
 
 /**
  * POST /api/portal/products/operator/invitations
@@ -56,10 +57,7 @@ function redirectWithStatus(status: string): Response {
 }
 
 function jsonError(status: number, message: string): Response {
-  return new Response(JSON.stringify({ error: message }), {
-    status,
-    headers: { 'Content-Type': 'application/json' },
-  })
+  return errorResponse(status, message)
 }
 
 interface AuthorizedContext {

--- a/src/pages/api/portal/products/operator/role-action.ts
+++ b/src/pages/api/portal/products/operator/role-action.ts
@@ -15,6 +15,7 @@ import {
 } from '../../../../../lib/portal/operator/rbac-audit'
 import { isPeopleAccessOperable } from '../../../../../lib/portal/operator/people-access-gate'
 import { env } from 'cloudflare:workers'
+import { errorResponse } from '../../../../../lib/api/helpers'
 
 /**
  * POST /api/portal/products/operator/role-action
@@ -58,10 +59,7 @@ function redirectWithStatus(status: string): Response {
 }
 
 function jsonError(status: number, message: string): Response {
-  return new Response(JSON.stringify({ error: message }), {
-    status,
-    headers: { 'Content-Type': 'application/json' },
-  })
+  return errorResponse(status, message)
 }
 
 interface AuthorizedContext {

--- a/src/pages/api/portal/quotes/[id]/sow.ts
+++ b/src/pages/api/portal/quotes/[id]/sow.ts
@@ -4,6 +4,7 @@ import { getQuoteForEntity } from '../../../../../lib/db/quotes'
 import { getPdf } from '../../../../../lib/storage/r2'
 import { getSOWStateForQuote } from '../../../../../lib/sow/service'
 import { env } from 'cloudflare:workers'
+import { errorResponse } from '../../../../../lib/api/helpers'
 
 /**
  * GET /api/portal/quotes/:id/sow
@@ -16,25 +17,16 @@ import { env } from 'cloudflare:workers'
 export const GET: APIRoute = async ({ locals, params }) => {
   const quoteId = params.id
   if (!quoteId) {
-    return new Response(JSON.stringify({ error: 'Quote ID required' }), {
-      status: 400,
-      headers: { 'Content-Type': 'application/json' },
-    })
+    return errorResponse(400, 'Quote ID required')
   }
 
   // Resolve client via Clerk identity bridge
   const portalData = await getPortalClient(env.DB, locals)
   if (!portalData) {
-    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
-      status: 401,
-      headers: { 'Content-Type': 'application/json' },
-    })
+    return errorResponse(401, 'Unauthorized')
   }
   if (!portalData.client) {
-    return new Response(JSON.stringify({ error: 'Client not found' }), {
-      status: 403,
-      headers: { 'Content-Type': 'application/json' },
-    })
+    return errorResponse(403, 'Client not found')
   }
 
   // Get quote scoped to this client
@@ -45,30 +37,21 @@ export const GET: APIRoute = async ({ locals, params }) => {
     quoteId
   )
   if (!quote) {
-    return new Response(JSON.stringify({ error: 'Quote not found' }), {
-      status: 404,
-      headers: { 'Content-Type': 'application/json' },
-    })
+    return errorResponse(404, 'Quote not found')
   }
 
   const sowState = await getSOWStateForQuote(env.DB, portalData.user.org_id, quote.id)
   const revision = sowState.downloadableRevision
 
   if (!revision) {
-    return new Response(JSON.stringify({ error: 'SOW not available' }), {
-      status: 404,
-      headers: { 'Content-Type': 'application/json' },
-    })
+    return errorResponse(404, 'SOW not available')
   }
 
   // Stream PDF from R2
   const key = revision.signed_storage_key ?? revision.unsigned_storage_key
   const object = await getPdf(env.STORAGE, key)
   if (!object) {
-    return new Response(JSON.stringify({ error: 'SOW file not found in storage' }), {
-      status: 404,
-      headers: { 'Content-Type': 'application/json' },
-    })
+    return errorResponse(404, 'SOW file not found in storage')
   }
 
   return new Response(object.body, {

--- a/src/pages/api/webhooks/resend.ts
+++ b/src/pages/api/webhooks/resend.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 import { env } from 'cloudflare:workers'
 import { handleResendEvent, type ResendWebhookPayload } from '../../../lib/webhooks/resend-handler'
 import { handleBookingEmailDeliveryFailure } from '../../../lib/webhooks/booking-email-failure'
+import { errorResponse, jsonResponse } from '../../../lib/api/helpers'
 
 /**
  * POST /api/webhooks/resend
@@ -70,10 +71,7 @@ const ResendWebhookPayloadSchema = z
   .catchall(z.unknown())
 
 function jsonErr(status: number, message: string): Response {
-  return new Response(JSON.stringify({ error: message }), {
-    status,
-    headers: { 'Content-Type': 'application/json' },
-  })
+  return errorResponse(status, message)
 }
 
 async function verifySvixHeaders(
@@ -150,16 +148,13 @@ async function handlePost({ request }: APIContext): Promise<Response> {
       env.RESEND_API_KEY,
       payload
     )
-    return new Response(
-      JSON.stringify({
-        ok: true,
-        recorded: result.recorded,
-        ...(result.reason ? { reason: result.reason } : {}),
-        ...(result.eventType ? { event_type: result.eventType } : {}),
-        ...(bookingFailure.handled ? { booking_alert: true } : {}),
-      }),
-      { status: 200, headers: { 'Content-Type': 'application/json' } }
-    )
+    return jsonResponse(200, {
+      ok: true,
+      recorded: result.recorded,
+      ...(result.reason ? { reason: result.reason } : {}),
+      ...(result.eventType ? { event_type: result.eventType } : {}),
+      ...(bookingFailure.handled ? { booking_alert: true } : {}),
+    })
   } catch (err) {
     console.error('[webhook/resend] handler failed:', err)
     // 500 → Svix retries with backoff.

--- a/src/pages/api/webhooks/signwell.ts
+++ b/src/pages/api/webhooks/signwell.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 import type { SignWellWebhookPayload } from '../../../lib/signwell/types'
 import { handleDocumentCompleted } from '../../../lib/webhooks/signwell-handler'
 import { env } from 'cloudflare:workers'
+import { errorResponse, jsonResponse } from '../../../lib/api/helpers'
 
 /**
  * POST /api/webhooks/signwell
@@ -82,10 +83,7 @@ const SignWellVerificationFieldsSchema = z.object({
 
 /** JSON error response shorthand used by every reject branch below. */
 function jsonError(status: number, error: string): Response {
-  return new Response(JSON.stringify({ error }), {
-    status,
-    headers: { 'Content-Type': 'application/json' },
-  })
+  return errorResponse(status, error)
 }
 
 export const POST: APIRoute = async ({ request }) => {
@@ -155,10 +153,7 @@ export const POST: APIRoute = async ({ request }) => {
   }
 
   // Acknowledge all other events without processing
-  return new Response(JSON.stringify({ ok: true, event: payload.event.type }), {
-    status: 200,
-    headers: { 'Content-Type': 'application/json' },
-  })
+  return jsonResponse(200, { ok: true, event: payload.event.type })
 }
 
 /**

--- a/src/pages/api/webhooks/stripe.ts
+++ b/src/pages/api/webhooks/stripe.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 import type { StripeWebhookEvent } from '../../../lib/stripe/types'
 import { handleInvoicePaid, handleInvoicePaymentFailed } from '../../../lib/webhooks/stripe-handler'
 import { env } from 'cloudflare:workers'
+import { errorResponse, jsonResponse } from '../../../lib/api/helpers'
 
 /**
  * POST /api/webhooks/stripe
@@ -60,10 +61,7 @@ function parseStripeWebhookEvent(rawBody: string): ParseStripeWebhookEventResult
     return { parsed: JSON.parse(rawBody) as unknown }
   } catch {
     return {
-      response: new Response(JSON.stringify({ error: 'Invalid JSON' }), {
-        status: 400,
-        headers: { 'Content-Type': 'application/json' },
-      }),
+      response: errorResponse(400, 'Invalid JSON'),
     }
   }
 }
@@ -72,10 +70,7 @@ export const POST: APIRoute = async ({ request }) => {
   const webhookSecret = env.STRIPE_WEBHOOK_SECRET
   if (!webhookSecret) {
     console.error('[webhook/stripe] STRIPE_WEBHOOK_SECRET not configured')
-    return new Response(JSON.stringify({ error: 'Server misconfigured' }), {
-      status: 500,
-      headers: { 'Content-Type': 'application/json' },
-    })
+    return errorResponse(500, 'Server misconfigured')
   }
 
   // --- Signature verification ---
@@ -85,10 +80,7 @@ export const POST: APIRoute = async ({ request }) => {
   const isValid = await verifyStripeSignature(rawBody, signatureHeader, webhookSecret)
   if (!isValid) {
     console.error('[webhook/stripe] Invalid webhook signature')
-    return new Response(JSON.stringify({ error: 'Invalid signature' }), {
-      status: 401,
-      headers: { 'Content-Type': 'application/json' },
-    })
+    return errorResponse(401, 'Invalid signature')
   }
 
   // --- Parse payload ---
@@ -98,10 +90,7 @@ export const POST: APIRoute = async ({ request }) => {
 
   const envelopeResult = StripeWebhookEnvelopeSchema.safeParse(parsed)
   if (!envelopeResult.success) {
-    return new Response(JSON.stringify({ error: 'Invalid JSON' }), {
-      status: 400,
-      headers: { 'Content-Type': 'application/json' },
-    })
+    return errorResponse(400, 'Invalid JSON')
   }
   const eventType = envelopeResult.data.type
 
@@ -109,10 +98,7 @@ export const POST: APIRoute = async ({ request }) => {
   if (eventType === 'invoice.paid') {
     const eventResult = StripeInvoiceWebhookEventSchema.safeParse(parsed)
     if (!eventResult.success) {
-      return new Response(JSON.stringify({ error: 'Malformed event payload' }), {
-        status: 400,
-        headers: { 'Content-Type': 'application/json' },
-      })
+      return errorResponse(400, 'Malformed event payload')
     }
     const event: StripeWebhookEvent = eventResult.data
     return handleInvoicePaid(env.DB, env.RESEND_API_KEY, event)
@@ -121,20 +107,14 @@ export const POST: APIRoute = async ({ request }) => {
   if (eventType === 'invoice.payment_failed') {
     const eventResult = StripeInvoiceWebhookEventSchema.safeParse(parsed)
     if (!eventResult.success) {
-      return new Response(JSON.stringify({ error: 'Malformed event payload' }), {
-        status: 400,
-        headers: { 'Content-Type': 'application/json' },
-      })
+      return errorResponse(400, 'Malformed event payload')
     }
     const event: StripeWebhookEvent = eventResult.data
     return handleInvoicePaymentFailed(env.DB, event)
   }
 
   // Acknowledge all other events without processing
-  return new Response(JSON.stringify({ ok: true, event: eventType }), {
-    status: 200,
-    headers: { 'Content-Type': 'application/json' },
-  })
+  return jsonResponse(200, { ok: true, event: eventType })
 }
 
 /**

--- a/tests/portal-quotes.test.ts
+++ b/tests/portal-quotes.test.ts
@@ -390,7 +390,8 @@ describe('portal quotes: SOW download API route', () => {
     // 403 with "Client not found".
     const code = readFileSync(resolve('src/pages/api/portal/quotes/[id]/sow.ts'), 'utf-8')
     expect(code).toContain('getPortalClient(env.DB, locals)')
-    expect(code).toContain('status: 401')
+    // Unauthorized now returns via the shared errorResponse(status, message) helper.
+    expect(code).toContain('errorResponse(401')
   })
 
   it('scopes quote to entity via getQuoteForEntity', () => {

--- a/tests/signwell.test.ts
+++ b/tests/signwell.test.ts
@@ -252,7 +252,8 @@ describe('signwell: webhook route', () => {
   it('acknowledges non-completed events with 200', () => {
     const code = source()
     expect(code).toContain('payload.event.type')
-    expect(code).toContain('status: 200')
+    // Responses now go through the shared jsonResponse(status, data) helper.
+    expect(code).toContain('jsonResponse(200')
   })
 
   it('uses constant-time comparison for hash check', () => {


### PR DESCRIPTION
Code review 2026-07-02 §1.7. ~40 API route files hand-rolled `new Response(JSON.stringify({ error: ... }), { status, headers })` while ~19 already used the shared `jsonResponse` helper, so error body shape and Content-Type were inconsistent across the API surface.

### Changes
- **`errorResponse(status, message)`** added to `src/lib/api/helpers.ts` (= `jsonResponse` with `{ error: message }`). `jsonResponse` unchanged.
- **All 77 raw `new Response(JSON.stringify(...))` sites across 40 route files** converted to `errorResponse`/`jsonResponse`. Verified up front that every one used only `Content-Type` (no `Set-Cookie`/`Cache-Control` to preserve), so conversions are behavior-identical: same status (literal, ternary, or variable) and same body. Local `json()`-style wrappers now delegate to the shared helper.
- **Lint gate**: an eslint `no-restricted-syntax` rule scoped to `src/pages/api/**/*.ts` bans `new Response(JSON.stringify(...))`. It's AST-matched, so it also catches the multi-line `new Response(` / `JSON.stringify(` split that a text search misses (one such straggler was found and fixed this way). The block re-declares the existing `jsonResponse`-redeclaration guard because flat config replaces the rule per-file.
- Two source-assertion tests (`signwell`, `portal-quotes`) that matched the old `status: NNN` text updated to the helper form; the behavior they assert is unchanged.

### Method note
The bulk conversion was done with a balance-parsing codemod (dry-run reviewed before apply), then the eslint AST rule was used as the completeness check — it caught the one occurrence the text-based codemod missed.

`npm run verify` green (typecheck, workers typecheck, format, lint incl. the new rule, build, 3152 tests + workers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)