### PR TITLE
feat(operator): Slice 2 — 'meet your operator' hero (identity + status) (ADR 0069)

### DIFF
--- a/src/components/portal/operator/facets/OperatorHero.astro
+++ b/src/components/portal/operator/facets/OperatorHero.astro
@@ -1,0 +1,55 @@
+---
+/**
+ * Operator hero — the shared "meet your operator" lead (ADR 0069 Slice 2).
+ *
+ * Renders who the operator is (persona identity) and whether it is alive and
+ * in-bounds (the aliveness signal, via the existing AlivenessHeader). ONE shared
+ * component, mounted in both portals per Lock 4; the facet registry points the
+ * `identity` and `status` facets at the resolver this consumes
+ * (lib/portal/operator/facets/identity/hero.ts).
+ *
+ * Identity is authored config — nothing fabricated. With no active persona the
+ * headline falls back to the generic label "Your operator" (a label, not an
+ * authored value), and a null aliveness signal renders AlivenessHeader's silent
+ * empty state (never a fabricated "healthy" chip).
+ */
+import AlivenessHeader from '../AlivenessHeader.astro'
+import type { OperatorHeroModel } from '../../../../lib/portal/operator/facets/identity/hero'
+
+interface Props {
+  model: OperatorHeroModel
+  /** Passed through to AlivenessHeader's escalation affordance; null is fine. */
+  escalationHref?: string | null
+}
+
+const { model, escalationHref = null } = Astro.props
+const displayName = model.name ?? 'Your operator'
+---
+
+<section
+  class="mt-8 border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)]"
+  aria-label="Operator identity and status"
+>
+  <div class="flex flex-col gap-5 px-5 py-6 md:px-7">
+    <div>
+      <p
+        class="font-mono text-label font-bold uppercase tracking-[0.18em] text-[color:var(--ss-color-primary)]"
+      >
+        Your operator
+      </p>
+      <h2
+        class="mt-1 font-body text-2xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)] md:text-3xl"
+      >
+        {displayName}
+      </h2>
+      {
+        model.title && (
+          <p class="mt-1 font-body text-base text-[color:var(--ss-color-text-secondary)]">
+            {model.title}
+          </p>
+        )
+      }
+    </div>
+    <AlivenessHeader signal={model.aliveness} escalationHref={escalationHref} />
+  </div>
+</section>

