### PR TITLE
docs(operator): webhook-loop verification, exclusion teaching + rehearsal-seat ops

### DIFF
--- a/operator/customers/_template/customer.yaml
+++ b/operator/customers/_template/customer.yaml
@@ -134,6 +134,19 @@ connectors:
 #     event_type: document.added
 #     skill: discovery-response
 #     persona: '[PERSONA SLUG]'
+#     # OPTIONAL trigger exceptions (gate-enforced: excluded deliveries get a 202 +
+#     # WEBHOOK_SUPPRESSED audit row, no agent wake). Author these when a skill must
+#     # NOT fire for specific matters or specific actors — e.g. an internal
+#     # ops/notepad matter the Operator should not supervise, or a principal whose
+#     # own edits should not trigger a supervision memo. Values are vendor GUIDs;
+#     # the validator rejects unknown keys and non-GUID entries because the runtime
+#     # gate FAILS OPEN — a typo must fail authoring loudly, not silently forward.
+#     # Unauthored = no exceptions (ADR 0035, no imposed defaults).
+#     exclude:
+#       matters:
+#         - '[MATTER GUID]'   # e.g. an internal ops/digest-home matter
+#       actors:
+#         - '[VENDOR USER GUID]'   # e.g. the supervising principal's own edits
 
 # ---- SCOPE ----
 scope:

--- a/operator/customers/ashton-price/TEST-PLAN.md
+++ b/operator/customers/ashton-price/TEST-PLAN.md
@@ -124,6 +124,27 @@ Seeding is test-infrastructure hydration on our own tenant. It is distinct
 from standing gate (b), which governs delivery writes on the client's
 account (Captain, 2026-07-04).
 
+**Rehearsal-seat lifecycle between waves.** The rehearsal seat stays seeded
+between test waves, so its `pre_run` wake-gate (which suppresses only on a
+_provably empty_ tenant) keeps waking the scheduled tracker/digest crons daily
+— ~$1–3/day of Sonnet for digests nobody reads. The gate is working as
+designed; the right lever is to quiesce the seat when no wave is running:
+
+```
+operator/bin/pause-customer.sh pilot-smokeball --reason "between L2 waves"
+operator/bin/pause-customer.sh pilot-smokeball --resume   # before the next wave
+```
+
+Pause writes `/opt/data/.paused` and restarts the machine warm; the agent loop
+and cron scheduler never start (`bootstrap.sh` step 9), so all wakes — cron,
+webhook, inbound — stop, with no `customer.yaml` edit and no re-provision. It
+is an all-or-nothing kill switch, fully reversible. De-seeding is rejected (no
+teardown script; a full re-seed each wave is fragile); always-on is rejected
+(nothing drives the seat between waves and the client is not connected).
+Pausing is a Captain directive (it disables scheduled behaviour); this documents
+the mechanism and the recommendation — actually pausing a given wave-gap is the
+Captain's call.
+
 ## 4. Scenario suites by process
 
 ### Discovery (the pattern lane — deepest, activates first)

