### PR TITLE
feat(operator): activate Sentry 24h error-count sync (ADR 0023 #4)

### DIFF
--- a/workers/cost-anomaly/src/index.ts
+++ b/workers/cost-anomaly/src/index.ts
@@ -55,7 +55,7 @@ export interface Env {
    * `smd-operator` Sentry project; staged on this Worker via
    * `wrangler secret put` after PR 5 lands.
    */
-  SENTRY_API_TOKEN?: string
+  SENTRY_AUTH_TOKEN?: string
   SENTRY_ORG_SLUG?: string
   SENTRY_PROJECT_ID?: string
 }
@@ -269,10 +269,10 @@ async function runSentrySync(
   env: Env,
   customers: CustomerRow[]
 ): Promise<RunSummary['sentrySync']> {
-  if (!env.SENTRY_API_TOKEN || !env.SENTRY_ORG_SLUG || !env.SENTRY_PROJECT_ID) {
+  if (!env.SENTRY_AUTH_TOKEN || !env.SENTRY_ORG_SLUG || !env.SENTRY_PROJECT_ID) {
     return {
       ran: false,
-      reason: 'SENTRY_API_TOKEN / SENTRY_ORG_SLUG / SENTRY_PROJECT_ID not configured',
+      reason: 'SENTRY_AUTH_TOKEN / SENTRY_ORG_SLUG / SENTRY_PROJECT_ID not configured',
       results: [],
     }
   }

--- a/workers/cost-anomaly/src/sentry-sync.test.ts
+++ b/workers/cost-anomaly/src/sentry-sync.test.ts
@@ -18,7 +18,7 @@ import {
 } from './sentry-sync'
 
 const FULL_ENV: SentrySyncEnv = {
-  SENTRY_API_TOKEN: 'sentry-tok',
+  SENTRY_AUTH_TOKEN: 'sentry-tok',
   SENTRY_ORG_SLUG: 'smd',
   SENTRY_PROJECT_ID: '12345',
 }

--- a/workers/cost-anomaly/src/sentry-sync.ts
+++ b/workers/cost-anomaly/src/sentry-sync.ts
@@ -9,13 +9,13 @@
  * Shape of the call (per https://docs.sentry.io/api/):
  *   GET https://sentry.io/api/0/organizations/{org}/events/
  *     ?field=count()&query=tenant:<slug>&statsPeriod=24h&project={project_id}
- *   Authorization: Bearer <SENTRY_API_TOKEN>
+ *   Authorization: Bearer <SENTRY_AUTH_TOKEN>
  *
  * Response shape (success):
  *   { "data": [{ "count()": N }] }
  *
  * Failure handling:
- *   - Missing env (no SENTRY_API_TOKEN / SENTRY_ORG_SLUG / SENTRY_PROJECT_ID)
+ *   - Missing env (no SENTRY_AUTH_TOKEN / SENTRY_ORG_SLUG / SENTRY_PROJECT_ID)
  *     → skip entirely; log once at INFO. Lets PR 4 ship before PR 5 wires
  *     the credentials.
  *   - Per-customer HTTP error / parse error → write `sentry_errors_last_24h
@@ -31,7 +31,7 @@
 const SENTRY_API_BASE = 'https://sentry.io/api/0'
 
 export interface SentrySyncEnv {
-  SENTRY_API_TOKEN?: string
+  SENTRY_AUTH_TOKEN?: string
   SENTRY_ORG_SLUG?: string
   SENTRY_PROJECT_ID?: string
 }
@@ -57,7 +57,7 @@ export async function fetchTenantErrorsLast24h(
   tenantSlug: string,
   fetchImpl: typeof fetch = fetch
 ): Promise<SentrySyncResult> {
-  if (!env.SENTRY_API_TOKEN || !env.SENTRY_ORG_SLUG || !env.SENTRY_PROJECT_ID) {
+  if (!env.SENTRY_AUTH_TOKEN || !env.SENTRY_ORG_SLUG || !env.SENTRY_PROJECT_ID) {
     return {
       customer_slug: tenantSlug,
       status: 'unavailable',
@@ -77,7 +77,7 @@ export async function fetchTenantErrorsLast24h(
   let response: Response
   try {
     response = await fetchImpl(url, {
-      headers: { Authorization: `Bearer ${env.SENTRY_API_TOKEN}` },
+      headers: { Authorization: `Bearer ${env.SENTRY_AUTH_TOKEN}` },
     })
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e)

--- a/workers/cost-anomaly/wrangler.toml
+++ b/workers/cost-anomaly/wrangler.toml
@@ -46,7 +46,17 @@ ANOMALY_THRESHOLD_BPS = "15000"
 # (team@smd.services). Captain expects a recognizable sender.
 ALERT_FROM_EMAIL = "SMD Services Ops <team@smd.services>"
 
+# Sentry 24h error-count sync (ADR 0023 Wave 1 #4). Org slug + project id are
+# non-sensitive identifiers of the shared smd-operator project, so they live
+# here declaratively; the read token is the secret (below). All three must be
+# present for the daily sync to run — missing any one skips it (disabled-safe).
+SENTRY_ORG_SLUG = "smdurgan-llc"
+SENTRY_PROJECT_ID = "4511689128148992"
+
 # Secrets (set via `wrangler secret put` after first deploy):
 #   RESEND_API_KEY        — Resend API key for Captain notification email
 #   ALERT_TO_EMAIL        — Captain inbox (e.g. smdurgan@venturecrane.com)
 #   COST_ANOMALY_BEARER   — Bearer token for manual /run invocations
+#   SENTRY_AUTH_TOKEN     — Sentry read token (event:read + project:read +
+#                           org:read), from Infisical /ss. Powers the 24h
+#                           error-count sync into fleet_status.


### PR DESCRIPTION
## Summary
The Sentry error-count sync (`workers/cost-anomaly/src/sentry-sync.ts`), the `fleet_status` columns, and the "Sentry 24h" admin dashboard column all already shipped. This wires the credentials so the daily sync **runs**.

- Renamed the worker env var `SENTRY_API_TOKEN` → **`SENTRY_AUTH_TOKEN`** across `sentry-sync.ts` + `index.ts` + tests. That's Sentry's own convention (sentry-cli/SDK) and matches the key already in Infisical `/ss`, so the standard `wrangler secret bulk` sync auto-wires it — no duplicate secret.
- Declared `SENTRY_ORG_SLUG=smdurgan-llc` + `SENTRY_PROJECT_ID=4511689128148992` as `[vars]` (non-sensitive identifiers of the shared `smd-operator` project).
- Verified the exact Discover query the sync makes returns `200` + `{"data":[{"count()":N}]}` against the live project with the `event:read` token.
- Still disabled-safe: missing any of the three skips the sync.

## Test plan
- [x] `workers/cost-anomaly` vitest — 17 passed.
- [x] Worker `tsc --noEmit` clean.
- [ ] CI green.

## Post-merge activation (out-of-band)
`wrangler secret put SENTRY_AUTH_TOKEN` on `ss-cost-anomaly` (value from `/ss`), then the 03:00 UTC cron populates `fleet_status.sentry_errors_last_24h` and the dashboard shows per-Machine counts. I'll set the secret + trigger a manual `/run` to verify.

## Not in this PR — the webhook (push) half of #4
`src/pages/api/webhooks/sentry.ts` is coded and HMAC-verified but needs a Sentry **Internal Integration** (to sign deliveries) + `SENTRY_WEBHOOK_SECRET`. That's a Sentry-side setup step; flagged for follow-up. Email alerts + the daily dashboard count already cover the monitoring need.

🤖 Generated with [Claude Code](https://claude.com/claude-code)