### PR TITLE
feat(cost): light up the cost telemetry pipeline on the central cost plane (ADR 0062)

### DIFF
--- a/docs/handbook/data-model.md
+++ b/docs/handbook/data-model.md
@@ -77,6 +77,8 @@ The `operator_*` tables (and the projection/audit tables around them) are the co
 | `operator_credential_custody` / `connector_secret_audit` | Credential-custody and connector-secret bookkeeping (migrations 0050, 0051). |
 | `operator_runtime_summary` / `operator_runtime_read_audit` | The runtime-read seam projection and its access audit (migrations 0052, 0053). |
 | `operator_mcp_clerk_bindings` / `operator_mcp_auth_contract` | Clerk-identity bindings and auth contract for the Operator's MCP channel (migrations 0071-0073). |
+| `cost_telemetry` / `captain_time_events` | Operator cost rows, keyed by `customer_slug` (migration 0083, ADR 0062). Written nightly by the `ss-cost-telemetry` worker from the Anthropic usage report; per-seat attribution maps `customer_configs.anthropic_workspace_id` to a seat, with reserved slugs `_org` (reconciliation) and `_unmapped` (unclaimed workspace usage). ADR 0062 superseded the per-customer-D1 placement, which was never provisioned. |
+| `cost_anomaly_alerts` | Nightly spike detections over `cost_telemetry` plus Captain snooze/ack state (migration 0041), written by the `ss-cost-anomaly` worker. |
 
 Secrets never enter any of these tables; non-secret references (token pointers) are denormalized where the portal needs them, and live values stay in Infisical (see `/admin/playbook/secrets-access`).
 

