### PR TITLE
feat(workflow): worktree guard — primary checkout is read-only for agent sessions

### DIFF
--- a/.claude/hooks/sync-primary.sh
+++ b/.claude/hooks/sync-primary.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# SessionStart hook: keep the PRIMARY checkout synced to origin/main.
+#
+# Companion to worktree-guard.mjs (which makes the primary checkout read-only
+# for agent sessions). With no session dirtying the tree, a fast-forward at
+# session start is always safe, so the primary checkout can never drift the
+# way it did before 2026-07-06 (87 commits behind, 46 dirty paths).
+#
+# Runs only when the session starts IN the primary checkout; worktree sessions
+# exit immediately. stdout is injected into the session's context, so speak
+# only when something needs the agent's attention. Never blocks startup.
+set -u
+
+cd "${CLAUDE_PROJECT_DIR:-.}" 2>/dev/null || exit 0
+gitdir=$(git rev-parse --git-dir 2>/dev/null) || exit 0
+common=$(git rev-parse --git-common-dir 2>/dev/null) || exit 0
+# Worktree sessions have git-dir != git-common-dir; only the primary syncs.
+[ "$gitdir" = "$common" ] || exit 0
+
+if [ -n "$(git status --porcelain)" ]; then
+  count=$(git status --porcelain | wc -l | tr -d ' ')
+  echo "worktree-guard: PRIMARY CHECKOUT IS DIRTY ($count paths). This tree is read-only for sessions (CLAUDE.md 'Worktree discipline') - do not build on this dirt. Verify each path against origin/main and reconcile, or escalate to Captain."
+  exit 0
+fi
+
+branch=$(git branch --show-current)
+if [ "$branch" != "main" ]; then
+  echo "worktree-guard: primary checkout is on '$branch', expected main; not syncing."
+  exit 0
+fi
+
+GIT_TERMINAL_PROMPT=0 git fetch -q origin main 2>/dev/null || {
+  echo "worktree-guard: fetch failed; primary checkout may be stale."
+  exit 0
+}
+
+# Quiet when already current.
+git merge-base --is-ancestor origin/main HEAD 2>/dev/null && exit 0
+
+before=$(git rev-parse --short HEAD)
+if git merge --ff-only -q origin/main 2>/dev/null; then
+  echo "worktree-guard: primary checkout fast-forwarded $before -> $(git rev-parse --short HEAD) (origin/main)."
+else
+  echo "worktree-guard: primary checkout has local commits not on origin/main; not syncing. Reconcile manually."
+fi
+exit 0

