### PR TITLE
fix(operator): export HERMES_TIMEZONE before cron materialization — closes the every-boot UTC first-fire double (#1691)

### DIFF
--- a/operator/bin/tests/test_seat_timezone.py
+++ b/operator/bin/tests/test_seat_timezone.py
@@ -61,6 +61,27 @@ def test_bootstrap_exports_seat_timezone_before_gateway() -> None:
     )
 
 
+def test_bootstrap_exports_seat_timezone_before_cron_materialization() -> None:
+    """ss-console#1691: the export must ALSO precede step 7 (`hermes-smd
+    bootstrap`), not just the gateway exec. Cron materialization persists each
+    managed job's first next_run_at computed via hermes_time.now() in the
+    step-7 process, and hermes_time caches its timezone per process — so an
+    export placed after step 7 stores UTC-computed first fires that the
+    gateway then fires at BOTH the UTC-interpreted and seat-local times (the
+    2026-07-04 escalator double-fire: midnight PT + 7:00 AM PT)."""
+    lines = _code_lines()
+    export_idx = _first_index(lines, r"export HERMES_TIMEZONE=")
+    overlay_bootstrap_idx = _first_index(lines, r"^\s*hermes-smd bootstrap\b")
+
+    assert export_idx != -1, "bootstrap.sh must export HERMES_TIMEZONE"
+    assert overlay_bootstrap_idx != -1, "could not find the hermes-smd bootstrap (step 7) line"
+    assert export_idx < overlay_bootstrap_idx, (
+        "HERMES_TIMEZONE must be exported BEFORE `hermes-smd bootstrap` — cron "
+        "materialization persists next_run_at with the timezone cached at that "
+        f"process's start (export={export_idx}, step7={overlay_bootstrap_idx})"
+    )
+
+
 def test_export_is_conditional_on_authored_timezone() -> None:
     """Unauthored business_hours must NOT export an empty/placeholder value —
     the export sits inside a non-empty guard so UTC remains the fallback."""

--- a/operator/templates/bootstrap.sh
+++ b/operator/templates/bootstrap.sh
@@ -375,6 +375,44 @@ else
   log "WARNING: /app/skills absent from image; skipping catalog seed (bound skills must already be on the volume)"
 fi
 
+# Publish the seat's timezone on the env channel Hermes' clock resolves first
+# (hermes_time._resolve_timezone_name: HERMES_TIMEZONE env > global config.yaml
+# `timezone` > server local). The container clock is UTC, so without this every
+# authored cron expression silently ran in UTC while the customer.yaml comments
+# claimed local time — caught 2026-07-03 when the pilot's "0623 PT" morning
+# digest turned out to mean 11:23 PM Pacific and the pre-existing escalator's
+# "0700 PT" had been firing at midnight Pacific since it shipped. Source of
+# truth is customer.yaml `business_hours.timezone` (IANA, validated by the
+# console); when the block is unauthored nothing is exported and Hermes keeps
+# server-local (UTC) — the prior behavior, not a new default (ADR 0037 tenet 3).
+# An invalid IANA name is safe: hermes_time logs a warning and falls back.
+#
+# ORDERING (ss-console#1691): this export MUST precede step 7. Cron
+# materialization (hermes-smd bootstrap -> cron_materialize -> Hermes
+# create_job) PERSISTS each job's first next_run_at computed via
+# hermes_time.now() in the step-7 process, and hermes_time caches its timezone
+# per process at first call. When this export sat below step 7 (with the
+# step-11 gateway exports), every boot re-created every managed job with a
+# UTC-computed first fire: the gateway then fired it at the UTC-interpreted
+# time AND at the correct seat-local time after advance_next_run recomputed —
+# the 2026-07-04 escalator double-fire (midnight PT + 7:00 AM PT).
+SEAT_TIMEZONE="$(/opt/hermes/.venv/bin/python3 - "${CUSTOMER_YAML}" <<'PY'
+import sys
+import yaml
+
+data = yaml.safe_load(open(sys.argv[1])) or {}
+hours = data.get("business_hours") or {}
+tz = hours.get("timezone") if isinstance(hours, dict) else ""
+print(tz.strip() if isinstance(tz, str) else "")
+PY
+)" || SEAT_TIMEZONE=""
+if [ -n "${SEAT_TIMEZONE}" ]; then
+  export HERMES_TIMEZONE="${SEAT_TIMEZONE}"
+  log "Hermes timezone: ${SEAT_TIMEZONE} (cron + clock run in seat-local time)"
+else
+  log "Hermes timezone: unset (business_hours.timezone unauthored) — cron + clock run in UTC"
+fi
+
 # ============================================================================
 # Step 7: hermes-smd bootstrap (customer.yaml -> per-profile config)
 # ============================================================================
