### PR TITLE
feat(admin): rebuild entity-detail stage actions as a worker-free toolbar

### DIFF
--- a/src/components/admin/EntityStageActions.astro
+++ b/src/components/admin/EntityStageActions.astro
@@ -1,11 +1,22 @@
 ---
 /**
- * Stage-transition action buttons for the entity detail page header.
- * Extracted from src/pages/admin/entities/[id].astro.
+ * Stage-transition action toolbar for the entity detail page header.
+ *
+ * Rebuilt 2026-07-03 (Review 4 Captain call). The original component was
+ * orphaned by the #762 detail-page redesign and carried dead lead-gen
+ * machinery (re-enrich against the removed /dossier endpoint, outreach
+ * mailto fed by machine-drafted outreach). This rebuild keeps only the
+ * manual-pipeline actions, every one backed by a live endpoint:
+ *
+ *   - Send booking link (prospect) — opens EntitySendBookingDialog via
+ *     the #send-booking-link-btn wiring in entity-detail-client.ts
+ *   - Draft proposal from meeting (meetings stage, draftable meeting)
+ *   - Stage transitions from ENTITY_DETAIL_TRANSITIONS, with the
+ *     Lost-reason picker
+ *   - Log reply — opens LogReplyDialog via [data-open-reply-dialog]
+ *   - New quote, with the optional supersede link
  */
 import { adminActionButtonClass } from '../../lib/ui/admin-action-button'
-import { relativeTime } from '../../lib/admin/relative-time'
-import { formatDate } from '../../lib/admin/entity-detail-page'
 import { LOST_REASONS } from '../../lib/db/lost-reasons'
 import type { EntityDetailTransition } from '../../lib/admin/entity-detail-page'
 
@@ -24,11 +35,6 @@ interface Props {
   entityStage: string
   transitions: EntityDetailTransition[]
   mostRecentDraftableMeeting: Meeting | null
-  outreachMailto: string | null
-  outreachContactEmail: string | null
-  showReEnrichButton: boolean
-  lastEnrichmentAt: string | null
-  hasOutreach: boolean
   showNewQuoteButton: boolean
   supersedeCandidates: SupersedeCandidate[]
 }
@@ -38,17 +44,12 @@ const {
   entityStage,
   transitions,
   mostRecentDraftableMeeting,
-  outreachMailto,
-  outreachContactEmail,
-  showReEnrichButton,
-  lastEnrichmentAt,
-  hasOutreach,
   showNewQuoteButton,
   supersedeCandidates,
 } = Astro.props
 ---
 
