### PR TITLE
fix(operator): seat-local cron — export HERMES_TIMEZONE from business_hours.timezone

### DIFF
--- a/operator/bin/tests/test_seat_timezone.py
+++ b/operator/bin/tests/test_seat_timezone.py
@@ -1,0 +1,82 @@
+"""bootstrap.sh must export HERMES_TIMEZONE from business_hours.timezone (#cron-tz).
+
+The container clock is UTC, and Hermes' cron engine computes due-ness with
+hermes_time.now(), whose highest-priority source is the HERMES_TIMEZONE env
+var. Without the export, every authored cron expression silently runs in UTC
+while the customer.yaml comments claim local time — caught live 2026-07-03:
+the pilot's "0623 PT" morning digest actually meant 11:23 PM Pacific, and the
+escalator's "0700 PT" had fired at midnight Pacific since it shipped.
+
+These asserts pin the seam:
+  * bootstrap extracts business_hours.timezone from the root customer.yaml
+  * exports it as HERMES_TIMEZONE BEFORE the gateway exec (the clock consumer)
+  * unauthored block exports nothing (UTC stays the prior behavior, not a
+    new default — ADR 0037 tenet 3)
+Plus: both A&P-arc seats actually author the block, so the export has a
+producer on the seats whose cron comments promise Pacific times.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+_OPERATOR = Path(__file__).resolve().parents[2]
+_BOOTSTRAP = _OPERATOR / "templates" / "bootstrap.sh"
+_SEATS = (
+    _OPERATOR / "customers" / "pilot-smokeball" / "customer.yaml",
+    _OPERATOR / "customers" / "ashton-price" / "customer.yaml",
+)
+
+
+def _code_lines() -> list[str]:
+    out = []
+    for line in _BOOTSTRAP.read_text(encoding="utf-8").splitlines():
+        out.append("" if line.lstrip().startswith("#") else line)
+    return out
+
+
+def _first_index(lines: list[str], pattern: str) -> int:
+    rx = re.compile(pattern)
+    for i, line in enumerate(lines):
+        if rx.search(line):
+            return i
+    return -1
+
+
+def test_bootstrap_exports_seat_timezone_before_gateway() -> None:
+    lines = _code_lines()
+    extract_idx = _first_index(lines, r"business_hours")
+    export_idx = _first_index(lines, r"export HERMES_TIMEZONE=")
+    gateway_idx = _first_index(lines, r"\bexec\b.*\bhermes\b.*\bgateway\s+run\b")
+
+    assert extract_idx != -1, "bootstrap.sh must read business_hours from customer.yaml"
+    assert export_idx != -1, "bootstrap.sh must export HERMES_TIMEZONE"
+    assert gateway_idx != -1, "could not find the gateway exec line"
+    assert extract_idx < export_idx < gateway_idx, (
+        "HERMES_TIMEZONE must be extracted and exported before the gateway exec "
+        f"(extract={extract_idx}, export={export_idx}, gateway={gateway_idx})"
+    )
+
+
+def test_export_is_conditional_on_authored_timezone() -> None:
+    """Unauthored business_hours must NOT export an empty/placeholder value —
+    the export sits inside a non-empty guard so UTC remains the fallback."""
+    text = _BOOTSTRAP.read_text(encoding="utf-8")
+    m = re.search(
+        r'if \[ -n "\$\{SEAT_TIMEZONE\}" \]; then\s*\n\s*export HERMES_TIMEZONE=',
+        text,
+    )
+    assert m, "export HERMES_TIMEZONE must be guarded on a non-empty SEAT_TIMEZONE"
+
+
+def test_ap_arc_seats_author_pacific_timezone() -> None:
+    for seat in _SEATS:
+        data = yaml.safe_load(seat.read_text(encoding="utf-8"))
+        hours = data.get("business_hours") or {}
+        assert hours.get("timezone") == "America/Los_Angeles", (
+            f"{seat.parent.name}: business_hours.timezone must be America/Los_Angeles — "
+            "its cron comments promise Pacific-local times"
+        )

--- a/operator/contracts/customer-yaml-blocks.yaml
+++ b/operator/contracts/customer-yaml-blocks.yaml
@@ -96,6 +96,15 @@ top_level:
       shared/gate_inbound_cap.resolve_inbound_cap (safety.sticky_stop.inbound_daily_cap ->
       the webhook-gate wake cap). Unauthored => platform defaults (5000 cents / 200 wakes),
       integrity control per ADR 0035/0062 — never fail-open.
+  business_hours:
+    status: implemented
+    materializer: >-
+      bootstrap.sh SEAT_TIMEZONE extraction -> `export HERMES_TIMEZONE` before the
+      gateway exec. Hermes' clock (hermes_time.now(), highest-priority env source)
+      and therefore the cron engine's due-computation run in the seat's IANA
+      timezone; unauthored = UTC (container clock, the prior behavior). days/start/
+      end are authored-but-inert today (future business-hours-aware behavior);
+      timezone is the load-bearing field.
   escalation:
     status: implemented
     materializer: translate _persona_config (config.yaml escalation)

--- a/operator/customers/ashton-price/customer.yaml
+++ b/operator/customers/ashton-price/customer.yaml
@@ -350,44 +350,45 @@ personas:
     # decides whether a deadline needs the ladder, else writes SUPPRESSED_WAKE.
     # The PI-pack schedules below are staggered (never :00/:30) and weekday- or
     # weekly-cadenced deliberately — every wake bills tokens, so the cadence
-    # matches how fast each item actually changes.
+    # matches how fast each item actually changes. All times are seat-local
+    # (business_hours.timezone -> HERMES_TIMEZONE): authored as Pacific.
     cron:
       - skill: deadline-miss-escalator
-        schedule: '0 7 * * *' # daily 0700 PT
+        schedule: '0 7 * * *' # daily 0700 seat-local (America/Los_Angeles via business_hours; was silently UTC = midnight PT before HERMES_TIMEZONE landed)
         pre_run: pre_run.py
         wake_policy: pre_run_decides
       - skill: daily-needs-you-digest
-        schedule: '23 6 * * 1-5' # weekday 0623 PT — the morning digest
+        schedule: '23 6 * * 1-5' # weekday 0623 seat-local — the morning digest
         wake_policy: always
       - skill: discovery-response-tracker
-        schedule: '17 7 * * 1-5' # weekday 0717 PT
+        schedule: '17 7 * * 1-5' # weekday 0717 seat-local
         wake_policy: always
       - skill: client-verification-tracker
-        schedule: '41 7 * * 1-5' # weekday 0741 PT
+        schedule: '41 7 * * 1-5' # weekday 0741 seat-local
         wake_policy: always
       - skill: motion-calendar-tracker
-        schedule: '27 7 * * 1-5' # weekday 0727 PT
+        schedule: '27 7 * * 1-5' # weekday 0727 seat-local
         wake_policy: always
       - skill: service-confirmation-watcher
-        schedule: '51 7 * * 1-5' # weekday 0751 PT
+        schedule: '51 7 * * 1-5' # weekday 0751 seat-local
         wake_policy: always
       - skill: medical-chronology-maintainer
-        schedule: '33 8 * * 1-5' # weekday 0833 PT — after records imports land
+        schedule: '33 8 * * 1-5' # weekday 0833 seat-local — after records imports land
         wake_policy: always
       - skill: medical-records-chaser
-        schedule: '9 8 * * 2' # weekly Tue 0809 PT
+        schedule: '9 8 * * 2' # weekly Tue 0809 seat-local
         wake_policy: always
       - skill: lien-ledger-tracker
-        schedule: '13 9 * * 2' # weekly Tue 0913 PT
+        schedule: '13 9 * * 2' # weekly Tue 0913 seat-local
         wake_policy: always
       - skill: mediation-settlement-tracker
-        schedule: '43 9 * * 2' # weekly Tue 0943 PT
+        schedule: '43 9 * * 2' # weekly Tue 0943 seat-local
         wake_policy: always
       - skill: minors-compromise-packet
-        schedule: '3 9 * * 3' # weekly Wed 0903 PT — GAL/hearing/lien-figure track
+        schedule: '3 9 * * 3' # weekly Wed 0903 seat-local — GAL/hearing/lien-figure track
         wake_policy: always
       - skill: trial-binder-assembler
-        schedule: '19 9 * * 1' # weekly Mon 0919 PT — trial-prep deadline sweep
+        schedule: '19 9 * * 1' # weekly Mon 0919 seat-local — trial-prep deadline sweep
         wake_policy: always
     # Native Google/Himalaya mail skills disabled — the Operator's inbox is AgentMail.
     skills_disabled:
@@ -483,6 +484,19 @@ scope:
   # governed by the roster above, not by this ceiling (ADR 0055 §3).
 
 # ---- ESCALATION ----
+
+# ---- BUSINESS HOURS ----
+# Sets the seat's IANA timezone. bootstrap.sh exports it as HERMES_TIMEZONE, so
+# Hermes' clock AND this seat's cron schedules run in this timezone (DST-correct
+# via ZoneInfo). Unauthored = UTC (the container clock). Hours/days are the
+# firm's working window for future business-hours-aware behavior; the timezone
+# is the load-bearing field today.
+business_hours:
+  timezone: America/Los_Angeles
+  days: [mon, tue, wed, thu, fri]
+  start: '08:00'
+  end: '18:00'
+
 escalation:
   red_flag_recipients:
     - scott@smd.services

--- a/operator/customers/pilot-smokeball/customer.yaml
+++ b/operator/customers/pilot-smokeball/customer.yaml
@@ -326,44 +326,45 @@ personas:
     # decides whether a deadline needs the ladder, else writes SUPPRESSED_WAKE.
     # The PI-pack schedules below are staggered (never :00/:30) and weekday- or
     # weekly-cadenced deliberately — every wake bills tokens, so the cadence
-    # matches how fast each item actually changes.
+    # matches how fast each item actually changes. All times are seat-local
+    # (business_hours.timezone -> HERMES_TIMEZONE): authored as Pacific.
     cron:
       - skill: deadline-miss-escalator
-        schedule: '0 7 * * *' # daily 0700 PT
+        schedule: '0 7 * * *' # daily 0700 seat-local (America/Los_Angeles via business_hours; was silently UTC = midnight PT before HERMES_TIMEZONE landed)
         pre_run: pre_run.py
         wake_policy: pre_run_decides
       - skill: daily-needs-you-digest
-        schedule: '23 6 * * 1-5' # weekday 0623 PT — the morning digest
+        schedule: '23 6 * * 1-5' # weekday 0623 seat-local — the morning digest
         wake_policy: always
       - skill: discovery-response-tracker
-        schedule: '17 7 * * 1-5' # weekday 0717 PT
+        schedule: '17 7 * * 1-5' # weekday 0717 seat-local
         wake_policy: always
       - skill: client-verification-tracker
-        schedule: '41 7 * * 1-5' # weekday 0741 PT
+        schedule: '41 7 * * 1-5' # weekday 0741 seat-local
         wake_policy: always
       - skill: motion-calendar-tracker
-        schedule: '27 7 * * 1-5' # weekday 0727 PT
+        schedule: '27 7 * * 1-5' # weekday 0727 seat-local
         wake_policy: always
       - skill: service-confirmation-watcher
-        schedule: '51 7 * * 1-5' # weekday 0751 PT
+        schedule: '51 7 * * 1-5' # weekday 0751 seat-local
         wake_policy: always
       - skill: medical-chronology-maintainer
-        schedule: '33 8 * * 1-5' # weekday 0833 PT — after records imports land
+        schedule: '33 8 * * 1-5' # weekday 0833 seat-local — after records imports land
         wake_policy: always
       - skill: medical-records-chaser
-        schedule: '9 8 * * 2' # weekly Tue 0809 PT
+        schedule: '9 8 * * 2' # weekly Tue 0809 seat-local
         wake_policy: always
       - skill: lien-ledger-tracker
-        schedule: '13 9 * * 2' # weekly Tue 0913 PT
+        schedule: '13 9 * * 2' # weekly Tue 0913 seat-local
         wake_policy: always
       - skill: mediation-settlement-tracker
-        schedule: '43 9 * * 2' # weekly Tue 0943 PT
+        schedule: '43 9 * * 2' # weekly Tue 0943 seat-local
         wake_policy: always
       - skill: minors-compromise-packet
-        schedule: '3 9 * * 3' # weekly Wed 0903 PT — GAL/hearing/lien-figure track
+        schedule: '3 9 * * 3' # weekly Wed 0903 seat-local — GAL/hearing/lien-figure track
         wake_policy: always
       - skill: trial-binder-assembler
-        schedule: '19 9 * * 1' # weekly Mon 0919 PT — trial-prep deadline sweep
+        schedule: '19 9 * * 1' # weekly Mon 0919 seat-local — trial-prep deadline sweep
         wake_policy: always
     # Native Google/Himalaya mail skills disabled — the Operator's inbox is AgentMail.
     skills_disabled:
@@ -463,6 +464,19 @@ scope:
   # destructive stays taint-gated regardless of this ceiling, so an untrusted-fed
   # turn can NEVER trigger a delete. A real client seat authors its own posture
   # (a firm would typically leave destructive refused/draft).
+
+# ---- BUSINESS HOURS ----
+# Sets the seat's IANA timezone. bootstrap.sh exports it as HERMES_TIMEZONE, so
+# Hermes' clock AND this seat's cron schedules run in this timezone (DST-correct
+# via ZoneInfo). Unauthored = UTC (the container clock). Hours/days are the
+# firm's working window for future business-hours-aware behavior; the timezone
+# is the load-bearing field today.
+business_hours:
+  timezone: America/Los_Angeles
+  days: [mon, tue, wed, thu, fri]
+  start: '08:00'
+  end: '18:00'
+
 escalation:
   red_flag_recipients:
     - scott@smd.services

--- a/operator/templates/bootstrap.sh
+++ b/operator/templates/bootstrap.sh
@@ -560,6 +560,34 @@ log "Active persona profile: ${ACTIVE_PROFILE}"
 # bootstrap — the boundary that selects the profile — is where it belongs.
 export HERMES_ACTIVE_PROFILE="${ACTIVE_PROFILE}"
 
+# Publish the seat's timezone on the env channel Hermes' clock resolves first
+# (hermes_time._resolve_timezone_name: HERMES_TIMEZONE env > global config.yaml
+# `timezone` > server local). The container clock is UTC, so without this every
+# authored cron expression silently ran in UTC while the customer.yaml comments
+# claimed local time — caught 2026-07-03 when the pilot's "0623 PT" morning
+# digest turned out to mean 11:23 PM Pacific and the pre-existing escalator's
+# "0700 PT" had been firing at midnight Pacific since it shipped. Source of
+# truth is customer.yaml `business_hours.timezone` (IANA, validated by the
+# console); when the block is unauthored nothing is exported and Hermes keeps
+# server-local (UTC) — the prior behavior, not a new default (ADR 0037 tenet 3).
+# An invalid IANA name is safe: hermes_time logs a warning and falls back.
+SEAT_TIMEZONE="$(/opt/hermes/.venv/bin/python3 - "${CUSTOMER_YAML}" <<'PY'
+import sys
+import yaml
+
+data = yaml.safe_load(open(sys.argv[1])) or {}
+hours = data.get("business_hours") or {}
+tz = hours.get("timezone") if isinstance(hours, dict) else ""
+print(tz.strip() if isinstance(tz, str) else "")
+PY
+)" || SEAT_TIMEZONE=""
+if [ -n "${SEAT_TIMEZONE}" ]; then
+  export HERMES_TIMEZONE="${SEAT_TIMEZONE}"
+  log "Hermes timezone: ${SEAT_TIMEZONE} (cron + clock run in seat-local time)"
+else
+  log "Hermes timezone: unset (business_hours.timezone unauthored) — cron + clock run in UTC"
+fi
+
 PROFILE_HERMES_HOME="${HERMES_HOME}/profiles/${ACTIVE_PROFILE}"
 
 # `exec` so the gateway inherits the foreground slot under tini cleanly.


### PR DESCRIPTION
## What

The container clock is UTC and Hermes' cron engine computes due-ness with `hermes_time.now()`, whose highest-priority source is the `HERMES_TIMEZONE` environment variable — which nothing set. Every authored cron expression silently ran in UTC while the customer.yaml comments claimed Pacific: the pilot's "0623 PT" morning digest actually meant 11:23 PM Pacific (today's 0623Z slot passed five minutes before the pack's first deploy finished, so it never fired at all), and the pre-existing escalator's "0700 PT" has fired at midnight Pacific since it shipped.

## Fix (root cause, no schedule arithmetic)

- `bootstrap.sh` extracts `business_hours.timezone` from the root customer.yaml (same pattern as the ACTIVE_PROFILE extraction) and exports `HERMES_TIMEZONE` before the gateway exec, guarded on non-empty — an unauthored block keeps UTC, the prior behavior, not a new default (ADR 0035/0037)
- Both A&P-arc seats author `business_hours` (America/Los_Angeles, M-F 08:00-18:00); every cron expression is UNCHANGED and now means what its comment always claimed, DST-correct via ZoneInfo
- `customer-yaml-blocks` registry: `business_hours` declared implemented with the bootstrap materializer (the conformance gate correctly refused the undeclared block)
- New `operator/bin/tests/test_seat_timezone.py` (3 tests): extraction+export+gateway ordering, the non-empty guard, both seats authoring Pacific

## Verification

- `operator` bin tests: 155 passed; `bash -n` on bootstrap; both seats validate; `npm run verify` exit 0
- After merge + reprovision: boot log shows `Hermes timezone: America/Los_Angeles`; scheduler tick timestamps print seat-local; the digest's first genuine unattended run is tomorrow 06:23 Pacific

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K8qUZdwzz4iE4n83EVSE2Y