--- a/docs/runbooks/operator/cost-telemetry-enable.md
+++ b/docs/runbooks/operator/cost-telemetry-enable.md
@@ -6,15 +6,17 @@ The `ss-cost-telemetry` worker ingests the Anthropic usage report nightly (02:00
 
 ## Step 1: Mint and stage the Anthropic Admin key
 
+**Status: DONE 2026-07-03** (key vaulted in `/ss`, value live-verified against the usage API, worker secret set on `ss-cost-telemetry`). Kept as the rotation procedure.
+
 The usage-report API (`/v1/organizations/usage_report/messages`) requires an ADMIN API key. The runtime `ANTHROPIC_API_KEY` is rejected with `authentication_error` (verified live 2026-07-03).
 
-1. Mint an Admin API key at <https://console.anthropic.com/settings/admin-keys> (key starts with `sk-ant-admin`).
+1. Mint an Admin API key at <https://platform.claude.com/settings/admin-keys> (key starts with `sk-ant-admin`). The page exists only for team organizations: an individual Console org 404s here until it is converted (Settings → Organization → "Convert to team organization" — done for SMDurgan, LLC 2026-07-03).
 2. Store it in Infisical, path `/ss`, environment `prod`, as `ANTHROPIC_ADMIN_KEY`. Copy the value to the clipboard and use `crane_secret_set` so the value never enters a transcript.
-3. Stage it on the worker:
+3. Stage it on the worker. Do NOT use `infisical secrets get --plain |` (blocked by the secrets hook — single-value reads leak into the transcript); inject via the process env instead:
 
    ```bash
-   cd ~/dev/ss-console && infisical secrets get ANTHROPIC_ADMIN_KEY --env=prod --path=/ss --plain \
-     | npx wrangler secret put ANTHROPIC_ADMIN_KEY --name ss-cost-telemetry
+   cd ~/dev/ss-console && infisical run --env=prod --path=/ss --silent -- \
+     sh -c 'printf "%s" "$ANTHROPIC_ADMIN_KEY" | npx wrangler secret put ANTHROPIC_ADMIN_KEY --name ss-cost-telemetry'
    ```
 
 4. Verify with a live call (manual run against yesterday):
@@ -29,7 +31,7 @@ The usage-report API (`/v1/organizations/usage_report/messages`) requires an ADM
 
 Per-seat attribution comes from per-customer Anthropic workspaces (ADR 0062 decision 2). Usage stays org-level until each Machine's spend is isolated in its own workspace.
 
-1. Create one workspace per live seat at <https://console.anthropic.com/settings/workspaces>. Name it after the customer slug (for example `op-ashton-price`).
+1. Create one workspace per live seat at <https://platform.claude.com/settings/workspaces>. Name it after the customer slug (for example `op-ashton-price`).
 2. Move each Machine's Anthropic spend into its workspace: mint a workspace-scoped API key inside the new workspace, stage it to that Machine as its `ANTHROPIC_API_KEY`, and reprovision the Machine (reprovision requires explicit Captain authorization per standing rule). Existing org-default keys cannot be moved between workspaces; a new key per workspace is the path.
 3. Author the workspace id (the `wrkspc_...` value shown in the Console) into the central database:
 

--- a/docs/runbooks/operator/cost-telemetry-enable.md
+++ b/docs/runbooks/operator/cost-telemetry-enable.md
@@ -1,0 +1,47 @@
+# Enable the cost telemetry pipeline
+
+**Status:** active runbook. **Owner:** Operator platform. **Source:** ADR 0062 (Operator cost plane), issue [#1660](https://github.com/venturecrane/ss-console/issues/1660).
+
+The `ss-cost-telemetry` worker ingests the Anthropic usage report nightly (02:00 UTC) into the central `cost_telemetry` table. Two Captain steps stand between the code and live per-seat data. Until step 1 is done the cron logs one error per night and exits cleanly (no crashloop). Until step 2 is done for a seat, that seat's usage lands under the reserved slug `_unmapped` and only the `_org` reconciliation row is authoritative.
+
+## Step 1: Mint and stage the Anthropic Admin key
+
+The usage-report API (`/v1/organizations/usage_report/messages`) requires an ADMIN API key. The runtime `ANTHROPIC_API_KEY` is rejected with `authentication_error` (verified live 2026-07-03).
+
+1. Mint an Admin API key at <https://console.anthropic.com/settings/admin-keys> (key starts with `sk-ant-admin`).
+2. Store it in Infisical, path `/ss`, environment `prod`, as `ANTHROPIC_ADMIN_KEY`. Copy the value to the clipboard and use `crane_secret_set` so the value never enters a transcript.
+3. Stage it on the worker:
+
+   ```bash
+   cd ~/dev/ss-console && infisical secrets get ANTHROPIC_ADMIN_KEY --env=prod --path=/ss --plain \
+     | npx wrangler secret put ANTHROPIC_ADMIN_KEY --name ss-cost-telemetry
+   ```
+
+4. Verify with a live call (manual run against yesterday):
+
+   ```bash
+   cd ~/dev/ss-console && npx wrangler tail ss-cost-telemetry --format=pretty
+   ```
+
+   then trigger the worker's `/` fetch handler (with the `COST_INGEST_BEARER` if set) or wait for the 02:00 UTC cron. A healthy run logs `ok=true` and writes at least the two `_org` rows for the day.
+
+## Step 2: Create one workspace per seat and author the mapping
+
+Per-seat attribution comes from per-customer Anthropic workspaces (ADR 0062 decision 2). Usage stays org-level until each Machine's spend is isolated in its own workspace.
+
+1. Create one workspace per live seat at <https://console.anthropic.com/settings/workspaces>. Name it after the customer slug (for example `op-ashton-price`).
+2. Move each Machine's Anthropic spend into its workspace: mint a workspace-scoped API key inside the new workspace, stage it to that Machine as its `ANTHROPIC_API_KEY`, and reprovision the Machine (reprovision requires explicit Captain authorization per standing rule). Existing org-default keys cannot be moved between workspaces; a new key per workspace is the path.
+3. Author the workspace id (the `wrkspc_...` value shown in the Console) into the central database:
+
+   ```bash
+   cd ~/dev/ss-console && npx wrangler d1 execute ss-console-db --remote \
+     --command "UPDATE customer_configs SET anthropic_workspace_id = 'wrkspc_XXXX' WHERE customer_slug = '<slug>'"
+   ```
+
+4. Verify the next nightly run: the seat's slug should appear in the run summary's `slugs` list, and its rows should show on the cost dashboard at <https://admin.smd.services/admin/operator/costs>. Any workspace id still unmapped is logged by name and lands under `_unmapped`.
+
+## How to read the data
+
+- `cost_telemetry` is keyed `(customer_slug, date, driver)` in the central `ss-console-db` (migration 0083).
+- `_org` rows (drivers `anthropic.org_total.input_tokens` / `anthropic.org_total.output_tokens`) are the reconciliation cross-check against the Anthropic invoice. The sum of per-seat plus `_unmapped` rows should match them.
+- Writes are idempotent day totals: re-running the ingest for a day replaces that day's rows, so a manual re-run is always safe.

--- a/docs/specs/operator/cost-attribution-rollup.md
+++ b/docs/specs/operator/cost-attribution-rollup.md
@@ -99,6 +99,8 @@ CREATE TABLE cost_telemetry (
 );
 ```
 
+> **Amended 2026-07-03 (ADR 0062, #1660).** The storage location moved to the central ss-console D1; see the amendment under "Privacy posture". `operator/migrations/0006` remains as historical record; the live tables are created by `migrations/0083_central_cost_telemetry.sql`.
+
 Migration `0006_cost_attribution_rollup.sql` adds:
 
 1. `captain_time_events` — the per-event Captain time table referenced by cost-telemetry-events.md "Captain time logging" but not present in migration 0001. The `crane operator log-time` CLI writes one row here per invocation and pairs that with a same-day UPSERT into `cost_telemetry` under `driver='captain_time'`.
@@ -107,6 +109,8 @@ Migration `0006_cost_attribution_rollup.sql` adds:
 Neither change touches existing rows. The migration is additive.
 
 ## Privacy posture
+
+> **Amended 2026-07-03 (ADR 0062, #1660).** Superseded for the cost tables: `cost_telemetry` and `captain_time_events` now live in the central ss-console D1 (migration `0083_central_cost_telemetry.sql`) with a `customer_slug` tenant column. Cost rows are SMD's own spend metadata, not customer content, and ADR 0009 explicitly carves out control-plane billing reconciliation. Cross-customer aggregation is therefore a single query against the central table; per-customer readers scope by `customer_slug` and must exclude the reserved `_org` / `_unmapped` slugs. The original text is retained below as historical record.
 
 Per [ADR 0009](../../adr/0009-cross-machine-query-prohibition.md), `cost_telemetry` and `captain_time_events` live in the per-customer D1 database. No row-level `customer_id` column. No cross-customer aggregate query is possible at the database layer. The rollup module accepts a single executor bound to one customer's database; computing a cross-customer total requires N calls and an aggregation in the Captain control plane.
 

--- a/docs/specs/operator/cost-telemetry-events.md
+++ b/docs/specs/operator/cost-telemetry-events.md
@@ -8,6 +8,8 @@ Per PM R7, telemetry instrumentation is a **Phase 2 scope item**, not Phase 1 â€
 
 ### Storage
 
+> **Amended 2026-07-03 (ADR 0062, #1660).** The per-customer-D1 placement below is superseded: those databases were never provisioned (see ADR 0009's wiring note), so this spec's storage clause described a store that did not exist. `cost_telemetry` and `captain_time_events` live in the **central ss-console D1** (`ss-console-db`, migration `0083_central_cost_telemetry.sql`) with a `customer_slug` tenant column, under ADR 0009's billing-reconciliation carve-out and the `fleet_status` precedent (ADR 0023). Reserved slugs: `_org` (org-level reconciliation rows under drivers `anthropic.org_total.input_tokens` / `anthropic.org_total.output_tokens`) and `_unmapped` (usage from Anthropic workspaces no seat claims). Per-seat attribution comes from per-customer Anthropic **workspaces** mapped via `customer_configs.anthropic_workspace_id` (see `docs/runbooks/operator/cost-telemetry-enable.md`). The nightly worker's writes are idempotent day totals (replace-on-conflict), because the usage-report API returns authoritative daily figures; the additive accumulate-on-conflict contract below still applies to per-event emitters such as the captain-time CLI rollup. The original text is retained below as historical record.
+
 All events land in the per-customer `cost_telemetry` D1 table per d1-schema.md:
 
 ```sql

--- a/docs/specs/operator/d1-schema.md
+++ b/docs/specs/operator/d1-schema.md
@@ -131,6 +131,10 @@ CREATE TABLE draft_queue (
 CREATE INDEX idx_draft_pending ON draft_queue(status, priority, created_at) WHERE status = 'pending';
 
 -- 6. Cost telemetry (per-day rollup; see cost-telemetry-events.md)
+-- AMENDED 2026-07-03 (ADR 0062, #1660): tables 6 and 6a moved to the CENTRAL
+-- ss-console D1 (migrations/0083_central_cost_telemetry.sql) with a
+-- customer_slug tenant column. The per-customer copies below are historical
+-- record; no new consumer may be designed against them.
 CREATE TABLE cost_telemetry (
   date          TEXT NOT NULL,              -- YYYY-MM-DD
   driver        TEXT NOT NULL,

--- a/migrations/0083_central_cost_telemetry.sql
+++ b/migrations/0083_central_cost_telemetry.sql
@@ -1,0 +1,76 @@
+-- 0083: central cost telemetry (ADR 0062, #1660).
+--
+-- ADR 0062 supersedes the per-customer-D1 placement of the Operator cost
+-- tables. The per-customer databases specced in operator/migrations/0001
+-- and 0006 were never provisioned (ADR 0009's wiring note: that storage
+-- model "was never built"), so the cost pipeline has been dark since it
+-- shipped. Cost rows are SMD's own spend metadata, not customer content,
+-- and ADR 0009 explicitly carves out control-plane billing reconciliation.
+-- These tables therefore live in the central ss-console-db with a
+-- customer_slug tenant column, following the fleet_status pattern
+-- (ADR 0023).
+--
+-- Reserved customer_slug values (not real customers, never rendered as
+-- customer rows by the dashboard, excluded from anomaly detection):
+--
+--   '_org'      — org-level reconciliation rows written by the
+--                 ss-cost-telemetry worker under the drivers
+--                 'anthropic.org_total.input_tokens' /
+--                 'anthropic.org_total.output_tokens'. The org total is a
+--                 cross-check against the sum of per-workspace rows, not
+--                 an attribution source.
+--   '_unmapped' — usage attributed by Anthropic to a workspace_id that no
+--                 customer_configs.anthropic_workspace_id claims. Nothing
+--                 is silently dropped; the worker logs the workspace id.
+--
+-- Write semantics: the nightly worker writes idempotent day totals
+-- (ON CONFLICT ... SET amount_cents = excluded.amount_cents), because the
+-- Anthropic usage-report API returns the authoritative total for the day.
+-- The additive accumulate-on-conflict contract in cost-telemetry-events.md
+-- applies to per-event emitters (the captain-time CLI rollup), not to this
+-- vendor-report ingest.
+
+CREATE TABLE IF NOT EXISTS cost_telemetry (
+  customer_slug TEXT NOT NULL,              -- customer_configs.customer_slug, or '_org' / '_unmapped'
+  date          TEXT NOT NULL,              -- YYYY-MM-DD (UTC)
+  driver        TEXT NOT NULL,              -- enum per cost-telemetry-events.md, plus the '_org' reconciliation drivers
+  amount_cents  INTEGER NOT NULL DEFAULT 0,
+  units         REAL,                       -- e.g. tokens, minutes
+  unit_type     TEXT,
+  updated_at    TEXT,                       -- ISO 8601 UTC of the last write
+  PRIMARY KEY (customer_slug, date, driver)
+);
+
+-- Cross-customer daily scans (anomaly windows, dashboard totals). The PK
+-- covers per-customer reads; this index serves date-first queries.
+CREATE INDEX IF NOT EXISTS idx_cost_telemetry_date
+  ON cost_telemetry(date);
+
+-- Captain time events, event-sourced (mirrors the per-customer shape from
+-- operator/migrations/0006 plus the customer_slug tenant column). One row
+-- per `crane operator log-time` invocation; the CLI pairs each insert with
+-- an additive UPSERT into cost_telemetry under driver='captain_time'.
+-- Intentionally not UPSERT-keyed: two distinct 15-minute sessions on the
+-- same day both persist.
+CREATE TABLE IF NOT EXISTS captain_time_events (
+  id            TEXT PRIMARY KEY,           -- ULID
+  customer_slug TEXT NOT NULL,
+  ts            TEXT NOT NULL,              -- ISO 8601 UTC of CLI invocation
+  date          TEXT NOT NULL,              -- YYYY-MM-DD; --date flag, defaults to today UTC
+  activity      TEXT NOT NULL,              -- closed activity-tag taxonomy
+  minutes       INTEGER NOT NULL,           -- > 0 and <= 600
+  amount_cents  INTEGER NOT NULL,           -- (minutes * 200 * 100) / 60 at the $200/hr Captain rate
+  note          TEXT                        -- optional free text, <= 280 chars
+);
+CREATE INDEX IF NOT EXISTS idx_captain_time_customer_date
+  ON captain_time_events(customer_slug, date);
+CREATE INDEX IF NOT EXISTS idx_captain_time_activity
+  ON captain_time_events(activity, date);
+
+-- The authored workspace mapping for per-seat attribution (ADR 0062
+-- decision 2). Captain creates one Anthropic workspace per seat in the
+-- Anthropic Console and records its id here (wrkspc_...). NULL means the
+-- seat is not yet attributed: its usage lands under '_unmapped' and only
+-- the '_org' reconciliation row is authoritative until the mapping is
+-- authored. See docs/runbooks/operator/cost-telemetry-enable.md.
+ALTER TABLE customer_configs ADD COLUMN anthropic_workspace_id TEXT;

--- a/operator/migrations/0001_per_customer_schema.sql
+++ b/operator/migrations/0001_per_customer_schema.sql
@@ -7,6 +7,11 @@
 -- enforced at the database binding layer (one binding per Machine), not at
 -- the row level — see ADR 0009 (cross-Machine query prohibition).
 --
+-- NOTE (2026-07-03, ADR 0062): the cost tables in this file (cost_telemetry,
+-- captain_time_events) had their placement superseded — they now live in the
+-- central ss-console D1 (migrations/0083_central_cost_telemetry.sql). This
+-- file stays as historical record.
+--
 -- Source spec: docs/specs/operator/d1-schema.md
 -- Applied by:  operator/adapter/run_migrations.py (invoked from
 --              bin/provision-customer.sh during customer provisioning)

--- a/operator/migrations/0006_cost_attribution_rollup.sql
+++ b/operator/migrations/0006_cost_attribution_rollup.sql
@@ -2,6 +2,10 @@
 -- Migration 0006: cost attribution rollup support (issue #884)
 -- ============================================================================
 --
+-- NOTE (2026-07-03, ADR 0062): the cost tables' placement was superseded —
+-- cost_telemetry and captain_time_events now live in the central ss-console
+-- D1 (migrations/0083_central_cost_telemetry.sql). Historical record.
+--
 -- Per-customer cost attribution rollup. The daily-roll `cost_telemetry` table
 -- already exists from migration 0001 with the shape
 -- `(date, driver, amount_cents, units, unit_type) PRIMARY KEY (date, driver)`

--- a/operator/migrations/README.md
+++ b/operator/migrations/README.md
@@ -20,7 +20,7 @@ Forward-only. There is no rollback path because audit-log immutability would be 
 - `0003_memory_ingestion.sql` — per-customer memory pipeline state.
 - `0004_sticky_stop_state.sql` — sticky-stop state machine table (substrate invariant #4).
 - `0005_voice_ingestion.sql` — voice-sample ingestion state.
-- `0006_cost_attribution_rollup.sql` — per-customer cost rollup.
+- `0006_cost_attribution_rollup.sql` — per-customer cost rollup. **Placement superseded by ADR 0062 (2026-07-03):** the cost tables (`cost_telemetry`, `captain_time_events`) now live in the central ss-console D1 (`migrations/0083_central_cost_telemetry.sql`); this file stays as historical record.
 - `0007_persona_observations.sql` — **rewritten 2026-05-25** per ADR 0016 rewrite (2026-05-24): mirror-don't-gate posture. Table holds Honcho conclusions mirrored by `hermes-smd-memory-mirror` plugin with `evidence_status` classification (defends against Honcho bug #626); `persona_observations_archive` for TTL'd rows.
 - `0008_agent_skills_inventory.sql` — **rewritten + renamed from `0008_skill_drafts.sql` 2026-05-25** per ADR 0017 rewrite (2026-05-24): trust-native posture. Table mirrors agent-authored skills the `skill_manage` tool creates; Captain reviews and physically removes in the admin portal.
 

--- a/src/components/admin/CostsTableRow.astro
+++ b/src/components/admin/CostsTableRow.astro
@@ -27,9 +27,7 @@ export interface CostsRowCard {
   entity_name: string | null
   subscription_status: string | null
   monthly_revenue_cents: number | null
-  per_customer_d1_database_id: string | null
   error: string | null
-  skippedReason: string | null
 }
 
 interface Props {
@@ -39,7 +37,6 @@ interface Props {
   rollingAvgDailyCents: number | null
   monthlyEstimateCents: number
   ratio: CogsRatio
-  cfConfigMissing: boolean
   windowStart: string
   windowEnd: string
   formatCurrency: (cents: number) => string
@@ -54,7 +51,6 @@ const {
   rollingAvgDailyCents,
   monthlyEstimateCents,
   ratio,
-  cfConfigMissing,
   windowStart,
   windowEnd,
   formatCurrency,
@@ -63,7 +59,8 @@ const {
 } = Astro.props
 
 const hb = heartbeatDisplay(fleet?.last_heartbeat_ts ?? null)
-const exportable = card.per_customer_d1_database_id && !cfConfigMissing
+// Central table (ADR 0062): every customer is exportable unless the read errored.
+const exportable = !card.error
 const showSentry24h =
   fleet?.sentry_errors_last_24h !== null && fleet?.sentry_errors_last_24h !== undefined
 const sentryTitle = fleet ? `Synced ${relativeTimestamp(fleet.sentry_errors_synced_at)}` : ''
@@ -88,7 +85,7 @@ const sentryTitle = fleet ? `Synced ${relativeTimestamp(fleet.sentry_errors_sync
   </td>
   <td class="py-3 text-right text-[color:var(--ss-color-text-primary)]">
     {
-      card.error || card.skippedReason ? (
+      card.error ? (
         <span class="text-[color:var(--ss-color-text-muted)]">—</span>
       ) : (
         formatCurrency(cogs30dCents)
@@ -106,7 +103,7 @@ const sentryTitle = fleet ? `Synced ${relativeTimestamp(fleet.sentry_errors_sync
   </td>
   <td class="py-3 text-right text-[color:var(--ss-color-text-secondary)]">
     {
-      card.error || card.skippedReason ? (
+      card.error ? (
         <span class="text-[color:var(--ss-color-text-muted)]">—</span>
       ) : (
         <span title="30-day COGS scaled to a 30.4375-day month">

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -175,20 +175,6 @@ declare namespace Cloudflare {
      */
     FLY_API_TOKEN?: string
     /**
-     * Cloudflare account id and D1 HTTP API token, used by the Captain
-     * cost dashboard (issue #885) to read per-customer `cost_telemetry`
-     * rows over HTTP. Per ADR 0009 each customer has their own D1
-     * database; declaring N per-customer bindings at deploy time does
-     * not scale, so the dashboard goes through the same HTTP path the
-     * `ss-cost-telemetry` worker uses to write those tables.
-     *
-     * The token requires D1:Read scope across customer databases. When
-     * unset the dashboard renders an explicit configuration warning
-     * rather than fabricating zero-cost data.
-     */
-    CF_ACCOUNT_ID?: string
-    CF_D1_API_TOKEN?: string
-    /**
      * Shared bearer secret for the per-customer Operator Machine
      * heartbeat path (`POST /api/internal/heartbeat`). Wave 1 uses a
      * single shared key authenticating ANY Machine; the X-Tenant-Slug

--- a/src/lib/admin/cost-query.ts
+++ b/src/lib/admin/cost-query.ts
@@ -1,25 +1,20 @@
 /**
- * Captain cost dashboard — query layer for the per-customer cost_telemetry
- * data populated by the `ss-cost-telemetry` worker (PR #1023).
+ * Captain cost dashboard — query layer for the central cost_telemetry
+ * data populated by the `ss-cost-telemetry` worker.
  *
- * Two data surfaces are involved:
+ * One data surface: central D1 (`env.DB`). It holds `customer_configs`
+ * (the customer enumeration), `subscriptions` (the delivery-status
+ * display), the `services` spine (the authoritative recurring-revenue
+ * figure, `recurring_price`, used by the COGS/MRR ratio — ADR 0046),
+ * and — since ADR 0062 (migration 0083) — the `cost_telemetry` table
+ * itself, keyed (customer_slug, date, driver).
  *
- *   1. Central D1 (`env.DB`) — holds `customer_configs` (the customer
- *      enumeration), `subscriptions` (the delivery-status display), and the
- *      `services` spine (the authoritative recurring-revenue figure,
- *      `recurring_price`, used by the COGS/MRR ratio — ADR 0046, single
- *      source of truth, no longer `subscriptions.settings_json`).
- *
- *   2. Per-customer D1 (one per customer, addressed via the Cloudflare
- *      D1 HTTP API) — holds the `cost_telemetry` table per ADR 0009.
- *      The per-customer database id is stored in
- *      `customer_configs.connectors_json.per_customer_d1_database_id`.
- *
- * Reading the per-customer DB from this Worker means we go through the
- * D1 HTTP API rather than a binding — same mechanism the telemetry
- * worker uses. This is deliberate: declaring N per-customer D1 bindings
- * in wrangler.toml at deploy time does not scale, and the dashboard is
- * a Captain-only surface where the modest extra latency is acceptable.
+ * The per-customer-D1 HTTP fan-out this module used to perform (per the
+ * original ADR 0009 storage premise) is retired: those databases were
+ * never provisioned, and ADR 0062 moved cost rows to the central store
+ * under the billing-reconciliation carve-out. Reserved slugs '_org'
+ * (org reconciliation) and '_unmapped' (workspace usage no seat claims)
+ * never appear here because the enumeration comes from customer_configs.
  *
  * Fabrication discipline (CLAUDE.md Pattern A/B): the dashboard never
  * fabricates per-skill or per-model breakdown that the underlying schema
@@ -29,16 +24,10 @@
  * data.
  */
 
-export interface CostQueryEnv {
-  CF_ACCOUNT_ID: string
-  CF_D1_API_TOKEN: string
-}
-
 export interface CustomerListRow {
   customer_slug: string
   entity_id: string | null
   entity_name: string | null
-  per_customer_d1_database_id: string | null
   subscription_status: string | null
   monthly_revenue_cents: number | null
 }
@@ -46,7 +35,6 @@ export interface CustomerListRow {
 interface CustomerConfigRow {
   customer_slug: string
   entity_id: string
-  connectors_json: string | null
 }
 
 interface SubscriptionRow {
@@ -66,9 +54,8 @@ interface EntityRow {
 
 /**
  * Enumerate every Operator customer with the data the dashboard
- * needs: the per-customer D1 id (required to read cost_telemetry), the
- * subscription status (for the COGS-vs-revenue indicator), and the
- * entity name (display).
+ * needs: the subscription status (for the COGS-vs-revenue indicator)
+ * and the entity name (display).
  *
  * The query joins customer_configs to subscriptions filtered to the
  * `operator` product slug — non-Operator customers don't apply.
@@ -76,7 +63,7 @@ interface EntityRow {
 export async function listCostCustomers(db: D1Database): Promise<CustomerListRow[]> {
   const configsResult = await db
     .prepare(
-      `SELECT customer_slug, entity_id, connectors_json
+      `SELECT customer_slug, entity_id
          FROM customer_configs
          ORDER BY customer_slug`
     )
@@ -128,13 +115,11 @@ export async function listCostCustomers(db: D1Database): Promise<CustomerListRow
   }
 
   return configs.map((c) => {
-    const { perCustomerDbId } = parseConnectors(c.connectors_json)
     const price = priceByEntity.get(c.entity_id) ?? null
     return {
       customer_slug: c.customer_slug,
       entity_id: c.entity_id,
       entity_name: namesByEntity.get(c.entity_id) ?? null,
-      per_customer_d1_database_id: perCustomerDbId,
       subscription_status: subStatusByEntity.get(c.entity_id) ?? null,
       // Authoritative recurring revenue from the spine, in cents for the ratio math.
       monthly_revenue_cents: price == null ? null : Math.round(price * 100),
@@ -142,28 +127,8 @@ export async function listCostCustomers(db: D1Database): Promise<CustomerListRow
   })
 }
 
-function parseConnectors(connectorsJson: string | null): {
-  perCustomerDbId: string | null
-} {
-  if (!connectorsJson) return { perCustomerDbId: null }
-  let parsed: unknown
-  try {
-    parsed = JSON.parse(connectorsJson)
-  } catch {
-    return { perCustomerDbId: null }
-  }
-  if (!parsed || typeof parsed !== 'object') {
-    return { perCustomerDbId: null }
-  }
-  const obj = parsed as Record<string, unknown>
-  const dbId = obj['per_customer_d1_database_id']
-  return {
-    perCustomerDbId: typeof dbId === 'string' && dbId.length > 0 ? dbId : null,
-  }
-}
-
 // ---------------------------------------------------------------------------
-// Per-customer cost_telemetry reads (D1 HTTP API)
+// Central cost_telemetry reads (D1 binding, ADR 0062)
 // ---------------------------------------------------------------------------
 
 export interface CostTelemetryRow {
@@ -174,7 +139,7 @@ export interface CostTelemetryRow {
   unit_type: string | null
 }
 
-interface D1HttpResultRow {
+interface RawCostRow {
   date?: string
   driver?: string
   amount_cents?: number
@@ -182,84 +147,43 @@ interface D1HttpResultRow {
   unit_type?: string | null
 }
 
-interface D1HttpResponse {
-  success?: boolean
-  errors?: unknown
-  result?: Array<{ results?: D1HttpResultRow[] }>
-}
-
 /**
  * Read raw cost_telemetry rows for one customer over a date window
- * (inclusive `startDate`, exclusive `endDate` — both 'YYYY-MM-DD').
+ * (inclusive `startDate`, exclusive `endDate` — both 'YYYY-MM-DD')
+ * from the central table via the D1 binding.
  *
- * The half-open range matches the `(date, driver)` PK index in
- * cost_rollup.py so D1 plans this as an index scan rather than a table
- * walk. Rows come back ordered by `(date, driver)` for stable rendering.
+ * The half-open range rides the `(customer_slug, date, driver)` PK so
+ * D1 plans this as an index scan. Rows come back ordered by
+ * `(date, driver)` for stable rendering.
  *
- * Returns `{ rows: [], error: <message> }` when the database is
- * unreachable; the caller renders an explicit warning rather than
- * an empty table that looks the same as "no usage yet". See
- * docs/style/empty-state-pattern.md.
+ * Returns `{ rows: [], error: <message> }` when the query fails; the
+ * caller renders an explicit warning rather than an empty table that
+ * looks the same as "no usage yet". See docs/style/empty-state-pattern.md.
  */
 export async function fetchCustomerCostRows(
-  env: CostQueryEnv,
-  databaseId: string,
+  db: D1Database,
+  customerSlug: string,
   startDate: string,
   endDate: string
 ): Promise<{ rows: CostTelemetryRow[]; error: string | null }> {
-  const fetched = await fetchD1Payload(env, databaseId, startDate, endDate)
-  if (fetched.error !== null) return { rows: [], error: fetched.error }
-  const resultRows = fetched.payload.result?.[0]?.results ?? []
-  return { rows: validateRows(resultRows), error: null }
-}
-
-async function fetchD1Payload(
-  env: CostQueryEnv,
-  databaseId: string,
-  startDate: string,
-  endDate: string
-): Promise<{ payload: D1HttpResponse; error: null } | { payload: null; error: string }> {
-  const sql =
-    'SELECT date, driver, amount_cents, units, unit_type ' +
-    'FROM cost_telemetry ' +
-    'WHERE date >= ? AND date < ? AND amount_cents >= 0 ' +
-    'ORDER BY date, driver'
-  const url =
-    `https://api.cloudflare.com/client/v4/accounts/${env.CF_ACCOUNT_ID}` +
-    `/d1/database/${databaseId}/query`
-  let response: Response
   try {
-    response = await fetch(url, {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${env.CF_D1_API_TOKEN}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ sql, params: [startDate, endDate] }),
-    })
+    const result = await db
+      .prepare(
+        'SELECT date, driver, amount_cents, units, unit_type ' +
+          'FROM cost_telemetry ' +
+          'WHERE customer_slug = ? AND date >= ? AND date < ? AND amount_cents >= 0 ' +
+          'ORDER BY date, driver'
+      )
+      .bind(customerSlug, startDate, endDate)
+      .all<RawCostRow>()
+    return { rows: validateRows(result.results ?? []), error: null }
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e)
-    return { payload: null, error: `D1 HTTP request failed: ${msg}` }
+    return { rows: [], error: `cost_telemetry query failed: ${msg}` }
   }
-  if (!response.ok) {
-    const text = await safeText(response)
-    return { payload: null, error: `D1 HTTP ${response.status}: ${text.slice(0, 200)}` }
-  }
-  let raw: unknown
-  try {
-    raw = await response.json()
-  } catch (e) {
-    const msg = e instanceof Error ? e.message : String(e)
-    return { payload: null, error: `D1 response parse failed: ${msg}` }
-  }
-  const payload = raw as D1HttpResponse
-  if (!payload.success) {
-    return { payload: null, error: `D1 query failed: ${JSON.stringify(payload.errors ?? {})}` }
-  }
-  return { payload, error: null }
 }
 
-function validateRows(resultRows: D1HttpResultRow[]): CostTelemetryRow[] {
+function validateRows(resultRows: RawCostRow[]): CostTelemetryRow[] {
   const rows: CostTelemetryRow[] = []
   for (const r of resultRows) {
     if (typeof r.date !== 'string' || typeof r.driver !== 'string') continue
@@ -273,14 +197,6 @@ function validateRows(resultRows: D1HttpResultRow[]): CostTelemetryRow[] {
     })
   }
   return rows
-}
-
-async function safeText(response: Response): Promise<string> {
-  try {
-    return await response.text()
-  } catch {
-    return ''
-  }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/pages/admin/operator/costs/[customer_slug].astro
+++ b/src/pages/admin/operator/costs/[customer_slug].astro
@@ -45,28 +45,16 @@ if (!customer) {
 }
 
 const window = defaultWindow()
-const cfConfigMissing = !env.CF_ACCOUNT_ID || !env.CF_D1_API_TOKEN
 
+// Central cost_telemetry read via the D1 binding (ADR 0062).
 let fetchError: string | null = null
 let summary: ReturnType<typeof summarizeCostRows> | null = null
-let skippedReason: string | null = null
 
-if (!customer.per_customer_d1_database_id) {
-  skippedReason = 'No per-customer D1 configured yet (connectors_json missing the database id)'
-} else if (cfConfigMissing) {
-  skippedReason = 'CF_ACCOUNT_ID / CF_D1_API_TOKEN not configured on this Worker'
+const result = await fetchCustomerCostRows(env.DB, customer_slug, window.start, window.end)
+if (result.error) {
+  fetchError = result.error
 } else {
-  const result = await fetchCustomerCostRows(
-    { CF_ACCOUNT_ID: env.CF_ACCOUNT_ID!, CF_D1_API_TOKEN: env.CF_D1_API_TOKEN! },
-    customer.per_customer_d1_database_id,
-    window.start,
-    window.end
-  )
-  if (result.error) {
-    fetchError = result.error
-  } else {
-    summary = summarizeCostRows(customer_slug, window.start, window.end, result.rows)
-  }
+  summary = summarizeCostRows(customer_slug, window.start, window.end, result.rows)
 }
 
 function formatCurrency(cents: number): string {
@@ -154,7 +142,7 @@ const exportHref = `/api/admin/operator/costs/export?customer_slug=${encodeURICo
         </p>
       </div>
       {
-        customer.per_customer_d1_database_id && !cfConfigMissing && (
+        !fetchError && (
           <a
             href={exportHref}
             class="inline-flex items-center min-h-11 px-3 text-sm font-medium border border-[color:var(--ss-color-border)] rounded-[var(--ss-radius-card)] text-[color:var(--ss-color-text-primary)] hover:bg-[color:var(--ss-color-border-subtle)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2"
@@ -166,21 +154,10 @@ const exportHref = `/api/admin/operator/costs/export?customer_slug=${encodeURICo
     </header>
 
     {
-      skippedReason && (
-        <div class="rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-attention)] bg-white p-card">
-          <h3 class="text-base font-semibold text-[color:var(--ss-color-text-primary)] mb-2">
-            Cost data unavailable
-          </h3>
-          <p class="text-sm text-[color:var(--ss-color-text-secondary)]">{skippedReason}</p>
-        </div>
-      )
-    }
-
-    {
       fetchError && (
         <div class="rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-error)] bg-white p-card">
           <h3 class="text-base font-semibold text-[color:var(--ss-color-error)] mb-2">
-            D1 query failed
+            Cost query failed
           </h3>
           <p class="text-sm text-[color:var(--ss-color-text-secondary)]">{fetchError}</p>
         </div>

--- a/src/pages/admin/operator/costs/index.astro
+++ b/src/pages/admin/operator/costs/index.astro
@@ -30,11 +30,15 @@ import { env } from 'cloudflare:workers'
  *
  * Issue #885 (PRD §15.1).
  *
+ * Cost rows live in the CENTRAL cost_telemetry table (ADR 0062,
+ * migration 0083), read through the D1 binding — the per-customer-D1
+ * HTTP fan-out is retired.
+ *
  * Fabrication discipline (CLAUDE.md Pattern A/B): every figure on this
  * page is computed from real `cost_telemetry` rows or labelled as an
  * estimate when normalizing (e.g. 30-day COGS scaled to a monthly
- * equivalent). When the D1 HTTP API is unreachable the row renders an
- * explicit error rather than zero.
+ * equivalent). When the query fails the row renders an explicit error
+ * rather than zero.
  */
 
 const session = Astro.locals.session!
@@ -46,8 +50,6 @@ const window = defaultWindow()
 if (session.role !== 'admin') {
   return Astro.redirect('/auth/sign-in')
 }
-
-const cfConfigMissing = !env.CF_ACCOUNT_ID || !env.CF_D1_API_TOKEN
 
 const customers = await listCostCustomers(env.DB)
 const openAlerts = await listOpenAlerts(env.DB)
@@ -65,47 +67,13 @@ interface CustomerCard {
   entity_name: string | null
   subscription_status: string | null
   monthly_revenue_cents: number | null
-  per_customer_d1_database_id: string | null
   summary: CustomerCostSummary | null
   error: string | null
-  skippedReason: string | null
 }
 
 const cards: CustomerCard[] = await Promise.all(
   customers.map(async (c): Promise<CustomerCard> => {
-    if (!c.per_customer_d1_database_id) {
-      return {
-        customer_slug: c.customer_slug,
-        entity_id: c.entity_id,
-        entity_name: c.entity_name,
-        subscription_status: c.subscription_status,
-        monthly_revenue_cents: c.monthly_revenue_cents,
-        per_customer_d1_database_id: c.per_customer_d1_database_id,
-        summary: null,
-        error: null,
-        skippedReason:
-          'No per-customer D1 configured yet (connectors_json missing the database id)',
-      }
-    }
-    if (cfConfigMissing) {
-      return {
-        customer_slug: c.customer_slug,
-        entity_id: c.entity_id,
-        entity_name: c.entity_name,
-        subscription_status: c.subscription_status,
-        monthly_revenue_cents: c.monthly_revenue_cents,
-        per_customer_d1_database_id: c.per_customer_d1_database_id,
-        summary: null,
-        error: null,
-        skippedReason: 'CF_ACCOUNT_ID / CF_D1_API_TOKEN not configured on this Worker',
-      }
-    }
-    const result = await fetchCustomerCostRows(
-      { CF_ACCOUNT_ID: env.CF_ACCOUNT_ID!, CF_D1_API_TOKEN: env.CF_D1_API_TOKEN! },
-      c.per_customer_d1_database_id,
-      window.start,
-      window.end
-    )
+    const result = await fetchCustomerCostRows(env.DB, c.customer_slug, window.start, window.end)
     if (result.error) {
       return {
         customer_slug: c.customer_slug,
@@ -113,10 +81,8 @@ const cards: CustomerCard[] = await Promise.all(
         entity_name: c.entity_name,
         subscription_status: c.subscription_status,
         monthly_revenue_cents: c.monthly_revenue_cents,
-        per_customer_d1_database_id: c.per_customer_d1_database_id,
         summary: null,
         error: result.error,
-        skippedReason: null,
       }
     }
     const summary = summarizeCostRows(c.customer_slug, window.start, window.end, result.rows)
@@ -126,10 +92,8 @@ const cards: CustomerCard[] = await Promise.all(
       entity_name: c.entity_name,
       subscription_status: c.subscription_status,
       monthly_revenue_cents: c.monthly_revenue_cents,
-      per_customer_d1_database_id: c.per_customer_d1_database_id,
       summary,
       error: null,
-      skippedReason: null,
     }
   })
 )
@@ -234,22 +198,6 @@ const totalCogs30dCents = rows.reduce((sum, r) => sum + r.cogs30dCents, 0)
         </p>
       </div>
     </header>
-
-    {
-      cfConfigMissing && (
-        <div class="rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-error)] bg-white p-card">
-          <h3 class="text-base font-semibold text-[color:var(--ss-color-error)] mb-2">
-            D1 HTTP API not configured
-          </h3>
-          <p class="text-sm text-[color:var(--ss-color-text-secondary)]">
-            <code>CF_ACCOUNT_ID</code> and <code>CF_D1_API_TOKEN</code> are not set on this Worker.
-            Per-customer cost data lives in per-customer D1 databases (ADR 0009); without the API
-            token the dashboard cannot read them. Set both secrets via{' '}
-            <code>wrangler secret put</code> and redeploy.
-          </p>
-        </div>
-      )
-    }
 
     {
       openAlerts.length > 0 && (
@@ -391,7 +339,6 @@ const totalCogs30dCents = rows.reduce((sum, r) => sum + r.cogs30dCents, 0)
                       rollingAvgDailyCents={rollingAvgDailyCents}
                       monthlyEstimateCents={monthlyEstimateCents}
                       ratio={ratio}
-                      cfConfigMissing={cfConfigMissing}
                       windowStart={window.start}
                       windowEnd={window.end}
                       formatCurrency={formatCurrency}
@@ -422,22 +369,20 @@ const totalCogs30dCents = rows.reduce((sum, r) => sum + r.cogs30dCents, 0)
     </div>
 
     {
-      rows.some((r) => r.card.error || r.card.skippedReason) && (
+      rows.some((r) => r.card.error) && (
         <div class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card">
           <h3 class="text-base font-semibold text-[color:var(--ss-color-text-primary)] mb-3">
-            Skipped or errored customers
+            Errored customers
           </h3>
           <ul class="space-y-2 text-sm">
             {rows
-              .filter((r) => r.card.error || r.card.skippedReason)
+              .filter((r) => r.card.error)
               .map((r) => (
                 <li class="flex items-start gap-2">
                   <span class="font-medium text-[color:var(--ss-color-text-primary)] shrink-0">
                     {r.card.customer_slug}
                   </span>
-                  <span class="text-[color:var(--ss-color-text-secondary)]">
-                    {r.card.error ?? r.card.skippedReason}
-                  </span>
+                  <span class="text-[color:var(--ss-color-text-secondary)]">{r.card.error}</span>
                 </li>
               ))}
           </ul>

--- a/src/pages/api/admin/operator/costs/export.ts
+++ b/src/pages/api/admin/operator/costs/export.ts
@@ -54,19 +54,9 @@ async function handleGet({ request, locals }: APIContext): Promise<Response> {
   if (!customer) {
     return jsonResponse(404, { error: 'customer not found' })
   }
-  if (!customer.per_customer_d1_database_id) {
-    return jsonResponse(409, { error: 'customer has no per-customer D1 database configured' })
-  }
-  if (!env.CF_ACCOUNT_ID || !env.CF_D1_API_TOKEN) {
-    return jsonResponse(503, { error: 'CF_ACCOUNT_ID / CF_D1_API_TOKEN not configured' })
-  }
 
-  const result = await fetchCustomerCostRows(
-    { CF_ACCOUNT_ID: env.CF_ACCOUNT_ID, CF_D1_API_TOKEN: env.CF_D1_API_TOKEN },
-    customer.per_customer_d1_database_id,
-    start,
-    end
-  )
+  // Central cost_telemetry read via the D1 binding (ADR 0062).
+  const result = await fetchCustomerCostRows(env.DB, customerSlug, start, end)
   if (result.error) {
     return jsonResponse(502, { error: result.error })
   }

--- a/tests/admin-cost-export.test.ts
+++ b/tests/admin-cost-export.test.ts
@@ -8,13 +8,16 @@
  *   - Bad date format → 400
  *   - start >= end → 400
  *   - Unknown customer → 404
- *   - Customer without per-customer D1 → 409
- *   - Worker env missing CF tokens → 503
+ *
+ * The CSV rows come from the CENTRAL cost_telemetry table via the D1
+ * binding (ADR 0062) — the per-customer-D1 / CF-token preconditions
+ * (409/503) are gone with the HTTP fan-out.
  *
  * Architecture note: the same `buildContext` shape used by other admin
  * cross-org tests applies here. The handler imports `env` from the
  * vitest-aliased `cloudflare:workers` stub; we populate it with a
- * minimal D1 mock that satisfies the customer enumeration query.
+ * minimal D1 mock that satisfies the customer enumeration and
+ * cost_telemetry queries.
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
@@ -52,10 +55,20 @@ interface FakeD1Result<T> {
   results: T[]
 }
 
+interface FakeCostRow {
+  customer_slug: string
+  date: string
+  driver: string
+  amount_cents: number
+  units: number | null
+  unit_type: string | null
+}
+
 function makeMockDb(
-  configs: Array<{ customer_slug: string; entity_id: string; connectors_json: string | null }>,
+  configs: Array<{ customer_slug: string; entity_id: string }>,
   subs: Array<{ entity_id: string; status: string; settings_json: string | null }> = [],
-  entities: Array<{ id: string; name: string }> = []
+  entities: Array<{ id: string; name: string }> = [],
+  costRows: FakeCostRow[] = []
 ): unknown {
   return {
     prepare(sql: string) {
@@ -77,6 +90,13 @@ function makeMockDb(
             const filtered = entities.filter((e) => boundParams.some((p) => p === e.id))
             return { results: filtered as unknown as T[] }
           }
+          if (sql.includes('FROM cost_telemetry')) {
+            const [slug, start, end] = boundParams as [string, string, string]
+            const filtered = costRows.filter(
+              (r) => r.customer_slug === slug && r.date >= start && r.date < end
+            )
+            return { results: filtered as unknown as T[] }
+          }
           return { results: [] }
         },
       }
@@ -90,8 +110,6 @@ describe('GET /api/admin/operator/costs/export', () => {
     for (const k of Object.keys(testEnv)) delete (testEnv as unknown as Record<string, unknown>)[k]
     Object.assign(testEnv, {
       DB: makeMockDb([]),
-      CF_ACCOUNT_ID: 'acct',
-      CF_D1_API_TOKEN: 'tok',
     })
   })
 
@@ -154,100 +172,46 @@ describe('GET /api/admin/operator/costs/export', () => {
     expect(res.status).toBe(404)
   })
 
-  it('returns 409 when customer has no per-customer D1', async () => {
-    Object.assign(testEnv, {
-      DB: makeMockDb(
-        [{ customer_slug: 'acme', entity_id: 'ent-1', connectors_json: null }],
-        [],
-        [{ id: 'ent-1', name: 'Acme Co' }]
-      ),
-    })
-    const ctx = buildContext({
-      session: adminSession(),
-      url: 'http://test.local/api/admin/operator/costs/export?customer_slug=acme',
-    })
-    const res = await GET(ctx)
-    expect(res.status).toBe(409)
-  })
-
-  it('returns 503 when CF env not configured', async () => {
-    Object.assign(testEnv, {
-      DB: makeMockDb(
-        [
-          {
-            customer_slug: 'acme',
-            entity_id: 'ent-1',
-            connectors_json: JSON.stringify({ per_customer_d1_database_id: 'db-id-1' }),
-          },
-        ],
-        [],
-        [{ id: 'ent-1', name: 'Acme Co' }]
-      ),
-    })
-    delete (testEnv as unknown as Record<string, unknown>).CF_ACCOUNT_ID
-    delete (testEnv as unknown as Record<string, unknown>).CF_D1_API_TOKEN
-    const ctx = buildContext({
-      session: adminSession(),
-      url: 'http://test.local/api/admin/operator/costs/export?customer_slug=acme',
-    })
-    const res = await GET(ctx)
-    expect(res.status).toBe(503)
-  })
-
   it('returns CSV with proper headers on happy path', async () => {
     Object.assign(testEnv, {
       DB: makeMockDb(
+        [{ customer_slug: 'acme', entity_id: 'ent-1' }],
+        [],
+        [{ id: 'ent-1', name: 'Acme Co' }],
         [
           {
             customer_slug: 'acme',
-            entity_id: 'ent-1',
-            connectors_json: JSON.stringify({ per_customer_d1_database_id: 'db-id-1' }),
+            date: '2026-05-01',
+            driver: 'fly_machine_minutes',
+            amount_cents: 30,
+            units: 30,
+            unit_type: 'minutes',
           },
-        ],
-        [],
-        [{ id: 'ent-1', name: 'Acme Co' }]
+          // Another customer's rows must not leak into acme's export.
+          {
+            customer_slug: 'globex',
+            date: '2026-05-01',
+            driver: 'fly_machine_minutes',
+            amount_cents: 99,
+            units: 99,
+            unit_type: 'minutes',
+          },
+        ]
       ),
-      CF_ACCOUNT_ID: 'acct',
-      CF_D1_API_TOKEN: 'tok',
     })
 
-    const originalFetch = globalThis.fetch
-    globalThis.fetch = async () =>
-      new Response(
-        JSON.stringify({
-          success: true,
-          result: [
-            {
-              results: [
-                {
-                  date: '2026-05-01',
-                  driver: 'fly_machine_minutes',
-                  amount_cents: 30,
-                  units: 30,
-                  unit_type: 'minutes',
-                },
-              ],
-            },
-          ],
-        }),
-        { status: 200 }
-      )
-
-    try {
-      const ctx = buildContext({
-        session: adminSession(),
-        url: 'http://test.local/api/admin/operator/costs/export?customer_slug=acme&start=2026-05-01&end=2026-05-15',
-      })
-      const res = await GET(ctx)
-      expect(res.status).toBe(200)
-      expect(res.headers.get('Content-Type')).toContain('text/csv')
-      expect(res.headers.get('Content-Disposition')).toContain('attachment')
-      expect(res.headers.get('Content-Disposition')).toContain('acme')
-      const text = await res.text()
-      expect(text).toContain('customer_slug,date,driver,amount_cents,units,unit_type')
-      expect(text).toContain('acme,2026-05-01,fly_machine_minutes,30,30,minutes')
-    } finally {
-      globalThis.fetch = originalFetch
-    }
+    const ctx = buildContext({
+      session: adminSession(),
+      url: 'http://test.local/api/admin/operator/costs/export?customer_slug=acme&start=2026-05-01&end=2026-05-15',
+    })
+    const res = await GET(ctx)
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Content-Type')).toContain('text/csv')
+    expect(res.headers.get('Content-Disposition')).toContain('attachment')
+    expect(res.headers.get('Content-Disposition')).toContain('acme')
+    const text = await res.text()
+    expect(text).toContain('customer_slug,date,driver,amount_cents,units,unit_type')
+    expect(text).toContain('acme,2026-05-01,fly_machine_minutes,30,30,minutes')
+    expect(text).not.toContain('globex')
   })
 })

--- a/tests/admin-cost-query.test.ts
+++ b/tests/admin-cost-query.test.ts
@@ -3,11 +3,13 @@
  *
  * Covers the pure-function pieces — aggregation, date enumeration,
  * COGS/MRR ratio thresholds, rolling-avg fewer-than-7-days handling,
- * and CSV serialization. The D1 HTTP fetch path is exercised by
- * stubbing global fetch in a separate block.
+ * and CSV serialization. The central cost_telemetry read (ADR 0062:
+ * D1 binding against the central table, replacing the per-customer
+ * D1 HTTP fan-out) is exercised with a fake binding in a separate
+ * block.
  */
 
-import { describe, it, expect, afterEach } from 'vitest'
+import { describe, it, expect } from 'vitest'
 import {
   cogsRatio,
   categoryForDriver,
@@ -290,106 +292,73 @@ describe('rowsToCsv', () => {
   })
 })
 
-describe('fetchCustomerCostRows (D1 HTTP API)', () => {
-  const originalFetch = globalThis.fetch
+describe('fetchCustomerCostRows (central D1 binding, ADR 0062)', () => {
+  function makeDb(opts: { rows?: unknown[]; error?: Error }) {
+    const captured: { sql?: string; params?: unknown[] } = {}
+    const db = {
+      prepare(sql: string) {
+        captured.sql = sql
+        return {
+          bind(...params: unknown[]) {
+            captured.params = params
+            return {
+              async all<T>() {
+                if (opts.error) throw opts.error
+                return { results: (opts.rows ?? []) as T[] }
+              },
+            }
+          },
+        }
+      },
+    } as unknown as D1Database
+    return { db, captured }
+  }
 
-  afterEach(() => {
-    globalThis.fetch = originalFetch
-  })
-
-  it('parses the D1 HTTP response into typed rows', async () => {
-    globalThis.fetch = async () =>
-      new Response(
-        JSON.stringify({
-          success: true,
-          result: [
-            {
-              results: [
-                {
-                  date: '2026-05-01',
-                  driver: 'claude_api_input_tokens',
-                  amount_cents: 100,
-                  units: 1000,
-                  unit_type: 'input_tokens',
-                },
-                {
-                  date: '2026-05-01',
-                  driver: 'fly_machine_minutes',
-                  amount_cents: 30,
-                  units: 30,
-                  unit_type: 'minutes',
-                },
-              ],
-            },
-          ],
-        }),
-        { status: 200 }
-      )
-    const result = await fetchCustomerCostRows(
-      { CF_ACCOUNT_ID: 'acct', CF_D1_API_TOKEN: 'tok' },
-      'db-id',
-      '2026-05-01',
-      '2026-06-01'
-    )
+  it('queries the central table scoped to the customer_slug and returns typed rows', async () => {
+    const { db, captured } = makeDb({
+      rows: [
+        {
+          date: '2026-05-01',
+          driver: 'claude_api_input_tokens',
+          amount_cents: 100,
+          units: 1000,
+          unit_type: 'input_tokens',
+        },
+        {
+          date: '2026-05-01',
+          driver: 'fly_machine_minutes',
+          amount_cents: 30,
+          units: 30,
+          unit_type: 'minutes',
+        },
+      ],
+    })
+    const result = await fetchCustomerCostRows(db, 'acme', '2026-05-01', '2026-06-01')
     expect(result.error).toBeNull()
     expect(result.rows).toHaveLength(2)
     expect(result.rows[0].driver).toBe('claude_api_input_tokens')
+    expect(captured.sql).toContain('customer_slug = ?')
+    expect(captured.params).toEqual(['acme', '2026-05-01', '2026-06-01'])
   })
 
-  it('returns an error string on non-2xx', async () => {
-    globalThis.fetch = async () => new Response('boom', { status: 500 })
-    const result = await fetchCustomerCostRows(
-      { CF_ACCOUNT_ID: 'acct', CF_D1_API_TOKEN: 'tok' },
-      'db-id',
-      '2026-05-01',
-      '2026-06-01'
-    )
+  it('returns an error string when the query throws', async () => {
+    const { db } = makeDb({ error: new Error('no such table: cost_telemetry') })
+    const result = await fetchCustomerCostRows(db, 'acme', '2026-05-01', '2026-06-01')
     expect(result.rows).toEqual([])
-    expect(result.error).toContain('D1 HTTP 500')
-  })
-
-  it('returns an error string on payload.success = false', async () => {
-    globalThis.fetch = async () =>
-      new Response(
-        JSON.stringify({ success: false, errors: [{ code: 1, message: 'no such table' }] }),
-        {
-          status: 200,
-        }
-      )
-    const result = await fetchCustomerCostRows(
-      { CF_ACCOUNT_ID: 'acct', CF_D1_API_TOKEN: 'tok' },
-      'db-id',
-      '2026-05-01',
-      '2026-06-01'
-    )
-    expect(result.rows).toEqual([])
-    expect(result.error).toContain('D1 query failed')
+    expect(result.error).toContain('cost_telemetry query failed')
+    expect(result.error).toContain('no such table')
   })
 
   it('drops malformed rows without crashing', async () => {
-    globalThis.fetch = async () =>
-      new Response(
-        JSON.stringify({
-          success: true,
-          result: [
-            {
-              results: [
-                { date: 'good', driver: 'fly_machine_minutes', amount_cents: 1 },
-                { driver: 'missing_date', amount_cents: 1 },
-                { date: '2026-05-01', amount_cents: 1 },
-                { date: '2026-05-01', driver: 'fly_machine_minutes' },
-              ],
-            },
-          ],
-        }),
-        { status: 200 }
-      )
-    const result = await fetchCustomerCostRows(
-      { CF_ACCOUNT_ID: 'acct', CF_D1_API_TOKEN: 'tok' },
-      'db-id',
-      '2026-05-01',
-      '2026-06-01'
-    )
+    const { db } = makeDb({
+      rows: [
+        { date: 'good', driver: 'fly_machine_minutes', amount_cents: 1 },
+        { driver: 'missing_date', amount_cents: 1 },
+        { date: '2026-05-01', amount_cents: 1 },
+        { date: '2026-05-01', driver: 'fly_machine_minutes' },
+      ],
+    })
+    const result = await fetchCustomerCostRows(db, 'acme', '2026-05-01', '2026-06-01')
     expect(result.error).toBeNull()
     expect(result.rows).toHaveLength(1)
     expect(result.rows[0].driver).toBe('fly_machine_minutes')

--- a/workers/cost-anomaly/src/customers.ts
+++ b/workers/cost-anomaly/src/customers.ts
@@ -1,48 +1,25 @@
 /**
  * Customer enumeration for the cost-anomaly worker.
  *
- * Reads the central `customer_configs` + `entities` tables and yields one
- * row per Operator customer with the per-customer D1 database id and
- * entity_id needed for downstream alert writes. Mirrors the projection
- * the ss-cost-telemetry Worker does — kept separate so changes in one
- * worker do not couple to the other.
+ * Reads the central `customer_configs` table and yields one row per
+ * Operator customer with the entity_id needed for downstream alert
+ * writes. Cost rows themselves live in the central `cost_telemetry`
+ * table (ADR 0062, migration 0083); the per-customer D1 id this module
+ * used to project from connectors_json is retired with the fan-out.
+ *
+ * Note the reserved cost_telemetry slugs '_org' and '_unmapped' are
+ * excluded by construction: they have no customer_configs row, so they
+ * never enter anomaly detection.
  */
 
 export interface CustomerRow {
   customer_slug: string
   entity_id: string
-  per_customer_d1_database_id: string | null
-}
-
-interface ConfigRow {
-  customer_slug: string
-  entity_id: string
-  connectors_json: string | null
 }
 
 export async function listCustomers(db: D1Database): Promise<CustomerRow[]> {
   const result = await db
-    .prepare('SELECT customer_slug, entity_id, connectors_json FROM customer_configs')
-    .all<ConfigRow>()
-  const out: CustomerRow[] = []
-  for (const row of result.results ?? []) {
-    let perCustomerDbId: string | null = null
-    if (row.connectors_json) {
-      try {
-        const parsed = JSON.parse(row.connectors_json) as Record<string, unknown>
-        const dbId = parsed['per_customer_d1_database_id']
-        if (typeof dbId === 'string' && dbId.length > 0) perCustomerDbId = dbId
-      } catch {
-        // Malformed connectors_json — projection layer's problem, not ours.
-        // Treated as "no per-customer DB" so the row is skipped with a logged
-        // reason rather than crashing the run.
-      }
-    }
-    out.push({
-      customer_slug: row.customer_slug,
-      entity_id: row.entity_id,
-      per_customer_d1_database_id: perCustomerDbId,
-    })
-  }
-  return out
+    .prepare('SELECT customer_slug, entity_id FROM customer_configs')
+    .all<CustomerRow>()
+  return result.results ?? []
 }

--- a/workers/cost-anomaly/src/index.ts
+++ b/workers/cost-anomaly/src/index.ts
@@ -1,22 +1,24 @@
 /**
  * Cost Anomaly Worker — nightly per-customer cost spike detector.
  *
- * Wires on top of the data path from PR #1023 (ss-cost-telemetry, 02:00
- * UTC ingest) and the dashboard from PR #1026. Runs at 03:00 UTC daily
- * so the trailing-day data is fresh when detection runs.
+ * Wires on top of the ss-cost-telemetry data path (02:00 UTC ingest)
+ * and the dashboard from PR #1026. Runs at 03:00 UTC daily so the
+ * trailing-day data is fresh when detection runs.
  *
  * Flow:
  *   1. Enumerate Operator customers from central customer_configs.
- *   2. For each customer with a per-customer D1 id:
- *      a. Read trailing 8 days of cost_telemetry via the D1 HTTP API.
+ *   2. For each customer:
+ *      a. Read the trailing 8 days from the CENTRAL cost_telemetry
+ *         table (ADR 0062, migration 0083) via the D1 binding.
  *      b. Run detectAnomaly() on the aggregate daily series.
  *      c. On breach, identify the top-1 driver by absolute delta and
  *         UPSERT one alert row into central D1's cost_anomaly_alerts.
  *   3. Send one digest email to Captain summarizing new alerts.
  *
- * Per ADR 0009, per-customer cost data lives in per-customer D1s; this
- * worker addresses each one via the D1 HTTP API rather than declaring N
- * bindings. The same pattern the dashboard query layer uses.
+ * The per-customer-D1 HTTP fan-out is retired (ADR 0062: those
+ * databases were never provisioned). The reserved slugs '_org' and
+ * '_unmapped' are excluded by construction — they have no
+ * customer_configs row.
  *
  * Fabrication discipline (CLAUDE.md Pattern A/B): every figure in an
  * alert traces to a real cost_telemetry row. The "top driver" attribution
@@ -33,19 +35,13 @@ import {
   pickTopDriverByDelta,
   upsertAlert,
 } from '../../../src/lib/admin/cost-anomaly'
-import {
-  fetchCustomerCostRows,
-  enumerateDates,
-  type CostQueryEnv,
-} from '../../../src/lib/admin/cost-query'
+import { fetchCustomerCostRows, enumerateDates } from '../../../src/lib/admin/cost-query'
 import { listCustomers, type CustomerRow } from './customers'
 import { sendAnomalyDigest, type AlertNotificationItem } from './notify'
 import { fetchTenantErrorsLast24h, writeSentrySync, type SentrySyncResult } from './sentry-sync'
 
 export interface Env {
   DB: D1Database
-  CF_ACCOUNT_ID: string
-  CF_D1_API_TOKEN: string
   ANOMALY_THRESHOLD_BPS?: string
   ALERT_FROM_EMAIL?: string
   ALERT_TO_EMAIL?: string
@@ -66,7 +62,7 @@ export interface Env {
 
 interface PerCustomerOutcome {
   customer_slug: string
-  status: 'skipped:no-d1' | 'skipped:insufficient-history' | 'no-anomaly' | 'anomaly' | 'error'
+  status: 'skipped:insufficient-history' | 'no-anomaly' | 'anomaly' | 'error'
   reason?: string
   alert?: AlertNotificationItem
 }
@@ -124,22 +120,13 @@ function parseThreshold(v: string | undefined): number {
 
 async function processCustomer(
   env: Env,
-  costEnv: CostQueryEnv,
   customer: CustomerRow,
   window: { windowStart: string; windowEnd: string; candidateDay: string },
   thresholdBps: number
 ): Promise<PerCustomerOutcome> {
-  if (!customer.per_customer_d1_database_id) {
-    return {
-      customer_slug: customer.customer_slug,
-      status: 'skipped:no-d1',
-      reason: 'no per_customer_d1_database_id in connectors_json',
-    }
-  }
-
   const fetched = await fetchCustomerCostRows(
-    costEnv,
-    customer.per_customer_d1_database_id,
+    env.DB,
+    customer.customer_slug,
     window.windowStart,
     window.windowEnd
   )
@@ -203,15 +190,11 @@ export async function run(env: Env, now: Date = new Date()): Promise<RunSummary>
   const window = computeWindow(now)
   const thresholdBps = parseThreshold(env.ANOMALY_THRESHOLD_BPS)
   const customers = await listCustomers(env.DB)
-  const costEnv: CostQueryEnv = {
-    CF_ACCOUNT_ID: env.CF_ACCOUNT_ID,
-    CF_D1_API_TOKEN: env.CF_D1_API_TOKEN,
-  }
 
   const perCustomer: PerCustomerOutcome[] = []
   for (const customer of customers) {
     try {
-      const outcome = await processCustomer(env, costEnv, customer, window, thresholdBps)
+      const outcome = await processCustomer(env, customer, window, thresholdBps)
       perCustomer.push(outcome)
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e)

--- a/workers/cost-anomaly/wrangler.toml
+++ b/workers/cost-anomaly/wrangler.toml
@@ -1,11 +1,14 @@
 # Cost Anomaly Worker — nightly per-customer spike detection for Operator
-# Per #886. Wires on top of the cost telemetry data path shipped in PR #1023
-# (ss-cost-telemetry runs at 02:00 UTC) and the dashboard from PR #1026.
+# Per #886. Wires on top of the ss-cost-telemetry data path (02:00 UTC
+# ingest into the central cost_telemetry table per ADR 0062) and the
+# dashboard from PR #1026.
 #
 # Each night at 03:00 UTC the worker:
 #   1. Enumerates Operator customers from the central customer_configs.
-#   2. Reads the trailing 8 days of cost_telemetry for each customer via
-#      the D1 HTTP API (per-customer DBs per ADR 0009).
+#   2. Reads each customer's trailing 8 days from the central
+#      cost_telemetry table (migration 0083) via the D1 binding. The
+#      reserved slugs '_org' / '_unmapped' have no customer_configs row
+#      and are excluded by construction.
 #   3. Runs detectAnomaly() against the aggregate daily series.
 #   4. When a breach is detected, picks the top-1 driver by absolute delta
 #      and UPSERTs one alert row into central D1's cost_anomaly_alerts.
@@ -22,7 +25,7 @@ main = "src/index.ts"
 compatibility_date = "2025-01-01"
 compatibility_flags = ["nodejs_compat"]
 
-# Central D1 — for customer enumeration and alert writes.
+# Central D1 — customer enumeration, cost_telemetry reads, alert writes.
 [[d1_databases]]
 binding = "DB"
 database_name = "ss-console-db"
@@ -44,8 +47,6 @@ ANOMALY_THRESHOLD_BPS = "15000"
 ALERT_FROM_EMAIL = "SMD Services Ops <team@smd.services>"
 
 # Secrets (set via `wrangler secret put` after first deploy):
-#   CF_ACCOUNT_ID         — Cloudflare account id for per-customer D1 HTTP API
-#   CF_D1_API_TOKEN       — Token with D1:Read scope across customer DBs
 #   RESEND_API_KEY        — Resend API key for Captain notification email
 #   ALERT_TO_EMAIL        — Captain inbox (e.g. smdurgan@venturecrane.com)
 #   COST_ANOMALY_BEARER   — Bearer token for manual /run invocations

--- a/workers/cost-telemetry/src/clients.ts
+++ b/workers/cost-telemetry/src/clients.ts
@@ -1,110 +1,120 @@
 /**
- * Production HTTP clients for the cost telemetry worker.
+ * Anthropic usage-report client for the cost telemetry worker.
  *
- * Two external surfaces:
+ * One external surface: the Anthropic Admin API's usage report,
+ * `GET /v1/organizations/usage_report/messages`. It requires an ADMIN
+ * API key (sk-ant-admin...); the runtime ANTHROPIC_API_KEY is rejected
+ * with authentication_error (verified live, 2026-07-03). The worker's
+ * secret is ANTHROPIC_ADMIN_KEY.
  *
- *   1. Cloudflare D1 HTTP API — used to write per-customer cost_telemetry
- *      rows. Each customer has a distinct database id, so the client
- *      takes the id per call rather than baking it in.
+ * Per ADR 0062 the report is grouped by workspace_id AND model:
+ * workspace_id carries the per-seat attribution (one Anthropic
+ * workspace per customer seat), model feeds the cents math against
+ * anthropic_pricing.json.
  *
- *   2. Anthropic billing / usage API — daily token usage per model. The
- *      Anthropic Console exposes a usage endpoint; the exact shape may
- *      shift between API versions, so the client normalizes to
- *      `AnthropicUsageRow[]`. If the upstream shape drifts, only this
- *      file needs to change.
- *
- * Both clients are thin wrappers — no caching, no retry. The cron run
- * is the natural retry boundary (a missed day rolls forward to the
- * next night).
+ * The client is a thin wrapper — no caching, no retry. The cron run is
+ * the natural retry boundary (a missed day rolls forward to the next
+ * night, and writes are idempotent day totals).
  */
 
-import type { AnthropicSource, AnthropicUsageRow, D1HttpClient } from './ingest'
+import type { AnthropicSource, AnthropicUsageRow } from './ingest'
 
-// ---------------------------------------------------------------------------
-// Cloudflare D1 HTTP client
-// ---------------------------------------------------------------------------
+/**
+ * Response shape of /v1/organizations/usage_report/messages (the fields
+ * this worker reads). `data` is a list of time buckets; with
+ * bucket_width=1d and a one-day window there is exactly one bucket, but
+ * the client tolerates several and paginates on `has_more`.
+ */
+interface UsageReportPayload {
+  data?: Array<{
+    starting_at?: string
+    ending_at?: string
+    results?: Array<{
+      workspace_id?: string | null
+      model?: string | null
+      uncached_input_tokens?: number
+      cache_read_input_tokens?: number
+      cache_creation?: {
+        ephemeral_1h_input_tokens?: number
+        ephemeral_5m_input_tokens?: number
+      }
+      output_tokens?: number
+    }>
+  }>
+  has_more?: boolean
+  next_page?: string | null
+}
 
-export class CloudflareD1Client implements D1HttpClient {
-  private readonly accountId: string
-  private readonly apiToken: string
+export class AnthropicHttpSource implements AnthropicSource {
+  async fetchDailyUsage(adminKey: string, day: string): Promise<AnthropicUsageRow[]> {
+    const out: AnthropicUsageRow[] = []
+    let page: string | null = null
 
-  constructor(accountId: string, apiToken: string) {
-    this.accountId = accountId
-    this.apiToken = apiToken
-  }
+    do {
+      const url = new URL('https://api.anthropic.com/v1/organizations/usage_report/messages')
+      url.searchParams.set('starting_at', `${day}T00:00:00Z`)
+      url.searchParams.set('ending_at', nextDayUtc(day))
+      url.searchParams.set('bucket_width', '1d')
+      url.searchParams.append('group_by[]', 'workspace_id')
+      url.searchParams.append('group_by[]', 'model')
+      if (page) url.searchParams.set('page', page)
 
-  async execute(databaseId: string, sql: string, params: unknown[]): Promise<void> {
-    const url =
-      `https://api.cloudflare.com/client/v4/accounts/${this.accountId}` +
-      `/d1/database/${databaseId}/query`
-    const res = await fetch(url, {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${this.apiToken}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ sql, params }),
-    })
-    if (!res.ok) {
-      const text = await res.text()
-      throw new Error(`D1 HTTP ${res.status}: ${text.slice(0, 200)}`)
-    }
-    const payload: { success?: boolean; errors?: unknown } = await res.json()
-    if (!payload.success) {
-      throw new Error(`D1 query failed: ${JSON.stringify(payload.errors ?? payload)}`)
-    }
+      const res = await fetch(url.toString(), {
+        method: 'GET',
+        headers: {
+          'x-api-key': adminKey,
+          'anthropic-version': '2023-06-01',
+        },
+      })
+      if (!res.ok) {
+        const text = await res.text()
+        throw new Error(`Anthropic usage HTTP ${res.status}: ${text.slice(0, 200)}`)
+      }
+      const payload: UsageReportPayload = await res.json()
+
+      for (const bucket of payload.data ?? []) {
+        for (const r of bucket.results ?? []) {
+          if (!r.model) continue
+          // Input tokens roll up every input variant. The v1 cents math
+          // prices them all at the model's input rate (cache reads and
+          // cache writes bill at different multipliers upstream; the
+          // uniform rate is a documented conservative approximation —
+          // the '_org' reconciliation row is the cross-check against
+          // the invoice).
+          const inputTokens =
+            num(r.uncached_input_tokens) +
+            num(r.cache_read_input_tokens) +
+            num(r.cache_creation?.ephemeral_1h_input_tokens) +
+            num(r.cache_creation?.ephemeral_5m_input_tokens)
+          out.push({
+            workspaceId:
+              typeof r.workspace_id === 'string' && r.workspace_id.length > 0
+                ? r.workspace_id
+                : null,
+            model: r.model,
+            inputTokens,
+            outputTokens: num(r.output_tokens),
+          })
+        }
+      }
+
+      page = payload.has_more && payload.next_page ? payload.next_page : null
+    } while (page)
+
+    return out
   }
 }
 
-// ---------------------------------------------------------------------------
-// Anthropic usage client
-// ---------------------------------------------------------------------------
+function num(v: number | undefined): number {
+  return typeof v === 'number' && Number.isFinite(v) ? v : 0
+}
 
-/**
- * Anthropic usage API client.
- *
- * The Anthropic Usage & Cost API exposes daily token usage per
- * workspace/model. The endpoint shape used here is the documented
- * `/v1/organizations/usage_report/messages` form. If the API surface
- * shifts, normalize within this class — the rest of the ingest
- * pipeline accepts `AnthropicUsageRow[]` only.
- */
-export class AnthropicHttpSource implements AnthropicSource {
-  async fetchDailyUsage(apiKey: string, day: string): Promise<AnthropicUsageRow[]> {
-    const url = new URL('https://api.anthropic.com/v1/organizations/usage_report/messages')
-    // The API expects a date range; we ask for exactly the one day.
-    url.searchParams.set('starting_at', `${day}T00:00:00Z`)
-    url.searchParams.set('ending_at', `${day}T23:59:59Z`)
-    url.searchParams.set('group_by[]', 'model')
-
-    const res = await fetch(url.toString(), {
-      method: 'GET',
-      headers: {
-        'x-api-key': apiKey,
-        'anthropic-version': '2023-06-01',
-      },
-    })
-    if (!res.ok) {
-      const text = await res.text()
-      throw new Error(`Anthropic usage HTTP ${res.status}: ${text.slice(0, 200)}`)
-    }
-    const payload: {
-      data?: Array<{
-        model?: string
-        input_tokens?: number
-        output_tokens?: number
-      }>
-    } = await res.json()
-    const rows = payload.data ?? []
-    const out: AnthropicUsageRow[] = []
-    for (const r of rows) {
-      if (!r.model) continue
-      out.push({
-        model: r.model,
-        inputTokens: Number(r.input_tokens ?? 0),
-        outputTokens: Number(r.output_tokens ?? 0),
-      })
-    }
-    return out
-  }
+/** 'YYYY-MM-DD' -> exclusive end-of-day RFC 3339 timestamp (next day 00:00 UTC). */
+function nextDayUtc(day: string): string {
+  const [y, m, d] = day.split('-').map(Number)
+  const next = new Date(Date.UTC(y, m - 1, d) + 86_400_000)
+  const yyyy = next.getUTCFullYear()
+  const mm = String(next.getUTCMonth() + 1).padStart(2, '0')
+  const dd = String(next.getUTCDate()).padStart(2, '0')
+  return `${yyyy}-${mm}-${dd}T00:00:00Z`
 }

--- a/workers/cost-telemetry/src/index.ts
+++ b/workers/cost-telemetry/src/index.ts
@@ -1,74 +1,41 @@
 /**
- * Cost Telemetry Worker — daily cost-driver ingest.
+ * Cost Telemetry Worker — daily cost-driver ingest (ADR 0062).
  *
- * Runs at 02:00 UTC daily per `triggers.crons` in wrangler.toml. Per
- * docs/specs/operator/cost-telemetry-events.md "Nightly Captain job",
- * the worker iterates every active Operator customer, pulls
- * yesterday's Anthropic usage, and UPSERTs into each customer's
- * per-customer `cost_telemetry` D1 table.
+ * Runs at 02:00 UTC daily per `triggers.crons` in wrangler.toml. The
+ * worker pulls yesterday's org-wide Anthropic usage grouped by
+ * (workspace_id, model) via the Admin usage-report API and UPSERTs
+ * per-seat rows into the CENTRAL `cost_telemetry` table in
+ * ss-console-db (migration 0083), keyed (customer_slug, date, driver).
  *
- * Cloudflare D1/R2/Vectorize metering is deferred to phase 2 per the
- * validation-spike outcome documented in
+ * Per-seat attribution comes from per-customer Anthropic workspaces:
+ * `customer_configs.anthropic_workspace_id` maps each workspace to a
+ * seat. Unmapped workspaces land under the reserved slug '_unmapped';
+ * the org total is written under '_org' as a reconciliation row. See
+ * src/ingest.ts and docs/runbooks/operator/cost-telemetry-enable.md.
+ *
+ * The per-customer-D1 enumeration this worker used to perform is gone:
+ * those databases were never provisioned (ADR 0062 context; ADR 0009's
+ * wiring note), so the old path skipped every seat.
+ *
+ * Cloudflare D1/R2/Vectorize metering remains deferred to phase 2 per
+ * the validation-spike outcome documented in
  * operator/adapter/cost_ingest.py. Token cost dominates the COGS
  * surface for v1.
- *
- * Customer enumeration: the central D1 `customer_configs` table holds
- * the list. The per-customer D1 database id is required to address
- * the right database via the D1 HTTP API. v1 reads from a metadata
- * column on `customer_configs` (`per_customer_d1_database_id` —
- * populated by the customer provisioner at create time; this worker
- * skips customers without one and logs the skip).
  */
 
-import { AnthropicHttpSource, CloudflareD1Client } from './clients'
-import {
-  runIngestForCustomer,
-  type CustomerIngestContext,
-  type CustomerIngestResult,
-} from './ingest'
+import { AnthropicHttpSource } from './clients'
+import { runIngest, type IngestResult } from './ingest'
 
 export interface Env {
   DB: D1Database
-  CF_ACCOUNT_ID: string
-  CF_D1_API_TOKEN: string
-  ANTHROPIC_API_KEY: string
+  /**
+   * Anthropic ADMIN API key (sk-ant-admin...). The usage-report API
+   * rejects regular runtime keys with authentication_error. Missing
+   * key: the run logs one clear error and exits cleanly — the cron
+   * must not crashloop while the Captain enablement step is pending.
+   */
+  ANTHROPIC_ADMIN_KEY?: string
   COST_INGEST_BEARER?: string
-}
-
-interface CustomerRow {
-  customer_slug: string
-  per_customer_d1_database_id: string | null
-}
-
-/** Read the active customer list with the per-customer D1 id resolved. */
-async function listCustomers(db: D1Database): Promise<CustomerRow[]> {
-  // `connectors_json` carries non-secret references including the
-  // per-customer Hermes database id. The projection layer denormalizes
-  // it into the JSON blob per ADR 0012. For v1 the worker uses one
-  // convention key; if not present the customer is skipped (logged,
-  // not errored).
-  const result = await db
-    .prepare('SELECT customer_slug, connectors_json FROM customer_configs')
-    .all<{ customer_slug: string; connectors_json: string | null }>()
-
-  const rows: CustomerRow[] = []
-  for (const row of result.results ?? []) {
-    let perCustomerDbId: string | null = null
-    if (row.connectors_json) {
-      try {
-        const parsed = JSON.parse(row.connectors_json) as Record<string, unknown>
-        const dbId = parsed['per_customer_d1_database_id']
-        if (typeof dbId === 'string' && dbId.length > 0) perCustomerDbId = dbId
-      } catch {
-        // Bad JSON — skip; not the worker's job to fix projection.
-      }
-    }
-    rows.push({
-      customer_slug: row.customer_slug,
-      per_customer_d1_database_id: perCustomerDbId,
-    })
-  }
-  return rows
 }
 
 function yesterdayUtc(now: Date = new Date()): string {
@@ -80,90 +47,40 @@ function yesterdayUtc(now: Date = new Date()): string {
   return `${yyyy}-${mm}-${dd}`
 }
 
-interface RunSummary {
-  day: string
-  customersTotal: number
-  customersSkipped: number
-  customersRun: number
-  customersWithFailures: number
-  totalCentsWritten: number
-  perCustomer: CustomerIngestResult[]
-  skipped: Array<{ customer_slug: string; reason: string }>
-}
-
-export async function run(env: Env, day?: string): Promise<RunSummary> {
+export async function run(env: Env, day?: string): Promise<IngestResult> {
   const targetDay = day ?? yesterdayUtc()
-  const customers = await listCustomers(env.DB)
 
-  const d1 = new CloudflareD1Client(env.CF_ACCOUNT_ID, env.CF_D1_API_TOKEN)
-  const anthropicSource = new AnthropicHttpSource()
-
-  const summary: RunSummary = {
-    day: targetDay,
-    customersTotal: customers.length,
-    customersSkipped: 0,
-    customersRun: 0,
-    customersWithFailures: 0,
-    totalCentsWritten: 0,
-    perCustomer: [],
-    skipped: [],
-  }
-
-  for (const customer of customers) {
-    if (!customer.per_customer_d1_database_id) {
-      summary.customersSkipped++
-      summary.skipped.push({
-        customer_slug: customer.customer_slug,
-        reason: 'no per_customer_d1_database_id in connectors_json',
-      })
-      console.warn(
-        `[cost-telemetry] skip ${customer.customer_slug}: no per_customer_d1_database_id`
-      )
-      continue
-    }
-
-    const ctx: CustomerIngestContext = {
-      customerSlug: customer.customer_slug,
-      perCustomerDatabaseId: customer.per_customer_d1_database_id,
-      anthropicApiKey: env.ANTHROPIC_API_KEY,
-    }
-
-    try {
-      const result = await runIngestForCustomer(ctx, d1, anthropicSource, targetDay)
-      summary.customersRun++
-      summary.perCustomer.push(result)
-      if (result.anyFailures) summary.customersWithFailures++
-      summary.totalCentsWritten += result.totalCents
-    } catch (e) {
-      summary.customersWithFailures++
-      summary.customersRun++
-      const msg = e instanceof Error ? e.message : String(e)
-      console.error(`[cost-telemetry] ${customer.customer_slug}: ${msg}`)
-      summary.perCustomer.push({
-        customerSlug: customer.customer_slug,
-        day: targetDay,
-        sources: [
-          {
-            source: 'orchestrator',
-            ok: false,
-            rowsWritten: 0,
-            centsWritten: 0,
-            reason: msg,
-          },
-        ],
-        anyFailures: true,
-        totalCents: 0,
-      })
+  if (!env.ANTHROPIC_ADMIN_KEY) {
+    const reason =
+      'ANTHROPIC_ADMIN_KEY is not set; skipping ingest. Mint an Admin API key and ' +
+      'stage it per docs/runbooks/operator/cost-telemetry-enable.md.'
+    console.error(`[cost-telemetry] ${reason}`)
+    return {
+      ok: false,
+      day: targetDay,
+      rowsWritten: 0,
+      centsWritten: 0,
+      slugs: [],
+      unmappedWorkspaceIds: [],
+      warnings: [],
+      reason,
     }
   }
 
-  console.log(
-    `[cost-telemetry] day=${summary.day} customers=${summary.customersTotal} ` +
-      `run=${summary.customersRun} skipped=${summary.customersSkipped} ` +
-      `failures=${summary.customersWithFailures} cents=${summary.totalCentsWritten}`
+  const result = await runIngest(
+    env.DB,
+    new AnthropicHttpSource(),
+    env.ANTHROPIC_ADMIN_KEY,
+    targetDay
   )
 
-  return summary
+  console.log(
+    `[cost-telemetry] day=${result.day} ok=${result.ok} rows=${result.rowsWritten} ` +
+      `cents=${result.centsWritten} slugs=${result.slugs.join(',')} ` +
+      `unmapped=${result.unmappedWorkspaceIds.join(',') || 'none'}`
+  )
+
+  return result
 }
 
 export default {

--- a/workers/cost-telemetry/src/ingest.test.ts
+++ b/workers/cost-telemetry/src/ingest.test.ts
@@ -1,18 +1,38 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import {
-  ingestAnthropic,
-  runIngestForCustomer,
+  ORG_INPUT_DRIVER,
+  ORG_OUTPUT_DRIVER,
+  ORG_SLUG,
+  UNMAPPED_SLUG,
+  loadWorkspaceMapping,
+  runIngest,
   type AnthropicSource,
   type AnthropicUsageRow,
-  type CustomerIngestContext,
-  type D1HttpClient,
+  type CentralDb,
 } from './ingest'
 import { anthropicPricing, computeAnthropicCents } from './pricing'
+import { run, type Env } from './index'
 
-class FakeD1 implements D1HttpClient {
-  public calls: Array<{ databaseId: string; sql: string; params: unknown[] }> = []
-  async execute(databaseId: string, sql: string, params: unknown[]): Promise<void> {
-    this.calls.push({ databaseId, sql, params })
+/** In-memory fake of the central D1 binding slice the ingest uses. */
+class FakeDb implements CentralDb {
+  public mappingRows: Array<{ customer_slug: string; anthropic_workspace_id: string }> = []
+  public writes: Array<{ sql: string; params: unknown[] }> = []
+
+  prepare(sql: string) {
+    return {
+      bind: (...params: unknown[]) => ({
+        run: async () => {
+          this.writes.push({ sql, params })
+        },
+        all: async <T>() => ({ results: [] as T[] }),
+      }),
+      all: async <T>() => {
+        if (sql.includes('FROM customer_configs')) {
+          return { results: this.mappingRows as unknown as T[] }
+        }
+        return { results: [] as T[] }
+      },
+    }
   }
 }
 
@@ -27,11 +47,17 @@ class FakeAnthropic implements AnthropicSource {
   }
 }
 
+function paramsFor(db: FakeDb, slug: string, driver: string): unknown[] | undefined {
+  return db.writes.find((w) => w.params[0] === slug && w.params[2] === driver)?.params
+}
+
 describe('pricing JSON shape', () => {
   it('anthropic pricing has expected models', () => {
     expect(anthropicPricing.models['claude-opus-4-7']).toBeDefined()
     expect(anthropicPricing.models['claude-opus-4-7'].input_per_million_cents).toBe(1500)
     expect(anthropicPricing.models['claude-opus-4-7'].output_per_million_cents).toBe(7500)
+    // #1658 added claude-opus-4-8; the fleet model selection depends on it.
+    expect(anthropicPricing.models['claude-opus-4-8']).toBeDefined()
   })
 })
 
@@ -51,72 +77,154 @@ describe('cents math', () => {
   })
 })
 
-describe('ingestAnthropic', () => {
-  it('writes two rows when both token totals are positive', async () => {
-    const d1 = new FakeD1()
-    const src = new FakeAnthropic([
-      { model: 'claude-opus-4-7', inputTokens: 1_000_000, outputTokens: 500_000 },
-    ])
-    const result = await ingestAnthropic(d1, 'db-1', src, 'k', '2026-05-22')
-    expect(result.ok).toBe(true)
-    expect(result.rowsWritten).toBe(2)
-    expect(d1.calls).toHaveLength(2)
-    expect(d1.calls[0].params[1]).toBe('claude_api_input_tokens')
-    expect(d1.calls[1].params[1]).toBe('claude_api_output_tokens')
-  })
-
-  it('writes zero rows when token totals are zero', async () => {
-    const d1 = new FakeD1()
-    const src = new FakeAnthropic([])
-    const result = await ingestAnthropic(d1, 'db-1', src, 'k', '2026-05-22')
-    expect(result.ok).toBe(true)
-    expect(result.rowsWritten).toBe(0)
-    expect(d1.calls).toHaveLength(0)
-  })
-
-  it('returns ok=false when source throws', async () => {
-    const d1 = new FakeD1()
-    const src = new FakeAnthropic([], new Error('HTTP 503'))
-    const result = await ingestAnthropic(d1, 'db-1', src, 'k', '2026-05-22')
-    expect(result.ok).toBe(false)
-    expect(result.reason).toContain('503')
-    expect(d1.calls).toHaveLength(0)
+describe('loadWorkspaceMapping', () => {
+  it('maps workspace ids to customer slugs', async () => {
+    const db = new FakeDb()
+    db.mappingRows = [
+      { customer_slug: 'acme', anthropic_workspace_id: 'wrkspc_1' },
+      { customer_slug: 'globex', anthropic_workspace_id: 'wrkspc_2' },
+    ]
+    const map = await loadWorkspaceMapping(db)
+    expect(map.get('wrkspc_1')).toBe('acme')
+    expect(map.get('wrkspc_2')).toBe('globex')
+    expect(map.size).toBe(2)
   })
 })
 
-describe('runIngestForCustomer', () => {
-  it('aggregates the anthropic source outcome', async () => {
-    const d1 = new FakeD1()
-    const ctx: CustomerIngestContext = {
-      customerSlug: 'acme',
-      perCustomerDatabaseId: 'db-acme',
-      anthropicApiKey: 'k',
-    }
-    const result = await runIngestForCustomer(
-      ctx,
-      d1,
-      new FakeAnthropic([{ model: 'claude-opus-4-7', inputTokens: 100, outputTokens: 200 }]),
-      '2026-05-22'
-    )
-    const sourceNames = result.sources.map((s) => s.source)
-    expect(sourceNames).toContain('anthropic_billing')
+describe('runIngest', () => {
+  it('writes per-seat rows keyed by the mapped customer_slug', async () => {
+    const db = new FakeDb()
+    db.mappingRows = [{ customer_slug: 'acme', anthropic_workspace_id: 'wrkspc_1' }]
+    const src = new FakeAnthropic([
+      {
+        workspaceId: 'wrkspc_1',
+        model: 'claude-opus-4-7',
+        inputTokens: 1_000_000,
+        outputTokens: 500_000,
+      },
+    ])
+    const result = await runIngest(db, src, 'admin-key', '2026-07-02')
+    expect(result.ok).toBe(true)
+
+    const input = paramsFor(db, 'acme', 'claude_api_input_tokens')
+    const output = paramsFor(db, 'acme', 'claude_api_output_tokens')
+    expect(input).toBeDefined()
+    expect(output).toBeDefined()
+    expect(input![1]).toBe('2026-07-02')
+    expect(input![3]).toBe(1500) // 1M input tokens at 1500c/M
+    expect(input![4]).toBe(1_000_000)
+    expect(output![3]).toBe(3750) // 0.5M output tokens at 7500c/M
+    expect(result.centsWritten).toBe(1500 + 3750)
   })
 
-  it('captures an anthropic source failure', async () => {
-    const d1 = new FakeD1()
-    const ctx: CustomerIngestContext = {
-      customerSlug: 'acme',
-      perCustomerDatabaseId: 'db-acme',
-      anthropicApiKey: 'k',
-    }
-    const result = await runIngestForCustomer(
-      ctx,
-      d1,
+  it('aggregates multiple models within one workspace into one row pair', async () => {
+    const db = new FakeDb()
+    db.mappingRows = [{ customer_slug: 'acme', anthropic_workspace_id: 'wrkspc_1' }]
+    const src = new FakeAnthropic([
+      {
+        workspaceId: 'wrkspc_1',
+        model: 'claude-opus-4-7',
+        inputTokens: 1_000_000,
+        outputTokens: 0,
+      },
+      {
+        workspaceId: 'wrkspc_1',
+        model: 'claude-opus-4-8',
+        inputTokens: 1_000_000,
+        outputTokens: 0,
+      },
+    ])
+    await runIngest(db, src, 'admin-key', '2026-07-02')
+    const input = paramsFor(db, 'acme', 'claude_api_input_tokens')
+    expect(input![4]).toBe(2_000_000)
+    // acme input+output(absent) + _org pair
+    expect(db.writes.filter((w) => w.params[0] === 'acme')).toHaveLength(1)
+  })
+
+  it('routes unmapped workspace usage to _unmapped and names the workspace', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const db = new FakeDb()
+    const src = new FakeAnthropic([
+      {
+        workspaceId: 'wrkspc_ghost',
+        model: 'claude-opus-4-7',
+        inputTokens: 100_000,
+        outputTokens: 100_000,
+      },
+    ])
+    const result = await runIngest(db, src, 'admin-key', '2026-07-02')
+    expect(result.unmappedWorkspaceIds).toEqual(['wrkspc_ghost'])
+    expect(paramsFor(db, UNMAPPED_SLUG, 'claude_api_input_tokens')).toBeDefined()
+    expect(warn.mock.calls.some((c) => String(c[0]).includes('wrkspc_ghost'))).toBe(true)
+    warn.mockRestore()
+  })
+
+  it('routes default-workspace (null) usage to _unmapped', async () => {
+    const db = new FakeDb()
+    const src = new FakeAnthropic([
+      { workspaceId: null, model: 'claude-opus-4-7', inputTokens: 10_000, outputTokens: 0 },
+    ])
+    const result = await runIngest(db, src, 'admin-key', '2026-07-02')
+    expect(paramsFor(db, UNMAPPED_SLUG, 'claude_api_input_tokens')).toBeDefined()
+    expect(result.unmappedWorkspaceIds).toEqual([])
+  })
+
+  it('always writes the _org reconciliation pair, summing all workspaces', async () => {
+    const db = new FakeDb()
+    db.mappingRows = [{ customer_slug: 'acme', anthropic_workspace_id: 'wrkspc_1' }]
+    const src = new FakeAnthropic([
+      {
+        workspaceId: 'wrkspc_1',
+        model: 'claude-opus-4-7',
+        inputTokens: 1_000_000,
+        outputTokens: 0,
+      },
+      { workspaceId: null, model: 'claude-opus-4-7', inputTokens: 1_000_000, outputTokens: 0 },
+    ])
+    const result = await runIngest(db, src, 'admin-key', '2026-07-02')
+    const orgInput = paramsFor(db, ORG_SLUG, ORG_INPUT_DRIVER)
+    const orgOutput = paramsFor(db, ORG_SLUG, ORG_OUTPUT_DRIVER)
+    expect(orgInput![4]).toBe(2_000_000)
+    expect(orgInput![3]).toBe(3000)
+    expect(orgOutput![3]).toBe(0)
+    // org rows are reconciliation, not attribution: excluded from centsWritten
+    expect(result.centsWritten).toBe(3000)
+    expect(result.slugs).toContain(ORG_SLUG)
+  })
+
+  it('writes the zero _org pair even with no usage at all', async () => {
+    const db = new FakeDb()
+    const result = await runIngest(db, new FakeAnthropic([]), 'admin-key', '2026-07-02')
+    expect(result.ok).toBe(true)
+    expect(paramsFor(db, ORG_SLUG, ORG_INPUT_DRIVER)![3]).toBe(0)
+    expect(db.writes).toHaveLength(2)
+  })
+
+  it('returns ok=false without writing when the usage fetch fails', async () => {
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const db = new FakeDb()
+    const result = await runIngest(
+      db,
       new FakeAnthropic([], new Error('HTTP 503')),
-      '2026-05-22'
+      'admin-key',
+      '2026-07-02'
     )
-    const byName = Object.fromEntries(result.sources.map((s) => [s.source, s]))
-    expect(byName.anthropic_billing.ok).toBe(false)
-    expect(result.anyFailures).toBe(true)
+    expect(result.ok).toBe(false)
+    expect(result.reason).toContain('503')
+    expect(db.writes).toHaveLength(0)
+    err.mockRestore()
+  })
+})
+
+describe('run (worker shell)', () => {
+  it('logs one error and exits cleanly when ANTHROPIC_ADMIN_KEY is missing', async () => {
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const env = { DB: new FakeDb() as unknown as D1Database } as Env
+    const result = await run(env, '2026-07-02')
+    expect(result.ok).toBe(false)
+    expect(result.reason).toContain('ANTHROPIC_ADMIN_KEY')
+    expect(result.rowsWritten).toBe(0)
+    expect(err).toHaveBeenCalledTimes(1)
+    err.mockRestore()
   })
 })

--- a/workers/cost-telemetry/src/ingest.ts
+++ b/workers/cost-telemetry/src/ingest.ts
@@ -1,107 +1,136 @@
 /**
- * Per-customer cost telemetry ingest — TS twin of
- * `operator/adapter/cost_ingest.py`.
+ * Central cost telemetry ingest (ADR 0062, #1660).
  *
- * Pulls yesterday's Anthropic usage and UPSERTs into the customer's
- * per-customer cost_telemetry D1 table via the Cloudflare D1 HTTP API.
- * Per ADR 0009 each customer has their own D1 database — there is no
- * cross-customer table — so the worker addresses each customer's
- * database id resolved from the central `customer_configs`.
+ * Pulls yesterday's org-wide Anthropic usage grouped by
+ * (workspace_id, model), maps each workspace to a customer seat via
+ * `customer_configs.anthropic_workspace_id`, and UPSERTs per-seat rows
+ * into the CENTRAL `cost_telemetry` table (migration 0083) keyed
+ * (customer_slug, date, driver).
  *
- * Failure isolation: each source's failure (Anthropic 503) is captured
- * in the result rather than crashing the run. The result names each
- * source's outcome so the cron summary can surface partial-success days.
+ * Attribution rules:
+ *   - workspace_id with an authored mapping  -> that customer_slug
+ *   - workspace_id without a mapping (or the default workspace, which
+ *     the API reports as null) -> reserved slug '_unmapped', with a
+ *     logged warning naming the workspace id. Nothing is silently
+ *     dropped.
+ *   - the org total across all workspaces    -> reserved slug '_org'
+ *     under drivers 'anthropic.org_total.input_tokens' /
+ *     'anthropic.org_total.output_tokens'. Reconciliation cross-check,
+ *     not an attribution source (ADR 0062 decision 2).
  *
- * Source-of-truth references:
- *   docs/specs/operator/cost-telemetry-events.md
- *   operator/adapter/cost_ingest.py
+ * Write semantics are idempotent day totals: the usage-report API
+ * returns the authoritative total for the day, so a re-run REPLACES the
+ * row instead of accumulating (unlike the per-event additive contract
+ * used by the captain-time CLI rollup).
+ *
+ * This module supersedes the per-customer-D1 fan-out (the databases it
+ * addressed were never provisioned; see ADR 0062 context).
  */
 
 import { computeAnthropicCents } from './pricing'
 
+/** One (workspace, model) usage row from the Anthropic usage report. */
 export interface AnthropicUsageRow {
+  /** Anthropic workspace id, or null for the org default workspace. */
+  workspaceId: string | null
   model: string
   inputTokens: number
   outputTokens: number
 }
 
 export interface AnthropicSource {
-  fetchDailyUsage(apiKey: string, day: string): Promise<AnthropicUsageRow[]>
+  fetchDailyUsage(adminKey: string, day: string): Promise<AnthropicUsageRow[]>
 }
 
-/** Minimal D1 HTTP API shape used here. */
-export interface D1HttpClient {
-  execute(databaseId: string, sql: string, params: unknown[]): Promise<void>
+/**
+ * Minimal structural slice of the D1 binding used here — satisfied by
+ * the real D1Database and trivially fakeable in tests.
+ */
+export interface CentralDb {
+  prepare(sql: string): {
+    bind(...params: unknown[]): {
+      run(): Promise<unknown>
+      all<T>(): Promise<{ results?: T[] }>
+    }
+    all<T>(): Promise<{ results?: T[] }>
+  }
 }
 
-export interface SourceResult {
-  source: string
+export const ORG_SLUG = '_org'
+export const UNMAPPED_SLUG = '_unmapped'
+
+export const ORG_INPUT_DRIVER = 'anthropic.org_total.input_tokens'
+export const ORG_OUTPUT_DRIVER = 'anthropic.org_total.output_tokens'
+
+export interface IngestResult {
   ok: boolean
+  day: string
   rowsWritten: number
   centsWritten: number
+  /** Slugs (customers + reserved) that received at least one row. */
+  slugs: string[]
+  /** Workspace ids seen in the report with no authored mapping. */
+  unmappedWorkspaceIds: string[]
+  warnings: string[]
   reason?: string
 }
 
-export interface CustomerIngestResult {
-  customerSlug: string
-  day: string
-  sources: SourceResult[]
-  anyFailures: boolean
-  totalCents: number
+interface WorkspaceMappingRow {
+  customer_slug: string
+  anthropic_workspace_id: string
+}
+
+/** Load the authored workspace_id -> customer_slug mapping from central D1. */
+export async function loadWorkspaceMapping(db: CentralDb): Promise<Map<string, string>> {
+  const result = await db
+    .prepare(
+      'SELECT customer_slug, anthropic_workspace_id FROM customer_configs ' +
+        "WHERE anthropic_workspace_id IS NOT NULL AND anthropic_workspace_id != ''"
+    )
+    .all<WorkspaceMappingRow>()
+  const map = new Map<string, string>()
+  for (const row of result.results ?? []) {
+    map.set(row.anthropic_workspace_id, row.customer_slug)
+  }
+  return map
 }
 
 const UPSERT_SQL =
-  'INSERT INTO cost_telemetry (date, driver, amount_cents, units, unit_type) ' +
-  'VALUES (?, ?, ?, ?, ?) ' +
-  'ON CONFLICT (date, driver) DO UPDATE SET ' +
-  '  amount_cents = amount_cents + excluded.amount_cents, ' +
-  '  units = units + excluded.units'
+  'INSERT INTO cost_telemetry (customer_slug, date, driver, amount_cents, units, unit_type, updated_at) ' +
+  'VALUES (?, ?, ?, ?, ?, ?, ?) ' +
+  'ON CONFLICT (customer_slug, date, driver) DO UPDATE SET ' +
+  '  amount_cents = excluded.amount_cents, ' +
+  '  units = excluded.units, ' +
+  '  unit_type = excluded.unit_type, ' +
+  '  updated_at = excluded.updated_at'
 
-interface UpsertRow {
-  dayStr: string
-  driver: string
-  amountCents: number
-  units: number
-  unitType: string
+interface Totals {
+  inputTokens: number
+  outputTokens: number
+  inputCents: number
+  outputCents: number
 }
 
-async function upsertRow(d1: D1HttpClient, databaseId: string, row: UpsertRow): Promise<void> {
-  await d1.execute(databaseId, UPSERT_SQL, [
-    row.dayStr,
-    row.driver,
-    row.amountCents,
-    row.units,
-    row.unitType,
-  ])
+function emptyTotals(): Totals {
+  return { inputTokens: 0, outputTokens: 0, inputCents: 0, outputCents: 0 }
 }
 
-export async function ingestAnthropic(
-  d1: D1HttpClient,
-  databaseId: string,
-  source: AnthropicSource,
-  apiKey: string,
-  day: string
-): Promise<SourceResult> {
-  let rows: AnthropicUsageRow[]
-  try {
-    rows = await source.fetchDailyUsage(apiKey, day)
-  } catch (e) {
-    const msg = e instanceof Error ? e.message : String(e)
-    console.warn(`anthropic_billing fetch failed for ${day}: ${msg}`)
-    return {
-      source: 'anthropic_billing',
-      ok: false,
-      rowsWritten: 0,
-      centsWritten: 0,
-      reason: `fetch failed: ${msg}`,
-    }
-  }
+interface Aggregation {
+  bySlug: Map<string, Totals>
+  org: Totals
+  unmappedWorkspaceIds: string[]
+  warnings: string[]
+}
 
-  let totalInTokens = 0
-  let totalOutTokens = 0
-  let totalInCents = 0
-  let totalOutCents = 0
+/** Attribute usage rows to slugs (mapped seat, '_unmapped') and total the org. */
+export function aggregateUsage(
+  rows: AnthropicUsageRow[],
+  mapping: Map<string, string>
+): Aggregation {
   const warnings: string[] = []
+  const bySlug = new Map<string, Totals>()
+  const org = emptyTotals()
+  const unmapped = new Set<string>()
 
   for (const row of rows) {
     const { inputCents, outputCents, warning } = computeAnthropicCents(
@@ -111,85 +140,122 @@ export async function ingestAnthropic(
     )
     if (warning) {
       warnings.push(warning)
-      console.warn(warning)
+      console.warn(`[cost-telemetry] ${warning}`)
     }
-    totalInTokens += row.inputTokens
-    totalOutTokens += row.outputTokens
-    totalInCents += inputCents
-    totalOutCents += outputCents
+
+    let slug: string
+    if (row.workspaceId && mapping.has(row.workspaceId)) {
+      slug = mapping.get(row.workspaceId)!
+    } else {
+      slug = UNMAPPED_SLUG
+      if (row.workspaceId) unmapped.add(row.workspaceId)
+    }
+
+    const t = bySlug.get(slug) ?? emptyTotals()
+    t.inputTokens += row.inputTokens
+    t.outputTokens += row.outputTokens
+    t.inputCents += inputCents
+    t.outputCents += outputCents
+    bySlug.set(slug, t)
+
+    org.inputTokens += row.inputTokens
+    org.outputTokens += row.outputTokens
+    org.inputCents += inputCents
+    org.outputCents += outputCents
   }
 
-  let rowsWritten = 0
-  if (totalInTokens > 0) {
-    await upsertRow(d1, databaseId, {
-      dayStr: day,
-      driver: 'claude_api_input_tokens',
-      amountCents: totalInCents,
-      units: totalInTokens,
-      unitType: 'input_tokens',
-    })
-    rowsWritten++
-  }
-  if (totalOutTokens > 0) {
-    await upsertRow(d1, databaseId, {
-      dayStr: day,
-      driver: 'claude_api_output_tokens',
-      amountCents: totalOutCents,
-      units: totalOutTokens,
-      unitType: 'output_tokens',
-    })
-    rowsWritten++
-  }
-
-  return {
-    source: 'anthropic_billing',
-    ok: true,
-    rowsWritten,
-    centsWritten: totalInCents + totalOutCents,
-    reason: warnings.length ? warnings.join('; ') : undefined,
-  }
-}
-
-export interface CustomerIngestContext {
-  customerSlug: string
-  perCustomerDatabaseId: string
-  anthropicApiKey: string
-}
-
-export async function runIngestForCustomer(
-  ctx: CustomerIngestContext,
-  d1: D1HttpClient,
-  anthropicSource: AnthropicSource,
-  day: string
-): Promise<CustomerIngestResult> {
-  const sources: SourceResult[] = []
-
-  try {
-    const anth = await ingestAnthropic(
-      d1,
-      ctx.perCustomerDatabaseId,
-      anthropicSource,
-      ctx.anthropicApiKey,
-      day
+  for (const workspaceId of unmapped) {
+    console.warn(
+      `[cost-telemetry] workspace ${workspaceId} has no ` +
+        `customer_configs.anthropic_workspace_id mapping; usage recorded under '${UNMAPPED_SLUG}'`
     )
-    sources.push(anth)
+  }
+
+  return { bySlug, org, unmappedWorkspaceIds: [...unmapped], warnings }
+}
+
+/** UPSERT the attributed rows plus the '_org' reconciliation pair. */
+async function writeRows(
+  db: CentralDb,
+  day: string,
+  agg: Aggregation
+): Promise<{ rowsWritten: number; centsWritten: number }> {
+  const updatedAt = new Date().toISOString()
+  let rowsWritten = 0
+  let centsWritten = 0
+
+  async function upsert(
+    slug: string,
+    driver: string,
+    amountCents: number,
+    units: number,
+    unitType: string
+  ): Promise<void> {
+    await db
+      .prepare(UPSERT_SQL)
+      .bind(slug, day, driver, amountCents, units, unitType, updatedAt)
+      .run()
+    rowsWritten++
+  }
+
+  // Per-seat attribution rows (including '_unmapped').
+  for (const [slug, t] of agg.bySlug) {
+    if (t.inputTokens > 0) {
+      await upsert(slug, 'claude_api_input_tokens', t.inputCents, t.inputTokens, 'input_tokens')
+      centsWritten += t.inputCents
+    }
+    if (t.outputTokens > 0) {
+      await upsert(slug, 'claude_api_output_tokens', t.outputCents, t.outputTokens, 'output_tokens')
+      centsWritten += t.outputCents
+    }
+  }
+
+  // Org reconciliation rows under '_org'. Written even at zero usage so
+  // "the ingest ran and the org total was 0" is distinguishable from
+  // "the ingest never ran". Their cents are excluded from centsWritten
+  // (they duplicate the attributed rows by construction).
+  const { org } = agg
+  await upsert(ORG_SLUG, ORG_INPUT_DRIVER, org.inputCents, org.inputTokens, 'input_tokens')
+  await upsert(ORG_SLUG, ORG_OUTPUT_DRIVER, org.outputCents, org.outputTokens, 'output_tokens')
+
+  return { rowsWritten, centsWritten }
+}
+
+export async function runIngest(
+  db: CentralDb,
+  source: AnthropicSource,
+  adminKey: string,
+  day: string
+): Promise<IngestResult> {
+  let rows: AnthropicUsageRow[]
+  try {
+    rows = await source.fetchDailyUsage(adminKey, day)
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e)
-    console.error(`anthropic ingest crashed for ${ctx.customerSlug}: ${msg}`)
-    sources.push({
-      source: 'anthropic_billing',
+    console.error(`[cost-telemetry] usage fetch failed for ${day}: ${msg}`)
+    return {
       ok: false,
+      day,
       rowsWritten: 0,
       centsWritten: 0,
-      reason: `unhandled exception: ${msg}`,
-    })
+      slugs: [],
+      unmappedWorkspaceIds: [],
+      warnings: [],
+      reason: `usage fetch failed: ${msg}`,
+    }
   }
 
+  const mapping = await loadWorkspaceMapping(db)
+  const agg = aggregateUsage(rows, mapping)
+  const { rowsWritten, centsWritten } = await writeRows(db, day, agg)
+
   return {
-    customerSlug: ctx.customerSlug,
+    ok: true,
     day,
-    sources,
-    anyFailures: sources.some((s) => !s.ok),
-    totalCents: sources.reduce((sum, s) => sum + s.centsWritten, 0),
+    rowsWritten,
+    centsWritten,
+    slugs: [...agg.bySlug.keys(), ORG_SLUG],
+    unmappedWorkspaceIds: agg.unmappedWorkspaceIds,
+    warnings: agg.warnings,
   }
 }

--- a/workers/cost-telemetry/wrangler.toml
+++ b/workers/cost-telemetry/wrangler.toml
@@ -1,16 +1,19 @@
-# Cost Telemetry Worker — nightly cost-driver ingest for Operator
-# Per docs/specs/operator/cost-telemetry-events.md "Nightly Captain job".
+# Cost Telemetry Worker — nightly cost-driver ingest for Operator (ADR 0062)
 #
-# The worker iterates every active Operator customer once per day at
-# 02:00 UTC. For each customer it pulls yesterday's Anthropic token usage,
-# computes cents via the hardcoded pricing JSON files at
-# operator/adapter/cost_telemetry/, and UPSERTs one or more rows into
-# the customer's per-customer cost_telemetry D1 table.
+# Once per day at 02:00 UTC the worker pulls yesterday's org-wide Anthropic
+# usage from the Admin usage-report API, grouped by (workspace_id, model),
+# computes cents via the pricing JSON at operator/adapter/cost_telemetry/,
+# and UPSERTs per-seat rows into the CENTRAL cost_telemetry table in
+# ss-console-db (migration 0083; customer_slug tenant column).
 #
-# The per-customer D1 database id is read from the central
-# customer_configs table (column lookup in src/index.ts). Per ADR 0009,
-# every customer has their own D1 database — there is no cross-customer
-# cost_telemetry table.
+# Per-seat attribution: one Anthropic workspace per customer seat, mapped
+# via customer_configs.anthropic_workspace_id (authored by Captain — see
+# docs/runbooks/operator/cost-telemetry-enable.md). Unmapped workspace
+# usage lands under '_unmapped'; the org total is written under '_org' as
+# a reconciliation row.
+#
+# The per-customer-D1 write path (and its CF_ACCOUNT_ID / CF_D1_API_TOKEN
+# secrets) is retired: those databases were never provisioned (ADR 0062).
 #
 # Cloudflare D1/R2/Vectorize metering is deferred to phase 2 per the
 # validation-spike result documented in operator/adapter/cost_ingest.py.
@@ -22,8 +25,7 @@ main = "src/index.ts"
 compatibility_date = "2025-01-01"
 compatibility_flags = ["nodejs_compat"]
 
-# Same central D1 database as ss-web — needed to enumerate customers
-# from customer_configs.
+# Central D1 — customer_configs (workspace mapping) + cost_telemetry writes.
 [[d1_databases]]
 binding = "DB"
 database_name = "ss-console-db"
@@ -33,10 +35,10 @@ database_id = "65171b23-d615-42a7-84e7-a4fac20d063c"
 [triggers]
 crons = ["0 2 * * *"]
 
-# Secrets (set via `wrangler secret put` after first deploy):
-#   CF_ACCOUNT_ID       — Cloudflare account id for per-customer D1 HTTP API
-#   CF_D1_API_TOKEN     — Token with D1:Edit scope across customer DBs
-#   ANTHROPIC_API_KEY   — Org-level key (per-customer keys would shift to
-#                         a per-customer secret lookup; v1 uses the org key
-#                         since billing rolls up at the org level)
+# Secrets (set via `wrangler secret put`):
+#   ANTHROPIC_ADMIN_KEY — Anthropic ADMIN API key (sk-ant-admin...), minted at
+#                         https://console.anthropic.com/settings/admin-keys.
+#                         The usage-report API rejects regular runtime keys.
+#                         When missing, the run logs one error and exits 0
+#                         (no crashloop while enablement is pending).
 #   COST_INGEST_BEARER  — Bearer token for manual /run invocations


### PR DESCRIPTION
Closes #1660. Implements the storage and attribution decisions of ADR 0062 (Operator cost plane). The pipeline was dark at every link: no per-customer D1 exists anywhere, so the nightly ingest skipped 100% of seats, and the runtime ANTHROPIC_API_KEY is rejected by the usage-report API.

## Migration (0083)

- Central `cost_telemetry` table in ss-console-db: `(customer_slug, date, driver)` PK, plus `updated_at` and a date index. Central `captain_time_events` mirroring the per-customer 0006 shape plus `customer_slug`.
- Reserved slugs documented in the header: `_org` (reconciliation rows under drivers `anthropic.org_total.input_tokens` / `anthropic.org_total.output_tokens`) and `_unmapped` (workspace usage no seat claims).
- `customer_configs.anthropic_workspace_id` (nullable TEXT): the authored per-seat workspace mapping. NULL = seat not yet attributed.

## workers/cost-telemetry (rewrite)

- Secret rename `ANTHROPIC_API_KEY` -> `ANTHROPIC_ADMIN_KEY`; wrangler.toml comments updated. Missing key logs one clear error and exits 0 (no crashloop while the Captain step is pending).
- Calls `/v1/organizations/usage_report/messages` with `group_by[]=workspace_id&group_by[]=model`, `bucket_width=1d`, one-day window, `has_more`/`next_page` pagination.
- Maps workspace_id -> customer_slug from central D1; UPSERTs per-seat `claude_api_input_tokens` / `claude_api_output_tokens` rows; cents math via anthropic_pricing.json unchanged (claude-opus-4-8 from #1658 covered by test).
- Org total written under `_org`; unmapped workspace usage lands under `_unmapped` with a warning naming the workspace id. Nothing silently dropped.
- Per-customer-D1 enumeration and the Cloudflare D1 HTTP client are deleted.
- **Deliberate semantics change:** writes are idempotent day totals (replace-on-conflict) instead of the old additive UPSERT. The usage report returns authoritative daily figures; the additive contract made every re-run double-count. The accumulate contract still applies to per-event emitters (captain-time CLI), noted in the spec amendment.
- **Documented approximation:** input tokens sum uncached + cache-read + cache-creation variants, all priced at the model input rate. Cache tiers bill at different multipliers upstream; the `_org` row is the invoice cross-check.

## workers/cost-anomaly

- Reads the central table via the D1 binding (same daily total vs 7-day rolling average math). `_org`/`_unmapped` excluded by construction (no customer_configs row).
- Per-customer D1 plumbing, `skipped:no-d1` status, and CF_ACCOUNT_ID/CF_D1_API_TOKEN env removed.

## Dashboard / cost-query

- `fetchCustomerCostRows(db, customerSlug, start, end)` queries the central table through `env.DB`; the CF token HTTP fan-out, `CostQueryEnv`, and the `connectors_json` db-id projection are deleted (cost-query.ts, both costs pages, CostsTableRow, CSV export, env.d.ts).
- Driver->category rollup, COGS/MRR math, CSV shape unchanged. Export endpoint drops the 409/503 preconditions.

## Docs (honesty contract)

- Dated amendment notes (2026-07-03, ADR 0062) on the storage/privacy clauses of `cost-telemetry-events.md`, `cost-attribution-rollup.md`, `d1-schema.md`; original text retained as historical record.
- `operator/migrations/README.md` + 0001/0006 headers get supersession pointers; files stay as historical record.
- New runbook `docs/runbooks/operator/cost-telemetry-enable.md` with the two Captain steps (below).
- Handbook `data-model.md` gains the central cost tables rows (maintenance contract).

## Captain steps to go live (from the runbook)

1. Mint an Admin API key at https://console.anthropic.com/settings/admin-keys, store as `ANTHROPIC_ADMIN_KEY` in Infisical /ss prod, and stage it: `npx wrangler secret put ANTHROPIC_ADMIN_KEY --name ss-cost-telemetry`.
2. Create one workspace per seat at https://console.anthropic.com/settings/workspaces, mint a workspace-scoped key per seat, stage it to that Machine as its ANTHROPIC_API_KEY (reprovision, Captain-gated), then author the `wrkspc_...` id into `customer_configs.anthropic_workspace_id`.

Post-merge cleanup (optional): the stale `CF_ACCOUNT_ID` / `CF_D1_API_TOKEN` / `ANTHROPIC_API_KEY` secrets on both workers can be deleted with `wrangler secret delete`; nothing reads them anymore. Migration 0083 needs `wrangler d1 migrations apply` on deploy per the standard pipeline.

## Verification

- `npm run verify` passes (typecheck app + both workers, lint, format, all vitest suites incl. updated admin-cost-query/export and the rewritten worker ingest tests).
- `python3 -m pytest operator/bin/tests operator/safety-substrate/tests operator/adapter/tests -q`: 424 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)