### PR TITLE
fix(operator): normalize Smokeball /contacts search — bare-term 400s tripped the MCP breaker (#1642)

### DIFF
--- a/operator/connectors/smokeball/smokeball_connector/server.py
+++ b/operator/connectors/smokeball/smokeball_connector/server.py
@@ -78,7 +78,12 @@ def list_matters(
 ) -> Any:
     """List matters/leads. status=Open|Pending|Closed|Deleted|Cancelled;
     is_lead splits leads vs matters. updated_since is passed verbatim (the
-    .NET-ticks vs ISO format is confirmed at connect)."""
+    .NET-ticks vs ISO format is confirmed at connect).
+
+    `search` here is a PLAIN full-text keyword (live-verified 2026-07-03:
+    "Johnson" matches the matter title; field-scoped syntax like
+    "name:*Johnson*" is NOT an error but silently returns zero results —
+    the opposite of the /contacts contract)."""
     return _get_client().get(
         "/matters",
         Status=status,
@@ -118,20 +123,45 @@ def get_stage_to_matter_mappings() -> Any:
     return _get_client().get("/stages")
 
 
+def _contact_search_terms(search: str | list[str] | None) -> list[str] | None:
+    """Normalize `search` for the /contacts endpoint, whose contract (Smokeball
+    "Searching" docs, live-verified 2026-07-03) is STRICT field:operator:value
+    expressions — a bare term like "Johnson" is a 400 ("Invalid search term"),
+    and three of those in a row trip the whole MCP breaker (#1642). A bare term
+    is auto-wrapped as a case-insensitive name contains-search (name:*term*),
+    which is what a caller almost always means; structured terms pass through.
+    Multiple terms combine with AND on the API side."""
+    if search is None:
+        return None
+    terms = [search] if isinstance(search, str) else list(search)
+    out: list[str] = []
+    for term in terms:
+        term = str(term).strip()
+        if not term:
+            continue
+        out.append(term if ":" in term else f"name:*{term}*")
+    return out or None
+
+
 # ---- Contacts -------------------------------------------------------------
 @server.tool()
 def get_contacts(
-    search: str | None = None,
+    search: str | list[str] | None = None,
     type: str | None = None,
     updated_since: str | None = None,
     sort: str | None = None,
     limit: int = 500,
     offset: int = 0,
 ) -> Any:
-    """Search/list contacts (intake dedupe + conflict cross-check)."""
+    """Search/list contacts (intake dedupe + conflict cross-check).
+
+    `search` uses Smokeball's field:operator:value syntax, e.g. "name:*johnson*"
+    (case-insensitive contains). A bare term is auto-wrapped as name:*term*.
+    Pass a list for multiple terms (combined with AND). Unlike list_matters,
+    a plain keyword is NOT valid on this endpoint's API."""
     return _get_client().get(
         "/contacts",
-        Search=search,
+        Search=_contact_search_terms(search),
         Type=type,
         UpdatedSince=updated_since,
         Sort=sort,

--- a/operator/connectors/smokeball/tests/test_contact_search.py
+++ b/operator/connectors/smokeball/tests/test_contact_search.py
@@ -1,0 +1,41 @@
+"""get_contacts search normalization (#1642).
+
+The /contacts endpoint requires field:operator:value search expressions; a bare
+term is an HTTP 400 ("Invalid search term 'Johnson'."), and three consecutive
+400s trip the whole MCP breaker mid-turn. _contact_search_terms auto-wraps bare
+terms as a case-insensitive name contains-search so the natural call succeeds.
+Contracts live-verified against the staging tenant 2026-07-03:
+  /contacts  search="Johnson"        -> 400
+  /contacts  search="name:*johnson*" -> 200, 1 result
+  /matters   search="Johnson"        -> 200, 1 result (plain-keyword contract)
+"""
+
+from smokeball_connector.server import _contact_search_terms
+
+
+def test_none_passes_through() -> None:
+    assert _contact_search_terms(None) is None
+
+
+def test_bare_term_wrapped_as_name_contains() -> None:
+    assert _contact_search_terms("Johnson") == ["name:*Johnson*"]
+
+
+def test_structured_term_passes_through() -> None:
+    assert _contact_search_terms("name:*johnson*") == ["name:*johnson*"]
+
+
+def test_operator_terms_pass_through() -> None:
+    assert _contact_search_terms("name:!*Hunter*") == ["name:!*Hunter*"]
+
+
+def test_list_mixes_wrapped_and_structured() -> None:
+    assert _contact_search_terms(["Johnson", "type:person"]) == [
+        "name:*Johnson*",
+        "type:person",
+    ]
+
+
+def test_whitespace_and_empty_terms_dropped() -> None:
+    assert _contact_search_terms(["  ", ""]) is None
+    assert _contact_search_terms(" Johnson ") == ["name:*Johnson*"]


### PR DESCRIPTION
## What

Live probes against the staging tenant established two opposite search contracts:
- `/contacts` requires `field:operator:value` (bare `"Johnson"` → 400 "Invalid search term")
- `/matters` takes a plain full-text keyword (field syntax silently returns zero)

The model naturally passes bare names to `get_contacts`; three consecutive 400s tripped the **entire smokeball MCP breaker** mid-turn (~57s unreachable), blocking matter reads — this is what degraded both live served-discovery captures to the minimal-note fallback.

## Fix

- `get_contacts`: `_contact_search_terms()` auto-wraps a bare term as `name:*term*` (case-insensitive contains, live-verified to return the right contact), passes structured terms through, accepts a list (AND semantics per the vendor's searching docs)
- Docstrings on `get_contacts` + `list_matters` state each endpoint's verified contract
- 6 unit tests; connector suite 65 passed, 1 skipped

## Verification

- Vendor contract: https://docs.smokeball.com/docs/api-docs/272770a37d359-searching
- Live: `search="name:*johnson*"` → 1 result (Marcus Johnson); bare `"Johnson"` → 400 with `"field": "/Search"`; `/matters` `search="Johnson"` → 1 result
- After merge + reprovision: re-run the served-discovery email expecting a full-quality capture (matter-verified, no breaker trip)

Closes #1642.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K8qUZdwzz4iE4n83EVSE2Y