-<div class="flex items-center gap-2 shrink-0">
+<div class="flex flex-wrap items-center gap-2 shrink-0">
   {
     entityStage === 'prospect' && (
       <button type="button" id="send-booking-link-btn" class={adminActionButtonClass('primary')}>
@@ -75,20 +76,6 @@ const {
           Draft proposal from meeting
         </button>
       </form>
-    )
-  }
-  {
-    /* Use the latest outreach draft as a pre-filled mailto when a
-       contact email exists. The dossier copy action stays as the
-       fallback when no recipient is available. */
-    outreachMailto && (
-      <a
-        href={outreachMailto}
-        class={adminActionButtonClass('ghost')}
-        title={`Open mail to ${outreachContactEmail ?? ''} with the draft pre-filled`}
-      >
-        Send outreach
-      </a>
     )
   }
   {
@@ -150,37 +137,11 @@ const {
     )
   }
   {
-    showReEnrichButton && (
-      <form
-        method="POST"
-        action={`/api/admin/entities/${entityId}/dossier`}
-        id="re-enrich-form"
-        class="flex items-center gap-2"
-      >
-        <button
-          type="submit"
-          id="re-enrich-btn"
-          class={`${adminActionButtonClass('ghost')} disabled:opacity-50 disabled:cursor-not-allowed`}
-          title="Refresh reviews and news — cheap, safe to re-run"
-        >
-          Re-enrich (reviews + news)
-        </button>
-        {lastEnrichmentAt && (
-          <span
-            class="text-xs text-[color:var(--ss-color-text-muted)]"
-            title={`Last enriched ${formatDate(lastEnrichmentAt)}`}
-          >
-            Last enriched {relativeTime(lastEnrichmentAt)}
-          </span>
-        )}
-      </form>
-    )
-  }
-  {
-    /* H3 — Log reply is hidden until outreach has been drafted. The
-       button only makes sense once there's something the prospect
-       could reply *to*. `hasOutreach` is the practical proxy. */
-    entityStage === 'prospect' && hasOutreach && (
+    /* Log reply is unconditional on prospect: with the automated
+       outreach machine retired (ADR 0060), outreach may happen entirely
+       outside the system, so there is no tracked "has outreach" signal
+       to gate on. */
+    entityStage === 'prospect' && (
       <button
         type="button"
         data-open-reply-dialog={entityId}

--- a/src/pages/admin/entities/[id].astro
+++ b/src/pages/admin/entities/[id].astro
@@ -4,6 +4,7 @@ import AdminFlashNotice from '../../../components/admin/AdminFlashNotice.astro'
 import EntityContactsPanel from '../../../components/admin/EntityContactsPanel.astro'
 import EntityIdentityStrip from '../../../components/admin/EntityIdentityStrip.astro'
 import EntitySendBookingDialog from '../../../components/admin/EntitySendBookingDialog.astro'
+import EntityStageActions from '../../../components/admin/EntityStageActions.astro'
 import EntityTimelineEntry from '../../../components/admin/EntityTimelineEntry.astro'
 import LogReplyDialog from '../../../components/admin/LogReplyDialog.astro'
 import { statusBadgeClass } from '../../../lib/ui/status-badge'
@@ -29,6 +30,10 @@ const {
   quotes,
   invoices,
   deduplicatedTimeline,
+  transitions,
+  mostRecentDraftableMeeting,
+  showNewQuoteButton,
+  supersedeCandidates,
   promoted,
   noteAdded,
   replyLogged,
@@ -80,12 +85,22 @@ function renderCollapsedSectionTitle(stage: EntityStage, count: number): string 
   {contactDeleted && <AdminFlashNotice message="Contact deleted." />}
   {error && <AdminFlashNotice kind="error" message={decodeURIComponent(error)} />}
 
-  <a
-    href={`/admin/entities?stage=${entity.stage}`}
-    class="mb-6 inline-flex items-center gap-1 text-sm text-[color:var(--ss-color-text-secondary)] transition-colors hover:text-[color:var(--ss-color-primary)]"
-  >
-    <span>Back to {stageLabel} list</span>
-  </a>
+  <div class="mb-6 flex flex-wrap items-center justify-between gap-3">
+    <a
+      href={`/admin/entities?stage=${entity.stage}`}
+      class="inline-flex items-center gap-1 text-sm text-[color:var(--ss-color-text-secondary)] transition-colors hover:text-[color:var(--ss-color-primary)]"
+    >
+      <span>Back to {stageLabel} list</span>
+    </a>
+    <EntityStageActions
+      entityId={entity.id}
+      entityStage={entity.stage}
+      transitions={transitions}
+      mostRecentDraftableMeeting={mostRecentDraftableMeeting}
+      showNewQuoteButton={showNewQuoteButton}
+      supersedeCandidates={supersedeCandidates}
+    />
+  </div>
 
   <LogReplyDialog entityId={entity.id} entityName={entity.name} />
   {entity.stage === 'prospect' && <EntitySendBookingDialog entityId={entity.id} />}

--- a/tests/entity-stage-actions.test.ts
+++ b/tests/entity-stage-actions.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Guard the entity-detail stage-actions toolbar: rendered, live-endpoint-only.
+ *
+ * Regression: EntityStageActions.astro was orphaned by the #762 detail-page
+ * redesign — the component existed but nothing imported it, so the Leads
+ * detail page shipped with no Promote/Lost/draft-proposal affordances and the
+ * booking/reply dialogs it opens were rendered but unreachable. The lead-gen
+ * retirement (ADR 0060) then left it pointing at a deleted /dossier endpoint.
+ * Rebuilt 2026-07-03 (Review 4 Captain call) as a worker-free toolbar; this
+ * test pins both halves: the page renders it, and it targets only endpoints
+ * that exist.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync, existsSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const read = (rel: string) => readFileSync(resolve(rel), 'utf-8')
+
+describe('entity detail page renders the stage-actions toolbar', () => {
+  const page = read('src/pages/admin/entities/[id].astro')
+
+  it('imports and renders EntityStageActions', () => {
+    expect(page).toMatch(/import EntityStageActions from/)
+    expect(page).toMatch(/<EntityStageActions/)
+  })
+
+  it('passes the loader-computed transition data through', () => {
+    expect(page).toMatch(/transitions=\{transitions\}/)
+    expect(page).toMatch(/mostRecentDraftableMeeting=\{mostRecentDraftableMeeting\}/)
+  })
+})
+
+describe('EntityStageActions targets only live endpoints', () => {
+  const src = read('src/components/admin/EntityStageActions.astro')
+
+  it('posts stage transitions to the live stage endpoint', () => {
+    expect(src).toMatch(/\/api\/admin\/entities\/\$\{entityId\}\/stage/)
+    expect(existsSync(resolve('src/pages/api/admin/entities/[id]/stage.ts'))).toBe(true)
+  })
+
+  it('posts draft-proposal to the live meeting draft-quote endpoint', () => {
+    expect(src).toMatch(/\/meetings\/\$\{mostRecentDraftableMeeting\.id\}\/draft-quote/)
+    expect(
+      existsSync(resolve('src/pages/api/admin/entities/[id]/meetings/[meetingId]/draft-quote.ts'))
+    ).toBe(true)
+  })
+
+  it('posts new quotes to the live quotes endpoint', () => {
+    expect(src).toMatch(/\/api\/admin\/entities\/\$\{entityId\}\/quotes/)
+    expect(existsSync(resolve('src/pages/api/admin/entities/[id]/quotes.ts'))).toBe(true)
+  })
+
+  it('opens the booking and reply dialogs via their real wiring hooks', () => {
+    // entity-detail-client.ts binds #send-booking-link-btn; LogReplyDialog
+    // binds [data-open-reply-dialog]. Both must exist or the dialogs are
+    // rendered-but-unreachable again.
+    expect(src).toMatch(/id="send-booking-link-btn"/)
+    expect(src).toMatch(/data-open-reply-dialog=\{entityId\}/)
+    expect(read('src/lib/admin/entity-detail-client.ts')).toMatch(/send-booking-link-btn/)
+  })
+
+  it('carries no retired lead-gen machinery', () => {
+    // The /dossier endpoint, re-enrich action, and machine-drafted outreach
+    // mailto were removed with the automated lead-gen machine (ADR 0060).
+    // Scan form targets and props, not the header comment (which names the
+    // history on purpose).
+    expect(src).not.toMatch(/action=.*dossier/)
+    expect(src).not.toMatch(/id="re-enrich/)
+    expect(src).not.toMatch(/outreachMailto/)
+    expect(src).not.toMatch(/showReEnrichButton/)
+  })
+})


### PR DESCRIPTION
## Summary

Review 4 Captain call: rebuild the Leads detail page's manual-pipeline stage actions.

- `EntityStageActions.astro` was orphaned by the #762 redesign — nothing imported it, so the detail page shipped with **no Promote/Lost/draft-proposal buttons**, and `EntitySendBookingDialog` + `LogReplyDialog` were rendered but unreachable (their only openers lived in the orphan). The lead-gen retirement (ADR 0060) then left it pointing at the deleted `/dossier` endpoint.
- Rebuilt worker-free: Send booking link (prospect), Draft proposal from meeting (auto-transitions to proposing), full stage-transition set with the Lost-reason picker, Log reply, New quote + supersede select. Every target verified live: `stage.ts`, `quotes.ts`, `draft-quote.ts`, `send-booking-link.ts`, `reply-log.ts`.
- Dropped for good: re-enrich (`/dossier`), machine-drafted outreach mailto, `hasOutreach` gating (outreach can now happen entirely outside the system, so Log reply is unconditional on prospect).
- The loader already computed `transitions` / `mostRecentDraftableMeeting` / quote flags on every request — this wires them to a renderer again. The meeting-page note "Drafting a proposal is a separate action on the entity page" becomes true again with no copy change.

## Test plan
- [x] `npm run verify` passes
- [x] New `tests/entity-stage-actions.test.ts`: page renders the toolbar; every form target resolves to an existing endpoint file; dialog wiring hooks (`#send-booking-link-btn`, `[data-open-reply-dialog]`) present; no retired lead-gen targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)