### PR TITLE
fix(hosted-agent): two template bugs found by live seat #1 — fly_region + webhook route

### DIFF
--- a/operator/customers/_hosted-template/customer.yaml
+++ b/operator/customers/_hosted-template/customer.yaml
@@ -30,7 +30,7 @@ vertical: mixed
 addons: []
 practice_areas:
   - general
-fly_region: phx
+fly_region: lax # nearest to Phoenix; Fly has no phx region — pick per customer geography
 
 # ---- RUNTIME ----
 # Cheap main model on the customer's own key; no escalation tier at this
@@ -97,7 +97,7 @@ connectors:
     adapter: agentmail
     backend: 'mcp:agentmail'
     enabled: true
-    webhook_url: 'https://hermes-[SLUG].fly.dev/webhooks/email'
+    webhook_url: 'https://hermes-[SLUG].fly.dev/webhooks/agentmail'
 
 webhook_triggers:
   - source: agentmail

--- a/operator/customers/scott/customer.yaml
+++ b/operator/customers/scott/customer.yaml
@@ -20,7 +20,7 @@ vertical: mixed
 addons: []
 practice_areas:
   - general
-fly_region: phx
+fly_region: lax # Phoenix-adjacent; Fly retired phx (fleet standard, same as customer-zero)
 
 # ---- RUNTIME ----
 # Cheap main model on the customer's own key; no escalation tier at this
@@ -87,7 +87,7 @@ connectors:
     adapter: agentmail
     backend: 'mcp:agentmail'
     enabled: true
-    webhook_url: 'https://hermes-scott.fly.dev/webhooks/email'
+    webhook_url: 'https://hermes-scott.fly.dev/webhooks/agentmail'
 
 webhook_triggers:
   - source: agentmail


### PR DESCRIPTION
## What (replaces #1773)

Two `_hosted-template` bugs found by provisioning the first live seat, fixed in the template + the scott seat yaml:

1. **`fly_region: phx` does not exist** — volume creation dies. Fleet standard is `lax`.
2. **`webhook_url` path `/webhooks/email`** — the gate resolves the route secret from the URL path; fleet convention is `/webhooks/agentmail`. First inbound bounced 401 "no secret for route".

`hermes-scott` runs both corrections live, all smoke checks green. This PR aligns repo truth with deployed reality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MJF9rQDhVKLv2ADbbApPgi