### PR TITLE
fix(operator-console): repair dead governance forms, quote link, green-lie fleet dot

### DIFF
--- a/src/lib/admin/fleet-roster.ts
+++ b/src/lib/admin/fleet-roster.ts
@@ -200,24 +200,36 @@ export interface RosterHealth {
   note: string | null
 }
 
-const HEALTH_RANK: Record<RosterHealthColor, number> = { gray: 0, green: 1, yellow: 2, red: 3 }
+// gray ("no signal") ranks ABOVE green: an unknown-liveness Machine must never
+// read calmer than a live one. Ordering: green < gray < yellow < red.
+const HEALTH_RANK: Record<RosterHealthColor, number> = { green: 0, gray: 1, yellow: 2, red: 3 }
 
 /**
  * Combine the heartbeat liveness ("is the process alive", fleet_status) with
  * the runtime-summary rollup ("is the operator OK" — folds in sticky-stop,
  * escalation pressure, connector health per migration 0052) into one fleet
- * dot. Takes the more alarming of the two so the column never reads calmer
- * than reality. `heartbeatColor` is the color from `heartbeatDisplay`;
- * `summaryStatus` is null when no Machine has pushed a summary yet.
+ * dot. The heartbeat is the source of truth for LIVENESS; the summary may only
+ * ESCALATE it (operator reports a warning/problem), never paint a Machine green
+ * or downgrade a live-green Machine to "unknown". So only a yellow/red summary
+ * participates — a green or absent summary leaves the heartbeat verdict standing.
+ *
+ * Previously the summary's own gray/green could override the heartbeat because
+ * gray was ranked below green: a Machine that had never sent a heartbeat (gray)
+ * but carried a stale "green" summary painted GREEN — the column reading calmer
+ * than reality, the one thing a fleet dot must never do. `summaryStatus` is null
+ * when no Machine has pushed a summary yet.
  */
 export function rosterHealth(
   heartbeatColor: RosterHealthColor,
   heartbeatLabel: string,
   summaryStatus: SummaryStatus | null
 ): RosterHealth {
-  const summaryColor = summaryStatusToColor(summaryStatus)
+  const escalation: RosterHealthColor | null =
+    summaryStatus === 'red' ? 'red' : summaryStatus === 'yellow' ? 'yellow' : null
   const color =
-    HEALTH_RANK[summaryColor] > HEALTH_RANK[heartbeatColor] ? summaryColor : heartbeatColor
+    escalation && HEALTH_RANK[escalation] > HEALTH_RANK[heartbeatColor]
+      ? escalation
+      : heartbeatColor
   const note =
     summaryStatus === 'red'
       ? 'operator reports a problem'
@@ -225,19 +237,6 @@ export function rosterHealth(
         ? 'operator reports a warning'
         : null
   return { color, label: heartbeatLabel, note }
-}
-
-function summaryStatusToColor(status: SummaryStatus | null): RosterHealthColor {
-  switch (status) {
-    case 'green':
-      return 'green'
-    case 'yellow':
-      return 'yellow'
-    case 'red':
-      return 'red'
-    default:
-      return 'gray'
-  }
 }
 
 export function rosterHealthDotClass(color: RosterHealthColor): string {

--- a/src/pages/admin/clients/[id].astro
+++ b/src/pages/admin/clients/[id].astro
@@ -246,11 +246,13 @@ const LINK_ACT =
           )
         }
 
-        <a
-          href={`/admin/quotes/new?entity=${entity.id}`}
-          class="mt-3.5 block w-full border border-dashed border-[color:var(--ss-color-border)] px-3.5 py-2.5 text-center font-['Archivo_Narrow'] text-[11px] font-bold uppercase tracking-[0.12em] text-[color:var(--ss-color-primary)]"
-          >+ New quote</a
-        >
+        <form method="POST" action={`/api/admin/entities/${entity.id}/quotes`}>
+          <button
+            type="submit"
+            class="mt-3.5 block w-full border border-dashed border-[color:var(--ss-color-border)] px-3.5 py-2.5 text-center font-['Archivo_Narrow'] text-[11px] font-bold uppercase tracking-[0.12em] text-[color:var(--ss-color-primary)]"
+            >+ New quote</button
+          >
+        </form>
       </section>
 
       <!-- billing -->

--- a/src/pages/admin/operator/[customer]/authority.astro
+++ b/src/pages/admin/operator/[customer]/authority.astro
@@ -124,7 +124,7 @@ const banner = status ? STATUS_MESSAGES[status] : null
                       <span class={badge.classes}>{badge.label}</span>
                       <form
                         method="post"
