### PR TITLE
feat(ads): GA4 conversion events — lead + book_confirmed (ADR 0066 gate 3, code side)

### DIFF
--- a/public/js/ga4-init.js
+++ b/public/js/ga4-init.js
@@ -46,6 +46,10 @@
   }
 
   window.gtag('js', new Date())
+  // allow_google_signals stays FALSE by conscious decision (ADR 0066 gate 3,
+  // #1724): GA4 is a reporting install. Flipping it (Google Ads remarketing,
+  // cross-device) is a deliberate step at Google Ads launch, paired with
+  // Consent Mode - do not enable it casually.
   window.gtag('config', measurementId, {
     anonymize_ip: true,
     allow_google_signals: false,

--- a/src/scripts/book.ts
+++ b/src/scripts/book.ts
@@ -64,6 +64,17 @@ function fireMetaBrowserEvent(eventName: 'Lead' | 'Schedule', eventId: string | 
   fbq('track', eventName, {}, { eventID: eventId })
 }
 
+/**
+ * GA4 conversion events (ADR 0066 gate 3, #1724), via the ssTrackEvent
+ * helper exposed by public/js/ga4-init.js. No-op when GA4 isn't loaded.
+ * Params must stay PII-free (GA4 policy) — slugs only, never email/name.
+ */
+function fireGa4Event(eventName: 'lead' | 'book_confirmed', params?: Record<string, string>): void {
+  const track = (window as { ssTrackEvent?: (name: string, params?: object) => void }).ssTrackEvent
+  if (typeof track !== 'function') return
+  track(eventName, params)
+}
+
 // ---------------------------------------------------------------------------
 // Form-data helpers
 // ---------------------------------------------------------------------------
@@ -145,6 +156,7 @@ async function submitIntake(
     }
 
     fireMetaBrowserEvent('Lead', body.meta_event_id)
+    fireGa4Event('lead', payload.interest ? { interest: payload.interest } : undefined)
 
     state.email = payload.email
     state.name = payload.name
@@ -202,6 +214,7 @@ async function handleConfirmSlot(els: BookElements, state: BookState): Promise<v
 
     if (res.status === 201) {
       fireMetaBrowserEvent('Schedule', body.meta_event_id)
+      fireGa4Event('book_confirmed')
       showClosedBooked(els, state, body)
       return
     }


### PR DESCRIPTION
Part of #1724 (leaves the issue open for the account-side steps).

## What

- `lead` GA4 event on intake success (interest slug as param when present — PII-free) and `book_confirmed` on booking 201, fired via the existing `window.ssTrackEvent` helper on the same success callbacks that fire the Meta dedup events (#1729). No-op when GA4 isn't loaded.
- Documents the conscious `allow_google_signals: false` posture in `ga4-init.js`: it stays off until Google Ads launch flips it deliberately, paired with Consent Mode v2 (ADR 0066 gate 3).

## Account-side remainder (kept on #1724, not closable by this PR)

1. Mark `lead` + `book_confirmed` as key events in the GA4 property UI
2. Migrate the GA4 property out of the Venture Crane account to SMD ownership (gate 5, identity-separation rule)

## Testing

`npm run verify` fully green. Events observable in GA4 DebugView once the account-side steps land; client helper is a guarded no-op otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dn4PdiBhaVUDhVazdUoocC