### PR TITLE
feat(portal): IA rebuild PR 2/6 — curated activity language on all client surfaces

### DIFF
--- a/src/components/portal/PortalNav.astro
+++ b/src/components/portal/PortalNav.astro
@@ -1,0 +1,99 @@
+---
+/**
+ * Portal navigation (portal IA rebuild, 2026-07-07). Renders the
+ * destination list produced by buildPortalNav — this component makes no
+ * decisions about WHICH destinations exist; that is the offerings
+ * resolver's job, done once in PortalShell. Markup carried over from
+ * PortalTabs.astro (desktop sticky tabs + mobile fixed bottom bar per
+ * .design/NAVIGATION.md §4.4), with two changes: Home has a real active
+ * state (exact match), and mobile labels tighten at 5+ destinations.
+ */
+import { isNavDestinationActive, type PortalNavDestination } from '../../lib/portal/nav'
+
+interface Props {
+  destinations: PortalNavDestination[]
+  pathname: string
+}
+
+const { destinations, pathname } = Astro.props
+
+// At five destinations a 375px viewport gives ~75px per mobile cell;
+// tighten the label type so "Engagement" fits without renaming it.
+const dense = destinations.length >= 5
+---
+
+<!-- Desktop: horizontal burnt-orange-active tabs below the header. -->
+<nav
+  aria-label="Portal sections"
+  class="hidden md:block sticky top-16 z-40 bg-[color:var(--ss-color-background)] border-b-[3px] border-[color:var(--ss-color-text-primary)]"
+>
+  <div class="max-w-5xl mx-auto">
+    <ul class="flex items-stretch" role="list">
+      {
+        destinations.map((dest, i) => {
+          const active = isNavDestinationActive(dest, pathname)
+          const base =
+            'inline-flex items-baseline gap-2 px-5 py-3 min-h-[44px] font-mono text-sm font-bold uppercase tracking-[0.14em] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2'
+          const state = active
+            ? 'bg-[color:var(--ss-color-primary)] text-[color:var(--ss-color-background)]'
+            : 'bg-transparent text-[color:var(--ss-color-text-secondary)] hover:text-[color:var(--ss-color-text-primary)] hover:bg-[color:var(--ss-color-border-subtle)]'
+          const isLast = i === destinations.length - 1
+          const divider = isLast ? '' : 'border-r-[2px] border-[color:var(--ss-color-text-primary)]'
+          return (
+            <li class={divider}>
+              <a
+                href={dest.href}
+                aria-current={active ? 'page' : undefined}
+                class={`${base} ${state}`}
+              >
+                <span
+                  aria-hidden="true"
+                  class={`font-mono text-xs tracking-[0.06em] ${active ? 'text-[color:var(--ss-color-background)]' : 'text-[color:var(--ss-color-primary)]'}`}
+                >
+                  § {dest.anchor}
+                </span>
+                <span>{dest.label}</span>
+              </a>
+            </li>
+          )
+        })
+      }
+    </ul>
+  </div>
+</nav>
+
+<!-- Mobile: fixed bottom bar, 3px ink top border, burnt-orange active tile. -->
+<nav
+  aria-label="Portal sections"
+  class="md:hidden fixed bottom-0 inset-x-0 z-40 bg-[color:var(--ss-color-background)] border-t-[3px] border-[color:var(--ss-color-text-primary)] pb-[env(safe-area-inset-bottom)]"
+>
+  <ul class="flex divide-x-[2px] divide-[color:var(--ss-color-text-primary)]" role="list">
+    {
+      destinations.map((dest) => {
+        const active = isNavDestinationActive(dest, pathname)
+        const labelSize = dense ? 'text-[10px] tracking-[0.08em]' : 'text-xs tracking-[0.14em]'
+        const base = `flex flex-col items-center justify-center gap-0.5 py-2 min-h-[64px] font-mono ${labelSize} font-bold uppercase transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-inset`
+        const state = active
+          ? 'bg-[color:var(--ss-color-primary)] text-[color:var(--ss-color-background)]'
+          : 'bg-transparent text-[color:var(--ss-color-text-primary)] active:bg-[color:var(--ss-color-border-subtle)]'
+        return (
+          <li class="flex-1">
+            <a
+              href={dest.href}
+              aria-current={active ? 'page' : undefined}
+              class={`${base} w-full ${state}`}
+            >
+              <span
+                aria-hidden="true"
+                class={`font-mono text-[11px] leading-none tracking-[0.06em] ${active ? 'text-[color:var(--ss-color-background)]' : 'text-[color:var(--ss-color-primary)]'}`}
+              >
+                § {dest.anchor}
+              </span>
+              <span class="leading-none">{dest.mobileLabel ?? dest.label}</span>
+            </a>
+          </li>
+        )
+      })
+    }
+  </ul>
+</nav>

--- a/src/components/portal/operator/AuditEntryRow.astro
+++ b/src/components/portal/operator/AuditEntryRow.astro
@@ -29,11 +29,11 @@
 import StatusPill from '../StatusPill.astro'
 import {
   decisionTone,
-  formatAuditAction,
   formatAuditDecision,
   formatAuditTimestamp,
   type AuditEntry,
 } from '../../../lib/portal/operator/audit'
