### PR TITLE
fix(operator): delivery discipline v2 — spine skills covered, substance survives the redraft

### DIFF
--- a/operator/skills/client-verification-tracker/SKILL.md
+++ b/operator/skills/client-verification-tracker/SKILL.md
@@ -232,7 +232,7 @@ the signer cannot be resolved with confidence; no authenticated approval path or
 firm send method is available; or the signature signal cannot be confirmed for a
 matter. Fail closed: surface and ask; never assert, auto-send, or auto-close.
 
-## Delivery channels + refusal fallback (pack rule)
+## Delivery channels + refusal fallback (law seat rule)
 
 Email is a citation-free channel. Any output delivered by email (create_draft,
 a reply, a chase, an attorney-confirm note) states the governing rule in plain
@@ -241,13 +241,21 @@ days for mail service; confirm before relying") and never as a citation: no
 section numbers, no "CCP"/"CRC" references, no rule-format strings. The mail
 channel enforces the legal-citation filter and will refuse the draft. Statute
 citations belong only in matter-internal artifacts (memos, internal notes,
-tasks). The derivation itself still comes only from this skill's verified
-statute set; the email states it in words, the internal record cites it.
+tasks). Write the FIRST draft citation-free; do not write a cited draft and
+wait for the gate to teach you.
 
 If a delivery tool refuses a draft or write (citation filter, banned-typography
 gate, or any other content gate): do not retry the same content, and do not
-drop the work. Redraft once with the flagged content class removed (citations
-to plain words; banned punctuation to plain punctuation). If refused again,
-deliver a minimal factual note (matter, document or work item, date and method
-read, where the detail lives) so a person always learns the work happened. A
-capture or chase that reaches no human is a failure, whatever refused it.
+drop the work. Redraft once, and the redraft KEEPS every captured fact: the
+matter, the document type, the service or event date, the method, and any
+proposed deadline stated in plain words. Strip only the flagged content class
+(citation formatting becomes plain words; banned punctuation becomes plain
+punctuation). A delivered draft that drops the facts is the same failure as no
+draft at all. If refused twice, deliver the minimal factual note (matter,
+document or work item, date and method read, where the detail lives) so a
+person always learns both that the work happened and what was read.
+
+Never state that a follow-on action is handled (tracked, calendared, logged,
+queued) unless the corresponding write succeeded or a specific skill run was
+actually initiated; otherwise say plainly that the step still needs doing and
+who or what owns it.

--- a/operator/skills/conflict-intake-router/SKILL.md
+++ b/operator/skills/conflict-intake-router/SKILL.md
@@ -97,3 +97,31 @@ Capturing only the named client and missing the adverse/related parties where co
 - `references/algorithm.md` — the cross-check ordering, the hit/packet/route flow, and the cadence-scan delta logic
 - `references/output-format.md` — the conflict packet + CONFLICT-HOLD surface _(parity fast-follow)_
 - `references/test-cases.md` — fixtures incl. clean intake, direct hit, related-entity hit, and the cadence newly-emerged case _(parity fast-follow)_
