### PR TITLE
feat(operator): provision prefers per-seat Anthropic workspace keys

### DIFF
--- a/docs/runbooks/operator/cost-telemetry-enable.md
+++ b/docs/runbooks/operator/cost-telemetry-enable.md
@@ -32,7 +32,7 @@ The usage-report API (`/v1/organizations/usage_report/messages`) requires an ADM
 Per-seat attribution comes from per-customer Anthropic workspaces (ADR 0062 decision 2). Usage stays org-level until each Machine's spend is isolated in its own workspace.
 
 1. Create one workspace per live seat at <https://platform.claude.com/settings/workspaces>. Name it after the customer slug (for example `op-ashton-price`).
-2. Move each Machine's Anthropic spend into its workspace: mint a workspace-scoped API key inside the new workspace, stage it to that Machine as its `ANTHROPIC_API_KEY`, and reprovision the Machine (reprovision requires explicit Captain authorization per standing rule). Existing org-default keys cannot be moved between workspaces; a new key per workspace is the path.
+2. Move each Machine's Anthropic spend into its workspace: mint a workspace-scoped API key inside the new workspace and vault it in Infisical `/ss` prod as `ANTHROPIC_API_KEY__<SLUG>` (slug uppercased, dashes to underscores — e.g. `ANTHROPIC_API_KEY__PILOT_SMOKEBALL`) via `crane_secret_set`. `provision-customer.sh` prefers the per-seat key automatically and stages it to the Machine as its `ANTHROPIC_API_KEY`; then reprovision the Machine (reprovision requires explicit Captain authorization per standing rule). Existing org-default keys cannot be moved between workspaces; a new key per workspace is the path.
 3. Author the workspace id (the `wrkspc_...` value shown in the Console) into the central database:
 
    ```bash

--- a/operator/bin/provision-customer.sh
+++ b/operator/bin/provision-customer.sh
@@ -339,7 +339,19 @@ stage_secret_from_env() {
 # This prompt was dead provisioning ceremony; customers act on real mailboxes
 # via mcp:google-gmail / ms-graph, not an agent mailbox. Re-add when a persona
 # email identity is actually wired.
-prompt_and_set ANTHROPIC_API_KEY  "Anthropic API key for hermes-${SLUG}"
+# ANTHROPIC_API_KEY: prefer the per-seat WORKSPACE key from /ss (ADR 0062 §2 —
+# per-customer Anthropic workspaces are the cost-attribution boundary; the
+# usage-report ingest groups by workspace_id). Same per-seat convention as
+# WEBHOOK_SECRET_AGENTMAIL__<CUSTOMER_ID> below. Falls back to the interactive
+# clipboard prompt when no per-seat key is vaulted (pre-workspace seats), which
+# reprovision runs answer 's' to — leaving the Machine's existing key in place.
+_ANTH_SEAT_KEY_NAME="ANTHROPIC_API_KEY__$(printf '%s' "${CUSTOMER_ID}" | tr '[:lower:]-' '[:upper:]_' | tr -cd 'A-Z0-9_')"
+_ANTH_SEAT_KEY="${!_ANTH_SEAT_KEY_NAME:-}"
+if [ -n "${_ANTH_SEAT_KEY}" ]; then
+  stage_secret_from_env ANTHROPIC_API_KEY "${_ANTH_SEAT_KEY}" "per-seat Anthropic workspace key (${_ANTH_SEAT_KEY_NAME})"
+else
+  prompt_and_set ANTHROPIC_API_KEY  "Anthropic API key for hermes-${SLUG}"
+fi
 
 # R2 access for bootstrap.sh's customer.yaml fetch + customer-sync sidecar's
 # polling for non-structural config changes. R2_BUCKET_CONFIG is in fly.toml


### PR DESCRIPTION
## Summary
- ADR 0062 §2: workspace keys are the per-seat cost-attribution boundary, but `ANTHROPIC_API_KEY` staging was interactive-prompt-only (skipped on reprovision) — rotation had no automated path.
- `provision-customer.sh` now prefers `ANTHROPIC_API_KEY__<SLUG>` from Infisical `/ss` (the existing `WEBHOOK_SECRET_AGENTMAIL__<CUSTOMER_ID>` per-seat convention) via `stage_secret_from_env`; interactive prompt remains the fallback for pre-workspace seats.
- Runbook step 2 updated to the vault-then-reprovision path.

## Test plan
- [x] `bash -n` clean; operator substrate suites 427 passed; `npm run verify` passes
- [x] `ANTHROPIC_API_KEY__SMD` already vaulted + live-verified (200 on /v1/models); first consumer is the smd reprovision

🤖 Generated with [Claude Code](https://claude.com/claude-code)