### PR TITLE
fix(operator): pull dead Calendar from nav + de-dup Account status (ADR 0069)

### DIFF
--- a/src/pages/portal/products/operator/account/index.astro
+++ b/src/pages/portal/products/operator/account/index.astro
@@ -86,13 +86,8 @@ const hasEscalation =
   entityId={client.id}
   pathname={Astro.url.pathname}
 >
-  <PortalPageHead
-    crumbHref="/portal/products/operator"
-    crumbLabel="Operator"
-    tag="Section"
-    h1="Account"
-    meta={subStatus ? subscriptionStatusLabel(account.subscription!.status) : null}
-  />
+  {/* Status is shown once, on the chip below — not repeated in the header meta. */}
+  <PortalPageHead crumbHref="/portal/products/operator" crumbLabel="Operator" h1="Account" />
 
   {
     crMessage && (
@@ -128,9 +123,13 @@ const hasEscalation =
               >
                 {subscriptionStatusLabel(account.subscription.status)}
               </span>
-              <p class="m-0 font-body text-[color:var(--ss-color-text-primary)]">
-                {subscriptionStatusProse(account.subscription.status)}
-              </p>
+              {/* The chip states the status; the prose only adds value when the
+                  status needs explaining (paused, etc.), so skip it for active. */}
+              {account.subscription.status !== 'active' && (
+                <p class="m-0 font-body text-[color:var(--ss-color-text-primary)]">
+                  {subscriptionStatusProse(account.subscription.status)}
+                </p>
+              )}
               {stripeCustomerId && (
                 <form method="POST" action="/api/portal/billing/manage" class="mt-2">
                   <input type="hidden" name="product_slug" value="operator" />

--- a/src/pages/portal/products/operator/index.astro
+++ b/src/pages/portal/products/operator/index.astro
@@ -126,16 +126,11 @@ if (access) {
   // duplicated nav items already present (Connections, Team) and is noise for a
   // running operator (ADR 0069 sub-page coherence pass). The onboarding page
   // still exists by URL; it is simply not featured.
-  const ACTIVE_DOER_ROLES = ['staff', 'principal']
-  const canAct = userRoles.some((r) => ACTIVE_DOER_ROLES.includes(r))
-  if (canAct) {
-    sectionCards.push({
-      href: '/portal/products/operator/calendar',
-      label: 'Calendar',
-      description: 'Appointments and deadlines your Operator has scheduled or proposed.',
-      group: 'direct',
-    })
-  }
+  // "Calendar" removed from the landing: it was a dead stub (a filter over no
+  // data) that conflated a calendar of appointments with scheduling the
+  // operator's recurring jobs. The real need is a Schedule view of authored
+  // crons, built separately. The page still exists by URL (ADR 0069 sub-page
+  // coherence pass).
   sectionCards.push({
     href: '/portal/products/operator/activity',
     label: 'Activity',


### PR DESCRIPTION
Two more from your walkthrough:
- **Calendar** removed from the landing nav — it was a dead stub (filter over no data) that conflated appointments with scheduling recurring jobs. Real need is a Schedule view, built separately. Page still exists by URL.
- **Account** status was stated 3× (header + chip + prose). Now once — the chip — with the prose kept only for states that need explaining (paused, etc.).

verify green. Part of #1798.