+import { clientSummaryFor } from '../../../lib/portal/operator/activity-language'
 
 interface Props {
   entry: AuditEntry
@@ -50,7 +50,10 @@ const resolvedSerial = serial ?? entry.id.slice(0, 2).toUpperCase()
 const decisionLabel = formatAuditDecision(entry.decision)
 const decisionToneValue = decisionTone(entry.decision)
 
-const actionLabel = formatAuditAction(entry.action)
+// Curated client language only; upstream filtering guarantees a mapped
+// entry, and an unmapped straggler renders an empty cell, never raw
+// vocabulary.
+const actionLabel = clientSummaryFor(entry) ?? ''
 const tsLabel = formatAuditTimestamp(entry.ts)
 
 // Truncate the reason in the row caption; the full text is in the

--- a/src/components/portal/operator/AuditFilterBar.astro
+++ b/src/components/portal/operator/AuditFilterBar.astro
@@ -17,7 +17,8 @@
  * form and the resolver.
  */
 
-import { AUDIT_ACTION_TYPES, AUDIT_SORTS, type AuditSort } from '../../../lib/portal/operator/audit'
+import { AUDIT_SORTS, type AuditSort } from '../../../lib/portal/operator/audit'
+import { CLIENT_ACTIVITY_CATEGORIES } from '../../../lib/portal/operator/activity-language'
 
 interface Props {
   /**
@@ -25,7 +26,8 @@ interface Props {
    * parsed URLSearchParams so the form re-hydrates after a submit.
    */
   skills: readonly string[]
-  actions: readonly string[]
+  /** Selected client-activity category keys (the `cat` URL param). */
+  categories: readonly string[]
   from: string | null
   to: string | null
   q: string | null
@@ -39,7 +41,7 @@ interface Props {
   availableSkills: readonly string[]
 }
 
-const { skills, actions, from, to, q, sort, availableSkills } = Astro.props
+const { skills, categories, from, to, q, sort, availableSkills } = Astro.props
 
 const SORT_LABELS: Record<AuditSort, string> = {
   ts_desc: 'Newest first',
@@ -47,7 +49,7 @@ const SORT_LABELS: Record<AuditSort, string> = {
 }
 
 const selectedSkills = new Set(skills)
-const selectedActions = new Set(actions)
+const selectedCategories = new Set(categories)
 
 // Strip time component from an ISO datetime for the `<input type="date">`
 // re-hydration. The resolver accepts both ISO date and ISO datetime so
@@ -112,25 +114,28 @@ function toDateValue(value: string | null): string {
       }
     </div>
 
-    {/* Action class multi-select */}
+    {
+      /* Activity category multi-select (client language; expands to the
+        mapped raw actions page-side — raw vocabulary never renders) */
+    }
     <div class="flex flex-col gap-1.5 min-w-0">
       <label
-        for="audit-filter-action"
+        for="audit-filter-category"
         class="font-mono text-label uppercase tracking-[0.14em] font-bold text-[color:var(--ss-color-text-secondary)]"
       >
-        Action class
+        Activity type
       </label>
       <select
-        id="audit-filter-action"
-        name="action"
+        id="audit-filter-category"
+        name="cat"
         multiple
         size="4"
         class="border-[2px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)] px-3 py-2 font-mono text-xs text-[color:var(--ss-color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2"
       >
         {
-          AUDIT_ACTION_TYPES.map((action) => (
-            <option value={action} selected={selectedActions.has(action)}>
-              {action}
+          CLIENT_ACTIVITY_CATEGORIES.map((category) => (
+            <option value={category.key} selected={selectedCategories.has(category.key)}>
+              {category.label}
             </option>
           ))
         }

--- a/src/layouts/PortalShell.astro
+++ b/src/layouts/PortalShell.astro
@@ -1,0 +1,66 @@
+---
+/**
+ * PortalShell — the single chrome owner for every client-portal page
+ * (portal IA rebuild, 2026-07-07).
+ *
+ * Owns the html/head scaffold, header, and navigation. Nav destinations
+ * are resolved HERE, once, from the offerings resolver — pages carry no
+ * nav-shaping props, so a page physically cannot render a different tab
+ * set (the per-page boolean-prop drift this replaces).
+ *
+ * Auth stays in pages (Astro layouts cannot return redirects): a page
+ * runs its gate (getPortalClient / resolveOperatorAccess /
+ * resolveHostedAgentAccess), then hands the bound identity here. Pages
+ * that already resolved offerings for their own content (Home) pass it
+ * via the optional prop to avoid a second resolution.
+ */
+import { GOOGLE_FONTS_URL } from '../lib/fonts'
+import '../styles/global.css'
+import { BRAND_NAME } from '../lib/config/brand'
+import SkipToMain from '../components/SkipToMain.astro'
+import PortalHeader from '../components/portal/PortalHeader.astro'
+import PortalNav from '../components/portal/PortalNav.astro'
+import { resolvePortalOfferings, type PortalOfferings } from '../lib/portal/offerings'
+import { buildPortalNav } from '../lib/portal/nav'
+import { env } from 'cloudflare:workers'
+
+interface Props {
+  title: string
+  clientName: string
+  orgId: string
+  entityId: string
+  pathname: string
+  /** Pass when the page already resolved offerings (e.g. Home). */
+  offerings?: PortalOfferings
+}
+
+const { title, clientName, orgId, entityId, pathname } = Astro.props
+
+const offerings = Astro.props.offerings ?? (await resolvePortalOfferings(env.DB, orgId, entityId))
+const destinations = buildPortalNav(offerings)
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link href={GOOGLE_FONTS_URL} rel="stylesheet" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap"
+      rel="stylesheet"
+    />
+    <title>{title} | {BRAND_NAME}</title>
+  </head>
+  <body class="min-h-screen bg-[color:var(--ss-color-background)]">
+    <SkipToMain />
+    <PortalHeader clientName={clientName} />
+    <PortalNav destinations={destinations} pathname={pathname} />
+
+    <main id="main" role="main" class="max-w-5xl mx-auto px-4 md:px-6 pb-24 md:pb-12">
+      <slot />
+    </main>
+  </body>
+</html>

--- a/src/lib/portal/billing.ts
+++ b/src/lib/portal/billing.ts
@@ -1,0 +1,52 @@
+/**
+ * Portal billing helpers (portal IA rebuild, 2026-07-07).
+ *
+ * The Stripe customer id for a product subscription lives in
+ * subscriptions.settings_json (written by the checkout webhook). This is
+ * the single parse point for it — the generalized Manage-Billing
+ * endpoint and the Billing surface both consume it. Extracted verbatim
+ * from the hosted-agent billing endpoint's inline parsing.
+ */
+
+import type { D1Database } from '@cloudflare/workers-types'
+import type { SubscriptionRow } from './product-access'
+
+export function parseStripeCustomerId(settingsJson: string | null): string | null {
+  try {
+    const settings: unknown = settingsJson ? JSON.parse(settingsJson) : null
+    if (settings && typeof settings === 'object' && 'stripe_customer_id' in settings) {
+      const v = (settings as Record<string, unknown>)['stripe_customer_id']
+      return typeof v === 'string' && v.startsWith('cus_') ? v : null
+    }
+  } catch {
+    // fall through
+  }
+  return null
+}
+
+export async function getStripeCustomerIdForSubscription(
+  db: D1Database,
+  entityId: string,
+  productSlug: string
+): Promise<string | null> {
+  const row = await db
+    .prepare(
+      `SELECT settings_json FROM subscriptions
+        WHERE entity_id = ? AND product_slug = ?
+          AND status IN ('provisioning', 'active', 'paused')
+        ORDER BY created_at DESC LIMIT 1`
+    )
+    .bind(entityId, productSlug)
+    .first<{ settings_json: string | null }>()
+  return parseStripeCustomerId(row?.settings_json ?? null)
+}
+
+/** Display names for subscription rows on the Billing surface. */
+export const PRODUCT_DISPLAY_NAMES: Record<string, string> = {
+  operator: 'Operator',
+  'hosted-agent': 'Hosted Agent',
+}
+
+export function productDisplayName(sub: SubscriptionRow): string {
+  return PRODUCT_DISPLAY_NAMES[sub.product_slug] ?? sub.product_slug
+}

--- a/src/lib/portal/hosted-agent-state.ts
+++ b/src/lib/portal/hosted-agent-state.ts
@@ -1,0 +1,68 @@
+/**
+ * Hosted Agent portal state derivation (extracted from the product
+ * landing during the portal IA rebuild, 2026-07-07) so the landing page
+ * and the Home dashboard card derive the SAME truth from the same rows.
+ */
+
+import type { D1Database } from '@cloudflare/workers-types'
+import { getIntakeByEntity, type HostedAgentIntakeRow } from '../db/hosted-agent-intake'
+import { getProductSubscription, listProductRoles, type SubscriptionRow } from './product-access'
+import { HOSTED_AGENT_PRODUCT_SLUG } from './hosted-agent-access'
+
+export type HostedAgentSurfaceState = 'no_subscription' | 'setup' | 'paused' | 'live' | 'no_role'
+
+export interface HostedAgentState {
+  surfaceState: HostedAgentSurfaceState
+  subscription: SubscriptionRow | null
+  intake: HostedAgentIntakeRow | null
+  needsIntake: boolean
+  needsKey: boolean
+  keyReceived: boolean
+}
+
+/** Pure derivation from already-fetched rows. */
+export function deriveHostedAgentState(input: {
+  subscription: SubscriptionRow | null
+  roles: string[]
+  intake: HostedAgentIntakeRow | null
+}): HostedAgentState {
+  const { subscription, roles, intake } = input
+  let surfaceState: HostedAgentSurfaceState
+  if (!subscription) {
+    surfaceState = 'no_subscription'
+  } else if (roles.length === 0) {
+    surfaceState = 'no_role'
+  } else if (subscription.status === 'paused') {
+    surfaceState = 'paused'
+  } else if (subscription.status === 'active' && intake?.status === 'live') {
+    surfaceState = 'live'
+  } else {
+    surfaceState = 'setup'
+  }
+
+  const needsIntake = surfaceState === 'setup' && intake?.status === 'awaiting_intake'
+  const needsKey =
+    surfaceState === 'setup' &&
+    intake !== null &&
+    intake.anthropic_key_status === 'pending' &&
+    intake.customer_slug !== null
+  const keyReceived = intake?.anthropic_key_status === 'received'
+
+  return { surfaceState, subscription, intake, needsIntake, needsKey, keyReceived }
+}
+
+export async function resolveHostedAgentState(
+  db: D1Database,
+  entityId: string,
+  userId: string
+): Promise<HostedAgentState> {
+  const subscription = await getProductSubscription(db, entityId, HOSTED_AGENT_PRODUCT_SLUG)
+  if (!subscription) {
+    return deriveHostedAgentState({ subscription: null, roles: [], intake: null })
+  }
+  const [roles, intake] = await Promise.all([
+    listProductRoles(db, userId, entityId, HOSTED_AGENT_PRODUCT_SLUG),
+    getIntakeByEntity(db, entityId),
+  ])
+  return deriveHostedAgentState({ subscription, roles, intake })
+}

--- a/src/lib/portal/nav.ts
+++ b/src/lib/portal/nav.ts
@@ -1,0 +1,69 @@
+/**
+ * Portal navigation model (portal IA rebuild, 2026-07-07).
+ *
+ * Pure function from PortalOfferings to the ordered destination list —
+ * offerings as destinations, fully composed (Captain decisions 1, 2, 10):
+ *
+ *   Home        always
+ *   Engagement  when any engagement or proposal exists
+ *   Operator    when an operator subscription exists
+ *   Agent       when a hosted-agent subscription exists
+ *   Billing     when any invoice or subscription exists
+ *
+ * Section anchors are assigned sequentially at build time so there is no
+ * conditional-anchor arithmetic anywhere.
+ */
+
+import type { PortalOfferings } from './offerings'
+
+export interface PortalNavDestination {
+  href: string
+  label: string
+  /** Escape hatch for narrow mobile cells; unused initially. */
+  mobileLabel?: string
+  anchor: string
+  matchPrefix: string
+  /** Home matches exactly; everything else matches by prefix. */
+  exact?: boolean
+}
+
+export function buildPortalNav(offerings: PortalOfferings): PortalNavDestination[] {
+  const destinations: Omit<PortalNavDestination, 'anchor'>[] = [
+    { href: '/portal', label: 'Home', matchPrefix: '/portal', exact: true },
+  ]
+  if (offerings.engagement.present) {
+    destinations.push({
+      href: '/portal/engagement',
+      label: 'Engagement',
+      matchPrefix: '/portal/engagement',
+    })
+  }
+  if (offerings.operator) {
+    destinations.push({
+      href: '/portal/products/operator',
+      label: 'Operator',
+      matchPrefix: '/portal/products/operator',
+    })
+  }
+  if (offerings.hostedAgent) {
+    destinations.push({
+      href: '/portal/products/hosted-agent',
+      label: 'Agent',
+      matchPrefix: '/portal/products/hosted-agent',
+    })
+  }
+  if (offerings.hasInvoices || offerings.subscriptions.length > 0) {
+    destinations.push({
+      href: '/portal/billing',
+      label: 'Billing',
+      matchPrefix: '/portal/billing',
+    })
+  }
+  return destinations.map((d, i) => ({ ...d, anchor: String(i + 1).padStart(2, '0') }))
+}
+
+export function isNavDestinationActive(dest: PortalNavDestination, pathname: string): boolean {
+  const path = pathname.endsWith('/') && pathname !== '/' ? pathname.slice(0, -1) : pathname
+  if (dest.exact) return path === dest.href
+  return path === dest.href || path.startsWith(dest.matchPrefix + '/')
+}

--- a/src/lib/portal/offerings.ts
+++ b/src/lib/portal/offerings.ts
@@ -1,0 +1,94 @@
+/**
+ * THE portal offerings resolver (portal IA rebuild, 2026-07-07).
+ *
+ * One module answers "what does this entity own?" for every portal
+ * surface: the nav (buildPortalNav), the Home dashboard cards, and the
+ * engagement destination's states all consume the same object, so the
+ * tab set can never drift page-to-page again (the defect that triggered
+ * the rebuild: per-page boolean props).
+ *
+ * Engagement facts are ORTHOGONAL, not a single state: an active client
+ * can hold an open follow-on proposal at the same time (Decision #27
+ * posture), and the engagement page renders the proposal spotlight above
+ * the active workspace when both are set.
+ */
+
+import type { D1Database } from '@cloudflare/workers-types'
+import { listEngagements, type Engagement } from '../db/engagements'
+import { listQuotesForEntity, type Quote } from '../db/quotes'
+import { listActiveSubscriptionsForEntity, type SubscriptionRow } from './product-access'
+
+const ENGAGEMENT_TERMINAL_STATUSES = new Set(['completed', 'cancelled'])
+
+export interface EngagementOfferings {
+  /** Any engagement row or portal-visible quote exists. */
+  present: boolean
+  activeEngagement: Engagement | null
+  /** Most recent quote awaiting the client (status 'sent'). */
+  openProposal: Quote | null
+  pastEngagements: Engagement[]
+}
+
+export interface PortalOfferings {
+  engagement: EngagementOfferings
+  operator: SubscriptionRow | null
+  hostedAgent: SubscriptionRow | null
+  /** Any portal-visible invoice exists (drives the Billing destination). */
+  hasInvoices: boolean
+  subscriptions: SubscriptionRow[]
+}
+
+/** Pure derivation from already-fetched rows; unit-tested in isolation. */
+export function deriveOfferings(input: {
+  engagements: Engagement[]
+  quotes: Quote[]
+  subscriptions: SubscriptionRow[]
+  hasInvoices: boolean
+}): PortalOfferings {
+  const activeEngagement =
+    input.engagements.find((e) => !ENGAGEMENT_TERMINAL_STATUSES.has(e.status)) ?? null
+  const pastEngagements = input.engagements.filter((e) =>
+    ENGAGEMENT_TERMINAL_STATUSES.has(e.status)
+  )
+  const openProposal = input.quotes.find((q) => q.status === 'sent') ?? null
+
+  const bySlug = (slug: string) => input.subscriptions.find((s) => s.product_slug === slug) ?? null
+
+  return {
+    engagement: {
+      present: activeEngagement !== null || pastEngagements.length > 0 || input.quotes.length > 0,
+      activeEngagement,
+      openProposal,
+      pastEngagements,
+    },
+    operator: bySlug('operator'),
+    hostedAgent: bySlug('hosted-agent'),
+    hasInvoices: input.hasInvoices,
+    subscriptions: input.subscriptions,
+  }
+}
+
+async function hasPortalVisibleInvoices(db: D1Database, entityId: string): Promise<boolean> {
+  const row = await db
+    .prepare(
+      `SELECT 1 AS present FROM invoices
+        WHERE entity_id = ? AND status IN ('sent', 'paid', 'overdue') LIMIT 1`
+    )
+    .bind(entityId)
+    .first<{ present: number }>()
+  return row !== null
+}
+
+export async function resolvePortalOfferings(
+  db: D1Database,
+  orgId: string,
+  entityId: string
+): Promise<PortalOfferings> {
+  const [engagements, quotes, subscriptions, hasInvoices] = await Promise.all([
+    listEngagements(db, orgId, entityId),
+    listQuotesForEntity(db, orgId, entityId),
+    listActiveSubscriptionsForEntity(db, entityId),
+    hasPortalVisibleInvoices(db, entityId),
+  ])
+  return deriveOfferings({ engagements, quotes, subscriptions, hasInvoices })
+}

--- a/src/lib/portal/operator/activity-language.ts
+++ b/src/lib/portal/operator/activity-language.ts
@@ -1,0 +1,193 @@
+/**
+ * Client-language allowlist for Operator activity (portal IA rebuild,
+ * Captain decision 7, 2026-07-07): clients see curated human-language
+ * summaries only. Raw runtime vocabulary ("INVARIANT_VIOLATION",
+ * "LLM_TURN_COMPLETED") never renders on a client surface.
+ *
+ * Every raw action string is either MAPPED (has authored client copy) or
+ * SUPPRESSED (renders nothing). The exhaustiveness test in
+ * activity-language.test.ts asserts that every member of
+ * AUDIT_ACTION_TYPES appears in exactly one of the two sets, so a new
+ * writer-side action forces a deliberate client-language decision at
+ * merge time. Unknown strings the runtime emits beyond the enum (e.g.
+ * LLM_TURN_COMPLETED) are implicitly suppressed by the absent-key rule.
+ *
+ * Copy rules: authored template sentences describing SHIPPED system
+ * behavior only; entry.skill / entry.target / entry.reason are real data
+ * and may be interpolated; nothing is invented (anti-fabrication policy).
+ * The admin console keeps the raw vocabulary via formatAuditAction; a
+ * guard test bans that function from client surfaces.
+ */
+
+import type { AuditEntry } from './audit'
+
+export interface ClientActivityCategory {
+  /** Stable filter value used in URLs. */
+  key: string
+  /** Human label for the filter control. */
+  label: string
+  /** Raw action types this bucket absorbs. */
+  actions: readonly string[]
+}
+
+export const CLIENT_ACTIVITY_CATEGORIES: readonly ClientActivityCategory[] = [
+  {
+    key: 'drafts',
+    label: 'Drafts and replies',
+    actions: [
+      'DRAFT_CREATED',
+      'DRAFT_APPROVED',
+      'DRAFT_REJECTED',
+      'DRAFT_EXPIRED',
+      'REPLY_SENT',
+      'REPLY_HELD',
+    ],
+  },
+  {
+    key: 'escalations',
+    label: 'Escalations',
+    actions: ['ESCALATION_FIRED', 'ESCALATION_ACKNOWLEDGED'],
+  },
+  {
+    key: 'status',
+    label: 'Operator status',
+    actions: ['AGENT_STOPPED', 'AGENT_RESUMED'],
+  },
+  {
+    key: 'configuration',
+    label: 'Configuration',
+    actions: [
+      'SKILL_ENABLED',
+      'SKILL_DISABLED',
+      'TRUST_PROMOTED',
+      'TRUST_DEMOTED',
+      'SCOPE_CHANGED',
+    ],
+  },
+  {
+    key: 'connections',
+    label: 'Connections',
+    actions: [
+      'CONNECTOR_BOUND',
+      'CONNECTOR_UNBOUND',
+      'CONNECTOR_AUTH_EXPIRED',
+      'CONNECTOR_AUTH_RESTORED',
+    ],
+  },
+  {
+    key: 'compliance',
+    label: 'Compliance',
+    actions: ['COMPLIANCE_PACKET_EXPORTED'],
+  },
+] as const
+
+/**
+ * Raw actions that deliberately render NOTHING on client surfaces:
+ * internal telemetry, safety substrate, mirrors, and lifecycle plumbing.
+ * Kept as an explicit set (not "everything else") so the exhaustiveness
+ * test can prove every writer-side action was consciously placed.
+ */
+export const SUPPRESSED_ACTIONS: ReadonlySet<string> = new Set([
+  'MEMORY_RULE_ADDED',
+  'MEMORY_RULE_EDITED',
+  'MEMORY_RULE_DELETED',
+  'CONNECTOR_TOKEN_REFRESHED',
+  'CONNECTOR_HEALTH_PROBE_FAILED',
+  'INVARIANT_VIOLATION',
+  'INVARIANT_BOOT_CHECK_FAILED',
+  'RBAC_EVENT',
+  'VOICE_GATE_PASSED',
+  'VOICE_GATE_NEAR_PASS',
+  'VOICE_GATE_FAILED',
+  'FABRICATION_FILTER_TRIGGERED',
+  'IDENTIFIER_UNVERIFIED',
+  'INBOUND_RECEIVED',
+  'HONCHO_CONCLUSION_DISMISSED',
+  'AGENT_SKILL_CREATED',
+  'AGENT_SKILL_REMOVED',
+  'CUSTOMER_YAML_SYNCED',
+  'CUSTOMER_YAML_STRUCTURAL_CHANGE_DEFERRED',
+  'SUBAGENT_STOPPED',
+  'SUBAGENT_INCOMPLETE',
+  'SUPPRESSED_WAKE',
+  'REPLY_FAILED',
+  'DECOMMISSION_INITIATED',
+  'DECOMMISSION_DRAIN_COMPLETE',
+  'DECOMMISSION_STEP_BEGIN',
+  'DECOMMISSION_STEP_COMPLETE',
+  'DECOMMISSION_STEP_FAILED',
+  'DECOMMISSION_FINAL',
+])
+
+type SummaryBuilder = (entry: AuditEntry) => string
+
+const withSkill = (base: string) => (entry: AuditEntry) =>
+  entry.skill ? `${base}: ${entry.skill}` : base
+
+const CLIENT_LANGUAGE: Record<string, SummaryBuilder> = {
+  DRAFT_CREATED: withSkill('Prepared a draft for your review'),
+  DRAFT_APPROVED: () => 'A draft was approved and sent',
+  DRAFT_REJECTED: () => 'A draft was declined',
+  DRAFT_EXPIRED: () => 'A draft expired without review',
+  REPLY_SENT: () => 'Replied to a message',
+  REPLY_HELD: () => 'Held a reply for your review',
+  ESCALATION_FIRED: (e) => e.reason ?? 'Flagged something for your attention',
+  ESCALATION_ACKNOWLEDGED: () => 'An escalation was acknowledged',
+  AGENT_STOPPED: () => 'Your operator was paused',
+  AGENT_RESUMED: () => 'Your operator resumed work',
+  SKILL_ENABLED: withSkill('A skill was turned on'),
+  SKILL_DISABLED: withSkill('A skill was turned off'),
+  TRUST_PROMOTED: withSkill('An approval level was raised'),
+  TRUST_DEMOTED: withSkill('An approval level was lowered'),
+  CONNECTOR_BOUND: (e) => (e.target ? `Connected ${e.target}` : 'Connected a system'),
+  CONNECTOR_UNBOUND: (e) => (e.target ? `Disconnected ${e.target}` : 'Disconnected a system'),
+  CONNECTOR_AUTH_EXPIRED: () => 'A connection needs re-authorization',
+  CONNECTOR_AUTH_RESTORED: () => 'A connection was restored',
+  SCOPE_CHANGED: () => 'Working scope was updated',
+  COMPLIANCE_PACKET_EXPORTED: () => 'A compliance export was produced',
+}
+
+/** Raw action strings with authored client copy. */
+export const MAPPED_ACTIONS: readonly string[] = Object.keys(CLIENT_LANGUAGE)
+
+/**
+ * The action filter to push into the runtime read (SQL-side) so a chatty
+ * agent's suppressed noise cannot starve client feeds to emptiness.
+ */
+export function mappedActionsForCategories(categoryKeys: readonly string[]): string[] {
+  if (categoryKeys.length === 0) return [...MAPPED_ACTIONS]
+  const wanted = new Set(categoryKeys)
+  return CLIENT_ACTIVITY_CATEGORIES.filter((c) => wanted.has(c.key)).flatMap((c) => [...c.actions])
+}
+
+export interface ClientActivityLine {
+  id: string
+  at: string
+  summary: string
+  categoryKey: string
+}
+
+const ACTION_TO_CATEGORY: ReadonlyMap<string, string> = new Map(
+  CLIENT_ACTIVITY_CATEGORIES.flatMap((c) => c.actions.map((a) => [a, c.key] as const))
+)
+
+/** Map raw entries to client lines; unmapped entries are DROPPED. */
+export function toClientActivity(entries: readonly AuditEntry[]): ClientActivityLine[] {
+  const lines: ClientActivityLine[] = []
+  for (const entry of entries) {
+    const build = CLIENT_LANGUAGE[entry.action]
+    if (!build) continue
+    lines.push({
+      id: entry.id,
+      at: entry.ts,
+      summary: build(entry),
+      categoryKey: ACTION_TO_CATEGORY.get(entry.action) ?? 'other',
+    })
+  }
+  return lines
+}
+
+/** Options for the client-facing activity filter control. */
+export function clientActivityFilterOptions(): { value: string; label: string }[] {
+  return CLIENT_ACTIVITY_CATEGORIES.map((c) => ({ value: c.key, label: c.label }))
+}

--- a/src/lib/portal/operator/activity-language.ts
+++ b/src/lib/portal/operator/activity-language.ts
@@ -171,6 +171,17 @@ const ACTION_TO_CATEGORY: ReadonlyMap<string, string> = new Map(
   CLIENT_ACTIVITY_CATEGORIES.flatMap((c) => c.actions.map((a) => [a, c.key] as const))
 )
 
+/** Client-language summary for one entry, or null when unmapped. */
+export function clientSummaryFor(entry: AuditEntry): string | null {
+  const build = CLIENT_LANGUAGE[entry.action]
+  return build ? build(entry) : null
+}
+
+/** True when the entry has authored client language. */
+export function isClientVisibleAction(action: string): boolean {
+  return action in CLIENT_LANGUAGE
+}
+
 /** Map raw entries to client lines; unmapped entries are DROPPED. */
 export function toClientActivity(entries: readonly AuditEntry[]): ClientActivityLine[] {
   const lines: ClientActivityLine[] = []

--- a/src/lib/portal/operator/activity-read.ts
+++ b/src/lib/portal/operator/activity-read.ts
@@ -22,6 +22,7 @@
 
 import type { D1Database } from '@cloudflare/workers-types'
 import { readMachineRuntime, type RuntimeReadActor } from '../../operator/runtime-read'
+import { isClientVisibleAction } from './activity-language'
 import {
   createMachineRuntimeTransport,
   createRuntimeReadAudit,
@@ -70,7 +71,10 @@ export async function loadActivityPage(
     actor
   )
   const rows = result.ok ? parseAuditEntries(result.data) : []
-  return buildAuditListPage(rows, params)
+  // Curated client language only (Captain decision 7): entries without
+  // authored client copy never reach the page, regardless of filters.
+  const clientRows = rows.filter((r) => isClientVisibleAction(r.action))
+  return buildAuditListPage(clientRows, params)
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib/portal/operator/home.ts
+++ b/src/lib/portal/operator/home.ts
@@ -141,7 +141,7 @@ async function readRecentAuditEntries(
  * read (that is the admin view's job; ADR 0052 keeps this surface scoped to
  * the client's own operator). Missing row / NULL depth / read failure → 0.
  */
-async function readDraftQueueDepth(db: D1Database, customerSlug: string): Promise<number> {
+export async function readDraftQueueDepth(db: D1Database, customerSlug: string): Promise<number> {
   try {
     const row = await db
       .prepare('SELECT draft_queue_depth FROM operator_runtime_summary WHERE customer_slug = ?')

--- a/src/lib/portal/operator/home.ts
+++ b/src/lib/portal/operator/home.ts
@@ -35,7 +35,8 @@ import {
   type RuntimeReadEnv,
 } from '../../operator/runtime-read-transport'
 import { parseAuditEntries } from './activity-read'
-import { formatAuditAction, type AuditEntry } from './audit'
+import type { AuditEntry } from './audit'
+import { toClientActivity } from './activity-language'
 
 export interface HomeActivityItem {
   id: string
@@ -67,9 +68,12 @@ export interface HomeFeedsDeps {
   actorUserId: string
 }
 
-/** How many audit rows one dashboard read requests. Enough to fill the
- * recent-activity list and catch recent escalations without paginating. */
-const HOME_READ_LIMIT = 20
+/** How many audit rows one dashboard read requests. The frozen ADR 0043
+ * seam has no action filter, so curated-language filtering happens
+ * console-side (activity-language allowlist); the window is wide enough
+ * that a chatty agent's suppressed telemetry cannot starve the six-line
+ * client feed. The Machine clamps oversized limits. */
+const HOME_READ_LIMIT = 200
 /** How many recent-activity lines the dashboard shows. */
 const RECENT_ACTIVITY_MAX = 6
 /** How many escalation lines the dashboard shows. */
@@ -103,7 +107,11 @@ export async function loadHomeFeeds(
 
   return {
     runtimeConfigured: true,
-    recentActivity: entries.slice(0, RECENT_ACTIVITY_MAX).map(toActivityItem),
+    // Curated client language only (Captain decision 7): filter through the
+    // allowlist FIRST, then take the six most recent mapped lines.
+    recentActivity: toClientActivity(entries)
+      .slice(0, RECENT_ACTIVITY_MAX)
+      .map((line) => ({ id: line.id, summary: line.summary, at: line.at })),
     needsAttentionCount,
     escalations: entries
       .filter((e) => e.action === 'ESCALATION_FIRED')
@@ -155,21 +163,12 @@ export async function readDraftQueueDepth(db: D1Database, customerSlug: string):
   }
 }
 
-function toActivityItem(entry: AuditEntry): HomeActivityItem {
-  const label = formatAuditAction(entry.action)
-  return {
-    id: entry.id,
-    summary: entry.skill !== null ? `${label} (${entry.skill})` : label,
-    at: entry.ts,
-  }
-}
-
 function toEscalationItem(entry: AuditEntry): HomeEscalationItem {
   // Prefer the writer's recorded reason (what was escalated and why); fall
   // back to the action label — never fabricate a friendlier story.
   return {
     id: entry.id,
-    summary: entry.reason ?? formatAuditAction(entry.action),
+    summary: entry.reason ?? 'Flagged something for your attention',
     at: entry.ts,
   }
 }

--- a/src/lib/portal/product-access.ts
+++ b/src/lib/portal/product-access.ts
@@ -70,6 +70,26 @@ export async function getProductSubscription(
 }
 
 /**
+ * All live (provisioning/active/paused) subscriptions for an entity in
+ * one query. The offerings resolver and the Billing surface consume this
+ * instead of per-slug getProductSubscription calls.
+ */
+export async function listActiveSubscriptionsForEntity(
+  db: D1Database,
+  entityId: string
+): Promise<SubscriptionRow[]> {
+  const result = await db
+    .prepare(
+      `SELECT * FROM subscriptions
+        WHERE entity_id = ? AND status IN ('provisioning', 'active', 'paused')
+        ORDER BY created_at ASC`
+    )
+    .bind(entityId)
+    .all<SubscriptionRow>()
+  return result.results ?? []
+}
+
+/**
  * Return the list of active (non-revoked) roles this user holds on this
  * (entity, product) tuple. Empty array means the user has no access
  * inside the product even if the customer has a subscription.

--- a/src/pages/portal/products/hosted-agent/index.astro
+++ b/src/pages/portal/products/hosted-agent/index.astro
@@ -3,12 +3,8 @@ import { GOOGLE_FONTS_URL } from '../../../../lib/fonts'
 import '../../../../styles/global.css'
 import { BRAND_NAME } from '../../../../lib/config/brand'
 import { getPortalClient } from '../../../../lib/portal/session'
-import { getProductSubscription, listProductRoles } from '../../../../lib/portal/product-access'
-import {
-  getIntakeByEntity,
-  type HostedAgentIntakeRow,
-} from '../../../../lib/db/hosted-agent-intake'
-import { HOSTED_AGENT_PRODUCT_SLUG } from '../../../../lib/portal/hosted-agent-access'
+import { getProductSubscription } from '../../../../lib/portal/product-access'
+import { resolveHostedAgentState } from '../../../../lib/portal/hosted-agent-state'
 import PortalHeader from '../../../../components/portal/PortalHeader.astro'
 import PortalTabs from '../../../../components/portal/PortalTabs.astro'
 import PortalPageHead from '../../../../components/portal/PortalPageHead.astro'
@@ -48,37 +44,10 @@ if (!portalData.client) {
 
 const { user, client } = portalData
 
-type SurfaceState = 'no_subscription' | 'setup' | 'paused' | 'live' | 'no_role'
-
-let surfaceState: SurfaceState
-let intake: HostedAgentIntakeRow | null = null
-
-const subscription = await getProductSubscription(env.DB, client.id, HOSTED_AGENT_PRODUCT_SLUG)
+const agentState = await resolveHostedAgentState(env.DB, client.id, user.id)
+const { surfaceState, subscription, intake, needsIntake, needsKey, keyReceived } = agentState
 const operatorSubscription = await getProductSubscription(env.DB, client.id, 'operator')
 const operatorActive = operatorSubscription !== null
-if (!subscription) {
-  surfaceState = 'no_subscription'
-} else {
-  const roles = await listProductRoles(env.DB, user.id, client.id, HOSTED_AGENT_PRODUCT_SLUG)
-  intake = await getIntakeByEntity(env.DB, client.id)
-  if (roles.length === 0) {
-    surfaceState = 'no_role'
-  } else if (subscription.status === 'paused') {
-    surfaceState = 'paused'
-  } else if (subscription.status === 'active' && intake?.status === 'live') {
-    surfaceState = 'live'
-  } else {
-    surfaceState = 'setup'
-  }
-}
-
-const needsIntake = surfaceState === 'setup' && intake?.status === 'awaiting_intake'
-const needsKey =
-  surfaceState === 'setup' &&
-  intake !== null &&
-  intake.anthropic_key_status === 'pending' &&
-  intake.customer_slug !== null
-const keyReceived = intake?.anthropic_key_status === 'received'
 
 /**
  * The setup journey, rendered as a numbered step list so a new customer

--- a/src/pages/portal/products/operator/activity/index.astro
+++ b/src/pages/portal/products/operator/activity/index.astro
@@ -9,6 +9,10 @@ import {
   parseAuditListParams,
 } from '../../../../../lib/portal/operator/audit'
 import { loadActivityPage } from '../../../../../lib/portal/operator/activity-read'
+import {
+  CLIENT_ACTIVITY_CATEGORIES,
+  mappedActionsForCategories,
+} from '../../../../../lib/portal/operator/activity-language'
 import { getCustomerConfig } from '../../../../../lib/portal/customer-config'
 import {
   resolveComplianceView,
@@ -67,14 +71,23 @@ const config = await getCustomerConfig(env.DB, client.id)
 const customerSlug = config?.customer_slug ?? client.id
 
 const params = parseAuditListParams(Astro.url.searchParams)
+// Client-facing category filter (`cat`): expands to the underlying mapped
+// raw actions page-side, so the URL contract for `action=` bookmarks stays
+// intact while the control speaks client language only.
+const selectedCategories = Astro.url.searchParams
+  .getAll('cat')
+  .filter((k) => CLIENT_ACTIVITY_CATEGORIES.some((c) => c.key === k))
 // Default "last 7 days" window when no explicit range was requested, mirroring
 // the legacy viewer — keeps the surface responsive over long histories.
 const resolvedParams = (() => {
-  if (params.from === null && params.to === null) {
-    const range = defaultAuditDateRange()
-    return { ...params, from: range.from, to: range.to }
+  const withRange =
+    params.from === null && params.to === null
+      ? { ...params, from: defaultAuditDateRange().from, to: defaultAuditDateRange().to }
+      : params
+  if (selectedCategories.length > 0 && withRange.actions.length === 0) {
+    return { ...withRange, actions: mappedActionsForCategories(selectedCategories) }
   }
-  return params
+  return withRange
 })()
 
 const activityPage = await loadActivityPage(
@@ -140,7 +153,7 @@ const complianceView =
       <div class="mt-8 flex flex-col gap-6">
         <AuditFilterBar
           skills={resolvedParams.skills}
-          actions={resolvedParams.actions}
+          categories={selectedCategories}
           from={resolvedParams.from}
           to={resolvedParams.to}
           q={resolvedParams.q}

--- a/tests/activity-language.test.ts
+++ b/tests/activity-language.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest'
+import {
+  CLIENT_ACTIVITY_CATEGORIES,
+  MAPPED_ACTIONS,
+  SUPPRESSED_ACTIONS,
+  mappedActionsForCategories,
+  toClientActivity,
+} from '../src/lib/portal/operator/activity-language'
+import { AUDIT_ACTION_TYPES } from '../src/lib/portal/operator/audit'
+import type { AuditEntry } from '../src/lib/portal/operator/audit'
+
+function entry(action: string, extra: Partial<AuditEntry> = {}): AuditEntry {
+  return {
+    id: `e-${action}`,
+    ts: '2026-07-07T00:00:00Z',
+    actor: 'agent',
+    actorRole: 'agent',
+    action,
+    target: null,
+    decision: null,
+    reason: null,
+    skill: null,
+    ...extra,
+  }
+}
+
+describe('activity-language exhaustiveness (writer parity)', () => {
+  it('every writer-side action is deliberately MAPPED or SUPPRESSED, never both', () => {
+    const mapped = new Set(MAPPED_ACTIONS)
+    for (const action of AUDIT_ACTION_TYPES) {
+      const inMapped = mapped.has(action)
+      const inSuppressed = SUPPRESSED_ACTIONS.has(action)
+      expect(inMapped || inSuppressed, `${action} has no client-language decision`).toBe(true)
+      expect(inMapped && inSuppressed, `${action} is in both sets`).toBe(false)
+    }
+  })
+
+  it('every category action has authored language', () => {
+    const mapped = new Set(MAPPED_ACTIONS)
+    for (const category of CLIENT_ACTIVITY_CATEGORIES) {
+      for (const action of category.actions) {
+        expect(mapped.has(action), `${category.key}:${action} lacks language`).toBe(true)
+      }
+    }
+  })
+
+  it('the mapped vocabulary is a deliberate snapshot (additions require editing this test)', () => {
+    expect([...MAPPED_ACTIONS].sort()).toEqual(
+      [
+        'AGENT_RESUMED',
+        'AGENT_STOPPED',
+        'COMPLIANCE_PACKET_EXPORTED',
+        'CONNECTOR_AUTH_EXPIRED',
+        'CONNECTOR_AUTH_RESTORED',
+        'CONNECTOR_BOUND',
+        'CONNECTOR_UNBOUND',
+        'DRAFT_APPROVED',
+        'DRAFT_CREATED',
+        'DRAFT_EXPIRED',
+        'DRAFT_REJECTED',
+        'ESCALATION_ACKNOWLEDGED',
+        'ESCALATION_FIRED',
+        'REPLY_HELD',
+        'REPLY_SENT',
+        'SCOPE_CHANGED',
+        'SKILL_DISABLED',
+        'SKILL_ENABLED',
+        'TRUST_DEMOTED',
+        'TRUST_PROMOTED',
+      ].sort()
+    )
+  })
+})
+
+describe('toClientActivity', () => {
+  it('drops unmapped and unknown actions entirely', () => {
+    const lines = toClientActivity([
+      entry('INVARIANT_VIOLATION'),
+      entry('LLM_TURN_COMPLETED'),
+      entry('HONCHO_CONCLUSION_DISMISSED'),
+      entry('DRAFT_CREATED'),
+    ])
+    expect(lines).toHaveLength(1)
+    expect(lines[0].summary).toContain('draft')
+  })
+
+  it('never leaks raw action vocabulary into summaries', () => {
+    const lines = toClientActivity(AUDIT_ACTION_TYPES.map((a) => entry(a)))
+    for (const line of lines) {
+      expect(line.summary).not.toMatch(/[A-Z]{2,}_[A-Z]/)
+      expect(line.summary.toLowerCase()).not.toContain('invariant')
+    }
+  })
+
+  it('interpolates real row data only where present', () => {
+    const withSkill = toClientActivity([entry('SKILL_ENABLED', { skill: 'inbox-triage' })])
+    expect(withSkill[0].summary).toBe('A skill was turned on: inbox-triage')
+    const noSkill = toClientActivity([entry('SKILL_ENABLED')])
+    expect(noSkill[0].summary).toBe('A skill was turned on')
+    const escalation = toClientActivity([entry('ESCALATION_FIRED', { reason: 'Payment bounced' })])
+    expect(escalation[0].summary).toBe('Payment bounced')
+  })
+
+  it('assigns the category that owns the action', () => {
+    const [line] = toClientActivity([entry('CONNECTOR_BOUND', { target: 'Google Calendar' })])
+    expect(line.categoryKey).toBe('connections')
+    expect(line.summary).toBe('Connected Google Calendar')
+  })
+})
+
+describe('mappedActionsForCategories', () => {
+  it('empty selection returns the full mapped vocabulary (the SQL-side default filter)', () => {
+    expect(mappedActionsForCategories([]).sort()).toEqual([...MAPPED_ACTIONS].sort())
+  })
+
+  it('a category selection returns only its actions', () => {
+    expect(mappedActionsForCategories(['escalations']).sort()).toEqual([
+      'ESCALATION_ACKNOWLEDGED',
+      'ESCALATION_FIRED',
+    ])
+  })
+})

--- a/tests/forbidden-strings.test.ts
+++ b/tests/forbidden-strings.test.ts
@@ -708,6 +708,28 @@ describe('operator customer.yaml invariants', () => {
   })
 })
 
+describe('client surfaces render curated activity language only', () => {
+  // Portal IA rebuild, Captain decision 7 (2026-07-07): raw runtime audit
+  // vocabulary ("INVARIANT_VIOLATION" title-cased to "Invariant Violation")
+  // must never render on a client surface. formatAuditAction is the raw
+  // mechanical transform and stays admin-side; client surfaces go through
+  // src/lib/portal/operator/activity-language.ts (allowlist; unmapped
+  // renders nothing).
+  const CLIENT_SURFACE_ROOTS = [resolve('src/pages/portal'), resolve('src/components/portal')]
+
+  it('formatAuditAction is not imported by any client surface', () => {
+    for (const root of CLIENT_SURFACE_ROOTS) {
+      for (const file of collectSourceFiles(root)) {
+        const content = readFileSync(file, 'utf-8')
+        expect(
+          content.includes('formatAuditAction'),
+          `${file} references formatAuditAction — client surfaces must use activity-language`
+        ).toBe(false)
+      }
+    }
+  })
+})
+
 describe('operator client-portal surfaces stay vertical-agnostic (ADR 0052)', () => {
   // The Operator is a vertical-agnostic product (ADR 0052): client-portal
   // surfaces must not reintroduce law-vertical vocabulary or demo persona

--- a/tests/operator-home-feeds.test.ts
+++ b/tests/operator-home-feeds.test.ts
@@ -151,10 +151,10 @@ describe('loadHomeFeeds: live feeds through the audit_log seam', () => {
     expect(feeds.recentActivity).toEqual([
       {
         id: 'a1',
-        summary: 'Draft Created (matter-memo-on-update)',
+        summary: 'Prepared a draft for your review: matter-memo-on-update',
         at: '2026-07-01T10:00:00.000Z',
       },
-      { id: 'a2', summary: 'Reply Sent', at: '2026-07-01T09:00:00.000Z' },
+      { id: 'a2', summary: 'Replied to a message', at: '2026-07-01T09:00:00.000Z' },
     ])
   })
 
@@ -189,7 +189,7 @@ describe('loadHomeFeeds: live feeds through the audit_log seam', () => {
         summary: 'Deadline conflict on discovery response',
         at: '2026-07-01T10:00:00.000Z',
       },
-      { id: 'e2', summary: 'Escalation Fired', at: '2026-07-01T08:00:00.000Z' },
+      { id: 'e2', summary: 'Flagged something for your attention', at: '2026-07-01T08:00:00.000Z' },
     ])
   })
 })

--- a/tests/portal-offerings.test.ts
+++ b/tests/portal-offerings.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from 'vitest'
+import { deriveOfferings } from '../src/lib/portal/offerings'
+import { buildPortalNav, isNavDestinationActive } from '../src/lib/portal/nav'
+import type { Engagement } from '../src/lib/db/engagements'
+import type { Quote } from '../src/lib/db/quotes'
+import type { SubscriptionRow } from '../src/lib/portal/product-access'
+
+function engagement(status: string, id = `eng-${status}`): Engagement {
+  return { id, status } as unknown as Engagement
+}
+function quote(status: string, id = `q-${status}`): Quote {
+  return { id, status } as unknown as Quote
+}
+function subscription(slug: string, status = 'active'): SubscriptionRow {
+  return { id: `sub-${slug}`, product_slug: slug, status } as unknown as SubscriptionRow
+}
+
+const NOTHING = { engagements: [], quotes: [], subscriptions: [], hasInvoices: false }
+
+describe('deriveOfferings', () => {
+  it('nothing owned: no engagement presence, no products, no invoices', () => {
+    const o = deriveOfferings(NOTHING)
+    expect(o.engagement.present).toBe(false)
+    expect(o.operator).toBeNull()
+    expect(o.hostedAgent).toBeNull()
+    expect(o.hasInvoices).toBe(false)
+  })
+
+  it('proposal-only: present with an open proposal and no active engagement', () => {
+    const o = deriveOfferings({ ...NOTHING, quotes: [quote('sent')] })
+    expect(o.engagement.present).toBe(true)
+    expect(o.engagement.openProposal?.id).toBe('q-sent')
+    expect(o.engagement.activeEngagement).toBeNull()
+  })
+
+  it('active engagement without proposals', () => {
+    const o = deriveOfferings({ ...NOTHING, engagements: [engagement('in_progress')] })
+    expect(o.engagement.activeEngagement?.id).toBe('eng-in_progress')
+    expect(o.engagement.openProposal).toBeNull()
+    expect(o.engagement.pastEngagements).toHaveLength(0)
+  })
+
+  it('active engagement AND open follow-on proposal are orthogonal (both set)', () => {
+    const o = deriveOfferings({
+      ...NOTHING,
+      engagements: [engagement('in_progress')],
+      quotes: [quote('sent')],
+    })
+    expect(o.engagement.activeEngagement).not.toBeNull()
+    expect(o.engagement.openProposal).not.toBeNull()
+  })
+
+  it('past-only: completed engagements keep the destination present', () => {
+    const o = deriveOfferings({
+      ...NOTHING,
+      engagements: [engagement('completed'), engagement('cancelled', 'eng-2')],
+    })
+    expect(o.engagement.present).toBe(true)
+    expect(o.engagement.activeEngagement).toBeNull()
+    expect(o.engagement.pastEngagements).toHaveLength(2)
+  })
+
+  it('signed/declined quotes do not create an open proposal but keep presence', () => {
+    const o = deriveOfferings({ ...NOTHING, quotes: [quote('accepted'), quote('declined', 'q2')] })
+    expect(o.engagement.present).toBe(true)
+    expect(o.engagement.openProposal).toBeNull()
+  })
+
+  it('products-only: subscriptions resolve by slug, engagement absent', () => {
+    const o = deriveOfferings({
+      ...NOTHING,
+      subscriptions: [subscription('hosted-agent', 'provisioning'), subscription('operator')],
+    })
+    expect(o.engagement.present).toBe(false)
+    expect(o.operator?.product_slug).toBe('operator')
+    expect(o.hostedAgent?.status).toBe('provisioning')
+  })
+})
+
+describe('buildPortalNav', () => {
+  it('nothing owned: Home only', () => {
+    const nav = buildPortalNav(deriveOfferings(NOTHING))
+    expect(nav.map((d) => d.label)).toEqual(['Home'])
+  })
+
+  it('everything owned: all five destinations in fixed order with sequential anchors', () => {
+    const nav = buildPortalNav(
+      deriveOfferings({
+        engagements: [engagement('in_progress')],
+        quotes: [],
+        subscriptions: [subscription('operator'), subscription('hosted-agent')],
+        hasInvoices: true,
+      })
+    )
+    expect(nav.map((d) => d.label)).toEqual(['Home', 'Engagement', 'Operator', 'Agent', 'Billing'])
+    expect(nav.map((d) => d.anchor)).toEqual(['01', '02', '03', '04', '05'])
+  })
+
+  it('agent-only subscriber: Home, Agent, Billing (subscription implies billing)', () => {
+    const nav = buildPortalNav(
+      deriveOfferings({ ...NOTHING, subscriptions: [subscription('hosted-agent')] })
+    )
+    expect(nav.map((d) => d.label)).toEqual(['Home', 'Agent', 'Billing'])
+    expect(nav.map((d) => d.anchor)).toEqual(['01', '02', '03'])
+  })
+
+  it('invoices alone light up Billing', () => {
+    const nav = buildPortalNav(deriveOfferings({ ...NOTHING, hasInvoices: true }))
+    expect(nav.map((d) => d.label)).toEqual(['Home', 'Billing'])
+  })
+})
+
+describe('isNavDestinationActive', () => {
+  const nav = buildPortalNav(
+    deriveOfferings({
+      engagements: [engagement('in_progress')],
+      quotes: [],
+      subscriptions: [subscription('operator')],
+      hasInvoices: true,
+    })
+  )
+  const byLabel = (label: string) => nav.find((d) => d.label === label)!
+
+  it('Home is active only on the exact root', () => {
+    expect(isNavDestinationActive(byLabel('Home'), '/portal')).toBe(true)
+    expect(isNavDestinationActive(byLabel('Home'), '/portal/')).toBe(true)
+    expect(isNavDestinationActive(byLabel('Home'), '/portal/engagement')).toBe(false)
+  })
+
+  it('destinations match self and descendants', () => {
+    expect(isNavDestinationActive(byLabel('Engagement'), '/portal/engagement')).toBe(true)
+    expect(isNavDestinationActive(byLabel('Engagement'), '/portal/engagement/proposals/abc')).toBe(
+      true
+    )
+    expect(isNavDestinationActive(byLabel('Operator'), '/portal/engagement')).toBe(false)
+  })
+})


### PR DESCRIPTION
## What (approved portal-IA plan, PR 2 of 6 — independent, small)

Captain decision 7 made real: **no raw runtime vocabulary on client surfaces.**

- **Operator home feed**: allowlist-filtered before slicing; read window 20→200 (the frozen ADR 0043 seam has no action-filter param — documented deviation from the critique's SQL-side suggestion; wide-window console-side filtering is the Activity page's existing design). Escalations stop falling back to raw labels.
- **Activity page**: unmapped rows never reach pagination; rows render curated summaries; the filter becomes an "Activity type" category control (`cat` param expands page-side to mapped actions — `action=` bookmark contract intact, portal-operator-audit tests untouched).
- **New merge gate**: guard test bans `formatAuditAction` from `src/pages/portal/**` + `src/components/portal/**`.

## Verification

`npm run verify` green (home-feeds expectations updated raw→curated). Post-deploy: operator-holding seat's live HTML greps zero for "Invariant"; feed non-empty despite noisy raw log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MJF9rQDhVKLv2ADbbApPgi