### PR TITLE
feat(portal): wire runtime-read into Operator home feeds + aliveness header

### DIFF
--- a/.claude/parallel-isolation-required-e6cf72eb-1dc6-46f3-aeea-57eb64f4edcd
+++ b/.claude/parallel-isolation-required-e6cf72eb-1dc6-46f3-aeea-57eb64f4edcd
@@ -1,0 +1,6 @@
+{
+  "session_id": "e6cf72eb-1dc6-46f3-aeea-57eb64f4edcd",
+  "toplevel": "/Users/scottdurgan/dev/ss-console",
+  "peer_pids": [1437],
+  "created_at": "2026-06-23T19:37:29Z"
+}

--- a/.claude/parallel-isolation-required-eaa91999-bb36-4ce0-8f03-c1d0306fc743
+++ b/.claude/parallel-isolation-required-eaa91999-bb36-4ce0-8f03-c1d0306fc743
@@ -1,0 +1,6 @@
+{
+  "session_id": "eaa91999-bb36-4ce0-8f03-c1d0306fc743",
+  "toplevel": "/Users/scottdurgan/dev/ss-console",
+  "peer_pids": [1437],
+  "created_at": "2026-06-20T18:53:04Z"
+}

--- a/docs/handbook/operator-console.md
+++ b/docs/handbook/operator-console.md
@@ -65,9 +65,9 @@ Two domains are never a client switch and are SMD-operated in every state: `prov
 
 The design behind this model is in `docs/design/operator/` and ADR 0041; the governance it expresses is `/admin/playbook/autonomy-governance`.
 
-## Honest before it is wired
+## Honest when it has nothing to show
 
-Several surfaces read live runtime state - the activity log, calendar items, the "where is the agent right now" header, the home feeds - through the runtime read seam (ADR 0043, `/admin/playbook/architecture-map`). That seam is built and the surfaces are built, but the per-customer runtime bridge that fills them is staged work; until it is wired for a given customer, those surfaces render honest empty states rather than fabricated content. This is the same no-fabrication discipline the rest of the product holds (`/admin/playbook/security-trust`): an empty feed says "nothing needs a person," never invents one.
+Several surfaces read live runtime state through the runtime read seam (ADR 0043, `/admin/playbook/architecture-map`). The activity log, the home feeds (recent activity, escalations), the "where is the agent right now" header, and the what-needs-you count are live: activity and escalations come from the customer Machine's own audit log over the seam, the aliveness header derives from the Machine's heartbeat row (ADR 0023), and the count comes from the Machine-pushed review-queue depth (`src/lib/portal/operator/home.ts`, `src/lib/portal/operator/aliveness.ts`). Calendar items remain staged work. Every one of these fails closed: a Machine that is unreachable, a customer with no heartbeat row yet, or a source that has not landed renders an honest empty state rather than fabricated content. This is the same no-fabrication discipline the rest of the product holds (`/admin/playbook/security-trust`): an empty feed says "nothing needs a person," never invents one.
 
 ## Home
 

--- a/src/lib/operator/runtime-read.ts
+++ b/src/lib/operator/runtime-read.ts
@@ -28,6 +28,19 @@
 /** The classes of runtime detail a drill-in can request. Each maps to a
  * read-only endpoint on the Machine. Extend as drill-in surfaces are added.
  *
+ * Reconciliation with the Machine (overlay `shared/runtime_read.py`,
+ * checked 2026-07-04 / #1678): every kind listed here is in the Machine's
+ * SUPPORTED_KINDS, so no console request can 404. `audit_log`,
+ * `memory_export`, `config_export`, and `jobs` are REAL (backed by a table
+ * or the broker ledger); `activity` is supported but serves an honest empty
+ * page until its runtime table lands — portal Home therefore derives its
+ * activity feed from `audit_log`, and only the admin observe surface still
+ * requests `activity` (renders the empty state it was built for). The
+ * Machine additionally serves `audit_export` / `config` / `draft` /
+ * `matter` for the decommission pipeline and drift audit; those are
+ * deliberately NOT listed here — portal/admin drill-ins must not request
+ * compliance-export payloads.
+ *
  * `memory_export` serves an allow-listed Machine-local memory table one at a
  * time via the `table` query field (ADR 0016 mirror tables + `peer_preferences`,
  * the relationship model's learned lane — per-peer working-preference memory the

--- a/src/lib/portal/operator/activity-read.ts
+++ b/src/lib/portal/operator/activity-read.ts
@@ -8,14 +8,16 @@
  * read on the single audited, fail-closed, one-customer-per-call path
  * (foundations §6, ADR 0043). Activity is one of those drill-ins.
  *
- * Until OPERATOR_RUNTIME_READ_URL is wired, the read path is not configured.
- * We short-circuit to an empty page BEFORE calling readMachineRuntime, so an
- * unwired deployment does not write an `unreachable` read-audit row on every
- * page view. Once wired, every read is attempted and audited per ADR 0043.
+ * In a deployment without OPERATOR_RUNTIME_READ_URL / _SECRET (a fresh
+ * environment), the read path is not configured. We short-circuit to an empty
+ * page BEFORE calling readMachineRuntime, so an unwired deployment does not
+ * write an `unreachable` read-audit row on every page view. In production the
+ * path is configured; every read is attempted and audited per ADR 0043.
  *
- * The Machine read endpoint (overlay-side) defines the wire format; until it
- * exists this path returns empty, so `parseAuditEntries` is dormant but written
- * defensively (parse, never cast) for the documented row shape.
+ * The Machine read endpoint (overlay `shared/runtime_read.py`) serves
+ * `audit_log` shaped to this module's `parseAuditEntries` contract — the
+ * overlay cites this file by name. Parsing stays defensive (parse, never
+ * cast): a malformed row is dropped, never rendered as a misleading line.
  */
 
 import type { D1Database } from '@cloudflare/workers-types'

--- a/src/lib/portal/operator/aliveness.ts
+++ b/src/lib/portal/operator/aliveness.ts
@@ -25,23 +25,23 @@
  *                 the Machine is down, the bridge is broken, or the
  *                 customer's agent is genuinely doing nothing.
  *
- * Data sources, when the Hermes bridge lands (#821):
+ * Data source (#1678, superseding the #821 bridge stub): this customer's
+ * `fleet_status` row — the console-side store each Machine's heartbeat
+ * emitter pushes to (ADR 0023 Wave 1). It carries `last_heartbeat_ts`,
+ * `last_audit_ts`, and the Machine-reported `sticky_stop_level`, which is
+ * everything the four-state signal needs:
  *
- *   - Latest `audit_log` row → `lastActionAt`, `currentSkill` (when the
- *     action is in flight per a future running-action marker — today
- *     we infer "running" only when the bridge explicitly says so), and
- *     the audit row drives the idle/offline split via timestamp age.
+ *   - heartbeat + audit timestamps drive the idle/offline split (freshest
+ *     wins — a quiet-but-healthy Machine heartbeats without acting);
+ *   - `sticky_stop_level` drives the sticky_stop posture (reason text is
+ *     not pushed on the heartbeat, so the chip shows the posture without
+ *     the substrate's reason string);
+ *   - no in-flight marker is pushed today, so 'running' never renders
+ *     from this source — we do not infer it from timestamps.
  *
- *   - `sticky_stop_state` (per-customer D1, schema in migration 0004)
- *     → the sticky_stop posture, reason, and the substrate condition
- *     that pinned it.
- *
- * Today the bridge is not wired. `resolveAlivenessSignal` returns null
- * and the AlivenessHeader component renders the empty-state branch
- * (no fabricated activity, per
- * `docs/style/empty-state-pattern.md`). When #821 lands, swap the body
- * of `fetchAlivenessFromHermes`; the derivation, formatters, and
- * threshold constant stay put.
+ * A customer with no `fleet_status` row resolves to null and the
+ * AlivenessHeader renders the empty-state branch (no fabricated
+ * activity, per `docs/style/empty-state-pattern.md`).
  *
  * The derivation helper `deriveAlivenessFromBridge` is exported pure
  * and tested directly. The component does not derive from raw inputs;
@@ -52,6 +52,7 @@
  * of scope — the issue AC is "per-customer status, not aggregate."
  */
 
+import type { D1Database } from '@cloudflare/workers-types'
 import type { SubscriptionRow } from '../product-access'
 
 /**
@@ -148,6 +149,16 @@ export interface AlivenessBridgeReading {
   /** ISO 8601 UTC of the most recent audit_log row, null if none. */
   lastAuditTs: string | null
   /**
+   * ISO 8601 UTC of the most recent Machine heartbeat (ADR 0023 Wave 1
+   * emitter → console `fleet_status`), null if the Machine has never
+   * reported one. A quiet-but-healthy Machine writes heartbeats without
+   * writing audit rows, so liveness (idle vs offline) is decided by the
+   * FRESHEST of heartbeat/audit — while `lastActionAt` display stays the
+   * audit timestamp (the last thing the operator *did*, not the last time
+   * it phoned home).
+   */
+  lastHeartbeatTs: string | null
+  /**
    * Slug of an in-flight skill at the moment the bridge was polled,
    * null if nothing is running. The bridge is responsible for the
    * "in-flight" determination (e.g., a started-but-not-completed
@@ -179,11 +190,16 @@ export interface AlivenessBridgeReading {
  *      pinned the agent, no other posture is interesting until Captain
  *      clears it.
  *   2. an in-flight skill → 'running'.
- *   3. lastAuditTs age compared against OFFLINE_THRESHOLD_MINUTES
- *      decides idle vs offline. No audit history at all (null ts) is
- *      treated as 'offline' too — the bridge is the authority on
- *      "agent is alive enough to write audit rows" and absence is
- *      the honest answer.
+ *   3. the FRESHEST parseable timestamp among lastHeartbeatTs /
+ *      lastAuditTs, compared against OFFLINE_THRESHOLD_MINUTES, decides
+ *      idle vs offline. Heartbeats count because a quiet-but-healthy
+ *      Machine phones home without writing audit rows; audit rows count
+ *      because a pre-heartbeat Machine (or a row that predates the
+ *      emitter) is still evidence of life. No parseable timestamp at all
+ *      is treated as 'offline' — absence is the honest answer.
+ *
+ * `lastActionAt` always carries the audit timestamp (the last thing the
+ * operator *did*), regardless of which timestamp decided liveness.
  *
  * `nowMs` is injectable for deterministic tests.
  */
@@ -209,17 +225,8 @@ export function deriveAlivenessFromBridge(
     }
   }
 
-  if (reading.lastAuditTs === null) {
-    return {
-      level: 'offline',
-      lastActionAt: null,
-      currentSkill: null,
-      stickyStopReason: null,
-    }
-  }
-
-  const lastMs = Date.parse(reading.lastAuditTs)
-  if (!Number.isFinite(lastMs)) {
+  const lastAliveMs = freshestMs(reading.lastHeartbeatTs, reading.lastAuditTs)
+  if (lastAliveMs === null) {
     return {
       level: 'offline',
       lastActionAt: reading.lastAuditTs,
@@ -228,7 +235,7 @@ export function deriveAlivenessFromBridge(
     }
   }
 
-  const ageMs = nowMs - lastMs
+  const ageMs = nowMs - lastAliveMs
   const thresholdMs = OFFLINE_THRESHOLD_MINUTES * 60_000
   if (ageMs > thresholdMs) {
     return {
@@ -245,6 +252,19 @@ export function deriveAlivenessFromBridge(
     currentSkill: null,
     stickyStopReason: null,
   }
+}
+
+/** The freshest parseable timestamp among the inputs, as epoch ms; null when
+ * none parses. Unparseable values are skipped, not treated as epoch 0. */
+function freshestMs(...timestamps: (string | null)[]): number | null {
+  let freshest: number | null = null
+  for (const ts of timestamps) {
+    if (ts === null) continue
+    const ms = Date.parse(ts)
+    if (!Number.isFinite(ms)) continue
+    if (freshest === null || ms > freshest) freshest = ms
+  }
+  return freshest
 }
 
 /**
@@ -342,34 +362,79 @@ export function needsEscalationAffordance(level: AlivenessLevel): boolean {
 }
 
 /**
- * Server-side resolver invoked by the dashboard header. Today this
- * returns null — the per-customer Hermes bridge that feeds real data
- * is tracked in #821. When the bridge lands, replace the body of
- * `fetchAlivenessFromHermes` and the typed contract above stays put.
+ * Server-side resolver invoked by the dashboard header. Reads this
+ * customer's `fleet_status` row — the console-side heartbeat store each
+ * Machine pushes to (ADR 0023 Wave 1) — and derives the signal from it
+ * (#1678 wired this; the prior revision was the #821 stub).
  *
- * IMPORTANT: do not seed a synthetic "idle" reading here. Per
+ * Source semantics:
+ *   - `sticky_stop_level` is the Machine-reported breaker ladder value;
+ *     anything outside the known non-OK set reads as 'OK' (under-reporting
+ *     beats a false "agent is stopped" chip). The reason text is not pushed
+ *     on the heartbeat, so `stickyStopReason` is null here — the chip shows
+ *     the posture; the reason lives with Captain.
+ *   - No in-flight-skill marker is pushed today, so 'running' never renders
+ *     from this source (honest: we do not infer it from timestamps).
+ *   - `last_heartbeat_ts` + `last_audit_ts` drive the idle/offline split in
+ *     the derivation above.
+ *
+ * IMPORTANT: no `fleet_status` row → null (chip renders nothing). Per
  * `docs/style/empty-state-pattern.md`, the component must render the
  * empty (silent) state until real data lands, never a fabricated
  * "agent is healthy" chip. A green chip the customer cannot trust is
- * worse than no chip at all.
+ * worse than no chip at all. A read failure degrades the same way.
  */
 export async function resolveAlivenessSignal(
+  db: D1Database,
   subscription: SubscriptionRow,
   nowMs: number = Date.now()
 ): Promise<AlivenessSignal | null> {
-  const reading = await fetchAlivenessFromHermes(subscription)
+  const reading = await fetchAlivenessFromFleetStatus(db, subscription)
   if (reading === null) return null
   return deriveAlivenessFromBridge(reading, nowMs)
 }
 
-/**
- * Hermes bridge stub. Returns null. When #821 (Hermes runtime wiring)
- * lands, replace the body with the bridge fetch — the subscription
- * row carries the customer identity needed to route to the right
- * Machine D1.
- */
-function fetchAlivenessFromHermes(
-  _subscription: SubscriptionRow
+/** Non-OK sticky-stop ladder values the Machine can report (mirrors
+ * `operator/safety-substrate/sticky_stop.py::StickyStopLevel`). */
+const NON_OK_STICKY_LEVELS: ReadonlySet<string> = new Set(['WARN', 'SOFT_STOP', 'HARD_STOP'])
+
+interface FleetStatusAlivenessRow {
+  last_heartbeat_ts: string | null
+  last_audit_ts: string | null
+  sticky_stop_level: string | null
+}
+
+/** Read exactly this customer's heartbeat row (never a fleet-wide read from
+ * the portal — ADR 0052 scopes this surface to the client's own operator). */
+async function fetchAlivenessFromFleetStatus(
+  db: D1Database,
+  subscription: SubscriptionRow
 ): Promise<AlivenessBridgeReading | null> {
-  return Promise.resolve(null)
+  let row: FleetStatusAlivenessRow | null
+  try {
+    row = await db
+      .prepare(
+        'SELECT last_heartbeat_ts, last_audit_ts, sticky_stop_level ' +
+          'FROM fleet_status WHERE entity_id = ?'
+      )
+      .bind(subscription.entity_id)
+      .first<FleetStatusAlivenessRow>()
+  } catch {
+    // A missing table (fresh environment) degrades to the silent empty state.
+    return null
+  }
+  if (!row) return null
+
+  const stickyStopLevel =
+    typeof row.sticky_stop_level === 'string' && NON_OK_STICKY_LEVELS.has(row.sticky_stop_level)
+      ? (row.sticky_stop_level as 'WARN' | 'SOFT_STOP' | 'HARD_STOP')
+      : 'OK'
+
+  return {
+    lastAuditTs: row.last_audit_ts,
+    lastHeartbeatTs: row.last_heartbeat_ts,
+    inFlightSkill: null,
+    stickyStopLevel,
+    stickyStopReason: null,
+  }
 }

--- a/src/lib/portal/operator/home.ts
+++ b/src/lib/portal/operator/home.ts
@@ -1,26 +1,41 @@
 /**
  * Home / Today runtime feeds (client-portal §5.1). The Home surface answers
- * "what's happening" with four elements: aliveness (resolved separately via the
- * summary mirror), recent activity, what-needs-you, and escalations. The latter
- * three are fed by the live runtime read path (ADR 0043 path A).
+ * "what's happening" with four elements: aliveness (resolved separately via
+ * the fleet-status heartbeat store), recent activity, what-needs-you, and
+ * escalations. The latter three are fed here.
  *
- * Until OPERATOR_RUNTIME_READ_URL is wired, the read path fails closed, so this
- * returns empty feeds — the design's documented honest empty state
- * (foundations §6: "until built, runtime surfaces render honest empty states").
+ * Data sources (issue #1678 wired this; the prior revision returned hardcoded
+ * empty feeds):
  *
- * `needsAttentionCount` stays 0 by construction here. The Home must never
- * fabricate a review queue the entitlements did not author (ADR 0035 /
- * client-portal §5.1): a "what needs you" entry exists only when a skill was
- * authored to route to a human AND the runtime switch hands it to the client.
- * Absent that authored routing, there is nothing — not a zeroed queue implying
- * one exists, but no surface at all.
+ *   - Recent activity + escalations: ONE live runtime read (ADR 0043 path A,
+ *     kind `audit_log`) against the customer's own Machine — the same frozen
+ *     seam the Activity page uses. Escalations are the `ESCALATION_FIRED`
+ *     rows in that page: a record of what the operator flagged to a human,
+ *     never an invented queue. Fails closed to empty on any transport
+ *     failure; when the read path is not configured we short-circuit BEFORE
+ *     calling the seam so an unwired deployment does not write an
+ *     `unreachable` read-audit row on every dashboard view (same posture as
+ *     activity-read.ts).
  *
- * PR2 (Activity & Audit) wires the actual readMachineRuntime call + payload
- * parse into this function; the Home page consumes this typed shape and does
- * not change when that lands.
+ *   - `needsAttentionCount`: the Machine-pushed `draft_queue_depth` in this
+ *     customer's own `operator_runtime_summary` row (ADR 0043 path B mirror).
+ *     The Home must never fabricate a review queue the entitlements did not
+ *     author (ADR 0035 / client-portal §5.1): the count renders only when the
+ *     Machine itself reported a pending-review depth. No row, NULL depth, or
+ *     an unreadable mirror all resolve to 0 — an honest absence, not a zeroed
+ *     queue implying one exists.
  */
 
-import { isRuntimeReadConfigured, type RuntimeReadEnv } from '../../operator/runtime-read-transport'
+import type { D1Database } from '@cloudflare/workers-types'
+import { readMachineRuntime, type RuntimeReadActor } from '../../operator/runtime-read'
+import {
+  createMachineRuntimeTransport,
+  createRuntimeReadAudit,
+  isRuntimeReadConfigured,
+  type RuntimeReadEnv,
+} from '../../operator/runtime-read-transport'
+import { parseAuditEntries } from './activity-read'
+import { formatAuditAction, type AuditEntry } from './audit'
 
 export interface HomeActivityItem {
   id: string
@@ -37,25 +52,124 @@ export interface HomeEscalationItem {
 export interface HomeFeeds {
   /** Whether the live runtime read path is wired. When false, every feed is empty. */
   runtimeConfigured: boolean
-  /** Recent completed actions, plain-language. Empty until the read path is wired. */
+  /** Recent completed actions, plain-language. */
   recentActivity: HomeActivityItem[]
-  /** Count of items routed to a human for THIS client. 0 unless authored + switched on. */
+  /** Count of items routed to a human for THIS client. 0 unless the Machine reported a depth. */
   needsAttentionCount: number
-  /** Items the operator flagged to a human per the escalation config. */
+  /** Items the operator flagged to a human (`ESCALATION_FIRED` audit records). */
   escalations: HomeEscalationItem[]
+}
+
+export interface HomeFeedsDeps {
+  db: D1Database
+  env: RuntimeReadEnv
+  /** Console-side actor id for the read-audit row (distinct from the operator's log). */
+  actorUserId: string
+}
+
+/** How many audit rows one dashboard read requests. Enough to fill the
+ * recent-activity list and catch recent escalations without paginating. */
+const HOME_READ_LIMIT = 20
+/** How many recent-activity lines the dashboard shows. */
+const RECENT_ACTIVITY_MAX = 6
+/** How many escalation lines the dashboard shows. */
+const ESCALATIONS_MAX = 5
+
+const EMPTY_UNCONFIGURED: HomeFeeds = {
+  runtimeConfigured: false,
+  recentActivity: [],
+  needsAttentionCount: 0,
+  escalations: [],
 }
 
 /**
  * Assemble the Home/Today feeds for the signed-in client's own operator.
- * Currently returns honest empty feeds (the runtime read path is not wired);
- * `runtimeConfigured` reflects whether it is, so the surface can distinguish
- * "wired but quiet" from "not wired" if it ever needs to.
+ * One customer per call (ADR 0009/0043); fails closed to empty feeds on any
+ * failure — never throws into the page render.
  */
-export function loadHomeFeeds(env: RuntimeReadEnv): HomeFeeds {
+export async function loadHomeFeeds(
+  deps: HomeFeedsDeps,
+  customerSlug: string,
+  actor: RuntimeReadActor
+): Promise<HomeFeeds> {
+  if (!isRuntimeReadConfigured(deps.env)) {
+    return EMPTY_UNCONFIGURED
+  }
+
+  const [entries, needsAttentionCount] = await Promise.all([
+    readRecentAuditEntries(deps, customerSlug, actor),
+    readDraftQueueDepth(deps.db, customerSlug),
+  ])
+
   return {
-    runtimeConfigured: isRuntimeReadConfigured(env),
-    recentActivity: [],
-    needsAttentionCount: 0,
-    escalations: [],
+    runtimeConfigured: true,
+    recentActivity: entries.slice(0, RECENT_ACTIVITY_MAX).map(toActivityItem),
+    needsAttentionCount,
+    escalations: entries
+      .filter((e) => e.action === 'ESCALATION_FIRED')
+      .slice(0, ESCALATIONS_MAX)
+      .map(toEscalationItem),
+  }
+}
+
+/** One page of this customer's audit log via the frozen ADR 0043 seam,
+ * newest first. Fail-closed empty on transport failure. */
+async function readRecentAuditEntries(
+  deps: HomeFeedsDeps,
+  customerSlug: string,
+  actor: RuntimeReadActor
+): Promise<AuditEntry[]> {
+  const result = await readMachineRuntime(
+    {
+      transport: createMachineRuntimeTransport(deps.env),
+      audit: createRuntimeReadAudit(deps.db, { actorUserId: deps.actorUserId }),
+    },
+    customerSlug,
+    { kind: 'audit_log', limit: HOME_READ_LIMIT },
+    actor
+  )
+  const rows = result.ok ? parseAuditEntries(result.data) : []
+  // The Machine serves newest-first, but the dashboard's ordering promise is
+  // its own: sort defensively so a cursor/ordering drift never scrambles the
+  // "recent" list.
+  return rows.sort((a, b) => (a.ts < b.ts ? 1 : a.ts > b.ts ? -1 : 0))
+}
+
+/**
+ * This customer's Machine-pushed pending-review depth from the path-B summary
+ * mirror. Reads exactly one row for exactly this customer — never a fleet-wide
+ * read (that is the admin view's job; ADR 0052 keeps this surface scoped to
+ * the client's own operator). Missing row / NULL depth / read failure → 0.
+ */
+async function readDraftQueueDepth(db: D1Database, customerSlug: string): Promise<number> {
+  try {
+    const row = await db
+      .prepare('SELECT draft_queue_depth FROM operator_runtime_summary WHERE customer_slug = ?')
+      .bind(customerSlug)
+      .first<{ draft_queue_depth: number | null }>()
+    const depth = row?.draft_queue_depth
+    return typeof depth === 'number' && Number.isFinite(depth) && depth > 0 ? Math.floor(depth) : 0
+  } catch {
+    // A missing mirror table (fresh environment) is an honest 0, not a crash.
+    return 0
+  }
+}
+
+function toActivityItem(entry: AuditEntry): HomeActivityItem {
+  const label = formatAuditAction(entry.action)
+  return {
+    id: entry.id,
+    summary: entry.skill !== null ? `${label} (${entry.skill})` : label,
+    at: entry.ts,
+  }
+}
+
+function toEscalationItem(entry: AuditEntry): HomeEscalationItem {
+  // Prefer the writer's recorded reason (what was escalated and why); fall
+  // back to the action label — never fabricate a friendlier story.
+  return {
+    id: entry.id,
+    summary: entry.reason ?? formatAuditAction(entry.action),
+    at: entry.ts,
   }
 }

--- a/src/pages/portal/products/operator/index.astro
+++ b/src/pages/portal/products/operator/index.astro
@@ -23,6 +23,7 @@ import {
 } from '../../../../lib/portal/operator/aliveness'
 import { getCustomerConfig } from '../../../../lib/portal/customer-config'
 import { loadHomeFeeds, type HomeFeeds } from '../../../../lib/portal/operator/home'
+import { formatAuditTimestamp } from '../../../../lib/portal/operator/audit'
 import { env } from 'cloudflare:workers'
 
 /**
@@ -172,17 +173,16 @@ if (access) {
   }
 }
 
-// Aliveness signal (per #875). Per-customer "where is the agent right
-// now" header: idle / running / sticky_stop / offline + last-action
-// timestamp. The Hermes bridge (#821) is not wired today, so the
-// resolver returns null and the AlivenessHeader component renders
-// nothing (empty-state pattern). When the bridge lands, the chip
-// appears without further page changes. Surfaced for any role so
-// operators and compliance see the same posture the principal sees;
-// access to the surface is already role-gated upstream.
+// Aliveness signal (per #875, wired in #1678). Per-customer "where is the
+// agent right now" header: idle / running / sticky_stop / offline +
+// last-action timestamp, derived from this customer's fleet_status
+// heartbeat row (ADR 0023 Wave 1). A customer with no row yet resolves to
+// null and the AlivenessHeader renders nothing (empty-state pattern).
+// Surfaced for any role so operators and compliance see the same posture
+// the principal sees; access to the surface is already role-gated upstream.
 let alivenessSignal: AlivenessSignal | null = null
 if (access) {
-  alivenessSignal = await resolveAlivenessSignal(access.subscription)
+  alivenessSignal = await resolveAlivenessSignal(env.DB, access.subscription)
 }
 
 // Promotion recommendation cards (per #811). Principal-only because the
@@ -198,12 +198,25 @@ if (access?.roles.includes('principal')) {
   promotionCandidates = await listPromotionReadySkills(env.DB, client.id)
 }
 
-// Home/Today runtime feeds (client-portal §5.1): recent activity, what-needs-you,
-// escalations. Fed by the live runtime read path (ADR 0043), which fails closed
-// until OPERATOR_RUNTIME_READ_URL is wired — so these render honest empty states
-// today. needsAttentionCount stays 0 by construction, so Home never fabricates a
-// review queue the entitlements did not author (ADR 0035). PR2 wires the read.
-const homeFeeds: HomeFeeds | null = access ? loadHomeFeeds(env) : null
+// Home/Today runtime feeds (client-portal §5.1, wired in #1678): recent
+// activity + escalations from ONE live runtime read (ADR 0043, kind
+// audit_log — the same frozen seam the Activity page uses), and
+// needsAttentionCount from the Machine-pushed draft_queue_depth in this
+// customer's summary-mirror row. Every source fails closed to an honest
+// empty; Home never fabricates a review queue the Machine did not report
+// (ADR 0035).
+const customerSlug = customerConfig?.customer_slug ?? client.id
+const homeActorRole = access?.roles.includes('principal')
+  ? 'principal'
+  : access?.roles.includes('compliance')
+    ? 'compliance'
+    : 'staff'
+const homeFeeds: HomeFeeds | null = access
+  ? await loadHomeFeeds({ db: env.DB, env, actorUserId: user.id }, customerSlug, {
+      actor: user.email,
+      actorRole: homeActorRole,
+    })
+  : null
 
 // Change-request filing outcome (client-portal §3). The dual-mode "Request a
 // change" form 303s back with ?cr=filed|invalid|error so the surface it returned
@@ -330,10 +343,10 @@ const crTone = crStatus === 'filed' ? 'complete' : 'error'
             </div>
 
             {/* Home / Today (client-portal §5.1): what needs you, what it did,
-                escalations. Runtime-fed; honest empty until the read path is
-                wired. "What needs you" appears ONLY when work is genuinely
-                routed to a human for this client — never a fabricated queue
-                (ADR 0035). */}
+                escalations. Runtime-fed (#1678); fails closed to honest empty
+                on any transport failure. "What needs you" appears ONLY when
+                the Machine reported work genuinely routed to a human for this
+                client — never a fabricated queue (ADR 0035). */}
             {homeFeeds && (
               <section class="mt-8 flex flex-col gap-8" aria-label="What's happening">
                 {homeFeeds.needsAttentionCount > 0 && (
@@ -377,6 +390,9 @@ const crTone = crStatus === 'filed' ? 'complete' : 'error'
                           <p class="text-sm text-[color:var(--ss-color-text-primary)]">
                             {item.summary}
                           </p>
+                          <p class="mt-1 font-['JetBrains_Mono'] text-xs text-[color:var(--ss-color-text-secondary)]">
+                            {formatAuditTimestamp(item.at)}
+                          </p>
                         </li>
                       ))}
                     </ul>
@@ -393,6 +409,9 @@ const crTone = crStatus === 'filed' ? 'complete' : 'error'
                         <li class="px-5 md:px-7 py-4">
                           <p class="text-sm text-[color:var(--ss-color-text-primary)]">
                             {item.summary}
+                          </p>
+                          <p class="mt-1 font-['JetBrains_Mono'] text-xs text-[color:var(--ss-color-text-secondary)]">
+                            {formatAuditTimestamp(item.at)}
                           </p>
                         </li>
                       ))}

--- a/tests/operator-home-feeds.test.ts
+++ b/tests/operator-home-feeds.test.ts
@@ -1,33 +1,222 @@
-import { describe, it, expect } from 'vitest'
+/**
+ * Tests for the Home/Today runtime feeds (src/lib/portal/operator/home.ts),
+ * wired to live sources in #1678:
+ *
+ *   - recent activity + escalations from ONE ADR 0043 runtime read
+ *     (kind audit_log) — exercised here end-to-end through the real
+ *     transport with a stubbed global fetch;
+ *   - needsAttentionCount from the Machine-pushed draft_queue_depth in
+ *     the customer's operator_runtime_summary row;
+ *   - every source fails closed to an honest empty (ADR 0035: never a
+ *     fabricated review queue).
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import type { D1Database } from '@cloudflare/workers-types'
 import { loadHomeFeeds } from '../src/lib/portal/operator/home'
 
-describe('loadHomeFeeds', () => {
-  it('returns honest empty feeds when the runtime read path is not wired', () => {
-    const feeds = loadHomeFeeds({})
+const ACTOR = { actor: 'partner@firm.com', actorRole: 'principal' }
+
+const CONFIGURED_ENV = {
+  OPERATOR_RUNTIME_READ_URL: 'https://{app}.example.test',
+  OPERATOR_RUNTIME_READ_SECRET: 'master-secret-for-tests',
+}
+
+// A DB that throws if touched — proves the not-configured path never queries.
+const NOOP_DB = {
+  prepare() {
+    throw new Error('DB must not be touched when the runtime read path is unconfigured')
+  },
+} as unknown as D1Database
+
+/**
+ * Fake of the two D1 surfaces loadHomeFeeds touches: the read-audit INSERT
+ * (prepare().bind().run()) and the summary-mirror SELECT
+ * (prepare().bind().first()). Dispatches on the SQL text.
+ */
+function makeDb(opts: { draftQueueDepth?: number | null; summaryRowExists?: boolean }): {
+  db: D1Database
+  auditInserts: unknown[][]
+} {
+  const auditInserts: unknown[][] = []
+  const db = {
+    prepare(sql: string) {
+      return {
+        bind(...args: unknown[]) {
+          return {
+            run() {
+              if (!sql.includes('operator_runtime_read_audit')) {
+                throw new Error(`unexpected run() for sql: ${sql}`)
+              }
+              auditInserts.push(args)
+              return Promise.resolve({})
+            },
+            first() {
+              if (!sql.includes('operator_runtime_summary')) {
+                throw new Error(`unexpected first() for sql: ${sql}`)
+              }
+              if (opts.summaryRowExists === false) return Promise.resolve(null)
+              return Promise.resolve({ draft_queue_depth: opts.draftQueueDepth ?? null })
+            },
+          }
+        },
+      }
+    },
+  }
+  return { db: db as unknown as D1Database, auditInserts }
+}
+
+function auditRow(overrides: Record<string, unknown>): Record<string, unknown> {
+  return {
+    id: 'row-1',
+    ts: '2026-07-01T10:00:00.000Z',
+    actor: 'agent',
+    action: 'DRAFT_CREATED',
+    skill: null,
+    reason: null,
+    ...overrides,
+  }
+}
+
+function stubFetchWith(entries: unknown[]): ReturnType<typeof vi.fn> {
+  const fetchMock = vi.fn().mockResolvedValue(
+    new Response(JSON.stringify({ entries, cursor: null }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    })
+  )
+  vi.stubGlobal('fetch', fetchMock)
+  return fetchMock
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('loadHomeFeeds: fail-closed contracts', () => {
+  it('returns honest empty feeds (and never touches D1 or fetch) when unconfigured', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    const feeds = await loadHomeFeeds({ db: NOOP_DB, env: {}, actorUserId: 'u-1' }, 'smd', ACTOR)
     expect(feeds.runtimeConfigured).toBe(false)
     expect(feeds.recentActivity).toEqual([])
     expect(feeds.escalations).toEqual([])
+    expect(feeds.needsAttentionCount).toBe(0)
+    expect(fetchMock).not.toHaveBeenCalled()
   })
 
-  it('never fabricates a review queue: needsAttentionCount is 0 (ADR 0035)', () => {
-    expect(loadHomeFeeds({}).needsAttentionCount).toBe(0)
-    expect(
-      loadHomeFeeds({ OPERATOR_RUNTIME_READ_URL: 'https://example.invalid' }).needsAttentionCount
-    ).toBe(0)
+  it('fails closed to empty feeds when the Machine read fails (still audited)', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('machine down')))
+    const { db, auditInserts } = makeDb({ summaryRowExists: false })
+    const feeds = await loadHomeFeeds({ db, env: CONFIGURED_ENV, actorUserId: 'u-1' }, 'smd', ACTOR)
+    expect(feeds.runtimeConfigured).toBe(true)
+    expect(feeds.recentActivity).toEqual([])
+    expect(feeds.escalations).toEqual([])
+    // The failed read attempt is still recorded (ADR 0043: audited at the console).
+    expect(auditInserts).toHaveLength(1)
   })
 
-  it('reflects whether the runtime read path is configured', () => {
-    expect(loadHomeFeeds({}).runtimeConfigured).toBe(false)
-    expect(loadHomeFeeds({ OPERATOR_RUNTIME_READ_URL: '' }).runtimeConfigured).toBe(false)
-    // Both the host template and the master secret are required now (ADR 0043 A).
-    expect(
-      loadHomeFeeds({ OPERATOR_RUNTIME_READ_URL: 'https://hermes-x.fly.dev' }).runtimeConfigured
-    ).toBe(false)
-    expect(
-      loadHomeFeeds({
-        OPERATOR_RUNTIME_READ_URL: 'https://hermes-x.fly.dev',
-        OPERATOR_RUNTIME_READ_SECRET: 'm',
-      }).runtimeConfigured
-    ).toBe(true)
+  it('refuses to target an unregistered customer (fail-closed empty)', async () => {
+    const fetchMock = stubFetchWith([auditRow({})])
+    const { db } = makeDb({ summaryRowExists: false })
+    const feeds = await loadHomeFeeds(
+      { db, env: CONFIGURED_ENV, actorUserId: 'u-1' },
+      'not-a-registered-customer',
+      ACTOR
+    )
+    expect(feeds.recentActivity).toEqual([])
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('loadHomeFeeds: live feeds through the audit_log seam', () => {
+  it('requests kind audit_log from the customer Machine and maps rows to plain language', async () => {
+    const fetchMock = stubFetchWith([
+      auditRow({
+        id: 'a1',
+        ts: '2026-07-01T10:00:00.000Z',
+        action: 'DRAFT_CREATED',
+        skill: 'matter-memo-on-update',
+      }),
+      auditRow({ id: 'a2', ts: '2026-07-01T09:00:00.000Z', action: 'REPLY_SENT' }),
+    ])
+    const { db } = makeDb({ summaryRowExists: false })
+    const feeds = await loadHomeFeeds({ db, env: CONFIGURED_ENV, actorUserId: 'u-1' }, 'smd', ACTOR)
+
+    const calledUrl = String(fetchMock.mock.calls[0][0])
+    expect(calledUrl).toContain('https://hermes-smd.example.test/runtime/audit_log')
+    expect(calledUrl).toContain('limit=20')
+
+    expect(feeds.runtimeConfigured).toBe(true)
+    expect(feeds.recentActivity).toEqual([
+      {
+        id: 'a1',
+        summary: 'Draft Created (matter-memo-on-update)',
+        at: '2026-07-01T10:00:00.000Z',
+      },
+      { id: 'a2', summary: 'Reply Sent', at: '2026-07-01T09:00:00.000Z' },
+    ])
+  })
+
+  it('sorts newest-first defensively and caps the recent list at 6', async () => {
+    const rows = Array.from({ length: 9 }, (_, i) =>
+      // Deliberately oldest-first input; the feed must re-sort.
+      auditRow({ id: `a${i}`, ts: `2026-07-01T0${i}:00:00.000Z` })
+    )
+    stubFetchWith(rows)
+    const { db } = makeDb({ summaryRowExists: false })
+    const feeds = await loadHomeFeeds({ db, env: CONFIGURED_ENV, actorUserId: 'u-1' }, 'smd', ACTOR)
+    expect(feeds.recentActivity).toHaveLength(6)
+    expect(feeds.recentActivity[0].id).toBe('a8')
+    expect(feeds.recentActivity[5].id).toBe('a3')
+  })
+
+  it('surfaces ESCALATION_FIRED rows as escalations, preferring the recorded reason', async () => {
+    stubFetchWith([
+      auditRow({
+        id: 'e1',
+        action: 'ESCALATION_FIRED',
+        reason: 'Deadline conflict on discovery response',
+      }),
+      auditRow({ id: 'e2', ts: '2026-07-01T08:00:00.000Z', action: 'ESCALATION_FIRED' }),
+      auditRow({ id: 'a1', action: 'DRAFT_CREATED' }),
+    ])
+    const { db } = makeDb({ summaryRowExists: false })
+    const feeds = await loadHomeFeeds({ db, env: CONFIGURED_ENV, actorUserId: 'u-1' }, 'smd', ACTOR)
+    expect(feeds.escalations).toEqual([
+      {
+        id: 'e1',
+        summary: 'Deadline conflict on discovery response',
+        at: '2026-07-01T10:00:00.000Z',
+      },
+      { id: 'e2', summary: 'Escalation Fired', at: '2026-07-01T08:00:00.000Z' },
+    ])
+  })
+})
+
+describe('loadHomeFeeds: needsAttentionCount from the summary mirror (ADR 0035)', () => {
+  it('surfaces a Machine-reported positive depth', async () => {
+    stubFetchWith([])
+    const { db } = makeDb({ draftQueueDepth: 3 })
+    const feeds = await loadHomeFeeds({ db, env: CONFIGURED_ENV, actorUserId: 'u-1' }, 'smd', ACTOR)
+    expect(feeds.needsAttentionCount).toBe(3)
+  })
+
+  it('never fabricates a queue: no row, NULL depth, and non-positive depth all read 0', async () => {
+    stubFetchWith([])
+    for (const opts of [
+      { summaryRowExists: false as const },
+      { draftQueueDepth: null },
+      { draftQueueDepth: 0 },
+      { draftQueueDepth: -2 },
+    ]) {
+      const { db } = makeDb(opts)
+      const feeds = await loadHomeFeeds(
+        { db, env: CONFIGURED_ENV, actorUserId: 'u-1' },
+        'smd',
+        ACTOR
+      )
+      expect(feeds.needsAttentionCount).toBe(0)
+    }
   })
 })

--- a/tests/portal-operator-aliveness.test.ts
+++ b/tests/portal-operator-aliveness.test.ts
@@ -7,28 +7,30 @@
  * plus a last-action timestamp and (for unhealthy postures) a
  * Captain-escalation affordance.
  *
- * The Hermes runtime bridge (#821) is not wired today; the resolver
- * returns null and the AlivenessHeader component renders nothing per
+ * The resolver reads the customer's `fleet_status` heartbeat row
+ * (ADR 0023 Wave 1, wired in #1678); a customer with no row resolves to
+ * null and the AlivenessHeader renders nothing per
  * docs/style/empty-state-pattern.md. These tests cover:
  *
  *   - The closed AlivenessLevel vocabulary
  *   - alivenessTone → Tone mapping (closed switch)
- *   - deriveAlivenessFromBridge — the pure transition that the Hermes
- *     wiring will call once real readings flow. Priority and edge
+ *   - deriveAlivenessFromBridge — the pure transition. Priority and edge
  *     cases (sticky-stop wins, in-flight wins, missing timestamp,
- *     unparseable timestamp, threshold crossing).
+ *     unparseable timestamp, threshold crossing, heartbeat-driven
+ *     liveness).
  *   - formatAlivenessLevel — friendly headline per level
  *   - formatLastActionRelative — relative-time bucket boundaries
  *   - formatLastActionAbsolute — null + unparseable handling
  *   - needsEscalationAffordance — true only for the unhealthy postures
- *   - resolveAlivenessSignal — empty-state contract (returns null
- *     under the bridge stub)
+ *   - resolveAlivenessSignal — fleet_status row → signal, plus the
+ *     empty-state contract (no row / failed read → null)
  *
  * OFFLINE_THRESHOLD_MINUTES is asserted as a constant so a future
  * customer-yaml override has a single source of truth to verify
  * against.
  */
 
+import type { D1Database } from '@cloudflare/workers-types'
 import { describe, it, expect } from 'vitest'
 import {
   ALIVENESS_LEVELS,
@@ -48,11 +50,35 @@ import type { SubscriptionRow } from '../src/lib/portal/product-access'
 function makeReading(overrides?: Partial<AlivenessBridgeReading>): AlivenessBridgeReading {
   return {
     lastAuditTs: '2026-05-24T12:00:00.000Z',
+    lastHeartbeatTs: null,
     inFlightSkill: null,
     stickyStopLevel: 'OK',
     stickyStopReason: null,
     ...overrides,
   }
+}
+
+/**
+ * Minimal fake of the D1 surface the fleet_status read touches:
+ * prepare().bind().first(). `row` is what first() resolves; `fail` makes
+ * first() throw (missing-table case).
+ */
+function makeDb(opts: { row?: unknown; fail?: boolean }): D1Database {
+  const db = {
+    prepare() {
+      return {
+        bind() {
+          return {
+            first() {
+              if (opts.fail) return Promise.reject(new Error('no such table: fleet_status'))
+              return Promise.resolve(opts.row ?? null)
+            },
+          }
+        },
+      }
+    },
+  }
+  return db as unknown as D1Database
 }
 
 function makeSubscription(overrides?: Partial<SubscriptionRow>): SubscriptionRow {
@@ -213,6 +239,47 @@ describe('deriveAlivenessFromBridge', () => {
       expect(deriveAlivenessFromBridge(reading, NOW_MS).level).toBe('idle')
     })
   })
+
+  describe('heartbeat-driven liveness (#1678)', () => {
+    it('a fresh heartbeat keeps a quiet Machine idle past stale audit rows', () => {
+      // Audit is 3 hours old (would read offline alone) but the Machine
+      // heartbeated 2 minutes ago → idle. lastActionAt stays the audit ts —
+      // the last thing the operator DID, not the last time it phoned home.
+      const reading = makeReading({
+        lastAuditTs: '2026-05-24T09:00:00.000Z',
+        lastHeartbeatTs: '2026-05-24T12:03:00.000Z',
+      })
+      const signal = deriveAlivenessFromBridge(reading, NOW_MS)
+      expect(signal.level).toBe('idle')
+      expect(signal.lastActionAt).toBe('2026-05-24T09:00:00.000Z')
+    })
+
+    it('a fresh heartbeat with NO audit history is idle with null lastActionAt', () => {
+      // First-day Machine: heartbeating, has not acted yet. Alive, and honest
+      // about having no last action.
+      const reading = makeReading({
+        lastAuditTs: null,
+        lastHeartbeatTs: '2026-05-24T12:04:00.000Z',
+      })
+      const signal = deriveAlivenessFromBridge(reading, NOW_MS)
+      expect(signal.level).toBe('idle')
+      expect(signal.lastActionAt).toBeNull()
+    })
+
+    it('a stale heartbeat AND stale audit is offline', () => {
+      const reading = makeReading({
+        lastAuditTs: '2026-05-24T09:00:00.000Z',
+        lastHeartbeatTs: '2026-05-24T09:05:00.000Z',
+      })
+      expect(deriveAlivenessFromBridge(reading, NOW_MS).level).toBe('offline')
+    })
+
+    it('an unparseable heartbeat is skipped, not treated as epoch 0', () => {
+      // Fresh audit + garbage heartbeat → the audit row still proves life.
+      const reading = makeReading({ lastHeartbeatTs: 'not a timestamp' })
+      expect(deriveAlivenessFromBridge(reading, NOW_MS).level).toBe('idle')
+    })
+  })
 })
 
 describe('formatLastActionRelative', () => {
@@ -269,15 +336,66 @@ describe('formatLastActionAbsolute', () => {
 })
 
 describe('resolveAlivenessSignal', () => {
-  it('returns null today (Hermes bridge not wired)', async () => {
-    const signal = await resolveAlivenessSignal(makeSubscription())
+  const NOW_MS = Date.parse('2026-05-24T12:05:00.000Z')
+
+  it('returns null when the customer has no fleet_status row (empty-state contract)', async () => {
+    const signal = await resolveAlivenessSignal(makeDb({}), makeSubscription(), NOW_MS)
     expect(signal).toBeNull()
   })
 
-  it('returns null for any subscription shape (empty-state contract)', async () => {
-    const provisioning = await resolveAlivenessSignal(makeSubscription({ status: 'provisioning' }))
-    const paused = await resolveAlivenessSignal(makeSubscription({ status: 'paused' }))
-    expect(provisioning).toBeNull()
-    expect(paused).toBeNull()
+  it('returns null when the fleet_status read fails (missing table)', async () => {
+    const signal = await resolveAlivenessSignal(makeDb({ fail: true }), makeSubscription(), NOW_MS)
+    expect(signal).toBeNull()
+  })
+
+  it('derives idle from a fresh heartbeat row', async () => {
+    const db = makeDb({
+      row: {
+        last_heartbeat_ts: '2026-05-24T12:04:00.000Z',
+        last_audit_ts: '2026-05-24T11:00:00.000Z',
+        sticky_stop_level: 'OK',
+      },
+    })
+    const signal = await resolveAlivenessSignal(db, makeSubscription(), NOW_MS)
+    expect(signal?.level).toBe('idle')
+    expect(signal?.lastActionAt).toBe('2026-05-24T11:00:00.000Z')
+  })
+
+  it('derives sticky_stop from a Machine-reported breaker level', async () => {
+    const db = makeDb({
+      row: {
+        last_heartbeat_ts: '2026-05-24T12:04:00.000Z',
+        last_audit_ts: '2026-05-24T12:00:00.000Z',
+        sticky_stop_level: 'HARD_STOP',
+      },
+    })
+    const signal = await resolveAlivenessSignal(db, makeSubscription(), NOW_MS)
+    expect(signal?.level).toBe('sticky_stop')
+    // Reason text is not pushed on the heartbeat; the chip shows the posture.
+    expect(signal?.stickyStopReason).toBeNull()
+  })
+
+  it('treats an unknown sticky_stop_level as OK (under-report, never false-alarm)', async () => {
+    const db = makeDb({
+      row: {
+        last_heartbeat_ts: '2026-05-24T12:04:00.000Z',
+        last_audit_ts: '2026-05-24T12:00:00.000Z',
+        sticky_stop_level: 'SOMETHING_NEW',
+      },
+    })
+    const signal = await resolveAlivenessSignal(db, makeSubscription(), NOW_MS)
+    expect(signal?.level).toBe('idle')
+  })
+
+  it('derives offline from a row whose heartbeat and audit are both stale', async () => {
+    const db = makeDb({
+      row: {
+        last_heartbeat_ts: '2026-05-24T09:00:00.000Z',
+        last_audit_ts: '2026-05-24T08:00:00.000Z',
+        sticky_stop_level: null,
+      },
+    })
+    const signal = await resolveAlivenessSignal(db, makeSubscription(), NOW_MS)
+    expect(signal?.level).toBe('offline')
   })
 })


### PR DESCRIPTION
## Summary

Closes #1678 (Wave 1 of the 2026-07-04 Operator strategic review, `docs/reviews/operator-strategic-review-2026-07-04.md`).

The paying customer's dashboard was the emptiest screen we ship while the operator did live work. Now:

- **Home feeds are live.** `loadHomeFeeds` reads the customer Machine's `audit_log` over the frozen ADR 0043 seam (identical path to the Activity page): recent activity in plain language, escalations from `ESCALATION_FIRED` records, and the what-needs-you count from the Machine-pushed `draft_queue_depth` in the path-B summary mirror. Fail-closed to honest empty everywhere; a review queue is never fabricated (ADR 0035).
- **Aliveness header is live.** Derives idle / running / sticky_stop / offline from the customer's `fleet_status` heartbeat row (ADR 0023 Wave 1). Heartbeat + audit timestamps drive the idle/offline split (freshest wins; a quiet-but-healthy Machine heartbeats without acting); `sticky_stop_level` drives the breaker posture. No row -> null -> silent empty state, never a fabricated healthy chip.
- **Kinds reconciled + documented** against the Machine's `runtime_read.py` serving surface: every console kind is served; `activity` is honest-empty until its table lands, so Home derives from `audit_log`. Compliance-export kinds are deliberately not in the console list.
- **Stale 'until wired' comments corrected**: prod secrets (`OPERATOR_RUNTIME_READ_URL`/`_SECRET`) are set; the seam is live. Handbook `operator-console.md` updated in the same PR per the maintenance contract.

## Verification
- `npm run verify` green: 3,181 tests (195 files) + workers
- New coverage: home feeds exercised end-to-end through the real transport with stubbed fetch (URL/bearer path, fail-closed, unregistered-customer refusal, sort/cap, escalation mapping, ADR 0035 zero-fabrication cases); aliveness resolver against a fake fleet_status read (no row, failed read, idle, sticky_stop, unknown level, offline)
- Handbook integrity tests green
- Live-runtime verification (portal render against a running Machine) follows on deploy; will be recorded via crane_verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)
