### PR TITLE
chore(operator): bump OVERLAY_REF c081223→7c10fd61 (caption provenance gate, overlay#140)

### DIFF
--- a/operator/contracts/overlay-pairs.json
+++ b/operator/contracts/overlay-pairs.json
@@ -1,7 +1,7 @@
 {
   "overlayRepo": "https://github.com/venturecrane/hermes-smd-overlay.git",
-  "overlayRef": "c081223bda47357e6f684a008d44433c145d2ff9",
-  "overlayRefNote": "MUST equal the ARG OVERLAY_REF pinned in operator/templates/Dockerfile \u2014 that is the overlay commit a customer Machine actually ships. The vitest gate asserts the two agree so the manifest cannot pin a stale overlay. Bump both together when OVERLAY_REF moves, then re-record each overlaySha256 from the runtime file at the new ref. 2026-07-05: 7e70b376 -> c85b0ddb (overlay#133 cost-breaker boot self-probe). Fast-forward, 3 files (hooks/smd-overlay-activation/handler.py, shared/cost_breaker.py, tests/test_activation_hook.py) \u2014 NO tracked twin touched, so every overlaySha256 below is unchanged; only overlayRef moved.",
+  "overlayRef": "7c10fd61a270422c3e5bcaa4bac58f5425aae561",
+  "overlayRefNote": "MUST equal the ARG OVERLAY_REF pinned in operator/templates/Dockerfile \u2014 that is the overlay commit a customer Machine actually ships. The vitest gate asserts the two agree so the manifest cannot pin a stale overlay. Bump both together when OVERLAY_REF moves, then re-record each overlaySha256 from the runtime file at the new ref. 2026-07-06: c081223b -> 7c10fd61 (overlay#140 caption provenance allowlist, ss #1758). Recomputed overlaySha256 for the runtime files #140 touched; ss-twin sha256 recomputed where the tracked twin changed (citation_filter caption allowlist + Cal ordinal reporter fix, ss #1764).",
   "pairs": [
     {
       "adapterPath": "operator/adapter/voice/transform.py",
@@ -37,6 +37,13 @@
       "syncNote": "2026-07-04 #1686 audit hash chain: overlayRef 122ee0a2 -> 7e70b376 (overlay#131 chain schema/export + #132 lint/format; also ships overlay#128-130 interactive metering + gate-clear from the cost-plane wave). emit.py overlaySha256 recomputed (ensure_schema now applies CHAIN_COLUMN_ALTERS). NEW PAIR: workspace_broker/chain.py <-> shared/audit_chain.py, byte-identical twins (canonicalization + verify_chain must never drift between the broker writer and the Machine-side export/verifier).",
       "sha256": "b84b14342ec9548c9dd7fe4a680269deda09b7413b41df5c24a2633311a369ed",
       "overlaySha256": "b84b14342ec9548c9dd7fe4a680269deda09b7413b41df5c24a2633311a369ed"
+    },
+    {
+      "adapterPath": "operator/safety-substrate/citation_filter.py",
+      "overlayPath": "shared/citation_filter.py",
+      "syncNote": "NEW PAIR 2026-07-06 (overlay#140 / ss#1758): the tier-2 citation filter is vendored from ss-console (source of truth; 'changes land there first') \u2014 now drift-tracked like the other twins. Deliberate cosmetic divergence: the overlay copy carries a VENDORED docstring note and overlay ruff formatting, so the two sha256s differ by design; each side's hash pins its own runtime bytes.",
+      "sha256": "7f925702dc8f8be56368cb59f12b8eb7d36f7fd058c50d948d1c5360ab3c0d0f",
+      "overlaySha256": "0774974277c082edab00d108db95d356224504079bab8558a301ccc25fec2143"
     }
   ]
 }

--- a/operator/templates/Dockerfile
+++ b/operator/templates/Dockerfile
@@ -254,7 +254,7 @@ ARG OVERLAY_REPO="https://github.com/venturecrane/hermes-smd-overlay.git"
 # AgentMail email-reply channel keeps the email prompt; MCP route untouched. Not a
 # tracked pair (bootstrap/translate.py); all 4 tracked twins unchanged across
 # 2b694947→9b20a1ac, overlaySha256 stable. Superset of 33b58ad.
-ARG OVERLAY_REF="c081223bda47357e6f684a008d44433c145d2ff9"
+ARG OVERLAY_REF="7c10fd61a270422c3e5bcaa4bac58f5425aae561"
 
 ARG CUSTOMER_SLUG=customer-zero
 

--- a/tests/operator-dockerfile.test.ts
+++ b/tests/operator-dockerfile.test.ts
@@ -279,7 +279,14 @@ describe('Operator customer Machine Dockerfile', () => {
     // credential-free cross-connector attachment transfer). Range
     // 3e5b8a9b..c081223b touches only translate.py + action_classes + tests;
     // no tracked twin moved.
-    expect(DOCKERFILE).toContain('ARG OVERLAY_REF="c081223bda47357e6f684a008d44433c145d2ff9"')
+    // 7c10fd61 (#140, ss#1758): caption provenance allowlist for the tier-2
+    // citation gate — captions harvested from READ results into the session
+    // register; only provenance-verified bare case-name hits are exempt
+    // (reporter cites/statutes/rules/tier-1 never relax; empty register =
+    // fail-closed). Vendored citation_filter synced from ss#1764 (allowlist +
+    // Cal ordinal reporter false-negative fix) and now drift-tracked as a
+    // SEC-32 pair in overlay-pairs.json.
+    expect(DOCKERFILE).toContain('ARG OVERLAY_REF="7c10fd61a270422c3e5bcaa4bac58f5425aae561"')
   })
 
   it('does NOT swallow a failed plugin install (no fail-open `|| echo ... continuing`)', () => {


### PR DESCRIPTION
Pins the customer-Machine image to overlay main after #140 (caption provenance allowlist for the tier-2 citation gate, #1758). Three coordinated updates the gates require: the Dockerfile ARG, the vitest ref gate (with changelog note), and the SEC-32 `overlay-pairs.json` manifest — which also gains a **new drift pair for the vendored citation filter** (ss `operator/safety-substrate/citation_filter.py` ↔ overlay `shared/citation_filter.py`), so the 'keep aligned, land in ss-console first' rule is now machine-checked instead of social.

Lands on seats at the next reprovision — the pending Captain-gated reprovision (already queued with the L2 F8 create_event fix and router fixes) picks everything up in one deploy.

`npm run verify` green (pre-push, 3,251 tests); operator suite 160.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HZNWr6C5XKUzBbBKrbWNUG