### PR TITLE
fix(operator): boot-env hygiene + citation unicode + conformance trigger (SEC-23/28, EFF-03/05)

### DIFF
--- a/.github/workflows/operator-substrate.yml
+++ b/.github/workflows/operator-substrate.yml
@@ -22,10 +22,16 @@ on:
       - 'operator/bin/**'
       - 'operator/safety-substrate/**'
       - 'operator/connectors/**'
+      # EFF-05: a customer.yaml-only change must trigger the block-conformance
+      # gate (test_customer_yaml_block_conformance.py) — otherwise an unclassified
+      # top-level block added to only a customer.yaml merges without the gate.
+      - 'operator/customers/**'
       - 'operator/contracts/overlay-pairs.json'
       - 'operator/contracts/runtime-controls.yaml'
       - 'operator/contracts/overlay-hook-surface.json'
+      - 'operator/contracts/customer-yaml-blocks.yaml'
       - 'operator/templates/Dockerfile'
+      - 'operator/templates/bootstrap.sh'
       - '.github/workflows/operator-substrate.yml'
   push:
     branches: [main]

--- a/operator/bin/tests/test_deploy_ordering.py
+++ b/operator/bin/tests/test_deploy_ordering.py
@@ -166,6 +166,44 @@ def test_webhook_gate_launched_with_r2_key_scrubbed() -> None:
     )
 
 
+def test_disabled_skills_reconciler_subshell_scrubs_r2() -> None:
+    """SEC-23: the disabled-skills reconciler subshell is forked ~300 lines before
+    the parent's R2 strip, so it must scrub the account-wide R2 key from its OWN
+    environ — else its /proc/<pid>/environ leaks the key to a same-uid code-executing
+    agent for the ~30s it lives. This guard fails if the `unset` inside the subshell
+    is removed."""
+    lines = _code_lines(_BOOTSTRAP)
+    loop_idx = _first_index(lines, r"for _ in 1 2 3 4 5 6")
+    assert loop_idx != -1, "could not find the disabled-skills reconciler loop"
+    window = "\n".join(lines[max(0, loop_idx - 6) : loop_idx])
+    assert re.search(r"\bunset\b.*\bR2_ACCESS_KEY_ID\b", window), (
+        "the disabled-skills reconciler subshell must `unset R2_ACCESS_KEY_ID "
+        "R2_SECRET_ACCESS_KEY` before its loop (SEC-23) so its /proc/environ does "
+        "not leak the account-wide key while it lives."
+    )
+
+
+def test_runtime_read_key_stripped_from_agent_before_gateway_exec() -> None:
+    """SEC-28: OPERATOR_RUNTIME_READ_KEY must be stripped from the agent (hermes
+    gateway) env — AFTER the webhook-gate launch (which serves + validates the seam
+    and keeps its inherited copy) and BEFORE the gateway exec — so a code-executing
+    agent cannot mint its own read-seam bearer."""
+    lines = _code_lines(_BOOTSTRAP)
+    strip_idx = _first_index(lines, r"\bunset\b.*\bOPERATOR_RUNTIME_READ_KEY\b")
+    gate_idx = _first_index(lines, r"hermes-smd-webhook-gate")
+    gateway_idx = _first_index(lines, r"\bexec\b.*\bhermes\b.*\bgateway\s+run\b")
+    assert strip_idx != -1, "OPERATOR_RUNTIME_READ_KEY is never unset in bootstrap.sh (SEC-28)"
+    assert gateway_idx != -1, "could not find the `exec ... hermes ... gateway run` line"
+    assert strip_idx < gateway_idx, (
+        "OPERATOR_RUNTIME_READ_KEY must be unset BEFORE the gateway exec so the agent "
+        "env does not carry the read-seam bearer (SEC-28)."
+    )
+    assert gate_idx == -1 or strip_idx > gate_idx, (
+        "the strip must run AFTER the webhook-gate launch — the gate validates the "
+        "seam and needs the key; only the agent loses it (SEC-28)."
+    )
+
+
 # ---------------------------------------------------------------------------
 # entrypoint.sh: root config-applier must launch BEFORE the gateway exec-drop
 # ---------------------------------------------------------------------------

--- a/operator/safety-substrate/citation_filter.py
+++ b/operator/safety-substrate/citation_filter.py
@@ -24,6 +24,7 @@ Usage:
 from __future__ import annotations
 
 import re
+import unicodedata
 from dataclasses import dataclass
 from typing import Iterable
 
@@ -123,16 +124,37 @@ PATTERNS: list[tuple[str, re.Pattern[str]]] = [
 ]
 
 