--- a/.claude/hooks/worktree-guard.mjs
+++ b/.claude/hooks/worktree-guard.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+/**
+ * PreToolUse guard: the primary checkout is read-only for agent sessions.
+ *
+ * Sessions work in isolated worktrees under .claude/worktrees/ (EnterWorktree).
+ * This hook rejects Edit/Write/NotebookEdit calls that target the primary
+ * checkout, so shipped-and-forgotten residue can never accumulate there again
+ * (the 46-dirty-file / 87-behind state found 2026-07-06). Everything under
+ * .claude/ is exempt: the worktrees themselves live there, along with
+ * handoff.md, session markers, and local settings.
+ *
+ * Scope: only this repository. Writes to other repos or non-repo paths pass.
+ * Escape hatch (Captain only): SS_ALLOW_PRIMARY_WRITES=1.
+ *
+ * Failure posture: parse/lookup errors fail OPEN. This is workflow hygiene,
+ * not a safety gate; a broken guard must not brick every session's edits, and
+ * a bypass shows up as a dirty tree in the next /sos briefing.
+ *
+ * Exit 2 blocks the tool call and surfaces stderr to the model.
+ */
+import { execFileSync } from 'node:child_process'
+import fs from 'node:fs'
+import path from 'node:path'
+
+/** Root of the PRIMARY checkout owning `dir` (worktrees resolve to their parent repo). */
+function primaryRootOf(dir) {
+  const out = execFileSync('git', ['-C', dir, 'rev-parse', '--git-common-dir'], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'ignore'],
+  }).trim()
+  const commonDir = path.isAbsolute(out) ? out : path.resolve(dir, out)
+  return fs.realpathSync(path.dirname(commonDir))
+}
+
+/** Deepest existing directory at or above `p` (Write targets may not exist yet). */
+function nearestExistingDir(p) {
+  let dir = p
+  while (!fs.existsSync(dir)) {
+    const parent = path.dirname(dir)
+    if (parent === dir) return null
+    dir = parent
+  }
+  return fs.statSync(dir).isDirectory() ? dir : path.dirname(dir)
+}
+
+try {
+  if (process.env.SS_ALLOW_PRIMARY_WRITES === '1') process.exit(0)
+
+  const payload = JSON.parse(fs.readFileSync(0, 'utf8'))
+  const target = payload?.tool_input?.file_path ?? payload?.tool_input?.notebook_path
+  if (typeof target !== 'string' || target.length === 0) process.exit(0)
+
+  const cwd = payload.cwd || process.cwd()
+  const abs = path.resolve(cwd, target)
+  const anchor = nearestExistingDir(abs)
+  if (!anchor) process.exit(0)
+
+  let targetRoot
+  try {
+    targetRoot = primaryRootOf(anchor)
+  } catch {
+    process.exit(0) // target is not inside any git repo
+  }
+
+  let sessionRoot
+  try {
+    sessionRoot = primaryRootOf(process.env.CLAUDE_PROJECT_DIR || cwd)
+  } catch {
+    process.exit(0)
+  }
+
+  if (targetRoot !== sessionRoot) process.exit(0) // other repos are out of scope
+
+  // Rebuild the target path on realpath'd ancestors so symlinked prefixes
+  // (e.g. /tmp -> /private/tmp on macOS) compare correctly against the root.
+  const real = path.join(fs.realpathSync(anchor), path.relative(anchor, abs))
+  const rel = path.relative(targetRoot, real)
+  if (rel.startsWith('..')) process.exit(0) // outside the primary root
+  if (rel === '.claude' || rel.startsWith(`.claude${path.sep}`)) process.exit(0)
+
+  process.stderr.write(
+    `worktree-guard: "${rel}" is in the PRIMARY checkout, which is read-only for agent sessions. ` +
+      'All repo mutations happen in an isolated worktree: call EnterWorktree, then re-apply this ' +
+      "change against the worktree path. See CLAUDE.md 'Worktree discipline'. " +
+      '(Captain-only escape hatch: SS_ALLOW_PRIMARY_WRITES=1.)\n'
+  )
+  process.exit(2)
+} catch {
+  process.exit(0) // fail open (see header)
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -14,5 +14,31 @@
       "NotebookEdit",
       "mcp__crane__*"
     ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/worktree-guard.mjs\"",
+            "timeout": 15
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/sync-primary.sh\"",
+            "timeout": 45
+          }
+        ]
+      }
+    ]
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,7 @@ SMD contact addresses:
 ## Enterprise Rules
 
 - **All changes through PRs.** Never push directly to main. Branch, PR, CI, QA, merge.
+- **Worktree discipline: the primary checkout is read-only.** All repo mutations happen in an isolated worktree (`EnterWorktree`). A PreToolUse hook (`.claude/hooks/worktree-guard.mjs`) rejects Edit/Write into the primary tree (paths under `.claude/` are exempt — the worktrees themselves live there), and a SessionStart hook (`.claude/hooks/sync-primary.sh`) fast-forwards a clean primary checkout to origin/main so it never drifts stale. Do not work around the guard with Bash writes. Captain-only escape hatch: `SS_ALLOW_PRIMARY_WRITES=1`. Guard tests: `tests/worktree-guard.test.ts`.
 - **Never echo secret values.** Transcripts persist in ~/.claude/ and are sent to API providers.
 - **Verify secret VALUES, not just key existence.**
 - **Never auto-save to VCMS** without explicit Captain approval.