--- a/operator/grading/lane-map.yaml
+++ b/operator/grading/lane-map.yaml
@@ -1,0 +1,88 @@
+# Lane map — machine-readable transcription of ashton-price/TEST-PLAN.md §4.
+#
+# Purpose: make the §6 regression rule executable. §6 says "any change to a skill
+# re-runs L1 for every touched skill AND the owning lane's L2 scenarios." That
+# requires knowing, for a changed skill, which lane(s) own it and which L2
+# scenario IDs to re-run. §4 encodes that only as prose tables; this file lifts it
+# into data so the mapping is looked up, not eyeballed.
+#
+# Source of truth remains TEST-PLAN.md §4 — if a lane's chain changes there, update
+# this file in the same edit. This is documentation (a lookup table used by hand
+# today); the driver-side lane-subset selection that would CONSUME it is deliberately
+# deferred until a second real re-cert needs it (automation with one consumer is
+# premature — see plan zesty-churning-bubble, Part D).
+#
+# Provenance: transcribed 2026-07-07 from TEST-PLAN.md §4 (Discovery … Cross-cutting).
+
+lanes:
+  discovery: # the pattern lane — deepest, activates first
+    scenarios: [DISC-1, DISC-2, DISC-3, DISC-4, DISC-5]
+    chain:
+      - matter-inbox-router # M6 email path
+      - discovery-served-watch
+      - client-verification-tracker
+      - discovery-response-tracker
+      - discovery-response-staging
+      - separate-statement-assembler
+      - opposing-response-deficiency-review
+      - meet-and-confer-drafter
+    safety_assertions:
+      - verification-attorney-approved-send
+      - assembly-no-argument
+      - meet-and-confer-attorney-decision
+
+  initiation:
+    scenarios: [INIT-1, INIT-2]
+    chain: [matter-initiation-setup, service-confirmation-watcher]
+
+  medical_records:
+    scenarios: [MED-1, MED-2]
+    chain: [medical-records-chaser, medical-chronology-maintainer]
+    safety_assertions: [medical-facts-quote-only]
+
+  motions:
+    scenarios: [MOT-1, MOT-2]
+    chain: [motion-calendar-tracker, motion-package-assembler]
+    safety_assertions: [assembly-no-argument]
+
+  minors_compromise:
+    scenarios: [MIN-1]
+    chain: [minors-compromise-packet]
+
+  trial_prep:
+    scenarios: [TRIAL-1]
+    chain: [trial-binder-assembler]
+
+  settlement_liens:
+    scenarios: [SETT-1, SETT-2, SETT-3]
+    chain: [mediation-settlement-tracker, lien-ledger-tracker, settlement-statement-feeder]
+    safety_assertions: [lien-no-reduction-math, settlement-figures-from-authored]
+
+  cross_cutting:
+    scenarios: [WATCH-1, ROUTE-1] # WATCH-1 = L3 backbone; ROUTE-1 = injection surface, adversarial variants mandatory every level
+    chain: [daily-needs-you-digest, matter-inbox-router]
+
+# Reverse index: skill -> lanes that must re-run their L2 suite when the skill changes.
+# matter-inbox-router appears in two lanes (discovery M6 path + cross-cutting ROUTE-1),
+# so a change to it re-runs BOTH — the case the prose is easy to miss.
+skill_to_lanes:
+  matter-inbox-router: [discovery, cross_cutting]
+  discovery-served-watch: [discovery]
+  client-verification-tracker: [discovery]
+  discovery-response-tracker: [discovery]
+  discovery-response-staging: [discovery]
+  separate-statement-assembler: [discovery]
+  opposing-response-deficiency-review: [discovery]
+  meet-and-confer-drafter: [discovery]
+  matter-initiation-setup: [initiation]
+  service-confirmation-watcher: [initiation]
+  medical-records-chaser: [medical_records]
+  medical-chronology-maintainer: [medical_records]
+  motion-calendar-tracker: [motions]
+  motion-package-assembler: [motions]
+  minors-compromise-packet: [minors_compromise]
+  trial-binder-assembler: [trial_prep]
+  mediation-settlement-tracker: [settlement_liens]
+  lien-ledger-tracker: [settlement_liens]
+  settlement-statement-feeder: [settlement_liens]
+  daily-needs-you-digest: [cross_cutting]

--- a/operator/skills/matter-memo-on-update/references/algorithm.md
+++ b/operator/skills/matter-memo-on-update/references/algorithm.md
@@ -16,7 +16,7 @@ A successful call resets the breaker's error count, so the realistic worst case 
 
 1. **Change key.** `op-mmou:<matterId>:<timestamp>` - the raw `.NET ticks` value verbatim.
 2. **Read existing memos once** with `get_memos_on_matter(matterId)`. If any memo body already contains that exact change-key tag, the change is already logged → **STOP, write nothing.** Webhook deliveries can repeat; a repeat is not a new change.