+def _normalize_unicode(text: str) -> str:
+    """Strip invisible characters and fold Unicode confusables to ASCII.
+
+    Closes the zero-width / confusable evasion of the citation scan: a cite like
+    "Roe v.<ZWSP>Wade, 410 U.<ZWSP>S.<ZWSP>113" (zero-width spaces) or a
+    one-dot-leader "U<U+2024>S<U+2024>" renders identically to a human but
+    evades the ASCII-only regex. We remove zero-width/format chars and NFKC-fold
+    compatibility confusables (one-dot leader U+2024 -> '.', fullwidth forms) to
+    their ASCII equivalents before the whitespace-collapse pass runs.
+    """
+    # Remove invisible / zero-width format characters (category Cf: ZWSP, ZWNJ,
+    # ZWJ, word joiner, BOM, soft hyphen, etc.).
+    text = "".join(ch for ch in text if unicodedata.category(ch) != "Cf")
+    # NFKC folds compatibility confusables (one-dot leader, fullwidth) to ASCII.
+    return unicodedata.normalize("NFKC", text)
+
+
 def _normalize_encoding_bypass(text: str) -> str:
     """Collapse adversarial whitespace inserted to defeat the citation regex.
 
     Examples this catches:
       "Roe v . Wade , 410 U . S . 113" -> "Roe v. Wade, 410 U.S. 113"
+      "Roe v.<ZWSP>Wade, 410 U.<ZWSP>S.<ZWSP>113" -> "Roe v.Wade, 410 U.S. 113"
       "S m i t h" stays "S m i t h" (each char is a single letter, not a token)
-    The heuristic: collapse whitespace that sits between two single-letter
-    tokens (typical abbreviation evasion) or between a token and punctuation.
-    Real prose with multi-letter words is preserved.
+    The heuristic: normalize away invisible/confusable characters, then collapse
+    whitespace that sits between two single-letter tokens (typical abbreviation
+    evasion) or between a token and punctuation. Real prose with multi-letter
+    words is preserved.
     """
+    # Strip zero-width / confusable evasion before the ASCII whitespace pass.
+    text = _normalize_unicode(text)
     # Collapse whitespace adjacent to punctuation: "v . Wade" -> "v. Wade"
     text = re.sub(r"\s+([.,;:])", r"\1", text)
     # Collapse "U . S . " -> "U.S. " — single letters glued by dots and spaces.

--- a/operator/templates/bootstrap.sh
+++ b/operator/templates/bootstrap.sh
@@ -438,6 +438,12 @@ log "Disabled skill guard passed"
 # startup so disabled bundled skills are removed again after that sync without
 # mutating the overlay's profile `skills` list shape.
 (
+  # SEC-23: strip the account-wide R2 key from THIS subshell's environ. The
+  # subshell is forked here, ~300 lines before the parent's `unset` (below), so
+  # without this its /proc/<pid>/environ would expose the account-wide key to a
+  # same-uid code-executing agent for the ~30s it lives. ensure-disabled-skills.py
+  # operates on local HERMES_HOME skill dirs and never needs R2.
+  unset R2_ACCESS_KEY_ID R2_SECRET_ACCESS_KEY
   for _ in 1 2 3 4 5 6; do
     sleep 5
     /opt/hermes/.venv/bin/python3 /app/ensure-disabled-skills.py "${CUSTOMER_YAML}" "${HERMES_HOME}" \
@@ -788,6 +794,14 @@ fi
 
 # (R2 account-wide key already stripped above, before the webhook-gate launch —
 # OP-P2-1. No same-uid child holds it.)
+
+# SEC-28: strip the runtime-read seam key from the AGENT (hermes gateway) env.
+# The seam is served + validated by the webhook gate (launched above, which keeps
+# its inherited copy); the agent has no reason to hold it, and leaving it in the
+# gateway env lets a code-executing agent mint its own read-seam bearer. Stripped
+# AFTER the webhook-gate fork and BEFORE the gateway exec, so the gate still
+# authenticates the seam while the agent cannot self-issue.
+unset OPERATOR_RUNTIME_READ_KEY
 log "Launching Hermes gateway for profile '${ACTIVE_PROFILE}' (overlay plugins enabled)..."
 
 exec /opt/hermes/.venv/bin/hermes -p "${ACTIVE_PROFILE}" gateway run


### PR DESCRIPTION
## Summary
Review-1/2 fix backlog, ss-console side. Pairs with the overlay hardening PR (hermes-smd-overlay#121).

- **EFF-03** — mirror the citation-filter Unicode normalization into the source-of-truth copy (strip category-Cf zero-width chars + NFKC-fold confusables like one-dot leader U+2024, fullwidth). Keeps it aligned with the overlay vendored copy; closes the `Roe v.<ZWSP>Wade` / `U<U+2024>S` evasion.
- **SEC-23** — the disabled-skills reconciler subshell (forked ~300 lines before the parent's R2 strip) now `unset`s the account-wide R2 key from its own environ, closing the ~30s `/proc/environ` leak to a same-uid agent.
- **SEC-28** — strip `OPERATOR_RUNTIME_READ_KEY` from the agent (hermes gateway) env, after the webhook-gate launch (the gate keeps its copy to validate the seam) and before the gateway exec, so a code-executing agent can't mint its own read-seam bearer.
- **EFF-05 (CI half)** — add `operator/customers/**`, `customer-yaml-blocks.yaml`, and `bootstrap.sh` to the operator-substrate trigger paths so a customer.yaml-only PR runs the block-conformance gate.
- +2 deploy-ordering guards locking in the SEC-23/28 scrubs.

## Deferred (documented in #1634, not silently dropped)
- **SEC-22/0009** wiring `verify_at_boot` — a fatal boot-refusal is crash-loop-risky on live infra; the ADR false-claim correction goes to Review 4.
- **SEC-31** root-owning `run_invariants.py` — it writes a boot log, needs a separate log path.

## Deploy
Ships via the same `OVERLAY_REF` bump + reprovision as overlay#121 (bootstrap.sh is baked into the Machine image).

## Test plan
- [x] `operator` substrate suite green (deploy-ordering incl. new SEC-23/28 guards, citation invariants)
- [x] `bash -n bootstrap.sh` clean; workflow YAML valid
- [ ] `npm run verify` (pre-push + CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)