### PR TITLE
feat(operator): pre_run no-agent gates live — cron wakes stop billing idle tokens (#1748)

### DIFF
--- a/operator/contracts/audit-action-type-producers.json
+++ b/operator/contracts/audit-action-type-producers.json
@@ -268,8 +268,8 @@
     },
     "SUPPRESSED_WAKE": {
       "side": "ss-console",
-      "producerFile": "operator/adapter/audit_log.py",
-      "note": "SuppressedWakeWriter emits SUPPRESSED_WAKE before pre_run.py prints {wakeAgent:false}; called from skills' pre_run.py."
+      "producerFile": "operator/workspace_broker/server.py",
+      "note": "Broker-stamped via the uid-gated suppressed_wake_append verb (#1748): skills' pre_run.py (shared empty-seat gate at operator/templates/pre_run_gate.py, plus deadline-miss-escalator's bespoke gate) send the row over the broker socket before printing {wakeAgent:false}. The adapter SuppressedWakeWriter (operator/adapter/audit_log.py) remains the dev/test writer."
     },
     "REPLY_SENT": {
       "side": "overlay",

--- a/operator/customers/ashton-price/customer.yaml
+++ b/operator/customers/ashton-price/customer.yaml
@@ -346,12 +346,15 @@ personas:
           scheduled: true
           webhook: false
         enabled: true
-    # The escalator runs on Hermes-native cron (ADR 0021 Stream B): pre_run.py
-    # decides whether a deadline needs the ladder, else writes SUPPRESSED_WAKE.
-    # The PI-pack schedules below are staggered (never :00/:30) and weekday- or
-    # weekly-cadenced deliberately — every wake bills tokens, so the cadence
-    # matches how fast each item actually changes. All times are seat-local
-    # (business_hours.timezone -> HERMES_TIMEZONE): authored as Pacific.
+    # Every entry is pre_run-gated (ADR 0021 Stream B, #1748). The escalator's
+    # bespoke pre_run decides whether a deadline needs the ladder; the other
+    # skills carry the shared empty-seat gate (operator/templates/pre_run_gate.py):
+    # zero open matters -> SUPPRESSED_WAKE heartbeat, no LLM turn. Any probe or
+    # heartbeat failure wakes (fail-open). Schedules stay staggered (never
+    # :00/:30) and weekday- or weekly-cadenced — a wake on a hydrated seat
+    # bills tokens, so the cadence matches how fast each item actually changes.
+    # All times are seat-local (business_hours.timezone -> HERMES_TIMEZONE):
+    # authored as Pacific.
     cron:
       - skill: deadline-miss-escalator
         schedule: '0 7 * * *' # daily 0700 seat-local (America/Los_Angeles via business_hours; was silently UTC = midnight PT before HERMES_TIMEZONE landed)
@@ -359,37 +362,48 @@ personas:
         wake_policy: pre_run_decides
       - skill: daily-needs-you-digest
         schedule: '23 6 * * 1-5' # weekday 0623 seat-local — the morning digest
-        wake_policy: always
+        pre_run: pre_run.py
+        wake_policy: pre_run_decides
       - skill: discovery-response-tracker
         schedule: '17 7 * * 1-5' # weekday 0717 seat-local
-        wake_policy: always
+        pre_run: pre_run.py
+        wake_policy: pre_run_decides
       - skill: client-verification-tracker
         schedule: '41 7 * * 1-5' # weekday 0741 seat-local
-        wake_policy: always
+        pre_run: pre_run.py
+        wake_policy: pre_run_decides
       - skill: motion-calendar-tracker
         schedule: '27 7 * * 1-5' # weekday 0727 seat-local
-        wake_policy: always
+        pre_run: pre_run.py
+        wake_policy: pre_run_decides
       - skill: service-confirmation-watcher
         schedule: '51 7 * * 1-5' # weekday 0751 seat-local
-        wake_policy: always
+        pre_run: pre_run.py
+        wake_policy: pre_run_decides
       - skill: medical-chronology-maintainer
         schedule: '33 8 * * 1-5' # weekday 0833 seat-local — after records imports land
-        wake_policy: always
+        pre_run: pre_run.py
+        wake_policy: pre_run_decides
       - skill: medical-records-chaser
         schedule: '9 8 * * 2' # weekly Tue 0809 seat-local
-        wake_policy: always
+        pre_run: pre_run.py
+        wake_policy: pre_run_decides
       - skill: lien-ledger-tracker
         schedule: '13 9 * * 2' # weekly Tue 0913 seat-local
-        wake_policy: always
+        pre_run: pre_run.py
+        wake_policy: pre_run_decides
       - skill: mediation-settlement-tracker
         schedule: '43 9 * * 2' # weekly Tue 0943 seat-local
-        wake_policy: always
+        pre_run: pre_run.py
+        wake_policy: pre_run_decides
       - skill: minors-compromise-packet
         schedule: '3 9 * * 3' # weekly Wed 0903 seat-local — GAL/hearing/lien-figure track
-        wake_policy: always
+        pre_run: pre_run.py
+        wake_policy: pre_run_decides
       - skill: trial-binder-assembler
         schedule: '19 9 * * 1' # weekly Mon 0919 seat-local — trial-prep deadline sweep
-        wake_policy: always
+        pre_run: pre_run.py
+        wake_policy: pre_run_decides
     # Native Google/Himalaya mail skills disabled — the Operator's inbox is AgentMail.
     skills_disabled:
       - google-workspace

--- a/operator/customers/pilot-smokeball/customer.yaml
+++ b/operator/customers/pilot-smokeball/customer.yaml
@@ -322,12 +322,15 @@ personas:
           scheduled: true
           webhook: false
         enabled: true
-    # The escalator runs on Hermes-native cron (ADR 0021 Stream B): pre_run.py
-    # decides whether a deadline needs the ladder, else writes SUPPRESSED_WAKE.
-    # The PI-pack schedules below are staggered (never :00/:30) and weekday- or
-    # weekly-cadenced deliberately — every wake bills tokens, so the cadence
-    # matches how fast each item actually changes. All times are seat-local
-    # (business_hours.timezone -> HERMES_TIMEZONE): authored as Pacific.
+    # Every entry is pre_run-gated (ADR 0021 Stream B, #1748). The escalator's
+    # bespoke pre_run decides whether a deadline needs the ladder; the other
+    # skills carry the shared empty-seat gate (operator/templates/pre_run_gate.py):
+    # zero open matters -> SUPPRESSED_WAKE heartbeat, no LLM turn. Any probe or
+    # heartbeat failure wakes (fail-open). Schedules stay staggered (never
+    # :00/:30) and weekday- or weekly-cadenced — a wake on a hydrated seat
+    # bills tokens, so the cadence matches how fast each item actually changes.
+    # All times are seat-local (business_hours.timezone -> HERMES_TIMEZONE):
+    # authored as Pacific.
     cron:
       - skill: deadline-miss-escalator
         schedule: '0 7 * * *' # daily 0700 seat-local (America/Los_Angeles via business_hours; was silently UTC = midnight PT before HERMES_TIMEZONE landed)
@@ -335,37 +338,48 @@ personas:
         wake_policy: pre_run_decides
       - skill: daily-needs-you-digest
         schedule: '23 6 * * 1-5' # weekday 0623 seat-local — the morning digest
-        wake_policy: always
+        pre_run: pre_run.py
+        wake_policy: pre_run_decides
       - skill: discovery-response-tracker
         schedule: '17 7 * * 1-5' # weekday 0717 seat-local
-        wake_policy: always
+        pre_run: pre_run.py
+        wake_policy: pre_run_decides
       - skill: client-verification-tracker
         schedule: '41 7 * * 1-5' # weekday 0741 seat-local
-        wake_policy: always
+        pre_run: pre_run.py
+        wake_policy: pre_run_decides
       - skill: motion-calendar-tracker
         schedule: '27 7 * * 1-5' # weekday 0727 seat-local
-        wake_policy: always
+        pre_run: pre_run.py
+        wake_policy: pre_run_decides
       - skill: service-confirmation-watcher
         schedule: '51 7 * * 1-5' # weekday 0751 seat-local
-        wake_policy: always
+        pre_run: pre_run.py
+        wake_policy: pre_run_decides
       - skill: medical-chronology-maintainer
         schedule: '33 8 * * 1-5' # weekday 0833 seat-local — after records imports land
-        wake_policy: always
+        pre_run: pre_run.py
+        wake_policy: pre_run_decides
       - skill: medical-records-chaser
         schedule: '9 8 * * 2' # weekly Tue 0809 seat-local
-        wake_policy: always
+        pre_run: pre_run.py
+        wake_policy: pre_run_decides
       - skill: lien-ledger-tracker
         schedule: '13 9 * * 2' # weekly Tue 0913 seat-local
-        wake_policy: always
+        pre_run: pre_run.py
+        wake_policy: pre_run_decides
       - skill: mediation-settlement-tracker
         schedule: '43 9 * * 2' # weekly Tue 0943 seat-local
-        wake_policy: always
+        pre_run: pre_run.py
+        wake_policy: pre_run_decides
       - skill: minors-compromise-packet
         schedule: '3 9 * * 3' # weekly Wed 0903 seat-local — GAL/hearing/lien-figure track
-        wake_policy: always
+        pre_run: pre_run.py
+        wake_policy: pre_run_decides
       - skill: trial-binder-assembler
         schedule: '19 9 * * 1' # weekly Mon 0919 seat-local — trial-prep deadline sweep
-        wake_policy: always
+        pre_run: pre_run.py
+        wake_policy: pre_run_decides
     # Native Google/Himalaya mail skills disabled — the Operator's inbox is AgentMail.
     skills_disabled:
       - google-workspace

--- a/operator/skills/client-verification-tracker/pre_run.py
+++ b/operator/skills/client-verification-tracker/pre_run.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Shared cron pre-run gate — the empty-seat wake suppressor (ADR 0021 Stream B).
+
+CANONICAL SOURCE: ``operator/templates/pre_run_gate.py``. The copies stamped
+into skill directories as ``pre_run.py`` MUST be byte-identical to this file —
+``operator/tests/test_pre_run_gate.py`` enforces the sync. Edit here, restamp.
+
+What this gate decides
+----------------------
+Scheduled tracker/watch/chase skills re-derive their work from the matter set
+in the practice-management system (they keep no local state — the matter is
+the system of record). On a seat with ZERO open matters there is provably no
+work for any of them, so waking the model is pure token burn. This gate:
+
+  1. Probes Smokeball for open matters (one ``GET /matters?Status=Open&Limit=1``
+     via the connector's own venv — the connector package is not importable
+     from the Hermes venv this script runs in).
+  2. Any open matter, any probe failure, any unknown response envelope, any
+     heartbeat-write failure → ``{"wakeAgent": true}`` (fail-open; the agent
+     wakes exactly as it would with no gate).
+  3. Zero open matters → writes a SUPPRESSED_WAKE heartbeat row through the
+     broker's uid-gated ``suppressed_wake_append`` verb, THEN emits
+     ``{"wakeAgent": false}``. Suppress-without-heartbeat never happens
+     (mirror-don't-gate): if the broker write fails, the agent wakes.
+
+What this gate deliberately does NOT decide
+-------------------------------------------
+It is NOT a per-skill "is there work" check. A hydrated seat (any open
+matter) always wakes — deeper UpdatedSince/state-delta gates are follow-on
+work once the Smokeball ``updated_since`` wire format is verified at connect.
+Lead-stage and inbound-driven work is unaffected either way: webhook and
+inbound wakes are ungated by design.
+
+Skill identity
+--------------
+The scheduler stages this file to ``<profile>/scripts/<skill>/pre_run.py`` and
+runs it with cwd = that directory, so the skill name is the cwd basename. That
+keeps every stamped copy byte-identical.
+
+Verification hook
+-----------------
+``pre_run.py --assume-empty`` skips the Smokeball probe and behaves as if the
+seat were empty — it exercises the heartbeat write + suppress path end-to-end
+on a live Machine without needing an actually-empty tenant. The cron daemon
+never passes arguments, so this path cannot trigger on a scheduled fire.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import subprocess
+import sys
+from pathlib import Path
+
+# Timeout budget: the Hermes scheduler kills the whole script at 120s
+# (cron/scheduler.py _DEFAULT_SCRIPT_TIMEOUT); the probe gets well under that.
+_PROBE_TIMEOUT_SECONDS = 45
+_HEARTBEAT_TIMEOUT_SECONDS = 10
+
+_CONNECTOR_PYTHON_DEFAULT = "/opt/connectors/smokeball/.venv/bin/python"
+
+# Runs inside the connector venv, where smokeball_connector IS importable and
+# build_client_from_env() owns auth (token mint + refresh-token self-heal).
+# Envelope parsing is deliberately defensive: the live /matters list shape is
+# connect-time-unverified, so an unrecognized shape reports null → wake.
+_PROBE_SNIPPET = """\
+import json
+from smokeball_connector.client import build_client_from_env
+
+r = build_client_from_env().get("/matters", Status="Open", Limit=1)
+items = None
+if isinstance(r, list):
+    items = r
+elif isinstance(r, dict):
+    for key in ("items", "value", "results", "matters", "data"):
+        v = r.get(key)
+        if isinstance(v, list):
+            items = v
+            break
+print(json.dumps({"openMatterCount": len(items) if items is not None else None}))
+"""
+
+
+def _emit(wake: bool) -> int:
+    print(json.dumps({"wakeAgent": wake}))
+    return 0
+
+
+def _skill_name() -> str:
+    return Path.cwd().name or "unknown-skill"
+
+
+def probe_open_matter_count() -> int | None:
+    """Return the open-matter count, or None when it cannot be determined."""
+    connector_python = os.environ.get(
+        "SMD_CONNECTOR_VENV_PYTHON", _CONNECTOR_PYTHON_DEFAULT
+    )
+    if not Path(connector_python).exists():
+        sys.stderr.write(f"[pre_run] connector python missing: {connector_python}\n")
+        return None
+    try:
+        result = subprocess.run(
+            [connector_python, "-c", _PROBE_SNIPPET],
+            capture_output=True,
+            text=True,
+            timeout=_PROBE_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        sys.stderr.write("[pre_run] smokeball probe timed out\n")
+        return None
+    except Exception as exc:  # noqa: BLE001 — any probe failure → unknown → wake
+        sys.stderr.write(f"[pre_run] smokeball probe failed: {exc}\n")
+        return None
+    if result.returncode != 0:
+        sys.stderr.write(
+            f"[pre_run] smokeball probe exit {result.returncode}: "
+            f"{(result.stderr or '').strip()[:500]}\n"
+        )
+        return None
+    try:
+        payload = json.loads((result.stdout or "").strip().splitlines()[-1])
+        count = payload.get("openMatterCount")
+    except Exception:  # noqa: BLE001 — malformed probe output → unknown → wake
+        sys.stderr.write("[pre_run] smokeball probe output unparseable\n")
+        return None
+    if isinstance(count, bool) or not isinstance(count, int):
+        return None
+    return count
+
+
+def write_suppressed_wake_heartbeat(skill_name: str) -> bool:
+    """Append the SUPPRESSED_WAKE row via the broker. True only on ack."""
+    socket_path = os.environ.get("SMD_AUDIT_BROKER_SOCKET") or os.environ.get(
+        "SMD_WORKSPACE_BROKER_SOCKET"
+    )
+    if not socket_path:
+        sys.stderr.write("[pre_run] no broker socket in env; cannot heartbeat\n")
+        return False
+    request = {
+        "action": "suppressed_wake_append",
+        "row": {
+            "action_type": "SUPPRESSED_WAKE",
+            "actor": "agent",
+            "actor_role": "agent",
+            "skill_name": skill_name,
+            "metadata": json.dumps(
+                {
+                    "decision_basis": "empty_seat:no_open_matters",
+                    "platform": "cron-pre-run",
+                    "customer": os.environ.get("CUSTOMER_SLUG", ""),
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+            ),
+        },
+    }
+    try:
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
+            sock.settimeout(_HEARTBEAT_TIMEOUT_SECONDS)
+            sock.connect(socket_path)
+            sock.sendall(json.dumps(request).encode("utf-8") + b"\n")
+            raw = b""
+            while not raw.endswith(b"\n"):
+                chunk = sock.recv(4096)
+                if not chunk:
+                    break
+                raw += chunk
+        response = json.loads(raw.decode("utf-8"))
+        if response.get("ok") is True:
+            return True
+        sys.stderr.write(f"[pre_run] heartbeat rejected: {response}\n")
+        return False
+    except Exception as exc:  # noqa: BLE001 — any heartbeat failure → wake
+        sys.stderr.write(f"[pre_run] heartbeat write failed: {exc}\n")
+        return False
+
+
+def decide_and_emit(count: int | None, skill_name: str) -> int:
+    """Pure-ish core: count → wake/suppress emission (heartbeat before suppress)."""
+    if count is None or count > 0:
+        return _emit(wake=True)
+    if not write_suppressed_wake_heartbeat(skill_name):
+        # Mirror-don't-gate: a silent suppress with no audit trail is
+        # indistinguishable from a broken pre_run. Wake instead — the full
+        # agent run is observable and the failure becomes visible.
+        return _emit(wake=True)
+    return _emit(wake=False)
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = sys.argv[1:] if argv is None else argv
+    skill_name = _skill_name()
+    if "--assume-empty" in argv:
+        sys.stderr.write("[pre_run] --assume-empty: skipping smokeball probe\n")
+        return decide_and_emit(0, skill_name)
+    return decide_and_emit(probe_open_matter_count(), skill_name)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/operator/skills/client-verification-tracker/pre_run.py
+++ b/operator/skills/client-verification-tracker/pre_run.py
@@ -101,6 +101,7 @@ def probe_open_matter_count() -> int | None:
         sys.stderr.write(f"[pre_run] connector python missing: {connector_python}\n")
         return None
     try:
+        # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-tainted-env-args.dangerous-subprocess-use-tainted-env-args — argv[0] is the module-constant connector-venv interpreter, overridable only via SMD_CONNECTOR_VENV_PYTHON, which comes from the Machine's own boot env (same trust domain as this file; the test seam). The snippet argument is a module constant; no request/agent-controlled data reaches argv.
         result = subprocess.run(
             [connector_python, "-c", _PROBE_SNIPPET],
             capture_output=True,

--- a/operator/skills/client-verification-tracker/pre_run.py
+++ b/operator/skills/client-verification-tracker/pre_run.py
@@ -101,8 +101,8 @@ def probe_open_matter_count() -> int | None:
         sys.stderr.write(f"[pre_run] connector python missing: {connector_python}\n")
         return None
     try:
-        # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-tainted-env-args.dangerous-subprocess-use-tainted-env-args — argv[0] is the module-constant connector-venv interpreter, overridable only via SMD_CONNECTOR_VENV_PYTHON, which comes from the Machine's own boot env (same trust domain as this file; the test seam). The snippet argument is a module constant; no request/agent-controlled data reaches argv.
         result = subprocess.run(
+            # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-tainted-env-args.dangerous-subprocess-use-tainted-env-args — argv[0] is the module-constant connector-venv interpreter, overridable only via SMD_CONNECTOR_VENV_PYTHON, which comes from the Machine's own boot env (same trust domain as this file; the test seam). The snippet argument is a module constant; no request/agent-controlled data reaches argv.
             [connector_python, "-c", _PROBE_SNIPPET],
             capture_output=True,
             text=True,

--- a/operator/skills/daily-needs-you-digest/pre_run.py
+++ b/operator/skills/daily-needs-you-digest/pre_run.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Shared cron pre-run gate — the empty-seat wake suppressor (ADR 0021 Stream B).
+
+CANONICAL SOURCE: ``operator/templates/pre_run_gate.py``. The copies stamped
+into skill directories as ``pre_run.py`` MUST be byte-identical to this file —
+``operator/tests/test_pre_run_gate.py`` enforces the sync. Edit here, restamp.
+
+What this gate decides
+----------------------
+Scheduled tracker/watch/chase skills re-derive their work from the matter set
+in the practice-management system (they keep no local state — the matter is
+the system of record). On a seat with ZERO open matters there is provably no
+work for any of them, so waking the model is pure token burn. This gate:
+
+  1. Probes Smokeball for open matters (one ``GET /matters?Status=Open&Limit=1``
+     via the connector's own venv — the connector package is not importable
+     from the Hermes venv this script runs in).
+  2. Any open matter, any probe failure, any unknown response envelope, any
+     heartbeat-write failure → ``{"wakeAgent": true}`` (fail-open; the agent
+     wakes exactly as it would with no gate).
+  3. Zero open matters → writes a SUPPRESSED_WAKE heartbeat row through the
+     broker's uid-gated ``suppressed_wake_append`` verb, THEN emits
+     ``{"wakeAgent": false}``. Suppress-without-heartbeat never happens
+     (mirror-don't-gate): if the broker write fails, the agent wakes.
+
+What this gate deliberately does NOT decide
+-------------------------------------------
+It is NOT a per-skill "is there work" check. A hydrated seat (any open
+matter) always wakes — deeper UpdatedSince/state-delta gates are follow-on
+work once the Smokeball ``updated_since`` wire format is verified at connect.
+Lead-stage and inbound-driven work is unaffected either way: webhook and
+inbound wakes are ungated by design.
+
+Skill identity
+--------------
+The scheduler stages this file to ``<profile>/scripts/<skill>/pre_run.py`` and
+runs it with cwd = that directory, so the skill name is the cwd basename. That
+keeps every stamped copy byte-identical.
+
+Verification hook
+-----------------
+``pre_run.py --assume-empty`` skips the Smokeball probe and behaves as if the
+seat were empty — it exercises the heartbeat write + suppress path end-to-end
+on a live Machine without needing an actually-empty tenant. The cron daemon
+never passes arguments, so this path cannot trigger on a scheduled fire.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import subprocess
+import sys
+from pathlib import Path
+
+# Timeout budget: the Hermes scheduler kills the whole script at 120s
+# (cron/scheduler.py _DEFAULT_SCRIPT_TIMEOUT); the probe gets well under that.
+_PROBE_TIMEOUT_SECONDS = 45
+_HEARTBEAT_TIMEOUT_SECONDS = 10
+
+_CONNECTOR_PYTHON_DEFAULT = "/opt/connectors/smokeball/.venv/bin/python"
+
+# Runs inside the connector venv, where smokeball_connector IS importable and
+# build_client_from_env() owns auth (token mint + refresh-token self-heal).
+# Envelope parsing is deliberately defensive: the live /matters list shape is
+# connect-time-unverified, so an unrecognized shape reports null → wake.
+_PROBE_SNIPPET = """\
+import json
+from smokeball_connector.client import build_client_from_env
+
+r = build_client_from_env().get("/matters", Status="Open", Limit=1)
+items = None
+if isinstance(r, list):
+    items = r
+elif isinstance(r, dict):
+    for key in ("items", "value", "results", "matters", "data"):
+        v = r.get(key)
+        if isinstance(v, list):
+            items = v
+            break
+print(json.dumps({"openMatterCount": len(items) if items is not None else None}))
+"""
+
+
+def _emit(wake: bool) -> int:
+    print(json.dumps({"wakeAgent": wake}))
+    return 0
+
+
+def _skill_name() -> str:
+    return Path.cwd().name or "unknown-skill"
+
+
+def probe_open_matter_count() -> int | None:
+    """Return the open-matter count, or None when it cannot be determined."""
+    connector_python = os.environ.get(
+        "SMD_CONNECTOR_VENV_PYTHON", _CONNECTOR_PYTHON_DEFAULT
+    )
+    if not Path(connector_python).exists():
+        sys.stderr.write(f"[pre_run] connector python missing: {connector_python}\n")
+        return None
+    try:
+        result = subprocess.run(
+            [connector_python, "-c", _PROBE_SNIPPET],
+            capture_output=True,
+            text=True,
+            timeout=_PROBE_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        sys.stderr.write("[pre_run] smokeball probe timed out\n")
+        return None
+    except Exception as exc:  # noqa: BLE001 — any probe failure → unknown → wake
+        sys.stderr.write(f"[pre_run] smokeball probe failed: {exc}\n")
+        return None
+    if result.returncode != 0:
+        sys.stderr.write(
+            f"[pre_run] smokeball probe exit {result.returncode}: "
+            f"{(result.stderr or '').strip()[:500]}\n"
+        )
+        return None
+    try:
+        payload = json.loads((result.stdout or "").strip().splitlines()[-1])
+        count = payload.get("openMatterCount")
+    except Exception:  # noqa: BLE001 — malformed probe output → unknown → wake
+        sys.stderr.write("[pre_run] smokeball probe output unparseable\n")
+        return None
+    if isinstance(count, bool) or not isinstance(count, int):
+        return None
+    return count
+
+
+def write_suppressed_wake_heartbeat(skill_name: str) -> bool:
+    """Append the SUPPRESSED_WAKE row via the broker. True only on ack."""
+    socket_path = os.environ.get("SMD_AUDIT_BROKER_SOCKET") or os.environ.get(
+        "SMD_WORKSPACE_BROKER_SOCKET"
+    )
+    if not socket_path:
+        sys.stderr.write("[pre_run] no broker socket in env; cannot heartbeat\n")
+        return False
+    request = {
+        "action": "suppressed_wake_append",
+        "row": {
+            "action_type": "SUPPRESSED_WAKE",
+            "actor": "agent",
+            "actor_role": "agent",
+            "skill_name": skill_name,
+            "metadata": json.dumps(
+                {
+                    "decision_basis": "empty_seat:no_open_matters",
+                    "platform": "cron-pre-run",
+                    "customer": os.environ.get("CUSTOMER_SLUG", ""),
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+            ),
+        },
+    }
+    try:
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
+            sock.settimeout(_HEARTBEAT_TIMEOUT_SECONDS)
+            sock.connect(socket_path)
+            sock.sendall(json.dumps(request).encode("utf-8") + b"\n")
+            raw = b""
+            while not raw.endswith(b"\n"):
+                chunk = sock.recv(4096)
+                if not chunk:
+                    break
+                raw += chunk
+        response = json.loads(raw.decode("utf-8"))
+        if response.get("ok") is True:
+            return True
+        sys.stderr.write(f"[pre_run] heartbeat rejected: {response}\n")
+        return False
+    except Exception as exc:  # noqa: BLE001 — any heartbeat failure → wake
+        sys.stderr.write(f"[pre_run] heartbeat write failed: {exc}\n")
+        return False
+
+
+def decide_and_emit(count: int | None, skill_name: str) -> int:
+    """Pure-ish core: count → wake/suppress emission (heartbeat before suppress)."""
+    if count is None or count > 0:
+        return _emit(wake=True)
+    if not write_suppressed_wake_heartbeat(skill_name):
+        # Mirror-don't-gate: a silent suppress with no audit trail is
+        # indistinguishable from a broken pre_run. Wake instead — the full
+        # agent run is observable and the failure becomes visible.
+        return _emit(wake=True)
+    return _emit(wake=False)
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = sys.argv[1:] if argv is None else argv
+    skill_name = _skill_name()
+    if "--assume-empty" in argv:
+        sys.stderr.write("[pre_run] --assume-empty: skipping smokeball probe\n")
+        return decide_and_emit(0, skill_name)
+    return decide_and_emit(probe_open_matter_count(), skill_name)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/operator/skills/daily-needs-you-digest/pre_run.py
+++ b/operator/skills/daily-needs-you-digest/pre_run.py
@@ -101,6 +101,7 @@ def probe_open_matter_count() -> int | None:
         sys.stderr.write(f"[pre_run] connector python missing: {connector_python}\n")
         return None
     try:
+        # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-tainted-env-args.dangerous-subprocess-use-tainted-env-args — argv[0] is the module-constant connector-venv interpreter, overridable only via SMD_CONNECTOR_VENV_PYTHON, which comes from the Machine's own boot env (same trust domain as this file; the test seam). The snippet argument is a module constant; no request/agent-controlled data reaches argv.
         result = subprocess.run(
             [connector_python, "-c", _PROBE_SNIPPET],
             capture_output=True,

--- a/operator/skills/daily-needs-you-digest/pre_run.py
+++ b/operator/skills/daily-needs-you-digest/pre_run.py
@@ -101,8 +101,8 @@ def probe_open_matter_count() -> int | None:
         sys.stderr.write(f"[pre_run] connector python missing: {connector_python}\n")
         return None
     try:
-        # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-tainted-env-args.dangerous-subprocess-use-tainted-env-args — argv[0] is the module-constant connector-venv interpreter, overridable only via SMD_CONNECTOR_VENV_PYTHON, which comes from the Machine's own boot env (same trust domain as this file; the test seam). The snippet argument is a module constant; no request/agent-controlled data reaches argv.
         result = subprocess.run(
+            # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-tainted-env-args.dangerous-subprocess-use-tainted-env-args — argv[0] is the module-constant connector-venv interpreter, overridable only via SMD_CONNECTOR_VENV_PYTHON, which comes from the Machine's own boot env (same trust domain as this file; the test seam). The snippet argument is a module constant; no request/agent-controlled data reaches argv.
             [connector_python, "-c", _PROBE_SNIPPET],
             capture_output=True,
             text=True,

--- a/operator/skills/deadline-miss-escalator/pre_run.py
+++ b/operator/skills/deadline-miss-escalator/pre_run.py
@@ -385,6 +385,7 @@ class SmokeballSubprocessSource:
         )
         frm = self._today.isoformat()
         to = (self._today + timedelta(days=self._windows.escalation_window_days)).isoformat()
+        # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-tainted-env-args.dangerous-subprocess-use-tainted-env-args — argv[0] is the module-constant connector-venv interpreter, overridable only via SMD_CONNECTOR_VENV_PYTHON from the Machine's own boot env (same trust domain; the test seam). The snippet is a module constant; frm/to are date.isoformat() strings computed here, never external input.
         result = subprocess.run(  # raises on timeout → caller wakes
             [connector_python, "-c", _PULL_SNIPPET, frm, to],
             capture_output=True,

--- a/operator/skills/deadline-miss-escalator/pre_run.py
+++ b/operator/skills/deadline-miss-escalator/pre_run.py
@@ -385,8 +385,8 @@ class SmokeballSubprocessSource:
         )
         frm = self._today.isoformat()
         to = (self._today + timedelta(days=self._windows.escalation_window_days)).isoformat()
-        # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-tainted-env-args.dangerous-subprocess-use-tainted-env-args — argv[0] is the module-constant connector-venv interpreter, overridable only via SMD_CONNECTOR_VENV_PYTHON from the Machine's own boot env (same trust domain; the test seam). The snippet is a module constant; frm/to are date.isoformat() strings computed here, never external input.
         result = subprocess.run(  # raises on timeout → caller wakes
+            # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-tainted-env-args.dangerous-subprocess-use-tainted-env-args — argv[0] is the module-constant connector-venv interpreter, overridable only via SMD_CONNECTOR_VENV_PYTHON from the Machine's own boot env (same trust domain; the test seam). The snippet is a module constant; frm/to are date.isoformat() strings computed here, never external input.
             [connector_python, "-c", _PULL_SNIPPET, frm, to],
             capture_output=True,
             text=True,

--- a/operator/skills/deadline-miss-escalator/pre_run.py
+++ b/operator/skills/deadline-miss-escalator/pre_run.py
@@ -38,8 +38,12 @@ Exit codes:
 
 from __future__ import annotations
 
+import asyncio
+import hashlib
 import json
 import os
+import socket
+import subprocess
 import sys
 from dataclasses import dataclass, field
 from datetime import date, datetime, timedelta, timezone
@@ -244,11 +248,224 @@ async def run_once(
 
 
 # ---------------------------------------------------------------------------
-# CLI bootstrap. The cron daemon invokes this directly. Production wiring
-# resolves the Smokeball deadline reader from customer.yaml and the audit writer from
-# env (ADR 0008 d1_env). Until the reader adapter ships, the cron invocation
-# falls through to wake — the agent wakes, the absence becomes visible.
+# Production wiring (#1748, ADR 0021 Stream B). The Smokeball pull runs in the
+# connector's own venv via subprocess (smokeball_connector is not importable
+# from the Hermes venv this script runs in); the SUPPRESSED_WAKE heartbeat goes
+# through the broker's uid-gated `suppressed_wake_append` verb (a cron pre_run
+# is a gateway CHILD — agent uid, non-gateway PID — so the strict audit_append
+# PID gate correctly rejects it). Every unknown stays conservative: pull
+# failure, unrecognized envelope, zero parseable dates on a non-empty pull,
+# heartbeat failure — all wake.
 # ---------------------------------------------------------------------------
+
+_CONNECTOR_PYTHON_DEFAULT = "/opt/connectors/smokeball/.venv/bin/python"
+_PULL_TIMEOUT_SECONDS = 60
+_HEARTBEAT_TIMEOUT_SECONDS = 10
+
+# Runs inside the connector venv. Both pulls are attempted independently and
+# errors are REPORTED, not swallowed — a partial view must not suppress.
+_PULL_SNIPPET = """\
+import json
+import sys
+
+from smokeball_connector.client import build_client_from_env
+
+frm, to = sys.argv[1], sys.argv[2]
+client = build_client_from_env()
+out = {}
+try:
+    out["tasks"] = client.get("/tasks", IsCompleted=False, Limit=500)
+except Exception as exc:
+    out["tasksError"] = str(exc)[:300]
+try:
+    out["events"] = client.get("/events", From=frm, To=to, Limit=500)
+except Exception as exc:
+    out["eventsError"] = str(exc)[:300]
+print(json.dumps(out, default=str))
+"""
+
+_TASK_DATE_KEYS = ("dueDate", "DueDate", "due_date")
+_EVENT_DATE_KEYS = ("startTime", "StartTime", "startDate", "start", "from")
+_MATTER_ID_KEYS = ("matterId", "MatterId", "matter_id", "id")
+
+
+def _extract_items(payload) -> list | None:
+    """Defensive envelope unwrap; None means the shape is unrecognized."""
+    if isinstance(payload, list):
+        return payload
+    if isinstance(payload, dict):
+        for key in ("items", "value", "results", "tasks", "events", "data"):
+            value = payload.get(key)
+            if isinstance(value, list):
+                return value
+    return None
+
+
+def _parse_iso_date(value) -> date | None:
+    if not isinstance(value, str) or len(value) < 10:
+        return None
+    try:
+        return date.fromisoformat(value[:10])
+    except ValueError:
+        return None
+
+
+def _first_date(item: dict, keys: Sequence[str]) -> date | None:
+    for key in keys:
+        parsed = _parse_iso_date(item.get(key))
+        if parsed is not None:
+            return parsed
+    return None
+
+
+def _matter_id_of(item: dict) -> str:
+    for key in _MATTER_ID_KEYS:
+        value = item.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return "unknown-matter"
+
+
+def parse_pull(raw: dict) -> tuple[list[MatterDeadline], str | None]:
+    """Pure parse of the connector pull. Returns (deadlines, problem).
+
+    A non-None problem means the view is partial or unrecognizable and the
+    caller MUST wake. Dateless items are skipped (a task without a due date
+    is not an authored deadline) — but a non-empty pull yielding ZERO
+    parseable dates is treated as an unrecognized wire shape, not an empty
+    deadline book. Every date here was read, never computed.
+    """
+    for error_key in ("tasksError", "eventsError"):
+        if raw.get(error_key):
+            return [], f"pull error: {error_key}={raw[error_key]}"
+    tasks = _extract_items(raw.get("tasks"))
+    events = _extract_items(raw.get("events"))
+    if tasks is None or events is None:
+        return [], "unrecognized pull envelope"
+    deadlines: list[MatterDeadline] = []
+    total_items = 0
+    for items, keys, label in (
+        (tasks, _TASK_DATE_KEYS, "task-deadline"),
+        (events, _EVENT_DATE_KEYS, "court-date"),
+    ):
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            total_items += 1
+            authored = _first_date(item, keys)
+            if authored is None:
+                continue
+            deadlines.append(
+                MatterDeadline(
+                    matter_id=_matter_id_of(item),
+                    authored_date=authored,
+                    label=label,
+                    # No acknowledgment ledger exists yet; conservative
+                    # defaults keep every in-range deadline waking the ladder.
+                    matter_open=True,
+                    conflict_hold=False,
+                    acknowledged=False,
+                )
+            )
+    if total_items > 0 and not deadlines:
+        return [], "non-empty pull with zero parseable dates"
+    return deadlines, None
+
+
+class SmokeballSubprocessSource:
+    """DeadlineSource over a connector-venv subprocess pull."""
+
+    def __init__(self, windows: EscalationWindows, today: date) -> None:
+        self._windows = windows
+        self._today = today
+
+    def pull_deadlines(self) -> Sequence[MatterDeadline]:
+        connector_python = os.environ.get(
+            "SMD_CONNECTOR_VENV_PYTHON", _CONNECTOR_PYTHON_DEFAULT
+        )
+        frm = self._today.isoformat()
+        to = (self._today + timedelta(days=self._windows.escalation_window_days)).isoformat()
+        result = subprocess.run(  # raises on timeout → caller wakes
+            [connector_python, "-c", _PULL_SNIPPET, frm, to],
+            capture_output=True,
+            text=True,
+            timeout=_PULL_TIMEOUT_SECONDS,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"smokeball pull exit {result.returncode}: "
+                f"{(result.stderr or '').strip()[:500]}"
+            )
+        raw = json.loads((result.stdout or "").strip().splitlines()[-1])
+        deadlines, problem = parse_pull(raw)
+        if problem:
+            raise RuntimeError(problem)
+        return deadlines
+
+
+class BrokerSuppressedWakeWriter:
+    """SuppressedWakeWriter over the broker's uid-gated heartbeat verb."""
+
+    def __init__(self, socket_path: str, customer_slug: str) -> None:
+        self._socket_path = socket_path
+        self._customer_slug = customer_slug
+
+    async def write_suppressed_wake(
+        self,
+        *,
+        skill_name: str,
+        pre_run_inputs: bytes,
+        decision_basis: str,
+        next_scheduled_at: str,
+        extra_metadata: dict | None = None,
+    ) -> str:
+        request = {
+            "action": "suppressed_wake_append",
+            "row": {
+                "action_type": "SUPPRESSED_WAKE",
+                "actor": "agent",
+                "actor_role": "agent",
+                "skill_name": skill_name,
+                "input_digest": hashlib.sha256(pre_run_inputs).hexdigest(),
+                "metadata": json.dumps(
+                    {
+                        "decision_basis": decision_basis,
+                        "next_scheduled_at": next_scheduled_at,
+                        "platform": "cron-pre-run",
+                        "customer": self._customer_slug,
+                        **(extra_metadata or {}),
+                    },
+                    sort_keys=True,
+                    separators=(",", ":"),
+                    default=str,
+                ),
+            },
+        }
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
+            sock.settimeout(_HEARTBEAT_TIMEOUT_SECONDS)
+            sock.connect(self._socket_path)
+            sock.sendall(json.dumps(request).encode("utf-8") + b"\n")
+            raw = b""
+            while not raw.endswith(b"\n"):
+                chunk = sock.recv(4096)
+                if not chunk:
+                    break
+                raw += chunk
+        response = json.loads(raw.decode("utf-8"))
+        if response.get("ok") is not True:
+            raise RuntimeError(f"heartbeat rejected: {response}")
+        return str(response.get("id", ""))
+
+
+def _writer_factory():
+    socket_path = os.environ.get("SMD_AUDIT_BROKER_SOCKET") or os.environ.get(
+        "SMD_WORKSPACE_BROKER_SOCKET"
+    )
+    if not socket_path:
+        return None  # run_once treats None as "no writer wired" → wake
+    return BrokerSuppressedWakeWriter(
+        socket_path, os.environ.get("CUSTOMER_SLUG", "")
+    )
 
 
 def main() -> int:
@@ -256,11 +473,16 @@ def main() -> int:
     if not customer_slug:
         sys.stderr.write("[pre_run] CUSTOMER_SLUG unset; falling back to wake\n")
         return _emit_wake()
-    sys.stderr.write(
-        "[pre_run] deadline-miss-escalator Smokeball reader not yet wired; "
-        "falling back to wake (see ADR 0021 Stream B follow-on)\n"
-    )
-    return _emit_wake()
+    windows = EscalationWindows()
+    today = datetime.now(timezone.utc).date()
+    source = SmokeballSubprocessSource(windows, today)
+    try:
+        return asyncio.run(
+            run_once([source], windows, _writer_factory, today=today)
+        )
+    except Exception as exc:  # noqa: BLE001 — any wiring failure → wake
+        sys.stderr.write(f"[pre_run] escalator pre_run failed ({exc}); waking\n")
+        return _emit_wake()
 
 
 if __name__ == "__main__":

--- a/operator/skills/deadline-miss-escalator/test_escalator_pre_run.py
+++ b/operator/skills/deadline-miss-escalator/test_escalator_pre_run.py
@@ -246,3 +246,72 @@ def test_run_once_falls_back_to_wake_when_no_writer():
     code, out = _capture_stdout(run_once(sources, EscalationWindows(), lambda: None, today=TODAY, now=NOW))
     assert code == 0
     assert json.loads(out) == {"wakeAgent": True}
+
+
+# ---------------------------------------------------------------------------
+# parse_pull — the production Smokeball pull parser (#1748 wiring)
+# ---------------------------------------------------------------------------
+
+parse_pull = _pre_run.parse_pull
+
+
+def test_parse_pull_clean_tasks_and_events() -> None:
+    raw = {
+        "tasks": {"items": [{"matterId": "m-1", "dueDate": "2026-07-20T00:00:00Z"}]},
+        "events": {"items": [{"matterId": "m-2", "startTime": "2026-07-09T09:00:00"}]},
+    }
+    deadlines, problem = parse_pull(raw)
+    assert problem is None
+    assert {(d.matter_id, d.label, d.authored_date.isoformat()) for d in deadlines} == {
+        ("m-1", "task-deadline", "2026-07-20"),
+        ("m-2", "court-date", "2026-07-09"),
+    }
+
+
+def test_parse_pull_bare_list_envelope() -> None:
+    raw = {"tasks": [{"matterId": "m-1", "dueDate": "2026-07-20"}], "events": []}
+    deadlines, problem = parse_pull(raw)
+    assert problem is None
+    assert len(deadlines) == 1
+
+
+def test_parse_pull_error_key_is_a_problem() -> None:
+    raw = {"tasks": {"items": []}, "events": {"items": []}, "eventsError": "boom"}
+    deadlines, problem = parse_pull(raw)
+    assert deadlines == [] and problem is not None
+
+
+def test_parse_pull_unrecognized_envelope_is_a_problem() -> None:
+    deadlines, problem = parse_pull({"tasks": {"weird": 1}, "events": {"items": []}})
+    assert deadlines == [] and problem is not None
+
+
+def test_parse_pull_nonempty_pull_with_zero_dates_is_a_problem() -> None:
+    """A wire shape whose date keys we don't recognize must WAKE, not read as
+    an empty deadline book."""
+    raw = {
+        "tasks": {"items": [{"matterId": "m-1", "deadline_when": "2026-07-20"}]},
+        "events": {"items": []},
+    }
+    deadlines, problem = parse_pull(raw)
+    assert deadlines == [] and problem is not None
+
+
+def test_parse_pull_dateless_items_skipped_when_others_parse() -> None:
+    raw = {
+        "tasks": {
+            "items": [
+                {"matterId": "m-1", "dueDate": "2026-07-20"},
+                {"matterId": "m-2"},  # dateless task: not an authored deadline
+            ]
+        },
+        "events": {"items": []},
+    }
+    deadlines, problem = parse_pull(raw)
+    assert problem is None
+    assert [d.matter_id for d in deadlines] == ["m-1"]
+
+
+def test_parse_pull_empty_pull_is_a_clean_empty_book() -> None:
+    deadlines, problem = parse_pull({"tasks": {"items": []}, "events": {"items": []}})
+    assert deadlines == [] and problem is None

--- a/operator/skills/discovery-response-tracker/pre_run.py
+++ b/operator/skills/discovery-response-tracker/pre_run.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Shared cron pre-run gate — the empty-seat wake suppressor (ADR 0021 Stream B).
+
+CANONICAL SOURCE: ``operator/templates/pre_run_gate.py``. The copies stamped
+into skill directories as ``pre_run.py`` MUST be byte-identical to this file —
+``operator/tests/test_pre_run_gate.py`` enforces the sync. Edit here, restamp.
+
+What this gate decides
+----------------------
+Scheduled tracker/watch/chase skills re-derive their work from the matter set
+in the practice-management system (they keep no local state — the matter is
+the system of record). On a seat with ZERO open matters there is provably no
+work for any of them, so waking the model is pure token burn. This gate:
+
+  1. Probes Smokeball for open matters (one ``GET /matters?Status=Open&Limit=1``
+     via the connector's own venv — the connector package is not importable
+     from the Hermes venv this script runs in).
+  2. Any open matter, any probe failure, any unknown response envelope, any
+     heartbeat-write failure → ``{"wakeAgent": true}`` (fail-open; the agent
+     wakes exactly as it would with no gate).
+  3. Zero open matters → writes a SUPPRESSED_WAKE heartbeat row through the
+     broker's uid-gated ``suppressed_wake_append`` verb, THEN emits
+     ``{"wakeAgent": false}``. Suppress-without-heartbeat never happens
+     (mirror-don't-gate): if the broker write fails, the agent wakes.
+
+What this gate deliberately does NOT decide
+-------------------------------------------
+It is NOT a per-skill "is there work" check. A hydrated seat (any open
+matter) always wakes — deeper UpdatedSince/state-delta gates are follow-on
+work once the Smokeball ``updated_since`` wire format is verified at connect.
+Lead-stage and inbound-driven work is unaffected either way: webhook and
+inbound wakes are ungated by design.
+
+Skill identity
+--------------
+The scheduler stages this file to ``<profile>/scripts/<skill>/pre_run.py`` and
+runs it with cwd = that directory, so the skill name is the cwd basename. That
+keeps every stamped copy byte-identical.
+
+Verification hook
+-----------------
+``pre_run.py --assume-empty`` skips the Smokeball probe and behaves as if the
+seat were empty — it exercises the heartbeat write + suppress path end-to-end
+on a live Machine without needing an actually-empty tenant. The cron daemon
+never passes arguments, so this path cannot trigger on a scheduled fire.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import subprocess
+import sys
+from pathlib import Path
+
+# Timeout budget: the Hermes scheduler kills the whole script at 120s
+# (cron/scheduler.py _DEFAULT_SCRIPT_TIMEOUT); the probe gets well under that.
+_PROBE_TIMEOUT_SECONDS = 45
+_HEARTBEAT_TIMEOUT_SECONDS = 10
+
+_CONNECTOR_PYTHON_DEFAULT = "/opt/connectors/smokeball/.venv/bin/python"
+
+# Runs inside the connector venv, where smokeball_connector IS importable and
+# build_client_from_env() owns auth (token mint + refresh-token self-heal).
+# Envelope parsing is deliberately defensive: the live /matters list shape is
+# connect-time-unverified, so an unrecognized shape reports null → wake.
+_PROBE_SNIPPET = """\
+import json
+from smokeball_connector.client import build_client_from_env
+
+r = build_client_from_env().get("/matters", Status="Open", Limit=1)
+items = None
+if isinstance(r, list):
+    items = r
+elif isinstance(r, dict):
+    for key in ("items", "value", "results", "matters", "data"):
+        v = r.get(key)
+        if isinstance(v, list):
+            items = v
+            break
+print(json.dumps({"openMatterCount": len(items) if items is not None else None}))
+"""
+
+
+def _emit(wake: bool) -> int:
+    print(json.dumps({"wakeAgent": wake}))
+    return 0
+
+
+def _skill_name() -> str:
+    return Path.cwd().name or "unknown-skill"
+
+
+def probe_open_matter_count() -> int | None:
+    """Return the open-matter count, or None when it cannot be determined."""
+    connector_python = os.environ.get(
+        "SMD_CONNECTOR_VENV_PYTHON", _CONNECTOR_PYTHON_DEFAULT
+    )
+    if not Path(connector_python).exists():
+        sys.stderr.write(f"[pre_run] connector python missing: {connector_python}\n")
+        return None
+    try:
+        result = subprocess.run(
+            [connector_python, "-c", _PROBE_SNIPPET],
+            capture_output=True,
+            text=True,
+            timeout=_PROBE_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        sys.stderr.write("[pre_run] smokeball probe timed out\n")
+        return None
+    except Exception as exc:  # noqa: BLE001 — any probe failure → unknown → wake
+        sys.stderr.write(f"[pre_run] smokeball probe failed: {exc}\n")
+        return None
+    if result.returncode != 0:
+        sys.stderr.write(
+            f"[pre_run] smokeball probe exit {result.returncode}: "
+            f"{(result.stderr or '').strip()[:500]}\n"
+        )
+        return None
+    try:
+        payload = json.loads((result.stdout or "").strip().splitlines()[-1])
+        count = payload.get("openMatterCount")
+    except Exception:  # noqa: BLE001 — malformed probe output → unknown → wake
+        sys.stderr.write("[pre_run] smokeball probe output unparseable\n")
+        return None
+    if isinstance(count, bool) or not isinstance(count, int):
+        return None
+    return count
+
+
+def write_suppressed_wake_heartbeat(skill_name: str) -> bool:
+    """Append the SUPPRESSED_WAKE row via the broker. True only on ack."""
+    socket_path = os.environ.get("SMD_AUDIT_BROKER_SOCKET") or os.environ.get(
+        "SMD_WORKSPACE_BROKER_SOCKET"
+    )
+    if not socket_path:
+        sys.stderr.write("[pre_run] no broker socket in env; cannot heartbeat\n")
+        return False
+    request = {
+        "action": "suppressed_wake_append",
+        "row": {
+            "action_type": "SUPPRESSED_WAKE",
+            "actor": "agent",
+            "actor_role": "agent",
+            "skill_name": skill_name,
+            "metadata": json.dumps(
+                {
+                    "decision_basis": "empty_seat:no_open_matters",
+                    "platform": "cron-pre-run",
+                    "customer": os.environ.get("CUSTOMER_SLUG", ""),
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+            ),
+        },
+    }
+    try:
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
+            sock.settimeout(_HEARTBEAT_TIMEOUT_SECONDS)
+            sock.connect(socket_path)
+            sock.sendall(json.dumps(request).encode("utf-8") + b"\n")
+            raw = b""
+            while not raw.endswith(b"\n"):
+                chunk = sock.recv(4096)
+                if not chunk:
+                    break
+                raw += chunk
+        response = json.loads(raw.decode("utf-8"))
+        if response.get("ok") is True:
+            return True
+        sys.stderr.write(f"[pre_run] heartbeat rejected: {response}\n")
+        return False
+    except Exception as exc:  # noqa: BLE001 — any heartbeat failure → wake
+        sys.stderr.write(f"[pre_run] heartbeat write failed: {exc}\n")
+        return False
+
+
+def decide_and_emit(count: int | None, skill_name: str) -> int:
+    """Pure-ish core: count → wake/suppress emission (heartbeat before suppress)."""
+    if count is None or count > 0:
+        return _emit(wake=True)
+    if not write_suppressed_wake_heartbeat(skill_name):
+        # Mirror-don't-gate: a silent suppress with no audit trail is
+        # indistinguishable from a broken pre_run. Wake instead — the full
+        # agent run is observable and the failure becomes visible.
+        return _emit(wake=True)
+    return _emit(wake=False)
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = sys.argv[1:] if argv is None else argv
+    skill_name = _skill_name()
+    if "--assume-empty" in argv:
+        sys.stderr.write("[pre_run] --assume-empty: skipping smokeball probe\n")
+        return decide_and_emit(0, skill_name)
+    return decide_and_emit(probe_open_matter_count(), skill_name)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/operator/skills/discovery-response-tracker/pre_run.py
+++ b/operator/skills/discovery-response-tracker/pre_run.py
@@ -101,6 +101,7 @@ def probe_open_matter_count() -> int | None:
         sys.stderr.write(f"[pre_run] connector python missing: {connector_python}\n")
         return None
     try:
+        # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-tainted-env-args.dangerous-subprocess-use-tainted-env-args — argv[0] is the module-constant connector-venv interpreter, overridable only via SMD_CONNECTOR_VENV_PYTHON, which comes from the Machine's own boot env (same trust domain as this file; the test seam). The snippet argument is a module constant; no request/agent-controlled data reaches argv.
         result = subprocess.run(
             [connector_python, "-c", _PROBE_SNIPPET],
             capture_output=True,

--- a/operator/skills/discovery-response-tracker/pre_run.py
+++ b/operator/skills/discovery-response-tracker/pre_run.py
@@ -101,8 +101,8 @@ def probe_open_matter_count() -> int | None:
         sys.stderr.write(f"[pre_run] connector python missing: {connector_python}\n")
         return None
     try:
-        # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-tainted-env-args.dangerous-subprocess-use-tainted-env-args — argv[0] is the module-constant connector-venv interpreter, overridable only via SMD_CONNECTOR_VENV_PYTHON, which comes from the Machine's own boot env (same trust domain as this file; the test seam). The snippet argument is a module constant; no request/agent-controlled data reaches argv.
         result = subprocess.run(
+            # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-tainted-env-args.dangerous-subprocess-use-tainted-env-args — argv[0] is the module-constant connector-venv interpreter, overridable only via SMD_CONNECTOR_VENV_PYTHON, which comes from the Machine's own boot env (same trust domain as this file; the test seam). The snippet argument is a module constant; no request/agent-controlled data reaches argv.
             [connector_python, "-c", _PROBE_SNIPPET],
             capture_output=True,
             text=True,

--- a/operator/skills/lien-ledger-tracker/pre_run.py
+++ b/operator/skills/lien-ledger-tracker/pre_run.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Shared cron pre-run gate — the empty-seat wake suppressor (ADR 0021 Stream B).
+
+CANONICAL SOURCE: ``operator/templates/pre_run_gate.py``. The copies stamped
+into skill directories as ``pre_run.py`` MUST be byte-identical to this file —
+``operator/tests/test_pre_run_gate.py`` enforces the sync. Edit here, restamp.
+
+What this gate decides
+----------------------
+Scheduled tracker/watch/chase skills re-derive their work from the matter set
+in the practice-management system (they keep no local state — the matter is
+the system of record). On a seat with ZERO open matters there is provably no
+work for any of them, so waking the model is pure token burn. This gate:
+
+  1. Probes Smokeball for open matters (one ``GET /matters?Status=Open&Limit=1``
+     via the connector's own venv — the connector package is not importable
+     from the Hermes venv this script runs in).
+  2. Any open matter, any probe failure, any unknown response envelope, any
+     heartbeat-write failure → ``{"wakeAgent": true}`` (fail-open; the agent
+     wakes exactly as it would with no gate).
+  3. Zero open matters → writes a SUPPRESSED_WAKE heartbeat row through the
+     broker's uid-gated ``suppressed_wake_append`` verb, THEN emits
+     ``{"wakeAgent": false}``. Suppress-without-heartbeat never happens
+     (mirror-don't-gate): if the broker write fails, the agent wakes.
+
+What this gate deliberately does NOT decide
+-------------------------------------------
+It is NOT a per-skill "is there work" check. A hydrated seat (any open
+matter) always wakes — deeper UpdatedSince/state-delta gates are follow-on
+work once the Smokeball ``updated_since`` wire format is verified at connect.
+Lead-stage and inbound-driven work is unaffected either way: webhook and
+inbound wakes are ungated by design.
+
+Skill identity
+--------------
+The scheduler stages this file to ``<profile>/scripts/<skill>/pre_run.py`` and
+runs it with cwd = that directory, so the skill name is the cwd basename. That
+keeps every stamped copy byte-identical.
+
+Verification hook
+-----------------
+``pre_run.py --assume-empty`` skips the Smokeball probe and behaves as if the
+seat were empty — it exercises the heartbeat write + suppress path end-to-end
+on a live Machine without needing an actually-empty tenant. The cron daemon
+never passes arguments, so this path cannot trigger on a scheduled fire.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import subprocess
+import sys
+from pathlib import Path
+
+# Timeout budget: the Hermes scheduler kills the whole script at 120s
+# (cron/scheduler.py _DEFAULT_SCRIPT_TIMEOUT); the probe gets well under that.
+_PROBE_TIMEOUT_SECONDS = 45
+_HEARTBEAT_TIMEOUT_SECONDS = 10
+
+_CONNECTOR_PYTHON_DEFAULT = "/opt/connectors/smokeball/.venv/bin/python"
+
+# Runs inside the connector venv, where smokeball_connector IS importable and
+# build_client_from_env() owns auth (token mint + refresh-token self-heal).
+# Envelope parsing is deliberately defensive: the live /matters list shape is
+# connect-time-unverified, so an unrecognized shape reports null → wake.
+_PROBE_SNIPPET = """\
+import json
+from smokeball_connector.client import build_client_from_env
+
+r = build_client_from_env().get("/matters", Status="Open", Limit=1)
+items = None
+if isinstance(r, list):
+    items = r
+elif isinstance(r, dict):
+    for key in ("items", "value", "results", "matters", "data"):
+        v = r.get(key)
+        if isinstance(v, list):
+            items = v
+            break
+print(json.dumps({"openMatterCount": len(items) if items is not None else None}))
+"""
+
+
+def _emit(wake: bool) -> int:
+    print(json.dumps({"wakeAgent": wake}))
+    return 0
+
+
+def _skill_name() -> str:
+    return Path.cwd().name or "unknown-skill"
+
+
+def probe_open_matter_count() -> int | None:
+    """Return the open-matter count, or None when it cannot be determined."""
+    connector_python = os.environ.get(
+        "SMD_CONNECTOR_VENV_PYTHON", _CONNECTOR_PYTHON_DEFAULT
+    )
+    if not Path(connector_python).exists():
+        sys.stderr.write(f"[pre_run] connector python missing: {connector_python}\n")
+        return None
+    try:
+        result = subprocess.run(
+            [connector_python, "-c", _PROBE_SNIPPET],
+            capture_output=True,
+            text=True,
+            timeout=_PROBE_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        sys.stderr.write("[pre_run] smokeball probe timed out\n")
+        return None
+    except Exception as exc:  # noqa: BLE001 — any probe failure → unknown → wake
+        sys.stderr.write(f"[pre_run] smokeball probe failed: {exc}\n")
+        return None
+    if result.returncode != 0:
+        sys.stderr.write(
+            f"[pre_run] smokeball probe exit {result.returncode}: "
+            f"{(result.stderr or '').strip()[:500]}\n"
+        )
+        return None
+    try:
+        payload = json.loads((result.stdout or "").strip().splitlines()[-1])
+        count = payload.get("openMatterCount")
+    except Exception:  # noqa: BLE001 — malformed probe output → unknown → wake
+        sys.stderr.write("[pre_run] smokeball probe output unparseable\n")
+        return None
+    if isinstance(count, bool) or not isinstance(count, int):
+        return None
+    return count
+
+
+def write_suppressed_wake_heartbeat(skill_name: str) -> bool:
+    """Append the SUPPRESSED_WAKE row via the broker. True only on ack."""
+    socket_path = os.environ.get("SMD_AUDIT_BROKER_SOCKET") or os.environ.get(
+        "SMD_WORKSPACE_BROKER_SOCKET"
+    )
+    if not socket_path:
+        sys.stderr.write("[pre_run] no broker socket in env; cannot heartbeat\n")
+        return False
+    request = {
+        "action": "suppressed_wake_append",
+        "row": {
+            "action_type": "SUPPRESSED_WAKE",
+            "actor": "agent",
+            "actor_role": "agent",
+            "skill_name": skill_name,
+            "metadata": json.dumps(
+                {
+                    "decision_basis": "empty_seat:no_open_matters",
+                    "platform": "cron-pre-run",
+                    "customer": os.environ.get("CUSTOMER_SLUG", ""),
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+            ),
+        },
+    }
+    try:
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
+            sock.settimeout(_HEARTBEAT_TIMEOUT_SECONDS)
+            sock.connect(socket_path)
+            sock.sendall(json.dumps(request).encode("utf-8") + b"\n")
+            raw = b""
+            while not raw.endswith(b"\n"):
+                chunk = sock.recv(4096)
+                if not chunk:
+                    break
+                raw += chunk
+        response = json.loads(raw.decode("utf-8"))
+        if response.get("ok") is True:
+            return True
+        sys.stderr.write(f"[pre_run] heartbeat rejected: {response}\n")
+        return False
+    except Exception as exc:  # noqa: BLE001 — any heartbeat failure → wake
+        sys.stderr.write(f"[pre_run] heartbeat write failed: {exc}\n")
+        return False
+
+
+def decide_and_emit(count: int | None, skill_name: str) -> int:
+    """Pure-ish core: count → wake/suppress emission (heartbeat before suppress)."""
+    if count is None or count > 0:
+        return _emit(wake=True)
+    if not write_suppressed_wake_heartbeat(skill_name):
+        # Mirror-don't-gate: a silent suppress with no audit trail is
+        # indistinguishable from a broken pre_run. Wake instead — the full
+        # agent run is observable and the failure becomes visible.
+        return _emit(wake=True)
+    return _emit(wake=False)
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = sys.argv[1:] if argv is None else argv
+    skill_name = _skill_name()
+    if "--assume-empty" in argv:
+        sys.stderr.write("[pre_run] --assume-empty: skipping smokeball probe\n")
+        return decide_and_emit(0, skill_name)
+    return decide_and_emit(probe_open_matter_count(), skill_name)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/operator/skills/lien-ledger-tracker/pre_run.py
+++ b/operator/skills/lien-ledger-tracker/pre_run.py
@@ -101,6 +101,7 @@ def probe_open_matter_count() -> int | None:
         sys.stderr.write(f"[pre_run] connector python missing: {connector_python}\n")
         return None
     try:
+        # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-tainted-env-args.dangerous-subprocess-use-tainted-env-args — argv[0] is the module-constant connector-venv interpreter, overridable only via SMD_CONNECTOR_VENV_PYTHON, which comes from the Machine's own boot env (same trust domain as this file; the test seam). The snippet argument is a module constant; no request/agent-controlled data reaches argv.
         result = subprocess.run(
             [connector_python, "-c", _PROBE_SNIPPET],
             capture_output=True,

--- a/operator/skills/lien-ledger-tracker/pre_run.py
+++ b/operator/skills/lien-ledger-tracker/pre_run.py
@@ -101,8 +101,8 @@ def probe_open_matter_count() -> int | None:
         sys.stderr.write(f"[pre_run] connector python missing: {connector_python}\n")
         return None
     try:
-        # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-tainted-env-args.dangerous-subprocess-use-tainted-env-args — argv[0] is the module-constant connector-venv interpreter, overridable only via SMD_CONNECTOR_VENV_PYTHON, which comes from the Machine's own boot env (same trust domain as this file; the test seam). The snippet argument is a module constant; no request/agent-controlled data reaches argv.
         result = subprocess.run(
+            # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-tainted-env-args.dangerous-subprocess-use-tainted-env-args — argv[0] is the module-constant connector-venv interpreter, overridable only via SMD_CONNECTOR_VENV_PYTHON, which comes from the Machine's own boot env (same trust domain as this file; the test seam). The snippet argument is a module constant; no request/agent-controlled data reaches argv.
             [connector_python, "-c", _PROBE_SNIPPET],
             capture_output=True,
             text=True,

--- a/operator/skills/mediation-settlement-tracker/pre_run.py
+++ b/operator/skills/mediation-settlement-tracker/pre_run.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Shared cron pre-run gate — the empty-seat wake suppressor (ADR 0021 Stream B).
+
+CANONICAL SOURCE: ``operator/templates/pre_run_gate.py``. The copies stamped
+into skill directories as ``pre_run.py`` MUST be byte-identical to this file —
+``operator/tests/test_pre_run_gate.py`` enforces the sync. Edit here, restamp.
+
+What this gate decides
+----------------------
+Scheduled tracker/watch/chase skills re-derive their work from the matter set
+in the practice-management system (they keep no local state — the matter is
+the system of record). On a seat with ZERO open matters there is provably no
+work for any of them, so waking the model is pure token burn. This gate:
+
+  1. Probes Smokeball for open matters (one ``GET /matters?Status=Open&Limit=1``
+     via the connector's own venv — the connector package is not importable
+     from the Hermes venv this script runs in).
+  2. Any open matter, any probe failure, any unknown response envelope, any
+     heartbeat-write failure → ``{"wakeAgent": true}`` (fail-open; the agent
+     wakes exactly as it would with no gate).
+  3. Zero open matters → writes a SUPPRESSED_WAKE heartbeat row through the
+     broker's uid-gated ``suppressed_wake_append`` verb, THEN emits
+     ``{"wakeAgent": false}``. Suppress-without-heartbeat never happens
+     (mirror-don't-gate): if the broker write fails, the agent wakes.
+
+What this gate deliberately does NOT decide
+-------------------------------------------
+It is NOT a per-skill "is there work" check. A hydrated seat (any open
+matter) always wakes — deeper UpdatedSince/state-delta gates are follow-on
+work once the Smokeball ``updated_since`` wire format is verified at connect.
+Lead-stage and inbound-driven work is unaffected either way: webhook and
+inbound wakes are ungated by design.
+
+Skill identity
+--------------
+The scheduler stages this file to ``<profile>/scripts/<skill>/pre_run.py`` and
+runs it with cwd = that directory, so the skill name is the cwd basename. That
+keeps every stamped copy byte-identical.
+
+Verification hook
+-----------------
+``pre_run.py --assume-empty`` skips the Smokeball probe and behaves as if the
+seat were empty — it exercises the heartbeat write + suppress path end-to-end
+on a live Machine without needing an actually-empty tenant. The cron daemon
+never passes arguments, so this path cannot trigger on a scheduled fire.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import subprocess
+import sys
+from pathlib import Path
+
+# Timeout budget: the Hermes scheduler kills the whole script at 120s
+# (cron/scheduler.py _DEFAULT_SCRIPT_TIMEOUT); the probe gets well under that.
+_PROBE_TIMEOUT_SECONDS = 45
+_HEARTBEAT_TIMEOUT_SECONDS = 10
+
+_CONNECTOR_PYTHON_DEFAULT = "/opt/connectors/smokeball/.venv/bin/python"
+
+# Runs inside the connector venv, where smokeball_connector IS importable and
+# build_client_from_env() owns auth (token mint + refresh-token self-heal).
+# Envelope parsing is deliberately defensive: the live /matters list shape is
+# connect-time-unverified, so an unrecognized shape reports null → wake.
+_PROBE_SNIPPET = """\
+import json
+from smokeball_connector.client import build_client_from_env
+
+r = build_client_from_env().get("/matters", Status="Open", Limit=1)
+items = None
+if isinstance(r, list):
+    items = r
+elif isinstance(r, dict):
+    for key in ("items", "value", "results", "matters", "data"):
+        v = r.get(key)
+        if isinstance(v, list):
+            items = v
+            break
+print(json.dumps({"openMatterCount": len(items) if items is not None else None}))
+"""
+
+
+def _emit(wake: bool) -> int:
+    print(json.dumps({"wakeAgent": wake}))
+    return 0
+
+
+def _skill_name() -> str:
+    return Path.cwd().name or "unknown-skill"
+
+
+def probe_open_matter_count() -> int | None:
+    """Return the open-matter count, or None when it cannot be determined."""
+    connector_python = os.environ.get(
+        "SMD_CONNECTOR_VENV_PYTHON", _CONNECTOR_PYTHON_DEFAULT
+    )
+    if not Path(connector_python).exists():
+        sys.stderr.write(f"[pre_run] connector python missing: {connector_python}\n")
+        return None
+    try:
+        result = subprocess.run(
+            [connector_python, "-c", _PROBE_SNIPPET],
+            capture_output=True,
+            text=True,
+            timeout=_PROBE_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        sys.stderr.write("[pre_run] smokeball probe timed out\n")
+        return None
+    except Exception as exc:  # noqa: BLE001 — any probe failure → unknown → wake
+        sys.stderr.write(f"[pre_run] smokeball probe failed: {exc}\n")
+        return None
+    if result.returncode != 0:
+        sys.stderr.write(
+            f"[pre_run] smokeball probe exit {result.returncode}: "
+            f"{(result.stderr or '').strip()[:500]}\n"
+        )
+        return None
+    try:
+        payload = json.loads((result.stdout or "").strip().splitlines()[-1])
+        count = payload.get("openMatterCount")
+    except Exception:  # noqa: BLE001 — malformed probe output → unknown → wake
+        sys.stderr.write("[pre_run] smokeball probe output unparseable\n")
+        return None
+    if isinstance(count, bool) or not isinstance(count, int):
+        return None
+    return count
+
+
+def write_suppressed_wake_heartbeat(skill_name: str) -> bool:
+    """Append the SUPPRESSED_WAKE row via the broker. True only on ack."""
+    socket_path = os.environ.get("SMD_AUDIT_BROKER_SOCKET") or os.environ.get(
+        "SMD_WORKSPACE_BROKER_SOCKET"
+    )
+    if not socket_path:
+        sys.stderr.write("[pre_run] no broker socket in env; cannot heartbeat\n")
+        return False
+    request = {
+        "action": "suppressed_wake_append",
+        "row": {
+            "action_type": "SUPPRESSED_WAKE",
+            "actor": "agent",
+            "actor_role": "agent",
+            "skill_name": skill_name,
+            "metadata": json.dumps(
+                {
+                    "decision_basis": "empty_seat:no_open_matters",
+                    "platform": "cron-pre-run",
+                    "customer": os.environ.get("CUSTOMER_SLUG", ""),
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+            ),
+        },
+    }
+    try:
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
+            sock.settimeout(_HEARTBEAT_TIMEOUT_SECONDS)
+            sock.connect(socket_path)
+            sock.sendall(json.dumps(request).encode("utf-8") + b"\n")
+            raw = b""
+            while not raw.endswith(b"\n"):
+                chunk = sock.recv(4096)
+                if not chunk:
+                    break
+                raw += chunk
+        response = json.loads(raw.decode("utf-8"))
+        if response.get("ok") is True:
+            return True
+        sys.stderr.write(f"[pre_run] heartbeat rejected: {response}\n")
+        return False
+    except Exception as exc:  # noqa: BLE001 — any heartbeat failure → wake
+        sys.stderr.write(f"[pre_run] heartbeat write failed: {exc}\n")
+        return False
+
+
+def decide_and_emit(count: int | None, skill_name: str) -> int:
+    """Pure-ish core: count → wake/suppress emission (heartbeat before suppress)."""
+    if count is None or count > 0:
+        return _emit(wake=True)
+    if not write_suppressed_wake_heartbeat(skill_name):
+        # Mirror-don't-gate: a silent suppress with no audit trail is
+        # indistinguishable from a broken pre_run. Wake instead — the full
+        # agent run is observable and the failure becomes visible.
+        return _emit(wake=True)
+    return _emit(wake=False)
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = sys.argv[1:] if argv is None else argv
+    skill_name = _skill_name()
+    if "--assume-empty" in argv:
+        sys.stderr.write("[pre_run] --assume-empty: skipping smokeball probe\n")
+        return decide_and_emit(0, skill_name)
+    return decide_and_emit(probe_open_matter_count(), skill_name)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/operator/skills/mediation-settlement-tracker/pre_run.py
+++ b/operator/skills/mediation-settlement-tracker/pre_run.py
@@ -101,6 +101,7 @@ def probe_open_matter_count() -> int | None:
         sys.stderr.write(f"[pre_run] connector python missing: {connector_python}\n")
         return None
     try:
+        # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-tainted-env-args.dangerous-subprocess-use-tainted-env-args — argv[0] is the module-constant connector-venv interpreter, overridable only via SMD_CONNECTOR_VENV_PYTHON, which comes from the Machine's own boot env (same trust domain as this file; the test seam). The snippet argument is a module constant; no request/agent-controlled data reaches argv.
         result = subprocess.run(
             [connector_python, "-c", _PROBE_SNIPPET],
             capture_output=True,

--- a/operator/skills/mediation-settlement-tracker/pre_run.py
+++ b/operator/skills/mediation-settlement-tracker/pre_run.py
@@ -101,8 +101,8 @@ def probe_open_matter_count() -> int | None:
         sys.stderr.write(f"[pre_run] connector python missing: {connector_python}\n")
         return None
     try:
-        # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-tainted-env-args.dangerous-subprocess-use-tainted-env-args — argv[0] is the module-constant connector-venv interpreter, overridable only via SMD_CONNECTOR_VENV_PYTHON, which comes from the Machine's own boot env (same trust domain as this file; the test seam). The snippet argument is a module constant; no request/agent-controlled data reaches argv.
         result = subprocess.run(
+            # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-tainted-env-args.dangerous-subprocess-use-tainted-env-args — argv[0] is the module-constant connector-venv interpreter, overridable only via SMD_CONNECTOR_VENV_PYTHON, which comes from the Machine's own boot env (same trust domain as this file; the test seam). The snippet argument is a module constant; no request/agent-controlled data reaches argv.
             [connector_python, "-c", _PROBE_SNIPPET],
             capture_output=True,
             text=True,

--- a/operator/skills/medical-chronology-maintainer/pre_run.py
+++ b/operator/skills/medical-chronology-maintainer/pre_run.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Shared cron pre-run gate — the empty-seat wake suppressor (ADR 0021 Stream B).
+
+CANONICAL SOURCE: ``operator/templates/pre_run_gate.py``. The copies stamped
+into skill directories as ``pre_run.py`` MUST be byte-identical to this file —
+``operator/tests/test_pre_run_gate.py`` enforces the sync. Edit here, restamp.
+
+What this gate decides
+----------------------
+Scheduled tracker/watch/chase skills re-derive their work from the matter set
+in the practice-management system (they keep no local state — the matter is
+the system of record). On a seat with ZERO open matters there is provably no
+work for any of them, so waking the model is pure token burn. This gate:
+
+  1. Probes Smokeball for open matters (one ``GET /matters?Status=Open&Limit=1``
+     via the connector's own venv — the connector package is not importable
+     from the Hermes venv this script runs in).
+  2. Any open matter, any probe failure, any unknown response envelope, any
+     heartbeat-write failure → ``{"wakeAgent": true}`` (fail-open; the agent
+     wakes exactly as it would with no gate).
+  3. Zero open matters → writes a SUPPRESSED_WAKE heartbeat row through the
+     broker's uid-gated ``suppressed_wake_append`` verb, THEN emits
+     ``{"wakeAgent": false}``. Suppress-without-heartbeat never happens
+     (mirror-don't-gate): if the broker write fails, the agent wakes.
+
+What this gate deliberately does NOT decide
+-------------------------------------------
+It is NOT a per-skill "is there work" check. A hydrated seat (any open
+matter) always wakes — deeper UpdatedSince/state-delta gates are follow-on
+work once the Smokeball ``updated_since`` wire format is verified at connect.
+Lead-stage and inbound-driven work is unaffected either way: webhook and
+inbound wakes are ungated by design.
+
+Skill identity
+--------------
+The scheduler stages this file to ``<profile>/scripts/<skill>/pre_run.py`` and
+runs it with cwd = that directory, so the skill name is the cwd basename. That
+keeps every stamped copy byte-identical.
+
+Verification hook
+-----------------
+``pre_run.py --assume-empty`` skips the Smokeball probe and behaves as if the
+seat were empty — it exercises the heartbeat write + suppress path end-to-end
+on a live Machine without needing an actually-empty tenant. The cron daemon
+never passes arguments, so this path cannot trigger on a scheduled fire.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import subprocess
+import sys
+from pathlib import Path
+
+# Timeout budget: the Hermes scheduler kills the whole script at 120s
+# (cron/scheduler.py _DEFAULT_SCRIPT_TIMEOUT); the probe gets well under that.
+_PROBE_TIMEOUT_SECONDS = 45
+_HEARTBEAT_TIMEOUT_SECONDS = 10
+
+_CONNECTOR_PYTHON_DEFAULT = "/opt/connectors/smokeball/.venv/bin/python"
+
+# Runs inside the connector venv, where smokeball_connector IS importable and
+# build_client_from_env() owns auth (token mint + refresh-token self-heal).
+# Envelope parsing is deliberately defensive: the live /matters list shape is
+# connect-time-unverified, so an unrecognized shape reports null → wake.
+_PROBE_SNIPPET = """\
+import json
+from smokeball_connector.client import build_client_from_env
+
+r = build_client_from_env().get("/matters", Status="Open", Limit=1)
+items = None
+if isinstance(r, list):
+    items = r
+elif isinstance(r, dict):
+    for key in ("items", "value", "results", "matters", "data"):
+        v = r.get(key)
+        if isinstance(v, list):
+            items = v
+            break
+print(json.dumps({"openMatterCount": len(items) if items is not None else None}))
+"""
+
+
+def _emit(wake: bool) -> int:
+    print(json.dumps({"wakeAgent": wake}))
+    return 0
+
+
+def _skill_name() -> str:
+    return Path.cwd().name or "unknown-skill"
+
+
+def probe_open_matter_count() -> int | None:
+    """Return the open-matter count, or None when it cannot be determined."""
+    connector_python = os.environ.get(
+        "SMD_CONNECTOR_VENV_PYTHON", _CONNECTOR_PYTHON_DEFAULT
+    )
+    if not Path(connector_python).exists():
+        sys.stderr.write(f"[pre_run] connector python missing: {connector_python}\n")
+        return None
+    try:
+        result = subprocess.run(
+            [connector_python, "-c", _PROBE_SNIPPET],
+            capture_output=True,
+            text=True,
+            timeout=_PROBE_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        sys.stderr.write("[pre_run] smokeball probe timed out\n")
+        return None
+    except Exception as exc:  # noqa: BLE001 — any probe failure → unknown → wake
+        sys.stderr.write(f"[pre_run] smokeball probe failed: {exc}\n")
+        return None
+    if result.returncode != 0:
+        sys.stderr.write(
+            f"[pre_run] smokeball probe exit {result.returncode}: "
+            f"{(result.stderr or '').strip()[:500]}\n"
+        )
+        return None
+    try:
+        payload = json.loads((result.stdout or "").strip().splitlines()[-1])
+        count = payload.get("openMatterCount")
+    except Exception:  # noqa: BLE001 — malformed probe output → unknown → wake
+        sys.stderr.write("[pre_run] smokeball probe output unparseable\n")
+        return None
+    if isinstance(count, bool) or not isinstance(count, int):
+        return None
+    return count
+
+
+def write_suppressed_wake_heartbeat(skill_name: str) -> bool:
+    """Append the SUPPRESSED_WAKE row via the broker. True only on ack."""
+    socket_path = os.environ.get("SMD_AUDIT_BROKER_SOCKET") or os.environ.get(
+        "SMD_WORKSPACE_BROKER_SOCKET"
+    )
+    if not socket_path:
+        sys.stderr.write("[pre_run] no broker socket in env; cannot heartbeat\n")
+        return False
+    request = {
+        "action": "suppressed_wake_append",
+        "row": {
+            "action_type": "SUPPRESSED_WAKE",
+            "actor": "agent",
+            "actor_role": "agent",
+            "skill_name": skill_name,
+            "metadata": json.dumps(
+                {
+                    "decision_basis": "empty_seat:no_open_matters",
+                    "platform": "cron-pre-run",
+                    "customer": os.environ.get("CUSTOMER_SLUG", ""),
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+            ),
+        },
+    }
+    try:
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
+            sock.settimeout(_HEARTBEAT_TIMEOUT_SECONDS)
+            sock.connect(socket_path)
+            sock.sendall(json.dumps(request).encode("utf-8") + b"\n")
+            raw = b""
+            while not raw.endswith(b"\n"):
+                chunk = sock.recv(4096)
+                if not chunk:
+                    break
+                raw += chunk
+        response = json.loads(raw.decode("utf-8"))
+        if response.get("ok") is True:
+            return True
+        sys.stderr.write(f"[pre_run] heartbeat rejected: {response}\n")
+        return False
+    except Exception as exc:  # noqa: BLE001 — any heartbeat failure → wake
+        sys.stderr.write(f"[pre_run] heartbeat write failed: {exc}\n")
+        return False
+
+
+def decide_and_emit(count: int | None, skill_name: str) -> int:
+    """Pure-ish core: count → wake/suppress emission (heartbeat before suppress)."""
+    if count is None or count > 0:
+        return _emit(wake=True)
+    if not write_suppressed_wake_heartbeat(skill_name):
+        # Mirror-don't-gate: a silent suppress with no audit trail is
+        # indistinguishable from a broken pre_run. Wake instead — the full
+        # agent run is observable and the failure becomes visible.
+        return _emit(wake=True)
+    return _emit(wake=False)
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = sys.argv[1:] if argv is None else argv
+    skill_name = _skill_name()
+    if "--assume-empty" in argv:
+        sys.stderr.write("[pre_run] --assume-empty: skipping smokeball probe\n")
+        return decide_and_emit(0, skill_name)
+    return decide_and_emit(probe_open_matter_count(), skill_name)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/operator/skills/medical-chronology-maintainer/pre_run.py
+++ b/operator/skills/medical-chronology-maintainer/pre_run.py
@@ -101,6 +101,7 @@ def probe_open_matter_count() -> int | None:
         sys.stderr.write(f"[pre_run] connector python missing: {connector_python}\n")
         return None
     try:
+        # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-tainted-env-args.dangerous-subprocess-use-tainted-env-args — argv[0] is the module-constant connector-venv interpreter, overridable only via SMD_CONNECTOR_VENV_PYTHON, which comes from the Machine's own boot env (same trust domain as this file; the test seam). The snippet argument is a module constant; no request/agent-controlled data reaches argv.
         result = subprocess.run(
             [connector_python, "-c", _PROBE_SNIPPET],
             capture_output=True,

--- a/operator/skills/medical-chronology-maintainer/pre_run.py
+++ b/operator/skills/medical-chronology-maintainer/pre_run.py
@@ -101,8 +101,8 @@ def probe_open_matter_count() -> int | None:
         sys.stderr.write(f"[pre_run] connector python missing: {connector_python}\n")
         return None
     try:
-        # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-tainted-env-args.dangerous-subprocess-use-tainted-env-args — argv[0] is the module-constant connector-venv interpreter, overridable only via SMD_CONNECTOR_VENV_PYTHON, which comes from the Machine's own boot env (same trust domain as this file; the test seam). The snippet argument is a module constant; no request/agent-controlled data reaches argv.
         result = subprocess.run(
+            # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-tainted-env-args.dangerous-subprocess-use-tainted-env-args — argv[0] is the module-constant connector-venv interpreter, overridable only via SMD_CONNECTOR_VENV_PYTHON, which comes from the Machine's own boot env (same trust domain as this file; the test seam). The snippet argument is a module constant; no request/agent-controlled data reaches argv.
             [connector_python, "-c", _PROBE_SNIPPET],
             capture_output=True,
             text=True,

--- a/operator/skills/medical-records-chaser/pre_run.py
+++ b/operator/skills/medical-records-chaser/pre_run.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Shared cron pre-run gate — the empty-seat wake suppressor (ADR 0021 Stream B).
+
+CANONICAL SOURCE: ``operator/templates/pre_run_gate.py``. The copies stamped
+into skill directories as ``pre_run.py`` MUST be byte-identical to this file —
+``operator/tests/test_pre_run_gate.py`` enforces the sync. Edit here, restamp.
+
+What this gate decides
+----------------------
+Scheduled tracker/watch/chase skills re-derive their work from the matter set
+in the practice-management system (they keep no local state — the matter is
+the system of record). On a seat with ZERO open matters there is provably no
+work for any of them, so waking the model is pure token burn. This gate:
+
+  1. Probes Smokeball for open matters (one ``GET /matters?Status=Open&Limit=1``
+     via the connector's own venv — the connector package is not importable
+     from the Hermes venv this script runs in).
+  2. Any open matter, any probe failure, any unknown response envelope, any
+     heartbeat-write failure → ``{"wakeAgent": true}`` (fail-open; the agent
+     wakes exactly as it would with no gate).
+  3. Zero open matters → writes a SUPPRESSED_WAKE heartbeat row through the
+     broker's uid-gated ``suppressed_wake_append`` verb, THEN emits
+     ``{"wakeAgent": false}``. Suppress-without-heartbeat never happens
+     (mirror-don't-gate): if the broker write fails, the agent wakes.
+
+What this gate deliberately does NOT decide
+-------------------------------------------
+It is NOT a per-skill "is there work" check. A hydrated seat (any open
+matter) always wakes — deeper UpdatedSince/state-delta gates are follow-on
+work once the Smokeball ``updated_since`` wire format is verified at connect.
+Lead-stage and inbound-driven work is unaffected either way: webhook and
+inbound wakes are ungated by design.
+
+Skill identity
+--------------
+The scheduler stages this file to ``<profile>/scripts/<skill>/pre_run.py`` and
+runs it with cwd = that directory, so the skill name is the cwd basename. That
+keeps every stamped copy byte-identical.
+
+Verification hook
+-----------------
+``pre_run.py --assume-empty`` skips the Smokeball probe and behaves as if the
+seat were empty — it exercises the heartbeat write + suppress path end-to-end
+on a live Machine without needing an actually-empty tenant. The cron daemon
+never passes arguments, so this path cannot trigger on a scheduled fire.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import subprocess
+import sys
+from pathlib import Path
+
+# Timeout budget: the Hermes scheduler kills the whole script at 120s
+# (cron/scheduler.py _DEFAULT_SCRIPT_TIMEOUT); the probe gets well under that.
+_PROBE_TIMEOUT_SECONDS = 45
+_HEARTBEAT_TIMEOUT_SECONDS = 10
+
+_CONNECTOR_PYTHON_DEFAULT = "/opt/connectors/smokeball/.venv/bin/python"
+
+# Runs inside the connector venv, where smokeball_connector IS importable and
+# build_client_from_env() owns auth (token mint + refresh-token self-heal).
+# Envelope parsing is deliberately defensive: the live /matters list shape is
+# connect-time-unverified, so an unrecognized shape reports null → wake.
+_PROBE_SNIPPET = """\
+import json
+from smokeball_connector.client import build_client_from_env
+
+r = build_client_from_env().get("/matters", Status="Open", Limit=1)
+items = None
+if isinstance(r, list):
+    items = r
+elif isinstance(r, dict):
+    for key in ("items", "value", "results", "matters", "data"):
+        v = r.get(key)
+        if isinstance(v, list):
+            items = v
+            break
+print(json.dumps({"openMatterCount": len(items) if items is not None else None}))
+"""
+
+
+def _emit(wake: bool) -> int:
+    print(json.dumps({"wakeAgent": wake}))
+    return 0
+
+
+def _skill_name() -> str:
+    return Path.cwd().name or "unknown-skill"
+
+
+def probe_open_matter_count() -> int | None:
+    """Return the open-matter count, or None when it cannot be determined."""
+    connector_python = os.environ.get(
+        "SMD_CONNECTOR_VENV_PYTHON", _CONNECTOR_PYTHON_DEFAULT
+    )
+    if not Path(connector_python).exists():
+        sys.stderr.write(f"[pre_run] connector python missing: {connector_python}\n")
+        return None
+    try:
+        result = subprocess.run(
+            [connector_python, "-c", _PROBE_SNIPPET],
+            capture_output=True,
+            text=True,
+            timeout=_PROBE_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        sys.stderr.write("[pre_run] smokeball probe timed out\n")
+        return None
+    except Exception as exc:  # noqa: BLE001 — any probe failure → unknown → wake
+        sys.stderr.write(f"[pre_run] smokeball probe failed: {exc}\n")
+        return None
+    if result.returncode != 0:
+        sys.stderr.write(
+            f"[pre_run] smokeball probe exit {result.returncode}: "
+            f"{(result.stderr or '').strip()[:500]}\n"
+        )
+        return None
+    try:
+        payload = json.loads((result.stdout or "").strip().splitlines()[-1])
+        count = payload.get("openMatterCount")
+    except Exception:  # noqa: BLE001 — malformed probe output → unknown → wake
+        sys.stderr.write("[pre_run] smokeball probe output unparseable\n")
+        return None
+    if isinstance(count, bool) or not isinstance(count, int):
+        return None
+    return count
+
+
+def write_suppressed_wake_heartbeat(skill_name: str) -> bool:
+    """Append the SUPPRESSED_WAKE row via the broker. True only on ack."""
+    socket_path = os.environ.get("SMD_AUDIT_BROKER_SOCKET") or os.environ.get(
+        "SMD_WORKSPACE_BROKER_SOCKET"
+    )
+    if not socket_path:
+        sys.stderr.write("[pre_run] no broker socket in env; cannot heartbeat\n")
+        return False
+    request = {
+        "action": "suppressed_wake_append",
+        "row": {
+            "action_type": "SUPPRESSED_WAKE",
+            "actor": "agent",
+            "actor_role": "agent",
+            "skill_name": skill_name,
+            "metadata": json.dumps(
+                {
+                    "decision_basis": "empty_seat:no_open_matters",
+                    "platform": "cron-pre-run",
+                    "customer": os.environ.get("CUSTOMER_SLUG", ""),
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+            ),
+        },
+    }
+    try:
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
+            sock.settimeout(_HEARTBEAT_TIMEOUT_SECONDS)
+            sock.connect(socket_path)
+            sock.sendall(json.dumps(request).encode("utf-8") + b"\n")
+            raw = b""
+            while not raw.endswith(b"\n"):
+                chunk = sock.recv(4096)
+                if not chunk:
+                    break
+                raw += chunk
+        response = json.loads(raw.decode("utf-8"))
+        if response.get("ok") is True:
+            return True
+        sys.stderr.write(f"[pre_run] heartbeat rejected: {response}\n")
+        return False
+    except Exception as exc:  # noqa: BLE001 — any heartbeat failure → wake
+        sys.stderr.write(f"[pre_run] heartbeat write failed: {exc}\n")
+        return False
+
+
+def decide_and_emit(count: int | None, skill_name: str) -> int:
+    """Pure-ish core: count → wake/suppress emission (heartbeat before suppress)."""
+    if count is None or count > 0:
+        return _emit(wake=True)
+    if not write_suppressed_wake_heartbeat(skill_name):
+        # Mirror-don't-gate: a silent suppress with no audit trail is
+        # indistinguishable from a broken pre_run. Wake instead — the full
+        # agent run is observable and the failure becomes visible.
+        return _emit(wake=True)
+    return _emit(wake=False)
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = sys.argv[1:] if argv is None else argv
+    skill_name = _skill_name()
+    if "--assume-empty" in argv:
+        sys.stderr.write("[pre_run] --assume-empty: skipping smokeball probe\n")
+        return decide_and_emit(0, skill_name)
+    return decide_and_emit(probe_open_matter_count(), skill_name)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/operator/skills/medical-records-chaser/pre_run.py
+++ b/operator/skills/medical-records-chaser/pre_run.py
@@ -101,6 +101,7 @@ def probe_open_matter_count() -> int | None:
         sys.stderr.write(f"[pre_run] connector python missing: {connector_python}\n")
         return None
     try:
+        # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-tainted-env-args.dangerous-subprocess-use-tainted-env-args — argv[0] is the module-constant connector-venv interpreter, overridable only via SMD_CONNECTOR_VENV_PYTHON, which comes from the Machine's own boot env (same trust domain as this file; the test seam). The snippet argument is a module constant; no request/agent-controlled data reaches argv.
         result = subprocess.run(
             [connector_python, "-c", _PROBE_SNIPPET],
             capture_output=True,

--- a/operator/skills/medical-records-chaser/pre_run.py
+++ b/operator/skills/medical-records-chaser/pre_run.py
@@ -101,8 +101,8 @@ def probe_open_matter_count() -> int | None:
         sys.stderr.write(f"[pre_run] connector python missing: {connector_python}\n")
         return None
     try:
-        # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-tainted-env-args.dangerous-subprocess-use-tainted-env-args — argv[0] is the module-constant connector-venv interpreter, overridable only via SMD_CONNECTOR_VENV_PYTHON, which comes from the Machine's own boot env (same trust domain as this file; the test seam). The snippet argument is a module constant; no request/agent-controlled data reaches argv.
         result = subprocess.run(
+            # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-tainted-env-args.dangerous-subprocess-use-tainted-env-args — argv[0] is the module-constant connector-venv interpreter, overridable only via SMD_CONNECTOR_VENV_PYTHON, which comes from the Machine's own boot env (same trust domain as this file; the test seam). The snippet argument is a module constant; no request/agent-controlled data reaches argv.
             [connector_python, "-c", _PROBE_SNIPPET],
             capture_output=True,
             text=True,

--- a/operator/skills/minors-compromise-packet/pre_run.py
+++ b/operator/skills/minors-compromise-packet/pre_run.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Shared cron pre-run gate — the empty-seat wake suppressor (ADR 0021 Stream B).
+
+CANONICAL SOURCE: ``operator/templates/pre_run_gate.py``. The copies stamped
+into skill directories as ``pre_run.py`` MUST be byte-identical to this file —
+``operator/tests/test_pre_run_gate.py`` enforces the sync. Edit here, restamp.
+
+What this gate decides
+----------------------
+Scheduled tracker/watch/chase skills re-derive their work from the matter set
+in the practice-management system (they keep no local state — the matter is
+the system of record). On a seat with ZERO open matters there is provably no
+work for any of them, so waking the model is pure token burn. This gate:
+
+  1. Probes Smokeball for open matters (one ``GET /matters?Status=Open&Limit=1``
+     via the connector's own venv — the connector package is not importable
+     from the Hermes venv this script runs in).
+  2. Any open matter, any probe failure, any unknown response envelope, any
+     heartbeat-write failure → ``{"wakeAgent": true}`` (fail-open; the agent
+     wakes exactly as it would with no gate).
+  3. Zero open matters → writes a SUPPRESSED_WAKE heartbeat row through the
+     broker's uid-gated ``suppressed_wake_append`` verb, THEN emits
+     ``{"wakeAgent": false}``. Suppress-without-heartbeat never happens
+     (mirror-don't-gate): if the broker write fails, the agent wakes.
+
+What this gate deliberately does NOT decide
+-------------------------------------------
+It is NOT a per-skill "is there work" check. A hydrated seat (any open
+matter) always wakes — deeper UpdatedSince/state-delta gates are follow-on
+work once the Smokeball ``updated_since`` wire format is verified at connect.
+Lead-stage and inbound-driven work is unaffected either way: webhook and
+inbound wakes are ungated by design.
+
+Skill identity
+--------------
+The scheduler stages this file to ``<profile>/scripts/<skill>/pre_run.py`` and
+runs it with cwd = that directory, so the skill name is the cwd basename. That
+keeps every stamped copy byte-identical.
+
+Verification hook
+-----------------
+``pre_run.py --assume-empty`` skips the Smokeball probe and behaves as if the
+seat were empty — it exercises the heartbeat write + suppress path end-to-end
+on a live Machine without needing an actually-empty tenant. The cron daemon
+never passes arguments, so this path cannot trigger on a scheduled fire.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import subprocess
+import sys
+from pathlib import Path
+
+# Timeout budget: the Hermes scheduler kills the whole script at 120s
+# (cron/scheduler.py _DEFAULT_SCRIPT_TIMEOUT); the probe gets well under that.
+_PROBE_TIMEOUT_SECONDS = 45
+_HEARTBEAT_TIMEOUT_SECONDS = 10
+
+_CONNECTOR_PYTHON_DEFAULT = "/opt/connectors/smokeball/.venv/bin/python"
+
+# Runs inside the connector venv, where smokeball_connector IS importable and
+# build_client_from_env() owns auth (token mint + refresh-token self-heal).
+# Envelope parsing is deliberately defensive: the live /matters list shape is
+# connect-time-unverified, so an unrecognized shape reports null → wake.
+_PROBE_SNIPPET = """\
+import json
+from smokeball_connector.client import build_client_from_env
+
+r = build_client_from_env().get("/matters", Status="Open", Limit=1)
+items = None
+if isinstance(r, list):
+    items = r
+elif isinstance(r, dict):
+    for key in ("items", "value", "results", "matters", "data"):
+        v = r.get(key)
+        if isinstance(v, list):
+            items = v
+            break
+print(json.dumps({"openMatterCount": len(items) if items is not None else None}))
+"""
+
+
+def _emit(wake: bool) -> int:
+    print(json.dumps({"wakeAgent": wake}))
+    return 0
+
+
+def _skill_name() -> str:
+    return Path.cwd().name or "unknown-skill"
+
+
+def probe_open_matter_count() -> int | None:
+    """Return the open-matter count, or None when it cannot be determined."""
+    connector_python = os.environ.get(
+        "SMD_CONNECTOR_VENV_PYTHON", _CONNECTOR_PYTHON_DEFAULT
+    )
+    if not Path(connector_python).exists():
+        sys.stderr.write(f"[pre_run] connector python missing: {connector_python}\n")
+        return None
+    try:
+        result = subprocess.run(
+            [connector_python, "-c", _PROBE_SNIPPET],
+            capture_output=True,
+            text=True,
+            timeout=_PROBE_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        sys.stderr.write("[pre_run] smokeball probe timed out\n")
+        return None
+    except Exception as exc:  # noqa: BLE001 — any probe failure → unknown → wake
+        sys.stderr.write(f"[pre_run] smokeball probe failed: {exc}\n")
+        return None
+    if result.returncode != 0:
+        sys.stderr.write(
+            f"[pre_run] smokeball probe exit {result.returncode}: "
+            f"{(result.stderr or '').strip()[:500]}\n"
+        )
+        return None
+    try:
+        payload = json.loads((result.stdout or "").strip().splitlines()[-1])
+        count = payload.get("openMatterCount")
+    except Exception:  # noqa: BLE001 — malformed probe output → unknown → wake
+        sys.stderr.write("[pre_run] smokeball probe output unparseable\n")
+        return None
+    if isinstance(count, bool) or not isinstance(count, int):
+        return None
+    return count
+
+
+def write_suppressed_wake_heartbeat(skill_name: str) -> bool:
+    """Append the SUPPRESSED_WAKE row via the broker. True only on ack."""
+    socket_path = os.environ.get("SMD_AUDIT_BROKER_SOCKET") or os.environ.get(
+        "SMD_WORKSPACE_BROKER_SOCKET"
+    )
+    if not socket_path:
+        sys.stderr.write("[pre_run] no broker socket in env; cannot heartbeat\n")
+        return False
+    request = {
+        "action": "suppressed_wake_append",
+        "row": {
+            "action_type": "SUPPRESSED_WAKE",
+            "actor": "agent",
+            "actor_role": "agent",
+            "skill_name": skill_name,
+            "metadata": json.dumps(
+                {
+                    "decision_basis": "empty_seat:no_open_matters",
+                    "platform": "cron-pre-run",
+                    "customer": os.environ.get("CUSTOMER_SLUG", ""),
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+            ),
+        },
+    }
+    try:
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
+            sock.settimeout(_HEARTBEAT_TIMEOUT_SECONDS)
+            sock.connect(socket_path)
+            sock.sendall(json.dumps(request).encode("utf-8") + b"\n")
+            raw = b""
+            while not raw.endswith(b"\n"):
+                chunk = sock.recv(4096)
+                if not chunk:
+                    break
+                raw += chunk
+        response = json.loads(raw.decode("utf-8"))
+        if response.get("ok") is True:
+            return True
+        sys.stderr.write(f"[pre_run] heartbeat rejected: {response}\n")
+        return False
+    except Exception as exc:  # noqa: BLE001 — any heartbeat failure → wake
+        sys.stderr.write(f"[pre_run] heartbeat write failed: {exc}\n")
+        return False
+
+
+def decide_and_emit(count: int | None, skill_name: str) -> int:
+    """Pure-ish core: count → wake/suppress emission (heartbeat before suppress)."""
+    if count is None or count > 0:
+        return _emit(wake=True)
+    if not write_suppressed_wake_heartbeat(skill_name):
+        # Mirror-don't-gate: a silent suppress with no audit trail is
+        # indistinguishable from a broken pre_run. Wake instead — the full
+        # agent run is observable and the failure becomes visible.
+        return _emit(wake=True)
+    return _emit(wake=False)
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = sys.argv[1:] if argv is None else argv
+    skill_name = _skill_name()
+    if "--assume-empty" in argv:
+        sys.stderr.write("[pre_run] --assume-empty: skipping smokeball probe\n")
+        return decide_and_emit(0, skill_name)
+    return decide_and_emit(probe_open_matter_count(), skill_name)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/operator/skills/minors-compromise-packet/pre_run.py
+++ b/operator/skills/minors-compromise-packet/pre_run.py
@@ -101,6 +101,7 @@ def probe_open_matter_count() -> int | None:
         sys.stderr.write(f"[pre_run] connector python missing: {connector_python}\n")
         return None
     try:
+        # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-tainted-env-args.dangerous-subprocess-use-tainted-env-args — argv[0] is the module-constant connector-venv interpreter, overridable only via SMD_CONNECTOR_VENV_PYTHON, which comes from the Machine's own boot env (same trust domain as this file; the test seam). The snippet argument is a module constant; no request/agent-controlled data reaches argv.
         result = subprocess.run(
             [connector_python, "-c", _PROBE_SNIPPET],
             capture_output=True,

--- a/operator/skills/minors-compromise-packet/pre_run.py
+++ b/operator/skills/minors-compromise-packet/pre_run.py
@@ -101,8 +101,8 @@ def probe_open_matter_count() -> int | None:
         sys.stderr.write(f"[pre_run] connector python missing: {connector_python}\n")
         return None
     try:
-        # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-tainted-env-args.dangerous-subprocess-use-tainted-env-args — argv[0] is the module-constant connector-venv interpreter, overridable only via SMD_CONNECTOR_VENV_PYTHON, which comes from the Machine's own boot env (same trust domain as this file; the test seam). The snippet argument is a module constant; no request/agent-controlled data reaches argv.
         result = subprocess.run(
+            # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-tainted-env-args.dangerous-subprocess-use-tainted-env-args — argv[0] is the module-constant connector-venv interpreter, overridable only via SMD_CONNECTOR_VENV_PYTHON, which comes from the Machine's own boot env (same trust domain as this file; the test seam). The snippet argument is a module constant; no request/agent-controlled data reaches argv.
             [connector_python, "-c", _PROBE_SNIPPET],
             capture_output=True,
             text=True,

--- a/operator/skills/motion-calendar-tracker/pre_run.py
+++ b/operator/skills/motion-calendar-tracker/pre_run.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Shared cron pre-run gate — the empty-seat wake suppressor (ADR 0021 Stream B).
+
+CANONICAL SOURCE: ``operator/templates/pre_run_gate.py``. The copies stamped
+into skill directories as ``pre_run.py`` MUST be byte-identical to this file —
+``operator/tests/test_pre_run_gate.py`` enforces the sync. Edit here, restamp.
+
+What this gate decides
+----------------------
+Scheduled tracker/watch/chase skills re-derive their work from the matter set
+in the practice-management system (they keep no local state — the matter is
+the system of record). On a seat with ZERO open matters there is provably no
+work for any of them, so waking the model is pure token burn. This gate:
+
+  1. Probes Smokeball for open matters (one ``GET /matters?Status=Open&Limit=1``
+     via the connector's own venv — the connector package is not importable
+     from the Hermes venv this script runs in).
+  2. Any open matter, any probe failure, any unknown response envelope, any
+     heartbeat-write failure → ``{"wakeAgent": true}`` (fail-open; the agent
+     wakes exactly as it would with no gate).
+  3. Zero open matters → writes a SUPPRESSED_WAKE heartbeat row through the
+     broker's uid-gated ``suppressed_wake_append`` verb, THEN emits
+     ``{"wakeAgent": false}``. Suppress-without-heartbeat never happens
+     (mirror-don't-gate): if the broker write fails, the agent wakes.
+
+What this gate deliberately does NOT decide
+-------------------------------------------
+It is NOT a per-skill "is there work" check. A hydrated seat (any open
+matter) always wakes — deeper UpdatedSince/state-delta gates are follow-on
+work once the Smokeball ``updated_since`` wire format is verified at connect.
+Lead-stage and inbound-driven work is unaffected either way: webhook and
+inbound wakes are ungated by design.
+
+Skill identity
+--------------
+The scheduler stages this file to ``<profile>/scripts/<skill>/pre_run.py`` and
+runs it with cwd = that directory, so the skill name is the cwd basename. That
+keeps every stamped copy byte-identical.
+
+Verification hook
+-----------------
+``pre_run.py --assume-empty`` skips the Smokeball probe and behaves as if the
+seat were empty — it exercises the heartbeat write + suppress path end-to-end
+on a live Machine without needing an actually-empty tenant. The cron daemon
+never passes arguments, so this path cannot trigger on a scheduled fire.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import subprocess
+import sys
+from pathlib import Path
+
+# Timeout budget: the Hermes scheduler kills the whole script at 120s
+# (cron/scheduler.py _DEFAULT_SCRIPT_TIMEOUT); the probe gets well under that.
+_PROBE_TIMEOUT_SECONDS = 45
+_HEARTBEAT_TIMEOUT_SECONDS = 10
+
+_CONNECTOR_PYTHON_DEFAULT = "/opt/connectors/smokeball/.venv/bin/python"
+
+# Runs inside the connector venv, where smokeball_connector IS importable and
+# build_client_from_env() owns auth (token mint + refresh-token self-heal).
+# Envelope parsing is deliberately defensive: the live /matters list shape is
+# connect-time-unverified, so an unrecognized shape reports null → wake.
+_PROBE_SNIPPET = """\
+import json
+from smokeball_connector.client import build_client_from_env
+
+r = build_client_from_env().get("/matters", Status="Open", Limit=1)
+items = None
+if isinstance(r, list):
+    items = r
+elif isinstance(r, dict):
+    for key in ("items", "value", "results", "matters", "data"):
+        v = r.get(key)
+        if isinstance(v, list):
+            items = v
+            break
+print(json.dumps({"openMatterCount": len(items) if items is not None else None}))
+"""
+
+
+def _emit(wake: bool) -> int:
+    print(json.dumps({"wakeAgent": wake}))
+    return 0
+
+
+def _skill_name() -> str:
+    return Path.cwd().name or "unknown-skill"
+
+
+def probe_open_matter_count() -> int | None:
+    """Return the open-matter count, or None when it cannot be determined."""
+    connector_python = os.environ.get(
+        "SMD_CONNECTOR_VENV_PYTHON", _CONNECTOR_PYTHON_DEFAULT
+    )
+    if not Path(connector_python).exists():
+        sys.stderr.write(f"[pre_run] connector python missing: {connector_python}\n")
+        return None
+    try:
+        result = subprocess.run(
+            [connector_python, "-c", _PROBE_SNIPPET],
+            capture_output=True,
+            text=True,
+            timeout=_PROBE_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        sys.stderr.write("[pre_run] smokeball probe timed out\n")
+        return None
+    except Exception as exc:  # noqa: BLE001 — any probe failure → unknown → wake
+        sys.stderr.write(f"[pre_run] smokeball probe failed: {exc}\n")
+        return None
+    if result.returncode != 0:
+        sys.stderr.write(
+            f"[pre_run] smokeball probe exit {result.returncode}: "
+            f"{(result.stderr or '').strip()[:500]}\n"
+        )
+        return None
+    try:
+        payload = json.loads((result.stdout or "").strip().splitlines()[-1])
+        count = payload.get("openMatterCount")
+    except Exception:  # noqa: BLE001 — malformed probe output → unknown → wake
+        sys.stderr.write("[pre_run] smokeball probe output unparseable\n")
+        return None
+    if isinstance(count, bool) or not isinstance(count, int):
+        return None
+    return count
+
+
+def write_suppressed_wake_heartbeat(skill_name: str) -> bool:
+    """Append the SUPPRESSED_WAKE row via the broker. True only on ack."""
+    socket_path = os.environ.get("SMD_AUDIT_BROKER_SOCKET") or os.environ.get(
+        "SMD_WORKSPACE_BROKER_SOCKET"
+    )
+    if not socket_path:
+        sys.stderr.write("[pre_run] no broker socket in env; cannot heartbeat\n")
+        return False
+    request = {
+        "action": "suppressed_wake_append",
+        "row": {
+            "action_type": "SUPPRESSED_WAKE",
+            "actor": "agent",
+            "actor_role": "agent",
+            "skill_name": skill_name,
+            "metadata": json.dumps(
+                {
+                    "decision_basis": "empty_seat:no_open_matters",
+                    "platform": "cron-pre-run",
+                    "customer": os.environ.get("CUSTOMER_SLUG", ""),
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+            ),
+        },
+    }
+    try:
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
+            sock.settimeout(_HEARTBEAT_TIMEOUT_SECONDS)
+            sock.connect(socket_path)
+            sock.sendall(json.dumps(request).encode("utf-8") + b"\n")
+            raw = b""
+            while not raw.endswith(b"\n"):
+                chunk = sock.recv(4096)
+                if not chunk:
+                    break
+                raw += chunk
+        response = json.loads(raw.decode("utf-8"))
+        if response.get("ok") is True:
+            return True
+        sys.stderr.write(f"[pre_run] heartbeat rejected: {response}\n")
+        return False
+    except Exception as exc:  # noqa: BLE001 — any heartbeat failure → wake
+        sys.stderr.write(f"[pre_run] heartbeat write failed: {exc}\n")
+        return False
+
+
+def decide_and_emit(count: int | None, skill_name: str) -> int:
+    """Pure-ish core: count → wake/suppress emission (heartbeat before suppress)."""
+    if count is None or count > 0:
+        return _emit(wake=True)
+    if not write_suppressed_wake_heartbeat(skill_name):
+        # Mirror-don't-gate: a silent suppress with no audit trail is
+        # indistinguishable from a broken pre_run. Wake instead — the full
+        # agent run is observable and the failure becomes visible.
+        return _emit(wake=True)
+    return _emit(wake=False)
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = sys.argv[1:] if argv is None else argv
+    skill_name = _skill_name()
+    if "--assume-empty" in argv:
+        sys.stderr.write("[pre_run] --assume-empty: skipping smokeball probe\n")
+        return decide_and_emit(0, skill_name)
+    return decide_and_emit(probe_open_matter_count(), skill_name)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/operator/skills/motion-calendar-tracker/pre_run.py
+++ b/operator/skills/motion-calendar-tracker/pre_run.py
@@ -101,6 +101,7 @@ def probe_open_matter_count() -> int | None:
         sys.stderr.write(f"[pre_run] connector python missing: {connector_python}\n")
         return None
     try:
+        # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-tainted-env-args.dangerous-subprocess-use-tainted-env-args — argv[0] is the module-constant connector-venv interpreter, overridable only via SMD_CONNECTOR_VENV_PYTHON, which comes from the Machine's own boot env (same trust domain as this file; the test seam). The snippet argument is a module constant; no request/agent-controlled data reaches argv.
         result = subprocess.run(
             [connector_python, "-c", _PROBE_SNIPPET],
             capture_output=True,

--- a/operator/skills/motion-calendar-tracker/pre_run.py
+++ b/operator/skills/motion-calendar-tracker/pre_run.py
@@ -101,8 +101,8 @@ def probe_open_matter_count() -> int | None:
         sys.stderr.write(f"[pre_run] connector python missing: {connector_python}\n")
         return None
     try:
-        # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-tainted-env-args.dangerous-subprocess-use-tainted-env-args — argv[0] is the module-constant connector-venv interpreter, overridable only via SMD_CONNECTOR_VENV_PYTHON, which comes from the Machine's own boot env (same trust domain as this file; the test seam). The snippet argument is a module constant; no request/agent-controlled data reaches argv.
         result = subprocess.run(
+            # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-tainted-env-args.dangerous-subprocess-use-tainted-env-args — argv[0] is the module-constant connector-venv interpreter, overridable only via SMD_CONNECTOR_VENV_PYTHON, which comes from the Machine's own boot env (same trust domain as this file; the test seam). The snippet argument is a module constant; no request/agent-controlled data reaches argv.
             [connector_python, "-c", _PROBE_SNIPPET],
             capture_output=True,
             text=True,

--- a/operator/skills/service-confirmation-watcher/pre_run.py
+++ b/operator/skills/service-confirmation-watcher/pre_run.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Shared cron pre-run gate — the empty-seat wake suppressor (ADR 0021 Stream B).
+
+CANONICAL SOURCE: ``operator/templates/pre_run_gate.py``. The copies stamped
+into skill directories as ``pre_run.py`` MUST be byte-identical to this file —
+``operator/tests/test_pre_run_gate.py`` enforces the sync. Edit here, restamp.
+
+What this gate decides
+----------------------
+Scheduled tracker/watch/chase skills re-derive their work from the matter set
+in the practice-management system (they keep no local state — the matter is
+the system of record). On a seat with ZERO open matters there is provably no
+work for any of them, so waking the model is pure token burn. This gate:
+
+  1. Probes Smokeball for open matters (one ``GET /matters?Status=Open&Limit=1``
+     via the connector's own venv — the connector package is not importable
+     from the Hermes venv this script runs in).
+  2. Any open matter, any probe failure, any unknown response envelope, any
+     heartbeat-write failure → ``{"wakeAgent": true}`` (fail-open; the agent
+     wakes exactly as it would with no gate).
+  3. Zero open matters → writes a SUPPRESSED_WAKE heartbeat row through the
+     broker's uid-gated ``suppressed_wake_append`` verb, THEN emits
+     ``{"wakeAgent": false}``. Suppress-without-heartbeat never happens
+     (mirror-don't-gate): if the broker write fails, the agent wakes.
+
+What this gate deliberately does NOT decide
+-------------------------------------------
+It is NOT a per-skill "is there work" check. A hydrated seat (any open
+matter) always wakes — deeper UpdatedSince/state-delta gates are follow-on
+work once the Smokeball ``updated_since`` wire format is verified at connect.
+Lead-stage and inbound-driven work is unaffected either way: webhook and
+inbound wakes are ungated by design.
+
+Skill identity
+--------------
+The scheduler stages this file to ``<profile>/scripts/<skill>/pre_run.py`` and
+runs it with cwd = that directory, so the skill name is the cwd basename. That
+keeps every stamped copy byte-identical.
+
+Verification hook
+-----------------
+``pre_run.py --assume-empty`` skips the Smokeball probe and behaves as if the
+seat were empty — it exercises the heartbeat write + suppress path end-to-end
+on a live Machine without needing an actually-empty tenant. The cron daemon
+never passes arguments, so this path cannot trigger on a scheduled fire.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import subprocess
+import sys
+from pathlib import Path
+
+# Timeout budget: the Hermes scheduler kills the whole script at 120s
+# (cron/scheduler.py _DEFAULT_SCRIPT_TIMEOUT); the probe gets well under that.
+_PROBE_TIMEOUT_SECONDS = 45
+_HEARTBEAT_TIMEOUT_SECONDS = 10
+
+_CONNECTOR_PYTHON_DEFAULT = "/opt/connectors/smokeball/.venv/bin/python"
+
+# Runs inside the connector venv, where smokeball_connector IS importable and
+# build_client_from_env() owns auth (token mint + refresh-token self-heal).
+# Envelope parsing is deliberately defensive: the live /matters list shape is
+# connect-time-unverified, so an unrecognized shape reports null → wake.
+_PROBE_SNIPPET = """\
+import json
+from smokeball_connector.client import build_client_from_env
+
+r = build_client_from_env().get("/matters", Status="Open", Limit=1)
+items = None
+if isinstance(r, list):
+    items = r
+elif isinstance(r, dict):
+    for key in ("items", "value", "results", "matters", "data"):
+        v = r.get(key)
+        if isinstance(v, list):
+            items = v
+            break
+print(json.dumps({"openMatterCount": len(items) if items is not None else None}))
+"""
+
+
+def _emit(wake: bool) -> int:
+    print(json.dumps({"wakeAgent": wake}))
+    return 0
+
+
+def _skill_name() -> str:
+    return Path.cwd().name or "unknown-skill"
+
+
+def probe_open_matter_count() -> int | None:
+    """Return the open-matter count, or None when it cannot be determined."""
+    connector_python = os.environ.get(
+        "SMD_CONNECTOR_VENV_PYTHON", _CONNECTOR_PYTHON_DEFAULT
+    )
+    if not Path(connector_python).exists():
+        sys.stderr.write(f"[pre_run] connector python missing: {connector_python}\n")
+        return None
+    try:
+        result = subprocess.run(
+            [connector_python, "-c", _PROBE_SNIPPET],
+            capture_output=True,
+            text=True,
+            timeout=_PROBE_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        sys.stderr.write("[pre_run] smokeball probe timed out\n")
+        return None
+    except Exception as exc:  # noqa: BLE001 — any probe failure → unknown → wake
+        sys.stderr.write(f"[pre_run] smokeball probe failed: {exc}\n")
+        return None
+    if result.returncode != 0:
+        sys.stderr.write(
+            f"[pre_run] smokeball probe exit {result.returncode}: "
+            f"{(result.stderr or '').strip()[:500]}\n"
+        )
+        return None
+    try:
+        payload = json.loads((result.stdout or "").strip().splitlines()[-1])
+        count = payload.get("openMatterCount")
+    except Exception:  # noqa: BLE001 — malformed probe output → unknown → wake
+        sys.stderr.write("[pre_run] smokeball probe output unparseable\n")
+        return None
+    if isinstance(count, bool) or not isinstance(count, int):
+        return None
+    return count
+
+
+def write_suppressed_wake_heartbeat(skill_name: str) -> bool:
+    """Append the SUPPRESSED_WAKE row via the broker. True only on ack."""
+    socket_path = os.environ.get("SMD_AUDIT_BROKER_SOCKET") or os.environ.get(
+        "SMD_WORKSPACE_BROKER_SOCKET"
+    )
+    if not socket_path:
+        sys.stderr.write("[pre_run] no broker socket in env; cannot heartbeat\n")
+        return False
+    request = {
+        "action": "suppressed_wake_append",
+        "row": {
+            "action_type": "SUPPRESSED_WAKE",
+            "actor": "agent",
+            "actor_role": "agent",
+            "skill_name": skill_name,
+            "metadata": json.dumps(
+                {
+                    "decision_basis": "empty_seat:no_open_matters",
+                    "platform": "cron-pre-run",
+                    "customer": os.environ.get("CUSTOMER_SLUG", ""),
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+            ),
+        },
+    }
+    try:
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
+            sock.settimeout(_HEARTBEAT_TIMEOUT_SECONDS)
+            sock.connect(socket_path)
+            sock.sendall(json.dumps(request).encode("utf-8") + b"\n")
+            raw = b""
+            while not raw.endswith(b"\n"):
+                chunk = sock.recv(4096)
+                if not chunk:
+                    break
+                raw += chunk
+        response = json.loads(raw.decode("utf-8"))
+        if response.get("ok") is True:
+            return True
+        sys.stderr.write(f"[pre_run] heartbeat rejected: {response}\n")
+        return False
+    except Exception as exc:  # noqa: BLE001 — any heartbeat failure → wake
+        sys.stderr.write(f"[pre_run] heartbeat write failed: {exc}\n")
+        return False
+
+
+def decide_and_emit(count: int | None, skill_name: str) -> int:
+    """Pure-ish core: count → wake/suppress emission (heartbeat before suppress)."""
+    if count is None or count > 0:
+        return _emit(wake=True)
+    if not write_suppressed_wake_heartbeat(skill_name):
+        # Mirror-don't-gate: a silent suppress with no audit trail is
+        # indistinguishable from a broken pre_run. Wake instead — the full
+        # agent run is observable and the failure becomes visible.
+        return _emit(wake=True)
+    return _emit(wake=False)
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = sys.argv[1:] if argv is None else argv
+    skill_name = _skill_name()
+    if "--assume-empty" in argv:
+        sys.stderr.write("[pre_run] --assume-empty: skipping smokeball probe\n")
+        return decide_and_emit(0, skill_name)
+    return decide_and_emit(probe_open_matter_count(), skill_name)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/operator/skills/service-confirmation-watcher/pre_run.py
+++ b/operator/skills/service-confirmation-watcher/pre_run.py
@@ -101,6 +101,7 @@ def probe_open_matter_count() -> int | None:
         sys.stderr.write(f"[pre_run] connector python missing: {connector_python}\n")
         return None
     try:
+        # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-tainted-env-args.dangerous-subprocess-use-tainted-env-args — argv[0] is the module-constant connector-venv interpreter, overridable only via SMD_CONNECTOR_VENV_PYTHON, which comes from the Machine's own boot env (same trust domain as this file; the test seam). The snippet argument is a module constant; no request/agent-controlled data reaches argv.
         result = subprocess.run(
             [connector_python, "-c", _PROBE_SNIPPET],
             capture_output=True,

--- a/operator/skills/service-confirmation-watcher/pre_run.py
+++ b/operator/skills/service-confirmation-watcher/pre_run.py
@@ -101,8 +101,8 @@ def probe_open_matter_count() -> int | None:
         sys.stderr.write(f"[pre_run] connector python missing: {connector_python}\n")
         return None
     try:
-        # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-tainted-env-args.dangerous-subprocess-use-tainted-env-args — argv[0] is the module-constant connector-venv interpreter, overridable only via SMD_CONNECTOR_VENV_PYTHON, which comes from the Machine's own boot env (same trust domain as this file; the test seam). The snippet argument is a module constant; no request/agent-controlled data reaches argv.
         result = subprocess.run(
+            # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-tainted-env-args.dangerous-subprocess-use-tainted-env-args — argv[0] is the module-constant connector-venv interpreter, overridable only via SMD_CONNECTOR_VENV_PYTHON, which comes from the Machine's own boot env (same trust domain as this file; the test seam). The snippet argument is a module constant; no request/agent-controlled data reaches argv.
             [connector_python, "-c", _PROBE_SNIPPET],
             capture_output=True,
             text=True,

--- a/operator/skills/trial-binder-assembler/pre_run.py
+++ b/operator/skills/trial-binder-assembler/pre_run.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Shared cron pre-run gate — the empty-seat wake suppressor (ADR 0021 Stream B).
+
+CANONICAL SOURCE: ``operator/templates/pre_run_gate.py``. The copies stamped
+into skill directories as ``pre_run.py`` MUST be byte-identical to this file —
+``operator/tests/test_pre_run_gate.py`` enforces the sync. Edit here, restamp.
+
+What this gate decides
+----------------------
+Scheduled tracker/watch/chase skills re-derive their work from the matter set
+in the practice-management system (they keep no local state — the matter is
+the system of record). On a seat with ZERO open matters there is provably no
+work for any of them, so waking the model is pure token burn. This gate:
+
+  1. Probes Smokeball for open matters (one ``GET /matters?Status=Open&Limit=1``
+     via the connector's own venv — the connector package is not importable
+     from the Hermes venv this script runs in).
+  2. Any open matter, any probe failure, any unknown response envelope, any
+     heartbeat-write failure → ``{"wakeAgent": true}`` (fail-open; the agent
+     wakes exactly as it would with no gate).
+  3. Zero open matters → writes a SUPPRESSED_WAKE heartbeat row through the
+     broker's uid-gated ``suppressed_wake_append`` verb, THEN emits
+     ``{"wakeAgent": false}``. Suppress-without-heartbeat never happens
+     (mirror-don't-gate): if the broker write fails, the agent wakes.
+
+What this gate deliberately does NOT decide
+-------------------------------------------
+It is NOT a per-skill "is there work" check. A hydrated seat (any open
+matter) always wakes — deeper UpdatedSince/state-delta gates are follow-on
+work once the Smokeball ``updated_since`` wire format is verified at connect.
+Lead-stage and inbound-driven work is unaffected either way: webhook and
+inbound wakes are ungated by design.
+
+Skill identity
+--------------
+The scheduler stages this file to ``<profile>/scripts/<skill>/pre_run.py`` and
+runs it with cwd = that directory, so the skill name is the cwd basename. That
+keeps every stamped copy byte-identical.
+
+Verification hook
+-----------------
+``pre_run.py --assume-empty`` skips the Smokeball probe and behaves as if the
+seat were empty — it exercises the heartbeat write + suppress path end-to-end
+on a live Machine without needing an actually-empty tenant. The cron daemon
+never passes arguments, so this path cannot trigger on a scheduled fire.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import subprocess
+import sys
+from pathlib import Path
+
+# Timeout budget: the Hermes scheduler kills the whole script at 120s
+# (cron/scheduler.py _DEFAULT_SCRIPT_TIMEOUT); the probe gets well under that.
+_PROBE_TIMEOUT_SECONDS = 45
+_HEARTBEAT_TIMEOUT_SECONDS = 10
+
+_CONNECTOR_PYTHON_DEFAULT = "/opt/connectors/smokeball/.venv/bin/python"
+
+# Runs inside the connector venv, where smokeball_connector IS importable and
+# build_client_from_env() owns auth (token mint + refresh-token self-heal).
+# Envelope parsing is deliberately defensive: the live /matters list shape is
+# connect-time-unverified, so an unrecognized shape reports null → wake.
+_PROBE_SNIPPET = """\
+import json
+from smokeball_connector.client import build_client_from_env
+
+r = build_client_from_env().get("/matters", Status="Open", Limit=1)
+items = None
+if isinstance(r, list):
+    items = r
+elif isinstance(r, dict):
+    for key in ("items", "value", "results", "matters", "data"):
+        v = r.get(key)
+        if isinstance(v, list):
+            items = v
+            break
+print(json.dumps({"openMatterCount": len(items) if items is not None else None}))
+"""
+
+
+def _emit(wake: bool) -> int:
+    print(json.dumps({"wakeAgent": wake}))
+    return 0
+
+
+def _skill_name() -> str:
+    return Path.cwd().name or "unknown-skill"
+
+
+def probe_open_matter_count() -> int | None:
+    """Return the open-matter count, or None when it cannot be determined."""
+    connector_python = os.environ.get(
+        "SMD_CONNECTOR_VENV_PYTHON", _CONNECTOR_PYTHON_DEFAULT
+    )
+    if not Path(connector_python).exists():
+        sys.stderr.write(f"[pre_run] connector python missing: {connector_python}\n")
+        return None
+    try:
+        result = subprocess.run(
+            [connector_python, "-c", _PROBE_SNIPPET],
+            capture_output=True,
+            text=True,
+            timeout=_PROBE_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        sys.stderr.write("[pre_run] smokeball probe timed out\n")
+        return None
+    except Exception as exc:  # noqa: BLE001 — any probe failure → unknown → wake
+        sys.stderr.write(f"[pre_run] smokeball probe failed: {exc}\n")
+        return None
+    if result.returncode != 0:
+        sys.stderr.write(
+            f"[pre_run] smokeball probe exit {result.returncode}: "
+            f"{(result.stderr or '').strip()[:500]}\n"
+        )
+        return None
+    try:
+        payload = json.loads((result.stdout or "").strip().splitlines()[-1])
+        count = payload.get("openMatterCount")
+    except Exception:  # noqa: BLE001 — malformed probe output → unknown → wake
+        sys.stderr.write("[pre_run] smokeball probe output unparseable\n")
+        return None
+    if isinstance(count, bool) or not isinstance(count, int):
+        return None
+    return count
+
+
+def write_suppressed_wake_heartbeat(skill_name: str) -> bool:
+    """Append the SUPPRESSED_WAKE row via the broker. True only on ack."""
+    socket_path = os.environ.get("SMD_AUDIT_BROKER_SOCKET") or os.environ.get(
+        "SMD_WORKSPACE_BROKER_SOCKET"
+    )
+    if not socket_path:
+        sys.stderr.write("[pre_run] no broker socket in env; cannot heartbeat\n")
+        return False
+    request = {
+        "action": "suppressed_wake_append",
+        "row": {
+            "action_type": "SUPPRESSED_WAKE",
+            "actor": "agent",
+            "actor_role": "agent",
+            "skill_name": skill_name,
+            "metadata": json.dumps(
+                {
+                    "decision_basis": "empty_seat:no_open_matters",
+                    "platform": "cron-pre-run",
+                    "customer": os.environ.get("CUSTOMER_SLUG", ""),
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+            ),
+        },
+    }
+    try:
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
+            sock.settimeout(_HEARTBEAT_TIMEOUT_SECONDS)
+            sock.connect(socket_path)
+            sock.sendall(json.dumps(request).encode("utf-8") + b"\n")
+            raw = b""
+            while not raw.endswith(b"\n"):
+                chunk = sock.recv(4096)
+                if not chunk:
+                    break
+                raw += chunk
+        response = json.loads(raw.decode("utf-8"))
+        if response.get("ok") is True:
+            return True
+        sys.stderr.write(f"[pre_run] heartbeat rejected: {response}\n")
+        return False
+    except Exception as exc:  # noqa: BLE001 — any heartbeat failure → wake
+        sys.stderr.write(f"[pre_run] heartbeat write failed: {exc}\n")
+        return False
+
+
+def decide_and_emit(count: int | None, skill_name: str) -> int:
+    """Pure-ish core: count → wake/suppress emission (heartbeat before suppress)."""
+    if count is None or count > 0:
+        return _emit(wake=True)
+    if not write_suppressed_wake_heartbeat(skill_name):
+        # Mirror-don't-gate: a silent suppress with no audit trail is
+        # indistinguishable from a broken pre_run. Wake instead — the full
+        # agent run is observable and the failure becomes visible.
+        return _emit(wake=True)
+    return _emit(wake=False)
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = sys.argv[1:] if argv is None else argv
+    skill_name = _skill_name()
+    if "--assume-empty" in argv:
+        sys.stderr.write("[pre_run] --assume-empty: skipping smokeball probe\n")
+        return decide_and_emit(0, skill_name)
+    return decide_and_emit(probe_open_matter_count(), skill_name)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/operator/skills/trial-binder-assembler/pre_run.py
+++ b/operator/skills/trial-binder-assembler/pre_run.py
@@ -101,6 +101,7 @@ def probe_open_matter_count() -> int | None:
         sys.stderr.write(f"[pre_run] connector python missing: {connector_python}\n")
         return None
     try:
+        # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-tainted-env-args.dangerous-subprocess-use-tainted-env-args — argv[0] is the module-constant connector-venv interpreter, overridable only via SMD_CONNECTOR_VENV_PYTHON, which comes from the Machine's own boot env (same trust domain as this file; the test seam). The snippet argument is a module constant; no request/agent-controlled data reaches argv.
         result = subprocess.run(
             [connector_python, "-c", _PROBE_SNIPPET],
             capture_output=True,

--- a/operator/skills/trial-binder-assembler/pre_run.py
+++ b/operator/skills/trial-binder-assembler/pre_run.py
@@ -101,8 +101,8 @@ def probe_open_matter_count() -> int | None:
         sys.stderr.write(f"[pre_run] connector python missing: {connector_python}\n")
         return None
     try:
-        # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-tainted-env-args.dangerous-subprocess-use-tainted-env-args — argv[0] is the module-constant connector-venv interpreter, overridable only via SMD_CONNECTOR_VENV_PYTHON, which comes from the Machine's own boot env (same trust domain as this file; the test seam). The snippet argument is a module constant; no request/agent-controlled data reaches argv.
         result = subprocess.run(
+            # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-tainted-env-args.dangerous-subprocess-use-tainted-env-args — argv[0] is the module-constant connector-venv interpreter, overridable only via SMD_CONNECTOR_VENV_PYTHON, which comes from the Machine's own boot env (same trust domain as this file; the test seam). The snippet argument is a module constant; no request/agent-controlled data reaches argv.
             [connector_python, "-c", _PROBE_SNIPPET],
             capture_output=True,
             text=True,

--- a/operator/templates/pre_run_gate.py
+++ b/operator/templates/pre_run_gate.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Shared cron pre-run gate — the empty-seat wake suppressor (ADR 0021 Stream B).
+
+CANONICAL SOURCE: ``operator/templates/pre_run_gate.py``. The copies stamped
+into skill directories as ``pre_run.py`` MUST be byte-identical to this file —
+``operator/tests/test_pre_run_gate.py`` enforces the sync. Edit here, restamp.
+
+What this gate decides
+----------------------
+Scheduled tracker/watch/chase skills re-derive their work from the matter set
+in the practice-management system (they keep no local state — the matter is
+the system of record). On a seat with ZERO open matters there is provably no
+work for any of them, so waking the model is pure token burn. This gate:
+
+  1. Probes Smokeball for open matters (one ``GET /matters?Status=Open&Limit=1``
+     via the connector's own venv — the connector package is not importable
+     from the Hermes venv this script runs in).
+  2. Any open matter, any probe failure, any unknown response envelope, any
+     heartbeat-write failure → ``{"wakeAgent": true}`` (fail-open; the agent
+     wakes exactly as it would with no gate).
+  3. Zero open matters → writes a SUPPRESSED_WAKE heartbeat row through the
+     broker's uid-gated ``suppressed_wake_append`` verb, THEN emits
+     ``{"wakeAgent": false}``. Suppress-without-heartbeat never happens
+     (mirror-don't-gate): if the broker write fails, the agent wakes.
+
+What this gate deliberately does NOT decide
+-------------------------------------------
+It is NOT a per-skill "is there work" check. A hydrated seat (any open
+matter) always wakes — deeper UpdatedSince/state-delta gates are follow-on
+work once the Smokeball ``updated_since`` wire format is verified at connect.
+Lead-stage and inbound-driven work is unaffected either way: webhook and
+inbound wakes are ungated by design.
+
+Skill identity
+--------------
+The scheduler stages this file to ``<profile>/scripts/<skill>/pre_run.py`` and
+runs it with cwd = that directory, so the skill name is the cwd basename. That
+keeps every stamped copy byte-identical.
+
+Verification hook
+-----------------
+``pre_run.py --assume-empty`` skips the Smokeball probe and behaves as if the
+seat were empty — it exercises the heartbeat write + suppress path end-to-end
+on a live Machine without needing an actually-empty tenant. The cron daemon
+never passes arguments, so this path cannot trigger on a scheduled fire.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import subprocess
+import sys
+from pathlib import Path
+
+# Timeout budget: the Hermes scheduler kills the whole script at 120s
+# (cron/scheduler.py _DEFAULT_SCRIPT_TIMEOUT); the probe gets well under that.
+_PROBE_TIMEOUT_SECONDS = 45
+_HEARTBEAT_TIMEOUT_SECONDS = 10
+
+_CONNECTOR_PYTHON_DEFAULT = "/opt/connectors/smokeball/.venv/bin/python"
+
+# Runs inside the connector venv, where smokeball_connector IS importable and
+# build_client_from_env() owns auth (token mint + refresh-token self-heal).
+# Envelope parsing is deliberately defensive: the live /matters list shape is
+# connect-time-unverified, so an unrecognized shape reports null → wake.
+_PROBE_SNIPPET = """\
+import json
+from smokeball_connector.client import build_client_from_env
+
+r = build_client_from_env().get("/matters", Status="Open", Limit=1)
+items = None
+if isinstance(r, list):
+    items = r
+elif isinstance(r, dict):
+    for key in ("items", "value", "results", "matters", "data"):
+        v = r.get(key)
+        if isinstance(v, list):
+            items = v
+            break
+print(json.dumps({"openMatterCount": len(items) if items is not None else None}))
+"""
+
+
+def _emit(wake: bool) -> int:
+    print(json.dumps({"wakeAgent": wake}))
+    return 0
+
+
+def _skill_name() -> str:
+    return Path.cwd().name or "unknown-skill"
+
+
+def probe_open_matter_count() -> int | None:
+    """Return the open-matter count, or None when it cannot be determined."""
+    connector_python = os.environ.get(
+        "SMD_CONNECTOR_VENV_PYTHON", _CONNECTOR_PYTHON_DEFAULT
+    )
+    if not Path(connector_python).exists():
+        sys.stderr.write(f"[pre_run] connector python missing: {connector_python}\n")
+        return None
+    try:
+        result = subprocess.run(
+            [connector_python, "-c", _PROBE_SNIPPET],
+            capture_output=True,
+            text=True,
+            timeout=_PROBE_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        sys.stderr.write("[pre_run] smokeball probe timed out\n")
+        return None
+    except Exception as exc:  # noqa: BLE001 — any probe failure → unknown → wake
+        sys.stderr.write(f"[pre_run] smokeball probe failed: {exc}\n")
+        return None
+    if result.returncode != 0:
+        sys.stderr.write(
+            f"[pre_run] smokeball probe exit {result.returncode}: "
+            f"{(result.stderr or '').strip()[:500]}\n"
+        )
+        return None
+    try:
+        payload = json.loads((result.stdout or "").strip().splitlines()[-1])
+        count = payload.get("openMatterCount")
+    except Exception:  # noqa: BLE001 — malformed probe output → unknown → wake
+        sys.stderr.write("[pre_run] smokeball probe output unparseable\n")
+        return None
+    if isinstance(count, bool) or not isinstance(count, int):
+        return None
+    return count
+
+
+def write_suppressed_wake_heartbeat(skill_name: str) -> bool:
+    """Append the SUPPRESSED_WAKE row via the broker. True only on ack."""
+    socket_path = os.environ.get("SMD_AUDIT_BROKER_SOCKET") or os.environ.get(
+        "SMD_WORKSPACE_BROKER_SOCKET"
+    )
+    if not socket_path:
+        sys.stderr.write("[pre_run] no broker socket in env; cannot heartbeat\n")
+        return False
+    request = {
+        "action": "suppressed_wake_append",
+        "row": {
+            "action_type": "SUPPRESSED_WAKE",
+            "actor": "agent",
+            "actor_role": "agent",
+            "skill_name": skill_name,
+            "metadata": json.dumps(
+                {
+                    "decision_basis": "empty_seat:no_open_matters",
+                    "platform": "cron-pre-run",
+                    "customer": os.environ.get("CUSTOMER_SLUG", ""),
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+            ),
+        },
+    }
+    try:
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
+            sock.settimeout(_HEARTBEAT_TIMEOUT_SECONDS)
+            sock.connect(socket_path)
+            sock.sendall(json.dumps(request).encode("utf-8") + b"\n")
+            raw = b""
+            while not raw.endswith(b"\n"):
+                chunk = sock.recv(4096)
+                if not chunk:
+                    break
+                raw += chunk
+        response = json.loads(raw.decode("utf-8"))
+        if response.get("ok") is True:
+            return True
+        sys.stderr.write(f"[pre_run] heartbeat rejected: {response}\n")
+        return False
+    except Exception as exc:  # noqa: BLE001 — any heartbeat failure → wake
+        sys.stderr.write(f"[pre_run] heartbeat write failed: {exc}\n")
+        return False
+
+
+def decide_and_emit(count: int | None, skill_name: str) -> int:
+    """Pure-ish core: count → wake/suppress emission (heartbeat before suppress)."""
+    if count is None or count > 0:
+        return _emit(wake=True)
+    if not write_suppressed_wake_heartbeat(skill_name):
+        # Mirror-don't-gate: a silent suppress with no audit trail is
+        # indistinguishable from a broken pre_run. Wake instead — the full
+        # agent run is observable and the failure becomes visible.
+        return _emit(wake=True)
+    return _emit(wake=False)
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = sys.argv[1:] if argv is None else argv
+    skill_name = _skill_name()
+    if "--assume-empty" in argv:
+        sys.stderr.write("[pre_run] --assume-empty: skipping smokeball probe\n")
+        return decide_and_emit(0, skill_name)
+    return decide_and_emit(probe_open_matter_count(), skill_name)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/operator/templates/pre_run_gate.py
+++ b/operator/templates/pre_run_gate.py
@@ -101,6 +101,7 @@ def probe_open_matter_count() -> int | None:
         sys.stderr.write(f"[pre_run] connector python missing: {connector_python}\n")
         return None
     try:
+        # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-tainted-env-args.dangerous-subprocess-use-tainted-env-args — argv[0] is the module-constant connector-venv interpreter, overridable only via SMD_CONNECTOR_VENV_PYTHON, which comes from the Machine's own boot env (same trust domain as this file; the test seam). The snippet argument is a module constant; no request/agent-controlled data reaches argv.
         result = subprocess.run(
             [connector_python, "-c", _PROBE_SNIPPET],
             capture_output=True,

--- a/operator/templates/pre_run_gate.py
+++ b/operator/templates/pre_run_gate.py
@@ -101,8 +101,8 @@ def probe_open_matter_count() -> int | None:
         sys.stderr.write(f"[pre_run] connector python missing: {connector_python}\n")
         return None
     try:
-        # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-tainted-env-args.dangerous-subprocess-use-tainted-env-args — argv[0] is the module-constant connector-venv interpreter, overridable only via SMD_CONNECTOR_VENV_PYTHON, which comes from the Machine's own boot env (same trust domain as this file; the test seam). The snippet argument is a module constant; no request/agent-controlled data reaches argv.
         result = subprocess.run(
+            # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-tainted-env-args.dangerous-subprocess-use-tainted-env-args — argv[0] is the module-constant connector-venv interpreter, overridable only via SMD_CONNECTOR_VENV_PYTHON, which comes from the Machine's own boot env (same trust domain as this file; the test seam). The snippet argument is a module constant; no request/agent-controlled data reaches argv.
             [connector_python, "-c", _PROBE_SNIPPET],
             capture_output=True,
             text=True,

--- a/operator/tests/test_pre_run_gate.py
+++ b/operator/tests/test_pre_run_gate.py
@@ -1,0 +1,239 @@
+"""Shared empty-seat pre-run gate: sync, decision core, probe, heartbeat wire.
+
+The canonical source is ``operator/templates/pre_run_gate.py``; the copies
+stamped into skill dirs must be byte-identical (edit template, restamp).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import socket
+import socketserver
+import sys
+import threading
+from pathlib import Path
+
+import pytest
+
+_OPERATOR_ROOT = Path(__file__).resolve().parents[1]
+_TEMPLATE = _OPERATOR_ROOT / "templates" / "pre_run_gate.py"
+
+# The 11 always-wake PI-pack skills gated by the empty-seat gate (#1748).
+# deadline-miss-escalator keeps its bespoke deadline pre_run and is NOT here.
+GATED_SKILLS = (
+    "daily-needs-you-digest",
+    "discovery-response-tracker",
+    "client-verification-tracker",
+    "motion-calendar-tracker",
+    "service-confirmation-watcher",
+    "medical-chronology-maintainer",
+    "medical-records-chaser",
+    "lien-ledger-tracker",
+    "mediation-settlement-tracker",
+    "minors-compromise-packet",
+    "trial-binder-assembler",
+)
+
+
+def _load_gate():
+    spec = importlib.util.spec_from_file_location("pre_run_gate_template", _TEMPLATE)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# ---------------------------------------------------------------------------
+# Stamp sync
+# ---------------------------------------------------------------------------
+
+
+def test_all_gated_skills_carry_a_byte_identical_stamp() -> None:
+    template_bytes = _TEMPLATE.read_bytes()
+    missing, drifted = [], []
+    for skill in GATED_SKILLS:
+        stamp = _OPERATOR_ROOT / "skills" / skill / "pre_run.py"
+        if not stamp.is_file():
+            missing.append(skill)
+        elif stamp.read_bytes() != template_bytes:
+            drifted.append(skill)
+    assert not missing, f"missing pre_run.py stamp: {missing}"
+    assert not drifted, (
+        f"pre_run.py drifted from templates/pre_run_gate.py: {drifted} — "
+        "edit the template and restamp, never the copy"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Decision core
+# ---------------------------------------------------------------------------
+
+
+def _emitted(capsys) -> dict:
+    return json.loads(capsys.readouterr().out.strip().splitlines()[-1])
+
+
+def test_open_matters_wake(capsys) -> None:
+    gate = _load_gate()
+    gate.decide_and_emit(3, "discovery-response-tracker")
+    assert _emitted(capsys) == {"wakeAgent": True}
+
+
+def test_unknown_count_wakes(capsys) -> None:
+    gate = _load_gate()
+    gate.decide_and_emit(None, "discovery-response-tracker")
+    assert _emitted(capsys) == {"wakeAgent": True}
+
+
+def test_empty_seat_suppresses_after_heartbeat(capsys, monkeypatch) -> None:
+    gate = _load_gate()
+    written = []
+    monkeypatch.setattr(
+        gate, "write_suppressed_wake_heartbeat", lambda skill: written.append(skill) or True
+    )
+    gate.decide_and_emit(0, "lien-ledger-tracker")
+    assert _emitted(capsys) == {"wakeAgent": False}
+    assert written == ["lien-ledger-tracker"]
+
+
+def test_empty_seat_with_failed_heartbeat_wakes(capsys, monkeypatch) -> None:
+    """Mirror-don't-gate: no heartbeat row → no suppress."""
+    gate = _load_gate()
+    monkeypatch.setattr(gate, "write_suppressed_wake_heartbeat", lambda skill: False)
+    gate.decide_and_emit(0, "lien-ledger-tracker")
+    assert _emitted(capsys) == {"wakeAgent": True}
+
+
+def test_assume_empty_flag_exercises_suppress_path(capsys, monkeypatch) -> None:
+    gate = _load_gate()
+    monkeypatch.setattr(gate, "write_suppressed_wake_heartbeat", lambda skill: True)
+    rc = gate.main(["--assume-empty"])
+    assert rc == 0
+    assert _emitted(capsys) == {"wakeAgent": False}
+
+
+# ---------------------------------------------------------------------------
+# Probe — execute the real snippet against a stubbed smokeball_connector
+# ---------------------------------------------------------------------------
+
+_STUB_CLIENT = """\
+class _Client:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def get(self, path, **params):
+        assert path == "/matters"
+        assert params.get("Status") == "Open"
+        assert params.get("Limit") == 1
+        return self._payload
+
+
+def build_client_from_env():
+    import json, os
+    return _Client(json.loads(os.environ["STUB_MATTERS_PAYLOAD"]))
+"""
+
+
+@pytest.fixture()
+def stub_connector(tmp_path, monkeypatch):
+    pkg = tmp_path / "smokeball_connector"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("")
+    (pkg / "client.py").write_text(_STUB_CLIENT)
+    monkeypatch.setenv("PYTHONPATH", str(tmp_path))
+    # Probe subprocess uses this interpreter instead of the connector venv.
+    monkeypatch.setenv("SMD_CONNECTOR_VENV_PYTHON", sys.executable)
+
+    def set_payload(payload) -> None:
+        monkeypatch.setenv("STUB_MATTERS_PAYLOAD", json.dumps(payload))
+
+    return set_payload
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected"),
+    [
+        ({"items": []}, 0),
+        ({"items": [{"id": "m1"}]}, 1),
+        ({"value": [{"id": "m1"}]}, 1),
+        ([], 0),
+        ([{"id": "m1"}], 1),
+        ({"weird": "envelope"}, None),  # unknown shape → wake
+        ("bare-string", None),
+    ],
+)
+def test_probe_envelope_shapes(stub_connector, payload, expected) -> None:
+    gate = _load_gate()
+    stub_connector(payload)
+    assert gate.probe_open_matter_count() == expected
+
+
+def test_probe_missing_connector_python_returns_unknown(monkeypatch) -> None:
+    gate = _load_gate()
+    monkeypatch.setenv("SMD_CONNECTOR_VENV_PYTHON", "/nonexistent/python")
+    assert gate.probe_open_matter_count() is None
+
+
+# ---------------------------------------------------------------------------
+# Heartbeat wire — dummy UDS broker
+# ---------------------------------------------------------------------------
+
+
+class _DummyBroker(socketserver.ThreadingUnixStreamServer):
+    allow_reuse_address = True
+    received: list = []
+    reply: dict = {"ok": True, "id": "01HTESTULID00000000000000"}
+
+
+class _DummyHandler(socketserver.StreamRequestHandler):
+    def handle(self) -> None:
+        raw = self.rfile.readline()
+        self.server.received.append(json.loads(raw))
+        self.wfile.write(json.dumps(self.server.reply).encode() + b"\n")
+
+
+@pytest.fixture()
+def dummy_broker(monkeypatch):
+    # AF_UNIX sun_path caps at ~104 chars on macOS; pytest's tmp_path routinely
+    # exceeds it. A short mkdtemp under the system tmp root stays portable.
+    import shutil
+    import tempfile
+
+    sock_dir = tempfile.mkdtemp(prefix="prg-")
+    sock_path = str(Path(sock_dir) / "b.sock")
+    server = _DummyBroker(sock_path, _DummyHandler)
+    server.received = []
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    monkeypatch.setenv("SMD_AUDIT_BROKER_SOCKET", sock_path)
+    monkeypatch.setenv("CUSTOMER_SLUG", "pilot-smokeball")
+    yield server
+    server.shutdown()
+    server.server_close()
+    shutil.rmtree(sock_dir, ignore_errors=True)
+
+
+def test_heartbeat_sends_locked_action_type_and_acks(dummy_broker) -> None:
+    gate = _load_gate()
+    assert gate.write_suppressed_wake_heartbeat("trial-binder-assembler") is True
+    (request,) = dummy_broker.received
+    assert request["action"] == "suppressed_wake_append"
+    row = request["row"]
+    assert row["action_type"] == "SUPPRESSED_WAKE"
+    assert row["skill_name"] == "trial-binder-assembler"
+    metadata = json.loads(row["metadata"])
+    assert metadata["decision_basis"] == "empty_seat:no_open_matters"
+    assert metadata["customer"] == "pilot-smokeball"
+
+
+def test_heartbeat_broker_rejection_returns_false(dummy_broker) -> None:
+    gate = _load_gate()
+    dummy_broker.reply = {"ok": False, "error": "PermissionError"}
+    assert gate.write_suppressed_wake_heartbeat("trial-binder-assembler") is False
+
+
+def test_heartbeat_without_socket_env_returns_false(monkeypatch) -> None:
+    gate = _load_gate()
+    monkeypatch.delenv("SMD_AUDIT_BROKER_SOCKET", raising=False)
+    monkeypatch.delenv("SMD_WORKSPACE_BROKER_SOCKET", raising=False)
+    assert gate.write_suppressed_wake_heartbeat("x") is False

--- a/operator/workspace_broker/server.py
+++ b/operator/workspace_broker/server.py
@@ -95,6 +95,10 @@ class Broker:
     # instances built via ``__new__`` (tests) and pre-B1 images have a defined,
     # job-disabled ledger.
     job_ledger: JobLedgerWriter | None = None
+    # ADR 0021 Stream B: agent uid for the suppressed_wake_append heartbeat
+    # verb. None (the ``__new__``/pre-heartbeat default) keeps the verb
+    # fail-closed until __init__ resolves it from the gateway process.
+    agent_uid: int | None = None
 
     def __init__(self) -> None:
         self.socket_path = Path(os.environ["SMD_WORKSPACE_BROKER_SOCKET"])
@@ -112,14 +116,47 @@ class Broker:
         # this broker does not touch it.
         audit_db_path = os.environ.get("SMD_AUDIT_DB_PATH")
         self.ledger = LedgerWriter(audit_db_path) if audit_db_path else None
+        # ADR 0021 Stream B: cron pre_run scripts run as subprocess CHILDREN of
+        # the gateway (hermes cron/scheduler.py `subprocess.run`), so they share
+        # the agent uid but never the gateway PID. The narrow heartbeat verb
+        # below gates on uid instead. Derive the agent uid from the gateway
+        # process at boot; if /proc is unavailable the verb stays fail-closed.
+        try:
+            self.agent_uid = os.stat(f"/proc/{self.gateway_pid}").st_uid
+        except OSError:
+            self.agent_uid = None
         # B1: the job ledger folds into the SAME broker-owned DB file (one
         # mount, one uid boundary). Mutable control state, distinct table set;
         # the audit_log append-only guarantee is untouched (no job verb writes
         # audit_log). Disabled when the audit DB is unconfigured (pre-B1 image).
         self.job_ledger = JobLedgerWriter(audit_db_path) if audit_db_path else None
 
-    def handle(self, request: dict[str, Any], peer_pid: int) -> dict[str, Any]:
+    def handle(
+        self, request: dict[str, Any], peer_pid: int, peer_uid: int | None = None
+    ) -> dict[str, Any]:
         action = request.get("action")
+        # ADR 0021 Stream B heartbeat: the ONE verb reachable by cron pre_run
+        # children (agent uid, non-gateway PID). Deliberately narrow — the row's
+        # action_type is locked to SUPPRESSED_WAKE, so this cannot be used to
+        # forge any other audit row; the generic audit_append verb below keeps
+        # its strict gateway-PID gate. The append still flows through the
+        # hash-chained LedgerWriter (broker stamps id/ts; chain intact).
+        if action == "suppressed_wake_append":
+            if self.ledger is None:
+                raise ValueError("audit ledger not configured on this broker")
+            if self.agent_uid is None or peer_uid != self.agent_uid:
+                raise PermissionError(
+                    "suppressed_wake_append requires a caller running as the agent uid"
+                )
+            row = request.get("row")
+            if not isinstance(row, dict):
+                raise ValueError("suppressed_wake_append requires a 'row' object")
+            if row.get("action_type") != "SUPPRESSED_WAKE":
+                raise ValueError(
+                    "suppressed_wake_append only accepts action_type=SUPPRESSED_WAKE"
+                )
+            row_id = self.ledger.append(row)
+            return {"ok": True, "id": row_id}
         if action == "health":
             return {
                 "ok": True,
@@ -261,7 +298,7 @@ class RequestHandler(socketserver.StreamRequestHandler):
     """One newline-delimited JSON request per connection."""
 
     def handle(self) -> None:
-        peer_pid, _, _ = struct.unpack(
+        peer_pid, peer_uid, _ = struct.unpack(
             "3i",
             self.request.getsockopt(socket.SOL_SOCKET, socket.SO_PEERCRED, 12),
         )
@@ -271,7 +308,7 @@ class RequestHandler(socketserver.StreamRequestHandler):
         else:
             try:
                 request = json.loads(raw)
-                response = self.server.broker.handle(request, peer_pid)  # type: ignore[attr-defined]
+                response = self.server.broker.handle(request, peer_pid, peer_uid)  # type: ignore[attr-defined]
             except Exception as exc:  # noqa: BLE001 - protocol returns bounded errors
                 response = {
                     "ok": False,

--- a/operator/workspace_broker/tests/test_suppressed_wake_append.py
+++ b/operator/workspace_broker/tests/test_suppressed_wake_append.py
@@ -1,0 +1,151 @@
+"""suppressed_wake_append verb: uid-gated, SUPPRESSED_WAKE-only (ADR 0021 Stream B).
+
+Cron pre_run scripts run as subprocess CHILDREN of the gateway (hermes
+cron/scheduler.py ``subprocess.run``), so they share the agent uid but never
+the gateway PID. This verb is the one heartbeat door for them; everything else
+about the ledger (hash chain, broker-stamped id/ts, append-only) is unchanged.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from workspace_broker.audit_ledger import LedgerWriter
+from workspace_broker.server import Broker
+
+AGENT_UID = 1000
+GATEWAY_PID = 42
+
+
+def _broker(tmp_path: Path) -> Broker:
+    broker = Broker.__new__(Broker)
+    broker.customer_slug = "smd"
+    broker.gateway_pid = GATEWAY_PID
+    broker.agent_uid = AGENT_UID
+    broker.ledger = LedgerWriter(str(tmp_path / "audit.db"))
+    return broker
+
+
+def _row(**overrides) -> dict:
+    row = {
+        "action_type": "SUPPRESSED_WAKE",
+        "actor": "pre_run",
+        "actor_role": "agent",
+        "skill_name": "discovery-response-tracker",
+    }
+    row.update(overrides)
+    return row
+
+
+def test_heartbeat_from_agent_uid_nongateway_pid_writes_a_row(tmp_path: Path) -> None:
+    """The load-bearing case: a cron pre_run child (agent uid, foreign PID)."""
+    broker = _broker(tmp_path)
+    resp = broker.handle(
+        {"action": "suppressed_wake_append", "row": _row()},
+        peer_pid=9999,  # NOT the gateway PID
+        peer_uid=AGENT_UID,
+    )
+    assert resp["ok"] is True
+    assert isinstance(resp["id"], str) and len(resp["id"]) == 26  # ULID
+    assert broker.ledger.count() == 1
+
+
+def test_heartbeat_rejected_from_foreign_uid(tmp_path: Path) -> None:
+    broker = _broker(tmp_path)
+    with pytest.raises(PermissionError):
+        broker.handle(
+            {"action": "suppressed_wake_append", "row": _row()},
+            peer_pid=9999,
+            peer_uid=AGENT_UID + 1,
+        )
+    assert broker.ledger.count() == 0
+
+
+def test_heartbeat_rejected_when_agent_uid_unresolved(tmp_path: Path) -> None:
+    """agent_uid=None (pre-heartbeat image / __new__ default) is fail-closed."""
+    broker = _broker(tmp_path)
+    broker.agent_uid = None
+    with pytest.raises(PermissionError):
+        broker.handle(
+            {"action": "suppressed_wake_append", "row": _row()},
+            peer_pid=9999,
+            peer_uid=AGENT_UID,
+        )
+    assert broker.ledger.count() == 0
+
+
+def test_heartbeat_rejected_when_peer_uid_missing(tmp_path: Path) -> None:
+    """Two-arg handle() callers (legacy wire) cannot reach the heartbeat verb."""
+    broker = _broker(tmp_path)
+    with pytest.raises(PermissionError):
+        broker.handle(
+            {"action": "suppressed_wake_append", "row": _row()}, peer_pid=GATEWAY_PID
+        )
+    assert broker.ledger.count() == 0
+
+
+def test_action_type_is_locked_to_suppressed_wake(tmp_path: Path) -> None:
+    """The verb cannot forge any other audit row."""
+    broker = _broker(tmp_path)
+    with pytest.raises(ValueError):
+        broker.handle(
+            {
+                "action": "suppressed_wake_append",
+                "row": _row(action_type="REPLY_SENT"),
+            },
+            peer_pid=9999,
+            peer_uid=AGENT_UID,
+        )
+    assert broker.ledger.count() == 0
+
+
+def test_row_must_be_an_object(tmp_path: Path) -> None:
+    broker = _broker(tmp_path)
+    with pytest.raises(ValueError):
+        broker.handle(
+            {"action": "suppressed_wake_append", "row": "SUPPRESSED_WAKE"},
+            peer_pid=9999,
+            peer_uid=AGENT_UID,
+        )
+
+
+def test_heartbeat_rejected_when_ledger_unconfigured(tmp_path: Path) -> None:
+    broker = _broker(tmp_path)
+    broker.ledger = None
+    with pytest.raises(ValueError):
+        broker.handle(
+            {"action": "suppressed_wake_append", "row": _row()},
+            peer_pid=9999,
+            peer_uid=AGENT_UID,
+        )
+
+
+def test_heartbeat_row_joins_the_hash_chain(tmp_path: Path) -> None:
+    """Heartbeat rows are ordinary chained ledger rows, not a side store."""
+    broker = _broker(tmp_path)
+    broker.handle(
+        {"action": "audit_append", "row": {"action_type": "TOOL_CALL_COMPLETED", "actor": "agent", "actor_role": "agent"}},
+        peer_pid=GATEWAY_PID,
+        peer_uid=AGENT_UID,
+    )
+    broker.handle(
+        {"action": "suppressed_wake_append", "row": _row()},
+        peer_pid=9999,
+        peer_uid=AGENT_UID,
+    )
+    import sqlite3
+
+    conn = sqlite3.connect(str(tmp_path / "audit.db"))
+    rows = conn.execute(
+        "SELECT action_type, prev_hash, row_hash FROM audit_log ORDER BY rowid"
+    ).fetchall()
+    conn.close()
+    assert [r[0] for r in rows] == ["TOOL_CALL_COMPLETED", "SUPPRESSED_WAKE"]
+    # The heartbeat row chains off the prior row's hash.
+    assert rows[1][1] == rows[0][2]
+    assert rows[1][2] is not None


### PR DESCRIPTION
## Why

Live cost forensics (2026-07-06, vfy_01KWW7GZ) found all 12 PI-pack cron entries waking the agent unconditionally on every fire — 11 authored `wake_policy: always`, and the one gated entry (deadline-miss-escalator) falling back to wake because its Smokeball reader was never wired. ~$1–2/day per seat of make-work on idle seats; ADR 0021's "idle ticks cost nothing" was untrue in production. #1748 has the full finding.

## What

1. **Broker: uid-gated `suppressed_wake_append` verb** (`operator/workspace_broker/server.py`). Cron pre_runs run as gateway *children* (`subprocess.run` in hermes `cron/scheduler.py` — verified against the pinned ref a91a57f) — agent uid, non-gateway PID — so the strict `audit_append` PID gate correctly rejects them. The new verb: action_type **locked to SUPPRESSED_WAKE** (cannot forge any other row), same hash-chained ledger, broker stamps id/ts, fail-closed when the agent uid is unresolved. Generic `audit_append` keeps its gateway-PID gate untouched.
2. **Shared empty-seat gate** (`operator/templates/pre_run_gate.py`), stamped byte-identical into the 11 tracker/watch/chase skills (sync enforced by `operator/tests/test_pre_run_gate.py`). Probes Smokeball for open matters via the connector's own venv (the package is not importable from the Hermes venv): zero → heartbeat → `{wakeAgent:false}`; any open matter / probe failure / unknown envelope / heartbeat failure → **wake** (fail-open, mirror-don't-gate). `--assume-empty` exercises the suppress path live without an empty tenant.
3. **Escalator production reader wired** — connector-venv pull of `/tasks` + `/events` feeding the existing tested `run_once()`; conservative parsing (partial pull / unknown envelope / non-empty-pull-with-zero-parseable-dates all wake).
4. **customer.yaml flips** on pilot-smokeball + ashton-price: 11 × `always` → `pre_run_decides` + `pre_run: pre_run.py`.
5. **Producers contract**: SUPPRESSED_WAKE producer is now the broker verb.

## Rehearsal safety

A hydrated seat (any open matter) wakes exactly as before — M1/L2 shadow-digest grading on pilot-smokeball is unaffected. Only truly idle seats go quiet, with a SUPPRESSED_WAKE heartbeat row per suppressed tick as the dead-man's-switch trail.

## Tests

- 243 operator pytest (17 new gate tests, 8 broker verb tests, 7 escalator parse tests)
- `npm run verify` green (3,247 tests)

## Post-merge plan

Reprovision pilot-smokeball, then live-verify: (a) `pre_run.py --assume-empty` on-machine writes a SUPPRESSED_WAKE row through the broker and emits `wakeAgent:false`; (b) tomorrow's scheduled fires on the hydrated rehearsal seat still wake. `crane_verify` records both.

## Follow-on (stays on #1748 discussion)

Per-skill UpdatedSince/state-delta gates once the `updated_since` wire format is verified at connect; chasers gate on open-chase-item existence, never activity.

Closes #1748

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EcUe7ViLSA73UwJ2SajH7E