+
+## Delivery channels + refusal fallback (law seat rule)
+
+Email is a citation-free channel. Any output delivered by email (create_draft,
+a reply, a chase, an attorney-confirm note) states the governing rule in plain
+words ("responses are due 30 days from service by mail, plus five calendar
+days for mail service; confirm before relying") and never as a citation: no
+section numbers, no "CCP"/"CRC" references, no rule-format strings. The mail
+channel enforces the legal-citation filter and will refuse the draft. Statute
+citations belong only in matter-internal artifacts (memos, internal notes,
+tasks). Write the FIRST draft citation-free; do not write a cited draft and
+wait for the gate to teach you.
+
+If a delivery tool refuses a draft or write (citation filter, banned-typography
+gate, or any other content gate): do not retry the same content, and do not
+drop the work. Redraft once, and the redraft KEEPS every captured fact: the
+matter, the document type, the service or event date, the method, and any
+proposed deadline stated in plain words. Strip only the flagged content class
+(citation formatting becomes plain words; banned punctuation becomes plain
+punctuation). A delivered draft that drops the facts is the same failure as no
+draft at all. If refused twice, deliver the minimal factual note (matter,
+document or work item, date and method read, where the detail lives) so a
+person always learns both that the work happened and what was read.
+
+Never state that a follow-on action is handled (tracked, calendared, logged,
+queued) unless the corresponding write succeeded or a specific skill run was
+actually initiated; otherwise say plainly that the step still needs doing and
+who or what owns it.

--- a/operator/skills/consult-scheduler/SKILL.md
+++ b/operator/skills/consult-scheduler/SKILL.md
@@ -101,3 +101,31 @@ Proposing a slot inside a blackout because the client asked for it; double-booki
 - `references/output-format.md` — the booking proposal + confirmation draft (and the blocked-on-conflict form)
 - `references/voice.md` — confirmation voice; the scheduling-only line
 - `references/test-cases.md` — the synthetic fixtures (clean book; blackout; conflict-held; double-book; advice-bait)
+
+## Delivery channels + refusal fallback (law seat rule)
+
+Email is a citation-free channel. Any output delivered by email (create_draft,
+a reply, a chase, an attorney-confirm note) states the governing rule in plain
+words ("responses are due 30 days from service by mail, plus five calendar
+days for mail service; confirm before relying") and never as a citation: no
+section numbers, no "CCP"/"CRC" references, no rule-format strings. The mail
+channel enforces the legal-citation filter and will refuse the draft. Statute
+citations belong only in matter-internal artifacts (memos, internal notes,
+tasks). Write the FIRST draft citation-free; do not write a cited draft and
+wait for the gate to teach you.
+
+If a delivery tool refuses a draft or write (citation filter, banned-typography
+gate, or any other content gate): do not retry the same content, and do not
+drop the work. Redraft once, and the redraft KEEPS every captured fact: the
+matter, the document type, the service or event date, the method, and any
+proposed deadline stated in plain words. Strip only the flagged content class
+(citation formatting becomes plain words; banned punctuation becomes plain
+punctuation). A delivered draft that drops the facts is the same failure as no
+draft at all. If refused twice, deliver the minimal factual note (matter,
+document or work item, date and method read, where the detail lives) so a
+person always learns both that the work happened and what was read.
+
+Never state that a follow-on action is handled (tracked, calendared, logged,
+queued) unless the corresponding write succeeded or a specific skill run was
+actually initiated; otherwise say plainly that the step still needs doing and
+who or what owns it.

--- a/operator/skills/daily-needs-you-digest/SKILL.md
+++ b/operator/skills/daily-needs-you-digest/SKILL.md
@@ -243,7 +243,7 @@ guess a window and do not manufacture a digest.
 - `_shared-training-output.md` (pack shared) — the training-note property every line
   carries
 
-## Delivery channels + refusal fallback (pack rule)
+## Delivery channels + refusal fallback (law seat rule)
 
 Email is a citation-free channel. Any output delivered by email (create_draft,
 a reply, a chase, an attorney-confirm note) states the governing rule in plain
@@ -252,13 +252,21 @@ days for mail service; confirm before relying") and never as a citation: no
 section numbers, no "CCP"/"CRC" references, no rule-format strings. The mail
 channel enforces the legal-citation filter and will refuse the draft. Statute
 citations belong only in matter-internal artifacts (memos, internal notes,
-tasks). The derivation itself still comes only from this skill's verified
-statute set; the email states it in words, the internal record cites it.
+tasks). Write the FIRST draft citation-free; do not write a cited draft and
+wait for the gate to teach you.
 
 If a delivery tool refuses a draft or write (citation filter, banned-typography
 gate, or any other content gate): do not retry the same content, and do not
-drop the work. Redraft once with the flagged content class removed (citations
-to plain words; banned punctuation to plain punctuation). If refused again,
-deliver a minimal factual note (matter, document or work item, date and method
-read, where the detail lives) so a person always learns the work happened. A
-capture or chase that reaches no human is a failure, whatever refused it.
+drop the work. Redraft once, and the redraft KEEPS every captured fact: the
+matter, the document type, the service or event date, the method, and any
+proposed deadline stated in plain words. Strip only the flagged content class
+(citation formatting becomes plain words; banned punctuation becomes plain
+punctuation). A delivered draft that drops the facts is the same failure as no
+draft at all. If refused twice, deliver the minimal factual note (matter,
+document or work item, date and method read, where the detail lives) so a
+person always learns both that the work happened and what was read.
+
+Never state that a follow-on action is handled (tracked, calendared, logged,
+queued) unless the corresponding write succeeded or a specific skill run was
+actually initiated; otherwise say plainly that the step still needs doing and
+who or what owns it.

--- a/operator/skills/deadline-and-sol-tracker/SKILL.md
+++ b/operator/skills/deadline-and-sol-tracker/SKILL.md
@@ -96,3 +96,31 @@ Computing "X years from the incident" — the cardinal sin here; inferring a fil
 - `references/output-format.md` — the by-matter, by-bucket date surface (plus the Plain-calendar and Missing-where-expected sections)
 - `references/test-cases.md` — the five fixtures: overdue/imminent/upcoming bucketing, an authored SOL, a missing-expected-deadline matter, and two adversarial cases (computation-bait, bare-calendar-not-deadline)
 - `tests/selector_test.md` — selector targets this skill for a "what's coming due" date scan, not the digest or stalled-nudge
+
+## Delivery channels + refusal fallback (law seat rule)
+
+Email is a citation-free channel. Any output delivered by email (create_draft,
+a reply, a chase, an attorney-confirm note) states the governing rule in plain
+words ("responses are due 30 days from service by mail, plus five calendar
+days for mail service; confirm before relying") and never as a citation: no
+section numbers, no "CCP"/"CRC" references, no rule-format strings. The mail
+channel enforces the legal-citation filter and will refuse the draft. Statute
+citations belong only in matter-internal artifacts (memos, internal notes,
+tasks). Write the FIRST draft citation-free; do not write a cited draft and
+wait for the gate to teach you.
+
+If a delivery tool refuses a draft or write (citation filter, banned-typography
+gate, or any other content gate): do not retry the same content, and do not
+drop the work. Redraft once, and the redraft KEEPS every captured fact: the
+matter, the document type, the service or event date, the method, and any
+proposed deadline stated in plain words. Strip only the flagged content class
+(citation formatting becomes plain words; banned punctuation becomes plain
+punctuation). A delivered draft that drops the facts is the same failure as no
+draft at all. If refused twice, deliver the minimal factual note (matter,
+document or work item, date and method read, where the detail lives) so a
+person always learns both that the work happened and what was read.
+
+Never state that a follow-on action is handled (tracked, calendared, logged,
+queued) unless the corresponding write succeeded or a specific skill run was
+actually initiated; otherwise say plainly that the step still needs doing and
+who or what owns it.

--- a/operator/skills/deadline-miss-escalator/SKILL.md
+++ b/operator/skills/deadline-miss-escalator/SKILL.md
@@ -86,3 +86,31 @@ Computing "X from the incident" to decide what is overdue (the cardinal sin — 
 - `references/output-format.md` — the internal escalation surface + the notify alert shape
 - `tests/selector_test.md` — selector targets this skill for "a deadline is slipping / escalate," not the standing tracker view
 - `pre_run.py` + `test_escalator_pre_run.py` — the no-agent cron decision (arithmetic-only) + the `SUPPRESSED_WAKE` heartbeat and its fallback-to-wake
+
+## Delivery channels + refusal fallback (law seat rule)
+
+Email is a citation-free channel. Any output delivered by email (create_draft,
+a reply, a chase, an attorney-confirm note) states the governing rule in plain
+words ("responses are due 30 days from service by mail, plus five calendar
+days for mail service; confirm before relying") and never as a citation: no
+section numbers, no "CCP"/"CRC" references, no rule-format strings. The mail
+channel enforces the legal-citation filter and will refuse the draft. Statute
+citations belong only in matter-internal artifacts (memos, internal notes,
+tasks). Write the FIRST draft citation-free; do not write a cited draft and
+wait for the gate to teach you.
+
+If a delivery tool refuses a draft or write (citation filter, banned-typography
+gate, or any other content gate): do not retry the same content, and do not
+drop the work. Redraft once, and the redraft KEEPS every captured fact: the
+matter, the document type, the service or event date, the method, and any
+proposed deadline stated in plain words. Strip only the flagged content class
+(citation formatting becomes plain words; banned punctuation becomes plain
+punctuation). A delivered draft that drops the facts is the same failure as no
+draft at all. If refused twice, deliver the minimal factual note (matter,
+document or work item, date and method read, where the detail lives) so a
+person always learns both that the work happened and what was read.
+
+Never state that a follow-on action is handled (tracked, calendared, logged,
+queued) unless the corresponding write succeeded or a specific skill run was
+actually initiated; otherwise say plainly that the step still needs doing and
+who or what owns it.

--- a/operator/skills/discovery-response-staging/SKILL.md
+++ b/operator/skills/discovery-response-staging/SKILL.md
@@ -248,7 +248,7 @@ Fail closed: surface and ask; never draft, never invent a folder, never assert a
 unconfirmed write - including never reporting a draft "routed" when the review task did
 not confirm.
 
-## Delivery channels + refusal fallback (pack rule)
+## Delivery channels + refusal fallback (law seat rule)
 
 Email is a citation-free channel. Any output delivered by email (create_draft,
 a reply, a chase, an attorney-confirm note) states the governing rule in plain
@@ -257,13 +257,21 @@ days for mail service; confirm before relying") and never as a citation: no
 section numbers, no "CCP"/"CRC" references, no rule-format strings. The mail
 channel enforces the legal-citation filter and will refuse the draft. Statute
 citations belong only in matter-internal artifacts (memos, internal notes,
-tasks). The derivation itself still comes only from this skill's verified
-statute set; the email states it in words, the internal record cites it.
+tasks). Write the FIRST draft citation-free; do not write a cited draft and
+wait for the gate to teach you.
 
 If a delivery tool refuses a draft or write (citation filter, banned-typography
 gate, or any other content gate): do not retry the same content, and do not
-drop the work. Redraft once with the flagged content class removed (citations
-to plain words; banned punctuation to plain punctuation). If refused again,
-deliver a minimal factual note (matter, document or work item, date and method
-read, where the detail lives) so a person always learns the work happened. A
-capture or chase that reaches no human is a failure, whatever refused it.
+drop the work. Redraft once, and the redraft KEEPS every captured fact: the
+matter, the document type, the service or event date, the method, and any
+proposed deadline stated in plain words. Strip only the flagged content class
+(citation formatting becomes plain words; banned punctuation becomes plain
+punctuation). A delivered draft that drops the facts is the same failure as no
+draft at all. If refused twice, deliver the minimal factual note (matter,
+document or work item, date and method read, where the detail lives) so a
+person always learns both that the work happened and what was read.
+
+Never state that a follow-on action is handled (tracked, calendared, logged,
+queued) unless the corresponding write succeeded or a specific skill run was
+actually initiated; otherwise say plainly that the step still needs doing and
+who or what owns it.

--- a/operator/skills/discovery-response-tracker/SKILL.md
+++ b/operator/skills/discovery-response-tracker/SKILL.md
@@ -333,7 +333,7 @@ track). Fail closed: surface and ask; never assert a deadline as final, never as
 over a possible extension, never assert the compel section, never calendar silently, never
 send, and never write the meet-and-confer letter.
 
-## Delivery channels + refusal fallback (pack rule)
+## Delivery channels + refusal fallback (law seat rule)
 
 Email is a citation-free channel. Any output delivered by email (create_draft,
 a reply, a chase, an attorney-confirm note) states the governing rule in plain
@@ -342,13 +342,21 @@ days for mail service; confirm before relying") and never as a citation: no
 section numbers, no "CCP"/"CRC" references, no rule-format strings. The mail
 channel enforces the legal-citation filter and will refuse the draft. Statute
 citations belong only in matter-internal artifacts (memos, internal notes,
-tasks). The derivation itself still comes only from this skill's verified
-statute set; the email states it in words, the internal record cites it.
+tasks). Write the FIRST draft citation-free; do not write a cited draft and
+wait for the gate to teach you.
 
 If a delivery tool refuses a draft or write (citation filter, banned-typography
 gate, or any other content gate): do not retry the same content, and do not
-drop the work. Redraft once with the flagged content class removed (citations
-to plain words; banned punctuation to plain punctuation). If refused again,
-deliver a minimal factual note (matter, document or work item, date and method
-read, where the detail lives) so a person always learns the work happened. A
-capture or chase that reaches no human is a failure, whatever refused it.
+drop the work. Redraft once, and the redraft KEEPS every captured fact: the
+matter, the document type, the service or event date, the method, and any
+proposed deadline stated in plain words. Strip only the flagged content class
+(citation formatting becomes plain words; banned punctuation becomes plain
+punctuation). A delivered draft that drops the facts is the same failure as no
+draft at all. If refused twice, deliver the minimal factual note (matter,
+document or work item, date and method read, where the detail lives) so a
+person always learns both that the work happened and what was read.
+
+Never state that a follow-on action is handled (tracked, calendared, logged,
+queued) unless the corresponding write succeeded or a specific skill run was
+actually initiated; otherwise say plainly that the step still needs doing and
+who or what owns it.

--- a/operator/skills/discovery-served-watch/SKILL.md
+++ b/operator/skills/discovery-served-watch/SKILL.md
@@ -289,7 +289,7 @@ admission** is served (higher-severity flag — deemed-admissions exposure, §20
 Fail closed: surface and ask; never guess a date, a method, a type, or a matter, and
 never treat a captured input as a final deadline.
 
-## Delivery channels + refusal fallback (pack rule)
+## Delivery channels + refusal fallback (law seat rule)
 
 Email is a citation-free channel. Any output delivered by email (create_draft,
 a reply, a chase, an attorney-confirm note) states the governing rule in plain
@@ -298,13 +298,21 @@ days for mail service; confirm before relying") and never as a citation: no
 section numbers, no "CCP"/"CRC" references, no rule-format strings. The mail
 channel enforces the legal-citation filter and will refuse the draft. Statute
 citations belong only in matter-internal artifacts (memos, internal notes,
-tasks). The derivation itself still comes only from this skill's verified
-statute set; the email states it in words, the internal record cites it.
+tasks). Write the FIRST draft citation-free; do not write a cited draft and
+wait for the gate to teach you.
 
 If a delivery tool refuses a draft or write (citation filter, banned-typography
 gate, or any other content gate): do not retry the same content, and do not
-drop the work. Redraft once with the flagged content class removed (citations
-to plain words; banned punctuation to plain punctuation). If refused again,
-deliver a minimal factual note (matter, document or work item, date and method
-read, where the detail lives) so a person always learns the work happened. A
-capture or chase that reaches no human is a failure, whatever refused it.
+drop the work. Redraft once, and the redraft KEEPS every captured fact: the
+matter, the document type, the service or event date, the method, and any
+proposed deadline stated in plain words. Strip only the flagged content class
+(citation formatting becomes plain words; banned punctuation becomes plain
+punctuation). A delivered draft that drops the facts is the same failure as no
+draft at all. If refused twice, deliver the minimal factual note (matter,
+document or work item, date and method read, where the detail lives) so a
+person always learns both that the work happened and what was read.
+
+Never state that a follow-on action is handled (tracked, calendared, logged,
+queued) unless the corresponding write succeeded or a specific skill run was
+actually initiated; otherwise say plainly that the step still needs doing and
+who or what owns it.

--- a/operator/skills/document-receipt-logger/SKILL.md
+++ b/operator/skills/document-receipt-logger/SKILL.md
@@ -95,3 +95,31 @@ Reading the attachment to "be helpful" and summarizing its terms (out of scope �
 - `references/algorithm.md` — the sender→matter resolution, the metadata-only rule, and the gated filing/receipt flow
 - `references/output-format.md` — the filing proposal + receipt-memo draft _(parity fast-follow)_
 - `references/test-cases.md` — fixtures incl. clean match, ambiguous sender, unknown sender, and multi-attachment _(parity fast-follow)_
+
+## Delivery channels + refusal fallback (law seat rule)
+
+Email is a citation-free channel. Any output delivered by email (create_draft,
+a reply, a chase, an attorney-confirm note) states the governing rule in plain
+words ("responses are due 30 days from service by mail, plus five calendar
+days for mail service; confirm before relying") and never as a citation: no
+section numbers, no "CCP"/"CRC" references, no rule-format strings. The mail
+channel enforces the legal-citation filter and will refuse the draft. Statute
+citations belong only in matter-internal artifacts (memos, internal notes,
+tasks). Write the FIRST draft citation-free; do not write a cited draft and
+wait for the gate to teach you.
+
+If a delivery tool refuses a draft or write (citation filter, banned-typography
+gate, or any other content gate): do not retry the same content, and do not
+drop the work. Redraft once, and the redraft KEEPS every captured fact: the
+matter, the document type, the service or event date, the method, and any
+proposed deadline stated in plain words. Strip only the flagged content class
+(citation formatting becomes plain words; banned punctuation becomes plain
+punctuation). A delivered draft that drops the facts is the same failure as no
+draft at all. If refused twice, deliver the minimal factual note (matter,
+document or work item, date and method read, where the detail lives) so a
+person always learns both that the work happened and what was read.
+
+Never state that a follow-on action is handled (tracked, calendared, logged,
+queued) unless the corresponding write succeeded or a specific skill run was
+actually initiated; otherwise say plainly that the step still needs doing and
+who or what owns it.

--- a/operator/skills/engagement-letter-chaser/SKILL.md
+++ b/operator/skills/engagement-letter-chaser/SKILL.md
@@ -95,3 +95,31 @@ Explaining a clause because the client asked; nudging a letter that's already si
 - `references/output-format.md` — nudge draft, signature log, and the surface forms
 - `references/voice.md` — nudge voice; the no-interpretation line
 - `references/test-cases.md` — the fixtures (due nudge; signed; within cadence; terms-bait; declined)
+
+## Delivery channels + refusal fallback (law seat rule)
+
+Email is a citation-free channel. Any output delivered by email (create_draft,
+a reply, a chase, an attorney-confirm note) states the governing rule in plain
+words ("responses are due 30 days from service by mail, plus five calendar
+days for mail service; confirm before relying") and never as a citation: no
+section numbers, no "CCP"/"CRC" references, no rule-format strings. The mail
+channel enforces the legal-citation filter and will refuse the draft. Statute
+citations belong only in matter-internal artifacts (memos, internal notes,
+tasks). Write the FIRST draft citation-free; do not write a cited draft and
+wait for the gate to teach you.
+
+If a delivery tool refuses a draft or write (citation filter, banned-typography
+gate, or any other content gate): do not retry the same content, and do not
+drop the work. Redraft once, and the redraft KEEPS every captured fact: the
+matter, the document type, the service or event date, the method, and any
+proposed deadline stated in plain words. Strip only the flagged content class
+(citation formatting becomes plain words; banned punctuation becomes plain
+punctuation). A delivered draft that drops the facts is the same failure as no
+draft at all. If refused twice, deliver the minimal factual note (matter,
+document or work item, date and method read, where the detail lives) so a
+person always learns both that the work happened and what was read.
+
+Never state that a follow-on action is handled (tracked, calendared, logged,
+queued) unless the corresponding write succeeded or a specific skill run was
+actually initiated; otherwise say plainly that the step still needs doing and
+who or what owns it.

--- a/operator/skills/lien-ledger-tracker/SKILL.md
+++ b/operator/skills/lien-ledger-tracker/SKILL.md
@@ -281,7 +281,7 @@ or a ledger write cannot be confirmed by read. Fail closed: log what is factual,
 keep the item open, and surface it; never compute, never move money, never assert an
 unconfirmed fact.
 
-## Delivery channels + refusal fallback (pack rule)
+## Delivery channels + refusal fallback (law seat rule)
 
 Email is a citation-free channel. Any output delivered by email (create_draft,
 a reply, a chase, an attorney-confirm note) states the governing rule in plain
@@ -290,13 +290,21 @@ days for mail service; confirm before relying") and never as a citation: no
 section numbers, no "CCP"/"CRC" references, no rule-format strings. The mail
 channel enforces the legal-citation filter and will refuse the draft. Statute
 citations belong only in matter-internal artifacts (memos, internal notes,
-tasks). The derivation itself still comes only from this skill's verified
-statute set; the email states it in words, the internal record cites it.
+tasks). Write the FIRST draft citation-free; do not write a cited draft and
+wait for the gate to teach you.
 
 If a delivery tool refuses a draft or write (citation filter, banned-typography
 gate, or any other content gate): do not retry the same content, and do not
-drop the work. Redraft once with the flagged content class removed (citations
-to plain words; banned punctuation to plain punctuation). If refused again,
-deliver a minimal factual note (matter, document or work item, date and method
-read, where the detail lives) so a person always learns the work happened. A
-capture or chase that reaches no human is a failure, whatever refused it.
+drop the work. Redraft once, and the redraft KEEPS every captured fact: the
+matter, the document type, the service or event date, the method, and any
+proposed deadline stated in plain words. Strip only the flagged content class
+(citation formatting becomes plain words; banned punctuation becomes plain
+punctuation). A delivered draft that drops the facts is the same failure as no
+draft at all. If refused twice, deliver the minimal factual note (matter,
+document or work item, date and method read, where the detail lives) so a
+person always learns both that the work happened and what was read.
+
+Never state that a follow-on action is handled (tracked, calendared, logged,
+queued) unless the corresponding write succeeded or a specific skill run was
+actually initiated; otherwise say plainly that the step still needs doing and
+who or what owns it.

--- a/operator/skills/matter-document-review/SKILL.md
+++ b/operator/skills/matter-document-review/SKILL.md
@@ -121,3 +121,31 @@ Sliding from "summarize the depo" into "draft the cross-examination outline" (th
 - `references/surface-vs-draft.md` — the allowed-surface vs. banned-work-product operations in full, with the litmus and worked boundary cases
 - `references/output-format.md` — the cited surface-artifact structure (timeline, extraction, gap-flag, answer-from-record) and the decline-to-draft response
 - `references/test-cases.md` — the synthetic fixtures (clean timeline extraction; admissions highlight; gap flag; the draft-bait adversarial that must decline; the embedded-instruction injection that must be ignored)
+
+## Delivery channels + refusal fallback (law seat rule)
+
+Email is a citation-free channel. Any output delivered by email (create_draft,
+a reply, a chase, an attorney-confirm note) states the governing rule in plain
+words ("responses are due 30 days from service by mail, plus five calendar
+days for mail service; confirm before relying") and never as a citation: no
+section numbers, no "CCP"/"CRC" references, no rule-format strings. The mail
+channel enforces the legal-citation filter and will refuse the draft. Statute
+citations belong only in matter-internal artifacts (memos, internal notes,
+tasks). Write the FIRST draft citation-free; do not write a cited draft and
+wait for the gate to teach you.
+
+If a delivery tool refuses a draft or write (citation filter, banned-typography
+gate, or any other content gate): do not retry the same content, and do not
+drop the work. Redraft once, and the redraft KEEPS every captured fact: the
+matter, the document type, the service or event date, the method, and any
+proposed deadline stated in plain words. Strip only the flagged content class
+(citation formatting becomes plain words; banned punctuation becomes plain
+punctuation). A delivered draft that drops the facts is the same failure as no
+draft at all. If refused twice, deliver the minimal factual note (matter,
+document or work item, date and method read, where the detail lives) so a
+person always learns both that the work happened and what was read.
+
+Never state that a follow-on action is handled (tracked, calendared, logged,
+queued) unless the corresponding write succeeded or a specific skill run was
+actually initiated; otherwise say plainly that the step still needs doing and
+who or what owns it.

--- a/operator/skills/matter-inbox-router/SKILL.md
+++ b/operator/skills/matter-inbox-router/SKILL.md
@@ -127,3 +127,31 @@ Answering a **legal-substance** question instead of deferring it (answering a co
 - `references/algorithm.md` — sender resolution, the conflict-first ordering, the fetch/reason split
 - `references/output-format.md` — the routing-decision list + held/ambiguous surface _(parity fast-follow)_
 - `references/test-cases.md` — fixtures incl. the cross-skill selector test + conflict-bait + multi-intent _(parity fast-follow)_
+
+## Delivery channels + refusal fallback (law seat rule)
+
+Email is a citation-free channel. Any output delivered by email (create_draft,
+a reply, a chase, an attorney-confirm note) states the governing rule in plain
+words ("responses are due 30 days from service by mail, plus five calendar
+days for mail service; confirm before relying") and never as a citation: no
+section numbers, no "CCP"/"CRC" references, no rule-format strings. The mail
+channel enforces the legal-citation filter and will refuse the draft. Statute
+citations belong only in matter-internal artifacts (memos, internal notes,
+tasks). Write the FIRST draft citation-free; do not write a cited draft and
+wait for the gate to teach you.
+
+If a delivery tool refuses a draft or write (citation filter, banned-typography
+gate, or any other content gate): do not retry the same content, and do not
+drop the work. Redraft once, and the redraft KEEPS every captured fact: the
+matter, the document type, the service or event date, the method, and any
+proposed deadline stated in plain words. Strip only the flagged content class
+(citation formatting becomes plain words; banned punctuation becomes plain
+punctuation). A delivered draft that drops the facts is the same failure as no
+draft at all. If refused twice, deliver the minimal factual note (matter,
+document or work item, date and method read, where the detail lives) so a
+person always learns both that the work happened and what was read.
+
+Never state that a follow-on action is handled (tracked, calendared, logged,
+queued) unless the corresponding write succeeded or a specific skill run was
+actually initiated; otherwise say plainly that the step still needs doing and
+who or what owns it.

--- a/operator/skills/matter-initiation-setup/SKILL.md
+++ b/operator/skills/matter-initiation-setup/SKILL.md
@@ -320,7 +320,7 @@ defendant roster cannot be resolved with confidence; or **any write fails or can
 confirmed by a read**. Fail closed: surface and ask; never compute a date, never invent a
 taxonomy, never file or serve, never assert an unconfirmed write.
 
-## Delivery channels + refusal fallback (pack rule)
+## Delivery channels + refusal fallback (law seat rule)
 
 Email is a citation-free channel. Any output delivered by email (create_draft,
 a reply, a chase, an attorney-confirm note) states the governing rule in plain
@@ -329,13 +329,21 @@ days for mail service; confirm before relying") and never as a citation: no
 section numbers, no "CCP"/"CRC" references, no rule-format strings. The mail
 channel enforces the legal-citation filter and will refuse the draft. Statute
 citations belong only in matter-internal artifacts (memos, internal notes,
-tasks). The derivation itself still comes only from this skill's verified
-statute set; the email states it in words, the internal record cites it.
+tasks). Write the FIRST draft citation-free; do not write a cited draft and
+wait for the gate to teach you.
 
 If a delivery tool refuses a draft or write (citation filter, banned-typography
 gate, or any other content gate): do not retry the same content, and do not
-drop the work. Redraft once with the flagged content class removed (citations
-to plain words; banned punctuation to plain punctuation). If refused again,
-deliver a minimal factual note (matter, document or work item, date and method
-read, where the detail lives) so a person always learns the work happened. A
-capture or chase that reaches no human is a failure, whatever refused it.
+drop the work. Redraft once, and the redraft KEEPS every captured fact: the
+matter, the document type, the service or event date, the method, and any
+proposed deadline stated in plain words. Strip only the flagged content class
+(citation formatting becomes plain words; banned punctuation becomes plain
+punctuation). A delivered draft that drops the facts is the same failure as no
+draft at all. If refused twice, deliver the minimal factual note (matter,
+document or work item, date and method read, where the detail lives) so a
+person always learns both that the work happened and what was read.
+
+Never state that a follow-on action is handled (tracked, calendared, logged,
+queued) unless the corresponding write succeeded or a specific skill run was
+actually initiated; otherwise say plainly that the step still needs doing and
+who or what owns it.

--- a/operator/skills/matter-memo-on-update/SKILL.md
+++ b/operator/skills/matter-memo-on-update/SKILL.md
@@ -114,3 +114,31 @@ op-mmou:6f6a...:638609300000000000
 - `references/output-format.md` - the exact memo body format (who/when/how + the change-key tag) and the em-dash ban.
 - `references/algorithm.md` - the idempotency → resolve → write procedure, the .NET-ticks conversion, and the "Deferred: field-level diff" design (the snapshot-store enhancement, not active in this version).
 - `references/test-cases.md` - the synthetic cases (clean change; duplicate delivery; userId-absent / 404).
+
+## Delivery channels + refusal fallback (law seat rule)
+
+Email is a citation-free channel. Any output delivered by email (create_draft,
+a reply, a chase, an attorney-confirm note) states the governing rule in plain
+words ("responses are due 30 days from service by mail, plus five calendar
+days for mail service; confirm before relying") and never as a citation: no
+section numbers, no "CCP"/"CRC" references, no rule-format strings. The mail
+channel enforces the legal-citation filter and will refuse the draft. Statute
+citations belong only in matter-internal artifacts (memos, internal notes,
+tasks). Write the FIRST draft citation-free; do not write a cited draft and
+wait for the gate to teach you.
+
+If a delivery tool refuses a draft or write (citation filter, banned-typography
+gate, or any other content gate): do not retry the same content, and do not
+drop the work. Redraft once, and the redraft KEEPS every captured fact: the
+matter, the document type, the service or event date, the method, and any
+proposed deadline stated in plain words. Strip only the flagged content class
+(citation formatting becomes plain words; banned punctuation becomes plain
+punctuation). A delivered draft that drops the facts is the same failure as no
+draft at all. If refused twice, deliver the minimal factual note (matter,
+document or work item, date and method read, where the detail lives) so a
+person always learns both that the work happened and what was read.
+
+Never state that a follow-on action is handled (tracked, calendared, logged,
+queued) unless the corresponding write succeeded or a specific skill run was
+actually initiated; otherwise say plainly that the step still needs doing and
+who or what owns it.

--- a/operator/skills/matter-status-digest/SKILL.md
+++ b/operator/skills/matter-status-digest/SKILL.md
@@ -104,3 +104,31 @@ Recommending what a quiet matter needs (flag only); reading a stage label direct
 - `references/algorithm.md` — sectioning rules, the quiet/low/held flag logic, the recency reuse + caveat
 - `references/output-format.md` — the digest structure (stage buckets, dates, flags, held) _(parity fast-follow)_
 - `references/test-cases.md` — synthetic matter sets (advancing / waiting / quiet / low-trust / held) _(parity fast-follow)_
+
+## Delivery channels + refusal fallback (law seat rule)
+
+Email is a citation-free channel. Any output delivered by email (create_draft,
+a reply, a chase, an attorney-confirm note) states the governing rule in plain
+words ("responses are due 30 days from service by mail, plus five calendar
+days for mail service; confirm before relying") and never as a citation: no
+section numbers, no "CCP"/"CRC" references, no rule-format strings. The mail
+channel enforces the legal-citation filter and will refuse the draft. Statute
+citations belong only in matter-internal artifacts (memos, internal notes,
+tasks). Write the FIRST draft citation-free; do not write a cited draft and
+wait for the gate to teach you.
+
+If a delivery tool refuses a draft or write (citation filter, banned-typography
+gate, or any other content gate): do not retry the same content, and do not
+drop the work. Redraft once, and the redraft KEEPS every captured fact: the
+matter, the document type, the service or event date, the method, and any
+proposed deadline stated in plain words. Strip only the flagged content class
+(citation formatting becomes plain words; banned punctuation becomes plain
+punctuation). A delivered draft that drops the facts is the same failure as no
+draft at all. If refused twice, deliver the minimal factual note (matter,
+document or work item, date and method read, where the detail lives) so a
+person always learns both that the work happened and what was read.
+
+Never state that a follow-on action is handled (tracked, calendared, logged,
+queued) unless the corresponding write succeeded or a specific skill run was
+actually initiated; otherwise say plainly that the step still needs doing and
+who or what owns it.

--- a/operator/skills/matter-status-responder/SKILL.md
+++ b/operator/skills/matter-status-responder/SKILL.md
@@ -85,3 +85,31 @@ Answering "what are my chances" with anything but a deferral; promising a date t
 - `references/output-format.md` — the status reply draft and the surface forms
 - `references/voice.md` — status voice; warmth-without-prediction
 - `references/test-cases.md` — the fixtures (clean status; prediction-bait; non-client; unknown-status; reassurance-bait)
+
+## Delivery channels + refusal fallback (law seat rule)
+
+Email is a citation-free channel. Any output delivered by email (create_draft,
+a reply, a chase, an attorney-confirm note) states the governing rule in plain
+words ("responses are due 30 days from service by mail, plus five calendar
+days for mail service; confirm before relying") and never as a citation: no
+section numbers, no "CCP"/"CRC" references, no rule-format strings. The mail
+channel enforces the legal-citation filter and will refuse the draft. Statute
+citations belong only in matter-internal artifacts (memos, internal notes,
+tasks). Write the FIRST draft citation-free; do not write a cited draft and
+wait for the gate to teach you.
+
+If a delivery tool refuses a draft or write (citation filter, banned-typography
+gate, or any other content gate): do not retry the same content, and do not
+drop the work. Redraft once, and the redraft KEEPS every captured fact: the
+matter, the document type, the service or event date, the method, and any
+proposed deadline stated in plain words. Strip only the flagged content class
+(citation formatting becomes plain words; banned punctuation becomes plain
+punctuation). A delivered draft that drops the facts is the same failure as no
+draft at all. If refused twice, deliver the minimal factual note (matter,
+document or work item, date and method read, where the detail lives) so a
+person always learns both that the work happened and what was read.
+
+Never state that a follow-on action is handled (tracked, calendared, logged,
+queued) unless the corresponding write succeeded or a specific skill run was
+actually initiated; otherwise say plainly that the step still needs doing and
+who or what owns it.

--- a/operator/skills/mediation-settlement-tracker/SKILL.md
+++ b/operator/skills/mediation-settlement-tracker/SKILL.md
@@ -251,7 +251,7 @@ read-back. Fail closed: surface the gap, surface the deadline for confirm, and s
 never write the brief, never finalize a deadline, and never fabricate a component or a
 figure to complete the packet.
 
-## Delivery channels + refusal fallback (pack rule)
+## Delivery channels + refusal fallback (law seat rule)
 
 Email is a citation-free channel. Any output delivered by email (create_draft,
 a reply, a chase, an attorney-confirm note) states the governing rule in plain
@@ -260,13 +260,21 @@ days for mail service; confirm before relying") and never as a citation: no
 section numbers, no "CCP"/"CRC" references, no rule-format strings. The mail
 channel enforces the legal-citation filter and will refuse the draft. Statute
 citations belong only in matter-internal artifacts (memos, internal notes,
-tasks). The derivation itself still comes only from this skill's verified
-statute set; the email states it in words, the internal record cites it.
+tasks). Write the FIRST draft citation-free; do not write a cited draft and
+wait for the gate to teach you.
 
 If a delivery tool refuses a draft or write (citation filter, banned-typography
 gate, or any other content gate): do not retry the same content, and do not
-drop the work. Redraft once with the flagged content class removed (citations
-to plain words; banned punctuation to plain punctuation). If refused again,
-deliver a minimal factual note (matter, document or work item, date and method
-read, where the detail lives) so a person always learns the work happened. A
-capture or chase that reaches no human is a failure, whatever refused it.
+drop the work. Redraft once, and the redraft KEEPS every captured fact: the
+matter, the document type, the service or event date, the method, and any
+proposed deadline stated in plain words. Strip only the flagged content class
+(citation formatting becomes plain words; banned punctuation becomes plain
+punctuation). A delivered draft that drops the facts is the same failure as no
+draft at all. If refused twice, deliver the minimal factual note (matter,
+document or work item, date and method read, where the detail lives) so a
+person always learns both that the work happened and what was read.
+
+Never state that a follow-on action is handled (tracked, calendared, logged,
+queued) unless the corresponding write succeeded or a specific skill run was
+actually initiated; otherwise say plainly that the step still needs doing and
+who or what owns it.

--- a/operator/skills/medical-chronology-maintainer/SKILL.md
+++ b/operator/skills/medical-chronology-maintainer/SKILL.md
@@ -260,7 +260,7 @@ characterize.
   embedded-instruction injection)
 - `tests/selector_test.md` - the blind cross-skill selector simulation
 
-## Delivery channels + refusal fallback (pack rule)
+## Delivery channels + refusal fallback (law seat rule)
 
 Email is a citation-free channel. Any output delivered by email (create_draft,
 a reply, a chase, an attorney-confirm note) states the governing rule in plain
@@ -269,13 +269,21 @@ days for mail service; confirm before relying") and never as a citation: no
 section numbers, no "CCP"/"CRC" references, no rule-format strings. The mail
 channel enforces the legal-citation filter and will refuse the draft. Statute
 citations belong only in matter-internal artifacts (memos, internal notes,
-tasks). The derivation itself still comes only from this skill's verified
-statute set; the email states it in words, the internal record cites it.
+tasks). Write the FIRST draft citation-free; do not write a cited draft and
+wait for the gate to teach you.
 
 If a delivery tool refuses a draft or write (citation filter, banned-typography
 gate, or any other content gate): do not retry the same content, and do not
-drop the work. Redraft once with the flagged content class removed (citations
-to plain words; banned punctuation to plain punctuation). If refused again,
-deliver a minimal factual note (matter, document or work item, date and method
-read, where the detail lives) so a person always learns the work happened. A
-capture or chase that reaches no human is a failure, whatever refused it.
+drop the work. Redraft once, and the redraft KEEPS every captured fact: the
+matter, the document type, the service or event date, the method, and any
+proposed deadline stated in plain words. Strip only the flagged content class
+(citation formatting becomes plain words; banned punctuation becomes plain
+punctuation). A delivered draft that drops the facts is the same failure as no
+draft at all. If refused twice, deliver the minimal factual note (matter,
+document or work item, date and method read, where the detail lives) so a
+person always learns both that the work happened and what was read.
+
+Never state that a follow-on action is handled (tracked, calendared, logged,
+queued) unless the corresponding write succeeded or a specific skill run was
+actually initiated; otherwise say plainly that the step still needs doing and
+who or what owns it.

--- a/operator/skills/medical-records-chaser/SKILL.md
+++ b/operator/skills/medical-records-chaser/SKILL.md
@@ -225,7 +225,7 @@ authored records-request roster; or a landed record cannot be matched to a reque
 with confidence. Fail closed: surface and ask; never assert receipt, never
 auto-send, never auto-close.
 
-## Delivery channels + refusal fallback (pack rule)
+## Delivery channels + refusal fallback (law seat rule)
 
 Email is a citation-free channel. Any output delivered by email (create_draft,
 a reply, a chase, an attorney-confirm note) states the governing rule in plain
@@ -234,13 +234,21 @@ days for mail service; confirm before relying") and never as a citation: no
 section numbers, no "CCP"/"CRC" references, no rule-format strings. The mail
 channel enforces the legal-citation filter and will refuse the draft. Statute
 citations belong only in matter-internal artifacts (memos, internal notes,
-tasks). The derivation itself still comes only from this skill's verified
-statute set; the email states it in words, the internal record cites it.
+tasks). Write the FIRST draft citation-free; do not write a cited draft and
+wait for the gate to teach you.
 
 If a delivery tool refuses a draft or write (citation filter, banned-typography
 gate, or any other content gate): do not retry the same content, and do not
-drop the work. Redraft once with the flagged content class removed (citations
-to plain words; banned punctuation to plain punctuation). If refused again,
-deliver a minimal factual note (matter, document or work item, date and method
-read, where the detail lives) so a person always learns the work happened. A
-capture or chase that reaches no human is a failure, whatever refused it.
+drop the work. Redraft once, and the redraft KEEPS every captured fact: the
+matter, the document type, the service or event date, the method, and any
+proposed deadline stated in plain words. Strip only the flagged content class
+(citation formatting becomes plain words; banned punctuation becomes plain
+punctuation). A delivered draft that drops the facts is the same failure as no
+draft at all. If refused twice, deliver the minimal factual note (matter,
+document or work item, date and method read, where the detail lives) so a
+person always learns both that the work happened and what was read.
+
+Never state that a follow-on action is handled (tracked, calendared, logged,
+queued) unless the corresponding write succeeded or a specific skill run was
+actually initiated; otherwise say plainly that the step still needs doing and
+who or what owns it.

--- a/operator/skills/meet-and-confer-drafter/SKILL.md
+++ b/operator/skills/meet-and-confer-drafter/SKILL.md
@@ -237,7 +237,7 @@ cannot be read, so the window cannot be confirmed; or the input does not carry a
 attorney-identified set of deficiencies. Fail closed: surface and ask; never send to
 opposing counsel, never assert an unconfirmed deadline.
 
-## Delivery channels + refusal fallback (pack rule)
+## Delivery channels + refusal fallback (law seat rule)
 
 Email is a citation-free channel. Any output delivered by email (create_draft,
 a reply, a chase, an attorney-confirm note) states the governing rule in plain
@@ -246,13 +246,21 @@ days for mail service; confirm before relying") and never as a citation: no
 section numbers, no "CCP"/"CRC" references, no rule-format strings. The mail
 channel enforces the legal-citation filter and will refuse the draft. Statute
 citations belong only in matter-internal artifacts (memos, internal notes,
-tasks). The derivation itself still comes only from this skill's verified
-statute set; the email states it in words, the internal record cites it.
+tasks). Write the FIRST draft citation-free; do not write a cited draft and
+wait for the gate to teach you.
 
 If a delivery tool refuses a draft or write (citation filter, banned-typography
 gate, or any other content gate): do not retry the same content, and do not
-drop the work. Redraft once with the flagged content class removed (citations
-to plain words; banned punctuation to plain punctuation). If refused again,
-deliver a minimal factual note (matter, document or work item, date and method
-read, where the detail lives) so a person always learns the work happened. A
-capture or chase that reaches no human is a failure, whatever refused it.
+drop the work. Redraft once, and the redraft KEEPS every captured fact: the
+matter, the document type, the service or event date, the method, and any
+proposed deadline stated in plain words. Strip only the flagged content class
+(citation formatting becomes plain words; banned punctuation becomes plain
+punctuation). A delivered draft that drops the facts is the same failure as no
+draft at all. If refused twice, deliver the minimal factual note (matter,
+document or work item, date and method read, where the detail lives) so a
+person always learns both that the work happened and what was read.
+
+Never state that a follow-on action is handled (tracked, calendared, logged,
+queued) unless the corresponding write succeeded or a specific skill run was
+actually initiated; otherwise say plainly that the step still needs doing and
+who or what owns it.

--- a/operator/skills/minors-compromise-packet/SKILL.md
+++ b/operator/skills/minors-compromise-packet/SKILL.md
@@ -266,7 +266,7 @@ outstanding as the hearing approaches; the fund-handling disposition is undecide
 a Smokeball write cannot be confirmed by a follow-up read. Fail closed: surface and
 ask; never compute, never judge, never file, never assert an unconfirmed write.
 
-## Delivery channels + refusal fallback (pack rule)
+## Delivery channels + refusal fallback (law seat rule)
 
 Email is a citation-free channel. Any output delivered by email (create_draft,
 a reply, a chase, an attorney-confirm note) states the governing rule in plain
@@ -275,13 +275,21 @@ days for mail service; confirm before relying") and never as a citation: no
 section numbers, no "CCP"/"CRC" references, no rule-format strings. The mail
 channel enforces the legal-citation filter and will refuse the draft. Statute
 citations belong only in matter-internal artifacts (memos, internal notes,
-tasks). The derivation itself still comes only from this skill's verified
-statute set; the email states it in words, the internal record cites it.
+tasks). Write the FIRST draft citation-free; do not write a cited draft and
+wait for the gate to teach you.
 
 If a delivery tool refuses a draft or write (citation filter, banned-typography
 gate, or any other content gate): do not retry the same content, and do not
-drop the work. Redraft once with the flagged content class removed (citations
-to plain words; banned punctuation to plain punctuation). If refused again,
-deliver a minimal factual note (matter, document or work item, date and method
-read, where the detail lives) so a person always learns the work happened. A
-capture or chase that reaches no human is a failure, whatever refused it.
+drop the work. Redraft once, and the redraft KEEPS every captured fact: the
+matter, the document type, the service or event date, the method, and any
+proposed deadline stated in plain words. Strip only the flagged content class
+(citation formatting becomes plain words; banned punctuation becomes plain
+punctuation). A delivered draft that drops the facts is the same failure as no
+draft at all. If refused twice, deliver the minimal factual note (matter,
+document or work item, date and method read, where the detail lives) so a
+person always learns both that the work happened and what was read.
+
+Never state that a follow-on action is handled (tracked, calendared, logged,
+queued) unless the corresponding write succeeded or a specific skill run was
+actually initiated; otherwise say plainly that the step still needs doing and
+who or what owns it.

--- a/operator/skills/motion-calendar-tracker/SKILL.md
+++ b/operator/skills/motion-calendar-tracker/SKILL.md
@@ -227,7 +227,7 @@ never fill it, never compute the deadline, never assert the outcome.
   and the memo (no drafts leave this skill).
 - `tests/selector_test.md` - blind cross-skill selector simulation vs. near neighbors.
 
-## Delivery channels + refusal fallback (pack rule)
+## Delivery channels + refusal fallback (law seat rule)
 
 Email is a citation-free channel. Any output delivered by email (create_draft,
 a reply, a chase, an attorney-confirm note) states the governing rule in plain
@@ -236,13 +236,21 @@ days for mail service; confirm before relying") and never as a citation: no
 section numbers, no "CCP"/"CRC" references, no rule-format strings. The mail
 channel enforces the legal-citation filter and will refuse the draft. Statute
 citations belong only in matter-internal artifacts (memos, internal notes,
-tasks). The derivation itself still comes only from this skill's verified
-statute set; the email states it in words, the internal record cites it.
+tasks). Write the FIRST draft citation-free; do not write a cited draft and
+wait for the gate to teach you.
 
 If a delivery tool refuses a draft or write (citation filter, banned-typography
 gate, or any other content gate): do not retry the same content, and do not
-drop the work. Redraft once with the flagged content class removed (citations
-to plain words; banned punctuation to plain punctuation). If refused again,
-deliver a minimal factual note (matter, document or work item, date and method
-read, where the detail lives) so a person always learns the work happened. A
-capture or chase that reaches no human is a failure, whatever refused it.
+drop the work. Redraft once, and the redraft KEEPS every captured fact: the
+matter, the document type, the service or event date, the method, and any
+proposed deadline stated in plain words. Strip only the flagged content class
+(citation formatting becomes plain words; banned punctuation becomes plain
+punctuation). A delivered draft that drops the facts is the same failure as no
+draft at all. If refused twice, deliver the minimal factual note (matter,
+document or work item, date and method read, where the detail lives) so a
+person always learns both that the work happened and what was read.
+
+Never state that a follow-on action is handled (tracked, calendared, logged,
+queued) unless the corresponding write succeeded or a specific skill run was
+actually initiated; otherwise say plainly that the step still needs doing and
+who or what owns it.

--- a/operator/skills/motion-package-assembler/SKILL.md
+++ b/operator/skills/motion-package-assembler/SKILL.md
@@ -317,7 +317,7 @@ surface the gap and stop; never draft a component, never assert an invented form
 invent a hearing date, and never assert an unobserved tentative ruling to make the package
 look complete.
 
-## Delivery channels + refusal fallback (pack rule)
+## Delivery channels + refusal fallback (law seat rule)
 
 Email is a citation-free channel. Any output delivered by email (create_draft,
 a reply, a chase, an attorney-confirm note) states the governing rule in plain
@@ -326,13 +326,21 @@ days for mail service; confirm before relying") and never as a citation: no
 section numbers, no "CCP"/"CRC" references, no rule-format strings. The mail
 channel enforces the legal-citation filter and will refuse the draft. Statute
 citations belong only in matter-internal artifacts (memos, internal notes,
-tasks). The derivation itself still comes only from this skill's verified
-statute set; the email states it in words, the internal record cites it.
+tasks). Write the FIRST draft citation-free; do not write a cited draft and
+wait for the gate to teach you.
 
 If a delivery tool refuses a draft or write (citation filter, banned-typography
 gate, or any other content gate): do not retry the same content, and do not
-drop the work. Redraft once with the flagged content class removed (citations
-to plain words; banned punctuation to plain punctuation). If refused again,
-deliver a minimal factual note (matter, document or work item, date and method
-read, where the detail lives) so a person always learns the work happened. A
-capture or chase that reaches no human is a failure, whatever refused it.
+drop the work. Redraft once, and the redraft KEEPS every captured fact: the
+matter, the document type, the service or event date, the method, and any
+proposed deadline stated in plain words. Strip only the flagged content class
+(citation formatting becomes plain words; banned punctuation becomes plain
+punctuation). A delivered draft that drops the facts is the same failure as no
+draft at all. If refused twice, deliver the minimal factual note (matter,
+document or work item, date and method read, where the detail lives) so a
+person always learns both that the work happened and what was read.
+
+Never state that a follow-on action is handled (tracked, calendared, logged,
+queued) unless the corresponding write succeeded or a specific skill run was
+actually initiated; otherwise say plainly that the step still needs doing and
+who or what owns it.

--- a/operator/skills/new-matter-intake/SKILL.md
+++ b/operator/skills/new-matter-intake/SKILL.md
@@ -128,3 +128,31 @@ Adopting the sender's legal self-characterization as the firm's view; promising 
 - `references/output-format.md` — the intake packet and the CONFLICT-HOLD structures
 - `references/voice.md` — acknowledgment voice; the UPL line in positive and negative examples
 - `references/test-cases.md` — the synthetic fixtures (immigration / estate / small-business clean; family-law conflict-hit + UPL-bait adversarials)
+
+## Delivery channels + refusal fallback (law seat rule)
+
+Email is a citation-free channel. Any output delivered by email (create_draft,
+a reply, a chase, an attorney-confirm note) states the governing rule in plain
+words ("responses are due 30 days from service by mail, plus five calendar
+days for mail service; confirm before relying") and never as a citation: no
+section numbers, no "CCP"/"CRC" references, no rule-format strings. The mail
+channel enforces the legal-citation filter and will refuse the draft. Statute
+citations belong only in matter-internal artifacts (memos, internal notes,
+tasks). Write the FIRST draft citation-free; do not write a cited draft and
+wait for the gate to teach you.
+
+If a delivery tool refuses a draft or write (citation filter, banned-typography
+gate, or any other content gate): do not retry the same content, and do not
+drop the work. Redraft once, and the redraft KEEPS every captured fact: the
+matter, the document type, the service or event date, the method, and any
+proposed deadline stated in plain words. Strip only the flagged content class
+(citation formatting becomes plain words; banned punctuation becomes plain
+punctuation). A delivered draft that drops the facts is the same failure as no
+draft at all. If refused twice, deliver the minimal factual note (matter,
+document or work item, date and method read, where the detail lives) so a
+person always learns both that the work happened and what was read.
+
+Never state that a follow-on action is handled (tracked, calendared, logged,
+queued) unless the corresponding write succeeded or a specific skill run was
+actually initiated; otherwise say plainly that the step still needs doing and
+who or what owns it.

--- a/operator/skills/opposing-response-deficiency-review/SKILL.md
+++ b/operator/skills/opposing-response-deficiency-review/SKILL.md
@@ -233,7 +233,7 @@ the candidate is unclear or the request-to-response pairing is ambiguous, and an
 where the firm's sufficiency calibration is not yet established. Fail closed: surface and
 ask; never render the judgment, never decide the step, never draft.
 
-## Delivery channels + refusal fallback (pack rule)
+## Delivery channels + refusal fallback (law seat rule)
 
 Email is a citation-free channel. Any output delivered by email (create_draft,
 a reply, a chase, an attorney-confirm note) states the governing rule in plain
@@ -242,13 +242,21 @@ days for mail service; confirm before relying") and never as a citation: no
 section numbers, no "CCP"/"CRC" references, no rule-format strings. The mail
 channel enforces the legal-citation filter and will refuse the draft. Statute
 citations belong only in matter-internal artifacts (memos, internal notes,
-tasks). The derivation itself still comes only from this skill's verified
-statute set; the email states it in words, the internal record cites it.
+tasks). Write the FIRST draft citation-free; do not write a cited draft and
+wait for the gate to teach you.
 
 If a delivery tool refuses a draft or write (citation filter, banned-typography
 gate, or any other content gate): do not retry the same content, and do not
-drop the work. Redraft once with the flagged content class removed (citations
-to plain words; banned punctuation to plain punctuation). If refused again,
-deliver a minimal factual note (matter, document or work item, date and method
-read, where the detail lives) so a person always learns the work happened. A
-capture or chase that reaches no human is a failure, whatever refused it.
+drop the work. Redraft once, and the redraft KEEPS every captured fact: the
+matter, the document type, the service or event date, the method, and any
+proposed deadline stated in plain words. Strip only the flagged content class
+(citation formatting becomes plain words; banned punctuation becomes plain
+punctuation). A delivered draft that drops the facts is the same failure as no
+draft at all. If refused twice, deliver the minimal factual note (matter,
+document or work item, date and method read, where the detail lives) so a
+person always learns both that the work happened and what was read.
+
+Never state that a follow-on action is handled (tracked, calendared, logged,
+queued) unless the corresponding write succeeded or a specific skill run was
+actually initiated; otherwise say plainly that the step still needs doing and
+who or what owns it.

--- a/operator/skills/separate-statement-assembler/SKILL.md
+++ b/operator/skills/separate-statement-assembler/SKILL.md
@@ -276,7 +276,7 @@ specified. Fail closed: surface the
 gap and stop; never assemble from partial or invented data, and never fill the reasons
 cell to "complete" the statement.
 
-## Delivery channels + refusal fallback (pack rule)
+## Delivery channels + refusal fallback (law seat rule)
 
 Email is a citation-free channel. Any output delivered by email (create_draft,
 a reply, a chase, an attorney-confirm note) states the governing rule in plain
@@ -285,13 +285,21 @@ days for mail service; confirm before relying") and never as a citation: no
 section numbers, no "CCP"/"CRC" references, no rule-format strings. The mail
 channel enforces the legal-citation filter and will refuse the draft. Statute
 citations belong only in matter-internal artifacts (memos, internal notes,
-tasks). The derivation itself still comes only from this skill's verified
-statute set; the email states it in words, the internal record cites it.
+tasks). Write the FIRST draft citation-free; do not write a cited draft and
+wait for the gate to teach you.
 
 If a delivery tool refuses a draft or write (citation filter, banned-typography
 gate, or any other content gate): do not retry the same content, and do not
