### PR TITLE
fix(operator): allow cdn.agentmail.to as an attachment source (post-deploy F16)

### DIFF
--- a/operator/connectors/smokeball/smokeball_connector/client.py
+++ b/operator/connectors/smokeball/smokeball_connector/client.py
@@ -97,8 +97,12 @@ _MAX_ERROR_BODY = 600
 # is a scan bundle or media file that text extraction shouldn't slurp into RAM.
 _MAX_DOWNLOAD_BYTES = 25 * 1024 * 1024
 # file_attachment_to_matter: hosts an attachment download URL may point at.
-# AgentMail mints time-limited URLs on this host (docs.agentmail.to/attachments).
-_DEFAULT_ATTACHMENT_HOSTS = "download.agentmail.to"
+# AgentMail mints time-limited URLs on these hosts (docs.agentmail.to/attachments).
+# cdn.agentmail.to observed live 2026-07-07: get_attachment returned a CDN-host
+# URL and the transfer fail-closed on the allowlist (post-reprovision
+# verification of overlay#140/ss#1744) — the allowlist was right in posture,
+# just missing the vendor's real serving host.
+_DEFAULT_ATTACHMENT_HOSTS = "download.agentmail.to,cdn.agentmail.to"
 
 
 def _truncate_body(text: str | None) -> str:

--- a/operator/connectors/smokeball/tests/test_attachment_filing.py
+++ b/operator/connectors/smokeball/tests/test_attachment_filing.py
@@ -31,6 +31,22 @@ def _handler(captured: list[httpx.Request], blob: bytes):
     return handler
 
 
+def test_cdn_host_allowed() -> None:
+    # Live finding 2026-07-07 (post-reprovision verification): AgentMail's
+    # get_attachment mints URLs on cdn.agentmail.to; the allowlist only knew
+    # download.agentmail.to and the transfer correctly fail-closed. Both
+    # vendor hosts are now defaults.
+    url = "https://cdn.agentmail.to/attachments/att_2?token=tok456"
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(200, content=b"%PDF-1.4 cdn copy")
+
+    client = _mock_client(handler)
+    assert client.fetch_attachment_url(url) == b"%PDF-1.4 cdn copy"
+
+
 def test_fetch_attachment_happy_path_no_auth_headers() -> None:
     captured: list[httpx.Request] = []
     client = _mock_client(_handler(captured, b"%PDF-1.4 served set"))


### PR DESCRIPTION
Post-reprovision live verification (pilot v46 @ overlay 7c10fd61) of the #1744 attachment transfer found the tool fail-closing on AgentMail's real CDN host: `get_attachment` mints `cdn.agentmail.to` URLs, the allowlist only knew `download.agentmail.to`. Security posture held exactly as designed (https-only, host allowlist, refused); the allowlist just gains the vendor's second host. Test locked (`test_cdn_host_allowed`).

Verification state from the same pass: **#1742 digest home PASS live** (digest memo on the authored ops matter 2026-OPS-001, matter-number discipline throughout). #1744 re-verifies after this lands at the next reprovision. Also filed overlay#141: the provenance register has never been populated at runtime (`register_was_empty` on every tier3 row ever), which currently no-ops both the #140 caption exemption and the A1 identifier gate — Machine-side diagnosis needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HZNWr6C5XKUzBbBKrbWNUG