-3. **On a `get_memos` error, do not retry.** Proceed to Phase 2. A missing dedupe read at worst yields one extra memo on a redelivery - bounded, and the skill can never loop: it is routed only from `{source: smokeball, event_type: matter.updated}`, and its own `create_memo` emits a `memo.*` event, never `matter.updated`. (If a `memo.*` event ever reaches this skill, that is a routing misconfiguration - STOP and surface it.)
+3. **On a `get_memos` error, do not retry.** Proceed to Phase 2. A missing dedupe read at worst yields one extra memo on a redelivery - bounded, and the skill can never loop: it is routed only from `{source: smokeball, event_type: matter.updated}`, and its own `create_memo` emits a `memo.*` event, never `matter.updated`. (If a `memo.*` event ever reaches this skill, that is a routing misconfiguration - STOP and surface it.) Verified live 2026-07-07 (`vfy_01KWYJV4EYMW1C575GC3H9B80V`): a seat `create_memo` produced no subsequent `matter.updated`. Apparent `matter.updated` "cycling" in the ledger is always an external editor (the L2 driver's `patch-matter`, or a human matter edit), not self-feed.
 
 ## Phase 2 - Resolve actor and source (degrade honestly, never fabricate)
 


### PR DESCRIPTION
## What this is

Doc/config output from the cost-forensics investigation that started with "another \$10 Anthropic charge." The thread traced to the M1/L2 rehearsal wave, then to a suspected self-feeding webhook loop in `matter-memo-on-update`. This PR captures what was **verified live** on pilot-smokeball; two runtime findings are surfaced (one in #1781) and one requires a Captain-timed redeploy (not in this PR).

## The headline: there is no autonomous loop

I framed the loop as a go-live blocker (#1781); a controlled test disproved it (`vfy_01KWYJV4EYMW1C575GC3H9B80V`):

- Fired one `matter.updated` on a non-excluded rehearsal matter → skill wrote one memo → **zero** subsequent `matter.updated` over a full 16-minute window.
- Real Smokeball webhook latency is 37s; the "8–30 min gaps" I mistook for a cascade were a SQL join artifact.
- The Jul 6–7 "cycling" was a prior agent's driven `patch-matter` test triggers (its EOS: "three rounds of chasing Smokeball's actual webhook format"). `matter.updated` fires on matter **edits**, not memo writes — so `algorithm.md`'s "can never loop" claim is **true**.

## Changes

| File | Change |
|---|---|
| `operator/skills/matter-memo-on-update/references/algorithm.md` | Anchor the (true) no-loop claim with the verification id — evidence, not a correction |
| `operator/customers/_template/customer.yaml` | Teach the `webhook_triggers.exclude` pattern (matters/actors) so new seats aren't loop/noise-exposed; the gate fails open, so authoring must be explicit |
| `operator/grading/lane-map.yaml` | Machine-readable transcription of TEST-PLAN §4 (lane→skills + reverse skill→lanes) making the §6 regression rule executable-by-hand |
| `operator/customers/ashton-price/TEST-PLAN.md` §3 | Document the `pause-customer.sh` quiesce policy for the rehearsal seat between waves (~\$1–3/day idle cron burn). Recommendation only; pausing is a Captain directive |

## Surfaced separately, NOT fixed here

**The ops-matter exclusion is not enforcing on the live seat** (`vfy_01KWYKTK3VQC550YZSABVX1TV4`, detailed in #1781). Firing `matter.updated` on the excluded ops matter routed to the skill and wrote a memo. Root cause: the deployed image (release v48) predates the #1779 nested-payload fix — the live envelope nests the matter id at `payload.id`, which the pre-#1779 gate can't read, so it fails open. The current checkout pins `OVERLAY_REF=6e685b03` (fix + passing test). **Fix = reprovision the seat at that ref, then re-run the positive test.** Left for a Captain-timed redeploy: it's an image rebuild (more than a restart) and low-severity under Branch D (the exclusion is a correctness nicety — don't memo the internal digest-home matter — not a loop-breaker).

## Verification

- No-loop: `vfy_01KWYJV4EYMW1C575GC3H9B80V` (16-min clean window + two non-excluded cron memos that produced no webhook).
- Exclusion-not-enforcing: `vfy_01KWYKTK3VQC550YZSABVX1TV4`.
- `npm run verify` green (typecheck/lint/format/test); prettier applied to all four files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)