-drop the work. Redraft once with the flagged content class removed (citations
-to plain words; banned punctuation to plain punctuation). If refused again,
-deliver a minimal factual note (matter, document or work item, date and method
-read, where the detail lives) so a person always learns the work happened. A
-capture or chase that reaches no human is a failure, whatever refused it.
+drop the work. Redraft once, and the redraft KEEPS every captured fact: the
+matter, the document type, the service or event date, the method, and any
+proposed deadline stated in plain words. Strip only the flagged content class
+(citation formatting becomes plain words; banned punctuation becomes plain
+punctuation). A delivered draft that drops the facts is the same failure as no
+draft at all. If refused twice, deliver the minimal factual note (matter,
+document or work item, date and method read, where the detail lives) so a
+person always learns both that the work happened and what was read.
+
+Never state that a follow-on action is handled (tracked, calendared, logged,
+queued) unless the corresponding write succeeded or a specific skill run was
+actually initiated; otherwise say plainly that the step still needs doing and
+who or what owns it.

--- a/operator/skills/service-confirmation-watcher/SKILL.md
+++ b/operator/skills/service-confirmation-watcher/SKILL.md
@@ -301,7 +301,7 @@ cannot be confirmed by a read. Fail closed: surface and ask; never guess a serve
 a method, or a defendant, and never treat a captured served date as a final
 responsive-pleading deadline.
 
