### PR TITLE
fix(ui): app-wide typography sweep — mono for labels/status/data only

### DIFF
--- a/src/components/admin/EntityContactsPanel.astro
+++ b/src/components/admin/EntityContactsPanel.astro
@@ -22,7 +22,7 @@ const inputClass =
     >
       Contacts ({contacts.length})
     </h2>
-    <span class="font-mono text-[12px] text-[color:var(--ss-color-text-muted)]">
+    <span class="text-[12px] text-[color:var(--ss-color-text-muted)]">
       People at this organization
     </span>
   </div>

--- a/src/components/admin/EntityIdentityStrip.astro
+++ b/src/components/admin/EntityIdentityStrip.astro
@@ -112,7 +112,7 @@ const chipClass =
   </div>
   {
     signalEvidence && (
-      <div class="font-mono text-[15px] font-medium leading-6 text-[color:var(--ss-color-text-primary)]">
+      <div class="text-[15px] font-medium leading-6 text-[color:var(--ss-color-text-primary)]">
         {signalEvidence}
       </div>
     )

--- a/src/components/portal/operator/AuditEntryRow.astro
+++ b/src/components/portal/operator/AuditEntryRow.astro
@@ -190,7 +190,7 @@ const hasExpandableContent = Boolean(entry.reason)
     {
       entry.reason && (
         <div class="px-5 pb-3 md:pl-[calc(56px+1.25rem)] md:pr-5 -mt-1 md:-mt-3">
-          <p class="font-mono text-sm text-[color:var(--ss-color-text-secondary)]">
+          <p class="font-body text-sm text-[color:var(--ss-color-text-secondary)]">
             {reasonTruncated}
           </p>
         </div>
@@ -206,7 +206,7 @@ const hasExpandableContent = Boolean(entry.reason)
             <p class="font-mono text-label uppercase tracking-[0.14em] font-bold text-[color:var(--ss-color-text-secondary)]">
               Full reason
             </p>
-            <p class="mt-1 font-mono text-sm text-[color:var(--ss-color-text-primary)] whitespace-pre-wrap break-words">
+            <p class="mt-1 font-body text-sm text-[color:var(--ss-color-text-primary)] whitespace-pre-wrap break-words">
               {entry.reason}
             </p>
           </div>

--- a/src/components/portal/operator/AuditFilterBar.astro
+++ b/src/components/portal/operator/AuditFilterBar.astro
@@ -224,7 +224,7 @@ function toDateValue(value: string | null): string {
       value={q ?? ''}
       placeholder="reason, actor, or target"
       autocomplete="off"
-      class="w-full border-[2px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)] px-3 py-2 font-mono text-sm text-[color:var(--ss-color-text-primary)] placeholder:text-[color:var(--ss-color-text-muted)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2"
+      class="w-full border-[2px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)] px-3 py-2 font-body text-sm text-[color:var(--ss-color-text-primary)] placeholder:text-[color:var(--ss-color-text-muted)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2"
     />
   </div>
 </form>

--- a/src/components/portal/operator/CalendarItemRow.astro
+++ b/src/components/portal/operator/CalendarItemRow.astro
@@ -116,7 +116,7 @@ const conflictId = conflictCount > 0 ? `conflict-${item.id}` : undefined
       </span>
       {
         item.location && (
-          <span class="font-mono text-sm text-[color:var(--ss-color-text-secondary)] truncate">
+          <span class="font-body text-sm text-[color:var(--ss-color-text-secondary)] truncate">
             {item.location}
           </span>
         )
@@ -148,11 +148,11 @@ const conflictId = conflictCount > 0 ? `conflict-${item.id}` : undefined
       </span>
       {
         item.relatedMatterTitle ? (
-          <span class="font-mono text-sm text-[color:var(--ss-color-text-primary)] truncate">
+          <span class="font-body text-sm text-[color:var(--ss-color-text-primary)] truncate">
             {item.relatedMatterTitle}
           </span>
         ) : (
-          <span class="font-mono text-sm text-[color:var(--ss-color-text-muted)]">None</span>
+          <span class="font-body text-sm text-[color:var(--ss-color-text-muted)]">None</span>
         )
       }
     </div>

--- a/src/pages/admin/entities/[id]/meetings/[meetingId].astro
+++ b/src/pages/admin/entities/[id]/meetings/[meetingId].astro
@@ -237,7 +237,7 @@ const isMeetingTerminal =
     <textarea
       id="live-notes"
       rows="10"
-      class="w-full text-sm border border-[color:var(--ss-color-border)] rounded-[var(--ss-radius-card)] px-3 py-2 resize-y focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary font-mono"
+      class="w-full text-sm border border-[color:var(--ss-color-border)] rounded-[var(--ss-radius-card)] px-3 py-2 resize-y focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
       placeholder="Take notes during the call...">{liveNotesValue}</textarea
     >
   </div>

--- a/src/pages/admin/playbook/index.astro
+++ b/src/pages/admin/playbook/index.astro
@@ -81,9 +81,7 @@ const BODY = 'text-sm leading-relaxed text-[color:var(--ss-color-text-secondary)
             <section class="border border-[color:var(--ss-color-text-primary)]">
               <div class="flex items-baseline justify-between border-b border-[color:var(--ss-color-text-primary)] px-[18px] py-3">
                 <span class={SEC}>{g.label}</span>
-                <span class="font-mono text-[11px] text-[color:var(--ss-color-text-muted)]">
-                  {g.blurb}
-                </span>
+                <span class="text-[11px] text-[color:var(--ss-color-text-muted)]">{g.blurb}</span>
               </div>
               <ul>
                 {g.items.map((it, i) => (

--- a/src/pages/portal/products/hosted-agent/api-key.astro
+++ b/src/pages/portal/products/hosted-agent/api-key.astro
@@ -99,7 +99,7 @@ const keyReceived = intake.anthropic_key_status === 'received'
 
       <div class="mt-8 flex flex-col gap-6">
         <div class="border-[3px] border-[color:var(--ss-color-text-primary)] p-6 md:p-8">
-          <p class="font-mono text-base text-[color:var(--ss-color-text-primary)]">
+          <p class="font-body text-base text-[color:var(--ss-color-text-primary)]">
             Your agent runs on your own Anthropic API key. Create a dedicated key in your Anthropic
             console, set a monthly spend limit on it there, and paste it below. The key relays
             straight into your agent's isolated vault: it is never stored on this site, never shown

--- a/src/pages/portal/products/hosted-agent/index.astro
+++ b/src/pages/portal/products/hosted-agent/index.astro
@@ -269,7 +269,7 @@ const stMessage =
               <p class="font-body text-2xl md:text-3xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]">
                 Setup in progress
               </p>
-              <p class="mt-3 font-mono text-base text-[color:var(--ss-color-text-secondary)]">
+              <p class="mt-3 font-body text-base text-[color:var(--ss-color-text-secondary)]">
                 Your subscription is active. We build each agent by hand, and this page shows the
                 true state of every step. Anything that needs you also arrives by email.
               </p>
@@ -290,7 +290,7 @@ const stMessage =
                         {badge.label}
                       </span>
                     </div>
-                    <p class="mt-2 font-mono text-base text-[color:var(--ss-color-text-secondary)]">
+                    <p class="mt-2 font-body text-base text-[color:var(--ss-color-text-secondary)]">
                       {step.detail}
                     </p>
                   </>
@@ -320,7 +320,7 @@ const stMessage =
               })}
             </ol>
 
-            <p class="font-mono text-base text-[color:var(--ss-color-text-secondary)]">
+            <p class="font-body text-base text-[color:var(--ss-color-text-secondary)]">
               Questions at any point: team@smd.services. A person answers.
             </p>
           </div>
@@ -335,11 +335,11 @@ const stMessage =
                 {intake?.agent_name ?? 'Your agent'} is live
               </p>
               {intake?.telegram_handle && (
-                <p class="mt-3 font-mono text-base text-[color:var(--ss-color-text-secondary)]">
+                <p class="mt-3 font-body text-base text-[color:var(--ss-color-text-secondary)]">
                   Connected to Telegram for {intake.telegram_handle}.
                 </p>
               )}
-              <p class="mt-3 font-mono text-base text-[color:var(--ss-color-text-secondary)]">
+              <p class="mt-3 font-body text-base text-[color:var(--ss-color-text-secondary)]">
                 Setup changes and questions: reply to any email from us, and we take it from there.
               </p>
             </div>

--- a/src/pages/portal/products/hosted-agent/intake.astro
+++ b/src/pages/portal/products/hosted-agent/intake.astro
@@ -55,9 +55,12 @@ const senders: string[] = (() => {
 
 const labelClass =
   'block font-mono text-label uppercase tracking-[0.14em] font-bold text-[color:var(--ss-color-text-primary)]'
-const inputClass =
-  'mt-2 w-full border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)] px-4 py-3 font-mono text-base text-[color:var(--ss-color-text-primary)] focus:outline-none focus:ring-2 focus:ring-[color:var(--ss-color-action)]'
-const hintClass = 'mt-1 font-mono text-sm text-[color:var(--ss-color-text-secondary)]'
+const inputBase =
+  'mt-2 w-full border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)] px-4 py-3 text-base text-[color:var(--ss-color-text-primary)] focus:outline-none focus:ring-2 focus:ring-[color:var(--ss-color-action)]'
+/* Data-like fields (handle, timezone, sender emails) render mono; natural-language fields render body. */
+const inputClass = `${inputBase} font-mono`
+const proseInputClass = `${inputBase} font-body`
+const hintClass = 'mt-1 font-body text-sm text-[color:var(--ss-color-text-secondary)]'
 ---
 
 <!doctype html>
@@ -112,7 +115,7 @@ const hintClass = 'mt-1 font-mono text-sm text-[color:var(--ss-color-text-second
             required
             maxlength="64"
             value={intake.agent_name ?? ''}
-            class={inputClass}
+            class={proseInputClass}
           />
           <p class={hintClass}>A first name works best. It signs its messages with this.</p>
         </div>
@@ -125,7 +128,7 @@ const hintClass = 'mt-1 font-mono text-sm text-[color:var(--ss-color-text-second
             required
             rows="6"
             maxlength="4000"
-            class={inputClass}>{intake.use_cases ?? ''}</textarea
+            class={proseInputClass}>{intake.use_cases ?? ''}</textarea
           >
           <p class={hintClass}>
             Plain language is perfect. Examples: a morning digest of what landed overnight, research
@@ -190,7 +193,7 @@ const hintClass = 'mt-1 font-mono text-sm text-[color:var(--ss-color-text-second
               checked={intake.spend_limit_confirmed === 1}
               class="mt-1 h-5 w-5"
             />
-            <span class="font-mono text-base text-[color:var(--ss-color-text-primary)]">
+            <span class="font-body text-base text-[color:var(--ss-color-text-primary)]">
               I created a dedicated Anthropic API key for this agent and set a spend limit on it in
               my Anthropic console. I understand my agent's model usage bills to my own Anthropic
               account and that SMD cannot see or cap that spend.


### PR DESCRIPTION
## What

Follow-up to #1766 (hosted-agent admin queue). Audited **every** `font-mono` occurrence app-wide (~300 across ~60 files) for the same anti-pattern: mono applied to human-readable values, prose, or natural-language inputs instead of labels/status/data.

## Method

Four parallel source reviewers (admin pages, portal pages, portal components, marketing/public), every flag re-verified against source and data-shape before editing. Marketing/public surfaces (incl. /agent post-#1757) came back clean.

## Fixes (10 files, 25+/24−)

**Portal hosted-agent** (the customer-facing sibling of #1766):
- `index.astro` — setup/live status prose + step details → body
- `api-key.astro` — explainer paragraph → body (the secret input stays mono)
- `intake.astro` — hint sentences + consent copy → body; input class split so agent-name/use-cases render body while telegram/timezone/senders stay mono

**Admin:** contacts-panel subtitle, playbook section blurbs, meeting live-notes textarea, entity signal-evidence line → body

**Operator portal components:** calendar location + related-matter title, audit `reason` (documented human-readable), audit free-text search input → body

## Deliberately unchanged

Audit `actor`/`target` (recorded identity / opaque handles per ADR 0052), skill slugs, date columns, status eyebrows/badges, YAML + config-error diagnostics, credential inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JxGqJcpZREAabNMRGE1heZ