--- a/src/lib/portal/operator/facet-registry.ts
+++ b/src/lib/portal/operator/facet-registry.ts
@@ -83,9 +83,12 @@ export const OPERATOR_FACETS: readonly OperatorFacet[] = [
     id: 'status',
     label: 'Status / aliveness',
     plane: 'central_runtime',
-    surface: { kind: 'planned', slice: 2 },
-    mounts: ['client', 'admin'],
-    note: 'idle/running/sticky_stop/offline + last action. running never renders today (no in-flight marker pushed).',
+    surface: {
+      kind: 'has_viewer',
+      viewerModule: 'src/lib/portal/operator/facets/identity/hero.ts',
+    },
+    mounts: ['client'],
+    note: 'Co-rendered with identity in the shared OperatorHero (Slice 2). Admin mount + running-state marker are follow-ups; running never renders today (no in-flight marker pushed).',
   },
   {
     id: 'activity',
@@ -101,8 +104,12 @@ export const OPERATOR_FACETS: readonly OperatorFacet[] = [
     id: 'identity',
     label: 'Identity / persona',
     plane: 'config_projection',
-    surface: { kind: 'planned', slice: 2 },
-    mounts: ['client', 'admin'],
+    surface: {
+      kind: 'has_viewer',
+      viewerModule: 'src/lib/portal/operator/facets/identity/hero.ts',
+    },
+    mounts: ['client'],
+    note: 'Active-persona name/title in the shared OperatorHero (Slice 2). Admin mount is a follow-up.',
   },
   {
     id: 'skills',

--- a/src/lib/portal/operator/facets/identity/hero.ts
+++ b/src/lib/portal/operator/facets/identity/hero.ts
@@ -1,0 +1,47 @@
+/**
+ * Operator hero — the shared identity + status view model (ADR 0069 Slice 2).
+ *
+ * The "meet your operator" lead: who the operator is (persona identity, from the
+ * config projection) and whether it is alive and in-bounds (the aliveness
+ * signal). One shared resolver + one shared component
+ * (`components/portal/operator/facets/OperatorHero.astro`), mounted in both
+ * portals per Lock 4 — the facet registry points `identity` and `status` here.
+ *
+ * Identity is authored config (Tier 1, real from `customer_configs`); nothing is
+ * fabricated. A missing persona or missing signal renders the honest empty
+ * branch, per docs/style/empty-state-pattern.md.
+ */
+
+import type { CustomerConfigRow } from '../../../customer-config'
+import type { AlivenessSignal } from '../../aliveness'
+
+export interface OperatorHeroModel {
+  /** Persona display name, e.g. "Quinn". null when no active persona. */
+  name: string | null
+  /** Persona title / role, e.g. "AI Case Coordinator". */
+  title: string | null
+  /** The live aliveness signal, or null when the customer has no fleet_status
+   *  row yet (the component renders the silent empty state — never a fabricated
+   *  "healthy" chip). */
+  aliveness: AlivenessSignal | null
+}
+
+/**
+ * Compose the hero view model from the config projection + the resolved
+ * aliveness signal. Pure and total: a null config or no-active-persona yields
+ * null identity fields; the caller passes the already-resolved signal.
+ */
+export function resolveOperatorHero(
+  config: CustomerConfigRow | null,
+  aliveness: AlivenessSignal | null
+): OperatorHeroModel {
+  // Select the active persona from the already-projected, typed config — no
+  // second DB read, no reparse of personas_json (the projection already parsed
+  // it). Mirrors the selection in customer-config.ts::getActivePersona.
+  const persona = config?.personas.find((p) => p.status === 'active') ?? null
+  return {
+    name: persona?.name ?? null,
+    title: persona?.title ?? null,
+    aliveness,
+  }
+}

--- a/src/pages/portal/products/operator/index.astro
+++ b/src/pages/portal/products/operator/index.astro
@@ -8,7 +8,8 @@ import {
 } from '../../../../lib/portal/product-access'
 import PortalPageHead from '../../../../components/portal/PortalPageHead.astro'
 import PromotionCardList from '../../../../components/portal/operator/PromotionCardList.astro'
-import AlivenessHeader from '../../../../components/portal/operator/AlivenessHeader.astro'
+import OperatorHero from '../../../../components/portal/operator/facets/OperatorHero.astro'
+import { resolveOperatorHero } from '../../../../lib/portal/operator/facets/identity/hero'
 import {
   listPromotionReadySkills,
   type PromotionCandidate,
@@ -181,6 +182,11 @@ if (access) {
   alivenessSignal = await resolveAlivenessSignal(env.DB, access.subscription)
 }
 
+// "Meet your operator" hero (ADR 0069 Slice 2): identity (active persona) +
+// status (aliveness), composed by the shared resolver. Both facets are Tier-1
+// real from the config projection / fleet_status; nothing fabricated.
+const heroModel = resolveOperatorHero(customerConfig, alivenessSignal)
+
 // Promotion recommendation cards (per #811). Principal-only because the
 // trust-ceiling promotion is the firm's decision per §11.3 — operator
 // and compliance roles do not see the prompt. The resolver returns an
@@ -311,9 +317,7 @@ const crTone = crStatus === 'filed' ? 'complete' : 'error'
   {
     surfaceState === 'active' && (
       <>
-        <div class="mt-8">
-          <AlivenessHeader signal={alivenessSignal} />
-        </div>
+        <OperatorHero model={heroModel} />
 
         {/* Home / Today (client-portal §5.1): what needs you, what it did,
                 escalations. Runtime-fed (#1678); fails closed to honest empty

--- a/tests/operator-hero.test.ts
+++ b/tests/operator-hero.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest'
+import { resolveOperatorHero } from '../src/lib/portal/operator/facets/identity/hero'
+import type { CustomerConfigRow, PersonaConfig } from '../src/lib/portal/customer-config'
+import type { AlivenessSignal } from '../src/lib/portal/operator/aliveness'
+
+/** Minimal persona fixture — only the fields the hero reads matter. */
+function persona(p: Partial<PersonaConfig>): PersonaConfig {
+  return {
+    slug: 'p',
+    status: 'active',
+    name: 'X',
+    title: null,
+    signature_html: null,
+    tone: [],
+    send_as: null,
+    entitlements: {} as PersonaConfig['entitlements'],
+    skills: [],
+    channel_bindings: [],
+    ...p,
+  }
+}
+
+function config(personas: PersonaConfig[]): CustomerConfigRow {
+  return { personas } as unknown as CustomerConfigRow
+}
+
+const signal: AlivenessSignal = {
+  level: 'idle',
+  lastActionAt: '2026-07-07T00:00:00Z',
+  currentSkill: null,
+  stickyStopReason: null,
+}
+
+describe('resolveOperatorHero (ADR 0069 Slice 2 — identity + status)', () => {
+  it('surfaces the active persona name + title, passing the signal through', () => {
+    const m = resolveOperatorHero(
+      config([persona({ status: 'active', name: 'Quinn', title: 'AI Case Coordinator' })]),
+      signal
+    )
+    expect(m).toEqual({ name: 'Quinn', title: 'AI Case Coordinator', aliveness: signal })
+  })
+
+  it('ignores archived personas — no fabricated identity', () => {
+    const m = resolveOperatorHero(
+      config([persona({ status: 'archived', name: 'Old', title: 'stale' })]),
+      null
+    )
+    expect(m.name).toBeNull()
+    expect(m.title).toBeNull()
+  })
+
+  it('null config yields null identity but still carries the signal (honest empty)', () => {
+    const m = resolveOperatorHero(null, signal)
+    expect(m).toEqual({ name: null, title: null, aliveness: signal })
+  })
+
+  it('an active persona with no title yields a null title (component falls back)', () => {
+    const m = resolveOperatorHero(
+      config([persona({ status: 'active', name: 'Crane', title: null })]),
+      null
+    )
+    expect(m.name).toBe('Crane')
+    expect(m.title).toBeNull()
+  })
+})


### PR DESCRIPTION
First shared facet viewer (Lock 4): the operator landing now leads with **identity** (active persona name/title, from the config projection) + **status** (aliveness), replacing the bare AlivenessHeader.

- `facets/identity/hero.ts` — pure shared resolver (selects active persona from the projected typed config; no reparse, no second query)
- `components/portal/operator/facets/OperatorHero.astro` — shared component
- registry: `identity`+`status` → `has_viewer`; **Lock 4 has_viewer guard now active and green**
- `tests/operator-hero.test.ts` — resolver unit tests incl. anti-fabrication (archived persona ignored)

**Verification:** data seams already prod-proven (same `customer_configs` + `fleet_status` the live Configure page and AlivenessHeader read); new code is composition (unit-tested) + presentation. `npm run verify` green (3279 passed, 7 todo). Visual render on an authed seat is the one pending check — issue stays open until confirmed.

Part of #1803. Epic #1798.