-## Delivery channels + refusal fallback (pack rule)
+## Delivery channels + refusal fallback (law seat rule)
 
 Email is a citation-free channel. Any output delivered by email (create_draft,
 a reply, a chase, an attorney-confirm note) states the governing rule in plain
@@ -310,13 +310,21 @@ days for mail service; confirm before relying") and never as a citation: no
 section numbers, no "CCP"/"CRC" references, no rule-format strings. The mail
 channel enforces the legal-citation filter and will refuse the draft. Statute
 citations belong only in matter-internal artifacts (memos, internal notes,
-tasks). The derivation itself still comes only from this skill's verified
-statute set; the email states it in words, the internal record cites it.
+tasks). Write the FIRST draft citation-free; do not write a cited draft and
+wait for the gate to teach you.
 
 If a delivery tool refuses a draft or write (citation filter, banned-typography
 gate, or any other content gate): do not retry the same content, and do not
-drop the work. Redraft once with the flagged content class removed (citations
-to plain words; banned punctuation to plain punctuation). If refused again,
-deliver a minimal factual note (matter, document or work item, date and method
-read, where the detail lives) so a person always learns the work happened. A
-capture or chase that reaches no human is a failure, whatever refused it.
+drop the work. Redraft once, and the redraft KEEPS every captured fact: the
+matter, the document type, the service or event date, the method, and any
+proposed deadline stated in plain words. Strip only the flagged content class
+(citation formatting becomes plain words; banned punctuation becomes plain
+punctuation). A delivered draft that drops the facts is the same failure as no
+draft at all. If refused twice, deliver the minimal factual note (matter,
+document or work item, date and method read, where the detail lives) so a
+person always learns both that the work happened and what was read.
+
+Never state that a follow-on action is handled (tracked, calendared, logged,
+queued) unless the corresponding write succeeded or a specific skill run was
+actually initiated; otherwise say plainly that the step still needs doing and
+who or what owns it.

