### PR TITLE
ci(operator): full-coverage substrate CI + coverage-conformance gate

### DIFF
--- a/.github/workflows/operator-substrate.yml
+++ b/.github/workflows/operator-substrate.yml
@@ -26,12 +26,20 @@ on:
       # gate (test_customer_yaml_block_conformance.py) — otherwise an unclassified
       # top-level block added to only a customer.yaml merges without the gate.
       - 'operator/customers/**'
-      - 'operator/contracts/overlay-pairs.json'
-      - 'operator/contracts/runtime-controls.yaml'
-      - 'operator/contracts/overlay-hook-surface.json'
-      - 'operator/contracts/customer-yaml-blocks.yaml'
-      - 'operator/templates/Dockerfile'
-      - 'operator/templates/bootstrap.sh'
+      # #1688 (2026-07-04 review): whole-directory coverage. The prior filter
+      # named 4 contract files, Dockerfile, and bootstrap.sh — so skill bodies,
+      # vertical packs, migrations, the broker, templates/tests, and the
+      # migration tests could all change without this workflow running.
+      # bin/tests/test_ci_coverage_conformance.py pins filter <-> test-inventory
+      # parity so the gap cannot silently reopen.
+      - 'operator/contracts/**'
+      - 'operator/templates/**'
+      - 'operator/skills/**'
+      - 'operator/verticals/**'
+      - 'operator/migrations/**'
+      - 'operator/workspace_broker/**'
+      - 'operator/tests/**'
+      - 'operator/pytest.ini'
       - '.github/workflows/operator-substrate.yml'
   push:
     branches: [main]
@@ -75,14 +83,20 @@ jobs:
           done
           exit $fail
 
-      - name: Run pytest suites (adapter + evidence + pytest-style invariants)
+      - name: Run pytest suites (adapter + evidence + invariants + bin + skills + templates + migrations)
         working-directory: operator
-        # bin/tests entries are named explicitly: some of bin/tests needs
-        # substrate deps (pyyaml etc.) not installed in this bare-pytest env;
-        # the named files import only stdlib + adapter/bin.lib modules.
-        # test_decommission.py + test_seam_pull.py joined the list with #1355
-        # (the decommission data-plane fix) — they previously ran nowhere in CI.
-        run: python3 -m pytest adapter/tests adapter/evidence/tests adapter/voice/tests safety-substrate/tests bin/tests/test_voice_corpus.py bin/tests/test_deploy_ordering.py bin/tests/test_env_contract_conformance.py bin/tests/test_env_array_generation.py bin/tests/test_customer_yaml_block_conformance.py bin/tests/test_runtime_control_conformance.py bin/tests/test_decommission.py bin/tests/test_seam_pull.py bin/tests/test_verify_overlay_pairs.py workspace_broker/tests -q
+        # #1688: full-directory invocation, replacing the prior hand-named
+        # bin/tests list. That list's exclusion rationale ("some of bin/tests
+        # needs substrate deps not installed here") went stale after pyyaml
+        # joined the install step: five suites — including the skill-frontmatter
+        # gate and the seat-timezone regression test — ran nowhere in CI, and
+        # skills/, templates/tests, and operator/tests ran nowhere at all.
+        # Everything below passes in a bare pytest+pyyaml venv (validated
+        # 2026-07-04, 636 tests). connectors/ stays out: it runs in its own
+        # per-connector venv conformance step further down.
+        # bin/tests/test_ci_coverage_conformance.py asserts this invocation
+        # covers every test_*.py under operator/ (connectors excepted).
+        run: python3 -m pytest adapter/tests adapter/evidence/tests adapter/voice/tests safety-substrate/tests bin/tests workspace_broker/tests templates/tests tests skills -q
 
       # SEC-32: overlay-RUNTIME side of the adapter <-> overlay drift gate.
       #

