### PR TITLE
feat(operator): console-sole Claude door — synchronous ask_operator via grant-gated console (ADR 0057)

### DIFF
--- a/docs/adr/0057-operator-claude-connector-access-model.md
+++ b/docs/adr/0057-operator-claude-connector-access-model.md
@@ -83,3 +83,18 @@ When EMA supports Microsoft Entra / M365 (Okta-only at writing), identity and of
 - **Ethical screening** — a real obligation, but the **firm's**, not ours to enforce in the product (see the amended §4). If we ever surface risk to a client, it is non-blocking disclosure, decided when there is a product to sell.
 - **The optional Operator-issued sign-in ticket** — built only if email-link login proves to carry meaningful friction.
 - **SMD-staff-overseer access** (one SMD person driving multiple Operators) — a separate future decision, modeled deliberately, never by loosening the per-customer principal lookup.
+
+## Amendment (2026-07-02): Console-sole Claude door — the Machine has no direct public MCP door
+
+**Source.** A security re-audit found the kill switch (§2) governed only the console route (`smd.services/api/operator/<slug>/mcp`), while the per-customer Machine exposed a **second** public Claude door — `webhook_gate.py`'s `/mcp` (a full synchronous agent turn via `ask_operator`) — that authorized on `mcp_connector.access[]` (and, when Clerk was unconfigured, a single shared static `SMD_MCP_STUB_TOKEN`) and **never read the grant table**. So the advertised "explicit revoke cuts on the next call" did not hold on the Machine door: two doors authorized Claude and the kill switch guarded only one. On the pilot Machine, Clerk was unconfigured, so the live door was the shared static bearer.
+
+**Decision.** There is **one** public Claude door: the console. It authenticates the caller (Clerk), enforces the grant kill-switch **per request** (§2), and then proxies the turn to the Machine's authenticated **`/mcp/turn`** endpoint over the console-proxy bearer (`Bearer WEBHOOK_SECRET_MCP`, the same per-customer derivation as `/webhooks/handoff`). The Machine trusts the console's asserted `principal_subject` because the console is the party that authenticated it and checked the grant. The Machine's **direct public MCP door is retired**: the stub-bearer path and the Clerk-direct authorization path are removed, and `POST /mcp` now returns `410 Gone`. A Cloudflare Worker has no wall-clock cap on an HTTP-triggered request, so the console awaits the synchronous turn; the async `operator_handoff_task` path remains the fallback for long work.
+
+**Consequences.**
+
+- **The kill switch is now the only path.** Every Claude request passes the console's per-request grant read (`revoked_at`/`expires_at` SQL-filtered); revoke cuts on the next call end-to-end. There is no door that bypasses it.
+- **Clerk lives only on the console.** Per-Machine Clerk materialization (`SMD_MCP_CLERK_ISSUER` / `SMD_MCP_RESOURCE_URI` / `SMD_MCP_CLERK_ORG_ID`) is no longer required or read by the Machine; those consumes are retired. `SMD_MCP_STUB_TOKEN` is retired and removed from the Machines.
+- **`mcp_connector.access[]` is read by the console, not the Machine** — it seeds console-side authorization (authored principals for the grant check). Its meaning is unchanged; only its reader moved.
+- **Deferred (follow-up):** the Machine JSON-RPC `job_status` / `job_cancel` verbs, previously reachable via the direct `/mcp`, are retained in the gate but no longer publicly routed; re-expose them as console tools when a caller needs them.
+
+**Ships as:** console `ask_operator` sync-proxy tool + turn transport (ss-console); Machine `/mcp/turn` endpoint + direct-door retirement (hermes-smd-overlay). Deploy is a coordinated `OVERLAY_REF` bump + reprovision, after which the connector target is the console and `SMD_MCP_STUB_TOKEN` is unset on the Machines.

--- a/operator/customers/ashton-price/customer.yaml
+++ b/operator/customers/ashton-price/customer.yaml
@@ -206,13 +206,14 @@ personas:
       - himalaya
 
 # ---- MCP CONNECTOR (Operator ⇄ Claude) ----
