### PR TITLE
chore(operator): move the trip-probe cap to the smd dogfood seat

### DIFF
--- a/operator/customers/smd-staging/customer.yaml
+++ b/operator/customers/smd-staging/customer.yaml
@@ -112,15 +112,6 @@ scope:
   trusted_sender_domains:
     - smd-staging.invalid
   # Inert: drafts only, and there is no inbound to act on anyway.
-# ---- SAFETY (ADR 0062) — PROBE CONFIGURATION, staging only ----
-# 1-cent daily cost cap so the ADR 0050 B3 live trip-fire probe can drive the
-# breaker to HARD_STOP with a single tiny durable job instead of $100 of real
-# spend. REMOVE after the probe (restore platform default 5000) — tracked in
-# the probe PR that flips runtime-controls sticky_stop_cost_cap to enforced.
-safety:
-  sticky_stop:
-    cost_cap_daily_cents: 1
-
 escalation:
   red_flag_recipients:
     - staging@smd-staging.invalid

--- a/operator/customers/smd/customer.yaml
+++ b/operator/customers/smd/customer.yaml
@@ -243,6 +243,17 @@ scope:
   # is a CODE_EXECUTION action, fail-closed unless authored). Re-opened on the
   # customer-zero dogfood seat for the two-tier cost test; the sticky taint gate
   # still withholds subagent-spawning on any turn that has read untrusted content.
+# ---- SAFETY (ADR 0062) — PROBE CONFIGURATION, temporary ----
+# 1-cent daily cost cap so the ADR 0050 B3 live trip-fire probe can drive the
+# breaker to HARD_STOP with one tiny durable job on the dogfood seat. The
+# probe moved here from smd-staging: the staging canary has no gateway (bare
+# connectors, no channels), so the job seam the probe drives does not exist
+# there. REMOVE after the probe (restore platform default 5000) in the PR
+# that flips runtime-controls sticky_stop_cost_cap to enforced.
+safety:
+  sticky_stop:
+    cost_cap_daily_cents: 1
+
 escalation:
   red_flag_recipients:
     - team@smd.services


### PR DESCRIPTION
Staging can't host the probe (no gateway — bare canary, connectors: {}). smd is proven live + observable on every leg incl. the fleet dot. Cap is temporary; removed in the enforced-flip PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)