### PR TITLE
feat(ads): first-touch ad attribution capture (ADR 0066 gate 1)

### DIFF
--- a/src/components/admin/EntityTimelineEntry.astro
+++ b/src/components/admin/EntityTimelineEntry.astro
@@ -1,6 +1,7 @@
 ---
 import { parseMetadata } from '../../lib/admin/entity-detail-page'
 import { relativeTime } from '../../lib/admin/relative-time'
+import { attributionFromUnknown, attributionSummary } from '../../lib/marketing/attribution'
 import type { ContextEntry } from '../../lib/db/context'
 
 interface Props {
@@ -73,10 +74,23 @@ function replyLogDetail(metadata: Record<string, unknown> | null): string | null
   return parts.length > 0 ? parts.join(' | ') : null
 }
 
+/**
+ * Intake rows append the ad-attribution summary (ADR 0066 gate 1, #1722)
+ * when the lead arrived from a paid click. Content itself may already BE
+ * the summary line (attribution-only booking intakes) — skip the suffix
+ * then to avoid printing it twice.
+ */
+function intakeDetail(current: ContextEntry, metadata: Record<string, unknown> | null): string {
+  const summary = attributionSummary(attributionFromUnknown(metadata?.attribution))
+  if (!summary || current.content.includes(summary)) return current.content
+  return `${current.content} | Ad source: ${summary}`
+}
+
 function entryDetail(current: ContextEntry, metadata: Record<string, unknown> | null): string {
   if (current.type === 'signal') return signalDetail(current, metadata) ?? current.content
   if (current.type === 'enrichment') return enrichmentDetail(current, metadata) ?? current.content
   if (current.type === 'stage_change') return stageChangeDetail(metadata) ?? current.content
+  if (current.type === 'intake') return intakeDetail(current, metadata)
   if (isReplyLog) return replyLogDetail(metadata) ?? current.content
   return current.content
 }

--- a/src/lib/booking/intake-core.ts
+++ b/src/lib/booking/intake-core.ts
@@ -12,6 +12,7 @@ import { updateAssessment, getAssessment } from '../db/assessments'
 import { createMeetingWithLegacyAssessment, ensureMeetingForAssessment } from '../db/meetings'
 import { appendContext } from '../db/context'
 import { interestLabel } from './config'
