### PR TITLE
feat(hosted-agent): real live view — persisted channel details, allowlist, billing door (ADR 0067)

### DIFF
--- a/migrations/0088_hosted_agent_channel_details.sql
+++ b/migrations/0088_hosted_agent_channel_details.sql
@@ -1,0 +1,8 @@
+-- 0088: persist the go-live channel details on the intake row (ADR 0067).
+--
+-- Found by the live dry-run: the Captain-authored channel details (how the
+-- customer reaches their agent) were rendered into the one-time go-live
+-- email and then dropped. The portal live view -- the page a subscriber
+-- lives with -- had no way to show them. The activate action now persists
+-- the authored text here, and the live view renders it verbatim.
+ALTER TABLE hosted_agent_intake ADD COLUMN channel_details TEXT;

--- a/src/lib/db/hosted-agent-intake.ts
+++ b/src/lib/db/hosted-agent-intake.ts
@@ -28,6 +28,8 @@ export interface HostedAgentIntakeRow {
   spend_limit_confirmed: number
   anthropic_key_status: 'pending' | 'received'
   customer_slug: string | null
+  /** Captain-authored go-live channel details; rendered verbatim on the live view. */
+  channel_details: string | null
   submitted_at: string | null
   created_at: string
   updated_at: string
@@ -36,7 +38,7 @@ export interface HostedAgentIntakeRow {
 const COLUMNS =
   'id, org_id, entity_id, subscription_id, status, agent_name, use_cases, telegram_handle, ' +
   'timezone, allowed_senders_json, spend_limit_confirmed, anthropic_key_status, customer_slug, ' +
-  'submitted_at, created_at, updated_at'
+  'channel_details, submitted_at, created_at, updated_at'
 
 export async function createHostedAgentIntake(
   db: D1Database,

--- a/src/lib/stripe/checkout.ts
+++ b/src/lib/stripe/checkout.ts
@@ -221,6 +221,36 @@ export async function createHostedAgentCheckoutSession(
   return { ...session, founding: false }
 }
 
+/**
+ * Create a Stripe Billing Portal session for a hosted-agent subscriber —
+ * the portal's "manage billing / cancel" door (the product terms promise
+ * cancellation from the portal). Uses the account's default portal
+ * configuration; card entry and cancellation happen on Stripe's surface.
+ */
+export async function createBillingPortalSession(
+  apiKey: string | undefined,
+  stripeCustomerId: string,
+  returnUrl: string
+): Promise<string> {
+  if (!apiKey) {
+    console.log('[DEV] Stripe: would create billing portal session')
+    return returnUrl
+  }
+  const body = new URLSearchParams()
+  body.append('customer', stripeCustomerId)
+  body.append('return_url', returnUrl)
+  const res = await fetch(`${STRIPE_API_BASE}/billing_portal/sessions`, {
+    method: 'POST',
+    headers: stripeHeaders(apiKey),
+    body: body.toString(),
+  })
+  if (!res.ok) {
+    throw new Error(`Stripe billing portal session failed ${res.status}: ${await res.text()}`)
+  }
+  const data: { url: string } = await res.json()
+  return data.url
+}
+
 export interface HostedAgentCheckoutSessionView {
   id: string
   status: string

--- a/src/pages/api/admin/hosted-agent/[id]/activate.ts
+++ b/src/pages/api/admin/hosted-agent/[id]/activate.ts
@@ -78,6 +78,14 @@ export const POST: APIRoute = async ({ locals, params, request }) => {
     )
       .bind(intake.subscription_id)
       .run()
+    // Persist the authored channel details: the live view renders them
+    // verbatim for the life of the subscription (migration 0088) — the
+    // go-live email must not be the only copy.
+    await env.DB.prepare(
+      `UPDATE hosted_agent_intake SET channel_details = ?, updated_at = datetime('now') WHERE id = ?`
+    )
+      .bind(channelDetails, id)
+      .run()
     await setIntakeStatus(env.DB, id, 'live')
   } catch (err) {
     console.error('[admin/hosted-agent] activate failed:', err)

--- a/src/pages/api/portal/products/hosted-agent/billing.ts
+++ b/src/pages/api/portal/products/hosted-agent/billing.ts
@@ -1,0 +1,63 @@
+import type { APIRoute } from 'astro'
+import { env } from 'cloudflare:workers'
+import { resolveHostedAgentAccess } from '../../../../../lib/portal/hosted-agent-access'
+import { createBillingPortalSession } from '../../../../../lib/stripe/checkout'
+import { getPortalBaseUrl } from '../../../../../lib/config/app-url'
+
+/**
+ * POST /api/portal/products/hosted-agent/billing (ADR 0067)
+ *
+ * "Manage billing" door on the live view: creates a Stripe Billing Portal
+ * session for the subscriber's Stripe customer and 303s to it. This is how
+ * the product terms' "cancel at any time from your portal" promise is kept:
+ * cancellation, card updates, and invoices all happen on Stripe's surface.
+ * Principal-gated; the Stripe customer id comes from the subscription's
+ * settings_json (written by the checkout webhook), never from user input.
+ */
+
+const LANDING = '/portal/products/hosted-agent'
+
+function back(cs: string): Response {
+  return new Response(null, { status: 303, headers: { Location: `${LANDING}?cs=${cs}` } })
+}
+
+export const POST: APIRoute = async ({ locals }) => {
+  const access = await resolveHostedAgentAccess(env.DB, locals, { allowedRoles: ['principal'] })
+  if (access.kind === 'redirect') {
+    return new Response(null, { status: 303, headers: { Location: access.to } })
+  }
+
+  const row = await env.DB.prepare(
+    `SELECT settings_json FROM subscriptions
+        WHERE entity_id = ? AND product_slug = 'hosted-agent'
+          AND status IN ('provisioning', 'active', 'paused')
+        ORDER BY created_at DESC LIMIT 1`
+  )
+    .bind(access.client.id)
+    .first<{ settings_json: string | null }>()
+
+  let stripeCustomerId: string | null = null
+  try {
+    const settings: unknown = row?.settings_json ? JSON.parse(row.settings_json) : null
+    if (settings && typeof settings === 'object' && 'stripe_customer_id' in settings) {
+      const v = (settings as Record<string, unknown>)['stripe_customer_id']
+      stripeCustomerId = typeof v === 'string' && v.startsWith('cus_') ? v : null
+    }
+  } catch {
+    stripeCustomerId = null
+  }
+  if (!stripeCustomerId) return back('billing_unavailable')
+
+  try {
+    const portalBase = getPortalBaseUrl(env) ?? ''
+    const url = await createBillingPortalSession(
+      env.STRIPE_API_KEY,
+      stripeCustomerId,
+      `${portalBase}${LANDING}`
+    )
+    return new Response(null, { status: 303, headers: { Location: url } })
+  } catch (err) {
+    console.error('[hosted-agent/billing] portal session failed:', err)
+    return back('billing_error')
+  }
+}

--- a/src/pages/portal/products/hosted-agent/index.astro
+++ b/src/pages/portal/products/hosted-agent/index.astro
@@ -170,15 +170,30 @@ const stepBadge: Record<StepState, { label: string; klass: string }> = {
   },
 }
 
-// Intake form outcome banner (?st=saved|invalid|error) and key form outcome
-// (?cs=saved|not_enabled|...) both land back here or on their own pages.
+/** Authored allowlist for the live view (from the intake row). */
+const allowedSenders: string[] = (() => {
+  try {
+    const parsed: unknown = JSON.parse(intake?.allowed_senders_json ?? '[]')
+    return Array.isArray(parsed) ? parsed.filter((s): s is string => typeof s === 'string') : []
+  } catch {
+    return []
+  }
+})()
+
+// Intake form outcome banner (?st=saved|invalid|error) and billing door
+// outcome (?cs=billing_*) both land back here.
 const stStatus = Astro.url.searchParams.get('st')
+const csStatus = Astro.url.searchParams.get('cs')
 const stMessage =
   stStatus === 'saved'
     ? 'Your setup answers were saved.'
     : stStatus === 'invalid'
       ? 'Some answers were missing or invalid. Please review the form and try again.'
-      : null
+      : csStatus === 'billing_unavailable'
+        ? 'Billing management is not available for this subscription yet. Write to team@smd.services and we sort it out.'
+        : csStatus === 'billing_error'
+          ? 'Could not open billing management. Try again, or write to team@smd.services.'
+          : null
 ---
 
 <!doctype html>
@@ -334,15 +349,78 @@ const stMessage =
               <p class="font-body text-2xl md:text-3xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]">
                 {intake?.agent_name ?? 'Your agent'} is live
               </p>
-              {intake?.telegram_handle && (
-                <p class="mt-3 font-body text-base text-[color:var(--ss-color-text-secondary)]">
-                  Connected to Telegram for {intake.telegram_handle}.
+              {intake?.channel_details && (
+                <p class="mt-4 font-body text-lg leading-relaxed whitespace-pre-wrap text-[color:var(--ss-color-text-primary)]">
+                  {intake.channel_details}
                 </p>
               )}
-              <p class="mt-3 font-body text-base text-[color:var(--ss-color-text-secondary)]">
-                Setup changes and questions: reply to any email from us, and we take it from there.
-              </p>
             </div>
+
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+              <div class="border-[3px] border-[color:var(--ss-color-text-primary)] p-6">
+                <p class="font-mono text-xs font-semibold uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)]">
+                  Who it accepts email from
+                </p>
+                {allowedSenders.length > 0 ? (
+                  <ul class="mt-3 flex flex-col gap-1 font-body text-base text-[color:var(--ss-color-text-primary)]">
+                    {allowedSenders.map((s) => (
+                      <li>{s}</li>
+                    ))}
+                  </ul>
+                ) : (
+                  <p class="mt-3 font-body text-base text-[color:var(--ss-color-text-secondary)]">
+                    No senders on file. Write to team@smd.services to set the allowlist.
+                  </p>
+                )}
+                <p class="mt-3 font-body text-sm text-[color:var(--ss-color-text-secondary)]">
+                  Mail from anyone else is ignored. Changes to this list go through our team.
+                </p>
+              </div>
+
+              <div class="border-[3px] border-[color:var(--ss-color-text-primary)] p-6">
+                <p class="font-mono text-xs font-semibold uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)]">
+                  How it works for you
+                </p>
+                <ul class="mt-3 flex flex-col gap-1 font-body text-base text-[color:var(--ss-color-text-primary)]">
+                  {intake?.timezone && <li>Morning digest, on your clock ({intake.timezone})</li>}
+                  <li>Replies to you arrive directly</li>
+                  <li>Anything for a third party comes to you as a draft first</li>
+                </ul>
+              </div>
+            </div>
+
+            <div class="border-[3px] border-[color:var(--ss-color-text-primary)] p-6">
+              <div class="flex flex-wrap items-center justify-between gap-4">
+                <div>
+                  <p class="font-mono text-xs font-semibold uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)]">
+                    Billing
+                  </p>
+                  <p class="mt-2 font-body text-base text-[color:var(--ss-color-text-secondary)]">
+                    Update your card, view invoices, or cancel. Cancellation takes effect at the end
+                    of the billing period, per the{' '}
+                    <a
+                      href="https://smd.services/agent/terms"
+                      class="underline decoration-[color:var(--ss-color-primary)] decoration-2 underline-offset-4 hover:text-[color:var(--ss-color-text-primary)]"
+                    >
+                      Hosted Agent terms
+                    </a>
+                    .
+                  </p>
+                </div>
+                <form method="POST" action="/api/portal/products/hosted-agent/billing">
+                  <button
+                    type="submit"
+                    class="px-6 py-3 border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)] font-bold uppercase tracking-[0.08em] font-body hover:bg-[color:var(--ss-color-text-primary)] hover:text-[color:var(--ss-color-background)] transition-colors"
+                  >
+                    Manage Billing
+                  </button>
+                </form>
+              </div>
+            </div>
+
+            <p class="font-body text-base text-[color:var(--ss-color-text-secondary)]">
+              Setup changes and questions: team@smd.services. A person answers.
+            </p>
           </div>
         )
       }


### PR DESCRIPTION
## What (dry-run finding round 3)

The live view — the page a subscriber lives with for the whole subscription — was a stub. Now it renders, all from authored data:

- **Channel details** (how to reach your agent): the Captain-authored activate-form text, now **persisted** on the intake row (migration 0088) instead of existing only in the one-time go-live email; rendered verbatim
- **Sender allowlist** from the intake row, with the honest "mail from anyone else is ignored" framing
- **How-it-works facts** (digest on their timezone, replies direct, third-party drafts) — shipped behavior only
- **Manage Billing** door: `POST /api/portal/products/hosted-agent/billing` creates a Stripe Billing Portal session (customer id from subscription settings_json, never user input) — this keeps the `/agent/terms` promise "cancel at any time from your portal"
- Support line + billing-failure banners

## Verification

- `npm run verify` green; migration is a single additive column, applied by deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MJF9rQDhVKLv2ADbbApPgi