### PR TITLE
feat(operator): bump OVERLAY_REF -> c85b0ddb (cost-breaker boot self-probe)

### DIFF
--- a/operator/contracts/overlay-pairs.json
+++ b/operator/contracts/overlay-pairs.json
@@ -1,7 +1,7 @@
 {
   "overlayRepo": "https://github.com/venturecrane/hermes-smd-overlay.git",
-  "overlayRef": "7e70b3766080019d9fa2cdadb8faa352b961790a",
-  "overlayRefNote": "MUST equal the ARG OVERLAY_REF pinned in operator/templates/Dockerfile \u2014 that is the overlay commit a customer Machine actually ships. The vitest gate asserts the two agree so the manifest cannot pin a stale overlay. Bump both together when OVERLAY_REF moves, then re-record each overlaySha256 from the runtime file at the new ref.",
+  "overlayRef": "c85b0ddb2c9c9158056865f53314348951dd2a5e",
+  "overlayRefNote": "MUST equal the ARG OVERLAY_REF pinned in operator/templates/Dockerfile \u2014 that is the overlay commit a customer Machine actually ships. The vitest gate asserts the two agree so the manifest cannot pin a stale overlay. Bump both together when OVERLAY_REF moves, then re-record each overlaySha256 from the runtime file at the new ref. 2026-07-05: 7e70b376 -> c85b0ddb (overlay#133 cost-breaker boot self-probe). Fast-forward, 3 files (hooks/smd-overlay-activation/handler.py, shared/cost_breaker.py, tests/test_activation_hook.py) \u2014 NO tracked twin touched, so every overlaySha256 below is unchanged; only overlayRef moved.",
   "pairs": [
     {
       "adapterPath": "operator/adapter/voice/transform.py",

--- a/operator/templates/Dockerfile
+++ b/operator/templates/Dockerfile
@@ -254,7 +254,7 @@ ARG OVERLAY_REPO="https://github.com/venturecrane/hermes-smd-overlay.git"
 # AgentMail email-reply channel keeps the email prompt; MCP route untouched. Not a
 # tracked pair (bootstrap/translate.py); all 4 tracked twins unchanged across
 # 2b694947→9b20a1ac, overlaySha256 stable. Superset of 33b58ad.
-ARG OVERLAY_REF="7e70b3766080019d9fa2cdadb8faa352b961790a"
+ARG OVERLAY_REF="c85b0ddb2c9c9158056865f53314348951dd2a5e"
 
 ARG CUSTOMER_SLUG=customer-zero
 

--- a/tests/operator-dockerfile.test.ts
+++ b/tests/operator-dockerfile.test.ts
@@ -254,7 +254,13 @@ describe('Operator customer Machine Dockerfile', () => {
     // lands as the new tracked twin of workspace_broker/chain.py. emit.py
     // twin changed (ensure applies CHAIN_COLUMN_ALTERS) and is re-pinned in
     // overlay-pairs; the broker stamps the chain, writers untouched.
-    expect(DOCKERFILE).toContain('ARG OVERLAY_REF="7e70b3766080019d9fa2cdadb8faa352b961790a"')
+    // c85b0ddb (#133, ss#1701): cost-breaker boot self-probe — the
+    // gateway:startup activation handler drives run_boot_probe (throwaway db,
+    // ladder trips HARD_STOP + assert_allowed refuses, os._exit(1) if inert),
+    // the recurring negative-fire check that earns sticky_stop_cost_cap its
+    // `enforced` status. Range 7e70b376..c85b0ddb is a fast-forward touching
+    // only handler.py + shared/cost_breaker.py + tests; no tracked twin moved.
+    expect(DOCKERFILE).toContain('ARG OVERLAY_REF="c85b0ddb2c9c9158056865f53314348951dd2a5e"')
   })
 
   it('does NOT swallow a failed plugin install (no fail-open `|| echo ... continuing`)', () => {


### PR DESCRIPTION
## Summary
- Pins the overlay commit (overlay#133, `c85b0ddb`) that adds the **cost-breaker boot self-probe**: `run_boot_probe` driven by the `gateway:startup` activation handler drives the sticky_stop ladder to HARD_STOP in a throwaway db and asserts `assert_allowed` then refuses — `os._exit(1)` if the breaker is inert. Same fail-closed contract as the trust/audit boot self-checks; this is the recurring negative-fire check that earns `sticky_stop_cost_cap` its `enforced` status.
- **Ref-only bump.** `7e70b376..c85b0ddb` is a clean fast-forward touching only `handler.py`, `shared/cost_breaker.py`, `tests/test_activation_hook.py`. **No tracked twin moves** — every `overlaySha256` in `overlay-pairs.json` is unchanged; only `overlayRef` advances. Verified against the overlay repo over the exact range.
- The runtime-controls flip to `enforced` is **deliberately NOT in this PR** — it follows only after a real Machine boots green through the probe on the fleet.

## Test plan
- [x] `tests/operator-dockerfile.test.ts` passes (15/15) — Dockerfile ARG ⇔ `overlayRef` agreement holds at the new sha.
- [ ] CI green.
- [ ] Post-merge: reprovision `smd` (dogfood seat), confirm boot passes the probe, then flip `enforced`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)