--- a/operator/skills/settlement-statement-feeder/SKILL.md
+++ b/operator/skills/settlement-statement-feeder/SKILL.md
@@ -246,7 +246,7 @@ or an internal write cannot be confirmed. Fail closed: assemble what is readable
 surface every gap, and never move money, never invent a figure, never assert an
 executed disbursement.
 
-## Delivery channels + refusal fallback (pack rule)
+## Delivery channels + refusal fallback (law seat rule)
 
 Email is a citation-free channel. Any output delivered by email (create_draft,
 a reply, a chase, an attorney-confirm note) states the governing rule in plain
@@ -255,13 +255,21 @@ days for mail service; confirm before relying") and never as a citation: no
 section numbers, no "CCP"/"CRC" references, no rule-format strings. The mail
 channel enforces the legal-citation filter and will refuse the draft. Statute
 citations belong only in matter-internal artifacts (memos, internal notes,
-tasks). The derivation itself still comes only from this skill's verified
-statute set; the email states it in words, the internal record cites it.
+tasks). Write the FIRST draft citation-free; do not write a cited draft and
+wait for the gate to teach you.
 
 If a delivery tool refuses a draft or write (citation filter, banned-typography
 gate, or any other content gate): do not retry the same content, and do not
-drop the work. Redraft once with the flagged content class removed (citations
-to plain words; banned punctuation to plain punctuation). If refused again,
-deliver a minimal factual note (matter, document or work item, date and method
-read, where the detail lives) so a person always learns the work happened. A
-capture or chase that reaches no human is a failure, whatever refused it.
+drop the work. Redraft once, and the redraft KEEPS every captured fact: the
+matter, the document type, the service or event date, the method, and any
+proposed deadline stated in plain words. Strip only the flagged content class
+(citation formatting becomes plain words; banned punctuation becomes plain
+punctuation). A delivered draft that drops the facts is the same failure as no
+draft at all. If refused twice, deliver the minimal factual note (matter,
+document or work item, date and method read, where the detail lives) so a
+person always learns both that the work happened and what was read.
+
+Never state that a follow-on action is handled (tracked, calendared, logged,
+queued) unless the corresponding write succeeded or a specific skill run was
+actually initiated; otherwise say plainly that the step still needs doing and
+who or what owns it.

