### PR TITLE
feat(billing): Stripe recurring subscription engine for the Operator retainer

### DIFF
--- a/migrations/0084_subscriptions_stripe_subscription_id.sql
+++ b/migrations/0084_subscriptions_stripe_subscription_id.sql
@@ -1,0 +1,26 @@
+-- 0084: subscriptions gains the Stripe billing linkage (#1679).
+--
+-- The Operator retainer is sold as a flat monthly subscription (ADR 0004
+-- shape, ADR 0063 price) but until now the codebase could only issue
+-- one-time Stripe invoices; every retainer month was a manual invoice and
+-- MRR was a display number. The billing engine (src/lib/stripe/
+-- subscriptions.ts) creates a Stripe subscription with
+-- collection_method=send_invoice; this column links the local product-access
+-- row to it so:
+--
+--   * the webhook mirror (invoice.finalized / invoice.paid /
+--     customer.subscription.*) can resolve WHICH customer a Stripe
+--     subscription event belongs to, and
+--   * pause / resume / cancel drive Stripe from the same row that gates
+--     portal access.
+--
+-- NULL = no billing attached (pilot/dogfood seats invoice $0 during pilot
+-- per ADR 0063 while carrying list price on services.recurring_price for
+-- the COGS/MRR gate). The partial unique index enforces one local row per
+-- Stripe subscription without constraining the NULL majority.
+
+ALTER TABLE subscriptions ADD COLUMN stripe_subscription_id TEXT;
+
+CREATE UNIQUE INDEX idx_subscriptions_stripe_subscription_id
+  ON subscriptions (stripe_subscription_id)
+  WHERE stripe_subscription_id IS NOT NULL;

--- a/migrations/rollbacks/0084_subscriptions_stripe_subscription_id_down.sql
+++ b/migrations/rollbacks/0084_subscriptions_stripe_subscription_id_down.sql
@@ -1,0 +1,7 @@
+-- Rollback for 0084: drop the Stripe billing linkage.
+--
+-- SQLite (D1) supports DROP COLUMN since 3.35; the index must go first.
+
+DROP INDEX IF EXISTS idx_subscriptions_stripe_subscription_id;
+
+ALTER TABLE subscriptions DROP COLUMN stripe_subscription_id;

--- a/src/lib/db/subscriptions.ts
+++ b/src/lib/db/subscriptions.ts
@@ -1,0 +1,97 @@
+/**
+ * Subscription-row helpers for the Operator billing engine (#1679).
+ *
+ * The `subscriptions` table is the product-access gate the portal reads
+ * (src/lib/portal/product-access.ts): status provisioning/active/paused/
+ * cancelled decides what a client sees. Provisioning owns row CREATION;
+ * this module only attaches/detaches Stripe billing to an existing row and
+ * mirrors billing-driven status transitions. It never inserts rows —
+ * granting portal access remains provisioning's decision, not billing's.
+ */
+
+import type { D1Database } from '@cloudflare/workers-types'
+
+export interface SubscriptionBillingRow {
+  id: string
+  org_id: string
+  entity_id: string
+  product_slug: string
+  status: string
+  stripe_subscription_id: string | null
+}
+
+const BILLING_COLUMNS = 'id, org_id, entity_id, product_slug, status, stripe_subscription_id'
+
+/** The (entity, product) subscription row, or null. */
+export async function getSubscriptionForBilling(
+  db: D1Database,
+  entityId: string,
+  productSlug: string
+): Promise<SubscriptionBillingRow | null> {
+  const row = await db
+    .prepare(
+      `SELECT ${BILLING_COLUMNS} FROM subscriptions WHERE entity_id = ? AND product_slug = ?`
+    )
+    .bind(entityId, productSlug)
+    .first<SubscriptionBillingRow>()
+  return row ?? null
+}
+
+/** Resolve the local row a Stripe subscription event belongs to. Webhooks
+ * carry no org context; the stripe id is globally unique (partial unique
+ * index, migration 0084). */
+export async function getSubscriptionByStripeId(
+  db: D1Database,
+  stripeSubscriptionId: string
+): Promise<SubscriptionBillingRow | null> {
+  const row = await db
+    .prepare(`SELECT ${BILLING_COLUMNS} FROM subscriptions WHERE stripe_subscription_id = ?`)
+    .bind(stripeSubscriptionId)
+    .first<SubscriptionBillingRow>()
+  return row ?? null
+}
+
+/** Attach a Stripe subscription to the local row (start billing). */
+export async function attachStripeSubscription(
+  db: D1Database,
+  subscriptionRowId: string,
+  stripeSubscriptionId: string
+): Promise<void> {
+  await db
+    .prepare(
+      "UPDATE subscriptions SET stripe_subscription_id = ?, updated_at = datetime('now') WHERE id = ?"
+    )
+    .bind(stripeSubscriptionId, subscriptionRowId)
+    .run()
+}
+
+/**
+ * Mirror a billing-driven status transition onto the local row. Restricted
+ * to the transitions billing legitimately drives — it must never resurrect
+ * a cancelled row or skip provisioning:
+ *
+ *   * `paused`    — collection paused (audit-only access)
+ *   * `active`    — collection resumed
+ *   * `cancelled` — subscription deleted at Stripe; ended_at is stamped
+ */
+export async function setSubscriptionBillingStatus(
+  db: D1Database,
+  subscriptionRowId: string,
+  status: 'active' | 'paused' | 'cancelled'
+): Promise<void> {
+  if (status === 'cancelled') {
+    await db
+      .prepare(
+        "UPDATE subscriptions SET status = 'cancelled', ended_at = datetime('now'), updated_at = datetime('now') WHERE id = ?"
+      )
+      .bind(subscriptionRowId)
+      .run()
+    return
+  }
+  await db
+    .prepare(
+      "UPDATE subscriptions SET status = ?, updated_at = datetime('now') WHERE id = ? AND status != 'cancelled'"
+    )
+    .bind(status, subscriptionRowId)
+    .run()
+}

--- a/src/lib/stripe/subscriptions.ts
+++ b/src/lib/stripe/subscriptions.ts
@@ -1,0 +1,271 @@
+/**
+ * Stripe subscription operations for the Operator retainer (#1679).
+ *
+ * The Operator is sold as a flat monthly retainer (ADR 0004 shape, ADR 0063
+ * price). This module gives the retainer a real billing engine: a Stripe
+ * subscription with `collection_method=send_invoice`, so Stripe emails the
+ * hosted invoice each cycle and the existing invoice webhooks
+ * (src/pages/api/webhooks/stripe.ts) mirror cycle invoices into the local
+ * `invoices` table as `type='retainer'` rows.
+ *
+ * Design choices, in order of consequence:
+ *
+ *   * **send_invoice, not charge_automatically.** The retainer is a B2B
+ *     relationship invoiced monthly; no card-on-file is required, the client
+ *     pays the hosted invoice exactly like the one-time deposit/completion
+ *     invoices they already know, and a payment failure is a dunning email
+ *     thread, never a surprise charge. Stripe auto-activates send_invoice
+ *     subscriptions regardless of first-invoice status.
+ *   * **One shared Product, inline per-seat prices.** Stripe's inline
+ *     `price_data` requires an existing product id, and every seat's price is
+ *     authored per engagement (services.recurring_price) — so we resolve one
+ *     "SMD Operator Retainer" product by metadata (create on first use, same
+ *     resolve-or-create idiom as customers) and attach a fresh inline monthly
+ *     price per subscription. Inline prices are single-use by design, which
+ *     matches per-seat authored pricing.
+ *   * **Pause = pause_collection[behavior]=void.** A paused seat (audit-only
+ *     access, drafts suspended) must not accumulate charges; cycle invoices
+ *     generated while paused are voided. Resume clears `pause_collection`
+ *     (the dedicated /resume endpoint is charge_automatically-only).
+ *   * **Payment failure never touches the Machine.** The webhook alerts
+ *     team@smd.services and marks the local invoice overdue; whether to
+ *     pause or decommission is a Captain decision under the offboarding
+ *     doctrine (#1684). No imposed default.
+ *
+ * DEV-MODE PATTERN: when apiKey is undefined, log and return a mock — same
+ * as client.ts / resend.ts.
+ */
+
+const STRIPE_API_BASE = 'https://api.stripe.com/v1'
+
+/** Metadata marker that identifies the shared retainer product. */
+const RETAINER_PRODUCT_MARKER = { key: 'smd_product', value: 'operator-retainer' } as const
+const RETAINER_PRODUCT_NAME = 'SMD Operator Retainer'
+
+function stripeHeaders(apiKey: string): Record<string, string> {
+  return {
+    Authorization: `Bearer ${apiKey}`,
+    'Content-Type': 'application/x-www-form-urlencoded',
+  }
+}
+
+export interface StripeSubscriptionResult {
+  id: string
+  status: string
+}
+
+export interface CreateOperatorSubscriptionParams {
+  /** Billing contact — Stripe resolves/creates the customer record by email. */
+  customer_email: string
+  /** Monthly retainer in cents (from services.recurring_price × 100). */
+  monthly_amount_cents: number
+  /** Local entity id, stamped into metadata for cross-reference. */
+  entity_id: string
+  /** Local subscriptions.id, stamped into metadata for cross-reference. */
+  subscription_row_id: string
+  /** Days the client has to pay each cycle invoice. */
+  days_until_due?: number
+  /** Extra metadata (e.g. a smoke-test marker). */
+  metadata?: Record<string, string>
+}
+
+async function resolveStripeCustomerId(apiKey: string, email: string): Promise<string> {
+  const searchRes = await fetch(
+    `${STRIPE_API_BASE}/customers/search?query=email:'${encodeURIComponent(email)}'`,
+    { method: 'GET', headers: { Authorization: `Bearer ${apiKey}` } }
+  )
+  if (searchRes.ok) {
+    const data: { data: Array<{ id: string }> } = await searchRes.json()
+    if (data.data.length > 0) return data.data[0].id
+  }
+  const body = new URLSearchParams()
+  body.append('email', email)
+  const res = await fetch(`${STRIPE_API_BASE}/customers`, {
+    method: 'POST',
+    headers: stripeHeaders(apiKey),
+    body: body.toString(),
+  })
+  if (!res.ok) {
+    throw new Error(`Stripe customer creation failed ${res.status}: ${await res.text()}`)
+  }
+  const data: { id: string } = await res.json()
+  return data.id
+}
+
+/**
+ * Resolve the shared retainer Product by its metadata marker; create it on
+ * first use. One product for the whole SKU — per-seat prices are inline.
+ */
+async function resolveRetainerProductId(apiKey: string): Promise<string> {
+  const query = `metadata['${RETAINER_PRODUCT_MARKER.key}']:'${RETAINER_PRODUCT_MARKER.value}'`
+  const searchRes = await fetch(
+    `${STRIPE_API_BASE}/products/search?query=${encodeURIComponent(query)}`,
+    { method: 'GET', headers: { Authorization: `Bearer ${apiKey}` } }
+  )
+  if (searchRes.ok) {
+    const data: { data: Array<{ id: string }> } = await searchRes.json()
+    if (data.data.length > 0) return data.data[0].id
+  }
+  const body = new URLSearchParams()
+  body.append('name', RETAINER_PRODUCT_NAME)
+  body.append(`metadata[${RETAINER_PRODUCT_MARKER.key}]`, RETAINER_PRODUCT_MARKER.value)
+  const res = await fetch(`${STRIPE_API_BASE}/products`, {
+    method: 'POST',
+    headers: stripeHeaders(apiKey),
+    body: body.toString(),
+  })
+  if (!res.ok) {
+    throw new Error(`Stripe product creation failed ${res.status}: ${await res.text()}`)
+  }
+  const data: { id: string } = await res.json()
+  return data.id
+}
+
+/**
+ * Create the monthly retainer subscription. Stripe generates and emails the
+ * first hosted invoice immediately (send_invoice), then one per month; the
+ * subscription is active regardless of invoice status.
+ */
+export async function createOperatorSubscription(
+  apiKey: string | undefined,
+  params: CreateOperatorSubscriptionParams
+): Promise<StripeSubscriptionResult> {
+  const dollars = (params.monthly_amount_cents / 100).toFixed(2)
+  if (!apiKey) {
+    const devId = 'dev_sub_' + crypto.randomUUID()
+    console.log(`[DEV] Stripe: would create $${dollars}/mo retainer subscription`)
+    console.log(`[DEV] Stripe: customer_email=${params.customer_email}`)
+    return { id: devId, status: 'active' }
+  }
+
+  const customerId = await resolveStripeCustomerId(apiKey, params.customer_email)
+  const productId = await resolveRetainerProductId(apiKey)
+
+  const body = new URLSearchParams()
+  body.append('customer', customerId)
+  body.append('collection_method', 'send_invoice')
+  body.append('days_until_due', String(params.days_until_due ?? 15))
+  body.append('description', 'Operator retainer')
+  body.append('items[0][price_data][unit_amount]', String(params.monthly_amount_cents))
+  body.append('items[0][price_data][currency]', 'usd')
+  body.append('items[0][price_data][product]', productId)
+  body.append('items[0][price_data][recurring][interval]', 'month')
+  body.append('metadata[smd_entity_id]', params.entity_id)
+  body.append('metadata[smd_subscription_id]', params.subscription_row_id)
+  for (const [key, value] of Object.entries(params.metadata ?? {})) {
+    body.append(`metadata[${key}]`, value)
+  }
+
+  const res = await fetch(`${STRIPE_API_BASE}/subscriptions`, {
+    method: 'POST',
+    headers: stripeHeaders(apiKey),
+    body: body.toString(),
+  })
+  if (!res.ok) {
+    throw new Error(`Stripe subscription creation failed ${res.status}: ${await res.text()}`)
+  }
+  const data: { id: string; status: string } = await res.json()
+  return { id: data.id, status: data.status }
+}
+
+/**
+ * Pause collection: cycle invoices generated while paused are voided — a
+ * paused seat is never charged. The subscription object stays `active` in
+ * Stripe's status vocabulary; `pause_collection` is the pause.
+ */
+export async function pauseOperatorSubscription(
+  apiKey: string | undefined,
+  subscriptionId: string
+): Promise<StripeSubscriptionResult> {
+  if (!apiKey) {
+    console.log(`[DEV] Stripe: would pause collection on ${subscriptionId}`)
+    return { id: subscriptionId, status: 'active' }
+  }
+  const body = new URLSearchParams()
+  body.append('pause_collection[behavior]', 'void')
+  const res = await fetch(`${STRIPE_API_BASE}/subscriptions/${subscriptionId}`, {
+    method: 'POST',
+    headers: stripeHeaders(apiKey),
+    body: body.toString(),
+  })
+  if (!res.ok) {
+    throw new Error(`Stripe pause failed ${res.status}: ${await res.text()}`)
+  }
+  const data: { id: string; status: string } = await res.json()
+  return { id: data.id, status: data.status }
+}
+
+/**
+ * Resume collection by clearing `pause_collection` (posting the bare key
+ * unsets it). The dedicated /resume endpoint applies only to
+ * charge_automatically subscriptions, not this send_invoice retainer.
+ */
+export async function resumeOperatorSubscription(
+  apiKey: string | undefined,
+  subscriptionId: string
+): Promise<StripeSubscriptionResult> {
+  if (!apiKey) {
+    console.log(`[DEV] Stripe: would resume collection on ${subscriptionId}`)
+    return { id: subscriptionId, status: 'active' }
+  }
+  const body = new URLSearchParams()
+  body.append('pause_collection', '')
+  const res = await fetch(`${STRIPE_API_BASE}/subscriptions/${subscriptionId}`, {
+    method: 'POST',
+    headers: stripeHeaders(apiKey),
+    body: body.toString(),
+  })
+  if (!res.ok) {
+    throw new Error(`Stripe resume failed ${res.status}: ${await res.text()}`)
+  }
+  const data: { id: string; status: string } = await res.json()
+  return { id: data.id, status: data.status }
+}
+
+/**
+ * Cancel immediately. The customer is not charged again; Stripe stops
+ * automatic collection of finalized invoices. Used on decommission and by
+ * the offboarding runbook (#1684).
+ */
+export async function cancelOperatorSubscription(
+  apiKey: string | undefined,
+  subscriptionId: string
+): Promise<StripeSubscriptionResult> {
+  if (!apiKey) {
+    console.log(`[DEV] Stripe: would cancel subscription ${subscriptionId}`)
+    return { id: subscriptionId, status: 'canceled' }
+  }
+  const res = await fetch(`${STRIPE_API_BASE}/subscriptions/${subscriptionId}`, {
+    method: 'DELETE',
+    headers: { Authorization: `Bearer ${apiKey}` },
+  })
+  if (!res.ok) {
+    throw new Error(`Stripe cancel failed ${res.status}: ${await res.text()}`)
+  }
+  const data: { id: string; status: string } = await res.json()
+  return { id: data.id, status: data.status }
+}
+
+/** Fetch current subscription state (status + pause posture) for display/verification. */
+export async function getOperatorSubscription(
+  apiKey: string | undefined,
+  subscriptionId: string
+): Promise<{ id: string; status: string; paused: boolean }> {
+  if (!apiKey) {
+    console.log(`[DEV] Stripe: would get subscription ${subscriptionId}`)
+    return { id: subscriptionId, status: 'active', paused: false }
+  }
+  const res = await fetch(`${STRIPE_API_BASE}/subscriptions/${subscriptionId}`, {
+    method: 'GET',
+    headers: { Authorization: `Bearer ${apiKey}` },
+  })
+  if (!res.ok) {
+    throw new Error(`Stripe subscription get failed ${res.status}: ${await res.text()}`)
+  }
+  const data: { id: string; status: string; pause_collection: unknown } = await res.json()
+  return {
+    id: data.id,
+    status: data.status,
+    paused: data.pause_collection !== null && data.pause_collection !== undefined,
+  }
+}

--- a/src/lib/webhooks/stripe-subscription-handler.ts
+++ b/src/lib/webhooks/stripe-subscription-handler.ts
@@ -1,0 +1,362 @@
+/**
+ * Stripe webhook handling for Operator retainer subscriptions (#1679).
+ *
+ * The legacy handler (stripe-handler.ts) matches events to PRE-EXISTING
+ * local invoice rows — the one-time deposit/completion/milestone flow where
+ * the console created the invoice first. Subscription cycle invoices invert
+ * that: STRIPE originates them monthly, so this module mirrors them into the
+ * local `invoices` table as `type='retainer'` rows (the CHECK constraint has
+ * carried the type since the schema was authored; it goes live here), keyed
+ * to the customer via `subscriptions.stripe_subscription_id` (migration
+ * 0084).
+ *
+ * Dispatch contract with the route: an invoice event with a subscription
+ * linkage is handled HERE; without one it belongs to the legacy handler.
+ * Retainer invoices are never console-originated, so linkage splits the two
+ * flows exactly.
+ *
+ * Payment-failure posture: mark the local row `overdue` and alert
+ * team@smd.services. NOTHING here touches the customer's Machine — whether
+ * a delinquent seat gets paused or decommissioned is a Captain decision
+ * under the offboarding doctrine (#1684), never a webhook side effect.
+ *
+ * Same two-phase discipline as the legacy handler: Phase 1 D1 writes decide
+ * the response; Phase 2 emails are best-effort.
+ */
+
+import type { D1Database } from '@cloudflare/workers-types'
+import { sendEmail } from '../email/resend'
+import { paymentConfirmationEmailHtml } from '../email/templates'
+import {
+  getSubscriptionByStripeId,
+  setSubscriptionBillingStatus,
+  type SubscriptionBillingRow,
+} from '../db/subscriptions'
+
+/** SMD operational-alert address (CLAUDE.md Contact Addresses). */
+const ALERT_EMAIL = 'team@smd.services'
+
+function ok(): Response {
+  return new Response(JSON.stringify({ ok: true }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+function serverError(): Response {
+  return new Response(JSON.stringify({ error: 'INTERNAL_ERROR' }), {
+    status: 500,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+/**
+ * Pull the parent subscription id off an invoice payload. Stripe moved the
+ * linkage across API versions — older versions carry a top-level
+ * `subscription` string; newer versions nest it under
+ * `parent.subscription_details.subscription`. This client pins no
+ * Stripe-Version header, so both shapes must parse (parse, never cast).
+ */
+export function extractStripeSubscriptionId(invoice: unknown): string | null {
+  if (typeof invoice !== 'object' || invoice === null) return null
+  const obj = invoice as Record<string, unknown>
+
+  const direct = obj['subscription']
+  if (typeof direct === 'string' && direct.length > 0) return direct
+
+  const parent = obj['parent']
+  if (typeof parent === 'object' && parent !== null) {
+    const details = (parent as Record<string, unknown>)['subscription_details']
+    if (typeof details === 'object' && details !== null) {
+      const nested = (details as Record<string, unknown>)['subscription']
+      if (typeof nested === 'string' && nested.length > 0) return nested
+    }
+  }
+  return null
+}
+
+/** The invoice-payload fields the retainer mirror consumes. */
+export interface RetainerInvoicePayload {
+  id: string
+  amount_due: number
+  amount_paid: number
+  hosted_invoice_url: string | null
+  due_date: number | null
+  status_transitions: { paid_at: number | null }
+}
+
+function unixToIso(unix: number | null): string | null {
+  return unix === null ? null : new Date(unix * 1000).toISOString()
+}
+
+async function getLocalRetainerInvoice(
+  db: D1Database,
+  stripeInvoiceId: string
+): Promise<{ id: string; org_id: string; status: string } | null> {
+  const row = await db
+    .prepare('SELECT id, org_id, status FROM invoices WHERE stripe_invoice_id = ?')
+    .bind(stripeInvoiceId)
+    .first<{ id: string; org_id: string; status: string }>()
+  return row ?? null
+}
+
+/**
+ * Mirror a finalized cycle invoice as a local `retainer` row (status
+ * `sent` — Stripe emails the hosted invoice itself on finalization). Runs
+ * before payment, so the portal shows the open invoice the client received.
+ * Idempotent: an existing mirror row is refreshed, never duplicated.
+ */
+export async function handleRetainerInvoiceFinalized(
+  db: D1Database,
+  stripeSubscriptionId: string,
+  invoice: RetainerInvoicePayload
+): Promise<Response> {
+  const sub = await getSubscriptionByStripeId(db, stripeSubscriptionId)
+  if (!sub) {
+    // A Stripe subscription we did not attach (e.g. a smoke test) — honest skip.
+    console.log(
+      `[stripe-subscription] No local subscription for ${stripeSubscriptionId}; skipping invoice ${invoice.id}`
+    )
+    return ok()
+  }
+
+  try {
+    const existing = await getLocalRetainerInvoice(db, invoice.id)
+    const now = new Date().toISOString()
+    const amount = invoice.amount_due / 100
+    const dueDate = unixToIso(invoice.due_date)
+
+    if (existing) {
+      await db
+        .prepare(
+          `UPDATE invoices SET amount = ?, due_date = ?, stripe_hosted_url = ?, sent_at = COALESCE(sent_at, ?), updated_at = ?
+           WHERE id = ? AND status IN ('draft', 'sent')`
+        )
+        .bind(amount, dueDate, invoice.hosted_invoice_url, now, now, existing.id)
+        .run()
+      return ok()
+    }
+
+    await db
+      .prepare(
+        `INSERT INTO invoices (id, org_id, entity_id, type, amount, description, status,
+                               stripe_invoice_id, stripe_hosted_url, due_date, sent_at, created_at, updated_at)
+         VALUES (?, ?, ?, 'retainer', ?, ?, 'sent', ?, ?, ?, ?, ?, ?)`
+      )
+      .bind(
+        crypto.randomUUID(),
+        sub.org_id,
+        sub.entity_id,
+        amount,
+        'Operator retainer — monthly',
+        invoice.id,
+        invoice.hosted_invoice_url,
+        dueDate,
+        now,
+        now,
+        now
+      )
+      .run()
+    return ok()
+  } catch (err) {
+    console.error('[stripe-subscription] finalized mirror failed:', err)
+    return serverError() // let Stripe retry
+  }
+}
+
+/**
+ * Mark a cycle invoice paid. Upserts (a paid event may arrive without the
+ * finalized mirror having landed), then sends the same confirmation email
+ * the one-time flow sends. Idempotent on the paid state.
+ */
+export async function handleRetainerInvoicePaid(
+  db: D1Database,
+  resendApiKey: string | undefined,
+  stripeSubscriptionId: string,
+  invoice: RetainerInvoicePayload
+): Promise<Response> {
+  const sub = await getSubscriptionByStripeId(db, stripeSubscriptionId)
+  if (!sub) {
+    console.log(
+      `[stripe-subscription] No local subscription for ${stripeSubscriptionId}; skipping paid invoice ${invoice.id}`
+    )
+    return ok()
+  }
+
+  const amount = (invoice.amount_paid > 0 ? invoice.amount_paid : invoice.amount_due) / 100
+  const paidAt = unixToIso(invoice.status_transitions.paid_at) ?? new Date().toISOString()
+  const now = new Date().toISOString()
+
+  try {
+    const existing = await getLocalRetainerInvoice(db, invoice.id)
+    if (existing?.status === 'paid') return ok() // idempotency guard
+
+    if (existing) {
+      await db
+        .prepare(
+          `UPDATE invoices SET status = 'paid', amount = ?, paid_at = ?, payment_method = 'stripe',
+                               stripe_hosted_url = COALESCE(?, stripe_hosted_url), updated_at = ?
+           WHERE id = ?`
+        )
+        .bind(amount, paidAt, invoice.hosted_invoice_url, now, existing.id)
+        .run()
+    } else {
+      await db
+        .prepare(
+          `INSERT INTO invoices (id, org_id, entity_id, type, amount, description, status,
+                                 stripe_invoice_id, stripe_hosted_url, due_date, sent_at, paid_at, payment_method,
+                                 created_at, updated_at)
+           VALUES (?, ?, ?, 'retainer', ?, ?, 'paid', ?, ?, ?, ?, ?, 'stripe', ?, ?)`
+        )
+        .bind(
+          crypto.randomUUID(),
+          sub.org_id,
+          sub.entity_id,
+          amount,
+          'Operator retainer — monthly',
+          invoice.id,
+          invoice.hosted_invoice_url,
+          unixToIso(invoice.due_date),
+          now,
+          paidAt,
+          now,
+          now
+        )
+        .run()
+    }
+  } catch (err) {
+    console.error('[stripe-subscription] paid mirror failed:', err)
+    return serverError() // let Stripe retry
+  }
+
+  // Phase 2: confirmation email, best-effort.
+  await sendRetainerConfirmationEmail(db, resendApiKey, sub, amount)
+  return ok()
+}
+
+/** Phase-2 side effect for a paid cycle invoice: the same confirmation email
+ * the one-time flow sends. Best-effort — never turns a mirrored payment into
+ * a webhook failure. */
+async function sendRetainerConfirmationEmail(
+  db: D1Database,
+  resendApiKey: string | undefined,
+  sub: SubscriptionBillingRow,
+  amount: number
+): Promise<void> {
+  try {
+    const contact = await db
+      .prepare(
+        'SELECT email FROM contacts WHERE org_id = ? AND entity_id = ? AND email IS NOT NULL ORDER BY created_at ASC LIMIT 1'
+      )
+      .bind(sub.org_id, sub.entity_id)
+      .first<{ email: string }>()
+    if (!contact?.email) return
+    const entity = await db
+      .prepare('SELECT name FROM entities WHERE id = ? AND org_id = ?')
+      .bind(sub.entity_id, sub.org_id)
+      .first<{ name: string }>()
+    const formatted = `$${amount.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
+    await sendEmail(resendApiKey, {
+      to: contact.email,
+      subject: 'Payment received — thank you',
+      html: paymentConfirmationEmailHtml(entity?.name ?? 'there', formatted),
+    })
+  } catch (err) {
+    console.error('[stripe-subscription] confirmation email failed:', err)
+  }
+}
+
+/**
+ * A cycle invoice's payment failed. Mark the local mirror `overdue` and
+ * alert the firm. Deliberately does NOT touch the subscription row, the
+ * portal gate, or the customer's Machine (#1684 owns that ladder).
+ */
+export async function handleRetainerInvoicePaymentFailed(
+  db: D1Database,
+  resendApiKey: string | undefined,
+  stripeSubscriptionId: string,
+  invoice: RetainerInvoicePayload
+): Promise<Response> {
+  const sub = await getSubscriptionByStripeId(db, stripeSubscriptionId)
+  if (!sub) return ok()
+
+  try {
+    await db
+      .prepare(
+        `UPDATE invoices SET status = 'overdue', updated_at = datetime('now')
+         WHERE stripe_invoice_id = ? AND status IN ('sent', 'draft')`
+      )
+      .bind(invoice.id)
+      .run()
+  } catch (err) {
+    console.error('[stripe-subscription] overdue update failed:', err)
+    return serverError()
+  }
+
+  try {
+    const entity = await db
+      .prepare('SELECT name FROM entities WHERE id = ? AND org_id = ?')
+      .bind(sub.entity_id, sub.org_id)
+      .first<{ name: string }>()
+    const amount = (invoice.amount_due / 100).toFixed(2)
+    await sendEmail(resendApiKey, {
+      to: ALERT_EMAIL,
+      subject: `Retainer payment failed — ${entity?.name ?? sub.entity_id}`,
+      html:
+        `<p>A retainer cycle invoice payment failed.</p>` +
+        `<ul><li>Customer: ${entity?.name ?? sub.entity_id}</li>` +
+        `<li>Amount: $${amount}</li>` +
+        `<li>Stripe invoice: ${invoice.id}</li>` +
+        `<li>Stripe subscription: ${stripeSubscriptionId}</li></ul>` +
+        `<p>No automatic action was taken. Pause/decommission is a Captain decision (offboarding doctrine, ss-console#1684).</p>`,
+    })
+  } catch (err) {
+    console.error('[stripe-subscription] failure alert email failed:', err)
+  }
+
+  return ok()
+}
+
+/** The subscription-payload fields the status mirror consumes. */
+export interface StripeSubscriptionEventPayload {
+  id: string
+  status: string
+  pause_collection?: unknown
+}
+
+/**
+ * Mirror `customer.subscription.updated` / `.deleted` onto the local row.
+ * Transitions are billing-scoped (see setSubscriptionBillingStatus): a
+ * deleted subscription cancels the row; pause_collection presence maps to
+ * paused/active. Unknown Stripe subscriptions are skipped honestly.
+ */
+export async function handleSubscriptionLifecycle(
+  db: D1Database,
+  eventType: 'customer.subscription.updated' | 'customer.subscription.deleted',
+  payload: StripeSubscriptionEventPayload
+): Promise<Response> {
+  const sub = await getSubscriptionByStripeId(db, payload.id)
+  if (!sub) {
+    console.log(
+      `[stripe-subscription] No local subscription for ${payload.id}; skipping ${eventType}`
+    )
+    return ok()
+  }
+
+  try {
+    if (eventType === 'customer.subscription.deleted' || payload.status === 'canceled') {
+      await setSubscriptionBillingStatus(db, sub.id, 'cancelled')
+    } else if (payload.pause_collection !== null && payload.pause_collection !== undefined) {
+      await setSubscriptionBillingStatus(db, sub.id, 'paused')
+    } else if (payload.status === 'active' || payload.status === 'past_due') {
+      // past_due keeps access: the failure alert + Captain decide, never the webhook.
+      await setSubscriptionBillingStatus(db, sub.id, 'active')
+    }
+    return ok()
+  } catch (err) {
+    console.error('[stripe-subscription] lifecycle mirror failed:', err)
+    return serverError()
+  }
+}
+
+export type { SubscriptionBillingRow }

--- a/src/pages/admin/clients/[id].astro
+++ b/src/pages/admin/clients/[id].astro
@@ -20,6 +20,7 @@ import {
 } from '../../../lib/admin/client-hub'
 import { ENTITY_VERTICALS, ENTITY_STAGES } from '../../../lib/db/entities'
 import { getOperatorServiceForEntity } from '../../../lib/db/services'
+import { getSubscriptionForBilling } from '../../../lib/db/subscriptions'
 import { statusBadgeClass } from '../../../lib/ui/status-badge'
 import { env } from 'cloudflare:workers'
 
@@ -43,6 +44,12 @@ const operatorService = operator
   ? await getOperatorServiceForEntity(env.DB, session.orgId, entityId)
   : null
 const operatorPrice = operatorService?.recurring_price ?? null
+// Retainer billing state (#1679): the (entity,'operator') subscriptions row +
+// its Stripe attachment. Billing controls render only when the row exists —
+// provisioning owns access grants; billing never creates one.
+const operatorSubscription = operator
+  ? await getSubscriptionForBilling(env.DB, entityId, 'operator')
+  : null
 
 const rollup = computeBillingRollup(invoices)
 const serviceRows = engagements.map((eng) => engagementToServiceRow(eng, quotes))
@@ -196,6 +203,86 @@ const LINK_ACT =
                   Save
                 </button>
               </form>
+              {operatorSubscription && (
+                <div class="mt-3 border-t border-[color:var(--ss-color-border-subtle)] pt-3">
+                  <div class="flex items-baseline justify-between">
+                    <span class="font-['Archivo_Narrow'] text-[11px] font-bold uppercase tracking-[0.1em] text-[color:var(--ss-color-text-secondary)]">
+                      Retainer billing
+                    </span>
+                    <span class="font-['JetBrains_Mono'] text-sm">
+                      {operatorSubscription.stripe_subscription_id
+                        ? `Stripe · ${operatorSubscription.status}`
+                        : 'Not attached'}
+                    </span>
+                  </div>
+                  {!operatorSubscription.stripe_subscription_id && operatorPrice != null && (
+                    <form
+                      method="POST"
+                      action={`/api/admin/clients/${entityId}/subscription-billing`}
+                      class="mt-2.5"
+                    >
+                      <input type="hidden" name="action" value="start" />
+                      <button
+                        type="submit"
+                        class="border border-[color:var(--ss-color-primary)] px-3 py-1 font-['Archivo_Narrow'] text-[11px] font-bold uppercase tracking-[0.1em] text-[color:var(--ss-color-primary)]"
+                      >
+                        Start monthly billing ({formatMoney(operatorPrice)}/mo)
+                      </button>
+                    </form>
+                  )}
+                  {!operatorSubscription.stripe_subscription_id && operatorPrice == null && (
+                    <p class="mt-2 text-sm text-[color:var(--ss-color-text-muted)]">
+                      Author the monthly price above to start billing.
+                    </p>
+                  )}
+                  {operatorSubscription.stripe_subscription_id && (
+                    <div class="mt-2.5 flex items-center gap-2">
+                      {operatorSubscription.status === 'active' && (
+                        <form
+                          method="POST"
+                          action={`/api/admin/clients/${entityId}/subscription-billing`}
+                        >
+                          <input type="hidden" name="action" value="pause" />
+                          <button
+                            type="submit"
+                            class="border border-[color:var(--ss-color-border)] px-3 py-1 font-['Archivo_Narrow'] text-[11px] font-bold uppercase tracking-[0.1em] text-[color:var(--ss-color-text-secondary)]"
+                          >
+                            Pause billing
+                          </button>
+                        </form>
+                      )}
+                      {operatorSubscription.status === 'paused' && (
+                        <form
+                          method="POST"
+                          action={`/api/admin/clients/${entityId}/subscription-billing`}
+                        >
+                          <input type="hidden" name="action" value="resume" />
+                          <button
+                            type="submit"
+                            class="border border-[color:var(--ss-color-primary)] px-3 py-1 font-['Archivo_Narrow'] text-[11px] font-bold uppercase tracking-[0.1em] text-[color:var(--ss-color-primary)]"
+                          >
+                            Resume billing
+                          </button>
+                        </form>
+                      )}
+                      {operatorSubscription.status !== 'cancelled' && (
+                        <form
+                          method="POST"
+                          action={`/api/admin/clients/${entityId}/subscription-billing`}
+                        >
+                          <input type="hidden" name="action" value="cancel" />
+                          <button
+                            type="submit"
+                            class="border border-[color:var(--ss-color-error)] px-3 py-1 font-['Archivo_Narrow'] text-[11px] font-bold uppercase tracking-[0.1em] text-[color:var(--ss-color-error)]"
+                          >
+                            Cancel
+                          </button>
+                        </form>
+                      )}
+                    </div>
+                  )}
+                </div>
+              )}
               <div class="mt-3 flex items-center justify-end border-t border-[color:var(--ss-color-border-subtle)] pt-3">
                 <a href="/admin/operator" class={LINK_ACT}>
                   Open cockpit →

--- a/src/pages/api/admin/clients/[id]/subscription-billing.ts
+++ b/src/pages/api/admin/clients/[id]/subscription-billing.ts
@@ -1,0 +1,142 @@
+import type { APIContext, APIRoute } from 'astro'
+import { env } from 'cloudflare:workers'
+import { requireAdminSession } from '../../../../../lib/auth/admin-session'
+import { getOperatorServiceForEntity } from '../../../../../lib/db/services'
+import {
+  attachStripeSubscription,
+  getSubscriptionForBilling,
+  setSubscriptionBillingStatus,
+} from '../../../../../lib/db/subscriptions'
+import {
+  cancelOperatorSubscription,
+  createOperatorSubscription,
+  pauseOperatorSubscription,
+  resumeOperatorSubscription,
+} from '../../../../../lib/stripe/subscriptions'
+
+/**
+ * POST /api/admin/clients/[id]/subscription-billing
+ *
+ * Drives the Operator retainer's Stripe billing from the client hub
+ * (#1679). Form field `action` ∈ start | pause | resume | cancel.
+ *
+ *   start  — creates the Stripe subscription (send_invoice, monthly) priced
+ *            from the authored `services.recurring_price` (ADR 0063 wrote
+ *            5000 on live seats) against the entity's primary contact email,
+ *            and attaches it to the (entity,'operator') subscriptions row.
+ *            Refused when: no subscriptions row (provisioning owns access
+ *            grants, billing never creates one), no authored price (never
+ *            invent a number), no billing contact, or billing already
+ *            attached.
+ *   pause  — pause_collection[behavior]=void at Stripe + local row `paused`.
+ *   resume — clears pause_collection + local row `active`.
+ *   cancel — cancels at Stripe immediately + local row `cancelled`.
+ *
+ * Local status is ALSO mirrored by the customer.subscription.* webhooks;
+ * writing it here too keeps the console truthful between webhook deliveries.
+ * Payment failure handling lives in the webhook (alert, never auto-act) —
+ * see stripe-subscription-handler.ts and the offboarding doctrine (#1684).
+ */
+
+const ACTIONS = ['start', 'pause', 'resume', 'cancel'] as const
+type BillingAction = (typeof ACTIONS)[number]
+
+function parseAction(raw: FormDataEntryValue | null): BillingAction | null {
+  return typeof raw === 'string' && (ACTIONS as readonly string[]).includes(raw)
+    ? (raw as BillingAction)
+    : null
+}
+
+async function getPrimaryContactEmail(
+  db: D1Database,
+  orgId: string,
+  entityId: string
+): Promise<string | null> {
+  const contact = await db
+    .prepare(
+      'SELECT email FROM contacts WHERE org_id = ? AND entity_id = ? AND email IS NOT NULL ORDER BY created_at ASC LIMIT 1'
+    )
+    .bind(orgId, entityId)
+    .first<{ email: string }>()
+  return contact?.email ?? null
+}
+
+/** `start`: create + attach the Stripe subscription. Refusals return a
+ * redirect query; billing never grants access and never invents a number. */
+async function handleStart(
+  orgId: string,
+  entityId: string,
+  sub: { id: string; stripe_subscription_id: string | null }
+): Promise<string> {
+  if (sub.stripe_subscription_id) return 'error=billing_already_attached'
+  const service = await getOperatorServiceForEntity(env.DB, orgId, entityId)
+  const price = service?.recurring_price
+  if (typeof price !== 'number' || !Number.isFinite(price) || price <= 0) {
+    return 'error=no_authored_price'
+  }
+  const email = await getPrimaryContactEmail(env.DB, orgId, entityId)
+  if (!email) return 'error=no_billing_contact'
+
+  const created = await createOperatorSubscription(env.STRIPE_API_KEY, {
+    customer_email: email,
+    monthly_amount_cents: Math.round(price * 100),
+    entity_id: entityId,
+    subscription_row_id: sub.id,
+  })
+  await attachStripeSubscription(env.DB, sub.id, created.id)
+  return 'billing=started'
+}
+
+/** pause / resume / cancel: drive Stripe, mirror the local row. */
+async function handleAttachedAction(
+  action: 'pause' | 'resume' | 'cancel',
+  subRowId: string,
+  stripeSubscriptionId: string
+): Promise<string> {
+  if (action === 'pause') {
+    await pauseOperatorSubscription(env.STRIPE_API_KEY, stripeSubscriptionId)
+    await setSubscriptionBillingStatus(env.DB, subRowId, 'paused')
+    return 'billing=paused'
+  }
+  if (action === 'resume') {
+    await resumeOperatorSubscription(env.STRIPE_API_KEY, stripeSubscriptionId)
+    await setSubscriptionBillingStatus(env.DB, subRowId, 'active')
+    return 'billing=resumed'
+  }
+  await cancelOperatorSubscription(env.STRIPE_API_KEY, stripeSubscriptionId)
+  await setSubscriptionBillingStatus(env.DB, subRowId, 'cancelled')
+  return 'billing=cancelled'
+}
+
+async function handlePost({ request, locals, params, redirect }: APIContext): Promise<Response> {
+  const auth = requireAdminSession(locals)
+  if (!auth.ok) return auth.response
+
+  const entityId = params.id
+  if (!entityId) return redirect('/admin/clients?error=missing', 302)
+  const back = (q: string) => redirect(`/admin/clients/${entityId}?${q}`, 302)
+
+  let action: BillingAction | null
+  try {
+    action = parseAction((await request.formData()).get('action'))
+  } catch {
+    action = null
+  }
+  if (!action) return back('error=bad_billing_action')
+
+  try {
+    const sub = await getSubscriptionForBilling(env.DB, entityId, 'operator')
+    if (!sub) return back('error=no_subscription_row')
+
+    if (action === 'start') {
+      return back(await handleStart(auth.session.orgId, entityId, sub))
+    }
+    if (!sub.stripe_subscription_id) return back('error=no_billing_attached')
+    return back(await handleAttachedAction(action, sub.id, sub.stripe_subscription_id))
+  } catch (err) {
+    console.error('[api/admin/clients/subscription-billing] error:', err)
+    return back('error=billing_server')
+  }
+}
+
+export const POST: APIRoute = (ctx) => handlePost(ctx)

--- a/src/pages/api/webhooks/stripe.ts
+++ b/src/pages/api/webhooks/stripe.ts
@@ -2,6 +2,13 @@ import type { APIRoute } from 'astro'
 import { z } from 'zod'
 import type { StripeWebhookEvent } from '../../../lib/stripe/types'
 import { handleInvoicePaid, handleInvoicePaymentFailed } from '../../../lib/webhooks/stripe-handler'
+import {
+  extractStripeSubscriptionId,
+  handleRetainerInvoiceFinalized,
+  handleRetainerInvoicePaid,
+  handleRetainerInvoicePaymentFailed,
+  handleSubscriptionLifecycle,
+} from '../../../lib/webhooks/stripe-subscription-handler'
 import { env } from 'cloudflare:workers'
 import { errorResponse, jsonResponse } from '../../../lib/api/helpers'
 
@@ -14,8 +21,13 @@ import { errorResponse, jsonResponse } from '../../../lib/api/helpers'
  * session tokens. Security is enforced via Stripe-Signature header
  * verification using the STRIPE_WEBHOOK_SECRET.
  *
- * Only processes `invoice.paid` and `invoice.payment_failed` events.
- * All other events are acknowledged with 200 but not acted upon.
+ * Dispatch (#1679): invoice events carrying a subscription linkage belong to
+ * the Operator retainer flow (stripe-subscription-handler.ts — Stripe
+ * originates those invoices monthly and we mirror them locally); invoice
+ * events without one belong to the legacy console-originated one-time flow
+ * (stripe-handler.ts). `customer.subscription.updated`/`.deleted` mirror
+ * billing state onto the local subscriptions row. All other events are
+ * acknowledged with 200 but not acted upon.
  */
 const StripeWebhookEnvelopeSchema = z.looseObject({
   type: z.string(),
@@ -53,6 +65,84 @@ const StripeInvoiceWebhookEventSchema = z.looseObject({
   }),
   created: z.number(),
 })
+
+// customer.subscription.* payload — only the fields the local mirror consumes
+// (#1679). `pause_collection` stays unknown-typed: presence is the signal.
+const StripeSubscriptionSchema = z.looseObject({
+  id: z.string().min(1),
+  object: z.literal('subscription'),
+  status: z.string(),
+  pause_collection: z.unknown().optional(),
+})
+
+const StripeSubscriptionWebhookEventSchema = z.looseObject({
+  id: z.string(),
+  object: z.literal('event'),
+  type: z.string(),
+  data: z.object({
+    object: StripeSubscriptionSchema,
+  }),
+  created: z.number(),
+})
+
+/**
+ * Route an invoice event. Subscription-linked payloads (both API shapes:
+ * top-level `subscription` and `parent.subscription_details.subscription` —
+ * looseObject retains them even though the schema does not declare them)
+ * belong to the retainer mirror; unlinked ones to the legacy one-time flow.
+ * Returns null when the event type is not an invoice event this route handles.
+ */
+async function dispatchInvoiceEvent(eventType: string, parsed: unknown): Promise<Response | null> {
+  if (
+    eventType !== 'invoice.paid' &&
+    eventType !== 'invoice.payment_failed' &&
+    eventType !== 'invoice.finalized'
+  ) {
+    return null
+  }
+  const eventResult = StripeInvoiceWebhookEventSchema.safeParse(parsed)
+  if (!eventResult.success) {
+    return errorResponse(400, 'Malformed event payload')
+  }
+  const invoice = eventResult.data.data.object
+  const subId = extractStripeSubscriptionId(invoice)
+
+  if (eventType === 'invoice.paid') {
+    if (subId !== null) return handleRetainerInvoicePaid(env.DB, env.RESEND_API_KEY, subId, invoice)
+    const event: StripeWebhookEvent = eventResult.data
+    return handleInvoicePaid(env.DB, env.RESEND_API_KEY, event)
+  }
+  if (eventType === 'invoice.payment_failed') {
+    if (subId !== null) {
+      return handleRetainerInvoicePaymentFailed(env.DB, env.RESEND_API_KEY, subId, invoice)
+    }
+    const event: StripeWebhookEvent = eventResult.data
+    return handleInvoicePaymentFailed(env.DB, event)
+  }
+  // invoice.finalized: mirror the open cycle invoice so the portal shows what
+  // Stripe emailed. One-time invoices are console-originated; no mirror needed.
+  if (subId !== null) return handleRetainerInvoiceFinalized(env.DB, subId, invoice)
+  return jsonResponse(200, { ok: true, event: eventType })
+}
+
+/** Route customer.subscription.updated/.deleted to the local status mirror.
+ * Returns null for other event types. */
+async function dispatchSubscriptionEvent(
+  eventType: string,
+  parsed: unknown
+): Promise<Response | null> {
+  if (
+    eventType !== 'customer.subscription.updated' &&
+    eventType !== 'customer.subscription.deleted'
+  ) {
+    return null
+  }
+  const eventResult = StripeSubscriptionWebhookEventSchema.safeParse(parsed)
+  if (!eventResult.success) {
+    return errorResponse(400, 'Malformed event payload')
+  }
+  return handleSubscriptionLifecycle(env.DB, eventType, eventResult.data.data.object)
+}
 
 type ParseStripeWebhookEventResult = { parsed: unknown } | { response: Response }
 
@@ -95,23 +185,11 @@ export const POST: APIRoute = async ({ request }) => {
   const eventType = envelopeResult.data.type
 
   // --- Dispatch by event type ---
-  if (eventType === 'invoice.paid') {
-    const eventResult = StripeInvoiceWebhookEventSchema.safeParse(parsed)
-    if (!eventResult.success) {
-      return errorResponse(400, 'Malformed event payload')
-    }
-    const event: StripeWebhookEvent = eventResult.data
-    return handleInvoicePaid(env.DB, env.RESEND_API_KEY, event)
-  }
+  const invoiceEventResponse = await dispatchInvoiceEvent(eventType, parsed)
+  if (invoiceEventResponse) return invoiceEventResponse
 
-  if (eventType === 'invoice.payment_failed') {
-    const eventResult = StripeInvoiceWebhookEventSchema.safeParse(parsed)
-    if (!eventResult.success) {
-      return errorResponse(400, 'Malformed event payload')
-    }
-    const event: StripeWebhookEvent = eventResult.data
-    return handleInvoicePaymentFailed(env.DB, event)
-  }
+  const subscriptionEventResponse = await dispatchSubscriptionEvent(eventType, parsed)
+  if (subscriptionEventResponse) return subscriptionEventResponse
 
   // Acknowledge all other events without processing
   return jsonResponse(200, { ok: true, event: eventType })

--- a/tests/stripe-subscription-webhook.test.ts
+++ b/tests/stripe-subscription-webhook.test.ts
@@ -1,0 +1,266 @@
+/**
+ * Tests for the Operator retainer webhook handling
+ * (src/lib/webhooks/stripe-subscription-handler.ts, #1679).
+ *
+ * Covers: subscription-id extraction across both Stripe API shapes, the
+ * finalized/paid cycle-invoice mirror (insert, refresh, idempotency), the
+ * payment-failure posture (overdue + alert, never a Machine action), and the
+ * customer.subscription.* status mirror onto the local row.
+ */
+
+import { describe, it, expect } from 'vitest'
+import type { D1Database } from '@cloudflare/workers-types'
+import {
+  extractStripeSubscriptionId,
+  handleRetainerInvoiceFinalized,
+  handleRetainerInvoicePaid,
+  handleRetainerInvoicePaymentFailed,
+  handleSubscriptionLifecycle,
+  type RetainerInvoicePayload,
+} from '../src/lib/webhooks/stripe-subscription-handler'
+
+// ---------------------------------------------------------------------------
+// Fakes
+// ---------------------------------------------------------------------------
+
+interface FakeDbState {
+  /** subscriptions row served by SELECT ... WHERE stripe_subscription_id = ? */
+  subRow?: {
+    id: string
+    org_id: string
+    entity_id: string
+    product_slug: string
+    status: string
+    stripe_subscription_id: string | null
+  } | null
+  /** invoices row served by SELECT ... WHERE stripe_invoice_id = ? */
+  invoiceRow?: { id: string; org_id: string; status: string } | null
+}
+
+interface Recorded {
+  sql: string
+  args: unknown[]
+}
+
+function makeDb(state: FakeDbState): { db: D1Database; writes: Recorded[] } {
+  const writes: Recorded[] = []
+  const db = {
+    prepare(sql: string) {
+      return {
+        bind(...args: unknown[]) {
+          return {
+            first() {
+              if (sql.includes('FROM subscriptions')) return Promise.resolve(state.subRow ?? null)
+              if (sql.includes('FROM invoices')) return Promise.resolve(state.invoiceRow ?? null)
+              if (sql.includes('FROM contacts')) return Promise.resolve(null)
+              if (sql.includes('FROM entities')) return Promise.resolve({ name: 'Test Firm' })
+              throw new Error(`unexpected first(): ${sql}`)
+            },
+            run() {
+              writes.push({ sql, args })
+              return Promise.resolve({})
+            },
+          }
+        },
+      }
+    },
+  }
+  return { db: db as unknown as D1Database, writes }
+}
+
+const SUB_ROW = {
+  id: 'local-sub-1',
+  org_id: 'org-1',
+  entity_id: 'ent-1',
+  product_slug: 'operator',
+  status: 'active',
+  stripe_subscription_id: 'sub_stripe_1',
+}
+
+function invoicePayload(overrides?: Partial<RetainerInvoicePayload>): RetainerInvoicePayload {
+  return {
+    id: 'in_cycle_1',
+    amount_due: 500000,
+    amount_paid: 0,
+    hosted_invoice_url: 'https://invoice.stripe.com/i/x',
+    due_date: 1785000000,
+    status_transitions: { paid_at: null },
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// extractStripeSubscriptionId — both API shapes
+// ---------------------------------------------------------------------------
+
+describe('extractStripeSubscriptionId', () => {
+  it('reads the legacy top-level subscription field', () => {
+    expect(extractStripeSubscriptionId({ subscription: 'sub_a' })).toBe('sub_a')
+  })
+
+  it('reads the current parent.subscription_details.subscription shape', () => {
+    expect(
+      extractStripeSubscriptionId({
+        parent: { subscription_details: { subscription: 'sub_b' } },
+      })
+    ).toBe('sub_b')
+  })
+
+  it('returns null for one-time invoices and junk', () => {
+    expect(extractStripeSubscriptionId({})).toBeNull()
+    expect(extractStripeSubscriptionId({ subscription: null })).toBeNull()
+    expect(extractStripeSubscriptionId({ subscription: '' })).toBeNull()
+    expect(extractStripeSubscriptionId({ parent: null })).toBeNull()
+    expect(extractStripeSubscriptionId(null)).toBeNull()
+    expect(extractStripeSubscriptionId('sub_x')).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Cycle-invoice mirror
+// ---------------------------------------------------------------------------
+
+describe('handleRetainerInvoiceFinalized', () => {
+  it('inserts a local retainer row (status sent) for a known subscription', async () => {
+    const { db, writes } = makeDb({ subRow: SUB_ROW, invoiceRow: null })
+    const res = await handleRetainerInvoiceFinalized(db, 'sub_stripe_1', invoicePayload())
+    expect(res.status).toBe(200)
+    expect(writes).toHaveLength(1)
+    expect(writes[0].sql).toContain('INSERT INTO invoices')
+    expect(writes[0].sql).toContain("'retainer'")
+    expect(writes[0].sql).toContain("'sent'")
+    // amount converted from cents; entity/org from the subscription row
+    expect(writes[0].args).toContain(5000)
+    expect(writes[0].args).toContain('ent-1')
+    expect(writes[0].args).toContain('org-1')
+  })
+
+  it('refreshes an existing mirror row instead of duplicating', async () => {
+    const { db, writes } = makeDb({
+      subRow: SUB_ROW,
+      invoiceRow: { id: 'local-inv-1', org_id: 'org-1', status: 'sent' },
+    })
+    await handleRetainerInvoiceFinalized(db, 'sub_stripe_1', invoicePayload())
+    expect(writes).toHaveLength(1)
+    expect(writes[0].sql).toContain('UPDATE invoices')
+  })
+
+  it('skips honestly when no local subscription matches (e.g. a smoke test)', async () => {
+    const { db, writes } = makeDb({ subRow: null })
+    const res = await handleRetainerInvoiceFinalized(db, 'sub_unknown', invoicePayload())
+    expect(res.status).toBe(200)
+    expect(writes).toHaveLength(0)
+  })
+})
+
+describe('handleRetainerInvoicePaid', () => {
+  it('upserts a paid retainer row when no mirror exists (paid arrived first)', async () => {
+    const { db, writes } = makeDb({ subRow: SUB_ROW, invoiceRow: null })
+    const res = await handleRetainerInvoicePaid(
+      db,
+      undefined,
+      'sub_stripe_1',
+      invoicePayload({ amount_paid: 500000, status_transitions: { paid_at: 1785100000 } })
+    )
+    expect(res.status).toBe(200)
+    expect(writes).toHaveLength(1)
+    expect(writes[0].sql).toContain('INSERT INTO invoices')
+    expect(writes[0].sql).toContain("'paid'")
+  })
+
+  it('marks an existing mirror row paid', async () => {
+    const { db, writes } = makeDb({
+      subRow: SUB_ROW,
+      invoiceRow: { id: 'local-inv-1', org_id: 'org-1', status: 'sent' },
+    })
+    await handleRetainerInvoicePaid(
+      db,
+      undefined,
+      'sub_stripe_1',
+      invoicePayload({ amount_paid: 500000, status_transitions: { paid_at: 1785100000 } })
+    )
+    expect(writes).toHaveLength(1)
+    expect(writes[0].sql).toContain("SET status = 'paid'")
+  })
+
+  it('is idempotent: an already-paid mirror row is not rewritten', async () => {
+    const { db, writes } = makeDb({
+      subRow: SUB_ROW,
+      invoiceRow: { id: 'local-inv-1', org_id: 'org-1', status: 'paid' },
+    })
+    const res = await handleRetainerInvoicePaid(db, undefined, 'sub_stripe_1', invoicePayload())
+    expect(res.status).toBe(200)
+    expect(writes).toHaveLength(0)
+  })
+})
+
+describe('handleRetainerInvoicePaymentFailed', () => {
+  it('marks the mirror row overdue and takes NO other local action', async () => {
+    const { db, writes } = makeDb({
+      subRow: SUB_ROW,
+      invoiceRow: { id: 'local-inv-1', org_id: 'org-1', status: 'sent' },
+    })
+    const res = await handleRetainerInvoicePaymentFailed(
+      db,
+      undefined,
+      'sub_stripe_1',
+      invoicePayload()
+    )
+    expect(res.status).toBe(200)
+    expect(writes).toHaveLength(1)
+    expect(writes[0].sql).toContain("SET status = 'overdue'")
+    // Exactly one write: no subscriptions-row change, no Machine-facing action.
+    const touchedSubscriptions = writes.some((w) => w.sql.includes('UPDATE subscriptions'))
+    expect(touchedSubscriptions).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Subscription lifecycle mirror
+// ---------------------------------------------------------------------------
+
+describe('handleSubscriptionLifecycle', () => {
+  it('deleted → cancelled with ended_at', async () => {
+    const { db, writes } = makeDb({ subRow: SUB_ROW })
+    await handleSubscriptionLifecycle(db, 'customer.subscription.deleted', {
+      id: 'sub_stripe_1',
+      status: 'canceled',
+    })
+    expect(writes).toHaveLength(1)
+    expect(writes[0].sql).toContain("status = 'cancelled'")
+    expect(writes[0].sql).toContain('ended_at')
+  })
+
+  it('updated with pause_collection present → paused', async () => {
+    const { db, writes } = makeDb({ subRow: SUB_ROW })
+    await handleSubscriptionLifecycle(db, 'customer.subscription.updated', {
+      id: 'sub_stripe_1',
+      status: 'active',
+      pause_collection: { behavior: 'void' },
+    })
+    expect(writes).toHaveLength(1)
+    expect(writes[0].args).toContain('paused')
+  })
+
+  it('updated active without pause_collection → active; past_due keeps access', async () => {
+    for (const status of ['active', 'past_due']) {
+      const { db, writes } = makeDb({ subRow: SUB_ROW })
+      await handleSubscriptionLifecycle(db, 'customer.subscription.updated', {
+        id: 'sub_stripe_1',
+        status,
+      })
+      expect(writes).toHaveLength(1)
+      expect(writes[0].args).toContain('active')
+    }
+  })
+
+  it('unknown Stripe subscription is skipped honestly', async () => {
+    const { db, writes } = makeDb({ subRow: null })
+    const res = await handleSubscriptionLifecycle(db, 'customer.subscription.updated', {
+      id: 'sub_unknown',
+      status: 'active',
+    })
+    expect(res.status).toBe(200)
+    expect(writes).toHaveLength(0)
+  })
+})

--- a/tests/stripe-subscriptions.test.ts
+++ b/tests/stripe-subscriptions.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Tests for the Operator retainer Stripe subscription client
+ * (src/lib/stripe/subscriptions.ts, #1679).
+ *
+ * The configured path is exercised through the real fetch layer with a
+ * stubbed global fetch, asserting the exact Stripe API shapes: send_invoice
+ * collection, inline monthly price_data against the shared retainer product,
+ * pause via pause_collection[behavior]=void, resume via clearing
+ * pause_collection, cancel via DELETE.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import {
+  cancelOperatorSubscription,
+  createOperatorSubscription,
+  getOperatorSubscription,
+  pauseOperatorSubscription,
+  resumeOperatorSubscription,
+} from '../src/lib/stripe/subscriptions'
+
+const KEY = 'sk_test_fake'
+
+interface RecordedCall {
+  url: string
+  method: string
+  body: string
+}
+
+/** Stub fetch with per-URL-substring responders; records every call. */
+function stubStripe(
+  responders: Array<{ match: string; method?: string; json: unknown; status?: number }>
+): { calls: RecordedCall[] } {
+  const calls: RecordedCall[] = []
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      const method = init?.method ?? 'GET'
+      const body = typeof init?.body === 'string' ? init.body : ''
+      calls.push({ url, method, body })
+      for (const r of responders) {
+        if (url.includes(r.match) && (!r.method || r.method === method)) {
+          return new Response(JSON.stringify(r.json), { status: r.status ?? 200 })
+        }
+      }
+      return new Response(JSON.stringify({ error: `unmatched ${method} ${url}` }), { status: 500 })
+    })
+  )
+  return { calls }
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('createOperatorSubscription', () => {
+  it('dev-mode stub when apiKey is undefined (no fetch)', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    const result = await createOperatorSubscription(undefined, {
+      customer_email: 'owner@firm.com',
+      monthly_amount_cents: 500000,
+      entity_id: 'ent-1',
+      subscription_row_id: 'sub-row-1',
+    })
+    expect(result.id).toMatch(/^dev_sub_/)
+    expect(result.status).toBe('active')
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('resolves customer + shared product, then creates a send_invoice monthly subscription', async () => {
+    const { calls } = stubStripe([
+      { match: '/customers/search', json: { data: [{ id: 'cus_1' }] } },
+      { match: '/products/search', json: { data: [{ id: 'prod_retainer' }] } },
+      { match: '/subscriptions', method: 'POST', json: { id: 'sub_9', status: 'active' } },
+    ])
+
+    const result = await createOperatorSubscription(KEY, {
+      customer_email: 'owner@firm.com',
+      monthly_amount_cents: 500000,
+      entity_id: 'ent-1',
+      subscription_row_id: 'sub-row-1',
+      metadata: { smd_smoke_test: '1' },
+    })
+    expect(result).toEqual({ id: 'sub_9', status: 'active' })
+
+    const create = calls.find((c) => c.url.endsWith('/subscriptions') && c.method === 'POST')
+    expect(create).toBeDefined()
+    const body = new URLSearchParams(create!.body)
+    expect(body.get('customer')).toBe('cus_1')
+    expect(body.get('collection_method')).toBe('send_invoice')
+    expect(body.get('days_until_due')).toBe('15')
+    expect(body.get('items[0][price_data][unit_amount]')).toBe('500000')
+    expect(body.get('items[0][price_data][currency]')).toBe('usd')
+    expect(body.get('items[0][price_data][product]')).toBe('prod_retainer')
+    expect(body.get('items[0][price_data][recurring][interval]')).toBe('month')
+    expect(body.get('metadata[smd_entity_id]')).toBe('ent-1')
+    expect(body.get('metadata[smd_subscription_id]')).toBe('sub-row-1')
+    expect(body.get('metadata[smd_smoke_test]')).toBe('1')
+  })
+
+  it('creates the shared retainer product on first use', async () => {
+    const { calls } = stubStripe([
+      { match: '/customers/search', json: { data: [{ id: 'cus_1' }] } },
+      { match: '/products/search', json: { data: [] } },
+      { match: '/products', method: 'POST', json: { id: 'prod_new' } },
+      { match: '/subscriptions', method: 'POST', json: { id: 'sub_9', status: 'active' } },
+    ])
+    await createOperatorSubscription(KEY, {
+      customer_email: 'owner@firm.com',
+      monthly_amount_cents: 500000,
+      entity_id: 'ent-1',
+      subscription_row_id: 'sub-row-1',
+    })
+    const productCreate = calls.find((c) => c.url.endsWith('/products') && c.method === 'POST')
+    expect(productCreate).toBeDefined()
+    const body = new URLSearchParams(productCreate!.body)
+    expect(body.get('name')).toBe('SMD Operator Retainer')
+    expect(body.get('metadata[smd_product]')).toBe('operator-retainer')
+    const subCreate = calls.find((c) => c.url.endsWith('/subscriptions') && c.method === 'POST')
+    expect(new URLSearchParams(subCreate!.body).get('items[0][price_data][product]')).toBe(
+      'prod_new'
+    )
+  })
+
+  it('throws on a Stripe error (caller decides the redirect)', async () => {
+    stubStripe([
+      { match: '/customers/search', json: { data: [{ id: 'cus_1' }] } },
+      { match: '/products/search', json: { data: [{ id: 'prod_1' }] } },
+      { match: '/subscriptions', method: 'POST', json: { error: 'nope' }, status: 402 },
+    ])
+    await expect(
+      createOperatorSubscription(KEY, {
+        customer_email: 'owner@firm.com',
+        monthly_amount_cents: 500000,
+        entity_id: 'ent-1',
+        subscription_row_id: 'sub-row-1',
+      })
+    ).rejects.toThrow(/402/)
+  })
+})
+
+describe('pause / resume / cancel', () => {
+  it('pauses with pause_collection[behavior]=void', async () => {
+    const { calls } = stubStripe([
+      { match: '/subscriptions/sub_9', method: 'POST', json: { id: 'sub_9', status: 'active' } },
+    ])
+    await pauseOperatorSubscription(KEY, 'sub_9')
+    expect(new URLSearchParams(calls[0].body).get('pause_collection[behavior]')).toBe('void')
+  })
+
+  it('resumes by clearing pause_collection (send_invoice cannot use /resume)', async () => {
+    const { calls } = stubStripe([
+      { match: '/subscriptions/sub_9', method: 'POST', json: { id: 'sub_9', status: 'active' } },
+    ])
+    await resumeOperatorSubscription(KEY, 'sub_9')
+    expect(calls[0].url.endsWith('/subscriptions/sub_9')).toBe(true)
+    expect(new URLSearchParams(calls[0].body).get('pause_collection')).toBe('')
+  })
+
+  it('cancels via DELETE', async () => {
+    const { calls } = stubStripe([
+      {
+        match: '/subscriptions/sub_9',
+        method: 'DELETE',
+        json: { id: 'sub_9', status: 'canceled' },
+      },
+    ])
+    const result = await cancelOperatorSubscription(KEY, 'sub_9')
+    expect(result.status).toBe('canceled')
+    expect(calls[0].method).toBe('DELETE')
+  })
+
+  it('getOperatorSubscription reports pause posture from pause_collection presence', async () => {
+    stubStripe([
+      {
+        match: '/subscriptions/sub_9',
+        json: { id: 'sub_9', status: 'active', pause_collection: { behavior: 'void' } },
+      },
+    ])
+    const state = await getOperatorSubscription(KEY, 'sub_9')
+    expect(state.paused).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

Closes #1679 (Wave 1 of the 2026-07-04 Operator strategic review). The retainer was sold as a flat monthly subscription (ADR 0004 shape, ADR 0063 price) with no billing engine behind it — `stripe/client.ts` had only one-time invoice primitives, every month was a manual invoice, and MRR was a display number. This wires the engine end to end.

## Design

- **send_invoice, not charge_automatically.** B2B hosted-invoice motion: Stripe emails the invoice each cycle, the client pays it like the deposit/completion invoices they already know, no card on file, and a payment failure is a dunning thread, never a surprise charge.
- **One shared Product, per-seat inline prices.** Inline `price_data` requires a product id; the "SMD Operator Retainer" product is resolved by metadata (created on first use), and each seat gets an inline monthly price from its authored `services.recurring_price` (ADR 0063 wrote 5000 on live seats).
- **Pause = `pause_collection[behavior]=void`** — a paused seat is never charged; resume clears the field (the `/resume` endpoint is charge_automatically-only, verified against current Stripe docs via Context7).
- **Webhook mirror.** Cycle invoices are Stripe-originated, inverting the legacy console-originated flow — dispatch splits on subscription linkage (parsed across BOTH API shapes: top-level `subscription` and `parent.subscription_details.subscription`). `invoice.finalized` mirrors an open `type='retainer'` row (portal shows what Stripe emailed); `invoice.paid` upserts + sends the confirmation email; `customer.subscription.updated/deleted` mirror pause/cancel onto the local `subscriptions` row.
- **Payment failure never touches the Machine.** Local row → `overdue`, alert → team@smd.services, and the pause/decommission ladder stays a Captain decision under the offboarding doctrine (#1684). No imposed default.
- **Admin controls** on the client hub's Operator card: start (refused without a provisioning-owned subscriptions row, an authored price, or a billing contact — billing never grants access and never invents a number), pause, resume, cancel.
- **Migration 0084**: `subscriptions.stripe_subscription_id` + partial unique index; NULL = no billing attached (pilot seats invoice $0 per ADR 0063 while carrying list price for the COGS gate).

## Verification
- `npm run verify` green; 22 new tests (client API shapes through the real transport with stubbed fetch; webhook mirror insert/refresh/idempotency; failure posture asserts exactly one local write and no subscriptions-row change; lifecycle mirror incl. past_due-keeps-access)
- Post-merge: migration applied to remote D1, Stripe webhook endpoint events extended (`invoice.finalized`, `customer.subscription.*`), and a marked live smoke subscription (create → verify → cancel, no email to any client) with `crane_verify` records

🤖 Generated with [Claude Code](https://claude.com/claude-code)