-# Enabled so translate.py emits the core /webhooks/mcp route (fail-closed: needs
-# enabled:true AND WEBHOOK_SECRET_MCP set). That route carries the SMD operator's
-# go-live verification turn (the post-connect smoke read: auth_status →
-# list_matters against A&P's real Smokeball) via the transitional stub bearer
-# (SMD_MCP_STUB_TOKEN), and the Clerk-gated bridge below once Clerk env is set.
-# Access here is the SMD operator ONLY (Scott's Clerk subjects). The FIRM's Claude
-# bridge — Chris's second ask — is a deliberate later step: it is scoped to Chris
+# Console-sole door (ADR 0057 amendment). Claude reaches this Operator ONLY through
+# the console (smd.services/api/operator/<slug>/mcp), which authenticates the caller
+# and enforces the ADR 0057 grant kill-switch per request, then proxies the turn to
+# the Machine's authenticated /mcp/turn endpoint. The Machine no longer exposes a
+# direct public MCP door (stub bearer + Clerk-direct path retired). The access[]
+# entry below seeds console-side authorization and is read by the console, not the
+# Machine. Access here is the SMD operator ONLY (Scott's Clerk subjects). The FIRM's
+# Claude bridge — Chris's second ask — is a deliberate later step: scoped to Chris
 # first, the per-user confidentiality walls are an unsolved-hard problem, and his
 # Clerk subject is unknown until he signs into the portal. Not granted at go-live.
 mcp_connector:

--- a/operator/customers/pilot-smokeball/customer.yaml
+++ b/operator/customers/pilot-smokeball/customer.yaml
@@ -182,13 +182,14 @@ personas:
       - himalaya
 
 # ---- MCP CONNECTOR (Operator ⇄ Claude) ----
-# Rehearsal channel: lets us drive a real agent turn on this staging rig to prove
-# the firm-delegated Smokeball read end-to-end (Allow → token file → connector →
-# list_matters). translate.py emits the core /webhooks/mcp route ONLY when this
-# block is enabled AND WEBHOOK_SECRET_MCP is set (fail-closed). Clerk is NOT
-# configured on the staging Machine, so /mcp auth falls to the transitional stub
-# bearer (SMD_MCP_STUB_TOKEN); the access[] entry below is the production shape
-# (Clerk-gated) and is inert until Clerk env is materialized.
+# Console-sole door (ADR 0057 amendment). Claude reaches this Operator ONLY
+# through the console (smd.services/api/operator/<slug>/mcp), which authenticates
+# the caller and enforces the ADR 0057 grant kill-switch per request, then proxies
+# the turn to the Machine's authenticated /mcp/turn endpoint. The Machine no longer
+# exposes a direct public MCP door (the shared stub bearer and the Clerk-direct
+# path are retired). The access[] entry below seeds console-side authorization
+# (authored principals for the grant check); it is read by the console, not the
+# Machine.
 mcp_connector:
   enabled: true
   data_posture: open

--- a/src/lib/operator/mcp/mcp-route.ts
+++ b/src/lib/operator/mcp/mcp-route.ts
@@ -33,6 +33,10 @@ export interface McpRouteDependencies {
     auth: Extract<McpAuthResult, { ok: true }>,
     params: { handoff_id: string; task: string; context?: string }
   ) => Promise<void>
+  driveTurn?: (
+    auth: Extract<McpAuthResult, { ok: true }>,
+    params: { message: string; thread_id?: string }
+  ) => Promise<{ reply: string; thread_id?: string }>
 }
 
 function jsonWithCors(body: unknown, status: number, extra?: Record<string, string>): Response {
@@ -193,6 +197,7 @@ export async function handleMcpPost(
     profile: auth.profile,
     readRuntime: (query) => deps.readRuntime(auth, query),
     sendHandoff: deps.sendHandoff ? (params) => deps.sendHandoff!(auth, params) : undefined,
+    driveTurn: deps.driveTurn ? (params) => deps.driveTurn!(auth, params) : undefined,
   })
   return withCorsHeaders(response)
 }