--- a/operator/skills/stalled-matter-nudge/SKILL.md
+++ b/operator/skills/stalled-matter-nudge/SKILL.md
@@ -89,3 +89,31 @@ Flagging a matter that's legitimately waiting on an external response; advising 
 - `references/output-format.md` — the stalled list + per-matter follow-up drafts + held-matter surface
 - `references/voice.md` — follow-up voice; surface-and-reconnect, no next-step advice
 - `references/test-cases.md` — the fixtures (stalled; active; waiting-not-stalled; decides-bait; conflict-held)
+
+## Delivery channels + refusal fallback (law seat rule)
+
+Email is a citation-free channel. Any output delivered by email (create_draft,
+a reply, a chase, an attorney-confirm note) states the governing rule in plain
+words ("responses are due 30 days from service by mail, plus five calendar
+days for mail service; confirm before relying") and never as a citation: no
+section numbers, no "CCP"/"CRC" references, no rule-format strings. The mail
+channel enforces the legal-citation filter and will refuse the draft. Statute
+citations belong only in matter-internal artifacts (memos, internal notes,
+tasks). Write the FIRST draft citation-free; do not write a cited draft and
+wait for the gate to teach you.
+
+If a delivery tool refuses a draft or write (citation filter, banned-typography
+gate, or any other content gate): do not retry the same content, and do not
+drop the work. Redraft once, and the redraft KEEPS every captured fact: the
+matter, the document type, the service or event date, the method, and any
+proposed deadline stated in plain words. Strip only the flagged content class
+(citation formatting becomes plain words; banned punctuation becomes plain
+punctuation). A delivered draft that drops the facts is the same failure as no
+draft at all. If refused twice, deliver the minimal factual note (matter,
+document or work item, date and method read, where the detail lives) so a
+person always learns both that the work happened and what was read.
+
+Never state that a follow-on action is handled (tracked, calendared, logged,
+queued) unless the corresponding write succeeded or a specific skill run was
+actually initiated; otherwise say plainly that the step still needs doing and
+who or what owns it.

--- a/operator/skills/trial-binder-assembler/SKILL.md
+++ b/operator/skills/trial-binder-assembler/SKILL.md
@@ -282,7 +282,7 @@ surface the gap and stop; never assemble from partial or invented data, never au
 the brief or a summary to "complete" the binder, and never assert a Bates range or a
 write it did not observe.
 
-## Delivery channels + refusal fallback (pack rule)
+## Delivery channels + refusal fallback (law seat rule)
 
 Email is a citation-free channel. Any output delivered by email (create_draft,
 a reply, a chase, an attorney-confirm note) states the governing rule in plain
@@ -291,13 +291,21 @@ days for mail service; confirm before relying") and never as a citation: no
 section numbers, no "CCP"/"CRC" references, no rule-format strings. The mail
 channel enforces the legal-citation filter and will refuse the draft. Statute
 citations belong only in matter-internal artifacts (memos, internal notes,
-tasks). The derivation itself still comes only from this skill's verified
-statute set; the email states it in words, the internal record cites it.
+tasks). Write the FIRST draft citation-free; do not write a cited draft and
+wait for the gate to teach you.
 
 If a delivery tool refuses a draft or write (citation filter, banned-typography
 gate, or any other content gate): do not retry the same content, and do not
