### PR TITLE
fix(operator): citation-safe email delivery + refusal fallback (#1641) + neutral persona identity

### DIFF
--- a/operator/customers/ashton-price/customer.yaml
+++ b/operator/customers/ashton-price/customer.yaml
@@ -80,7 +80,10 @@ users:
 personas:
   - slug: quinn
     status: active
-    name: Quinn
+    # Neutral display identity (Captain call 2026-07-02): SMD proposes no
+    # persona name. The firm authors a name at onboarding if it wants one at
+    # all (ADR 0035, no imposed defaults). The slug is internal plumbing only.
+    name: Operator
     title: AI Case Coordinator
     tone:
       - plainspoken

--- a/operator/customers/pilot-smokeball/customer.yaml
+++ b/operator/customers/pilot-smokeball/customer.yaml
@@ -55,7 +55,10 @@ users:
 personas:
   - slug: quinn
     status: active
-    name: Quinn
+    # Neutral display identity (Captain call 2026-07-02): SMD proposes no
+    # persona name. The firm authors a name at onboarding if it wants one at
+    # all (ADR 0035, no imposed defaults). The slug is internal plumbing only.
+    name: Operator
     title: AI Case Coordinator
     tone:
       - plainspoken

--- a/operator/skills/client-verification-tracker/SKILL.md
+++ b/operator/skills/client-verification-tracker/SKILL.md
@@ -231,3 +231,23 @@ verification is unsigned and its response deadline is near (RFAs highest severit
 the signer cannot be resolved with confidence; no authenticated approval path or
 firm send method is available; or the signature signal cannot be confirmed for a
 matter. Fail closed: surface and ask; never assert, auto-send, or auto-close.
+
+## Delivery channels + refusal fallback (pack rule)
+
+Email is a citation-free channel. Any output delivered by email (create_draft,
+a reply, a chase, an attorney-confirm note) states the governing rule in plain
+words ("responses are due 30 days from service by mail, plus five calendar
+days for mail service; confirm before relying") and never as a citation: no
+section numbers, no "CCP"/"CRC" references, no rule-format strings. The mail
+channel enforces the legal-citation filter and will refuse the draft. Statute
+citations belong only in matter-internal artifacts (memos, internal notes,
+tasks). The derivation itself still comes only from this skill's verified
+statute set; the email states it in words, the internal record cites it.
+
+If a delivery tool refuses a draft or write (citation filter, banned-typography
+gate, or any other content gate): do not retry the same content, and do not
+drop the work. Redraft once with the flagged content class removed (citations
+to plain words; banned punctuation to plain punctuation). If refused again,
+deliver a minimal factual note (matter, document or work item, date and method
+read, where the detail lives) so a person always learns the work happened. A
+capture or chase that reaches no human is a failure, whatever refused it.

--- a/operator/skills/daily-needs-you-digest/SKILL.md
+++ b/operator/skills/daily-needs-you-digest/SKILL.md
@@ -242,3 +242,23 @@ guess a window and do not manufacture a digest.
   neighbors (`matter-status-digest`, the owning chase skills, `deadline-miss-escalator`)
 - `_shared-training-output.md` (pack shared) — the training-note property every line
   carries
+
+## Delivery channels + refusal fallback (pack rule)
+
+Email is a citation-free channel. Any output delivered by email (create_draft,
+a reply, a chase, an attorney-confirm note) states the governing rule in plain
+words ("responses are due 30 days from service by mail, plus five calendar
+days for mail service; confirm before relying") and never as a citation: no
+section numbers, no "CCP"/"CRC" references, no rule-format strings. The mail
+channel enforces the legal-citation filter and will refuse the draft. Statute
+citations belong only in matter-internal artifacts (memos, internal notes,
+tasks). The derivation itself still comes only from this skill's verified
+statute set; the email states it in words, the internal record cites it.
+
+If a delivery tool refuses a draft or write (citation filter, banned-typography
+gate, or any other content gate): do not retry the same content, and do not
+drop the work. Redraft once with the flagged content class removed (citations
+to plain words; banned punctuation to plain punctuation). If refused again,
+deliver a minimal factual note (matter, document or work item, date and method
+read, where the detail lives) so a person always learns the work happened. A
+capture or chase that reaches no human is a failure, whatever refused it.

--- a/operator/skills/discovery-response-staging/SKILL.md
+++ b/operator/skills/discovery-response-staging/SKILL.md
@@ -247,3 +247,23 @@ or a returned-draft candidate cannot be matched to the response-set with confide
 Fail closed: surface and ask; never draft, never invent a folder, never assert an
 unconfirmed write - including never reporting a draft "routed" when the review task did
 not confirm.
+
+## Delivery channels + refusal fallback (pack rule)
+
+Email is a citation-free channel. Any output delivered by email (create_draft,
+a reply, a chase, an attorney-confirm note) states the governing rule in plain
+words ("responses are due 30 days from service by mail, plus five calendar
+days for mail service; confirm before relying") and never as a citation: no
+section numbers, no "CCP"/"CRC" references, no rule-format strings. The mail
+channel enforces the legal-citation filter and will refuse the draft. Statute
+citations belong only in matter-internal artifacts (memos, internal notes,
+tasks). The derivation itself still comes only from this skill's verified
+statute set; the email states it in words, the internal record cites it.
+
+If a delivery tool refuses a draft or write (citation filter, banned-typography
+gate, or any other content gate): do not retry the same content, and do not
+drop the work. Redraft once with the flagged content class removed (citations
+to plain words; banned punctuation to plain punctuation). If refused again,
+deliver a minimal factual note (matter, document or work item, date and method
+read, where the detail lives) so a person always learns the work happened. A
+capture or chase that reaches no human is a failure, whatever refused it.

--- a/operator/skills/discovery-response-tracker/SKILL.md
+++ b/operator/skills/discovery-response-tracker/SKILL.md
@@ -332,3 +332,23 @@ highest severity, deemed admissions under §2033.280; thin verified response = c
 track). Fail closed: surface and ask; never assert a deadline as final, never assert "late"
 over a possible extension, never assert the compel section, never calendar silently, never
 send, and never write the meet-and-confer letter.
+
+## Delivery channels + refusal fallback (pack rule)
+
+Email is a citation-free channel. Any output delivered by email (create_draft,
+a reply, a chase, an attorney-confirm note) states the governing rule in plain
+words ("responses are due 30 days from service by mail, plus five calendar
+days for mail service; confirm before relying") and never as a citation: no
+section numbers, no "CCP"/"CRC" references, no rule-format strings. The mail
+channel enforces the legal-citation filter and will refuse the draft. Statute
+citations belong only in matter-internal artifacts (memos, internal notes,
+tasks). The derivation itself still comes only from this skill's verified
+statute set; the email states it in words, the internal record cites it.
+
+If a delivery tool refuses a draft or write (citation filter, banned-typography
+gate, or any other content gate): do not retry the same content, and do not
+drop the work. Redraft once with the flagged content class removed (citations
+to plain words; banned punctuation to plain punctuation). If refused again,
+deliver a minimal factual note (matter, document or work item, date and method
+read, where the detail lives) so a person always learns the work happened. A
+capture or chase that reaches no human is a failure, whatever refused it.

--- a/operator/skills/discovery-served-watch/SKILL.md
+++ b/operator/skills/discovery-served-watch/SKILL.md
@@ -288,3 +288,23 @@ an inbound served document cannot be matched to a **single unique** matter; a wr
 admission** is served (higher-severity flag — deemed-admissions exposure, §2033.280).
 Fail closed: surface and ask; never guess a date, a method, a type, or a matter, and
 never treat a captured input as a final deadline.
+
+## Delivery channels + refusal fallback (pack rule)
+
+Email is a citation-free channel. Any output delivered by email (create_draft,
+a reply, a chase, an attorney-confirm note) states the governing rule in plain
+words ("responses are due 30 days from service by mail, plus five calendar
+days for mail service; confirm before relying") and never as a citation: no
+section numbers, no "CCP"/"CRC" references, no rule-format strings. The mail
+channel enforces the legal-citation filter and will refuse the draft. Statute
+citations belong only in matter-internal artifacts (memos, internal notes,
+tasks). The derivation itself still comes only from this skill's verified
+statute set; the email states it in words, the internal record cites it.
+
+If a delivery tool refuses a draft or write (citation filter, banned-typography
+gate, or any other content gate): do not retry the same content, and do not
+drop the work. Redraft once with the flagged content class removed (citations
+to plain words; banned punctuation to plain punctuation). If refused again,
+deliver a minimal factual note (matter, document or work item, date and method
+read, where the detail lives) so a person always learns the work happened. A
+capture or chase that reaches no human is a failure, whatever refused it.

--- a/operator/skills/discovery-served-watch/references/output-format.md
+++ b/operator/skills/discovery-served-watch/references/output-format.md
@@ -24,10 +24,17 @@ Every capture is keyed to `(matter, served-document, type)`.
 
 > <the POS text located and read — the source of the date + method; nothing inferred>
 
-## Surfaced to <responsible attorney> (confirm task)
+## Surfaced to <responsible attorney> (confirm task — the EMAIL-SAFE block)
 
-> Served <type> captured on <case>. Service <date> by <method> (POS located).
-> Confirm the type, service date, and method so the deadline is set. <RFA: flag deemed-admissions exposure.>
+When the surface goes out by email (create_draft), the draft carries ONLY this
+block, written citation-free (see SKILL.md "Delivery channels + refusal
+fallback"): the governing rule in plain words, never a section number. The full
+capture record above (header + POS quote, with citations) is the matter-internal
+artifact, never the email body.
+
+> Served <type> captured on <case>. Service <date> by <method> (proof of service located).
+> Proposed response deadline <date>: <plain words, e.g. "30 days from service by mail plus five calendar days for mail service">. Not final until you confirm.
+> Confirm the type, service date, and method so the deadline is set. <RFA: flag in plain words that an unanswered set risks the requests being deemed admitted.>
 
 ## Internal log (create_memo body)
 

--- a/operator/skills/lien-ledger-tracker/SKILL.md
+++ b/operator/skills/lien-ledger-tracker/SKILL.md
@@ -280,3 +280,23 @@ settlement approaches (Medicare and ERISA highest, given the reimbursement expos
 or a ledger write cannot be confirmed by read. Fail closed: log what is factual,
 keep the item open, and surface it; never compute, never move money, never assert an
 unconfirmed fact.
+
+## Delivery channels + refusal fallback (pack rule)
+
+Email is a citation-free channel. Any output delivered by email (create_draft,
+a reply, a chase, an attorney-confirm note) states the governing rule in plain
+words ("responses are due 30 days from service by mail, plus five calendar
+days for mail service; confirm before relying") and never as a citation: no
+section numbers, no "CCP"/"CRC" references, no rule-format strings. The mail
+channel enforces the legal-citation filter and will refuse the draft. Statute
+citations belong only in matter-internal artifacts (memos, internal notes,
+tasks). The derivation itself still comes only from this skill's verified
+statute set; the email states it in words, the internal record cites it.
+
+If a delivery tool refuses a draft or write (citation filter, banned-typography
+gate, or any other content gate): do not retry the same content, and do not
+drop the work. Redraft once with the flagged content class removed (citations
+to plain words; banned punctuation to plain punctuation). If refused again,
+deliver a minimal factual note (matter, document or work item, date and method
+read, where the detail lives) so a person always learns the work happened. A
+capture or chase that reaches no human is a failure, whatever refused it.

--- a/operator/skills/matter-initiation-setup/SKILL.md
+++ b/operator/skills/matter-initiation-setup/SKILL.md
@@ -319,3 +319,23 @@ setup convention (folders / tasks) is not established for the matter type; a par
 defendant roster cannot be resolved with confidence; or **any write fails or cannot be
 confirmed by a read**. Fail closed: surface and ask; never compute a date, never invent a
 taxonomy, never file or serve, never assert an unconfirmed write.
+
+## Delivery channels + refusal fallback (pack rule)
+
+Email is a citation-free channel. Any output delivered by email (create_draft,
+a reply, a chase, an attorney-confirm note) states the governing rule in plain
+words ("responses are due 30 days from service by mail, plus five calendar
+days for mail service; confirm before relying") and never as a citation: no
+section numbers, no "CCP"/"CRC" references, no rule-format strings. The mail
+channel enforces the legal-citation filter and will refuse the draft. Statute
+citations belong only in matter-internal artifacts (memos, internal notes,
+tasks). The derivation itself still comes only from this skill's verified
+statute set; the email states it in words, the internal record cites it.
+
+If a delivery tool refuses a draft or write (citation filter, banned-typography
+gate, or any other content gate): do not retry the same content, and do not
+drop the work. Redraft once with the flagged content class removed (citations
+to plain words; banned punctuation to plain punctuation). If refused again,
+deliver a minimal factual note (matter, document or work item, date and method
+read, where the detail lives) so a person always learns the work happened. A
+capture or chase that reaches no human is a failure, whatever refused it.

--- a/operator/skills/mediation-settlement-tracker/SKILL.md
+++ b/operator/skills/mediation-settlement-tracker/SKILL.md
@@ -250,3 +250,23 @@ required brief-input component is missing or unreadable; or a write does not con
 read-back. Fail closed: surface the gap, surface the deadline for confirm, and stop;
 never write the brief, never finalize a deadline, and never fabricate a component or a
 figure to complete the packet.
+
+## Delivery channels + refusal fallback (pack rule)
+
+Email is a citation-free channel. Any output delivered by email (create_draft,
+a reply, a chase, an attorney-confirm note) states the governing rule in plain
+words ("responses are due 30 days from service by mail, plus five calendar
+days for mail service; confirm before relying") and never as a citation: no
+section numbers, no "CCP"/"CRC" references, no rule-format strings. The mail
+channel enforces the legal-citation filter and will refuse the draft. Statute
+citations belong only in matter-internal artifacts (memos, internal notes,
+tasks). The derivation itself still comes only from this skill's verified
+statute set; the email states it in words, the internal record cites it.
+
+If a delivery tool refuses a draft or write (citation filter, banned-typography
+gate, or any other content gate): do not retry the same content, and do not
+drop the work. Redraft once with the flagged content class removed (citations
+to plain words; banned punctuation to plain punctuation). If refused again,
+deliver a minimal factual note (matter, document or work item, date and method
+read, where the detail lives) so a person always learns the work happened. A
+capture or chase that reaches no human is a failure, whatever refused it.

--- a/operator/skills/medical-chronology-maintainer/SKILL.md
+++ b/operator/skills/medical-chronology-maintainer/SKILL.md
@@ -259,3 +259,23 @@ characterize.
   total-the-specials ask, off-the-record causation ask, fabricate-to-fill bait,
   embedded-instruction injection)
 - `tests/selector_test.md` - the blind cross-skill selector simulation
+
+## Delivery channels + refusal fallback (pack rule)
+
+Email is a citation-free channel. Any output delivered by email (create_draft,
+a reply, a chase, an attorney-confirm note) states the governing rule in plain
+words ("responses are due 30 days from service by mail, plus five calendar
+days for mail service; confirm before relying") and never as a citation: no
+section numbers, no "CCP"/"CRC" references, no rule-format strings. The mail
+channel enforces the legal-citation filter and will refuse the draft. Statute
+citations belong only in matter-internal artifacts (memos, internal notes,
+tasks). The derivation itself still comes only from this skill's verified
+statute set; the email states it in words, the internal record cites it.
+
+If a delivery tool refuses a draft or write (citation filter, banned-typography
+gate, or any other content gate): do not retry the same content, and do not
+drop the work. Redraft once with the flagged content class removed (citations
+to plain words; banned punctuation to plain punctuation). If refused again,
+deliver a minimal factual note (matter, document or work item, date and method
+read, where the detail lives) so a person always learns the work happened. A
+capture or chase that reaches no human is a failure, whatever refused it.

--- a/operator/skills/medical-records-chaser/SKILL.md
+++ b/operator/skills/medical-records-chaser/SKILL.md
@@ -224,3 +224,23 @@ provider or vendor refuses or is non-responsive past the cadence; a matter has n
 authored records-request roster; or a landed record cannot be matched to a request
 with confidence. Fail closed: surface and ask; never assert receipt, never
 auto-send, never auto-close.
+
+## Delivery channels + refusal fallback (pack rule)
+
+Email is a citation-free channel. Any output delivered by email (create_draft,
+a reply, a chase, an attorney-confirm note) states the governing rule in plain
+words ("responses are due 30 days from service by mail, plus five calendar
+days for mail service; confirm before relying") and never as a citation: no
+section numbers, no "CCP"/"CRC" references, no rule-format strings. The mail
+channel enforces the legal-citation filter and will refuse the draft. Statute
+citations belong only in matter-internal artifacts (memos, internal notes,
+tasks). The derivation itself still comes only from this skill's verified
+statute set; the email states it in words, the internal record cites it.
+
+If a delivery tool refuses a draft or write (citation filter, banned-typography
+gate, or any other content gate): do not retry the same content, and do not
+drop the work. Redraft once with the flagged content class removed (citations
+to plain words; banned punctuation to plain punctuation). If refused again,
+deliver a minimal factual note (matter, document or work item, date and method
+read, where the detail lives) so a person always learns the work happened. A
+capture or chase that reaches no human is a failure, whatever refused it.

--- a/operator/skills/meet-and-confer-drafter/SKILL.md
+++ b/operator/skills/meet-and-confer-drafter/SKILL.md
@@ -236,3 +236,23 @@ deficiencies unresolved (waiver risk); the verified-response service date or met
 cannot be read, so the window cannot be confirmed; or the input does not carry an
 attorney-identified set of deficiencies. Fail closed: surface and ask; never send to
 opposing counsel, never assert an unconfirmed deadline.
+
+## Delivery channels + refusal fallback (pack rule)
+
+Email is a citation-free channel. Any output delivered by email (create_draft,
+a reply, a chase, an attorney-confirm note) states the governing rule in plain
+words ("responses are due 30 days from service by mail, plus five calendar
+days for mail service; confirm before relying") and never as a citation: no
+section numbers, no "CCP"/"CRC" references, no rule-format strings. The mail
+channel enforces the legal-citation filter and will refuse the draft. Statute
+citations belong only in matter-internal artifacts (memos, internal notes,
+tasks). The derivation itself still comes only from this skill's verified
+statute set; the email states it in words, the internal record cites it.
+
+If a delivery tool refuses a draft or write (citation filter, banned-typography
+gate, or any other content gate): do not retry the same content, and do not
+drop the work. Redraft once with the flagged content class removed (citations
+to plain words; banned punctuation to plain punctuation). If refused again,
+deliver a minimal factual note (matter, document or work item, date and method
+read, where the detail lives) so a person always learns the work happened. A
+capture or chase that reaches no human is a failure, whatever refused it.

--- a/operator/skills/minors-compromise-packet/SKILL.md
+++ b/operator/skills/minors-compromise-packet/SKILL.md
@@ -265,3 +265,23 @@ the minor or another required figure is missing; a lien payoff the disclosure ne
 outstanding as the hearing approaches; the fund-handling disposition is undecided; or
 a Smokeball write cannot be confirmed by a follow-up read. Fail closed: surface and
 ask; never compute, never judge, never file, never assert an unconfirmed write.
+
+## Delivery channels + refusal fallback (pack rule)
+
+Email is a citation-free channel. Any output delivered by email (create_draft,
+a reply, a chase, an attorney-confirm note) states the governing rule in plain
+words ("responses are due 30 days from service by mail, plus five calendar
+days for mail service; confirm before relying") and never as a citation: no
+section numbers, no "CCP"/"CRC" references, no rule-format strings. The mail
+channel enforces the legal-citation filter and will refuse the draft. Statute
+citations belong only in matter-internal artifacts (memos, internal notes,
+tasks). The derivation itself still comes only from this skill's verified
+statute set; the email states it in words, the internal record cites it.
+
+If a delivery tool refuses a draft or write (citation filter, banned-typography
+gate, or any other content gate): do not retry the same content, and do not
+drop the work. Redraft once with the flagged content class removed (citations
+to plain words; banned punctuation to plain punctuation). If refused again,
+deliver a minimal factual note (matter, document or work item, date and method
+read, where the detail lives) so a person always learns the work happened. A
+capture or chase that reaches no human is a failure, whatever refused it.

--- a/operator/skills/motion-calendar-tracker/SKILL.md
+++ b/operator/skills/motion-calendar-tracker/SKILL.md
@@ -226,3 +226,23 @@ never fill it, never compute the deadline, never assert the outcome.
 - `references/voice.md` - the internal, sourced, anti-fiction voice for the surface
   and the memo (no drafts leave this skill).
 - `tests/selector_test.md` - blind cross-skill selector simulation vs. near neighbors.
+
+## Delivery channels + refusal fallback (pack rule)
+
+Email is a citation-free channel. Any output delivered by email (create_draft,
+a reply, a chase, an attorney-confirm note) states the governing rule in plain
+words ("responses are due 30 days from service by mail, plus five calendar
+days for mail service; confirm before relying") and never as a citation: no
+section numbers, no "CCP"/"CRC" references, no rule-format strings. The mail
+channel enforces the legal-citation filter and will refuse the draft. Statute
+citations belong only in matter-internal artifacts (memos, internal notes,
+tasks). The derivation itself still comes only from this skill's verified
+statute set; the email states it in words, the internal record cites it.
+
+If a delivery tool refuses a draft or write (citation filter, banned-typography
+gate, or any other content gate): do not retry the same content, and do not
+drop the work. Redraft once with the flagged content class removed (citations
+to plain words; banned punctuation to plain punctuation). If refused again,
+deliver a minimal factual note (matter, document or work item, date and method
+read, where the detail lives) so a person always learns the work happened. A
+capture or chase that reaches no human is a failure, whatever refused it.

--- a/operator/skills/motion-package-assembler/SKILL.md
+++ b/operator/skills/motion-package-assembler/SKILL.md
@@ -316,3 +316,23 @@ for the venue is unknown; or a Smokeball write cannot be confirmed by a read. Fa
 surface the gap and stop; never draft a component, never assert an invented format, never
 invent a hearing date, and never assert an unobserved tentative ruling to make the package
 look complete.
+
+## Delivery channels + refusal fallback (pack rule)
+
+Email is a citation-free channel. Any output delivered by email (create_draft,
+a reply, a chase, an attorney-confirm note) states the governing rule in plain
+words ("responses are due 30 days from service by mail, plus five calendar
+days for mail service; confirm before relying") and never as a citation: no
+section numbers, no "CCP"/"CRC" references, no rule-format strings. The mail
+channel enforces the legal-citation filter and will refuse the draft. Statute
+citations belong only in matter-internal artifacts (memos, internal notes,
+tasks). The derivation itself still comes only from this skill's verified
+statute set; the email states it in words, the internal record cites it.
+
+If a delivery tool refuses a draft or write (citation filter, banned-typography
+gate, or any other content gate): do not retry the same content, and do not
+drop the work. Redraft once with the flagged content class removed (citations
+to plain words; banned punctuation to plain punctuation). If refused again,
+deliver a minimal factual note (matter, document or work item, date and method
+read, where the detail lives) so a person always learns the work happened. A
+capture or chase that reaches no human is a failure, whatever refused it.

--- a/operator/skills/opposing-response-deficiency-review/SKILL.md
+++ b/operator/skills/opposing-response-deficiency-review/SKILL.md
@@ -232,3 +232,23 @@ attorney in on every run. It additionally flags, at the top of the artifact, any
 the candidate is unclear or the request-to-response pairing is ambiguous, and any matter
 where the firm's sufficiency calibration is not yet established. Fail closed: surface and
 ask; never render the judgment, never decide the step, never draft.
+
+## Delivery channels + refusal fallback (pack rule)
+
+Email is a citation-free channel. Any output delivered by email (create_draft,
+a reply, a chase, an attorney-confirm note) states the governing rule in plain
+words ("responses are due 30 days from service by mail, plus five calendar
+days for mail service; confirm before relying") and never as a citation: no
+section numbers, no "CCP"/"CRC" references, no rule-format strings. The mail
+channel enforces the legal-citation filter and will refuse the draft. Statute
+citations belong only in matter-internal artifacts (memos, internal notes,
+tasks). The derivation itself still comes only from this skill's verified
+statute set; the email states it in words, the internal record cites it.
+
+If a delivery tool refuses a draft or write (citation filter, banned-typography
+gate, or any other content gate): do not retry the same content, and do not
+drop the work. Redraft once with the flagged content class removed (citations
+to plain words; banned punctuation to plain punctuation). If refused again,
+deliver a minimal factual note (matter, document or work item, date and method
+read, where the detail lives) so a person always learns the work happened. A
+capture or chase that reaches no human is a failure, whatever refused it.

--- a/operator/skills/separate-statement-assembler/SKILL.md
+++ b/operator/skills/separate-statement-assembler/SKILL.md
@@ -275,3 +275,23 @@ responses appear to be the firm's own rather than the opposing party's served re
 specified. Fail closed: surface the
 gap and stop; never assemble from partial or invented data, and never fill the reasons
 cell to "complete" the statement.
+
+## Delivery channels + refusal fallback (pack rule)
+
+Email is a citation-free channel. Any output delivered by email (create_draft,
+a reply, a chase, an attorney-confirm note) states the governing rule in plain
+words ("responses are due 30 days from service by mail, plus five calendar
+days for mail service; confirm before relying") and never as a citation: no
+section numbers, no "CCP"/"CRC" references, no rule-format strings. The mail
+channel enforces the legal-citation filter and will refuse the draft. Statute
+citations belong only in matter-internal artifacts (memos, internal notes,
+tasks). The derivation itself still comes only from this skill's verified
+statute set; the email states it in words, the internal record cites it.
+
+If a delivery tool refuses a draft or write (citation filter, banned-typography
+gate, or any other content gate): do not retry the same content, and do not
+drop the work. Redraft once with the flagged content class removed (citations
+to plain words; banned punctuation to plain punctuation). If refused again,
+deliver a minimal factual note (matter, document or work item, date and method
+read, where the detail lives) so a person always learns the work happened. A
+capture or chase that reaches no human is a failure, whatever refused it.

--- a/operator/skills/service-confirmation-watcher/SKILL.md
+++ b/operator/skills/service-confirmation-watcher/SKILL.md
@@ -300,3 +300,23 @@ defendant was served on different dates; or a write (`create_memo` / `create_tas
 cannot be confirmed by a read. Fail closed: surface and ask; never guess a served date,
 a method, or a defendant, and never treat a captured served date as a final
 responsive-pleading deadline.
+
+## Delivery channels + refusal fallback (pack rule)
+
+Email is a citation-free channel. Any output delivered by email (create_draft,
+a reply, a chase, an attorney-confirm note) states the governing rule in plain
+words ("responses are due 30 days from service by mail, plus five calendar
+days for mail service; confirm before relying") and never as a citation: no
+section numbers, no "CCP"/"CRC" references, no rule-format strings. The mail
+channel enforces the legal-citation filter and will refuse the draft. Statute
+citations belong only in matter-internal artifacts (memos, internal notes,
+tasks). The derivation itself still comes only from this skill's verified
+statute set; the email states it in words, the internal record cites it.
+
+If a delivery tool refuses a draft or write (citation filter, banned-typography
+gate, or any other content gate): do not retry the same content, and do not
+drop the work. Redraft once with the flagged content class removed (citations
+to plain words; banned punctuation to plain punctuation). If refused again,
+deliver a minimal factual note (matter, document or work item, date and method
+read, where the detail lives) so a person always learns the work happened. A
+capture or chase that reaches no human is a failure, whatever refused it.

--- a/operator/skills/settlement-statement-feeder/SKILL.md
+++ b/operator/skills/settlement-statement-feeder/SKILL.md
@@ -245,3 +245,23 @@ trust `availableBalance` is below the gross to be disbursed (funds not in trust 
 or an internal write cannot be confirmed. Fail closed: assemble what is readable,
 surface every gap, and never move money, never invent a figure, never assert an
 executed disbursement.
+
+## Delivery channels + refusal fallback (pack rule)
+
+Email is a citation-free channel. Any output delivered by email (create_draft,
+a reply, a chase, an attorney-confirm note) states the governing rule in plain
+words ("responses are due 30 days from service by mail, plus five calendar
+days for mail service; confirm before relying") and never as a citation: no
+section numbers, no "CCP"/"CRC" references, no rule-format strings. The mail
+channel enforces the legal-citation filter and will refuse the draft. Statute
+citations belong only in matter-internal artifacts (memos, internal notes,
+tasks). The derivation itself still comes only from this skill's verified
+statute set; the email states it in words, the internal record cites it.
+
+If a delivery tool refuses a draft or write (citation filter, banned-typography
+gate, or any other content gate): do not retry the same content, and do not
+drop the work. Redraft once with the flagged content class removed (citations
+to plain words; banned punctuation to plain punctuation). If refused again,
+deliver a minimal factual note (matter, document or work item, date and method
+read, where the detail lives) so a person always learns the work happened. A
+capture or chase that reaches no human is a failure, whatever refused it.

--- a/operator/skills/trial-binder-assembler/SKILL.md
+++ b/operator/skills/trial-binder-assembler/SKILL.md
@@ -281,3 +281,23 @@ deadline is approaching; or a gated write cannot be confirmed by a read. Fail cl
 surface the gap and stop; never assemble from partial or invented data, never author
 the brief or a summary to "complete" the binder, and never assert a Bates range or a
 write it did not observe.
+
+## Delivery channels + refusal fallback (pack rule)
+
+Email is a citation-free channel. Any output delivered by email (create_draft,
+a reply, a chase, an attorney-confirm note) states the governing rule in plain
+words ("responses are due 30 days from service by mail, plus five calendar
+days for mail service; confirm before relying") and never as a citation: no
+section numbers, no "CCP"/"CRC" references, no rule-format strings. The mail
+channel enforces the legal-citation filter and will refuse the draft. Statute
+citations belong only in matter-internal artifacts (memos, internal notes,
+tasks). The derivation itself still comes only from this skill's verified
+statute set; the email states it in words, the internal record cites it.
+
+If a delivery tool refuses a draft or write (citation filter, banned-typography
+gate, or any other content gate): do not retry the same content, and do not
+drop the work. Redraft once with the flagged content class removed (citations
+to plain words; banned punctuation to plain punctuation). If refused again,
+deliver a minimal factual note (matter, document or work item, date and method
+read, where the detail lives) so a person always learns the work happened. A
+capture or chase that reaches no human is a failure, whatever refused it.

--- a/operator/verticals/law-firm/addons/pi/references/_shared-delivery-channels.md
+++ b/operator/verticals/law-firm/addons/pi/references/_shared-delivery-channels.md
@@ -1,0 +1,47 @@
+# Shared: Delivery Channels + Refusal Fallback (PI-litigation pack)
+
+Authoring canon for every pack skill. The runtime copy of this rule lives in
+each skill's SKILL.md ("Delivery channels + refusal fallback" section) because
+only `operator/skills/` ships to the Machine image; keep the two in step.
+
+Born from the first live lifecycle test (2026-07-03, issue #1641): a served-
+discovery capture executed perfectly and then reached no human, because the
+attorney-confirm email draft carried statute citations (the mail channel's
+legal-citation filter, ADR 0028 safety invariant #6, refused it), the redrafts
+repeated the same content, and the memo fallback was blocked by the tenant's
+write entitlement. The floors did their job; the skill had no delivery
+discipline. This canon is that discipline.
+
+## Rule 1: email is a citation-free channel
+
+Any output delivered by email (create_draft, a reply, a chase, an
+attorney-confirm note) states the governing rule in plain words:
+
+> "Responses are due 30 days from service by mail, plus five calendar days for
+> mail service. Proposed deadline August 3, 2026. Confirm before relying."
+
+and never as a citation: no section numbers, no "CCP" or "CRC" references, no
+rule-format strings. The mail channel enforces the legal-citation filter and
+will refuse the draft. Statute citations belong only in matter-internal
+artifacts: memos, internal notes, tasks (per `_shared-training-output.md`,
+which already keeps the teaching note out of client-facing sends).
+
+This is not a loosening of the grounding rule. The derivation must still come
+from the capture spec's verified statute set; the skill simply expresses it in
+words on the email channel and cites it in the internal record.
+
+## Rule 2: a refusal is a redraft instruction, not a stop
+
+If a delivery tool refuses a draft or write (citation filter,
+banned-typography gate, or any other content gate):
+
+1. Do not retry the same content. The gate is deterministic; identical content
+   is refused identically.
+2. Redraft once with the flagged content class removed: citations become plain
+   words; banned punctuation becomes plain punctuation.
+3. If refused again, deliver a minimal factual note: the matter, the document
+   or work item, the date and method read, and where the detail lives. A
+   person must always learn the work happened.
+
+A capture or chase that reaches no human is a failure, whatever refused it.
+Silence is never an acceptable outcome of a completed piece of work.

--- a/operator/verticals/law-firm/addons/pi/references/_shared-training-output.md
+++ b/operator/verticals/law-firm/addons/pi/references/_shared-training-output.md
@@ -23,7 +23,10 @@ A short, plain note carrying four things:
   not recalled-and-hoped. If a rule is uncertain, say "confirm the rule" rather than
   invent a citation.
 - It lives in the internal/matter-facing output (memo, internal note), so the
-  reasoning sits next to the work — not in client-facing sends.
+  reasoning sits next to the work — not in client-facing sends, and not in ANY
+  emailed output: the mail channel enforces the legal-citation filter, so an
+  emailed note states the rule in plain words and the citation stays in the
+  matter-internal artifact (see `_shared-delivery-channels.md`).
 - Keep it short. A paralegal learns from a clear sentence, not a treatise.
 
 ## Example (on a verification prepared for a minor)


### PR DESCRIPTION
## What

Two changes riding together per Captain direction:

**1. Fix #1641 — the live-test deliverability defect.** The first live served-discovery test executed perfectly and delivered nothing: the attorney-confirm draft carried statute citations, the mail channel's legal-citation filter (ADR 0028 invariant #6) refused it, the redrafts repeated the same content, and the memo fallback was the known Smokeball 403. Silent drop.
- Pack rule appended to all 19 SKILL.md bodies (the runtime copy — only `operator/skills/` ships in the image): email is a citation-free channel (plain-words derivation; citations live in matter-internal artifacts), and a content-gate refusal means redraft once without the flagged class, then a minimal factual note. A capture that reaches no human is a failure.
- Authoring canon `_shared-delivery-channels.md` + training-output canon scoped away from emailed output.
- `discovery-served-watch` output format: the email draft is ONLY the citation-free confirm block with a plain-words proposed deadline.
- The citation filter itself is untouched — invariant #6 stays at full strength.

**2. Neutral persona display identity (Captain call 2026-07-02).** 'Quinn' was an agent-proposed placeholder, never a Captain or firm choice. `name: Operator` on both seats; the firm authors a name at onboarding if it wants one at all (ADR 0035). Slug untouched (plumbing).

## Verification

- operator pytest: 152 bin/tests pass (incl. the SKILL.md frontmatter gate over the 19 edited files)
- Both customer.yamls validate
- Live re-test after reprovision: re-send the synthetic served-discovery email, expect a delivered citation-free draft

Closes #1641.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K8qUZdwzz4iE4n83EVSE2Y