@@ -560,33 +598,10 @@ log "Active persona profile: ${ACTIVE_PROFILE}"
 # bootstrap — the boundary that selects the profile — is where it belongs.
 export HERMES_ACTIVE_PROFILE="${ACTIVE_PROFILE}"
 
-# Publish the seat's timezone on the env channel Hermes' clock resolves first
-# (hermes_time._resolve_timezone_name: HERMES_TIMEZONE env > global config.yaml
-# `timezone` > server local). The container clock is UTC, so without this every
-# authored cron expression silently ran in UTC while the customer.yaml comments
-# claimed local time — caught 2026-07-03 when the pilot's "0623 PT" morning
-# digest turned out to mean 11:23 PM Pacific and the pre-existing escalator's
-# "0700 PT" had been firing at midnight Pacific since it shipped. Source of
-# truth is customer.yaml `business_hours.timezone` (IANA, validated by the
-# console); when the block is unauthored nothing is exported and Hermes keeps
-# server-local (UTC) — the prior behavior, not a new default (ADR 0037 tenet 3).
-# An invalid IANA name is safe: hermes_time logs a warning and falls back.
-SEAT_TIMEZONE="$(/opt/hermes/.venv/bin/python3 - "${CUSTOMER_YAML}" <<'PY'
-import sys
-import yaml
-
-data = yaml.safe_load(open(sys.argv[1])) or {}
-hours = data.get("business_hours") or {}
-tz = hours.get("timezone") if isinstance(hours, dict) else ""
-print(tz.strip() if isinstance(tz, str) else "")
-PY
-)" || SEAT_TIMEZONE=""
-if [ -n "${SEAT_TIMEZONE}" ]; then
-  export HERMES_TIMEZONE="${SEAT_TIMEZONE}"
-  log "Hermes timezone: ${SEAT_TIMEZONE} (cron + clock run in seat-local time)"
-else
-  log "Hermes timezone: unset (business_hours.timezone unauthored) — cron + clock run in UTC"
-fi
+# (HERMES_TIMEZONE is exported ABOVE step 7, not here — cron materialization at
+# step 7 persists each job's first next_run_at, so the timezone must already be
+# on the env when that process starts. See the ordering note at the export,
+# ss-console#1691.)
 
 PROFILE_HERMES_HOME="${HERMES_HOME}/profiles/${ACTIVE_PROFILE}"
 


### PR DESCRIPTION
Closes the mechanism behind #1691.

**Root cause (confirmed in Hermes core + bootstrap ordering):** cron materialization at bootstrap step 7 persists each managed job's first `next_run_at` via `hermes_time.now()`, which caches its timezone per process. The `HERMES_TIMEZONE` export sat at step 11 (gateway exec), so the step-7 process always computed UTC — and since every boot removes + recreates all managed jobs, **every reprovision gave every job one UTC-timed first fire**. The timezone-aware gateway fired the stale UTC time, then `advance_next_run` recomputed seat-local — the observed escalator double-fire (midnight PT + 7:00 AM PT, vfy_01KWPYZ2T6DBRBJE3AWWS86B5B).

**Fix:** move the export above step 7 (customer.yaml is validated present at step 2). Regression test pins export-before-materialization ordering (fails on the old layout).

**Flush:** reprovision re-creates all jobs under the correct timezone — deploying this IS the flush for the pilot's 11 never-fired jobs whose stale UTC first-fires would otherwise land Sunday evening PT (digest at 23:23 PT Sunday).

**Companion:** venturecrane/hermes-smd-overlay#126 exposes `next_run_at` on the config seam; post-reprovision verification target: digest = Mon 06:23-07:00, escalator = 07:00-07:00.

Tests: `bin/tests safety-substrate/tests adapter/tests` 428 passed; `bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K8qUZdwzz4iE4n83EVSE2Y