### PR TITLE
fix(hosted-agent): dry-run findings — portal host, icon font, setup journey, intake alert

### DIFF
--- a/src/lib/email/hosted-agent-templates.ts
+++ b/src/lib/email/hosted-agent-templates.ts
@@ -60,6 +60,28 @@ export function hostedAgentOrderNotificationEmailHtml(
   )
 }
 
+export interface HostedAgentIntakeNotificationInput {
+  entityName: string
+  agentName: string | null
+  adminQueueUrl: string
+}
+
+/** Operational alert to team@ when a customer submits the setup
+ * questionnaire — the "ready to provision" baton. */
+export function hostedAgentIntakeNotificationEmailHtml(
+  input: HostedAgentIntakeNotificationInput
+): string {
+  return portalDocument(
+    [
+      paragraph('A Hosted Agent setup questionnaire was submitted.', '0 0 8px'),
+      detailPanel('Customer', escapeEmailHtml(input.entityName)),
+      detailPanel('Agent name', escapeEmailHtml(input.agentName ?? 'not provided')),
+      paragraph('Next concierge steps: assign the customer slug, then provision.'),
+      actionButton(input.adminQueueUrl, 'Open the Queue'),
+    ].join('\n')
+  )
+}
+
 /**
  * Sent by the Captain's activate action when the agent goes live. Channel
  * details are authored per customer in the admin activate form, never

--- a/src/lib/routing/legacy-redirects.ts
+++ b/src/lib/routing/legacy-redirects.ts
@@ -79,6 +79,24 @@ const ADMIN_HOST_CANONICALIZE: RedirectRule = {
   status: 301,
 }
 
+/**
+ * Apex `/portal/*` canonicalizes to the portal subdomain, mirroring the admin
+ * rule above. Found in the Hosted Agent live dry-run (2026-07-06): a relative
+ * portal link on a marketing page kept the buyer on smd.services, serving the
+ * portal on the wrong host. Absolute target (host change).
+ */
+const PORTAL_HOST_CANONICALIZE: RedirectRule = {
+  label: 'portal-host-canonicalize',
+  match: ({ hostname, pathname }) =>
+    hostname === 'smd.services' && (pathname === '/portal' || pathname.startsWith('/portal/')),
+  location: ({ url }) => {
+    const next = new URL(url)
+    next.hostname = 'portal.smd.services'
+    return next.toString()
+  },
+  status: 301,
+}
+
 /** Old dual-auth-era paths → the unified Clerk sign-in/up. Query preserved. */
 const LEGACY_AUTH_PATHS: Record<string, string> = {
   '/auth/login': '/auth/sign-in',
@@ -150,6 +168,7 @@ export const PRE_REWRITE_REDIRECTS: readonly RedirectRule[] = [OPERATOR_RENAME]
 /** Redirects that run AFTER the subdomain rewrite. Order is significant. */
 export const POST_REWRITE_REDIRECTS: readonly RedirectRule[] = [
   ADMIN_HOST_CANONICALIZE,
+  PORTAL_HOST_CANONICALIZE,
   LEGACY_AUTH,
   BOOK_THANKS,
   RETIRED_MARKETING_EXACT,

--- a/src/lib/webhooks/hosted-agent-checkout-handler.ts
+++ b/src/lib/webhooks/hosted-agent-checkout-handler.ts
@@ -292,7 +292,11 @@ async function sendPurchaseEmails(
     await sendEmail(resendApiKey, {
       to: input.buyerEmail,
       subject: 'Your Hosted Agent subscription is active',
-      html: hostedAgentWelcomeEmailHtml(input.buyerName, portalUrl),
+      // Deep-link the product page on the portal host, not the portal root.
+      html: hostedAgentWelcomeEmailHtml(
+        input.buyerName,
+        `${portalUrl}/portal/products/hosted-agent`
+      ),
     })
   } catch (err) {
     console.error('[hosted-agent-checkout] welcome email failed:', err)

--- a/src/pages/agent/thanks.astro
+++ b/src/pages/agent/thanks.astro
@@ -5,6 +5,7 @@ import Base from '../../layouts/Base.astro'
 import Nav from '../../components/Nav.astro'
 import Footer from '../../components/Footer.astro'
 import { getHostedAgentCheckoutSession } from '../../lib/stripe/checkout'
+import { getPortalBaseUrl } from '../../lib/config/app-url'
 import { env } from 'cloudflare:workers'
 
 /**
@@ -12,6 +13,10 @@ import { env } from 'cloudflare:workers'
  * Stripe substitutes into the success URL and confirms the payment state
  * honestly. The portal is the durable home; this page is a signpost.
  */
+
+// Absolute portal-host URL: a relative /portal link from this marketing page
+// would keep the buyer on the apex host (found in the live dry-run).
+const portalProductUrl = `${getPortalBaseUrl(env) ?? ''}/portal/products/hosted-agent`
 
 const sessionId = Astro.url.searchParams.get('session_id')
 
@@ -43,7 +48,7 @@ if (sessionId && /^[A-Za-z0-9_]+$/.test(sessionId)) {
             email from.
           </p>
           <a
-            href="/portal/products/hosted-agent"
+            href={portalProductUrl}
             class="mt-8 inline-flex items-center justify-center px-8 py-4 border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-primary)] text-white font-bold uppercase tracking-[0.08em] font-['Archivo'] hover:bg-[color:var(--ss-color-primary-hover)] transition-colors"
           >
             Open Your Portal
@@ -64,7 +69,7 @@ if (sessionId && /^[A-Za-z0-9_]+$/.test(sessionId)) {
               : 'This page could not confirm a checkout. If you completed payment, your portal is the source of truth.'}
           </p>
           <a
-            href="/portal/products/hosted-agent"
+            href={portalProductUrl}
             class="mt-8 inline-flex items-center justify-center px-8 py-4 border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)] text-[color:var(--ss-color-text-primary)] font-bold uppercase tracking-[0.08em] font-['Archivo'] hover:bg-[color:var(--ss-color-text-primary)] hover:text-[color:var(--ss-color-background)] transition-colors"
           >
             Check Your Portal

--- a/src/pages/api/portal/products/hosted-agent/intake.ts
+++ b/src/pages/api/portal/products/hosted-agent/intake.ts
@@ -6,6 +6,9 @@ import {
   submitHostedAgentIntake,
 } from '../../../../../lib/db/hosted-agent-intake'
 import { isValidEmail, trimString } from '../../../../../lib/api/helpers'
+import { sendEmail } from '../../../../../lib/email/resend'
+import { hostedAgentIntakeNotificationEmailHtml } from '../../../../../lib/email/hosted-agent-templates'
+import { getAdminBaseUrl } from '../../../../../lib/config/app-url'
 
 /**
  * POST /api/portal/products/hosted-agent/intake (ADR 0067)
@@ -76,6 +79,23 @@ export const POST: APIRoute = async ({ locals, request }) => {
   } catch (err) {
     console.error('[hosted-agent/intake] save failed:', err)
     return back('error')
+  }
+
+  // Best-effort concierge baton: tell team@ the questionnaire landed and
+  // provisioning can start. Never blocks the customer's save.
+  try {
+    const adminBase = getAdminBaseUrl(env) ?? 'https://admin.smd.services'
+    await sendEmail(env.RESEND_API_KEY, {
+      to: 'team@smd.services',
+      subject: `Hosted Agent intake submitted: ${access.client.name}`,
+      html: hostedAgentIntakeNotificationEmailHtml({
+        entityName: access.client.name,
+        agentName: parsed.agentName,
+        adminQueueUrl: `${adminBase}/admin/hosted-agent`,
+      }),
+    })
+  } catch (err) {
+    console.error('[hosted-agent/intake] team notification failed:', err)
   }
   return back('saved')
 }

--- a/src/pages/portal/products/hosted-agent/api-key.astro
+++ b/src/pages/portal/products/hosted-agent/api-key.astro
@@ -65,6 +65,10 @@ const keyReceived = intake.anthropic_key_status === 'received'
       href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;900&family=Archivo+Narrow:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
       rel="stylesheet"
     />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap"
+      rel="stylesheet"
+    />
     <title>API Key | {BRAND_NAME}</title>
   </head>
   <body class="min-h-screen bg-[color:var(--ss-color-background)]">

--- a/src/pages/portal/products/hosted-agent/index.astro
+++ b/src/pages/portal/products/hosted-agent/index.astro
@@ -69,13 +69,105 @@ if (!subscription) {
 }
 
 const needsIntake = surfaceState === 'setup' && intake?.status === 'awaiting_intake'
-const intakeSubmitted =
-  surfaceState === 'setup' && intake !== null && intake.status !== 'awaiting_intake'
 const needsKey =
   surfaceState === 'setup' &&
   intake !== null &&
   intake.anthropic_key_status === 'pending' &&
   intake.customer_slug !== null
+const keyReceived = intake?.anthropic_key_status === 'received'
+
+/**
+ * The setup journey, rendered as a numbered step list so a new customer
+ * always knows what they bought, whose move it is, and what happens next.
+ * Every state derives from authored rows; every sentence describes shipped
+ * system behavior (the go-live email exists, the page does switch to live).
+ */
+type StepState = 'done' | 'action' | 'team' | 'upcoming'
+interface SetupStep {
+  title: string
+  detail: string
+  state: StepState
+  href?: string
+}
+
+const setupSteps: SetupStep[] =
+  surfaceState === 'setup'
+    ? [
+        {
+          title: 'Payment received',
+          detail: 'Your subscription is active.',
+          state: 'done',
+        },
+        needsIntake
+          ? {
+              title: 'Setup questionnaire',
+              state: 'action',
+              href: '/portal/products/hosted-agent/intake',
+              detail:
+                'Tell us what to call your agent, what it should work on, and which senders it accepts email from. Takes a few minutes.',
+            }
+          : {
+              title: 'Setup questionnaire',
+              state: 'done',
+              detail: intake?.agent_name
+                ? `Received. Your agent will be called ${intake.agent_name}.`
+                : 'Received.',
+            },
+        keyReceived
+          ? {
+              title: 'Your Anthropic API key',
+              state: 'done',
+              detail:
+                "Received. It lives in your agent's isolated vault and is never shown or logged.",
+            }
+          : needsKey
+            ? {
+                title: 'Your Anthropic API key',
+                state: 'action',
+                href: '/portal/products/hosted-agent/api-key',
+                detail:
+                  "Your agent's secure vault is ready. Add the API key you created in the Anthropic Console, with a spend limit you set.",
+              }
+            : {
+                title: 'Your Anthropic API key',
+                state: 'upcoming',
+                detail:
+                  "Unlocks once our team prepares your agent's secure vault. You will create this key in your own Anthropic Console with a spend limit you control; it goes into your agent's vault only.",
+              },
+        {
+          title: 'We build and test your agent',
+          state: keyReceived ? 'team' : 'upcoming',
+          detail:
+            'Our team configures your agent by hand, connects Telegram and its private email inbox, and runs it through a safety check before anything goes live.',
+        },
+        {
+          title: 'Go live',
+          state: 'upcoming',
+          detail:
+            'You get an email with exactly how to reach your agent, and this page switches to your live status view.',
+        },
+      ]
+    : []
+
+const stepBadge: Record<StepState, { label: string; klass: string }> = {
+  done: {
+    label: 'Done',
+    klass: 'border-[color:var(--ss-color-complete)] text-[color:var(--ss-color-complete)]',
+  },
+  action: {
+    label: 'Your turn',
+    klass: 'border-[color:var(--ss-color-primary)] text-[color:var(--ss-color-primary)]',
+  },
+  team: {
+    label: 'Our team is on it',
+    klass: 'border-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-text-primary)]',
+  },
+  upcoming: {
+    label: 'Up next',
+    klass:
+      'border-[color:var(--ss-color-text-secondary)] text-[color:var(--ss-color-text-secondary)]',
+  },
+}
 
 // Intake form outcome banner (?st=saved|invalid|error) and key form outcome
 // (?cs=saved|not_enabled|...) both land back here or on their own pages.
@@ -97,6 +189,10 @@ const stMessage =
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link
       href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;900&family=Archivo+Narrow:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap"
       rel="stylesheet"
     />
     <title>Hosted Agent | {BRAND_NAME}</title>
@@ -176,54 +272,59 @@ const stMessage =
                 Setup in progress
               </p>
               <p class="mt-3 font-['Archivo_Narrow'] text-base text-[color:var(--ss-color-text-secondary)]">
-                Your subscription is active and your agent is being prepared. This page shows the
-                current setup state at every step.
+                Your subscription is active. We build each agent by hand, and this page shows the
+                true state of every step. Anything that needs you also arrives by email.
               </p>
             </div>
 
-            {needsIntake && (
-              <a
-                href="/portal/products/hosted-agent/intake"
-                class="block border-[3px] border-[color:var(--ss-color-primary)] p-6 md:p-8 hover:bg-[color:var(--ss-color-border-subtle)] transition-colors"
-              >
-                <p class="font-['Archivo'] text-xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-primary)]">
-                  Next step: setup questionnaire
-                </p>
-                <p class="mt-2 font-['Archivo_Narrow'] text-base text-[color:var(--ss-color-text-secondary)]">
-                  Tell us what to call your agent, what it should work on, and which senders it
-                  accepts email from. Takes a few minutes.
-                </p>
-              </a>
-            )}
+            <ol class="flex flex-col gap-4">
+              {setupSteps.map((step, i) => {
+                const badge = stepBadge[step.state]
+                const inner = (
+                  <>
+                    <div class="flex flex-wrap items-baseline justify-between gap-2">
+                      <p class="font-['Archivo'] text-lg font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]">
+                        {i + 1}. {step.title}
+                      </p>
+                      <span
+                        class={`border-[2px] px-2 py-0.5 font-['Archivo_Narrow'] text-xs font-bold uppercase tracking-[0.14em] ${badge.klass}`}
+                      >
+                        {badge.label}
+                      </span>
+                    </div>
+                    <p class="mt-2 font-['Archivo_Narrow'] text-base text-[color:var(--ss-color-text-secondary)]">
+                      {step.detail}
+                    </p>
+                  </>
+                )
+                return (
+                  <li>
+                    {step.href ? (
+                      <a
+                        href={step.href}
+                        class="block border-[3px] border-[color:var(--ss-color-primary)] p-5 md:p-6 hover:bg-[color:var(--ss-color-border-subtle)] transition-colors"
+                      >
+                        {inner}
+                      </a>
+                    ) : (
+                      <div
+                        class={`border-[3px] p-5 md:p-6 ${
+                          step.state === 'done'
+                            ? 'border-[color:var(--ss-color-complete)]'
+                            : 'border-[color:var(--ss-color-text-primary)]'
+                        }`}
+                      >
+                        {inner}
+                      </div>
+                    )}
+                  </li>
+                )
+              })}
+            </ol>
 
-            {intakeSubmitted && (
-              <div class="border-[3px] border-[color:var(--ss-color-text-primary)] p-6 md:p-8">
-                <p class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold text-[color:var(--ss-color-complete)]">
-                  Questionnaire received
-                </p>
-                {intake?.agent_name && (
-                  <p class="mt-2 font-['Archivo_Narrow'] text-base text-[color:var(--ss-color-text-secondary)]">
-                    Agent name: {intake.agent_name}
-                  </p>
-                )}
-              </div>
-            )}
-
-            {needsKey && (
-              <a
-                href="/portal/products/hosted-agent/api-key"
-                class="block border-[3px] border-[color:var(--ss-color-primary)] p-6 md:p-8 hover:bg-[color:var(--ss-color-border-subtle)] transition-colors"
-              >
-                <p class="font-['Archivo'] text-xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-primary)]">
-                  Next step: add your Anthropic API key
-                </p>
-                <p class="mt-2 font-['Archivo_Narrow'] text-base text-[color:var(--ss-color-text-secondary)]">
-                  Your agent runs on your own Anthropic key with a spend limit you control. The key
-                  is relayed straight to your agent's isolated vault and is never stored or shown
-                  here.
-                </p>
-              </a>
-            )}
+            <p class="font-['Archivo_Narrow'] text-base text-[color:var(--ss-color-text-secondary)]">
+              Questions at any point: team@smd.services. A person answers.
+            </p>
           </div>
         )
       }

--- a/src/pages/portal/products/hosted-agent/intake.astro
+++ b/src/pages/portal/products/hosted-agent/intake.astro
@@ -70,6 +70,10 @@ const hintClass = "mt-1 font-['Archivo_Narrow'] text-sm text-[color:var(--ss-col
       href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;900&family=Archivo+Narrow:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
       rel="stylesheet"
     />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap"
+      rel="stylesheet"
+    />
     <title>Agent Setup | {BRAND_NAME}</title>
   </head>
   <body class="min-h-screen bg-[color:var(--ss-color-background)]">

--- a/tests/forbidden-strings.test.ts
+++ b/tests/forbidden-strings.test.ts
@@ -470,6 +470,12 @@ const LIST_INDEX_ALLOWLIST: string[] = [
   // a repeating card — a different primitive than `PortalListItem`. Track
   // as a follow-up if milestone rail drifts or gains a second use.
   resolve('src/pages/portal/engagement/index.astro'),
+  // `products/hosted-agent/index.astro` is the Hosted Agent status surface
+  // (one subscription per render), not a list of products. Its `.map(` is
+  // the setup-journey stepper: numbered steps with whose-move state badges
+  // (done / your turn / our team / up next) — milestone-rail semantics like
+  // the engagement surface above, not list-row cards.
+  resolve('src/pages/portal/products/hosted-agent/index.astro'),
   // `products/operator/index.astro` is the Operator dashboard
   // landing (one customer per render), not a list of products. The
   // small `.map(roles, …)` inside the sidebar renders a bullet list of


### PR DESCRIPTION
## What (all found by the live dry-run purchase)

1. **Portal host**: apex `/portal/*` now 301s to `portal.smd.services` (mirrors the admin canonicalization rule) — the buyer had been kept on `smd.services` by a relative link. Thanks page + welcome email now deep-link the product page absolutely on the portal host.
2. **Icon font**: the three hosted-agent portal pages were missing the Material Symbols link, so the header rendered "mail sms calllogout" as raw text.
3. **Setup journey**: the status page now shows a five-step journey (payment → questionnaire → API key → we build and test → go live) with whose-move badges (Done / Your turn / Our team is on it / Up next) and a "team@smd.services, a person answers" support line. Copy is status-framed, no timeline promises, and describes only shipped behavior.
4. **Intake baton**: submitting the questionnaire now emails team@ "ready to provision" with the queue link (best-effort, never blocks the save) — previously the queue flipped silently.

## Verification

- `npm run verify` green; R7 list-row registry allowlists the stepper with the milestone-rail justification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MJF9rQDhVKLv2ADbbApPgi