--- a/operator/bin/tests/test_ci_coverage_conformance.py
+++ b/operator/bin/tests/test_ci_coverage_conformance.py
@@ -1,0 +1,128 @@
+"""CI coverage conformance (#1688) — the forcing-function culture applied to
+the CI wiring itself.
+
+The 2026-07-04 strategic review found five bin/tests suites (including the
+skill-frontmatter gate and the seat-timezone regression test), the per-skill
+pre_run tests, the migration tests, and templates/tests running NOWHERE in CI:
+the workflow's pytest invocation was a hand-named list and its `paths:` filter
+omitted whole directories, so a regression in those areas merged green.
+
+This test pins the contract so the gap cannot silently reopen:
+
+  1. Every ``test_*.py`` under ``operator/`` (excluding ``connectors/``,
+     which the workflow's dedicated per-connector-venv conformance step
+     covers) must fall under a directory the workflow's pytest step invokes.
+  2. Every test file's path must be matched by at least one entry in the
+     workflow's ``on.pull_request.paths`` filter — otherwise a change to that
+     area does not even trigger the job that runs its tests.
+  3. The workflow must keep triggering on itself.
+
+Stdlib + PyYAML only (the workflow's bare env installs exactly pytest+pyyaml,
+and this file runs inside that env).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+OPERATOR_DIR = Path(__file__).resolve().parents[2]
+REPO_ROOT = OPERATOR_DIR.parent
+WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "operator-substrate.yml"
+
+# Directories whose tests are deliberately NOT part of the bare pytest step.
+# connectors/ runs in the workflow's per-connector uv-venv conformance step
+# (real installed artifact + live stdio MCP), never in the bare env.
+PYTEST_EXEMPT_TOPDIRS = {"connectors"}
+
+# Cache/build dirs that legitimately contain no first-class tests.
+IGNORED_PARTS = {".pytest_cache", ".ruff_cache", "__pycache__", ".rendered", "node_modules"}
+
+
+def _load_workflow() -> dict:
+    with WORKFLOW_PATH.open() as f:
+        return yaml.safe_load(f)
+
+
+def _trigger_paths(wf: dict) -> list[str]:
+    # PyYAML parses the bare `on:` key as boolean True.
+    on = wf.get("on") or wf.get(True)
+    assert on is not None, "workflow has no `on:` block"
+    return on["pull_request"]["paths"]
+
+
+def _pytest_dirs(wf: dict) -> list[str]:
+    """Extract the directory/file arguments of the workflow's pytest step."""
+    for job in wf["jobs"].values():
+        for step in job["steps"]:
+            run = step.get("run", "")
+            if "-m pytest" in run and step.get("working-directory") == "operator":
+                args = run.split("-m pytest", 1)[1].split()
+                return [a for a in args if not a.startswith("-")]
+    raise AssertionError("no pytest step with working-directory: operator found in the workflow")
+
+
+def _matches(pattern: str, path: str) -> bool:
+    """Minimal GitHub-Actions-paths glob matcher for the shapes we use:
+    ``dir/**`` (prefix), exact file, and single-``*`` segments."""
+    if pattern.endswith("/**"):
+        return path.startswith(pattern[:-2])
+    if "*" not in pattern:
+        return path == pattern
+    regex = re.escape(pattern).replace(r"\*\*", ".*").replace(r"\*", "[^/]*")
+    return re.fullmatch(regex, path) is not None
+
+
+def _operator_test_files() -> list[Path]:
+    out = []
+    for p in OPERATOR_DIR.rglob("test_*.py"):
+        rel = p.relative_to(OPERATOR_DIR)
+        if IGNORED_PARTS.intersection(rel.parts):
+            continue
+        out.append(rel)
+    return sorted(out)
+
+
+def test_every_test_file_is_invoked_by_the_pytest_step() -> None:
+    wf = _load_workflow()
+    invoked = _pytest_dirs(wf)
+    uncovered = []
+    for rel in _operator_test_files():
+        top = rel.parts[0]
+        if top in PYTEST_EXEMPT_TOPDIRS:
+            continue
+        posix = rel.as_posix()
+        if not any(posix == d or posix.startswith(d.rstrip("/") + "/") for d in invoked):
+            uncovered.append(posix)
+    assert not uncovered, (
+        "test files not reachable by the CI pytest step (add their dir to the "
+        f"pytest invocation in {WORKFLOW_PATH.name}): {uncovered}"
+    )
+
+
+def test_every_test_file_area_triggers_the_workflow() -> None:
+    wf = _load_workflow()
+    paths = _trigger_paths(wf)
+    untriggered = []
+    for rel in _operator_test_files():
+        repo_rel = f"operator/{rel.as_posix()}"
+        if not any(_matches(pat, repo_rel) for pat in paths):
+            untriggered.append(repo_rel)
+    assert not untriggered, (
+        "test files whose changes would NOT trigger the substrate workflow "
+        f"(extend on.pull_request.paths in {WORKFLOW_PATH.name}): {untriggered}"
+    )
+
+
+def test_workflow_triggers_on_itself() -> None:
+    wf = _load_workflow()
+    assert ".github/workflows/operator-substrate.yml" in _trigger_paths(wf)
+
+
+def test_connector_tests_are_covered_by_the_conformance_step_trigger() -> None:
+    # connectors/ is pytest-exempt above, so pin its trigger path explicitly:
+    # if it left the filter, connector regressions would merge green too.
+    wf = _load_workflow()
+    assert any(_matches(p, "operator/connectors/smokeball/server.py") for p in _trigger_paths(wf))


### PR DESCRIPTION
## Summary

Closes #1688 (Wave 3 of the 2026-07-04 Operator strategic review, `docs/reviews/operator-strategic-review-2026-07-04.md`).

The substrate CI's hand-named `bin/tests` list and narrow `paths:` filter left real gates unrun:

- **Five bin suites ran nowhere in CI**: `test_skill_frontmatter.py` (the skill gating checker), `test_seat_timezone.py` (the regression test for the 2026-07-03 fleet-wide timezone fix), `test_active_persona_env_export.py`, `test_overlay_ref_drift.py`, `test_webhook_reconcile_orchestrator.py`. The exclusion rationale ("needs deps not in the bare env") went stale when pyyaml joined the install step.
- **Three whole test areas ran nowhere**: per-skill `pre_run` tests, `operator/tests/` migration tests, `templates/tests/`.
- **Whole directories did not trigger the job**: `skills/`, `verticals/`, `migrations/`, `workspace_broker/` (its tests ran, but changes to it never triggered them), most of `contracts/` and `templates/`.

## Changes

- pytest step runs whole directories: 636→640 tests, validated in a bare pytest+pyyaml venv matching the CI env exactly
- `paths:` filter covers every operator area that carries tests (+ `pytest.ini`)
- New `bin/tests/test_ci_coverage_conformance.py` pins filter ↔ test-inventory parity — the same forcing-function shape as the block-conformance registry. Proven to FAIL against the old workflow (negative test in the session log), so this class of gap cannot silently reopen.

## Verification
- Full new pytest invocation green in a bare pytest+pyyaml venv: 640 passed
- Negative test: both conformance assertions correctly fail when pointed at the pre-fix workflow
- `npm run verify` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
