### PR TITLE
feat(operator): bump OVERLAY_REF -> 3e5b8a9b (Sentry boot marker)

### DIFF
--- a/operator/contracts/overlay-pairs.json
+++ b/operator/contracts/overlay-pairs.json
@@ -1,6 +1,6 @@
 {
   "overlayRepo": "https://github.com/venturecrane/hermes-smd-overlay.git",
-  "overlayRef": "50a6545e76afd947a7bbff9bcc17a30cf10f61ac",
+  "overlayRef": "3e5b8a9b773eeb44f0cae752ae272716e1e21840",
   "overlayRefNote": "MUST equal the ARG OVERLAY_REF pinned in operator/templates/Dockerfile \u2014 that is the overlay commit a customer Machine actually ships. The vitest gate asserts the two agree so the manifest cannot pin a stale overlay. Bump both together when OVERLAY_REF moves, then re-record each overlaySha256 from the runtime file at the new ref. 2026-07-05: 7e70b376 -> c85b0ddb (overlay#133 cost-breaker boot self-probe). Fast-forward, 3 files (hooks/smd-overlay-activation/handler.py, shared/cost_breaker.py, tests/test_activation_hook.py) \u2014 NO tracked twin touched, so every overlaySha256 below is unchanged; only overlayRef moved.",
   "pairs": [
     {

--- a/operator/templates/Dockerfile
+++ b/operator/templates/Dockerfile
@@ -254,7 +254,7 @@ ARG OVERLAY_REPO="https://github.com/venturecrane/hermes-smd-overlay.git"
 # AgentMail email-reply channel keeps the email prompt; MCP route untouched. Not a
 # tracked pair (bootstrap/translate.py); all 4 tracked twins unchanged across
 # 2b694947→9b20a1ac, overlaySha256 stable. Superset of 33b58ad.
-ARG OVERLAY_REF="50a6545e76afd947a7bbff9bcc17a30cf10f61ac"
+ARG OVERLAY_REF="3e5b8a9b773eeb44f0cae752ae272716e1e21840"
 
 ARG CUSTOMER_SLUG=customer-zero
 

--- a/tests/operator-dockerfile.test.ts
+++ b/tests/operator-dockerfile.test.ts
@@ -266,7 +266,14 @@ describe('Operator customer Machine Dockerfile', () => {
     // discovery, opposing responses), so reading a matter document taints the
     // session like an inbound email. Range c85b0ddb..50a6545e touches only
     // shared/action_classes.py + the inbound fence + tests; no tracked twin moved.
-    expect(DOCKERFILE).toContain('ARG OVERLAY_REF="50a6545e76afd947a7bbff9bcc17a30cf10f61ac"')
+    // (That range ALSO carried #134/#135, the Sentry init + PII scrub — see the
+    // Sentry-on-Machines memory; likewise no tracked twin.)
+    // 3e5b8a9b (#137, ss#0023): Sentry boot marker — init_sentry now sends one
+    // info capture_message("boot: monitoring active") per process, the direct
+    // in-Sentry confirmation the gateway init fired (its INFO log is filtered by
+    // Hermes' root=WARNING) + a per-boot restart signal. Range 50a6545e..3e5b8a9b
+    // touches only shared/sentry_init.py + tests; no tracked twin moved.
+    expect(DOCKERFILE).toContain('ARG OVERLAY_REF="3e5b8a9b773eeb44f0cae752ae272716e1e21840"')
   })
 
   it('does NOT swallow a failed plugin install (no fail-open `|| echo ... continuing`)', () => {


### PR DESCRIPTION
## Summary
Pins overlay #137 — `init_sentry` now sends one info `capture_message("boot: monitoring active")` per process after a successful init. The direct in-Sentry confirmation the gateway init fired (its INFO log is filtered by Hermes' root=WARNING logger, so `fly logs` never showed it), plus a per-boot restart signal.
- Clean fast-forward `50a6545e..3e5b8a9b` touching only `shared/sentry_init.py` + tests. **No tracked twin moved** — every `overlaySha256` unchanged, only `overlayRef` advances.

## Test plan
- [x] `tests/operator-dockerfile.test.ts` (15) — Dockerfile ARG ⇔ `overlayRef` agreement holds at the new sha.
- [ ] CI green.
- [ ] Post-merge: reprovision `hermes-smd`, confirm a `component=gateway` "boot: monitoring active" event in the `smd-operator` Sentry project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)