-                        action={`/admin/operator/${encodeURIComponent(slug)}/authority`}
+                        action={`/api/admin/operator/${encodeURIComponent(slug)}/authority`}
                       >
                         <input type="hidden" name="domain" value={d.domain} />
                         <input type="hidden" name="new_holder" value={target} />

--- a/src/pages/admin/operator/[customer]/governance.astro
+++ b/src/pages/admin/operator/[customer]/governance.astro
@@ -43,7 +43,7 @@ const STATUS_MESSAGES: Record<string, { text: string; ok: boolean }> = {
   malformed: { text: 'Config projection is malformed.', ok: false },
 }
 const banner = status ? STATUS_MESSAGES[status] : null
-const formAction = `/admin/operator/${encodeURIComponent(slug)}/governance`
+const formAction = `/api/admin/operator/${encodeURIComponent(slug)}/governance`
 ---
 
 <AdminLayout

--- a/tests/fleet-roster.test.ts
+++ b/tests/fleet-roster.test.ts
@@ -217,6 +217,15 @@ describe('rosterHealth', () => {
     expect(rosterHealth('yellow', '3m ago', null).color).toBe('yellow')
     expect(rosterHealth('gray', 'no signal yet', null).color).toBe('gray')
   })
+
+  it('a green summary never paints an un-heartbeating (gray) Machine green', () => {
+    // The regression: no liveness signal must not read calmer than reality.
+    // A stale/green summary can only leave the gray verdict standing, never
+    // upgrade it — only a yellow/red summary escalates.
+    expect(rosterHealth('gray', 'no signal yet', 'green').color).toBe('gray')
+    expect(rosterHealth('gray', 'no signal yet', 'red').color).toBe('red')
+    expect(rosterHealth('gray', 'no signal yet', 'yellow').color).toBe('yellow')
+  })
 })
 
 describe('rosterHealthDotClass', () => {

--- a/tests/operator-write-form-targets.test.ts
+++ b/tests/operator-write-form-targets.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Guard the per-customer Operator governance forms POST to their /api handlers,
+ * not the GET-only page paths.
+ *
+ * Regression: authority.astro and governance.astro built their form `action`
+ * as `/admin/operator/<slug>/<x>` (the PAGE path) instead of
+ * `/api/admin/operator/<slug>/<x>` (the real POST handler). No `.astro` page
+ * exports a POST, so the two core governance mutations — authority flips and
+ * entitlement/exposure changes — 404'd silently on submit. The unit tests call
+ * the POST handlers directly, so nothing asserted the form target; this closes
+ * that gap by reading the rendered source.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const read = (rel: string) => readFileSync(resolve(rel), 'utf-8')
+
+describe('Operator governance forms target their /api handlers', () => {
+  it('authority.astro posts to /api/admin/operator/<slug>/authority', () => {
+    const src = read('src/pages/admin/operator/[customer]/authority.astro')
+    // The form action must be the /api handler, never the page path.
+    expect(src).toMatch(/action=\{`\/api\/admin\/operator\/\$\{[^}]+\}\/authority`\}/)
+    expect(src).not.toMatch(/action=\{`\/admin\/operator\/\$\{[^}]+\}\/authority`\}/)
+  })
+
+  it('governance.astro posts to /api/admin/operator/<slug>/governance', () => {
+    const src = read('src/pages/admin/operator/[customer]/governance.astro')
+    expect(src).toMatch(/formAction = `\/api\/admin\/operator\/\$\{[^}]+\}\/governance`/)
+    expect(src).not.toMatch(/formAction = `\/admin\/operator\/\$\{[^}]+\}\/governance`/)
+  })
+})


### PR DESCRIPTION
## Summary
Three broken write/read paths surfaced by Review 3 (product review of portal + admin console):

- **P0 — governance mutations 404 silently.** `authority.astro` and `governance.astro` posted to the GET-only **page** path instead of the `/api` handler, so authority flips and entitlement/exposure changes never ran. Fixed both + added `operator-write-form-targets.test.ts` (unit tests call the POST handlers directly, so the form target was untested — that's how it shipped).
- **P1 — dead "+ New quote" CTA.** The client hub linked to `/admin/quotes/new` (nonexistent → 404). Now a POST form to the real creator `/api/admin/entities/<id>/quotes`.
- **P1 — fleet dot could read green when liveness is unknown.** `rosterHealth` ranked `gray` below `green`, so a never-heartbeating Machine with a stale green summary painted green. Heartbeat is now the liveness source of truth; the summary can only *escalate*. Regression test added. Directly reachable during the ADR 0023 heartbeat rollout.

## Test plan
- [x] `vitest tests/fleet-roster.test.ts tests/operator-write-form-targets.test.ts` — 18 pass
- [x] `astro check` — 0 errors
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)