### PR TITLE
fix(admin): hosted-agent queue — mono for labels only, Archivo body for values and prose

### DIFF
--- a/src/components/admin/HostedAgentQueueCard.astro
+++ b/src/components/admin/HostedAgentQueueCard.astro
@@ -45,17 +45,17 @@ const showActivate = row.customer_slug && row.status !== 'live' && row.status !=
     </span>
   </div>
 
-  <dl class="mt-4 grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-2 font-mono text-base">
+  <dl class="mt-4 grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-2 text-base">
     {
       fields.map((f) => (
         <div>
-          <dt class="font-bold uppercase text-label tracking-[0.14em]">{f.label}</dt>
+          <dt class="font-mono font-bold uppercase text-label tracking-[0.14em]">{f.label}</dt>
           <dd>{f.value}</dd>
         </div>
       ))
     }
     <div class="md:col-span-2">
-      <dt class="font-bold uppercase text-label tracking-[0.14em]">Use cases</dt>
+      <dt class="font-mono font-bold uppercase text-label tracking-[0.14em]">Use cases</dt>
       <dd class="whitespace-pre-wrap">{row.use_cases ?? 'not submitted'}</dd>
     </div>
   </dl>
@@ -100,7 +100,7 @@ const showActivate = row.customer_slug && row.status !== 'live' && row.status !=
             name="channel_details"
             required
             rows="4"
-            class="mt-1 border-[3px] border-[color:var(--ss-color-text-primary)] px-3 py-2 font-mono text-base normal-case"
+            class="mt-1 border-[3px] border-[color:var(--ss-color-text-primary)] px-3 py-2 font-body text-base normal-case"
             placeholder="Message @YourAgentBot on Telegram. Its email address is agent@example.agentmail.to and it accepts mail from the senders you listed."
           />
         </label>

--- a/src/pages/admin/hosted-agent/index.astro
+++ b/src/pages/admin/hosted-agent/index.astro
@@ -51,7 +51,7 @@ const openCount = queue.filter((r) => openStatuses.has(r.status)).length
     )
   }
 
-  <p class="font-mono text-base text-[color:var(--ss-color-text-secondary)]">
+  <p class="text-base text-[color:var(--ss-color-text-secondary)]">
     {queue.length} purchase{queue.length === 1 ? '' : 's'} · {openCount} open work item{
       openCount === 1 ? '' : 's'
     }. Runbook: docs/runbooks/hosted-agent/concierge.md
@@ -61,9 +61,7 @@ const openCount = queue.filter((r) => openStatuses.has(r.status)).length
     {queue.map((row) => <HostedAgentQueueCard row={row} />)}
     {
       queue.length === 0 && (
-        <p class="font-mono text-base text-[color:var(--ss-color-text-secondary)]">
-          No purchases yet.
-        </p>
+        <p class="text-base text-[color:var(--ss-color-text-secondary)]">No purchases yet.</p>
       )
     }
   </div>


### PR DESCRIPTION
## Problem

The Hosted Agent queue page (admin) read as if the typography unification (#1760) missed it — nearly everything rendered in JetBrains Mono.

The fonts were actually correct (Archivo + JetBrains Mono, token utilities only); the issue was application: the card wrapped the entire field `<dl>` (labels **and** values), the page summary lines, and the go-live textarea in `font-mono`.

## Fix

Match the established admin convention (operator customer pages, GovernanceSkillCard): mono for uppercase labels/eyebrows, Archivo body for values and prose.

- `<dl>` wrapper: drop `font-mono`; move it onto the `<dt>` labels
- Go-live channel-details textarea: `font-mono` → `font-body` (it's authored prose)
- Summary line + empty-state line: drop `font-mono`
- Unchanged (deliberately mono): status eyebrow, field labels, slug input, banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JxGqJcpZREAabNMRGE1heZ