### PR TITLE
feat(ads): consent hygiene — privacy choices, ad-measurement disclosure, GPC (ADR 0066 gate 4)

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -69,6 +69,9 @@ import { bookHref } from '../lib/booking/config'
       <div class="flex flex-wrap gap-x-6 gap-y-2">
         <a href="/terms" class="hover:text-white" data-ev="footer-terms">Terms</a>
         <a href="/privacy" class="hover:text-white" data-ev="footer-privacy">Privacy</a>
+        <a href="/privacy#privacy-choices" class="hover:text-white" data-ev="footer-privacy-choices"
+          >Your Privacy Choices</a
+        >
         <a href="/security" class="hover:text-white" data-ev="footer-security">Security</a>
         <a href="/ai-disclosure" class="hover:text-white" data-ev="footer-ai-disclosure"
           >AI Disclosure</a

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -20,7 +20,7 @@ import Footer from '../components/Footer.astro'
       <p
         class="mt-3 font-['Archivo_Narrow'] text-xs uppercase tracking-[0.12em] text-[color:var(--ss-color-text-muted)]"
       >
-        Effective: 2026-05-04
+        Effective: 2026-07-05
       </p>
 
       <div
@@ -28,7 +28,7 @@ import Footer from '../components/Footer.astro'
       >
         <p>
           We collect only what you give us, use it to respond and prepare for our conversation, and
-          never sell or share it with third parties.
+          do not sell your personal information.
         </p>
 
         <section>
@@ -52,7 +52,8 @@ import Footer from '../components/Footer.astro'
           </h2>
           <p>
             To respond to your inquiry, prepare for our conversation, and deliver the work if we are
-            engaged. We do not sell, rent, or share this information with third parties.
+            engaged. We do not sell or rent your information, and we share it only with the service
+            providers and the advertising measurement described below.
           </p>
         </section>
 
@@ -78,13 +79,47 @@ import Footer from '../components/Footer.astro'
           <p>
             We use a first-party session cookie to support the booking and contact flows. We use
             Google Analytics 4 to measure overall site traffic, with IP addresses anonymized and
-            Google's advertising and personalization signals disabled. We do not run advertising
-            trackers or behavioral profiling. See <a
+            Google's advertising and personalization signals disabled. See <a
               href="https://policies.google.com/privacy"
               class="underline decoration-[color:var(--ss-color-primary)] decoration-2 underline-offset-4 hover:text-[color:var(--ss-color-primary)]"
               rel="noopener noreferrer"
               target="_blank">Google's privacy policy</a
             > for how Analytics processes data.
+          </p>
+          <p class="mt-4">
+            If you arrive here from one of our ads, we store the campaign parameters carried by that
+            link (such as the campaign and ad name) in a first-party cookie for 90 days, so we can
+            tell which ads lead to real conversations. That cookie describes the ad you clicked, not
+            you.
+          </p>
+          <p class="mt-4">
+            When we run advertising campaigns, we also use Meta's pixel and Conversions API to
+            measure whether our ads lead to booked conversations. That measurement shares limited
+            technical data with Meta, such as a hashed form of your email and the ad click
+            identifier, with Meta's Limited Data Use mode enabled. We honor the Global Privacy
+            Control signal: if your browser sends it, the pixel never loads.
+          </p>
+        </section>
+
+        <section id="privacy-choices">
+          <h2
+            class="mb-3 font-['Archivo_Narrow'] text-sm font-bold uppercase tracking-[0.14em] text-[color:var(--ss-color-primary)]"
+          >
+            Your privacy choices
+          </h2>
+          <p>
+            We do not sell your personal information. Where advertising measurement counts as
+            sharing under state privacy laws such as the California Consumer Privacy Act, you can
+            opt out two ways: turn on <a
+              href="https://globalprivacycontrol.org/"
+              class="underline decoration-[color:var(--ss-color-primary)] decoration-2 underline-offset-4 hover:text-[color:var(--ss-color-primary)]"
+              rel="noopener noreferrer"
+              target="_blank">Global Privacy Control</a
+            > in your browser and we honor it automatically, or <a
+              href="/contact"
+              class="underline decoration-[color:var(--ss-color-primary)] decoration-2 underline-offset-4 hover:text-[color:var(--ss-color-primary)]"
+              >reach out</a
+            > and we will exclude you from advertising measurement.
           </p>
         </section>
 


### PR DESCRIPTION
Part of #1725. **Requesting Captain review — compliance-sensitive policy copy; not self-merging.**

## What

- **Privacy policy** (`/privacy`): discloses the first-party attribution cookie (90d, campaign params, 'describes the ad you clicked, not you') and Meta pixel/CAPI measurement in conditional *when we run advertising campaigns* language — truthful today (pixel fail-closed) and after activation. Removes the absolute *'we do not run advertising trackers'* / *'never share'* claims that pixel activation would falsify.
- **Your Privacy Choices** (`/privacy#privacy-choices`): CCPA/CPRA share opt-out — GPC honored automatically (pixel loader already checks it, #1729), or contact us to be excluded. Footer link added.
- Effective date bumped to 2026-07-05.

## Sequencing (load-bearing)

Must be **deployed before** `PUBLIC_META_PIXEL_ID` is ever set. Recorded for the #1727 launch runbook.

## Consent-banner decision

Recorded as **no banner**: GA4 is anonymized with signals off, the pixel honors GPC, US opt-out regime applies. Revisit only on counsel advice.

## Testing

`npm run verify` fully green (forbidden-strings/style guards included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dn4PdiBhaVUDhVazdUoocC