--- a/docs/handbook/building-the-platform.md
+++ b/docs/handbook/building-the-platform.md
@@ -75,16 +75,21 @@ the pytest suite run locally before merge (`cd operator && python3 -m pytest ...
 
 Parallel sessions do not share a working tree. Each runs in its own git worktree -
 an isolated checkout on its own branch - so independent work does not collide.
-The cost to watch: Bash runs in the worktree, but `Write` and `Edit` follow the
-absolute path given. A parent-repo absolute path lands the file in the parent
-while tests run against the untouched worktree, producing a false green. Inside a
-worktree session, write to worktree-prefixed paths.
+Since 2026-07-06 this is enforced, not conventional: the primary checkout is
+read-only for agent sessions. A `PreToolUse` hook (`.claude/hooks/worktree-guard.mjs`,
+wired in the checked-in `.claude/settings.json`) rejects `Edit`/`Write`/`NotebookEdit`
+calls targeting the primary tree; paths under `.claude/` are exempt because the
+worktrees themselves live there. A `SessionStart` hook (`.claude/hooks/sync-primary.sh`)
+fast-forwards a clean primary checkout to `origin/main` at session start, so the
+primary tree can no longer drift stale the way it did before the guard (87 commits
+behind, 46 dirty paths of already-merged residue).
 
-> TODO(why): The worktree isolation convention is operational practice (it is how
-> this handbook was authored and is recorded in session memory) rather than a
-> documented file in this repo. I verified the mechanism and the false-green
-> failure mode from the worktree this session runs in, but did not find a
-> canonical runbook page to cite for the convention itself.
+The guard also closes an older failure mode: Bash runs in the worktree, but
+`Write` and `Edit` follow the absolute path given, so a parent-repo absolute path
+used to land the file in the parent while tests ran green against the untouched
+worktree. Those writes are now rejected instead of silently landing.
+`tests/worktree-guard.test.ts` pins the blocked and exempt paths; the Captain-only
+escape hatch is `SS_ALLOW_PRIMARY_WRITES=1`.
 
 ## The portable coding standards
 

--- a/tests/worktree-guard.test.ts
+++ b/tests/worktree-guard.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Guard tests for .claude/hooks/worktree-guard.mjs (the PreToolUse hook that
+ * makes the primary checkout read-only for agent sessions).
+ *
+ * The hook is exercised as Claude Code runs it: a node subprocess with the
+ * PreToolUse payload on stdin. Exit 2 = blocked, exit 0 = allowed. Paths are
+ * built from the resolved primary-repo root so the suite passes both in CI
+ * (where the checkout IS the primary root) and inside a worktree session
+ * (where the primary root is the parent repo).
+ */
+import { describe, it, expect } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import os from 'node:os'
+import path from 'node:path'
+
+const primaryRoot = (() => {
+  const out = execFileSync('git', ['rev-parse', '--git-common-dir'], { encoding: 'utf8' }).trim()
+  const common = path.isAbsolute(out) ? out : path.resolve(process.cwd(), out)
+  return path.dirname(common)
+})()
+
+const script = path.join(process.cwd(), '.claude', 'hooks', 'worktree-guard.mjs')
+
+function runGuard(input: string, extraEnv: Record<string, string> = {}): number {
+  try {
+    execFileSync('node', [script], {
+      input,
+      env: {
+        ...process.env,
+        CLAUDE_PROJECT_DIR: primaryRoot,
+        SS_ALLOW_PRIMARY_WRITES: '',
+        ...extraEnv,
+      },
+      stdio: ['pipe', 'ignore', 'ignore'],
+    })
+    return 0
+  } catch (err) {
+    return (err as { status?: number }).status ?? -1
+  }
+}
+
+function payloadFor(filePath: string): string {
+  return JSON.stringify({
+    cwd: primaryRoot,
+    hook_event_name: 'PreToolUse',
+    tool_name: 'Write',
+    tool_input: { file_path: filePath },
+  })
+}
+
+describe('worktree-guard hook', () => {
+  it('blocks writes to repo files in the primary checkout', () => {
+    expect(runGuard(payloadFor(path.join(primaryRoot, 'src', 'pages', 'index.astro')))).toBe(2)
+  })
+
+  it('blocks new files in the primary checkout, even in directories that do not exist yet', () => {
+    expect(
+      runGuard(payloadFor(path.join(primaryRoot, 'operator', 'skills', 'brand-new', 'SKILL.md')))
+    ).toBe(2)
+  })
+
+  it('allows writes under .claude/ (session files, settings)', () => {
+    expect(runGuard(payloadFor(path.join(primaryRoot, '.claude', 'handoff.md')))).toBe(0)
+  })
+
+  it('allows writes inside worktrees (they live under .claude/worktrees/)', () => {
+    expect(
+      runGuard(
+        payloadFor(
+          path.join(primaryRoot, '.claude', 'worktrees', 'some-wt', 'src', 'pages', 'index.astro')
+        )
+      )
+    ).toBe(0)
+  })
+
+  it('allows writes outside the repository', () => {
+    expect(runGuard(payloadFor(path.join(os.tmpdir(), 'scratch-file.md')))).toBe(0)
+  })
+
+  it('honors the Captain escape hatch', () => {
+    expect(
+      runGuard(payloadFor(path.join(primaryRoot, 'src', 'pages', 'index.astro')), {
+        SS_ALLOW_PRIMARY_WRITES: '1',
+      })
+    ).toBe(0)
+  })
+
+  it('fails open on malformed input', () => {
+    expect(runGuard('not json at all')).toBe(0)
+  })
+
+  it('fails open when the payload has no file path', () => {
+    expect(runGuard(JSON.stringify({ tool_name: 'Write', tool_input: {} }))).toBe(0)
+  })
+})


### PR DESCRIPTION
## Problem

The primary checkout kept accumulating residue: at /sos on 2026-07-06 it sat 87 commits behind origin/main with 46 dirty paths — all stale duplicates of already-squash-merged work (#1630, #1637). Worktree isolation was prose convention (skill instructions), not enforcement, and nothing ever synced or reconciled the primary tree.

## Fix (harness-enforced)

- **`.claude/hooks/worktree-guard.mjs`** (PreToolUse on Edit|Write|NotebookEdit): rejects mutations targeting the primary checkout. Paths under `.claude/` exempt (worktrees live there), other repos out of scope, fails open on errors (workflow hygiene, not a safety gate — a bypass surfaces as a dirty tree at /sos). Captain escape hatch: `SS_ALLOW_PRIMARY_WRITES=1`.
- **`.claude/hooks/sync-primary.sh`** (SessionStart): clean primary on main → fast-forward to origin/main; dirty → loud context warning; worktree sessions → silent no-op.
- **`.claude/settings.json`**: hooks wiring (checked in, so every checkout carries the guard). Diff is the `hooks` block only; permissions untouched. Commit authored via Captain-staged change per the self-modification gate.
- **CLAUDE.md** Enterprise Rule + **handbook** `building-the-platform` update (resolves the TODO documenting that the convention was unenforced; also documents that the parent-path false-green failure mode is now rejected).
- **`tests/worktree-guard.test.ts`** — 8 cases pinning blocked/exempt/fail-open behavior; runs in `npm run verify` and CI.

## Verification

- 8/8 guard tests green; full `npm run verify` green.
- Live smoke: guard exits 2 on a primary `src/` write and 0 on worktree/.claude/out-of-repo paths; sync hook reported the real dirty primary (46 paths) and mutated nothing; silent from a worktree session.

## Out of scope (follow-ups)

- One-time reconciliation of the primary checkout's existing dirt (this session, post-merge, verified file-by-file against origin/main).
- crane_worktree_doctor squash-merge blindness (content-based merged check) — lives in crane-console; needs a cross-venture issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JxGqJcpZREAabNMRGE1heZ