### PR TITLE
fix(portal): strip four fabricated soft-promises to status-only

### DIFF
--- a/src/pages/portal/index.astro
+++ b/src/pages/portal/index.astro
@@ -100,7 +100,7 @@ for (const q of quotes) {
     timeline.push({
       ts: q.accepted_at,
       date: shortDate(q.accepted_at),
-      body: 'Proposal signed. Deposit due.',
+      body: 'Proposal signed.',
       artifactLabel: 'Proposal',
       artifactHref: `/portal/quotes/${q.id}`,
       artifactIcon: 'description',

--- a/src/pages/portal/invoices/[id].astro
+++ b/src/pages/portal/invoices/[id].astro
@@ -70,7 +70,6 @@ const { invoice, lineItems, engagement } = invoiceDetail
 
 // Money — invoices.amount is dollars (REAL); convert to cents for display.
 const amountCents = Math.round(invoice.amount * 100)
-const lineItemsTotalCents = lineItems.reduce((sum, li) => sum + li.amount_cents, 0)
 // Show the invoice's own amount as Total so rounding always matches the CTA.
 const totalCents = amountCents
 
@@ -152,16 +151,11 @@ if (isPaid) {
   else pillLabel = `Due in ${daysRemaining} day${daysRemaining === 1 ? '' : 's'}`
 }
 
-// Deposit note: surface when this is a completion invoice with a dollar delta
-// from the line-items sum (common when a deposit has already been taken).
-const depositNote =
-  invoice.type === 'completion' && lineItemsTotalCents > amountCents
-    ? `Deposit of ${((lineItemsTotalCents - amountCents) / 100).toLocaleString('en-US', {
-        style: 'currency',
-        currency: 'USD',
-        maximumFractionDigits: 0,
-      })} already received.`
-    : null
+// A "deposit already received" note must come from an authoritative payment
+// record, never inferred from the line-items/amount delta — asserting a payment
+// fact from arithmetic is a fabrication (Pattern B). Left null until a real
+// deposit-payment source exists to render it from.
+const depositNote = null
 ---
 
 <!doctype html>

--- a/src/pages/portal/products/operator/account/index.astro
+++ b/src/pages/portal/products/operator/account/index.astro
@@ -155,8 +155,7 @@ const hasEscalation =
                     Not provisioned yet
                   </p>
                   <p class={`m-0 ${emptyNoteClass}`}>
-                    Your operator subscription has not been set up yet. We will let you know when it
-                    is ready.
+                    Your operator subscription has not been set up yet.
                   </p>
                 </div>
               )

--- a/src/pages/portal/quotes/[id].astro
+++ b/src/pages/portal/quotes/[id].astro
@@ -231,7 +231,7 @@ const supersedingQuoteId = isSuperseded ? (superseding?.id ?? null) : null
                   </a>
                 ) : (
                   <p class="border-t-[2px] border-[color:var(--ss-color-text-primary)] px-5 py-4 text-sm text-[color:var(--ss-color-text-secondary)]">
-                    Your proposal is being prepared. You'll get an email when it's ready to sign.
+                    Your proposal is being prepared.
                   </p>
                 )
               }
@@ -408,7 +408,7 @@ const supersedingQuoteId = isSuperseded ? (superseding?.id ?? null) : null
                   </a>
                 ) : (
                   <p class="border-t-[2px] border-[color:var(--ss-color-text-primary)] px-5 py-4 text-sm text-[color:var(--ss-color-text-secondary)]">
-                    Your proposal is being prepared. You'll get an email when it's ready.
+                    Your proposal is being prepared.
                   </p>
                 )
               }


### PR DESCRIPTION
## Summary
Review 3 surfaced four committed sentences that promise uncontracted future behavior or assert facts from non-authoritative sources (Pattern A/B). Per Captain call, product notification/status copy is not exempt — all four fixed to state current status only.

- **quotes/[id].astro** (×2): dropped "You'll get an email when it's ready…"
- **index.astro**: "Proposal signed. Deposit due." → "Proposal signed." (deposit-due was ungated on any invoice)
- **invoices/[id].astro**: removed "Deposit of $X already received." — it was *derived from arithmetic* (line-items − amount), a fabricated payment fact — plus its orphaned source var
- **operator/account/index.astro**: dropped "We will let you know when it is ready."

## Test plan
- [x] `vitest tests/forbidden-strings.test.ts` — 76 pass
- [x] `astro check` — 0 errors
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)