### PR TITLE
feat(operator): secret custody classification + fail-closed keyless-build guard (#1783)

### DIFF
--- a/docs/runbooks/operator/keyless-build-handoff.md
+++ b/docs/runbooks/operator/keyless-build-handoff.md
@@ -1,0 +1,62 @@
+# Keyless build → inject-at-handoff (Operator provisioning discipline)
+
+**Issue:** [#1783](https://github.com/venturecrane/ss-console/issues/1783) · **Guard:** `operator/bin/lib/secret_custody.py` · **Classification:** `operator/contracts/env-consumption.yaml` (`custody:`)
+
+## Why
+
+`provision-customer.sh` is driven by `reprovision.sh` = `infisical run --env=prod --path=/ss -- provision-customer.sh <slug>`, which injects the **entire `/ss` vault** as env vars and stages the customer-owned ones onto the Machine in one uninterrupted pass. We have repeatedly been burned by real secrets and fixture data entering the build too early. The discipline: **build the overlay against placeholders, inject real customer credentials only at handoff through a door we never see.**
+
+## The custody boundary
+
+Every provisioning secret is one of two classes (see `operator/contracts/env-consumption.yaml` `custody:` and the connector tables in `secret_custody.py`):
+
+- **infra** — operator/SMD-owned (R2, Fly, Sentry, HMAC masters, bucket names, D1 bindings). Safe to be **real or emulated** during a build; we hold it regardless of which customer is provisioning.
+- **customer** — carries or grants access to a specific customer's world (their model key, connector OAuth creds, inbox/webhook secrets, Google identity). Enters **only at handoff**. A build sees a placeholder; staging/keyless runs must not borrow the live value. `GOOGLE_*` is customer-by-**effect** (DWD impersonation) → staging **substitutes** an isolated credential rather than the live one.
+
+Classify one name:
+
+```bash
+uv run --with pyyaml python3 operator/bin/lib/secret_custody.py classify SMOKEBALL_CLIENT_ID   # -> customer
+```
+
+**Fail-closed rule:** an unclassified secret raises. `operator/bin/tests/test_secret_custody.py::test_every_staged_secret_is_classified` asserts every secret `provision-customer.sh` stages is classified — so a newly added customer secret cannot slip past the placeholder allowlist. If you add a staged secret, classify it in the same PR (default customer-owned secrets to `customer`).
+
+## Phase A — keyless build (no real customer secret in scope)
+
+Validate + materialize `customer.yaml`, render `fly.toml`, create app/volume/bucket, deploy, boot smoke test, safety-substrate invariants, overlay activation gate — all with **placeholder** customer-owned values and real (or emulated) infra creds. The Machine comes up fully governed and **inert on every customer capability**; connectors bound to placeholders fail closed at the connector boundary (existing posture).
+
+The live, exercised form of Phase A today is **staging**:
+
+```bash
+operator/bin/reprovision-staging.sh          # hermes-smd-staging, wired to nothing real
+```
+
+It computes the isolate set from the classification (`secret_custody.py isolate-names smd-staging`), **blanks every customer-owned secret**, and **substitutes** an isolated Google SA. This replaced a hand-maintained `CLIO_*`-only denylist that failed open (it leaked AgentMail / Smokeball / per-seat Anthropic / webhook secrets onto staging the moment a staging seat bound that connector).
+
+Inspect the isolate set for any seat:
+
+```bash
+uv run --with pyyaml python3 operator/bin/lib/secret_custody.py isolate-names <slug>
+```
+
+## Phase B — real injection at handoff (the door we never see)
+
+The customer (or Captain at go-live) injects each customer-owned secret through a relay whose plaintext the build never observes:
+
+- **BYO Anthropic (Hosted Agent):** `src/lib/operator/infisical-secret-transport.ts` writes the key to per-customer `/ss/hosted/<slug>/ANTHROPIC_API_KEY`; the provisioner's per-seat path reads it back. Ships dark until `INFISICAL_UA_*` is wired (returns `not_enabled`).
+- **Connector secrets:** `src/lib/operator/credential-secret-transport.ts` (ADR 0036 per-customer Fly-secret relay). Deliberately stubbed fail-closed (`not_enabled`) until wired.
+
+The value flows in over TLS and only a non-secret `ref` comes back; it is never logged or returned.
+
+## Follow-on (phase 2, not yet built — issue #1783)
+
+- `operator/bin/build-keyless.sh` — prod keyless build against an **emulated vault**: every customer-owned slot filled with `secret_custody.placeholder_for(name)` and `SMD_BUILD_PHASE=keyless`, guarded by `secret_custody.assert_no_real_customer_secret(env)` (raises if any customer-owned var holds a non-placeholder value). _(This whole-env guard is NOT wired into `reprovision-staging.sh`: `/ss` legitimately holds other seats' per-seat keys, so staging isolates by the contract-derived blank list instead.)_
+- `assert_sealed` wired into `provision-customer.sh` post-deploy — refuse go-live while any bound customer-owned secret is still a placeholder.
+- Emulated S3 for the config-bucket upload during a keyless build.
+
+## Do / don't
+
+- **Do** classify every new staged secret in `env-consumption.yaml` (or the `secret_custody.py` connector tables) in the same PR that adds it.
+- **Do** run `reprovision-staging.sh` before touching a real seat with any deploy/boot/env change.
+- **Don't** re-introduce a hand-maintained blank list — derive from the classification.
+- **Don't** echo any secret value; the guard and CLI operate on **names** only.

--- a/operator/bin/lib/secret_custody.py
+++ b/operator/bin/lib/secret_custody.py
@@ -1,0 +1,287 @@
+"""Secret custody classification for the keyless-build / inject-at-handoff discipline.
+
+WHY THIS EXISTS. `provision-customer.sh` is driven by `reprovision.sh` =
+`infisical run --env=prod --path=/ss -- provision-customer.sh <slug>`, which
+injects the ENTIRE /ss vault as env vars and stages the customer-owned ones onto
+the Machine in one uninterrupted pass. There is no phase boundary between
+"build the overlay against placeholders" and "inject the real customer's
+credentials at handoff." The embryonic version of the right pattern —
+`reprovision-staging.sh` — is a hand-maintained DENYLIST that fails OPEN: any
+customer-owned secret it does not explicitly blank (Smokeball, AgentMail,
+per-seat Anthropic, webhook secrets) leaks straight onto the box.
+
+This module is the single classification API. Every provisioning secret is
+`infra` (operator/SMD-owned; safe to be real or emulated during a keyless build)
+or `customer` (carries or grants access to a specific customer's world; must
+enter only at handoff through a door we never see). `classify()` FAILS CLOSED:
+an unrecognized secret raises `UnclassifiedSecret`, and the completeness test
+(operator/bin/tests/test_secret_custody.py) asserts nothing `provision-customer.sh`
+stages raises — so a newly added customer secret cannot silently slip past the
+keyless-build placeholder allowlist.
+
+Sources of truth, in order:
+  1. operator/contracts/env-consumption.yaml `custody:` field (the ~22 vars it
+     already tracks — the boot/agent/broker core).
+  2. The connector + provisioning secrets NOT in that contract (it explicitly
+     scopes out mcp-subprocess connector creds; see operator/bin/lib/env_arrays.py).
+     Those live in the explicit tables below, cited to their provision-customer.sh
+     staging sites so the two cannot drift silently.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+INFRA = "infra"
+CUSTOMER = "customer"
+VALID_CUSTODY = frozenset({INFRA, CUSTOMER})
+
+# Placeholder sentinel a keyless build stamps into every customer-owned slot.
+# Deliberately unmistakable so `looks_like_placeholder` can never false-positive
+# a real credential (no real Anthropic/Clio/Smokeball/AgentMail secret is shaped
+# like this).
+PLACEHOLDER_SENTINEL = "SMD_KEYLESS_PLACEHOLDER::"
+
+
+class UnclassifiedSecret(KeyError):
+    """A provisioning secret whose custody class is unknown. Fail closed — a new
+    customer secret must be classified before it can reach the build path."""
+
+
+# ---------------------------------------------------------------------------
+# Connector + provisioning secrets NOT carried by env-consumption.yaml.
+# Each is cited to its provision-customer.sh staging site. Adding a connector
+# secret to the provisioner without adding it here fails the completeness test.
+# ---------------------------------------------------------------------------
+
+# Customer-owned by EXACT name (staged, or read as a source, by the provisioner).
+_CUSTOMER_EXACT: frozenset[str] = frozenset(
+    {
+        # Clio connector (provision-customer.sh:471-474). CLIO_CLIENT_ID/SECRET
+        # are also in env-consumption; the encryption key + seed token are not.
+        "CLIO_ENCRYPTION_KEY",
+        "CLIO_TOKENS_ENC_B64",
+        # AgentMail inbound (provision-customer.sh:494-502). The Svix signing
+        # secret + the router forward-verify secret are per-customer.
+        "WEBHOOK_SECRET_AGENTMAIL",
+        "SMD_WEBHOOK_SIGNING_SECRET",
+        # Smokeball connector (provision-customer.sh:560-575). Both the
+        # environment-specific SOURCE names in /ss and the env-agnostic runtime
+        # names the connector reads.
+        "SMOKEBALL_STAGING_CLIENT_ID",
+        "SMOKEBALL_STAGING_CLIENT_SECRET",
+        "SMOKEBALL_STAGING_API_KEY",
+        "SMOKEBALL_PROD_CLIENT_ID",
+        "SMOKEBALL_PROD_CLIENT_SECRET",
+        "SMOKEBALL_PROD_API_KEY",
+        "SMOKEBALL_CLIENT_ID",
+        "SMOKEBALL_CLIENT_SECRET",
+        "SMOKEBALL_API_KEY",
+        "SMOKEBALL_REFRESH_TOKEN",
+        # Smokeball webhook ingress (provision-customer.sh:611-616).
+        "WEBHOOK_SECRET_SMOKEBALL",
+        "WEBHOOK_SMOKEBALL_CLIENT_ID",
+    }
+)
+
+# Customer-owned by PREFIX: per-seat and environment-specific names. The
+# provisioner reads per-seat overrides like ANTHROPIC_API_KEY__<CID> (:348) and
+# WEBHOOK_SECRET_AGENTMAIL__<CID> (:495); a `build:` connector may declare its
+# own SMOKEBALL_-family credentials.
+_CUSTOMER_PREFIX: tuple[str, ...] = (
+    "ANTHROPIC_API_KEY__",
+    "WEBHOOK_SECRET_AGENTMAIL__",
+    "WEBHOOK_SECRET_SMOKEBALL__",
+    "WEBHOOK_SMOKEBALL_CLIENT_ID__",
+    "CLIO_",
+    "SMOKEBALL_STAGING_",
+    "SMOKEBALL_PROD_",
+)
+
+# Infra-owned staged/derived names NOT in env-consumption. These are SMD-owned
+# masters, values DERIVED from an infra master, or non-secret config strings the
+# provisioner happens to stage. Enumerated so the completeness check classifies
+# every staged name without falling through to CUSTOMER by accident.
+_INFRA_EXACT: frozenset[str] = frozenset(
+    {
+        # Shared observability (provision-customer.sh:424-425).
+        "SENTRY_DSN",
+        "MACHINE_HEARTBEAT_KEY",
+        # Per-customer keys DERIVED from an infra HMAC master (never the master).
+        "OPERATOR_RUNTIME_READ_KEY",  # from OPERATOR_RUNTIME_READ_SECRET (:439)
+        "WEBHOOK_SECRET_MCP",  # from OPERATOR_MCP_WEBHOOK_SECRET (:454)
+        "WEBHOOK_SECRET_HANDOFF",  # == WEBHOOK_SECRET_MCP (:455)
+        "SMOKEBALL_OAUTH_STATE_KEY",  # from OPERATOR_OAUTH_STATE_MASTER (:588)
+        # Infra HMAC masters / infra tokens read on the provisioning host.
+        "OPERATOR_MCP_WEBHOOK_SECRET",
+        "OPERATOR_OAUTH_STATE_MASTER",
+        "HEALTHCHECKS_API_KEY",
+        "HEALTHCHECKS_WEBHOOK_SECRET",
+        "HEALTHCHECKS_PING_URL",  # derived ping URL, staged (:720)
+        # Non-secret Smokeball config strings staged as secrets for uniformity.
+        "SMOKEBALL_ENVIRONMENT",  # 'staging' | 'production' (:577)
+        "SMOKEBALL_AUTH_MODE",  # grant mode literal (:581)
+        "SMOKEBALL_ACCOUNT_ID",  # multi-account URL prefix (:595)
+    }
+)
+
+
+def repo_root() -> Path:
+    """ss-console repo root, anchored to THIS module's own location.
+    operator/bin/lib/secret_custody.py -> parents[3] == repo root."""
+    return Path(__file__).resolve().parents[3]
+
+
+def contract_path(root: Path | None = None) -> Path:
+    return (root or repo_root()) / "operator" / "contracts" / "env-consumption.yaml"
+
+
+def load_contract_custody(path: Path | None = None) -> dict[str, str]:
+    """Return {var: custody} from env-consumption.yaml. Raises if any tracked
+    var is missing or carries an invalid custody class (fail closed)."""
+    p = path or contract_path()
+    data = yaml.safe_load(p.read_text(encoding="utf-8")) or {}
+    vars_ = data.get("vars")
+    if not isinstance(vars_, dict) or not vars_:
+        raise ValueError(f"env-consumption contract {p} has no `vars` map")
+    out: dict[str, str] = {}
+    for name, spec in vars_.items():
+        if not isinstance(spec, dict):
+            raise ValueError(f"{name}: contract entry is not a mapping")
+        custody = spec.get("custody")
+        if custody not in VALID_CUSTODY:
+            raise ValueError(
+                f"{name}: missing or invalid custody {custody!r} "
+                f"(must be one of {sorted(VALID_CUSTODY)})"
+            )
+        out[name] = custody
+    return out
+
+
+def classify(name: str, contract_custody: dict[str, str] | None = None) -> str:
+    """Classify a provisioning secret NAME as INFRA or CUSTOMER. Fails closed
+    (`UnclassifiedSecret`) on an unrecognized name so a new customer secret
+    cannot silently reach the build path unclassified."""
+    contract = load_contract_custody() if contract_custody is None else contract_custody
+    if name in contract:
+        return contract[name]
+    if name in _INFRA_EXACT:
+        return INFRA
+    if name in _CUSTOMER_EXACT:
+        return CUSTOMER
+    if any(name.startswith(p) for p in _CUSTOMER_PREFIX):
+        return CUSTOMER
+    raise UnclassifiedSecret(
+        f"{name!r} is not classified. Add it to operator/contracts/env-consumption.yaml "
+        f"(custody:) or to operator/bin/lib/secret_custody.py. Default customer-owned "
+        f"secrets to `customer` — fail closed."
+    )
+
+
+def is_customer_owned(name: str, contract_custody: dict[str, str] | None = None) -> bool:
+    return classify(name, contract_custody) == CUSTOMER
+
+
+def customer_owned_names(contract_custody: dict[str, str] | None = None) -> set[str]:
+    """The exact customer-owned secret NAMES (no per-seat expansion). Prefix
+    families are represented by their base entries in the explicit tables plus
+    any env-consumption customer vars."""
+    contract = load_contract_custody() if contract_custody is None else contract_custody
+    names = {n for n, c in contract.items() if c == CUSTOMER}
+    names |= set(_CUSTOMER_EXACT)
+    return names
+
+
+def customer_owned_source_names(customer_id: str) -> list[str]:
+    """Concrete env var names to ISOLATE (blank or substitute) for a seat before
+    running the provisioner in a keyless/staging build. Expands the per-seat
+    `__<CID>` suffix used by the Anthropic + webhook source vars
+    (provision-customer.sh:348,495,611,614)."""
+    suffix = _seat_suffix(customer_id)
+    names = set(customer_owned_names())
+    # Per-seat source overrides the provisioner reads.
+    names.add(f"ANTHROPIC_API_KEY__{suffix}")
+    names.add(f"WEBHOOK_SECRET_AGENTMAIL__{suffix}")
+    names.add(f"WEBHOOK_SECRET_SMOKEBALL__{suffix}")
+    names.add(f"WEBHOOK_SMOKEBALL_CLIENT_ID__{suffix}")
+    return sorted(names)
+
+
+def _seat_suffix(customer_id: str) -> str:
+    """Mirror the provisioner's slug->env-suffix transform
+    (`tr '[:lower:]-' '[:upper:]_' | tr -cd 'A-Z0-9_'`, provision-customer.sh:348)."""
+    out = []
+    for ch in customer_id:
+        if ch.islower():
+            out.append(ch.upper())
+        elif ch == "-":
+            out.append("_")
+        elif ch.isupper() or ch.isdigit() or ch == "_":
+            out.append(ch)
+        # else drop (matches tr -cd 'A-Z0-9_')
+    return "".join(out)
+
+
+def looks_like_placeholder(value: str) -> bool:
+    """True iff the value is an explicit keyless placeholder (or empty). Only the
+    sentinel counts — a real credential is never treated as a placeholder."""
+    return value == "" or value.startswith(PLACEHOLDER_SENTINEL)
+
+
+def placeholder_for(name: str) -> str:
+    """The placeholder a keyless build stamps into a customer-owned slot."""
+    return f"{PLACEHOLDER_SENTINEL}{name}"
+
+
+def assert_no_real_customer_secret(
+    env: dict[str, str], contract_custody: dict[str, str] | None = None
+) -> None:
+    """KEYLESS-BUILD GUARD. Raise if any env var that classifies as customer-owned
+    holds a value that is NOT an explicit placeholder. This is the fail-closed
+    backstop against a keyless build accidentally running with a real customer
+    credential in scope. Unclassified names are ignored here (the completeness
+    test is what forces classification); this guard only judges values."""
+    contract = load_contract_custody() if contract_custody is None else contract_custody
+    offenders: list[str] = []
+    for name, value in env.items():
+        try:
+            owned = classify(name, contract) == CUSTOMER
+        except UnclassifiedSecret:
+            continue
+        if owned and value and not looks_like_placeholder(value):
+            offenders.append(name)
+    if offenders:
+        raise RuntimeError(
+            "keyless build has REAL customer-owned secret(s) in scope: "
+            + ", ".join(sorted(offenders))
+            + ". Blank/placeholder them before building; real values enter only at handoff."
+        )
+
+
+def _main(argv: list[str]) -> int:
+    """Small CLI so shell wrappers consume the classification without re-encoding
+    it. `isolate-names <slug>` prints (newline-separated) the customer-owned
+    source names a keyless/staging build must blank or substitute for that seat;
+    `classify <name>` prints the custody class (exit 2 if unclassified)."""
+    if len(argv) >= 3 and argv[1] == "isolate-names":
+        for name in customer_owned_source_names(argv[2]):
+            print(name)
+        return 0
+    if len(argv) >= 3 and argv[1] == "classify":
+        try:
+            print(classify(argv[2]))
+        except UnclassifiedSecret as exc:
+            print(str(exc), file=__import__("sys").stderr)
+            return 2
+        return 0
+    print("usage: secret_custody.py {isolate-names <slug>|classify <name>}",
+          file=__import__("sys").stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    import sys as _sys
+
+    raise SystemExit(_main(_sys.argv))

--- a/operator/bin/reprovision-staging.sh
+++ b/operator/bin/reprovision-staging.sh
@@ -9,12 +9,29 @@
 #
 # ISOLATION (the load-bearing part): the normal reprovision injects every
 # Infisical /ss key as an env var, and provision-customer.sh stages the
-# per-customer ones (GOOGLE_SERVICE_ACCOUNT_JSON, CLIO_*) onto the Machine.
-# Those are the REAL customer credentials. This wrapper:
-#   - replaces GOOGLE_SERVICE_ACCOUNT_JSON with a freshly generated ISOLATED
-#     service account (gen-staging-google-cred.py) — boots the broker
-#     identically to prod, wired to nothing real; and
-#   - BLANKS CLIO_* so the real Clio credentials never reach the staging box.
+# customer-owned ones (GOOGLE_*, CLIO_*, AGENTMAIL_*, SMOKEBALL_*, webhook
+# secrets, the per-seat Anthropic key) onto the Machine. Those are REAL customer
+# credentials. This wrapper isolates staging from ALL of them.
+#
+# FAIL-CLOSED (2026-07 rework, issue #1783). The previous version blanked a
+# HAND-MAINTAINED DENYLIST (`CLIO_*` only) and so failed OPEN: any customer-owned
+# secret it did not name (AgentMail, Smokeball, per-seat Anthropic, webhook
+# secrets) leaked onto the staging box the moment a staging seat bound that
+# connector. This version derives the isolate set from the custody classification
+# (operator/bin/lib/secret_custody.py, sourced from
+# operator/contracts/env-consumption.yaml + the connector tables), so a NEWLY
+# added customer-owned secret is isolated automatically. The classification's
+# completeness against provision-customer.sh is CI-enforced
+# (operator/bin/tests/test_secret_custody.py::test_every_staged_secret_is_classified),
+# which is what makes this allowlist trustworthy.
+#
+# Two isolation moves:
+#   - BLANK every customer-owned secret (contract-driven) so the real value never
+#     reaches the staging Machine.
+#   - SUBSTITUTE GOOGLE_SERVICE_ACCOUNT_JSON with a freshly generated ISOLATED
+#     service account (gen-staging-google-cred.py): Google is customer-by-EFFECT
+#     (DWD impersonation), so the broker still needs *a* credential to boot
+#     identically to prod — wired to nothing real.
 # Result: staging borrows none of the live business's access.
 #
 # The slug is HARDCODED to smd-staging. This wrapper must never touch a real
@@ -25,18 +42,35 @@ set -euo pipefail
 
 SLUG="smd-staging"
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${HERE}/../.." && pwd)"
+
+# Contract-driven isolate set, computed BEFORE infisical run (it needs no secret —
+# only the classification + the slug). Newline-separated customer-owned source
+# names, per-seat __<CID> expanded. Fails loud if the classification cannot load.
+ISOLATE_NAMES="$(cd "${REPO_ROOT}" && uv run --quiet --with pyyaml python3 \
+  operator/bin/lib/secret_custody.py isolate-names "${SLUG}")" \
+  || { echo "reprovision-staging: could not compute the customer-owned isolate set" >&2; exit 1; }
+[ -n "${ISOLATE_NAMES}" ] \
+  || { echo "reprovision-staging: empty isolate set — refusing to run without isolation" >&2; exit 1; }
 
 exec infisical run --env=prod --path=/ss --silent -- bash -c '
   set -euo pipefail
-  HERE="$1"; SLUG="$2"
-  # Generated isolated Google credential (throwaway RSA key, fictitious project).
+  HERE="$1"; SLUG="$2"; ISOLATE_NAMES="$3"
+
+  # Blank every customer-owned secret so the real value never reaches the staging
+  # Machine. Empty-string assignments, not secrets (gitleaks false positive). # gitleaks:allow
+  while IFS= read -r _n; do
+    [ -n "${_n}" ] || continue
+    export "${_n}="
+  done <<< "${ISOLATE_NAMES}"
+
+  # SUBSTITUTE the isolated Google service account (throwaway RSA key, fictitious
+  # project). Set AFTER the blank loop (which also blanks GOOGLE_SERVICE_ACCOUNT_JSON).
   # Value flows env -> fly secrets import; never printed.
   GEN_JSON="$(uv run --quiet --with cryptography python3 "${HERE}/gen-staging-google-cred.py")"
   export GOOGLE_SERVICE_ACCOUNT_JSON="$(printf "%s" "${GEN_JSON}" | base64 | tr -d "\n")"
   unset GEN_JSON
-  # Blank real per-customer secrets so they never leak onto the staging Machine.
-  # The values are empty strings (blanking), not secrets — gitleaks false positive.
-  export CLIO_CLIENT_ID="" CLIO_CLIENT_SECRET="" CLIO_ENCRYPTION_KEY="" CLIO_TOKENS_ENC_B64="" # gitleaks:allow
+
   # Non-interactive: Machine secrets persist; nothing to paste.
   yes s | "${HERE}/provision-customer.sh" "${SLUG}"
-' _ "${HERE}" "${SLUG}"
+' _ "${HERE}" "${SLUG}" "${ISOLATE_NAMES}"

--- a/operator/bin/tests/test_secret_custody.py
+++ b/operator/bin/tests/test_secret_custody.py
@@ -1,0 +1,155 @@
+"""Secret custody classification — schema, completeness, and guard behavior.
+
+The load-bearing test is `test_every_staged_secret_is_classified`: it parses the
+NAMES `provision-customer.sh` stages and asserts each classifies without raising.
+That is the fail-closed drift guard — a customer secret added to the provisioner
+without being classified turns red here, which is what keeps the keyless-build
+placeholder allowlist complete.
+
+Run::
+
+    cd operator && python -m pytest bin/tests/test_secret_custody.py -v
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "lib"))
+
+import secret_custody as sc  # noqa: E402
+
+_OP = Path(__file__).resolve().parents[2]
+_PROVISION = _OP / "bin" / "provision-customer.sh"
+
+# Secrets a reader can see are unambiguously a customer's own credential — the
+# set that MUST classify as customer or the keyless/staging isolation leaks.
+_KNOWN_CUSTOMER = {
+    "ANTHROPIC_API_KEY",
+    "CLIO_CLIENT_ID",
+    "CLIO_CLIENT_SECRET",
+    "CLIO_ENCRYPTION_KEY",
+    "CLIO_TOKENS_ENC_B64",
+    "AGENTMAIL_API_KEY",
+    "WEBHOOK_SECRET_AGENTMAIL",
+    "SMD_WEBHOOK_SIGNING_SECRET",
+    "GOOGLE_SERVICE_ACCOUNT_JSON",
+    "SMOKEBALL_CLIENT_ID",
+    "SMOKEBALL_CLIENT_SECRET",
+    "SMOKEBALL_API_KEY",
+    "WEBHOOK_SECRET_SMOKEBALL",
+    "WEBHOOK_SMOKEBALL_CLIENT_ID",
+}
+
+
+def _staged_secret_names() -> set[str]:
+    """NAMES the provisioner stages: `stage_secret_from_env NAME`,
+    `prompt_and_set NAME`, and literal `printf '%s=%s\\n' "NAME"` piped to
+    `fly secrets import`. Dynamic (manifest-driven) names are not literals and
+    are intentionally out of this static parse."""
+    text = _PROVISION.read_text(encoding="utf-8")
+    names: set[str] = set()
+    for m in re.finditer(r"\bstage_secret_from_env\s+([A-Z_][A-Z0-9_]*)", text):
+        names.add(m.group(1))
+    for m in re.finditer(r"\bprompt_and_set\s+([A-Z_][A-Z0-9_]*)", text):
+        names.add(m.group(1))
+    # printf '%s=%s\n' "NAME" ... | fly secrets import  (the healthchecks ping url)
+    for m in re.finditer(r'''printf\s+'%s=%s\\n'\s+"([A-Z_][A-Z0-9_]*)"''', text):
+        names.add(m.group(1))
+    return names
+
+
+def test_contract_every_var_has_valid_custody() -> None:
+    # load_contract_custody raises on any missing/invalid custody class.
+    custody = sc.load_contract_custody()
+    assert custody, "env-consumption contract produced no custody map"
+    assert set(custody.values()) <= sc.VALID_CUSTODY
+
+
+def test_every_staged_secret_is_classified() -> None:
+    """FAIL CLOSED: every secret NAME provision-customer.sh stages must classify
+    (no UnclassifiedSecret). Adding a staged secret without classifying it here
+    is the drift this guard exists to catch."""
+    staged = _staged_secret_names()
+    # Sanity: the parse found the real surface, not zero.
+    assert "ANTHROPIC_API_KEY" in staged and "SMOKEBALL_CLIENT_ID" in staged, (
+        "provision-customer.sh parse found too few staged names; the regex drifted"
+    )
+    unclassified: list[str] = []
+    for name in sorted(staged):
+        try:
+            klass = sc.classify(name)
+        except sc.UnclassifiedSecret:
+            unclassified.append(name)
+            continue
+        assert klass in sc.VALID_CUSTODY
+    assert not unclassified, f"staged but unclassified (classify these): {unclassified}"
+
+
+def test_known_customer_secrets_classify_customer() -> None:
+    for name in sorted(_KNOWN_CUSTOMER):
+        assert sc.classify(name) == sc.CUSTOMER, f"{name} must be customer-owned"
+
+
+def test_infra_secrets_classify_infra() -> None:
+    for name in ("R2_ACCESS_KEY_ID", "SENTRY_DSN", "MACHINE_HEARTBEAT_KEY",
+                 "WEBHOOK_SECRET_MCP", "SMOKEBALL_OAUTH_STATE_KEY",
+                 "SMOKEBALL_ENVIRONMENT", "R2_BUCKET_CONFIG"):
+        assert sc.classify(name) == sc.INFRA, f"{name} must be infra"
+
+
+def test_per_seat_prefix_is_customer() -> None:
+    assert sc.classify("ANTHROPIC_API_KEY__ASHTON_PRICE") == sc.CUSTOMER
+    assert sc.classify("WEBHOOK_SECRET_AGENTMAIL__PILOT_SMOKEBALL") == sc.CUSTOMER
+    assert sc.classify("SMOKEBALL_PROD_CLIENT_SECRET") == sc.CUSTOMER
+
+
+def test_unknown_secret_fails_closed() -> None:
+    with pytest.raises(sc.UnclassifiedSecret):
+        sc.classify("SOME_BRAND_NEW_CONNECTOR_TOKEN")
+
+
+def test_seat_suffix_matches_provisioner_transform() -> None:
+    # slug -> upper, '-' -> '_', drop the rest (tr '[:lower:]-' '[:upper:]_' | tr -cd 'A-Z0-9_')
+    assert sc._seat_suffix("ashton-price") == "ASHTON_PRICE"
+    assert sc._seat_suffix("smd-staging") == "SMD_STAGING"
+
+
+def test_customer_owned_source_names_expands_per_seat() -> None:
+    names = sc.customer_owned_source_names("ashton-price")
+    assert "ANTHROPIC_API_KEY__ASHTON_PRICE" in names
+    assert "WEBHOOK_SECRET_AGENTMAIL__ASHTON_PRICE" in names
+    assert "GOOGLE_SERVICE_ACCOUNT_JSON" in names
+    assert "CLIO_ENCRYPTION_KEY" in names
+    # No infra names leak into the isolate list.
+    assert "R2_ACCESS_KEY_ID" not in names
+    assert "SENTRY_DSN" not in names
+
+
+def test_guard_raises_on_real_customer_value() -> None:
+    env = {"ANTHROPIC_API_KEY": "sk-ant-realvalue", "SENTRY_DSN": "https://real@sentry"}
+    with pytest.raises(RuntimeError) as exc:
+        sc.assert_no_real_customer_secret(env)
+    assert "ANTHROPIC_API_KEY" in str(exc.value)
+    # Infra value in scope is fine — not named as an offender.
+    assert "SENTRY_DSN" not in str(exc.value)
+
+
+def test_guard_passes_on_placeholder_or_empty() -> None:
+    env = {
+        "ANTHROPIC_API_KEY": sc.placeholder_for("ANTHROPIC_API_KEY"),
+        "CLIO_CLIENT_SECRET": "",
+        "SMOKEBALL_CLIENT_SECRET": sc.PLACEHOLDER_SENTINEL + "x",
+        "R2_ACCESS_KEY_ID": "real-infra-key-ok",
+    }
+    sc.assert_no_real_customer_secret(env)  # must not raise
+
+
+def test_looks_like_placeholder() -> None:
+    assert sc.looks_like_placeholder("")
+    assert sc.looks_like_placeholder(sc.placeholder_for("X"))
+    assert not sc.looks_like_placeholder("sk-ant-real")

--- a/operator/contracts/env-consumption.yaml
+++ b/operator/contracts/env-consumption.yaml
@@ -37,10 +37,27 @@
 #                  stripped - explicitly unset before the gateway exec (must NOT be stage:agent)
 #                  n/a      - never on the Machine (provisioning-host / image-build)
 #   strip_site:  (only when agent_env: stripped) the file that unsets it
+#   custody:     infra | customer
+#                  infra    - operator/SMD-owned (R2, Fly, Sentry, HMAC masters,
+#                             bucket names, D1 bindings). Safe to be REAL — or
+#                             emulated — during a keyless build; the operator
+#                             holds it regardless of which customer is provisioning.
+#                  customer - carries (or grants access to) a specific customer's
+#                             world: their model key, their connector OAuth creds,
+#                             their inbox/webhook secrets, their Google identity.
+#                             MUST enter only at handoff through a door we never
+#                             see (portal relay / Captain go-live). A keyless build
+#                             sees only a placeholder; staging/keyless runs must
+#                             NOT borrow the live value. `GOOGLE_*` is customer-by-
+#                             EFFECT (DWD impersonation), so staging substitutes an
+#                             isolated credential rather than the live one.
 #   note:        free text
 #
 # Adding a consumer? Add/update the var here FIRST. If a plugin needs a var at
 # `stage: agent`, it must be `agent_env: held` — the boot invariant enforces it.
+# Every var MUST carry a `custody` class — operator/bin/lib/secret_custody.py and
+# its completeness test fail closed on an unclassified provisioning secret, which
+# is what keeps the keyless-build placeholder allowlist complete.
 
 vars:
   # ---- Agent-held credentials/config (the long-running gateway + overlay plugins) ----
@@ -48,46 +65,55 @@ vars:
     stage: agent
     requirement: required
     agent_env: held
-    note: the gateway's model credential
+    custody: customer
+    note: the gateway's model credential (per-seat Anthropic workspace key or BYO key)
   SMD_D1_AUDIT_BINDING:
     stage: agent
     requirement: required
     agent_env: held
+    custody: infra
     note: hermes-smd-audit D1 binding (path or var-name indirection)
   SMD_D1_AGENT_STATE_BINDING:
     stage: agent
     requirement: optional
     agent_env: held
+    custody: infra
     note: mutable agent-state binding (agent_skills_inventory) from fly.toml [env]; falls back to SMD_D1_AUDIT_BINDING when unset (OP-P1-4 ledger/state split)
   SMD_AUDIT_BROKER_SOCKET:
     stage: agent
     requirement: optional
     agent_env: held
+    custody: infra
     note: from fly.toml [env]; set => overlay routes audit writes through the broker's append-only audit_append (OP-P1-4); the broker-side ledger path (SMD_AUDIT_DB_PATH) is entrypoint-computed and broker-only, like SMD_WORKSPACE_BROKER_SOCKET
   R2_SKILL_BODIES_BUCKET:
     stage: agent
     requirement: required
     agent_env: held
+    custody: infra
     note: bucket NAME (not a credential) from fly.toml [env]; skill_capture target
   R2_ENDPOINT_URL:
     stage: agent
     requirement: optional
     agent_env: held
+    custody: infra
     note: endpoint URL (NOT a credential) read by skill_capture + the voice reader path; intentionally kept across the R2 strip
   SMD_VOICE_VAULT_DIR:
     stage: agent
     requirement: optional
     agent_env: held
+    custody: infra
     note: local voice-vault dir set by bootstrap Step 2a; the voice plugin reads samples from here so the agent holds NO R2 credential (OP-P0-2)
   R2_SKILL_BODIES_ACCESS_KEY_ID:
     stage: agent
     requirement: optional
     agent_env: held
+    custody: infra
     note: bucket-SCOPED token for agent-authored skill persistence; OFF by default; NEVER the account-wide pair
   R2_SKILL_BODIES_SECRET_ACCESS_KEY:
     stage: agent
     requirement: optional
     agent_env: held
+    custody: infra
     note: paired with R2_SKILL_BODIES_ACCESS_KEY_ID
 
   # ---- Boot-stage credentials: read before the agent, then STRIPPED ----
@@ -96,17 +122,20 @@ vars:
     requirement: required
     agent_env: stripped
     strip_site: operator/templates/bootstrap.sh
+    custody: infra
     note: ACCOUNT-WIDE R2 key; read by the customer.yaml fetch (Step 2) + voice-vault sync (Step 2a); unset before gateway exec (OP-P0-2)
   R2_SECRET_ACCESS_KEY:
     stage: boot
     requirement: required
     agent_env: stripped
     strip_site: operator/templates/bootstrap.sh
+    custody: infra
     note: paired with R2_ACCESS_KEY_ID
   R2_BUCKET_CONFIG:
     stage: boot
     requirement: required
     agent_env: held
+    custody: infra
     note: config-bucket NAME (not a credential); fly.toml [env]; used by the boot fetches and is harmless in the agent env
 
   # ---- Broker-stage credentials: read by the uid-split broker, unset for the agent ----
@@ -115,30 +144,35 @@ vars:
     requirement: optional
     agent_env: stripped
     strip_site: operator/templates/entrypoint.sh
-    note: DWD service-account key; only the workspace-broker process decodes it; unset for the gateway
+    custody: customer
+    note: DWD service-account key; customer-by-EFFECT (impersonates the seat's authored subject); only the workspace-broker process decodes it; unset for the gateway. Staging SUBSTITUTES an isolated cred (gen-staging-google-cred.py), never the live one.
   GOOGLE_TOKEN_JSON:
     stage: broker
     requirement: optional
     agent_env: stripped
     strip_site: operator/templates/entrypoint.sh
-    note: legacy user-OAuth token; broker-only
+    custody: customer
+    note: legacy user-OAuth token; grants the customer's own Google; broker-only
   GOOGLE_CLIENT_SECRET_JSON:
     stage: broker
     requirement: optional
     agent_env: stripped
     strip_site: operator/templates/entrypoint.sh
-    note: broker-only OAuth client secret
+    custody: customer
+    note: broker-only OAuth client secret for the customer's Google app
 
   # ---- MCP-subprocess credentials (passed only into the connector subprocess env) ----
   CLIO_CLIENT_ID:
     stage: mcp-subprocess
     requirement: optional
     agent_env: held
+    custody: customer
     note: Clio MCP connector; materialized into the mcp_servers subprocess env when the customer binds Clio
   CLIO_CLIENT_SECRET:
     stage: mcp-subprocess
     requirement: optional
     agent_env: held
+    custody: customer
     note: paired with CLIO_CLIENT_ID
 
   # ---- Optional agent observability / Phase-2 forward-compat ----
@@ -146,26 +180,31 @@ vars:
     stage: agent
     requirement: optional
     agent_env: held
+    custody: infra
     note: Honcho observations mirror; inert in Phase 1 (ADR 0016 revised)
   HONCHO_API_KEY:
     stage: agent
     requirement: optional
     agent_env: held
+    custody: infra
     note: Honcho inferred-memory; inert in Phase 1
   AGENTMAIL_API_KEY:
     stage: agent
     requirement: optional
     agent_env: held
-    note: deferred Phase 2; no consumer wired today
+    custody: customer
+    note: AgentMail REST credential (send + inbox/webhook mgmt); reaches the shared account's OTHER inboxes, so staging must not borrow it
 
   # ---- Provisioning-host only (never reach the Machine) ----
   OPERATOR_RUNTIME_READ_SECRET:
     stage: provisioning-host
     requirement: optional
     agent_env: n/a
+    custody: infra
     note: HMAC seed used at provisioning to derive the per-customer OPERATOR_RUNTIME_READ_KEY; never staged to the Machine
   CF_API_TOKEN:
     stage: provisioning-host
     requirement: optional
     agent_env: n/a
+    custody: infra
     note: Cloudflare token for R2 bucket creation at provisioning; never staged


### PR DESCRIPTION
Closes the spine of #1783 (keyless-build / inject-at-handoff provisioning discipline). Pure internal risk reduction.

## What

Turns "which secrets are safe to build against vs. must wait for handoff" from tribal knowledge into a machine-checkable classification, and fixes a live fail-open in the staging isolation.

- **`operator/contracts/env-consumption.yaml`** — new `custody: infra | customer` field on every tracked var. `infra` = operator/SMD-owned (safe real-or-emulated in a build). `customer` = carries/grants access to a specific customer's world (enters only at handoff).
- **`operator/bin/lib/secret_custody.py`** — single classification API. `classify()` **fails closed** (unknown secret raises). Sources: the contract + explicit connector tables cited to their `provision-customer.sh` staging sites. Also: per-seat isolate-name expansion, a placeholder sentinel + `assert_no_real_customer_secret` (for the phase-2 keyless build), and a small CLI (`classify` / `isolate-names`).
- **`operator/bin/tests/test_secret_custody.py`** — the load-bearing guard: `test_every_staged_secret_is_classified` parses the names `provision-customer.sh` stages and asserts each classifies. A customer secret added to the provisioner without classification turns this red. Runs in CI via `operator-substrate.yml` (`bin/tests`).
- **`operator/bin/reprovision-staging.sh`** — replaces the hand-maintained `CLIO_*`-only denylist (which **failed OPEN** — it leaked AgentMail / Smokeball / per-seat Anthropic / webhook secrets onto the staging box the moment a staging seat bound that connector) with the contract-derived allowlist. Isolate set went **4 → 27** names. Provably a no-op for `smd-staging` today (`connectors: {}`, Google via the broker), pure fail-closed protection going forward.
- **`docs/runbooks/operator/keyless-build-handoff.md`** — the two-phase runbook.

## Why it's not theater

The classification is bound to reality by a CI test that fails closed on any unclassified staged secret, and it immediately drives a live path (the staging wrapper), where it fixes an actual current leak. No dead code: the one currently-unwired function (`assert_no_real_customer_secret`) is unit-tested and reserved for the phase-2 `build-keyless.sh`, documented as such.

## Verification

- `operator/bin/tests/`, `safety-substrate/tests/test_invariant_9_*`, `bin/tests/test_env_contract_conformance.py`, `bin/tests/test_env_array_generation.py`, `bin/tests/test_ci_coverage_conformance.py` — 171 passed.
- `gen-env-arrays.py --check` in sync (the `custody:` field is additive; `stage`/`requirement` unchanged).
- `bash -n reprovision-staging.sh` OK; CLI output verified (`isolate-names smd-staging` → 27 names; `classify` fail-closed exit 2 on unknown).
- em-dash / forbidden-string guards scope to `docs/handbook/` and `src/` respectively — untouched.

## Follow-on (phase 2, tracked in #1783)

`build-keyless.sh` against an emulated vault; `assert_sealed` wired into `provision-customer.sh` post-deploy; emulated S3 for the config-bucket upload. Captain decision noted: `GOOGLE_SERVICE_ACCOUNT_JSON` classified `customer` (infra-by-storage, customer-by-effect via DWD impersonation — staging already substitutes an isolated cred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JxGqJcpZREAabNMRGE1heZ