+import { attributionSummary, type AdAttribution } from '../marketing/attribution'
 
 export interface IntakeInput {
   name: string
@@ -43,6 +44,15 @@ export interface IntakeInput {
    * canonical code, not the display label.
    */
   interest?: string | null
+  /**
+   * First-touch ad-click attribution (enumerated utm_*, gclid, fbclid),
+   * read server-side from the ss_attr cookie at the API boundary
+   * (ADR 0066 launch gate 1, #1722). Stored in context metadata for
+   * campaign attribution. INTERNAL-ONLY: never rendered on client-facing
+   * surfaces — keep it out of intakeLines, which flow into the
+   * guest-visible calendar event description.
+   */
+  attribution?: AdAttribution | null
 }
 
 /**
@@ -231,6 +241,58 @@ function buildIntakeLines(input: IntakeInput): string[] {
 }
 
 /**
+ * Append the intake context row: the prospect's own words, the categorical
+ * intake lines, and (in metadata) the first-touch ad attribution. Returns
+ * the context row id, or null when there is nothing to write.
+ */
+async function appendIntakeContext(
+  db: D1Database,
+  orgId: string,
+  args: { entityId: string; input: IntakeInput; intakeLines: string[]; pipeline: string }
+): Promise<string | null> {
+  const { entityId, input, intakeLines, pipeline } = args
+  const trimmedMessage = input.userMessage?.trim() ?? ''
+  const contentParts: string[] = []
+  if (trimmedMessage) contentParts.push(trimmedMessage)
+  if (intakeLines.length > 0) contentParts.push(intakeLines.join('\n'))
+
+  // Attribution must not be silently dropped when the submission carries no
+  // other content (e.g. the V4 booking path sends only name/email/slot): an
+  // admin-facing summary line makes the context row exist so the metadata
+  // is persisted. Deliberately NOT part of intakeLines — those are rendered
+  // into the guest-visible calendar event description.
+  const attribution = input.attribution ?? null
+  if (attribution && contentParts.length === 0) {
+    const summary = attributionSummary(attribution)
+    if (summary) contentParts.push(`Ad attribution: ${summary}`)
+  }
+
+  if (contentParts.length === 0) return null
+
+  const contextEntry = await appendContext(db, orgId, {
+    entity_id: entityId,
+    type: 'intake',
+    content: contentParts.join('\n\n'),
+    source: pipeline,
+    metadata: {
+      name: input.name,
+      email: input.email,
+      phone: input.phone ?? null,
+      website: input.website ?? null,
+      user_message: trimmedMessage || null,
+      vertical: input.vertical,
+      employee_count: input.employeeCount,
+      years_in_business: input.yearsInBusiness,
+      biggest_challenge: input.biggestChallenge,
+      how_heard: input.howHeard,
+      interest: input.interest,
+      attribution,
+    },
+  })
+  return contextEntry.id
+}
+
+/**
  * Process an intake submission: find-or-create entity, create contact (if
  * new email), create meeting, and append intake context.
  *
@@ -251,34 +313,7 @@ export async function processIntakeSubmission(
   const meetingRes = await resolveMeeting(db, orgId, entityId, scheduledAt, preSeeded)
 
   const intakeLines = buildIntakeLines(input)
-  const trimmedMessage = input.userMessage?.trim() ?? ''
-  const contentParts: string[] = []
-  if (trimmedMessage) contentParts.push(trimmedMessage)
-  if (intakeLines.length > 0) contentParts.push(intakeLines.join('\n'))
-
-  let contextId: string | null = null
-  if (contentParts.length > 0) {
-    const contextEntry = await appendContext(db, orgId, {
-      entity_id: entityId,
-      type: 'intake',
-      content: contentParts.join('\n\n'),
-      source: pipeline,
-      metadata: {
-        name: input.name,
-        email: input.email,
-        phone: input.phone ?? null,
-        website: input.website ?? null,
-        user_message: trimmedMessage || null,
-        vertical: input.vertical,
-        employee_count: input.employeeCount,
-        years_in_business: input.yearsInBusiness,
-        biggest_challenge: input.biggestChallenge,
-        how_heard: input.howHeard,
-        interest: input.interest,
-      },
-    })
-    contextId = contextEntry.id
-  }
+  const contextId = await appendIntakeContext(db, orgId, { entityId, input, intakeLines, pipeline })
 
   return {
     entityId,

--- a/src/lib/marketing/attribution.ts
+++ b/src/lib/marketing/attribution.ts
@@ -1,0 +1,164 @@
+/**
+ * Ad-click attribution capture (ADR 0066 launch gate 1, #1722).
+ *
+ * First-touch capture of the enumerated paid-ad params into a first-party
+ * cookie at landing (set by middleware), read server-side at the intake and
+ * booking API boundaries, and persisted onto the D1 context row for the
+ * lead/booking so a closed engagement can be attributed to a campaign.
+ *
+ * DESIGN EXCEPTION — enumerated params only. The first-party events
+ * pipeline (src/pages/api/events.ts) deliberately never stores URL query
+ * strings. This module is the one sanctioned exception to that posture:
+ * it captures ONLY the enumerated ad-click keys below — never arbitrary
+ * query strings — with values length-capped and control-chars stripped.
+ *
+ * UTM convention (ADR 0066 §§5-6): `utm_content` carries the creative-angle
+ * key, mapped 1:1 to the ad creative under test; `utm_campaign` names the
+ * campaign; `utm_source`/`utm_medium` follow platform defaults
+ * (facebook/paid-social, google/cpc); `gclid`/`fbclid` are the platform
+ * click ids consumed by offline conversion upload (#1723 follow-on).
+ *
+ * Attribution is internal-only data: it must never render on any
+ * client-facing surface (calendar event descriptions, confirmation emails,
+ * portal pages). Admin surfaces (team notification email, entity timeline)
+ * are the only consumers.
+ */
+
+export const AD_ATTRIBUTION_KEYS = [
+  'utm_source',
+  'utm_medium',
+  'utm_campaign',
+  'utm_content',
+  'utm_term',
+  'gclid',
+  'fbclid',
+] as const
+
+export type AdAttributionKey = (typeof AD_ATTRIBUTION_KEYS)[number]
+
+export interface AdAttribution extends Partial<Record<AdAttributionKey, string>> {
+  /** ISO timestamp of the first-touch landing that set the cookie. */
+  landed_at?: string
+  /** Pathname (no query) of the first-touch landing page. */
+  landing_path?: string
+}
+
+export const ATTRIBUTION_COOKIE = 'ss_attr'
+
+/** 90 days — long enough to cover a considered B2B purchase cycle. */
+export const ATTRIBUTION_COOKIE_MAX_AGE_S = 90 * 24 * 60 * 60
+
+const MAX_VALUE_CHARS = 200
+
+// eslint-disable-next-line no-control-regex
+const CONTROL_CHARS = /[\u0000-\u001f\u007f]/g
+
+function sanitizeValue(raw: string): string | null {
+  const value = raw.trim().replace(CONTROL_CHARS, '').slice(0, MAX_VALUE_CHARS)
+  return value.length > 0 ? value : null
+}
+
+/**
+ * Cheap pre-check so the middleware skips URL parsing on the overwhelming
+ * majority of requests that carry no ad params at all.
+ */
+export function urlHasAttributionParams(url: URL): boolean {
+  const search = url.search
+  if (!search) return false
+  return search.includes('utm_') || search.includes('gclid') || search.includes('fbclid')
+}
+
+/**
+ * Extract the enumerated ad params from a landing URL. Returns null when
+ * none are present, so callers never store an empty attribution.
+ */
+export function parseAttributionFromUrl(url: URL, now: Date = new Date()): AdAttribution | null {
+  const out: AdAttribution = {}
+  let found = false
+  for (const key of AD_ATTRIBUTION_KEYS) {
+    const raw = url.searchParams.get(key)
+    if (raw === null) continue
+    const value = sanitizeValue(raw)
+    if (!value) continue
+    out[key] = value
+    found = true
+  }
+  if (!found) return null
+  out.landed_at = now.toISOString()
+  out.landing_path = url.pathname.slice(0, MAX_VALUE_CHARS)
+  return out
+}
+
+/**
+ * Re-validate an untrusted parsed object (cookie JSON, context metadata)
+ * into an AdAttribution. Enumerated keys only; anything else is dropped.
+ * Fail-closed: returns null unless at least one ad param survives.
+ */
+export function attributionFromUnknown(value: unknown): AdAttribution | null {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return null
+  const rec = value as Record<string, unknown>
+  const out: AdAttribution = {}
+  let found = false
+  for (const key of AD_ATTRIBUTION_KEYS) {
+    const raw = rec[key]
+    if (typeof raw !== 'string') continue
+    const sanitized = sanitizeValue(raw)
+    if (!sanitized) continue
+    out[key] = sanitized
+    found = true
+  }
+  if (!found) return null
+  if (typeof rec.landed_at === 'string') {
+    const landedAt = sanitizeValue(rec.landed_at)
+    if (landedAt) out.landed_at = landedAt
+  }
+  if (typeof rec.landing_path === 'string') {
+    const landingPath = sanitizeValue(rec.landing_path)
+    if (landingPath) out.landing_path = landingPath
+  }
+  return out
+}
+
+/**
+ * Cookie payload is plain JSON — Astro's cookies.set() URL-encodes it on
+ * write, and readAttributionFromCookieHeader decodes exactly once on read.
+ * Do not pre-encode here (double encoding breaks the read path).
+ */
+export function encodeAttributionCookie(attr: AdAttribution): string {
+  return JSON.stringify(attr)
+}
+
+/** Parse + fail-closed-validate a raw Cookie header into an AdAttribution. */
+export function readAttributionFromCookieHeader(cookieHeader: string | null): AdAttribution | null {
+  if (!cookieHeader) return null
+  for (const part of cookieHeader.split(';')) {
+    const eq = part.indexOf('=')
+    if (eq === -1) continue
+    if (part.slice(0, eq).trim() !== ATTRIBUTION_COOKIE) continue
+    try {
+      return attributionFromUnknown(JSON.parse(decodeURIComponent(part.slice(eq + 1).trim())))
+    } catch {
+      return null
+    }
+  }
+  return null
+}
+
+/**
+ * Compact one-line summary for ADMIN surfaces only (team notification
+ * email, entity timeline). Never render this on a client-facing surface.
+ */
+export function attributionSummary(attr: AdAttribution | null | undefined): string | null {
+  if (!attr) return null
+  const parts: string[] = []
+  const sourceMedium = [attr.utm_source, attr.utm_medium].filter(Boolean).join('/')
+  if (sourceMedium) parts.push(sourceMedium)
+  if (attr.utm_campaign) parts.push(`campaign: ${attr.utm_campaign}`)
+  if (attr.utm_content) parts.push(`ad: ${attr.utm_content}`)
+  if (attr.utm_term) parts.push(`term: ${attr.utm_term}`)
+  if (!sourceMedium) {
+    if (attr.gclid) parts.push('google ads click')
+    else if (attr.fbclid) parts.push('meta ads click')
+  }
+  return parts.length > 0 ? parts.join(' | ') : null
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -10,6 +10,13 @@ import {
   POST_REWRITE_REDIRECTS,
   firstRedirect,
 } from './lib/routing/legacy-redirects'
+import {
+  ATTRIBUTION_COOKIE,
+  ATTRIBUTION_COOKIE_MAX_AGE_S,
+  encodeAttributionCookie,
+  parseAttributionFromUrl,
+  urlHasAttributionParams,
+} from './lib/marketing/attribution'
 import { env } from 'cloudflare:workers'
 
 /**
@@ -176,6 +183,30 @@ function enforceAuth(context: APIContext, pathname: string): Response | null {
   return null
 }
 
+/**
+ * First-touch ad-attribution capture (ADR 0066 launch gate 1, #1722).
+ *
+ * On marketing hosts only: when a request lands carrying any enumerated ad
+ * param (utm_*, gclid, fbclid) and no attribution cookie exists yet, persist
+ * the params in a first-party httpOnly cookie. First-touch semantics: an
+ * existing cookie is never overwritten. The intake/booking APIs read the
+ * cookie server-side and store it on the lead's D1 context row.
+ */
+function captureAdAttribution(context: APIContext, hostname: string): void {
+  if (hostname.startsWith('admin.') || hostname.startsWith('portal.')) return
+  if (!urlHasAttributionParams(context.url)) return
+  if (context.cookies.has(ATTRIBUTION_COOKIE)) return
+  const attribution = parseAttributionFromUrl(context.url)
+  if (!attribution) return
+  context.cookies.set(ATTRIBUTION_COOKIE, encodeAttributionCookie(attribution), {
+    path: '/',
+    httpOnly: true,
+    secure: true,
+    sameSite: 'lax',
+    maxAge: ATTRIBUTION_COOKIE_MAX_AGE_S,
+  })
+}
+
 async function handleRequest(context: APIContext, next: NextFn): Promise<Response> {
   const { pathname } = context.url
   const hostname = context.url.hostname
@@ -194,6 +225,8 @@ async function handleRequest(context: APIContext, next: NextFn): Promise<Respons
   // legacy auth paths, retired marketing surfaces).
   const postRewrite = firstRedirect(POST_REWRITE_REDIRECTS, redirectCtx)
   if (postRewrite) return context.redirect(postRewrite.location, postRewrite.status)
+
+  captureAdAttribution(context, hostname)
 
   context.locals.session = null
   await resolveAdminSession(context, pathname)

--- a/src/pages/api/booking/reserve.ts
+++ b/src/pages/api/booking/reserve.ts
@@ -9,6 +9,10 @@ import {
   computeManageTokenExpiry,
 } from '../../../lib/booking/tokens'
 import { processIntakeSubmission, type PreSeededIntake } from '../../../lib/booking/intake-core'
+import {
+  readAttributionFromCookieHeader,
+  type AdAttribution,
+} from '../../../lib/marketing/attribution'
 import { rollbackFailedBooking } from '../../../lib/booking/rollback'
 import { createScheduleStatement, updateScheduleGoogleSync } from '../../../lib/booking/schedule'
 import { verifyBookingLink } from '../../../lib/booking/signed-link'
@@ -165,6 +169,8 @@ function calendarUnavailableJson(): Response {
 interface DbCommitArgs {
   input: ValidatedInput
   preSeeded: PreSeededIntake | null
+  /** First-touch ad attribution from the ss_attr cookie (ADR 0066 gate 1). */
+  attribution: AdAttribution | null
 }
 
 interface DbCommitResult {
@@ -228,8 +234,22 @@ async function seedScheduleSidecars(
   return { scheduleId, meetingScheduleId }
 }
 
+async function mintManageToken(
+  slotEndUtc: string
+): Promise<{ manageToken: string; manageTokenHash: string; manageTokenExpiresAt: string }> {
+  const manageToken = generateManageToken()
+  return {
+    manageToken,
+    manageTokenHash: await hashManageToken(manageToken),
+    manageTokenExpiresAt: computeManageTokenExpiry(
+      slotEndUtc,
+      BOOKING_CONFIG.manage_token_ttl_hours_after_slot
+    ),
+  }
+}
+
 async function commitBookingToDb(args: DbCommitArgs): Promise<DbCommitResult> {
-  const { input, preSeeded } = args
+  const { input, preSeeded, attribution } = args
   const {
     name,
     email,
@@ -262,6 +282,7 @@ async function commitBookingToDb(args: DbCommitArgs): Promise<DbCommitResult> {
       yearsInBusiness,
       biggestChallenge,
       howHeard,
+      attribution,
     },
     {
       scheduledAt: slotStartUtc,
@@ -277,12 +298,7 @@ async function commitBookingToDb(args: DbCommitArgs): Promise<DbCommitResult> {
   const assessmentId = intakeResult.assessmentId!
   const meetingId = intakeResult.meetingId!
 
-  const manageToken = generateManageToken()
-  const manageTokenHash = await hashManageToken(manageToken)
-  const manageTokenExpiresAt = computeManageTokenExpiry(
-    slotEndUtc,
-    BOOKING_CONFIG.manage_token_ttl_hours_after_slot
-  )
+  const { manageToken, manageTokenHash, manageTokenExpiresAt } = await mintManageToken(slotEndUtc)
 
   // Create assessment_schedule (legacy) and meeting_schedule (canonical) sidecars.
   const { scheduleId, meetingScheduleId } = await seedScheduleSidecars({
@@ -447,9 +463,13 @@ async function handlePost({ request }: APIContext): Promise<Response> {
     })
   }
 
+  // First-touch ad attribution, set by middleware on the landing request
+  // (ADR 0066 gate 1). Server-side read — the client never sends it.
+  const attribution = readAttributionFromCookieHeader(request.headers.get('cookie'))
+
   let dbResult: DbCommitResult
   try {
-    dbResult = await commitBookingToDb({ input: validated, preSeeded })
+    dbResult = await commitBookingToDb({ input: validated, preSeeded, attribution })
   } catch (err) {
     console.error('[api/booking/reserve] DB commit failed:', err)
     await releaseHold(env.DB, holdResult.id!)

--- a/src/pages/api/intake/send.ts
+++ b/src/pages/api/intake/send.ts
@@ -7,6 +7,11 @@ import { ALLOWED_INTERESTS, interestLabel } from '../../../lib/booking/config'
 import { trimString, isValidEmail, escapeHtml, jsonResponse } from '../../../lib/api/helpers'
 import { sendEmail } from '../../../lib/email/resend'
 import { buildAdminUrl } from '../../../lib/config/app-url'
+import {
+  attributionSummary,
+  readAttributionFromCookieHeader,
+  type AdAttribution,
+} from '../../../lib/marketing/attribution'
 
 const NOTIFY_EMAIL = 'team@smd.services'
 const RATE_LIMIT_PER_HOUR = 10
@@ -116,6 +121,10 @@ async function handlePost({ request, clientAddress }: APIContext): Promise<Respo
   const validated = validateSendBody(body)
   if (validated instanceof Response) return validated
 
+  // First-touch ad attribution, set by middleware on the landing request
+  // (ADR 0066 gate 1). Server-side read — the client never sends it.
+  const attribution = readAttributionFromCookieHeader(request.headers.get('cookie'))
+
   let intakeResult: Awaited<ReturnType<typeof processIntakeSubmission>>
   try {
     intakeResult = await processIntakeSubmission(
@@ -129,6 +138,7 @@ async function handlePost({ request, clientAddress }: APIContext): Promise<Respo
         website: validated.website,
         userMessage: validated.messageRaw || null,
         interest: validated.interest,
+        attribution,
       },
       { source: 'website_intake_send' }
     )
@@ -142,6 +152,7 @@ async function handlePost({ request, clientAddress }: APIContext): Promise<Respo
       ...validated,
       entityId: intakeResult.entityId,
       message: validated.messageRaw,
+      attribution,
     })
   } catch (emailErr) {
     console.error('[api/intake/send] Admin notification failed:', emailErr)
@@ -161,6 +172,7 @@ interface AdminNotificationParams {
   message: string
   entityId: string
   interest: string | null
+  attribution: AdAttribution | null
 }
 
 async function sendAdminNotification(
@@ -176,10 +188,13 @@ async function sendAdminNotification(
   const escapedMessage = params.message ? escapeHtml(params.message) : null
   const intentLabel = interestLabel(params.interest)
   const escapedInterest = intentLabel ? escapeHtml(intentLabel) : null
+  const attrSummary = attributionSummary(params.attribution)
+  const escapedAttribution = attrSummary ? escapeHtml(attrSummary) : null
 
   const html = [
     `<p><strong>${escapedName}</strong> &lt;${escapedEmail}&gt; from <strong>${escapedBusiness}</strong> sent a message via the Send path on /book.</p>`,
     escapedInterest ? `<p><strong>Inquiring about:</strong> ${escapedInterest}</p>` : '',
+    escapedAttribution ? `<p><strong>Ad source:</strong> ${escapedAttribution}</p>` : '',
     escapedPhone ? `<p>Phone: ${escapedPhone}</p>` : '',
     escapedWebsite ? `<p>Website: <a href="${escapedWebsite}">${escapedWebsite}</a></p>` : '',
     '<hr>',
@@ -192,7 +207,10 @@ async function sendAdminNotification(
     .filter(Boolean)
     .join('')
 
-  const subjectPrefix = interestLabel ? `[${interestLabel}] ` : ''
+  // Pre-existing bug fixed alongside #1722: this interpolated the imported
+  // interestLabel FUNCTION (always truthy — every subject got function
+  // source), not the resolved label for this lead.
+  const subjectPrefix = intentLabel ? `[${intentLabel}] ` : ''
   await sendEmail(workerEnv.RESEND_API_KEY, {
     to: NOTIFY_EMAIL,
     reply_to: params.email,

--- a/tests/attribution.test.ts
+++ b/tests/attribution.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Unit tests for the ad-click attribution module (ADR 0066 launch gate 1,
+ * #1722): enumerated-params-only parsing, fail-closed cookie decoding,
+ * first-party cookie header reading, and the admin summary line.
+ *
+ * The enumerated-keys constraint is load-bearing: the first-party events
+ * pipeline deliberately never stores query strings, and this module is the
+ * one sanctioned exception — these tests pin that it can never widen into
+ * arbitrary-query-string capture.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  AD_ATTRIBUTION_KEYS,
+  ATTRIBUTION_COOKIE,
+  attributionFromUnknown,
+  attributionSummary,
+  encodeAttributionCookie,
+  parseAttributionFromUrl,
+  readAttributionFromCookieHeader,
+  urlHasAttributionParams,
+} from '../src/lib/marketing/attribution'
+
+const NOW = new Date('2026-07-05T12:00:00.000Z')
+
+describe('urlHasAttributionParams', () => {
+  it('is false for clean URLs and true for each param family', () => {
+    expect(urlHasAttributionParams(new URL('https://smd.services/packs/law-firm'))).toBe(false)
+    expect(urlHasAttributionParams(new URL('https://smd.services/?ref=x'))).toBe(false)
+    expect(urlHasAttributionParams(new URL('https://smd.services/?utm_source=facebook'))).toBe(true)
+    expect(urlHasAttributionParams(new URL('https://smd.services/?gclid=abc'))).toBe(true)
+    expect(urlHasAttributionParams(new URL('https://smd.services/?fbclid=abc'))).toBe(true)
+  })
+})
+
+describe('parseAttributionFromUrl', () => {
+  it('captures only the enumerated ad params, never arbitrary query strings', () => {
+    const url = new URL(
+      'https://smd.services/packs/law-firm?utm_source=facebook&utm_medium=paid-social&utm_campaign=law-ops-r1&utm_content=angle-salary&secret=nope&email=x%40y.com'
+    )
+    const attr = parseAttributionFromUrl(url, NOW)
+    expect(attr).not.toBeNull()
+    expect(attr!.utm_source).toBe('facebook')
+    expect(attr!.utm_medium).toBe('paid-social')
+    expect(attr!.utm_campaign).toBe('law-ops-r1')
+    expect(attr!.utm_content).toBe('angle-salary')
+    expect(attr!.landing_path).toBe('/packs/law-firm')
+    expect(attr!.landed_at).toBe(NOW.toISOString())
+    // The non-enumerated params must not appear anywhere in the output.
+    expect(JSON.stringify(attr)).not.toContain('nope')
+    expect(JSON.stringify(attr)).not.toContain('y.com')
+  })
+
+  it('returns null when no ad params are present (never stores empty attribution)', () => {
+    expect(parseAttributionFromUrl(new URL('https://smd.services/?page=2'), NOW)).toBeNull()
+  })
+
+  it('caps value length and strips control characters', () => {
+    const long = 'a'.repeat(500)
+    const url = new URL(`https://smd.services/?utm_source=${long}&utm_term=a%0Ab%00c`)
+    const attr = parseAttributionFromUrl(url, NOW)
+    expect(attr!.utm_source!.length).toBe(200)
+    expect(attr!.utm_term).toBe('abc')
+  })
+})
+
+describe('attributionFromUnknown (fail-closed re-validation)', () => {
+  it('rejects non-objects', () => {
+    expect(attributionFromUnknown(null)).toBeNull()
+    expect(attributionFromUnknown('utm_source=x')).toBeNull()
+    expect(attributionFromUnknown(42)).toBeNull()
+    expect(attributionFromUnknown(['utm_source'])).toBeNull()
+  })
+
+  it('drops non-enumerated keys and non-string values', () => {
+    const attr = attributionFromUnknown({
+      utm_source: 'google',
+      utm_medium: 7,
+      injected_key: 'evil',
+      __proto__: { hacked: true },
+    })
+    expect(attr).toEqual(expect.objectContaining({ utm_source: 'google' }))
+    expect(attr).not.toHaveProperty('utm_medium')
+    expect(attr).not.toHaveProperty('injected_key')
+    expect(attr).not.toHaveProperty('hacked')
+  })
+
+  it('returns null when no enumerated ad param survives (landed_at alone is not attribution)', () => {
+    expect(attributionFromUnknown({ landed_at: '2026-07-05', landing_path: '/x' })).toBeNull()
+  })
+})
+
+describe('cookie round-trip', () => {
+  it('encodes plain JSON and reads back through a raw Cookie header', () => {
+    const attr = parseAttributionFromUrl(
+      new URL('https://smd.services/operator?utm_source=google&utm_medium=cpc&gclid=XyZ123'),
+      NOW
+    )!
+    // Astro's cookies.set URL-encodes the value on write; simulate that.
+    const header = `other=1; ${ATTRIBUTION_COOKIE}=${encodeURIComponent(encodeAttributionCookie(attr))}; theme=dark`
+    const restored = readAttributionFromCookieHeader(header)
+    expect(restored).toEqual(attr)
+  })
+
+  it('fails closed on missing, malformed, and garbage cookie values', () => {
+    expect(readAttributionFromCookieHeader(null)).toBeNull()
+    expect(readAttributionFromCookieHeader('theme=dark')).toBeNull()
+    expect(readAttributionFromCookieHeader(`${ATTRIBUTION_COOKIE}=not-json`)).toBeNull()
+    expect(readAttributionFromCookieHeader(`${ATTRIBUTION_COOKIE}=%7B%22a%22%3A`)).toBeNull()
+    expect(
+      readAttributionFromCookieHeader(`${ATTRIBUTION_COOKIE}=${encodeURIComponent('{"x":"y"}')}`)
+    ).toBeNull()
+  })
+})
+
+describe('attributionSummary', () => {
+  it('renders source/medium, campaign, ad angle, and term', () => {
+    const summary = attributionSummary({
+      utm_source: 'facebook',
+      utm_medium: 'paid-social',
+      utm_campaign: 'law-ops-r1',
+      utm_content: 'angle-salary',
+    })
+    expect(summary).toBe('facebook/paid-social | campaign: law-ops-r1 | ad: angle-salary')
+  })
+
+  it('falls back to the click-id family when no utm_source is present', () => {
+    expect(attributionSummary({ gclid: 'abc' })).toBe('google ads click')
+    expect(attributionSummary({ fbclid: 'abc' })).toBe('meta ads click')
+    expect(attributionSummary(null)).toBeNull()
+  })
+})
+
+describe('enumerated key list', () => {
+  it('stays the sanctioned seven — widening this list needs a recorded decision', () => {
+    expect([...AD_ATTRIBUTION_KEYS]).toEqual([
+      'utm_source',
+      'utm_medium',
+      'utm_campaign',
+      'utm_content',
+      'utm_term',
+      'gclid',
+      'fbclid',
+    ])
+  })
+})


### PR DESCRIPTION
Closes #1722.

## What

First launch gate of ADR 0066: the funnel can now attribute a lead/booking to a paid ad.

- **Middleware capture** (`src/middleware.ts`): marketing-host landings carrying any enumerated ad param (`utm_source|medium|campaign|content|term`, `gclid`, `fbclid`) set a first-party httpOnly `ss_attr` cookie (90d, lax, secure). **First-touch: an existing cookie is never overwritten.** Admin/portal hosts excluded.
- **New module** `src/lib/marketing/attribution.ts`: enumerated-params-only parsing (values length-capped, control-chars stripped), fail-closed cookie decoding, admin summary line. This is the one documented exception to the events-pipeline never-store-query-strings posture — pinned by a test that the key list can't silently widen.
- **API threading**: `/api/intake/send` and `/api/booking/reserve` read the cookie **server-side** (the client never sends attribution) and persist it in the intake context metadata via `processIntakeSubmission`. On the booking path (which carries no message content) an attribution-only context row is written so the data survives.
- **Admin surfacing**: entity timeline intake rows append `Ad source: <summary>`; the send-path team email gets an **Ad source** line. Attribution stays out of `intakeLines` — those render into the **guest-visible** calendar event description.
- **utm_content = creative angle** convention documented in the module header (ADR 0066 §§5-6).

## Also fixes

Pre-existing bug surfaced by lint in the same function: the send-path admin email subject interpolated the imported `interestLabel` **function** (always truthy) instead of the resolved label — every subject prefix rendered function source.

## Refactors (lint ceilings)

- `appendIntakeContext` extracted from `processIntakeSubmission` (complexity 19→under 15)
- `mintManageToken` extracted from `commitBookingToDb` (76→under 75 lines)

## Testing

- 12 new unit tests (`tests/attribution.test.ts`): enumerated-only capture, arbitrary-param exclusion, length caps/control-char stripping, fail-closed decode (garbage/malformed/prototype keys), cookie round-trip incl. Astro URL-encoding, summary rendering, key-list pin.
- `npm run verify` green (typecheck, workers typecheck, format, lint, build, tests, workers tests).
- **Post-deploy live verification** (issue AC): synthetic UTM visit → booking → D1 context row shows attribution; will record via crane_verify and comment on #1722.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dn4PdiBhaVUDhVazdUoocC