--- a/src/lib/operator/mcp/tools.ts
+++ b/src/lib/operator/mcp/tools.ts
@@ -8,9 +8,16 @@
  * via the signed webhook gate (`/webhooks/mcp`). The Operator works it and
  * reports back via its authored channels.
  *
- * Both capabilities are injected via {@link McpToolContext} so tool handlers
- * stay free of env/db wiring. `sendHandoff` is optional — when unconfigured the
- * tool returns a `not_configured` error rather than throwing.
+ * Phase 3 (ADR 0057 amendment — console-sole door): `ask_operator` — drive a
+ * synchronous agent turn on the Machine and return the reply in this call. The
+ * console is the sole public Claude door; every request first passes the
+ * per-request grant kill-switch in the route layer, then this tool proxies the
+ * turn to the Machine over the authenticated turn channel. The Machine no longer
+ * exposes a direct public MCP door.
+ *
+ * Capabilities are injected via {@link McpToolContext} so tool handlers stay
+ * free of env/db wiring. `sendHandoff` and `driveTurn` are optional — when
+ * unconfigured the tool returns a `not_configured` error rather than throwing.
  *
  * See docs/design/operator/03-mcp-server-exposure.md.
  */
@@ -42,7 +49,18 @@ export interface McpToolDescriptor {
  * request to the Machine and returns once the Machine acknowledges receipt.
  * Absent when `OPERATOR_MCP_WEBHOOK_SECRET` is unset; the handoff tool returns
  * `not_configured` rather than throwing.
+ *
+ * `driveTurn` — optional. When configured (Phase 3), proxies a synchronous agent
+ * turn to the Machine over the authenticated turn channel and returns the reply.
+ * Throws on transport failure so the tool can map it to a fail-closed result.
+ * Absent when the turn transport is unconfigured; `ask_operator` returns
+ * `not_configured` rather than throwing.
  */
+export interface OperatorTurnResult {
+  reply: string
+  thread_id?: string
+}
+
 export interface McpToolContext {
   customerId: string
   subject: string
@@ -50,6 +68,7 @@ export interface McpToolContext {
   profile: string
   readRuntime: (query: RuntimeReadQuery) => Promise<RuntimeReadResult>
   sendHandoff?: (params: { handoff_id: string; task: string; context?: string }) => Promise<void>
+  driveTurn?: (params: { message: string; thread_id?: string }) => Promise<OperatorTurnResult>
 }
 
 /** MCP `tools/call` result content block (text only for the spike). */
@@ -220,9 +239,86 @@ const operatorHandoffTask: McpTool = {
   },
 }
 
+/**
+ * Phase 3 tool: `ask_operator`. Drives a synchronous agent turn on the Machine
+ * and returns the Operator's reply in this call. This is the conversational
+ * door: the console has already enforced the ADR 0057 grant kill-switch for the
+ * caller before this handler runs, and the turn is proxied to the Machine over
+ * the authenticated turn channel (never a direct public Machine door).
+ *
+ * Fail-closed: `message_required` when empty, `not_configured` when the turn
+ * transport is absent, `delivery_failed` when the Machine turn errors. Never
+ * fabricates a reply.
+ */
+const askOperator: McpTool = {
+  descriptor: {
+    name: 'ask_operator',
+    description:
+      'Ask the Operator to do something and get its reply in this turn. Use for ' +
+      'synchronous requests where you want the answer now. Pass thread_id to continue ' +
+      'a prior conversation. For long-running work that does not need an immediate ' +
+      'answer, use operator_handoff_task instead.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        message: {
+          type: 'string',
+          description: 'What you want to ask or tell the Operator.',
+        },
+        thread_id: {
+          type: 'string',
+          description:
+            'Optional. Continue a prior conversation by passing the thread_id returned earlier.',
+        },
+      },
+      required: ['message'],
+    },
+  },
+  handle: async (args, ctx) => {
+    const message = typeof args.message === 'string' ? args.message.trim() : ''
+    if (!message) {
+      return {
+        content: [{ type: 'text', text: JSON.stringify({ ok: false, error: 'message_required' }) }],
+        isError: true,
+      }
+    }
+    if (!ctx.driveTurn) {
+      return {
+        content: [{ type: 'text', text: JSON.stringify({ ok: false, error: 'not_configured' }) }],
+        isError: true,
+      }
+    }
+    const thread_id =
+      typeof args.thread_id === 'string' && args.thread_id.trim()
+        ? args.thread_id.trim()
+        : undefined
+    try {
+      const result = await ctx.driveTurn({ message, thread_id })
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({
+              ok: true,
+              reply: result.reply,
+              thread_id: result.thread_id ?? null,
+            }),
+          },
+        ],
+      }
+    } catch {
+      return {
+        content: [{ type: 'text', text: JSON.stringify({ ok: false, error: 'delivery_failed' }) }],
+        isError: true,
+      }
+    }
+  },
+}
+
 const REGISTRY: ReadonlyMap<string, McpTool> = new Map([
   [operatorStatus.descriptor.name, operatorStatus],
   [operatorHandoffTask.descriptor.name, operatorHandoffTask],
+  [askOperator.descriptor.name, askOperator],
 ])
 
 /** All tool descriptors for `tools/list`. */

