### PR TITLE
feat(operator): caption provenance allowlist in the citation filter + first-draft rules (#1758 items 1-2)

### DIFF
--- a/operator/safety-substrate/citation_filter.py
+++ b/operator/safety-substrate/citation_filter.py
@@ -25,8 +25,8 @@ from __future__ import annotations
 
 import re
 import unicodedata
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Iterable
 
 
 # ---------- Case-name patterns ----------
@@ -275,7 +275,7 @@ def contains_citation(text: str, allowed_case_names: Iterable[str] | None = None
     bluebook_hits = [h for h in hits if h.pattern == "bluebook-signal"]
     if len(bluebook_hits) >= 2:
         spans = sorted(h.span for h in bluebook_hits)
-        for a, b in zip(spans, spans[1:]):
+        for a, b in zip(spans, spans[1:], strict=False):
             if b[0] - a[1] < 200:
                 return True
     return False

--- a/operator/safety-substrate/citation_filter.py
+++ b/operator/safety-substrate/citation_filter.py
@@ -53,8 +53,11 @@ _REPORTER_ABBREVS = [
     r"S\.\s?Ct\.",
     r"L\.\s?Ed\.(?:\s?2d)?",
     r"F\.\s?(?:Supp\.?\s?(?:2d|3d)?|App'?x|R\.D\.|[1-4]?(?:st|nd|rd|th|d))?",  # F., F.2d, F.3d, F. Supp., F. Supp. 2d, F. App'x, F.R.D.
-    # State (common)
-    r"Cal\.\s?(?:App\.?\s?)?(?:[2-5]d)?",
+    # State (common). California's modern series are ordinal (Cal.4th,
+    # Cal.App.5th, Cal.Rptr.3d) — "[2-5]d" alone missed them (found via
+    # #1758's allowlist tests: "123 Cal. App. 5th 456" scanned clean).
+    r"Cal\.\s?(?:App\.?\s?)?(?:[2-5]\s?(?:d|th)\.?)?",
+    r"Cal\.\s?Rptr\.(?:\s?[2-3]d)?",
     r"N\.\s?Y\.(?:\s?[2-3]d)?",
     r"Ill\.(?:\s?(?:App\.?\s?)?[2-3]d)?",
     r"Tex\.(?:\s?(?:App\.?\s?)?)?",
@@ -164,17 +167,81 @@ def _normalize_encoding_bypass(text: str) -> str:
     return text
 
 
-def scan(text: str) -> list[Hit]:
+def canonical_caption(text: str) -> str:
+    """Canonical form of a case caption for allowlist comparison.
+
+    Applies the same anti-evasion normalization the scanner uses, then folds
+    case, collapses whitespace, and normalizes the party separator so
+    "ALVAREZ V DRAPER", "Alvarez vs. Draper", and "Alvarez v. Draper" all
+    compare equal. Used by :func:`scan`'s ``allowed_case_names`` and by
+    callers building a provenance register of captions actually read.
+    """
+    s = _normalize_encoding_bypass(text or "")
+    s = re.sub(r"\s+", " ", s).strip().casefold()
+    return re.sub(r"\bv(?:s)?\.?\s", "v. ", s)
+
+
+def _canonical_allowlist(
+    allowed_case_names: Iterable[str] | None,
+) -> tuple[re.Pattern[str], ...]:
+    """Compile boundary-bounded containment patterns for the allowlist.
+
+    The case-name regex greedily swallows adjacent prose into its parties
+    ("Discovery capture on Alvarez v. Draper is our matter" is ONE hit), so
+    the exemption tests containment at word boundaries rather than equality:
+    the registered caption must appear whole inside the canonical hit, with
+    no name-character touching either edge ("Alvarez v. Drapers" never
+    matches a registered "Alvarez v. Draper"). Prose spillover beyond the
+    caption's own tokens is tolerated; a caption used as fabricated AUTHORITY
+    still dies on the reporter-cite/statute/rule patterns, which are never
+    allowlisted.
+
+    Fail-closed: any error yields an EMPTY tuple (everything stays blocked),
+    never a broadened one.
+    """
+    if not allowed_case_names:
+        return ()
+    try:
+        # Boundary classes guard NAME CONTINUATION only (word chars,
+        # apostrophe, hyphen). Sentence punctuation is deliberately NOT
+        # excluded: the case-name regex swallows a trailing period into the
+        # party ("...Alvarez v. Draper. No signed..."), and a caption ending
+        # a sentence is the commonest legitimate form.
+        return tuple(
+            re.compile(rf"(?<![\w'\-]){re.escape(canonical_caption(s))}(?![\w'\-])")
+            for s in allowed_case_names
+            if s
+        )
+    except Exception:  # noqa: BLE001 — allowlist failure must narrow, not widen
+        return ()
+
+
+def scan(text: str, allowed_case_names: Iterable[str] | None = None) -> list[Hit]:
     """Return every citation-shaped hit in `text`. Empty list = clean.
 
     Scans both the raw text and a whitespace-normalized version to catch
     adversarial encoding (extra spaces inserted to bypass the regex).
+
+    ``allowed_case_names`` is a provenance allowlist of case CAPTIONS the
+    caller can attest the agent actually read this session (e.g. the matter's
+    own caption harvested from read-tool results — issue #1758). A
+    ``case-name`` hit whose matched text canonicalizes to an allowlisted
+    caption is dropped: repeating a caption you read is quoting the record,
+    not fabricating authority. The exemption is deliberately narrow —
+    reporter cites, statutes, and rules are NEVER allowlisted, so an
+    allowlisted caption followed by a reporter cite ("Alvarez v. Draper, 123
+    Cal.App.5th 456") still blocks on the reporter-cite pattern.
     """
+    allow = _canonical_allowlist(allowed_case_names)
     seen_matches: set[tuple[str, str]] = set()
     hits: list[Hit] = []
     for source_text in (text, _normalize_encoding_bypass(text)):
         for label, pat in PATTERNS:
             for m in pat.finditer(source_text):
+                if label == "case-name" and allow:
+                    canon_hit = canonical_caption(m.group(0))
+                    if any(p.search(canon_hit) for p in allow):
+                        continue
                 key = (label, m.group(0))
                 if key in seen_matches:
                     continue
@@ -183,7 +250,7 @@ def scan(text: str) -> list[Hit]:
     return hits
 
 
-def contains_citation(text: str) -> bool:
+def contains_citation(text: str, allowed_case_names: Iterable[str] | None = None) -> bool:
     """Fast yes/no check. True if any strong pattern matches.
 
     `bluebook-signal` alone is NOT enough (too many false positives — "id." is
@@ -191,6 +258,8 @@ def contains_citation(text: str) -> bool:
     returns True if a stronger pattern fires, OR a bluebook signal co-occurs
     with another bluebook signal in close proximity (Bluebook prose typically
     has multiple signals per paragraph).
+
+    ``allowed_case_names`` — see :func:`scan`.
     """
     strong_labels = {
         "case-name",
@@ -200,7 +269,7 @@ def contains_citation(text: str) -> bool:
         "federal-rule",
         "local-rule",
     }
-    hits = scan(text)
+    hits = scan(text, allowed_case_names=allowed_case_names)
     if any(h.pattern in strong_labels for h in hits):
         return True
     bluebook_hits = [h for h in hits if h.pattern == "bluebook-signal"]

--- a/operator/safety-substrate/tests/test_citation_caption_allowlist.py
+++ b/operator/safety-substrate/tests/test_citation_caption_allowlist.py
@@ -1,0 +1,92 @@
+"""Caption provenance allowlist (#1758 item 2).
+
+The tier-2 citation gate's case-name pattern cannot distinguish fabricated
+case law from the matter's own caption — 92 false-positive refusals in one
+rehearsal day, on the highest-frequency legitimate string in the vertical.
+The fix: ``scan``/``contains_citation`` accept ``allowed_case_names``, a
+provenance allowlist of captions the caller attests were actually READ this
+session. Only bare case-name hits are exempt; fabricated-authority patterns
+(reporter cites, statutes, rules) never are.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from citation_filter import canonical_caption, contains_citation, scan  # noqa: E402
+
+CAPTION = "Alvarez v. Draper"
+
+
+def test_unlisted_caption_still_blocks() -> None:
+    assert contains_citation("Deadline proposed on Alvarez v. Draper.")
+
+
+def test_allowlisted_caption_passes() -> None:
+    body = "Discovery capture on Alvarez v. Draper: RFP Set One served by mail."
+    assert not contains_citation(body, allowed_case_names=[CAPTION])
+    assert scan(body, allowed_case_names=[CAPTION]) == []
+
+
+def test_allowlist_matches_caption_variants() -> None:
+    for variant in (
+        "ALVAREZ V. DRAPER",
+        "Alvarez v Draper",
+        "Alvarez vs. Draper",
+        "alvarez  v.  draper",
+    ):
+        assert not contains_citation(variant, allowed_case_names=[CAPTION]), variant
+
+
+def test_caption_ending_a_sentence_is_exempt() -> None:
+    # The case-name regex swallows the sentence period into the party; the
+    # boundary check must not treat punctuation as name continuation.
+    body = "Verification chase run on Alvarez v. Draper. No signed document found."
+    assert not contains_citation(body, allowed_case_names=[CAPTION])
+
+
+def test_name_continuation_is_not_exempt() -> None:
+    assert contains_citation("Alvarez v. Drapers", allowed_case_names=[CAPTION])
+    assert contains_citation("Alvarez v. Draper-Smith", allowed_case_names=[CAPTION])
+
+
+def test_other_case_names_still_block_alongside_allowlisted() -> None:
+    body = "Alvarez v. Draper is our matter; compare Mata v. Avianca."
+    assert contains_citation(body, allowed_case_names=[CAPTION])
+    hits = scan(body, allowed_case_names=[CAPTION])
+    assert any("Mata" in h.match for h in hits)
+    assert not any("Alvarez" in h.match and h.pattern == "case-name" for h in hits)
+
+
+def test_reporter_cite_never_allowlisted() -> None:
+    # An allowlisted caption used as fabricated authority still dies on the
+    # reporter-cite pattern.
+    body = "Alvarez v. Draper, 123 Cal. App. 5th 456 controls here."
+    assert contains_citation(body, allowed_case_names=[CAPTION])
+    assert any(h.pattern == "reporter-cite" for h in scan(body, allowed_case_names=[CAPTION]))
+
+
+def test_statutes_and_rules_never_allowlisted() -> None:
+    assert contains_citation("See 42 U.S.C. § 1983.", allowed_case_names=[CAPTION])
+    assert contains_citation("Per Fed. R. Civ. P. 26(f).", allowed_case_names=[CAPTION])
+
+
+def test_evasion_normalization_applies_to_allowlist_comparison() -> None:
+    # Adversarial spacing in the body still canonicalizes to the allowlisted
+    # caption — exempt; and vice versa an evasive NON-listed caption still hits.
+    assert not contains_citation("Alvarez v . Draper", allowed_case_names=[CAPTION])
+    assert contains_citation("Mata v . Avianca", allowed_case_names=[CAPTION])
+
+
+def test_empty_or_bad_allowlist_narrows_never_widens() -> None:
+    assert contains_citation(CAPTION, allowed_case_names=[])
+    assert contains_citation(CAPTION, allowed_case_names=None)
+    assert contains_citation(CAPTION, allowed_case_names=["", None])  # type: ignore[list-item]
+
+
+def test_canonical_caption_folds_separator_and_case() -> None:
+    assert canonical_caption("ALVAREZ VS. DRAPER") == canonical_caption("alvarez v draper")
+    assert canonical_caption("In re  Ramirez") == "in re ramirez"

--- a/operator/skills/client-verification-tracker/SKILL.md
+++ b/operator/skills/client-verification-tracker/SKILL.md
@@ -244,6 +244,20 @@ citations belong only in matter-internal artifacts (memos, internal notes,
 tasks). Write the FIRST draft citation-free; do not write a cited draft and
 wait for the gate to teach you.
 
+Three more first-draft rules, same rationale (the gates enforce them; a
+refusal is a stalled deliverable and a full-context redraft — write it right
+the first time):
+
+- No em dashes anywhere, in any channel. Use commas, colons, or periods.
+- In email and task text, refer to the matter by its NUMBER (e.g.
+  2026-PI-101), never by its case caption. The matter's own caption is
+  acceptable inside matter memos; cited case law is never acceptable
+  anywhere.
+- State a specific dollar figure only when it exists in an authored source
+  on the matter, and name that source in the same sentence ("per the MedFin
+  payoff letter dated..."). Never total, estimate, or round figures into
+  existence.
+
 If a delivery tool refuses a draft or write (citation filter, banned-typography
 gate, or any other content gate): do not retry the same content, and do not
 drop the work. Redraft once, and the redraft KEEPS every captured fact: the

--- a/operator/skills/conflict-intake-router/SKILL.md
+++ b/operator/skills/conflict-intake-router/SKILL.md
@@ -110,6 +110,20 @@ citations belong only in matter-internal artifacts (memos, internal notes,
 tasks). Write the FIRST draft citation-free; do not write a cited draft and
 wait for the gate to teach you.
 
+Three more first-draft rules, same rationale (the gates enforce them; a
+refusal is a stalled deliverable and a full-context redraft — write it right
+the first time):
+
+- No em dashes anywhere, in any channel. Use commas, colons, or periods.
+- In email and task text, refer to the matter by its NUMBER (e.g.
+  2026-PI-101), never by its case caption. The matter's own caption is
+  acceptable inside matter memos; cited case law is never acceptable
+  anywhere.
+- State a specific dollar figure only when it exists in an authored source
+  on the matter, and name that source in the same sentence ("per the MedFin
+  payoff letter dated..."). Never total, estimate, or round figures into
+  existence.
+
 If a delivery tool refuses a draft or write (citation filter, banned-typography
 gate, or any other content gate): do not retry the same content, and do not
 drop the work. Redraft once, and the redraft KEEPS every captured fact: the

--- a/operator/skills/consult-scheduler/SKILL.md
+++ b/operator/skills/consult-scheduler/SKILL.md
@@ -114,6 +114,20 @@ citations belong only in matter-internal artifacts (memos, internal notes,
 tasks). Write the FIRST draft citation-free; do not write a cited draft and
 wait for the gate to teach you.
 
+Three more first-draft rules, same rationale (the gates enforce them; a
+refusal is a stalled deliverable and a full-context redraft — write it right
+the first time):
+
+- No em dashes anywhere, in any channel. Use commas, colons, or periods.
+- In email and task text, refer to the matter by its NUMBER (e.g.
+  2026-PI-101), never by its case caption. The matter's own caption is
+  acceptable inside matter memos; cited case law is never acceptable
+  anywhere.
+- State a specific dollar figure only when it exists in an authored source
+  on the matter, and name that source in the same sentence ("per the MedFin
+  payoff letter dated..."). Never total, estimate, or round figures into
+  existence.
+
 If a delivery tool refuses a draft or write (citation filter, banned-typography
 gate, or any other content gate): do not retry the same content, and do not
 drop the work. Redraft once, and the redraft KEEPS every captured fact: the

--- a/operator/skills/daily-needs-you-digest/SKILL.md
+++ b/operator/skills/daily-needs-you-digest/SKILL.md
@@ -263,6 +263,20 @@ citations belong only in matter-internal artifacts (memos, internal notes,
 tasks). Write the FIRST draft citation-free; do not write a cited draft and
 wait for the gate to teach you.
 
+Three more first-draft rules, same rationale (the gates enforce them; a
+refusal is a stalled deliverable and a full-context redraft — write it right
+the first time):
+
+- No em dashes anywhere, in any channel. Use commas, colons, or periods.
+- In email and task text, refer to the matter by its NUMBER (e.g.
+  2026-PI-101), never by its case caption. The matter's own caption is
+  acceptable inside matter memos; cited case law is never acceptable
+  anywhere.
+- State a specific dollar figure only when it exists in an authored source
+  on the matter, and name that source in the same sentence ("per the MedFin
+  payoff letter dated..."). Never total, estimate, or round figures into
+  existence.
+
 If a delivery tool refuses a draft or write (citation filter, banned-typography
 gate, or any other content gate): do not retry the same content, and do not
 drop the work. Redraft once, and the redraft KEEPS every captured fact: the

--- a/operator/skills/deadline-and-sol-tracker/SKILL.md
+++ b/operator/skills/deadline-and-sol-tracker/SKILL.md
@@ -109,6 +109,20 @@ citations belong only in matter-internal artifacts (memos, internal notes,
 tasks). Write the FIRST draft citation-free; do not write a cited draft and
 wait for the gate to teach you.
 
+Three more first-draft rules, same rationale (the gates enforce them; a
+refusal is a stalled deliverable and a full-context redraft — write it right
+the first time):
+
+- No em dashes anywhere, in any channel. Use commas, colons, or periods.
+- In email and task text, refer to the matter by its NUMBER (e.g.
+  2026-PI-101), never by its case caption. The matter's own caption is
+  acceptable inside matter memos; cited case law is never acceptable
+  anywhere.
+- State a specific dollar figure only when it exists in an authored source
+  on the matter, and name that source in the same sentence ("per the MedFin
+  payoff letter dated..."). Never total, estimate, or round figures into
+  existence.
+
 If a delivery tool refuses a draft or write (citation filter, banned-typography
 gate, or any other content gate): do not retry the same content, and do not
 drop the work. Redraft once, and the redraft KEEPS every captured fact: the

--- a/operator/skills/deadline-miss-escalator/SKILL.md
+++ b/operator/skills/deadline-miss-escalator/SKILL.md
@@ -99,6 +99,20 @@ citations belong only in matter-internal artifacts (memos, internal notes,
 tasks). Write the FIRST draft citation-free; do not write a cited draft and
 wait for the gate to teach you.
 
+Three more first-draft rules, same rationale (the gates enforce them; a
+refusal is a stalled deliverable and a full-context redraft — write it right
+the first time):
+
+- No em dashes anywhere, in any channel. Use commas, colons, or periods.
+- In email and task text, refer to the matter by its NUMBER (e.g.
+  2026-PI-101), never by its case caption. The matter's own caption is
+  acceptable inside matter memos; cited case law is never acceptable
+  anywhere.
+- State a specific dollar figure only when it exists in an authored source
+  on the matter, and name that source in the same sentence ("per the MedFin
+  payoff letter dated..."). Never total, estimate, or round figures into
+  existence.
+
 If a delivery tool refuses a draft or write (citation filter, banned-typography
 gate, or any other content gate): do not retry the same content, and do not
 drop the work. Redraft once, and the redraft KEEPS every captured fact: the

--- a/operator/skills/discovery-response-staging/SKILL.md
+++ b/operator/skills/discovery-response-staging/SKILL.md
@@ -260,6 +260,20 @@ citations belong only in matter-internal artifacts (memos, internal notes,
 tasks). Write the FIRST draft citation-free; do not write a cited draft and
 wait for the gate to teach you.
 
+Three more first-draft rules, same rationale (the gates enforce them; a
+refusal is a stalled deliverable and a full-context redraft — write it right
+the first time):
+
+- No em dashes anywhere, in any channel. Use commas, colons, or periods.
+- In email and task text, refer to the matter by its NUMBER (e.g.
+  2026-PI-101), never by its case caption. The matter's own caption is
+  acceptable inside matter memos; cited case law is never acceptable
+  anywhere.
+- State a specific dollar figure only when it exists in an authored source
+  on the matter, and name that source in the same sentence ("per the MedFin
+  payoff letter dated..."). Never total, estimate, or round figures into
+  existence.
+
 If a delivery tool refuses a draft or write (citation filter, banned-typography
 gate, or any other content gate): do not retry the same content, and do not
 drop the work. Redraft once, and the redraft KEEPS every captured fact: the

--- a/operator/skills/discovery-response-tracker/SKILL.md
+++ b/operator/skills/discovery-response-tracker/SKILL.md
@@ -345,6 +345,20 @@ citations belong only in matter-internal artifacts (memos, internal notes,
 tasks). Write the FIRST draft citation-free; do not write a cited draft and
 wait for the gate to teach you.
 
+Three more first-draft rules, same rationale (the gates enforce them; a
+refusal is a stalled deliverable and a full-context redraft — write it right
+the first time):
+
+- No em dashes anywhere, in any channel. Use commas, colons, or periods.
+- In email and task text, refer to the matter by its NUMBER (e.g.
+  2026-PI-101), never by its case caption. The matter's own caption is
+  acceptable inside matter memos; cited case law is never acceptable
+  anywhere.
+- State a specific dollar figure only when it exists in an authored source
+  on the matter, and name that source in the same sentence ("per the MedFin
+  payoff letter dated..."). Never total, estimate, or round figures into
+  existence.
+
 If a delivery tool refuses a draft or write (citation filter, banned-typography
 gate, or any other content gate): do not retry the same content, and do not
 drop the work. Redraft once, and the redraft KEEPS every captured fact: the

--- a/operator/skills/discovery-served-watch/SKILL.md
+++ b/operator/skills/discovery-served-watch/SKILL.md
@@ -318,6 +318,20 @@ citations belong only in matter-internal artifacts (memos, internal notes,
 tasks). Write the FIRST draft citation-free; do not write a cited draft and
 wait for the gate to teach you.
 
+Three more first-draft rules, same rationale (the gates enforce them; a
+refusal is a stalled deliverable and a full-context redraft — write it right
+the first time):
+
+- No em dashes anywhere, in any channel. Use commas, colons, or periods.
+- In email and task text, refer to the matter by its NUMBER (e.g.
+  2026-PI-101), never by its case caption. The matter's own caption is
+  acceptable inside matter memos; cited case law is never acceptable
+  anywhere.
+- State a specific dollar figure only when it exists in an authored source
+  on the matter, and name that source in the same sentence ("per the MedFin
+  payoff letter dated..."). Never total, estimate, or round figures into
+  existence.
+
 If a delivery tool refuses a draft or write (citation filter, banned-typography
 gate, or any other content gate): do not retry the same content, and do not
 drop the work. Redraft once, and the redraft KEEPS every captured fact: the

--- a/operator/skills/document-receipt-logger/SKILL.md
+++ b/operator/skills/document-receipt-logger/SKILL.md
@@ -108,6 +108,20 @@ citations belong only in matter-internal artifacts (memos, internal notes,
 tasks). Write the FIRST draft citation-free; do not write a cited draft and
 wait for the gate to teach you.
 
+Three more first-draft rules, same rationale (the gates enforce them; a
+refusal is a stalled deliverable and a full-context redraft — write it right
+the first time):
+
+- No em dashes anywhere, in any channel. Use commas, colons, or periods.
+- In email and task text, refer to the matter by its NUMBER (e.g.
+  2026-PI-101), never by its case caption. The matter's own caption is
+  acceptable inside matter memos; cited case law is never acceptable
+  anywhere.
+- State a specific dollar figure only when it exists in an authored source
+  on the matter, and name that source in the same sentence ("per the MedFin
+  payoff letter dated..."). Never total, estimate, or round figures into
+  existence.
+
 If a delivery tool refuses a draft or write (citation filter, banned-typography
 gate, or any other content gate): do not retry the same content, and do not
 drop the work. Redraft once, and the redraft KEEPS every captured fact: the

--- a/operator/skills/engagement-letter-chaser/SKILL.md
+++ b/operator/skills/engagement-letter-chaser/SKILL.md
@@ -108,6 +108,20 @@ citations belong only in matter-internal artifacts (memos, internal notes,
 tasks). Write the FIRST draft citation-free; do not write a cited draft and
 wait for the gate to teach you.
 
+Three more first-draft rules, same rationale (the gates enforce them; a
+refusal is a stalled deliverable and a full-context redraft — write it right
+the first time):
+
+- No em dashes anywhere, in any channel. Use commas, colons, or periods.
+- In email and task text, refer to the matter by its NUMBER (e.g.
+  2026-PI-101), never by its case caption. The matter's own caption is
+  acceptable inside matter memos; cited case law is never acceptable
+  anywhere.
+- State a specific dollar figure only when it exists in an authored source
+  on the matter, and name that source in the same sentence ("per the MedFin
+  payoff letter dated..."). Never total, estimate, or round figures into
+  existence.
+
 If a delivery tool refuses a draft or write (citation filter, banned-typography
 gate, or any other content gate): do not retry the same content, and do not
 drop the work. Redraft once, and the redraft KEEPS every captured fact: the

--- a/operator/skills/lien-ledger-tracker/SKILL.md
+++ b/operator/skills/lien-ledger-tracker/SKILL.md
@@ -293,6 +293,20 @@ citations belong only in matter-internal artifacts (memos, internal notes,
 tasks). Write the FIRST draft citation-free; do not write a cited draft and
 wait for the gate to teach you.
 
+Three more first-draft rules, same rationale (the gates enforce them; a
+refusal is a stalled deliverable and a full-context redraft — write it right
+the first time):
+
+- No em dashes anywhere, in any channel. Use commas, colons, or periods.
+- In email and task text, refer to the matter by its NUMBER (e.g.
+  2026-PI-101), never by its case caption. The matter's own caption is
+  acceptable inside matter memos; cited case law is never acceptable
+  anywhere.
+- State a specific dollar figure only when it exists in an authored source
+  on the matter, and name that source in the same sentence ("per the MedFin
+  payoff letter dated..."). Never total, estimate, or round figures into
+  existence.
+
 If a delivery tool refuses a draft or write (citation filter, banned-typography
 gate, or any other content gate): do not retry the same content, and do not
 drop the work. Redraft once, and the redraft KEEPS every captured fact: the

--- a/operator/skills/matter-document-review/SKILL.md
+++ b/operator/skills/matter-document-review/SKILL.md
@@ -134,6 +134,20 @@ citations belong only in matter-internal artifacts (memos, internal notes,
 tasks). Write the FIRST draft citation-free; do not write a cited draft and
 wait for the gate to teach you.
 
+Three more first-draft rules, same rationale (the gates enforce them; a
+refusal is a stalled deliverable and a full-context redraft — write it right
+the first time):
+
+- No em dashes anywhere, in any channel. Use commas, colons, or periods.
+- In email and task text, refer to the matter by its NUMBER (e.g.
+  2026-PI-101), never by its case caption. The matter's own caption is
+  acceptable inside matter memos; cited case law is never acceptable
+  anywhere.
+- State a specific dollar figure only when it exists in an authored source
+  on the matter, and name that source in the same sentence ("per the MedFin
+  payoff letter dated..."). Never total, estimate, or round figures into
+  existence.
+
 If a delivery tool refuses a draft or write (citation filter, banned-typography
 gate, or any other content gate): do not retry the same content, and do not
 drop the work. Redraft once, and the redraft KEEPS every captured fact: the

--- a/operator/skills/matter-inbox-router/SKILL.md
+++ b/operator/skills/matter-inbox-router/SKILL.md
@@ -143,6 +143,20 @@ citations belong only in matter-internal artifacts (memos, internal notes,
 tasks). Write the FIRST draft citation-free; do not write a cited draft and
 wait for the gate to teach you.
 
+Three more first-draft rules, same rationale (the gates enforce them; a
+refusal is a stalled deliverable and a full-context redraft — write it right
+the first time):
+
+- No em dashes anywhere, in any channel. Use commas, colons, or periods.
+- In email and task text, refer to the matter by its NUMBER (e.g.
+  2026-PI-101), never by its case caption. The matter's own caption is
+  acceptable inside matter memos; cited case law is never acceptable
+  anywhere.
+- State a specific dollar figure only when it exists in an authored source
+  on the matter, and name that source in the same sentence ("per the MedFin
+  payoff letter dated..."). Never total, estimate, or round figures into
+  existence.
+
 If a delivery tool refuses a draft or write (citation filter, banned-typography
 gate, or any other content gate): do not retry the same content, and do not
 drop the work. Redraft once, and the redraft KEEPS every captured fact: the

--- a/operator/skills/matter-initiation-setup/SKILL.md
+++ b/operator/skills/matter-initiation-setup/SKILL.md
@@ -332,6 +332,20 @@ citations belong only in matter-internal artifacts (memos, internal notes,
 tasks). Write the FIRST draft citation-free; do not write a cited draft and
 wait for the gate to teach you.
 
+Three more first-draft rules, same rationale (the gates enforce them; a
+refusal is a stalled deliverable and a full-context redraft — write it right
+the first time):
+
+- No em dashes anywhere, in any channel. Use commas, colons, or periods.
+- In email and task text, refer to the matter by its NUMBER (e.g.
+  2026-PI-101), never by its case caption. The matter's own caption is
+  acceptable inside matter memos; cited case law is never acceptable
+  anywhere.
+- State a specific dollar figure only when it exists in an authored source
+  on the matter, and name that source in the same sentence ("per the MedFin
+  payoff letter dated..."). Never total, estimate, or round figures into
+  existence.
+
 If a delivery tool refuses a draft or write (citation filter, banned-typography
 gate, or any other content gate): do not retry the same content, and do not
 drop the work. Redraft once, and the redraft KEEPS every captured fact: the

--- a/operator/skills/matter-memo-on-update/SKILL.md
+++ b/operator/skills/matter-memo-on-update/SKILL.md
@@ -127,6 +127,20 @@ citations belong only in matter-internal artifacts (memos, internal notes,
 tasks). Write the FIRST draft citation-free; do not write a cited draft and
 wait for the gate to teach you.
 
+Three more first-draft rules, same rationale (the gates enforce them; a
+refusal is a stalled deliverable and a full-context redraft — write it right
+the first time):
+
+- No em dashes anywhere, in any channel. Use commas, colons, or periods.
+- In email and task text, refer to the matter by its NUMBER (e.g.
+  2026-PI-101), never by its case caption. The matter's own caption is
+  acceptable inside matter memos; cited case law is never acceptable
+  anywhere.
+- State a specific dollar figure only when it exists in an authored source
+  on the matter, and name that source in the same sentence ("per the MedFin
+  payoff letter dated..."). Never total, estimate, or round figures into
+  existence.
+
 If a delivery tool refuses a draft or write (citation filter, banned-typography
 gate, or any other content gate): do not retry the same content, and do not
 drop the work. Redraft once, and the redraft KEEPS every captured fact: the

--- a/operator/skills/matter-status-digest/SKILL.md
+++ b/operator/skills/matter-status-digest/SKILL.md
@@ -117,6 +117,20 @@ citations belong only in matter-internal artifacts (memos, internal notes,
 tasks). Write the FIRST draft citation-free; do not write a cited draft and
 wait for the gate to teach you.
 
+Three more first-draft rules, same rationale (the gates enforce them; a
+refusal is a stalled deliverable and a full-context redraft — write it right
+the first time):
+
+- No em dashes anywhere, in any channel. Use commas, colons, or periods.
+- In email and task text, refer to the matter by its NUMBER (e.g.
+  2026-PI-101), never by its case caption. The matter's own caption is
+  acceptable inside matter memos; cited case law is never acceptable
+  anywhere.
+- State a specific dollar figure only when it exists in an authored source
+  on the matter, and name that source in the same sentence ("per the MedFin
+  payoff letter dated..."). Never total, estimate, or round figures into
+  existence.
+
 If a delivery tool refuses a draft or write (citation filter, banned-typography
 gate, or any other content gate): do not retry the same content, and do not
 drop the work. Redraft once, and the redraft KEEPS every captured fact: the

--- a/operator/skills/matter-status-responder/SKILL.md
+++ b/operator/skills/matter-status-responder/SKILL.md
@@ -98,6 +98,20 @@ citations belong only in matter-internal artifacts (memos, internal notes,
 tasks). Write the FIRST draft citation-free; do not write a cited draft and
 wait for the gate to teach you.
 
+Three more first-draft rules, same rationale (the gates enforce them; a
+refusal is a stalled deliverable and a full-context redraft — write it right
+the first time):
+
+- No em dashes anywhere, in any channel. Use commas, colons, or periods.
+- In email and task text, refer to the matter by its NUMBER (e.g.
+  2026-PI-101), never by its case caption. The matter's own caption is
+  acceptable inside matter memos; cited case law is never acceptable
+  anywhere.
+- State a specific dollar figure only when it exists in an authored source
+  on the matter, and name that source in the same sentence ("per the MedFin
+  payoff letter dated..."). Never total, estimate, or round figures into
+  existence.
+
 If a delivery tool refuses a draft or write (citation filter, banned-typography
 gate, or any other content gate): do not retry the same content, and do not
 drop the work. Redraft once, and the redraft KEEPS every captured fact: the

--- a/operator/skills/mediation-settlement-tracker/SKILL.md
+++ b/operator/skills/mediation-settlement-tracker/SKILL.md
@@ -263,6 +263,20 @@ citations belong only in matter-internal artifacts (memos, internal notes,
 tasks). Write the FIRST draft citation-free; do not write a cited draft and
 wait for the gate to teach you.
 
+Three more first-draft rules, same rationale (the gates enforce them; a
+refusal is a stalled deliverable and a full-context redraft — write it right
+the first time):
+
+- No em dashes anywhere, in any channel. Use commas, colons, or periods.
+- In email and task text, refer to the matter by its NUMBER (e.g.
+  2026-PI-101), never by its case caption. The matter's own caption is
+  acceptable inside matter memos; cited case law is never acceptable
+  anywhere.
+- State a specific dollar figure only when it exists in an authored source
+  on the matter, and name that source in the same sentence ("per the MedFin
+  payoff letter dated..."). Never total, estimate, or round figures into
+  existence.
+
 If a delivery tool refuses a draft or write (citation filter, banned-typography
 gate, or any other content gate): do not retry the same content, and do not
 drop the work. Redraft once, and the redraft KEEPS every captured fact: the

--- a/operator/skills/medical-chronology-maintainer/SKILL.md
+++ b/operator/skills/medical-chronology-maintainer/SKILL.md
@@ -272,6 +272,20 @@ citations belong only in matter-internal artifacts (memos, internal notes,
 tasks). Write the FIRST draft citation-free; do not write a cited draft and
 wait for the gate to teach you.
 
+Three more first-draft rules, same rationale (the gates enforce them; a
+refusal is a stalled deliverable and a full-context redraft — write it right
+the first time):
+
+- No em dashes anywhere, in any channel. Use commas, colons, or periods.
+- In email and task text, refer to the matter by its NUMBER (e.g.
+  2026-PI-101), never by its case caption. The matter's own caption is
+  acceptable inside matter memos; cited case law is never acceptable
+  anywhere.
+- State a specific dollar figure only when it exists in an authored source
+  on the matter, and name that source in the same sentence ("per the MedFin
+  payoff letter dated..."). Never total, estimate, or round figures into
+  existence.
+
 If a delivery tool refuses a draft or write (citation filter, banned-typography
 gate, or any other content gate): do not retry the same content, and do not
 drop the work. Redraft once, and the redraft KEEPS every captured fact: the

--- a/operator/skills/medical-records-chaser/SKILL.md
+++ b/operator/skills/medical-records-chaser/SKILL.md
@@ -237,6 +237,20 @@ citations belong only in matter-internal artifacts (memos, internal notes,
 tasks). Write the FIRST draft citation-free; do not write a cited draft and
 wait for the gate to teach you.
 
+Three more first-draft rules, same rationale (the gates enforce them; a
+refusal is a stalled deliverable and a full-context redraft — write it right
+the first time):
+
+- No em dashes anywhere, in any channel. Use commas, colons, or periods.
+- In email and task text, refer to the matter by its NUMBER (e.g.
+  2026-PI-101), never by its case caption. The matter's own caption is
+  acceptable inside matter memos; cited case law is never acceptable
+  anywhere.
+- State a specific dollar figure only when it exists in an authored source
+  on the matter, and name that source in the same sentence ("per the MedFin
+  payoff letter dated..."). Never total, estimate, or round figures into
+  existence.
+
 If a delivery tool refuses a draft or write (citation filter, banned-typography
 gate, or any other content gate): do not retry the same content, and do not
 drop the work. Redraft once, and the redraft KEEPS every captured fact: the

--- a/operator/skills/meet-and-confer-drafter/SKILL.md
+++ b/operator/skills/meet-and-confer-drafter/SKILL.md
@@ -255,6 +255,20 @@ citations belong only in matter-internal artifacts (memos, internal notes,
 tasks). Write the FIRST draft citation-free; do not write a cited draft and
 wait for the gate to teach you.
 
+Three more first-draft rules, same rationale (the gates enforce them; a
+refusal is a stalled deliverable and a full-context redraft — write it right
+the first time):
+
+- No em dashes anywhere, in any channel. Use commas, colons, or periods.
+- In email and task text, refer to the matter by its NUMBER (e.g.
+  2026-PI-101), never by its case caption. The matter's own caption is
+  acceptable inside matter memos; cited case law is never acceptable
+  anywhere.
+- State a specific dollar figure only when it exists in an authored source
+  on the matter, and name that source in the same sentence ("per the MedFin
+  payoff letter dated..."). Never total, estimate, or round figures into
+  existence.
+
 If a delivery tool refuses a draft or write (citation filter, banned-typography
 gate, or any other content gate): do not retry the same content, and do not
 drop the work. Redraft once, and the redraft KEEPS every captured fact: the

--- a/operator/skills/minors-compromise-packet/SKILL.md
+++ b/operator/skills/minors-compromise-packet/SKILL.md
@@ -278,6 +278,20 @@ citations belong only in matter-internal artifacts (memos, internal notes,
 tasks). Write the FIRST draft citation-free; do not write a cited draft and
 wait for the gate to teach you.
 
+Three more first-draft rules, same rationale (the gates enforce them; a
+refusal is a stalled deliverable and a full-context redraft — write it right
+the first time):
+
+- No em dashes anywhere, in any channel. Use commas, colons, or periods.
+- In email and task text, refer to the matter by its NUMBER (e.g.
+  2026-PI-101), never by its case caption. The matter's own caption is
+  acceptable inside matter memos; cited case law is never acceptable
+  anywhere.
+- State a specific dollar figure only when it exists in an authored source
+  on the matter, and name that source in the same sentence ("per the MedFin
+  payoff letter dated..."). Never total, estimate, or round figures into
+  existence.
+
 If a delivery tool refuses a draft or write (citation filter, banned-typography
 gate, or any other content gate): do not retry the same content, and do not
 drop the work. Redraft once, and the redraft KEEPS every captured fact: the

--- a/operator/skills/motion-calendar-tracker/SKILL.md
+++ b/operator/skills/motion-calendar-tracker/SKILL.md
@@ -239,6 +239,20 @@ citations belong only in matter-internal artifacts (memos, internal notes,
 tasks). Write the FIRST draft citation-free; do not write a cited draft and
 wait for the gate to teach you.
 
+Three more first-draft rules, same rationale (the gates enforce them; a
+refusal is a stalled deliverable and a full-context redraft — write it right
+the first time):
+
+- No em dashes anywhere, in any channel. Use commas, colons, or periods.
+- In email and task text, refer to the matter by its NUMBER (e.g.
+  2026-PI-101), never by its case caption. The matter's own caption is
+  acceptable inside matter memos; cited case law is never acceptable
+  anywhere.
+- State a specific dollar figure only when it exists in an authored source
+  on the matter, and name that source in the same sentence ("per the MedFin
+  payoff letter dated..."). Never total, estimate, or round figures into
+  existence.
+
 If a delivery tool refuses a draft or write (citation filter, banned-typography
 gate, or any other content gate): do not retry the same content, and do not
 drop the work. Redraft once, and the redraft KEEPS every captured fact: the

--- a/operator/skills/motion-package-assembler/SKILL.md
+++ b/operator/skills/motion-package-assembler/SKILL.md
@@ -329,6 +329,20 @@ citations belong only in matter-internal artifacts (memos, internal notes,
 tasks). Write the FIRST draft citation-free; do not write a cited draft and
 wait for the gate to teach you.
 
+Three more first-draft rules, same rationale (the gates enforce them; a
+refusal is a stalled deliverable and a full-context redraft — write it right
+the first time):
+
+- No em dashes anywhere, in any channel. Use commas, colons, or periods.
+- In email and task text, refer to the matter by its NUMBER (e.g.
+  2026-PI-101), never by its case caption. The matter's own caption is
+  acceptable inside matter memos; cited case law is never acceptable
+  anywhere.
+- State a specific dollar figure only when it exists in an authored source
+  on the matter, and name that source in the same sentence ("per the MedFin
+  payoff letter dated..."). Never total, estimate, or round figures into
+  existence.
+
 If a delivery tool refuses a draft or write (citation filter, banned-typography
 gate, or any other content gate): do not retry the same content, and do not
 drop the work. Redraft once, and the redraft KEEPS every captured fact: the

--- a/operator/skills/new-matter-intake/SKILL.md
+++ b/operator/skills/new-matter-intake/SKILL.md
@@ -141,6 +141,20 @@ citations belong only in matter-internal artifacts (memos, internal notes,
 tasks). Write the FIRST draft citation-free; do not write a cited draft and
 wait for the gate to teach you.
 
+Three more first-draft rules, same rationale (the gates enforce them; a
+refusal is a stalled deliverable and a full-context redraft — write it right
+the first time):
+
+- No em dashes anywhere, in any channel. Use commas, colons, or periods.
+- In email and task text, refer to the matter by its NUMBER (e.g.
+  2026-PI-101), never by its case caption. The matter's own caption is
+  acceptable inside matter memos; cited case law is never acceptable
+  anywhere.
+- State a specific dollar figure only when it exists in an authored source
+  on the matter, and name that source in the same sentence ("per the MedFin
+  payoff letter dated..."). Never total, estimate, or round figures into
+  existence.
+
 If a delivery tool refuses a draft or write (citation filter, banned-typography
 gate, or any other content gate): do not retry the same content, and do not
 drop the work. Redraft once, and the redraft KEEPS every captured fact: the

--- a/operator/skills/opposing-response-deficiency-review/SKILL.md
+++ b/operator/skills/opposing-response-deficiency-review/SKILL.md
@@ -245,6 +245,20 @@ citations belong only in matter-internal artifacts (memos, internal notes,
 tasks). Write the FIRST draft citation-free; do not write a cited draft and
 wait for the gate to teach you.
 
+Three more first-draft rules, same rationale (the gates enforce them; a
+refusal is a stalled deliverable and a full-context redraft — write it right
+the first time):
+
+- No em dashes anywhere, in any channel. Use commas, colons, or periods.
+- In email and task text, refer to the matter by its NUMBER (e.g.
+  2026-PI-101), never by its case caption. The matter's own caption is
+  acceptable inside matter memos; cited case law is never acceptable
+  anywhere.
+- State a specific dollar figure only when it exists in an authored source
+  on the matter, and name that source in the same sentence ("per the MedFin
+  payoff letter dated..."). Never total, estimate, or round figures into
+  existence.
+
 If a delivery tool refuses a draft or write (citation filter, banned-typography
 gate, or any other content gate): do not retry the same content, and do not
 drop the work. Redraft once, and the redraft KEEPS every captured fact: the

--- a/operator/skills/separate-statement-assembler/SKILL.md
+++ b/operator/skills/separate-statement-assembler/SKILL.md
@@ -288,6 +288,20 @@ citations belong only in matter-internal artifacts (memos, internal notes,
 tasks). Write the FIRST draft citation-free; do not write a cited draft and
 wait for the gate to teach you.
 
+Three more first-draft rules, same rationale (the gates enforce them; a
+refusal is a stalled deliverable and a full-context redraft — write it right
+the first time):
+
+- No em dashes anywhere, in any channel. Use commas, colons, or periods.
+- In email and task text, refer to the matter by its NUMBER (e.g.
+  2026-PI-101), never by its case caption. The matter's own caption is
+  acceptable inside matter memos; cited case law is never acceptable
+  anywhere.
+- State a specific dollar figure only when it exists in an authored source
+  on the matter, and name that source in the same sentence ("per the MedFin
+  payoff letter dated..."). Never total, estimate, or round figures into
+  existence.
+
 If a delivery tool refuses a draft or write (citation filter, banned-typography
 gate, or any other content gate): do not retry the same content, and do not
 drop the work. Redraft once, and the redraft KEEPS every captured fact: the

--- a/operator/skills/service-confirmation-watcher/SKILL.md
+++ b/operator/skills/service-confirmation-watcher/SKILL.md
@@ -313,6 +313,20 @@ citations belong only in matter-internal artifacts (memos, internal notes,
 tasks). Write the FIRST draft citation-free; do not write a cited draft and
 wait for the gate to teach you.
 
+Three more first-draft rules, same rationale (the gates enforce them; a
+refusal is a stalled deliverable and a full-context redraft — write it right
+the first time):
+
+- No em dashes anywhere, in any channel. Use commas, colons, or periods.
+- In email and task text, refer to the matter by its NUMBER (e.g.
+  2026-PI-101), never by its case caption. The matter's own caption is
+  acceptable inside matter memos; cited case law is never acceptable
+  anywhere.
+- State a specific dollar figure only when it exists in an authored source
+  on the matter, and name that source in the same sentence ("per the MedFin
+  payoff letter dated..."). Never total, estimate, or round figures into
+  existence.
+
 If a delivery tool refuses a draft or write (citation filter, banned-typography
 gate, or any other content gate): do not retry the same content, and do not
 drop the work. Redraft once, and the redraft KEEPS every captured fact: the

--- a/operator/skills/settlement-statement-feeder/SKILL.md
+++ b/operator/skills/settlement-statement-feeder/SKILL.md
@@ -258,6 +258,20 @@ citations belong only in matter-internal artifacts (memos, internal notes,
 tasks). Write the FIRST draft citation-free; do not write a cited draft and
 wait for the gate to teach you.
 
+Three more first-draft rules, same rationale (the gates enforce them; a
+refusal is a stalled deliverable and a full-context redraft — write it right
+the first time):
+
+- No em dashes anywhere, in any channel. Use commas, colons, or periods.
+- In email and task text, refer to the matter by its NUMBER (e.g.
+  2026-PI-101), never by its case caption. The matter's own caption is
+  acceptable inside matter memos; cited case law is never acceptable
+  anywhere.
+- State a specific dollar figure only when it exists in an authored source
+  on the matter, and name that source in the same sentence ("per the MedFin
+  payoff letter dated..."). Never total, estimate, or round figures into
+  existence.
+
 If a delivery tool refuses a draft or write (citation filter, banned-typography
 gate, or any other content gate): do not retry the same content, and do not
 drop the work. Redraft once, and the redraft KEEPS every captured fact: the

--- a/operator/skills/stalled-matter-nudge/SKILL.md
+++ b/operator/skills/stalled-matter-nudge/SKILL.md
@@ -102,6 +102,20 @@ citations belong only in matter-internal artifacts (memos, internal notes,
 tasks). Write the FIRST draft citation-free; do not write a cited draft and
 wait for the gate to teach you.
 
+Three more first-draft rules, same rationale (the gates enforce them; a
+refusal is a stalled deliverable and a full-context redraft — write it right
+the first time):
+
+- No em dashes anywhere, in any channel. Use commas, colons, or periods.
+- In email and task text, refer to the matter by its NUMBER (e.g.
+  2026-PI-101), never by its case caption. The matter's own caption is
+  acceptable inside matter memos; cited case law is never acceptable
+  anywhere.
+- State a specific dollar figure only when it exists in an authored source
+  on the matter, and name that source in the same sentence ("per the MedFin
+  payoff letter dated..."). Never total, estimate, or round figures into
+  existence.
+
 If a delivery tool refuses a draft or write (citation filter, banned-typography
 gate, or any other content gate): do not retry the same content, and do not
 drop the work. Redraft once, and the redraft KEEPS every captured fact: the

--- a/operator/skills/trial-binder-assembler/SKILL.md
+++ b/operator/skills/trial-binder-assembler/SKILL.md
@@ -294,6 +294,20 @@ citations belong only in matter-internal artifacts (memos, internal notes,
 tasks). Write the FIRST draft citation-free; do not write a cited draft and
 wait for the gate to teach you.
 
+Three more first-draft rules, same rationale (the gates enforce them; a
+refusal is a stalled deliverable and a full-context redraft — write it right
+the first time):
+
+- No em dashes anywhere, in any channel. Use commas, colons, or periods.
+- In email and task text, refer to the matter by its NUMBER (e.g.
+  2026-PI-101), never by its case caption. The matter's own caption is
+  acceptable inside matter memos; cited case law is never acceptable
+  anywhere.
+- State a specific dollar figure only when it exists in an authored source
+  on the matter, and name that source in the same sentence ("per the MedFin
+  payoff letter dated..."). Never total, estimate, or round figures into
+  existence.
+
 If a delivery tool refuses a draft or write (citation filter, banned-typography
 gate, or any other content gate): do not retry the same content, and do not
 drop the work. Redraft once, and the redraft KEEPS every captured fact: the

--- a/operator/skills/trust-balance-nudge/SKILL.md
+++ b/operator/skills/trust-balance-nudge/SKILL.md
@@ -107,6 +107,20 @@ citations belong only in matter-internal artifacts (memos, internal notes,
 tasks). Write the FIRST draft citation-free; do not write a cited draft and
 wait for the gate to teach you.
 
+Three more first-draft rules, same rationale (the gates enforce them; a
+refusal is a stalled deliverable and a full-context redraft — write it right
+the first time):
+
+- No em dashes anywhere, in any channel. Use commas, colons, or periods.
+- In email and task text, refer to the matter by its NUMBER (e.g.
+  2026-PI-101), never by its case caption. The matter's own caption is
+  acceptable inside matter memos; cited case law is never acceptable
+  anywhere.
+- State a specific dollar figure only when it exists in an authored source
+  on the matter, and name that source in the same sentence ("per the MedFin
+  payoff letter dated..."). Never total, estimate, or round figures into
+  existence.
+
 If a delivery tool refuses a draft or write (citation filter, banned-typography
 gate, or any other content gate): do not retry the same content, and do not
 drop the work. Redraft once, and the redraft KEEPS every captured fact: the


### PR DESCRIPTION
## What (#1758 items 1 and 2, ss-console half)

**Item 2 — caption provenance allowlist (source-of-truth substrate).** `citation_filter.scan`/`contains_citation` accept `allowed_case_names`: case CAPTIONS the caller attests were actually READ this session. Doctrine: repeating a caption you read is quoting the record; inventing authority is the venture-killer. Only bare case-name hits are exempt, via boundary-bounded containment (the case-name regex greedily swallows adjacent prose; name continuation like "Drapers"/"Draper-Smith" never matches). **Reporter cites, statutes, rules, and every tier-1 marker are never allowlisted** — a registered caption used as fabricated authority ("Alvarez v. Draper, 123 Cal. App. 5th 456") still blocks. Fail-closed: allowlist errors narrow to empty. `canonical_caption()` exported for register builders.

**Bonus fix the new tests exposed — a real false NEGATIVE:** California's modern ordinal reporter series (Cal.4th, Cal.App.5th, Cal.Rptr.3d) didn't match `REPORTER_CITE_RE`; "123 Cal. App. 5th 456" scanned clean. Now covered.

**Item 1 — first-draft rules.** The 33 law-seat SKILL.md delivery-discipline blocks gain: no em dashes anywhere; matter NUMBER (not caption) in email/task text; dollar figures only from a named authored source. The gates stay as backstops instead of doing a prompt's job 118×/day.

**Companion:** overlay PR wires the register (captions harvested from READ results in `provenance.record_read`) into the tier-2 gate and syncs the vendored filter copy. The runtime behavior changes only when both land + reprovision.

## Evidence
#1758 audit (92/day case-name refusals were the matter's own caption on the citation-bearing memo surface, corroborated by L2 round 2). 161 substrate tests pass incl. `test_citation_caption_allowlist.py`; operator suite 443; `npm run verify` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HZNWr6C5XKUzBbBKrbWNUG