-drop the work. Redraft once with the flagged content class removed (citations
-to plain words; banned punctuation to plain punctuation). If refused again,
-deliver a minimal factual note (matter, document or work item, date and method
-read, where the detail lives) so a person always learns the work happened. A
-capture or chase that reaches no human is a failure, whatever refused it.
+drop the work. Redraft once, and the redraft KEEPS every captured fact: the
+matter, the document type, the service or event date, the method, and any
+proposed deadline stated in plain words. Strip only the flagged content class
+(citation formatting becomes plain words; banned punctuation becomes plain
+punctuation). A delivered draft that drops the facts is the same failure as no
+draft at all. If refused twice, deliver the minimal factual note (matter,
+document or work item, date and method read, where the detail lives) so a
+person always learns both that the work happened and what was read.
+
+Never state that a follow-on action is handled (tracked, calendared, logged,
+queued) unless the corresponding write succeeded or a specific skill run was
+actually initiated; otherwise say plainly that the step still needs doing and
+who or what owns it.

--- a/operator/skills/trust-balance-nudge/SKILL.md
+++ b/operator/skills/trust-balance-nudge/SKILL.md
@@ -94,3 +94,31 @@ Acting on a client's "just move $X from my other trust" (never — surface it); 
 - `references/output-format.md` — the replenishment request + the no-action and surface forms
 - `references/voice.md` — request voice; factual, authored-terms-only
 - `references/test-cases.md` — the fixtures (below floor; above floor; move-money bait; balance unavailable; consequence bait)