--- a/src/lib/operator/mcp/webhook-transport.ts
+++ b/src/lib/operator/mcp/webhook-transport.ts
@@ -82,3 +82,68 @@ export function createMachineWebhookTransport(env: MachineWebhookEnv): MachineWe
     },
   }
 }
+
+/**
+ * Synchronous console→Machine turn request (ADR 0057 amendment, Phase 3). The
+ * console is the sole public Claude door; it has already enforced the grant
+ * kill-switch for the principal before calling this, and forwards the identity
+ * so the Machine turn is attributed. The Machine's turn endpoint accepts only
+ * this authenticated console-proxy bearer — it is not a public door.
+ */
+export interface OperatorTurnRequest {
+  message: string
+  thread_id?: string
+  principal_subject: string
+  from_email: string
+  from_profile: string
+}
+
+export interface OperatorTurnReply {
+  reply: string
+  thread_id?: string
+}
+
+export interface MachineTurnTransport {
+  driveTurn(customerSlug: string, req: OperatorTurnRequest): Promise<OperatorTurnReply>
+}
+
+/**
+ * Construct the production console→Machine synchronous turn transport. Posts to
+ * the Machine's authenticated `/mcp/turn` endpoint (bearer
+ * `HMAC-SHA256(OPERATOR_MCP_WEBHOOK_SECRET, slug)`, same derivation as the
+ * handoff path) and returns the Operator's reply. Throws on transport failure or
+ * a non-2xx so the caller maps it to a fail-closed `delivery_failed`. A Worker
+ * has no wall-clock cap on an HTTP-triggered request, so the turn is awaited
+ * synchronously; the async handoff path remains the fallback for long work.
+ */
+export function createMachineTurnTransport(env: MachineWebhookEnv): MachineTurnTransport {
+  return {
+    driveTurn: async (customerSlug, req) => {
+      if (!isWebhookConfigured(env)) {
+        throw new Error('MCP turn transport not configured (OPERATOR_MCP_WEBHOOK_SECRET unset)')
+      }
+      const app = resolveCustomerFlyApp(customerSlug)
+      if (!app) throw new Error(`turn transport: unknown customer ${customerSlug}`)
+
+      const baseUrl = machineBaseUrl(env.OPERATOR_RUNTIME_READ_URL!, app)
+      const bearer = await deriveRuntimeReadKey(env.OPERATOR_MCP_WEBHOOK_SECRET!, customerSlug)
+
+      const resp = await fetch(`${baseUrl}/mcp/turn`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${bearer}`,
+          'X-Tenant-Slug': customerSlug,
+        },
+        body: JSON.stringify(req),
+      })
+      if (!resp.ok) throw new Error(`turn delivery failed: ${resp.status}`)
+
+      const data = await resp.json<{ reply?: unknown; thread_id?: unknown }>()
+      return {
+        reply: typeof data.reply === 'string' ? data.reply : '',
+        thread_id: typeof data.thread_id === 'string' ? data.thread_id : undefined,
+      }
+    },
+  }
+}

--- a/src/pages/api/operator/[customer]/mcp.ts
+++ b/src/pages/api/operator/[customer]/mcp.ts
@@ -11,6 +11,7 @@ import {
 } from '../../../../lib/operator/mcp/mcp-route'
 import type { HandoffEnvelope } from '../../../../lib/operator/mcp/webhook-transport'
 import {
+  createMachineTurnTransport,
   createMachineWebhookTransport,
   isWebhookConfigured,
 } from '../../../../lib/operator/mcp/webhook-transport'
@@ -34,6 +35,7 @@ export const POST: APIRoute = async ({ request, url, params }) => {
 
   const transport = createMachineRuntimeTransport(env)
   const webhookTransport = isWebhookConfigured(env) ? createMachineWebhookTransport(env) : null
+  const turnTransport = isWebhookConfigured(env) ? createMachineTurnTransport(env) : null
 
   return handleMcpPost(request, url, {
     db: env.DB,
@@ -59,6 +61,16 @@ export const POST: APIRoute = async ({ request, url, params }) => {
           }
           return webhookTransport.send(customer.customerId, envelope)
         }
+      : undefined,
+    driveTurn: turnTransport
+      ? (auth, params) =>
+          turnTransport.driveTurn(customer.customerId, {
+            message: params.message,
+            thread_id: params.thread_id,
+            principal_subject: auth.subject,
+            from_email: auth.email,
+            from_profile: auth.profile,
+          })
       : undefined,
   })
 }

--- a/tests/operator-mcp-endpoint.test.ts
+++ b/tests/operator-mcp-endpoint.test.ts
@@ -920,3 +920,141 @@ describe('operator_handoff_task', () => {
     expect(typeof handoffs[0].handoff_id).toBe('string')
   })
 })
+
+describe('ask_operator', () => {
+  it('lists ask_operator in tools/list', async () => {
+    const listed = await dispatchMcpRequest({ jsonrpc: '2.0', id: 1, method: 'tools/list' }, CTX)
+    const body = await listed.json<{ result: { tools: { name: string }[] } }>()
+    expect(body.result.tools.map((t) => t.name)).toContain('ask_operator')
+  })
+
+  it('returns not_configured when driveTurn is absent', async () => {
+    const response = await dispatchMcpRequest(
+      {
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'tools/call',
+        params: { name: 'ask_operator', arguments: { message: 'what is my status?' } },
+      },
+      CTX
+    )
+    const body = await response.json<{ result: { content: { text: string }[] } }>()
+    expect(JSON.parse(body.result.content[0].text)).toMatchObject({
+      ok: false,
+      error: 'not_configured',
+    })
+  })
+
+  it('returns message_required when message is missing or empty', async () => {
+    for (const args of [{}, { message: '' }, { message: '   ' }]) {
+      const response = await dispatchMcpRequest(
+        {
+          jsonrpc: '2.0',
+          id: 3,
+          method: 'tools/call',
+          params: { name: 'ask_operator', arguments: args },
+        },
+        { ...CTX, driveTurn: async () => ({ reply: 'unreached' }) }
+      )
+      const body = await response.json<{ result: { content: { text: string }[] } }>()
+      expect(JSON.parse(body.result.content[0].text)).toMatchObject({
+        ok: false,
+        error: 'message_required',
+      })
+    }
+  })
+
+  it('returns the reply and thread_id on success', async () => {
+    const calls: { message: string; thread_id?: string }[] = []
+    const response = await dispatchMcpRequest(
+      {
+        jsonrpc: '2.0',
+        id: 4,
+        method: 'tools/call',
+        params: {
+          name: 'ask_operator',
+          arguments: { message: 'summarize the Ochoa matter', thread_id: 'thr_1' },
+        },
+      },
+      {
+        ...CTX,
+        driveTurn: async (params) => {
+          calls.push(params)
+          return { reply: 'The Ochoa matter is in discovery.', thread_id: 'thr_1' }
+        },
+      }
+    )
+    expect(calls).toHaveLength(1)
+    expect(calls[0].message).toBe('summarize the Ochoa matter')
+    expect(calls[0].thread_id).toBe('thr_1')
+    const body = await response.json<{ result: { content: { text: string }[] } }>()
+    expect(JSON.parse(body.result.content[0].text)).toMatchObject({
+      ok: true,
+      reply: 'The Ochoa matter is in discovery.',
+      thread_id: 'thr_1',
+    })
+  })
+
+  it('returns delivery_failed when driveTurn throws', async () => {
+    const response = await dispatchMcpRequest(
+      {
+        jsonrpc: '2.0',
+        id: 5,
+        method: 'tools/call',
+        params: { name: 'ask_operator', arguments: { message: 'anything' } },
+      },
+      {
+        ...CTX,
+        driveTurn: async () => {
+          throw new Error('machine unreachable')
+        },
+      }
+    )
+    const body = await response.json<{ result: { content: { text: string }[] } }>()
+    expect(JSON.parse(body.result.content[0].text)).toMatchObject({
+      ok: false,
+      error: 'delivery_failed',
+    })
+  })
+
+  it('routes driveTurn through mcp-route with auth-bound identity', async () => {
+    const db: D1Database = await freshDb()
+    await seedCustomer(db)
+    const loaded = await loadMcpCustomer(db, 'smd')
+    if (!loaded) throw new Error('test customer did not load')
+
+    const turns: { message: string; auth: { subject: string; email: string; profile: string } }[] =
+      []
+    const response = await handleMcpPost(
+      new Request(RESOURCE_URI, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token' },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tools/call',
+          params: { name: 'ask_operator', arguments: { message: 'status please' } },
+        }),
+      }),
+      new URL(RESOURCE_URI),
+      {
+        db,
+        customer: loaded,
+        verifier: claimsVerifier(claims()),
+        readRuntime: unreachableRead,
+        driveTurn: async (auth, params) => {
+          turns.push({
+            message: params.message,
+            auth: { subject: auth.subject, email: auth.email, profile: auth.profile },
+          })
+          return { reply: 'all clear' }
+        },
+      }
+    )
+    expect(response.status).toBe(200)
+    expect(turns).toHaveLength(1)
+    expect(turns[0].message).toBe('status please')
+    expect(typeof turns[0].auth.subject).toBe('string')
+    expect(turns[0].auth.subject.length).toBeGreaterThan(0)
+  })
+})


### PR DESCRIPTION
## Why
The security re-audit found the per-customer Machine exposed a **second public Claude door** (`webhook_gate.py` `/mcp`, a full agent turn) that **bypassed the ADR 0057 grant kill-switch** — it authorized on `access[]` / a shared static `SMD_MCP_STUB_TOKEN` and never read the grant table. The kill-switch lived only on this console route. Two doors authorized Claude; revoke guarded one.

## What
The console becomes the **one** public Claude door. Adds a synchronous **`ask_operator`** tool that, **after** the route's existing per-request grant check (`customer-resolution.ts`, SQL-filtered on `revoked_at`/`expires_at`), proxies the turn to the Machine's authenticated `/mcp/turn` and returns the reply in-line. A Cloudflare Worker has no wall-clock cap on an HTTP-triggered request, so the turn is awaited synchronously; `operator_handoff_task` stays the async fallback.

- `tools.ts`: `ask_operator` tool + `driveTurn` context capability (fail-closed: `message_required` / `not_configured` / `delivery_failed`).
- `webhook-transport.ts`: `createMachineTurnTransport` → `POST /mcp/turn` → `{reply, thread_id}`.
- `mcp-route.ts` + route: wire `driveTurn` with the auth-bound principal/email/profile.
- `docs/adr/0057`: amendment — console-sole door; the Machine has no direct public MCP door.
- pilot + A&P `customer.yaml`: comments updated to the console-sole model.

## Pairs with
**hermes-smd-overlay#119** (Machine `/mcp/turn` + direct-door retirement). Deploy is a coordinated `OVERLAY_REF` bump + reprovision; then the connector target is the console and `SMD_MCP_STUB_TOKEN` is unset on the Machines. **Do not merge/deploy in isolation.**

## Tests
`operator-mcp-endpoint` (46) + `forbidden-strings` green; eslint + `astro check` clean. New `ask_operator` coverage (tool-level + route-level auth-bound identity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)