### PR TITLE
feat(trust): public security + AI-disclosure pages, DPA template (Captain review: legal-shaped copy)

### DIFF
--- a/docs/handbook/security-trust.md
+++ b/docs/handbook/security-trust.md
@@ -59,6 +59,10 @@ The policy is not enforced by vigilance alone; it is wired into CI and into test
 
 The content-integrity controls also feed the external story: the same fail-closed posture and no-storage architecture are what `docs/security/smd-services-security-overview.md` presents to a partner's security review.
 
+## The buyer-facing trust surface
+
+A prospect's compliance reviewer gets the same story in three client-visible artifacts (added 2026-07-04, #1680): the public security page (`src/pages/security.astro`, at smd.services/security - architecture-derived claims, the sub-processor list, and a plain statement of what we do not claim, including no SOC 2 of our own), the AI-disclosure page (`src/pages/ai-disclosure.astro` - what the Operator is, that review posture is an authored choice with no imposed default, and what it never does), and the data processing addendum template (`docs/legal/operator-dpa-template.md` - the contractual half, carrying the notification and return/destruction windows the public pages deliberately leave to paper; counsel review precedes first execution). All three derive from the security overview and the ADR spine; if a control changes, they change in the same wave.
+
 ## Operator runtime security
 
 The Operator is an autonomous agent acting on a client's live business data, so its security model is about constraining action, not just constraining output. The full analysis is `docs/security/operator-threat-model.md` - a maintained, adversarially-tested register, not a one-time design doc. Its shape:

--- a/docs/legal/operator-dpa-template.md
+++ b/docs/legal/operator-dpa-template.md
@@ -1,0 +1,82 @@
+# Data Processing Addendum - Operator Service (Template)
+
+**Status:** Template, v0.1 (2026-07-04, issue #1680). Fulfills the obligation named in ADR 0057 §"login layer" (SMD becomes a processor of firm employee-identity data). Reviewed by Captain before any execution; have counsel review before the first client signature. Per-engagement values (notification windows, retention figures, governing law) are completed in the signing flow, never assumed.
+
+---
+
+This Data Processing Addendum ("DPA") forms part of the services agreement (the "Agreement") between **SMDurgan, LLC d/b/a SMD Services** ("SMD") and the client identified in the Agreement ("Client"), and governs SMD's processing of Client Data in connection with the Operator service.
+
+## 1. Roles and scope
+
+1.1. Client is the controller of Client Data. SMD acts as processor, processing Client Data only to provide the Operator service and only on Client's documented instructions, which consist of the Agreement, the authored Operator configuration, and instructions given through the client portal or the Operator's authorized channels.
+
+1.2. Client's business systems (practice management, email, calendars, documents) remain the systems of record. SMD does not warehouse copies of the data held in those systems; the Operator accesses them transiently through Client-authorized connections to perform requested work.
+
+## 2. Data processed
+
+| Category                 | Examples                                                                             | Where it lives                                          |
+| ------------------------ | ------------------------------------------------------------------------------------ | ------------------------------------------------------- |
+| Employee identity data   | Names, work email addresses, roles of Client staff granted Operator or portal access | SMD control plane (identity provider and access grants) |
+| Configuration data       | Authored skills, permissions, voice samples, rosters                                 | Client's dedicated machine and SMD control plane        |
+| Operational memory       | Working memory the Operator builds performing Client's work                          | Client's dedicated machine                              |
+| Governance records       | Append-only audit log of Operator actions; access-grant audit                        | Client's dedicated machine and SMD control plane        |
+| Transient task content   | Business data read through Client's systems while performing a task                  | In memory during the task; not retained by SMD          |
+| Account and billing data | Contacts, invoices, subscription records                                             | SMD control plane and billing sub-processor             |
+
+Data subjects are Client's personnel and the individuals whose information appears in Client's business records in the ordinary course of Client's work.
+
+## 3. Security measures
+
+SMD implements the measures described in its Security Overview (published at smd.services/security and available in long form on request), including: a dedicated, isolated compute instance and encrypted volume per client; connection credentials stored only on Client's machine with process-level custody separation; a fail-closed authority model in which unconfigured action classes are refused; structural isolation of untrusted inbound content; an append-only audit log the agent cannot modify; access grants evaluated live per request with immediate revocation effect; and a controlled software delivery pipeline with automated security gates.
+
+## 4. Sub-processors
+
+4.1. Client authorizes the sub-processors listed in Exhibit A. SMD will notify Client at least **\_\_** days before adding or replacing a sub-processor that will process Client Data, and Client may object on reasonable grounds relating to data protection.
+
+4.2. SMD remains responsible for its sub-processors' performance of this DPA's obligations.
+
+## 5. Confidentiality
+
+SMD limits access to Client Data to personnel and processes that need it to deliver the service, binds personnel to confidentiality obligations, and does not sell Client Data or use it for any purpose other than providing the service. Content processed through the language model provider is not used to train models, per that provider's commercial terms.
+
+## 6. Incident notification
+
+SMD will notify Client without undue delay, and in any case within **\_\_** hours, after becoming aware of a security incident affecting Client Data, will provide information reasonably required for Client's own notification obligations as it becomes available, and will cooperate in the investigation and remediation.
+
+## 7. Return and deletion
+
+7.1. During the term, Client may export its governance records from the client portal and may request an evidence packet at any time.
+
+7.2. On termination of the Agreement, SMD will: (a) deliver Client's audit record and the Operator's operational memory in exportable form; (b) revoke all access grants and connection credentials; (c) destroy Client's dedicated machine and volume; and (d) delete residual Client Data from the control plane, excepting records SMD must retain for legal, tax, or accounting purposes. Return and destruction are completed within **\_\_** days of termination, and SMD will confirm destruction in writing on request.
+
+## 8. Assistance and audits
+
+8.1. SMD will reasonably assist Client with data subject requests and regulatory inquiries that concern the Operator's processing.
+
+8.2. Once per year, or following a security incident affecting Client Data, Client may request a review of SMD's controls in the form of a documented walkthrough with SMD's security contact, together with supporting evidence. SMD does not hold its own SOC 2 or ISO 27001 certification and says so plainly; sub-processor attestations are listed in Exhibit A.
+
+## 9. Term and precedence
+
+This DPA applies for as long as SMD processes Client Data and survives termination until return and deletion complete. If this DPA conflicts with the Agreement, this DPA controls with respect to data protection.
+
+---
+
+## Exhibit A - Sub-processors
+
+| Sub-processor | Role                                                          | Client Data touched                                                                                         | Attestation                              |
+| ------------- | ------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
+| Fly.io        | Hosts Client's dedicated machine and encrypted volume         | Transient task content in memory; credentials, configuration, memory, and audit records at rest (encrypted) | SOC 2 Type II (trust.fly.io)             |
+| Anthropic     | Language model inference                                      | Task content, transiently; not used for model training per commercial terms                                 | SOC 2 Type II (trust.anthropic.com)      |
+| Cloudflare    | Control plane, client portal, governance record store         | Employee identity data, configuration projections, governance summaries                                     | SOC 2 / ISO 27001                        |
+| AgentMail     | The Operator's own mailbox, where the engagement includes one | Email sent to and from the Operator's address                                                               | Vendor security documentation on request |
+| Clerk         | Portal and access sign-in                                     | Employee identity data                                                                                      | SOC 2 Type II                            |
+| Stripe        | Billing                                                       | Billing contact and payment records                                                                         | PCI DSS Level 1, SOC 2                   |
+| SignWell      | Agreement signing                                             | Signatory names and executed documents                                                                      | SOC 2                                    |
+| Resend        | Transactional email                                           | Recipient names and addresses                                                                               | SOC 2 Type II                            |
+| Infisical     | SMD-side secrets management                                   | No Client Data                                                                                              | Encrypted store, named-principal access  |
+
+Google Workspace appears as a sub-processor only for engagements where Client connects its own Google tenancy; in that case processing occurs within Client's tenancy under Client's own Google terms.
+
+---
+
+**Completion checklist (per engagement, at signing):** notice period for sub-processor changes (§4.1); incident notification window (§6, keep consistent with the Security Overview commitments); return and destruction window (§7.2); governing law inherited from the Agreement.

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -69,6 +69,10 @@ import { bookHref } from '../lib/booking/config'
       <div class="flex flex-wrap gap-x-6 gap-y-2">
         <a href="/terms" class="hover:text-white" data-ev="footer-terms">Terms</a>
         <a href="/privacy" class="hover:text-white" data-ev="footer-privacy">Privacy</a>
+        <a href="/security" class="hover:text-white" data-ev="footer-security">Security</a>
+        <a href="/ai-disclosure" class="hover:text-white" data-ev="footer-ai-disclosure"
+          >AI Disclosure</a
+        >
       </div>
     </nav>
 

--- a/src/pages/ai-disclosure.astro
+++ b/src/pages/ai-disclosure.astro
@@ -1,0 +1,118 @@
+---
+import Base from '../layouts/Base.astro'
+import Nav from '../components/Nav.astro'
+import Footer from '../components/Footer.astro'
+
+/**
+ * AI disclosure page (#1680). Plain statement of what the Operator is, how
+ * human review works, and what it never does. Aligned with the guardrail
+ * language on the pack pages (e.g. packs/law-firm.astro: everything goes to
+ * a person for review under that firm's authored posture) and the fail-closed
+ * entitlement doctrine (ADR 0035/0056). No fabricated commitments: review
+ * postures are described as authored choices, never promised defaults.
+ */
+
+const H2 =
+  "mb-3 font-['Archivo_Narrow'] text-sm font-bold uppercase tracking-[0.14em] text-[color:var(--ss-color-primary)]"
+---
+
+<Base
+  title="AI Disclosure | SMD Services"
+  description="The Operator is an AI system, and we say so plainly: what it is, how human review works, where the AI runs, and what it never does."
+>
+  <Nav />
+  <main id="main" role="main" class="bg-[color:var(--ss-color-background)] px-6 py-20 md:py-24">
+    <div class="mx-auto max-w-2xl">
+      <h1
+        class="font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
+      >
+        AI Disclosure
+      </h1>
+
+      <p
+        class="mt-3 font-['Archivo_Narrow'] text-xs uppercase tracking-[0.12em] text-[color:var(--ss-color-text-muted)]"
+      >
+        Effective: 2026-07-04
+      </p>
+
+      <div
+        class="mt-10 space-y-10 font-['Archivo'] text-lg leading-relaxed text-[color:var(--ss-color-text-primary)]"
+      >
+        <p>
+          The Operator is an artificial intelligence system. We never present it as a person, and we
+          built the product so you never have to wonder what it is allowed to do. This page states
+          plainly what it is, how human oversight works, and where the limits sit.
+        </p>
+
+        <section>
+          <h2 class={H2}>What the Operator is</h2>
+          <p>
+            The Operator is an AI agent that runs on infrastructure dedicated to your business,
+            connected to the systems you already use. It reads, drafts, coordinates, tracks, and
+            executes the working procedures we configure with you. Its reasoning is powered by
+            frontier language models; its authority is governed by a permission system we author
+            with you, in writing, before it acts.
+          </p>
+        </section>
+
+        <section>
+          <h2 class={H2}>Human review is a setting you control</h2>
+          <p>
+            How much of your Operator's work passes through a person before it lands is an authored
+            choice, made per action class during configuration. Many clients start with every
+            outbound piece routed to a reviewer and widen autonomy as trust builds. Others authorize
+            routine internal work to run unattended from day one. The system imposes no default in
+            either direction: an action class you have not configured is refused, not guessed at.
+            Whatever posture you author, every action is recorded in an audit trail you can read in
+            your portal.
+          </p>
+        </section>
+
+        <section>
+          <h2 class={H2}>What it never does</h2>
+          <p>
+            Some limits are not settings. The Operator never sends communications impersonating you
+            or your staff; it works under its own identity. It never gives itself more authority;
+            only you and we can change what it is allowed to do, and every change is logged. It
+            never performs licensed professional work: in a law firm it coordinates and drafts for
+            attorney review but never advises or signs; the same boundary applies to every regulated
+            profession we serve. And output that fails our integrity gate, such as a claim it cannot
+            support from your records, is blocked before it can be sent.
+          </p>
+        </section>
+
+        <section>
+          <h2 class={H2}>Where the AI runs, and your data</h2>
+          <p>
+            Language model inference runs through Anthropic's commercial API. Content passes through
+            transiently when your Operator performs a task, and under Anthropic's commercial terms
+            it is not used to train models. Your business data stays in your systems; the Operator's
+            own working memory and audit record live on your dedicated machine. The full
+            data-handling picture, including sub-processors, is on our
+            <a
+              href="/security"
+              class="underline underline-offset-4 hover:text-[color:var(--ss-color-primary)]"
+              >security page</a
+            > and in your data processing addendum.
+          </p>
+        </section>
+
+        <section>
+          <h2 class={H2}>When AI is the wrong answer</h2>
+          <p>
+            Part of our job is telling you when it is not the right tool. Some problems are solved
+            with a better process, a clearer role, or a simpler workflow, and we will say so rather
+            than sell you an Operator you do not need. If you have questions about how AI is used in
+            your engagement, write to
+            <a
+              href="mailto:team@smd.services"
+              class="underline underline-offset-4 hover:text-[color:var(--ss-color-primary)]"
+              >team@smd.services</a
+            >.
+          </p>
+        </section>
+      </div>
+    </div>
+  </main>
+  <Footer />
+</Base>

--- a/src/pages/portal/products/operator/activity/index.astro
+++ b/src/pages/portal/products/operator/activity/index.astro
@@ -210,6 +210,17 @@ const complianceView =
                     An evidence packet of this record can be produced for verification. Use Request
                     a change to ask your SMD team to prepare one.
                   </p>
+                  <p class="text-sm text-[color:var(--ss-color-text-secondary)]">
+                    The security controls behind this record, including sub-processors and
+                    data-handling posture, are documented at{' '}
+                    <a
+                      href="https://smd.services/security"
+                      class="underline underline-offset-2 hover:text-[color:var(--ss-color-primary)]"
+                    >
+                      smd.services/security
+                    </a>
+                    . Your data processing addendum carries the contractual windows.
+                  </p>
                 </div>
               </div>
             </DomainSurface>

--- a/src/pages/security.astro
+++ b/src/pages/security.astro
@@ -1,0 +1,206 @@
+---
+import Base from '../layouts/Base.astro'
+import Nav from '../components/Nav.astro'
+import Footer from '../components/Footer.astro'
+
+/**
+ * Public security page (#1680). Every claim on this page derives from
+ * committed architecture (docs/security/smd-services-security-overview.md,
+ * ADRs 0007/0009/0010/0035/0042/0057/0062) rather than aspiration. The
+ * marketing site makes strong trust claims on /operator; this page is where
+ * a buyer's compliance reviewer verifies them. Numbers that belong in paper
+ * (notification windows, retention specifics) live in the engagement
+ * agreement and DPA, not here.
+ */
+
+const H2 =
+  "mb-3 font-['Archivo_Narrow'] text-sm font-bold uppercase tracking-[0.14em] text-[color:var(--ss-color-primary)]"
+---
+
+<Base
+  title="Security | SMD Services"
+  description="How the Operator is secured: per-client isolation, fail-closed authority, credential custody, and a tamper-resistant audit record. Stated plainly, including what we do not claim."
+>
+  <Nav />
+  <main id="main" role="main" class="bg-[color:var(--ss-color-background)] px-6 py-20 md:py-24">
+    <div class="mx-auto max-w-2xl">
+      <h1
+        class="font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
+      >
+        Security
+      </h1>
+
+      <p
+        class="mt-3 font-['Archivo_Narrow'] text-xs uppercase tracking-[0.12em] text-[color:var(--ss-color-text-muted)]"
+      >
+        Effective: 2026-07-04
+      </p>
+
+      <div
+        class="mt-10 space-y-10 font-['Archivo'] text-lg leading-relaxed text-[color:var(--ss-color-text-primary)]"
+      >
+        <p>
+          The Operator works inside your business, so its security posture has to survive your
+          scrutiny, not just ours. This page describes the controls as they are actually built.
+          Where we hold no certification, we say so. Where a specific commitment belongs in your
+          agreement rather than on a marketing site, we tell you which document carries it.
+        </p>
+
+        <section>
+          <h2 class={H2}>The control that matters most</h2>
+          <p>
+            Your systems remain the system of record. The Operator reads and writes through the same
+            authorized channels a staff member would use, holds data transiently to do the task in
+            front of it, and returns the output to you or to your system. We do not warehouse copies
+            of your business data. What we do store, on infrastructure dedicated to your account
+            alone, is limited to your encrypted connection credentials, your authored configuration,
+            and the audit record of everything your Operator did.
+          </p>
+        </section>
+
+        <section>
+          <h2 class={H2}>One client, one machine</h2>
+          <p>
+            Every client runs on a dedicated, isolated compute instance with its own private volume.
+            There is no shared application tier and no shared data store between clients. A
+            different client's data lives on a different machine entirely, so cross-client exposure
+            is prevented by architecture, not by an access check that could fail. Our own console
+            cannot query across client machines; that prohibition is enforced in code and checked in
+            our build pipeline.
+          </p>
+        </section>
+
+        <section>
+          <h2 class={H2}>Credential custody</h2>
+          <p>
+            Connection credentials for your systems are stored only on your machine's encrypted
+            volume, with file permissions restricted to the single process that needs them. They are
+            never written to logs, never placed in a shared store, and never visible to other
+            clients. The most sensitive credentials are held by a separate broker process the agent
+            itself cannot read, so even a compromised agent cannot extract them. You choose per
+            connection whether we hold credentials on your behalf or you hold them yourself.
+          </p>
+        </section>
+
+        <section>
+          <h2 class={H2}>Fail-closed authority</h2>
+          <p>
+            The Operator's permission model defaults to refusal. Consequential action classes,
+            including sending externally, making commitments, and deleting anything, are refused
+            unless you have explicitly authorized them for your account. An unconfigured Operator
+            can read and draft but cannot act on the world. Untrusted inbound content, such as an
+            email from outside your firm, is structurally fenced so instructions hidden inside it
+            cannot drive privileged actions. A content gate blocks fabricated or unsupported output
+            before any send. A spend circuit breaker halts a runaway agent and stays halted until a
+            human clears it.
+          </p>
+        </section>
+
+        <section>
+          <h2 class={H2}>The audit record</h2>
+          <p>
+            Every action your Operator takes is written to an append-only audit log owned by a
+            privileged process the agent cannot modify. Your Operator cannot rewrite or delete its
+            own history. You can read this record in your client portal at any time, and you can
+            request an evidence packet for compliance or dispute purposes. Access granted to your
+            staff through outside tools is authorized per request against a live grant table, so
+            revoking a person's access takes effect on their next call, not at some future expiry.
+          </p>
+        </section>
+
+        <section id="data">
+          <h2 class={H2}>What we store, what we return, what we destroy</h2>
+          <p>
+            Stored on your dedicated infrastructure: encrypted connection credentials, your authored
+            configuration, the operational memory your Operator builds doing your work, and the
+            audit record. Stored on our control plane: your account records, billing records, and
+            governance summaries of Operator activity. Not stored anywhere: copies of your practice
+            or business data, which stays in your systems.
+          </p>
+          <p class="mt-4">
+            When an engagement ends, you receive your audit record and operational memory in
+            exportable form, credentials are revoked, and your dedicated infrastructure is
+            destroyed. The mechanics and windows for return and destruction are specified in your
+            agreement and data processing addendum.
+          </p>
+        </section>
+
+        <section>
+          <h2 class={H2}>Sub-processors</h2>
+          <p>
+            We keep the set of vendors that can touch your data deliberately small, and each is
+            independently audited even though we are not yet.
+          </p>
+          <ul class="mt-4 space-y-3">
+            <li>
+              <strong>Fly.io</strong> hosts your dedicated machine and its encrypted volume. SOC 2 Type
+              II.
+            </li>
+            <li>
+              <strong>Anthropic</strong> provides the language model. Task content passes through its
+              API transiently when your Operator works, and under its commercial terms is not used to
+              train models. SOC 2 Type II.
+            </li>
+            <li>
+              <strong>Cloudflare</strong> runs our control plane, the client portal, and the governance
+              record store. SOC 2 and ISO 27001 attested.
+            </li>
+            <li>
+              <strong>AgentMail</strong> provides your Operator's own mailbox when the engagement includes
+              one, so its email never mixes with your staff's accounts.
+            </li>
+            <li>
+              <strong>Stripe</strong> (billing), <strong>Clerk</strong> (portal sign-in),
+              <strong>SignWell</strong> (document signing), and <strong>Resend</strong>
+              (transactional email) handle account, identity, and commerce data, not your operational
+              business data.
+            </li>
+          </ul>
+          <p class="mt-4">
+            A current list with each vendor's role and attestations ships with your data processing
+            addendum, and we notify you before adding a sub-processor that would touch your data.
+          </p>
+        </section>
+
+        <section>
+          <h2 class={H2}>What we do not claim</h2>
+          <p>
+            SMD Services does not currently hold ISO 27001 or SOC 2 certification of its own. We are
+            a small firm whose controls derive their strength from architecture rather than from
+            process volume, and we would rather show you the actual controls than imply a
+            certificate we do not have. Our material sub-processors are independently SOC 2 audited,
+            and we will walk your reviewer through any control on this page with supporting
+            evidence.
+          </p>
+        </section>
+
+        <section>
+          <h2 class={H2}>Development and review</h2>
+          <p>
+            Every change to the platform goes through pull-request review with automated security
+            gates: dependency vulnerability scanning, secret detection across full history, and
+            static analysis. Security reviews run on a recurring cadence against a maintained threat
+            model, and we conduct periodic in-depth adversarial audits with live exploit
+            verification and tracked remediation.
+          </p>
+        </section>
+
+        <section>
+          <h2 class={H2}>Incidents and questions</h2>
+          <p>
+            Security incidents affecting your data or access are reported to you within the
+            notification windows defined in your agreement, investigated by us within the platform,
+            and tracked to resolution with regular updates. For security questions, reviewer
+            walkthroughs, or evidence requests, write to
+            <a
+              href="mailto:team@smd.services"
+              class="underline underline-offset-4 hover:text-[color:var(--ss-color-primary)]"
+              >team@smd.services</a
+            >.
+          </p>
+        </section>
+      </div>
+    </div>
+  </main>
+  <Footer />
+</Base>


### PR DESCRIPTION
Closes #1680 (Wave 1 of the 2026-07-04 strategic review — the last sales-blocking artifact in the buyer journey).

**Holds for Captain review before merge** — this PR ships legal-shaped, client-facing language (security commitments, DPA terms, AI-disclosure claims).

Three artifacts, every claim derived from committed architecture (`docs/security/smd-services-security-overview.md` + the ADR spine):

- **/security** — no-warehouse posture, one-client-one-machine isolation, credential custody, fail-closed authority, the audit record, what we store/return/destroy, the full sub-processor list, and a plain what-we-do-not-claim section (no SOC 2 of our own; sub-processors independently attested). Contractual numbers deliberately stay in paper, consistent with the pending #1683 SLA doctrine.
- **/ai-disclosure** — what the Operator is, human review as an authored per-action-class choice with no imposed default (ADR 0035/0056), the hard limits (own identity, no self-escalation, no licensed professional work, output integrity gate), where inference runs + no-training terms, and the honest-broker close.
- **docs/legal/operator-dpa-template.md** — the ADR 0057:59 obligation as a working addendum: roles, data-category table, security measures, sub-processor Exhibit A with attestations, incident notification, return/destruction ladder matching the decommission tooling. Per-engagement blanks marked; counsel review precedes first execution.

Plus: footer links, the portal compliance surface now points reviewers at /security, and the handbook security-trust page gained a buyer-facing-trust-surface section (same-PR maintenance contract).

**Verification:** `npm run verify` green (forbidden-strings, landing-page voice, handbook integrity all pass); no em dashes in any shipped copy; no dollar amounts; no fixed engagement timeframes on public pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)