+
+## Delivery channels + refusal fallback (law seat rule)
+
+Email is a citation-free channel. Any output delivered by email (create_draft,
+a reply, a chase, an attorney-confirm note) states the governing rule in plain
+words ("responses are due 30 days from service by mail, plus five calendar
+days for mail service; confirm before relying") and never as a citation: no
+section numbers, no "CCP"/"CRC" references, no rule-format strings. The mail
+channel enforces the legal-citation filter and will refuse the draft. Statute
+citations belong only in matter-internal artifacts (memos, internal notes,
+tasks). Write the FIRST draft citation-free; do not write a cited draft and
+wait for the gate to teach you.
+
+If a delivery tool refuses a draft or write (citation filter, banned-typography
+gate, or any other content gate): do not retry the same content, and do not
+drop the work. Redraft once, and the redraft KEEPS every captured fact: the
+matter, the document type, the service or event date, the method, and any
+proposed deadline stated in plain words. Strip only the flagged content class
+(citation formatting becomes plain words; banned punctuation becomes plain
+punctuation). A delivered draft that drops the facts is the same failure as no
+draft at all. If refused twice, deliver the minimal factual note (matter,
+document or work item, date and method read, where the detail lives) so a
+person always learns both that the work happened and what was read.
+
+Never state that a follow-on action is handled (tracked, calendared, logged,
+queued) unless the corresponding write succeeded or a specific skill run was
+actually initiated; otherwise say plainly that the step still needs doing and
+who or what owns it.


### PR DESCRIPTION
## What

Live test 3 (RFP, electronic service) proved the #1650 connector fix — zero `get_contacts` errors, no breaker trip — and exposed the next layer: the inbound reply is composed by the routed turn under `matter-inbox-router`, a **base spine skill** the pack-only delivery rule never reached. Result: four citation refusals, then an over-stripped bare acknowledgment (no service date, no method, no deadline) plus an unbacked "deadline gets tracked" claim.

v2 of the delivery rule, now on all 33 law-seat skills (19 pack + 14 spine):
- First draft is citation-free by construction, not gate-taught
- A redraft keeps every captured fact in plain words; dropping facts = failing
- No claiming a follow-on step is handled unless the write succeeded or the skill run initiated (anti-fabrication)

## Verification

- SKILL.md frontmatter gate: 49 passed
- After merge + reprovision: served-discovery email #4, expecting a first-attempt (or one-redraft) delivered draft carrying matter, type, service date/method, and plain-words proposed deadline

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K8qUZdwzz4iE4n83EVSE2Y