### PR TITLE
feat(operator): reshape landing to Status / Role / Management (surface brief)

### DIFF
--- a/docs/design/operator/surface-briefs/operator-landing.md
+++ b/docs/design/operator/surface-briefs/operator-landing.md
@@ -1,0 +1,77 @@
+# Surface Brief — Operator landing (`/portal/products/operator`)
+
+Signed off 2026-07-08. The first brief run under the
+[Surface Brief](../../../style/surface-brief.md) process. This is the operator's
+front door in the client portal.
+
+## 1. Target user
+
+A client at a firm that runs an Operator (SMD's AI employee on a retainer). Three
+roles land here — **principal** (bought it, holds the decisions), **staff** (whose
+work it touches), **compliance** (oversight). All arrive already subscribed; this
+is a returning, exception-driven visit, not first-run.
+
+## 2. User tasks
+
+- "When I open my operator, I want to know it's healthy or something needs me —
+  at a glance, without hunting."
+- "I want to understand what this thing actually does — its role, its jobs, what
+  it can do."
+- "When I need to change a setting, or retrieve my data, I want an obvious way in."
+
+The client hopes never to _have_ to come here; they come when they suspect a
+problem, or to understand or adjust the operator.
+
+## 3. Business objective
+
+Make the retainer feel legible and trustworthy every time they look: prove the
+operator is alive and in-bounds, make its role and capabilities visible, and be
+the calm front door to every configuration and data facet. It kills "is this
+thing even working / what does it even do?" support pings.
+
+## 4. Inward paths
+
+The portal "Operator" nav tab; an escalation email; a returning bookmark. Rarely
+a first visit (onboarding owns that).
+
+## 5. Core content — the three questions
+
+This console is about the **operator itself**, not the work it produces. Business
+work (a draft to review) flows through the real channels — the mailbox, the alert
+— **not here**. The surface answers three questions and nothing else:
+
+- **Status** — is it OK? Operator health only: running / paused / offline, and
+  operator-level problems surfaced right here (never a business-work queue).
+- **Role** — what does it do? Persona · Scope · Skills · Schedule · Workflows.
+- **Management** — fix, change, or retrieve. Governance · Voice · Connections ·
+  Team · Memory · Activity. Account (the commercial layer) sits last.
+
+Every client-facing facet in the registry has a home above; the folds:
+Skills absorbs bundles + agent-authored skills; Schedule absorbs business hours;
+Connections absorbs channels + webhook triggers; Team absorbs escalation contacts;
+Memory absorbs the relationship lane; Activity absorbs compliance (role-scoped).
+
+## 6. Forward paths
+
+Each facet is a door to its own page (each page is its own future Surface Brief).
+Status surfaces a fix action when there's an operator problem (e.g. reconnect,
+contact consultant). Account holds subscription, data/memory export, cancellation.
+
+## 7. Verdict
+
+Reshape, not re-skin. The landing is **health-at-a-glance + a complete, legible
+map of the operator**, organized as Status / Role / Management, with Account last.
+The prior "identity masthead + activity preview + management directory" is
+replaced. No work-queue. "Configure" is dissolved — its contents (Scope, Skills,
+Governance, Voice) become top-level facets.
+
+## Build notes (honesty)
+
+- Status is wired to the real aliveness signal; when the runtime bridge has no
+  data the block says so honestly, never a fabricated "healthy."
+- Live connection health is not yet a real probe, so it is not asserted on the
+  landing.
+- Facet pages that don't exist yet (Persona, Schedule, Workflows, Memory) show in
+  the map as present-but-not-yet-built (honest, never "coming soon"); Scope,
+  Skills, Governance, Voice deep-link to today's Configure page until each is
+  built as its own briefed surface.

--- a/docs/style/surface-brief.md
+++ b/docs/style/surface-brief.md
@@ -1,0 +1,61 @@
+# Surface Brief — the per-surface definition exercise
+
+Every portal/admin surface is defined by a **Surface Brief** before it is designed
+or built. The brief is the thing we agree and sign off; the page is downstream of
+it. This exists so we stop guessing our way through pages one after the next —
+each surface earns its shape from a repeatable exercise, not from a vibe.
+
+The exercise is the **Core Model** (Are & Mona Halland,
+[A List Apart](https://alistapart.com/article/the-core-model-designing-inside-out-for-better-results/)),
+adapted to this console. Adopted 2026-07-08 (Captain decision).
+
+## The template
+
+Fill this out for a surface, agree it, then design to it.
+
+```
+Surface Brief — <page / route>
+
+1. Target user        — who actually lands here (role + context).
+2. User tasks         — what they're trying to get done, in their words:
+                        "When I come here, I want to ___ so I can ___."
+3. Business objective — why WE put this in front of them; what it must
+                        accomplish for SMD.
+4. Inward paths       — how they arrive (nav, an email link, a hand-off from
+                        another surface). Catches orphan pages.
+5. Core content       — the essential thing(s) this surface must show to satisfy
+                        the task AND the objective. Anything not serving the task
+                        or the objective gets cut. (This answers "why present
+                        anything at all.")
+6. Forward paths      — what they do next and what they can do here (actions,
+                        exits). (This answers "what can they do.")
+7. Verdict            — given 1–6, what this surface should BE: keep / cut / add /
+                        reshape. This is the line we sign off before any design
+                        or code.
+```
+
+## The loop (how we run it)
+
+One surface at a time:
+
+1. **Brief** — fill the template above from real ground truth (the code, the
+   config model, the facet registry — never memory).
+2. **Agree** — put it in front of the Captain; add/cut/correct fields; sign off
+   the verdict. Nothing is built off an unsigned brief.
+3. **Design** — mock the surface to the agreed brief; the Captain reacts to a
+   real rendering, not a description.
+4. **Build** — implement the signed-off design in the calm register
+   ([UI-PATTERNS.md](./UI-PATTERNS.md) Rule 8), honest where data isn't wired
+   ([empty-state-pattern.md](./empty-state-pattern.md)).
+5. **Sign off** — the Captain confirms the built result, then we point at the
+   next surface.
+
+## Ground-truth discipline
+
+Fill the brief from what actually exists, not from memory — memory is how facets
+get orphaned. For operator surfaces the authoritative inventory is the **facet
+registry** (`src/lib/portal/operator/facet-registry.ts`): the closed set of every
+facet the operator has, each with a deliberate surface decision. If a brief needs
+a facet, it is in the registry or it is not real.
+
+Completed briefs live in `docs/design/<area>/surface-briefs/`.

--- a/src/components/portal/operator/FacetDoorList.astro
+++ b/src/components/portal/operator/FacetDoorList.astro
@@ -1,0 +1,62 @@
+---
+/**
+ * FacetDoorList — the calm-register list of operator facet doors (ADR 0069;
+ * landing brief 2026-07-08). One raised card, hairline-divided rows.
+ *
+ * A door with an `href` is a link (arrow + optional real status hint). A door
+ * with `href: null` renders as a non-interactive, muted row marked "Not yet
+ * available" — the facet is on the map but its page isn't built, and we never
+ * fabricate a destination or promise a date.
+ */
+import type { FacetDoor } from '../../../lib/portal/operator/facet-doors'
+
+interface Props {
+  doors: FacetDoor[]
+}
+
+const { doors } = Astro.props
+---
+
+<div class="border border-[color:var(--color-border)] bg-surface-raised">
+  {
+    doors.map((d, i) => {
+      const divider = i > 0 ? 'border-t border-[color:var(--color-border-subtle)]' : ''
+      return d.href ? (
+        <a
+          href={d.href}
+          class={`group flex items-center justify-between gap-6 p-card transition-colors hover:bg-[color:var(--color-border-subtle)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-inset ${divider}`}
+        >
+          <div class="min-w-0">
+            <p class="text-body font-semibold text-[color:var(--color-text-primary)]">{d.label}</p>
+            <p class="mt-0.5 text-caption text-[color:var(--color-text-secondary)]">{d.desc}</p>
+          </div>
+          <div class="flex flex-none items-center gap-3">
+            {d.status && (
+              <span class="font-mono text-label uppercase tracking-[0.1em] text-[color:var(--color-error)]">
+                {d.status}
+              </span>
+            )}
+            <span
+              aria-hidden="true"
+              class="text-[color:var(--color-text-muted)] transition-transform group-hover:translate-x-0.5"
+            >
+              →
+            </span>
+          </div>
+        </a>
+      ) : (
+        <div class={`flex items-center justify-between gap-6 p-card ${divider}`}>
+          <div class="min-w-0">
+            <p class="text-body font-semibold text-[color:var(--color-text-secondary)]">
+              {d.label}
+            </p>
+            <p class="mt-0.5 text-caption text-[color:var(--color-text-muted)]">{d.desc}</p>
+          </div>
+          <span class="flex-none font-mono text-label uppercase tracking-[0.1em] text-[color:var(--color-text-muted)]">
+            Not yet available
+          </span>
+        </div>
+      )
+    })
+  }
+</div>

--- a/src/components/portal/operator/facets/OperatorHero.astro
+++ b/src/components/portal/operator/facets/OperatorHero.astro
@@ -1,45 +1,97 @@
 ---
 /**
- * Operator hero — the shared "meet your operator" lead (ADR 0069 Slice 2).
+ * Operator STATUS block — the shared "is it OK?" lead (ADR 0069; landing brief
+ * 2026-07-08). Health-led: the persona is a small line, the operator's health is
+ * the headline. Answers the first of the landing's three questions at a glance.
  *
- * Renders who the operator is (persona identity) and whether it is alive and
- * in-bounds (the aliveness signal, via AlivenessHeader). ONE shared component,
- * mounted in both portals per Lock 4; the facet registry points the `identity`
- * and `status` facets at the resolver this consumes
+ * ONE shared component, mounted in both portals per Lock 4; the facet registry
+ * points the `identity` and `status` facets at the resolver this consumes
  * (lib/portal/operator/facets/identity/hero.ts).
  *
- * Calm register (UI-PATTERNS Rule 8): a raised Card, a mono `text-label`
- * eyebrow, the persona name in sentence case at `text-title`, and the aliveness
- * signal as a calm inline status — no loud 3px rules or black-uppercase name.
- *
- * Identity is authored config — nothing fabricated. With no active persona the
- * headline falls back to the generic label "Your operator" (a label, not an
- * authored value), and a null aliveness signal renders AlivenessHeader's silent
- * empty state (never a fabricated "healthy" chip).
+ * Honesty: identity is authored config (no fabrication; falls back to the generic
+ * "Your operator" label). Health is the real aliveness signal — when the runtime
+ * bridge has no data (`aliveness === null`) the block says so plainly rather than
+ * fabricating a healthy state. Only operator problems surface here (paused /
+ * offline); business work never does (landing brief §5).
  */
 import Card from '../../Card.astro'
-import AlivenessHeader from '../AlivenessHeader.astro'
+import StatusDot from '../../StatusDot.astro'
+import {
+  formatLastActionRelative,
+  formatLastActionAbsolute,
+  needsEscalationAffordance,
+  type AlivenessLevel,
+} from '../../../../lib/portal/operator/aliveness'
+import type { Tone } from '../../../../lib/portal/status'
 import type { OperatorHeroModel } from '../../../../lib/portal/operator/facets/identity/hero'
 
 interface Props {
   model: OperatorHeroModel
-  /** Passed through to AlivenessHeader's escalation affordance; null is fine. */
+  /** Escalation target for the two unhealthy states; null falls back to settings. */
   escalationHref?: string | null
 }
 
 const { model, escalationHref = null } = Astro.props
 const displayName = model.name ?? 'Your operator'
+const personaLine = model.title ? `${displayName} · ${model.title}` : displayName
+
+// Client-facing health headline for each aliveness level. Healthy states read as
+// reassurance; the two problem states name the problem and offer the fix.
+const HEALTH: Record<AlivenessLevel, { headline: string; tone: Tone; problem: boolean }> = {
+  idle: { headline: 'Running normally', tone: 'success', problem: false },
+  running: { headline: 'Working now', tone: 'success', problem: false },
+  sticky_stop: { headline: 'Paused, needs your attention', tone: 'danger', problem: true },
+  offline: { headline: 'Offline, needs your attention', tone: 'danger', problem: true },
+}
+
+const signal = model.aliveness
+const level = signal?.level ?? null
+const health = level ? HEALTH[level] : null
+const lastRel = signal ? formatLastActionRelative(signal.lastActionAt) : null
+const lastAbs = signal ? formatLastActionAbsolute(signal.lastActionAt) : null
+const currentSkill = signal?.level === 'running' ? signal.currentSkill : null
+const stickyReason = signal?.level === 'sticky_stop' ? signal.stickyStopReason : null
+const showEscalation = level ? needsEscalationAffordance(level) : false
+const escalationTarget = escalationHref ?? '/portal/products/operator/settings'
 ---
 
-<Card class="mt-8" ariaLabel="Operator identity and status">
-  <p class="text-label uppercase text-[color:var(--color-text-muted)]">Your operator</p>
-  <h2 class="mt-1 text-title text-[color:var(--color-text-primary)]">{displayName}</h2>
+<Card ariaLabel="Operator status">
+  <p class="font-mono text-label uppercase tracking-[0.14em] text-[color:var(--color-text-muted)]">
+    {personaLine}
+  </p>
+
   {
-    model.title && (
-      <p class="mt-1 text-caption text-[color:var(--color-text-secondary)]">{model.title}</p>
+    health ? (
+      <>
+        <div class="mt-2 flex items-center gap-2.5">
+          <StatusDot tone={health.tone} />
+          <h2 class="text-title text-[color:var(--color-text-primary)]">{health.headline}</h2>
+        </div>
+        {stickyReason && (
+          <p class="mt-2 text-caption text-[color:var(--color-text-secondary)]">{stickyReason}</p>
+        )}
+        {(currentSkill || lastRel) && (
+          <p
+            class="mt-2 text-caption text-[color:var(--color-text-secondary)]"
+            title={lastAbs ?? undefined}
+          >
+            {currentSkill ? `${currentSkill} · ` : ''}
+            {lastRel ? `Last action ${lastRel}` : ''}
+          </p>
+        )}
+        {showEscalation && (
+          <a
+            href={escalationTarget}
+            class="mt-4 inline-flex min-h-11 items-center border border-[color:var(--color-text-primary)] bg-[color:var(--color-text-primary)] px-4 text-caption font-semibold text-[color:var(--color-background)] transition-colors hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2"
+          >
+            Contact your consultant
+          </a>
+        )}
+      </>
+    ) : (
+      <p class="mt-2 text-caption text-[color:var(--color-text-secondary)]">
+        Live status isn't reporting yet.
+      </p>
     )
   }
-  <div class="mt-4">
-    <AlivenessHeader signal={model.aliveness} escalationHref={escalationHref} />
-  </div>
 </Card>

--- a/src/lib/portal/operator/facet-doors.ts
+++ b/src/lib/portal/operator/facet-doors.ts
@@ -1,0 +1,14 @@
+/**
+ * A facet door on the operator landing (ADR 0069; landing brief 2026-07-08).
+ *
+ * Each door leads to a facet's own page. `href: null` means the dedicated page
+ * isn't built yet — the door renders as present-but-not-yet-built (honest, never
+ * "coming soon"). `status` is an optional at-a-glance hint (e.g. a connection
+ * needing attention) and is only ever set from REAL data — never fabricated.
+ */
+export interface FacetDoor {
+  label: string
+  desc: string
+  href: string | null
+  status?: string | null
+}

--- a/src/pages/portal/products/operator/index.astro
+++ b/src/pages/portal/products/operator/index.astro
@@ -6,47 +6,34 @@ import {
   listProductRoles,
   type ProductAccess,
 } from '../../../../lib/portal/product-access'
-import PromotionCardList from '../../../../components/portal/operator/PromotionCardList.astro'
 import OperatorHero from '../../../../components/portal/operator/facets/OperatorHero.astro'
-import Card from '../../../../components/portal/Card.astro'
-import CardHeader from '../../../../components/portal/CardHeader.astro'
 import { resolveOperatorHero } from '../../../../lib/portal/operator/facets/identity/hero'
-import {
-  listPromotionReadySkills,
-  type PromotionCandidate,
-} from '../../../../lib/portal/operator/promotion-cards'
 import {
   resolveAlivenessSignal,
   type AlivenessSignal,
 } from '../../../../lib/portal/operator/aliveness'
 import { getCustomerConfig } from '../../../../lib/portal/customer-config'
-import { loadHomeFeeds, type HomeFeeds } from '../../../../lib/portal/operator/home'
-import { formatAuditTimestamp } from '../../../../lib/portal/operator/audit'
+import Card from '../../../../components/portal/Card.astro'
+import FacetDoorList from '../../../../components/portal/operator/FacetDoorList.astro'
+import type { FacetDoor } from '../../../../lib/portal/operator/facet-doors'
 import { env } from 'cloudflare:workers'
 
 /**
- * Operator dashboard — landing page.
+ * Operator landing — the operator's front door (ADR 0069; signed-off landing
+ * brief docs/design/operator/surface-briefs/operator-landing.md, 2026-07-08).
  *
- * URL: portal.smd.services/portal/products/operator
+ * This console is about the OPERATOR itself, not the work it produces. Business
+ * work (a draft to review) flows through the real channels — the mailbox, the
+ * alert — never here. The surface answers three questions:
+ *   Status     — is it OK? (operator health only; no business-work queue)
+ *   Role       — what does it do? (Persona · Scope · Skills · Schedule · Workflows)
+ *   Management — fix, change, or retrieve (Governance · Voice · Connections ·
+ *                Team · Memory · Activity), with Account (the commercial layer) last.
  *
- * Access model (per PR #904 substrate, PR #906 Clerk rewire):
- *   1. Clerk session required (gated by middleware)
- *   2. Local users row linked to a Clerk org with a matching local
- *      entity (resolved by getPortalClient)
- *   3. Active subscription on (entity, 'operator') in the
- *      subscriptions table
- *   4. At least one role granted on (user, entity, 'operator') in
- *      product_roles — vocabulary: principal | staff | compliance
- *
- * Anything less degrades to the appropriate empty state per
- * docs/style/empty-state-pattern.md. No fabrication.
- *
- * This page is the routing entry point. Internal product surfaces
- * (Activity, Calendar, Connections, Configure, Team, Account) live under
- * /portal/products/operator/* and are reached via the section card
- * grid rendered in the active-state branch below. Each child surface
- * uses the shared resolveOperatorAccess helper to enforce its own
- * role gate; the landing only orchestrates which cards to render.
+ * Every door leads to a facet's own page. Facets whose page isn't built yet carry
+ * href: null and render as present-but-not-yet-built (honest, never "coming
+ * soon"); each becomes its own Surface Brief. Access is gated per destination
+ * (resolveOperatorAccess) — this landing only maps the doors.
  */
 
 const PRODUCT_SLUG = 'operator'
@@ -61,17 +48,7 @@ if (!portalData.client) {
 
 const { user, client } = portalData
 
-// Surface state derived in priority order. We render exactly one state.
-//   no_subscription   — customer has no Operator subscription on file
-//   provisioning      — subscription exists but the per-customer Hermes
-//                       Machine + D1 are still being set up
-//   paused            — subscription is paused (audit-only access)
-//   no_role           — subscription is active but the user has no role
-//                       granted; principal needs to grant access
-//   active            — subscription active + at least one role; render
-//                       the dashboard
 type SurfaceState = 'no_subscription' | 'provisioning' | 'paused' | 'no_role' | 'active'
-
 let surfaceState: SurfaceState
 let access: ProductAccess | null = null
 
@@ -92,151 +69,77 @@ if (!subscription) {
   }
 }
 
-// Section cards in the active-state main column. Filtered by the
-// caller's roles so staff / principals see the act-on-the-product
-// surfaces (Calendar) and every role sees Activity.
-// Each destination uses resolveOperatorAccess to enforce the gate
-// server-side; this list is the visual filter only.
-//
-// Compliance card surfacing (per #895): when the firm has opted in to
-// the dedicated Compliance view (customer.yaml.compliance_enabled =
-// true), surface the card to compliance and principal roles. Staff
-// never see it — their surfaces are Activity and Calendar.
-// When the firm has NOT opted in, surface only to compliance-role
-// users so they have a path to confirm the firm's posture; the
-// destination renders an explicit "not enabled for this firm" empty
-// state per docs/style/empty-state-pattern.md.
-// Management surfaces, grouped by the three console jobs (ADR 0052): Direct
-// (shape the employment), Review (what it did), Administer (the relationship).
-// "Get started" is the transitional setup lead. Role gates are preserved
-// exactly — each card is still conditionally included; only the presentation
-// changed, from a §-numbered card grid to a quiet grouped nav (ADR 0069
-// landing restructure).
-type SectionGroup = 'direct' | 'review' | 'administer'
-interface SectionCard {
-  href: string
-  label: string
-  description: string
-  group: SectionGroup
-}
-const sectionCards: SectionCard[] = []
 const customerConfig = access ? await getCustomerConfig(env.DB, client.id) : null
-const complianceViewEnabled = customerConfig?.compliance_enabled ?? false
-if (access) {
-  const userRoles = access.roles
-  // "Get started" (onboarding) intentionally removed from the landing: it
-  // duplicated nav items already present (Connections, Team) and is noise for a
-  // running operator (ADR 0069 sub-page coherence pass). The onboarding page
-  // still exists by URL; it is simply not featured.
-  // "Calendar" removed from the landing: it was a dead stub (a filter over no
-  // data) that conflated a calendar of appointments with scheduling the
-  // operator's recurring jobs. The real need is a Schedule view of authored
-  // crons, built separately. The page still exists by URL (ADR 0069 sub-page
-  // coherence pass).
-  sectionCards.push({
-    href: '/portal/products/operator/activity',
-    label: 'Activity',
-    description:
-      'A full record of every action your Operator takes: drafts created, sends approved, identity changes.',
-    group: 'review',
-  })
-  sectionCards.push({
-    href: '/portal/products/operator/connections',
-    label: 'Connections',
-    description: 'The systems your Operator connects to, and how their credentials are held.',
-    group: 'direct',
-  })
-  sectionCards.push({
-    href: '/portal/products/operator/configure',
-    label: 'Configure',
-    description: "Your Operator's skills, governance, voice, scope, and hours.",
-    group: 'direct',
-  })
-  sectionCards.push({
-    href: '/portal/products/operator/team',
-    label: 'Team',
-    description: 'The people on your account, their roles, and who is covering for whom.',
-    group: 'administer',
-  })
-  sectionCards.push({
-    href: '/portal/products/operator/account',
-    label: 'Account',
-    description: 'Your subscription, escalation contacts, and notification preferences.',
-    group: 'administer',
-  })
-  const isCompliance = userRoles.includes('compliance')
-  const isPrincipal = userRoles.includes('principal')
-  const showComplianceCard =
-    (complianceViewEnabled && (isCompliance || isPrincipal)) || isCompliance
-  if (showComplianceCard) {
-    sectionCards.push({
-      href: '/portal/products/operator/compliance',
-      label: 'Compliance',
-      description:
-        'Separation-of-duties view: audit history, retention posture, and evidence packet entry.',
-      group: 'review',
-    })
-  }
-}
-const SECTION_GROUPS: { key: SectionGroup; label: string }[] = [
-  { key: 'direct', label: 'Direct' },
-  { key: 'review', label: 'Review' },
-  { key: 'administer', label: 'Administer' },
-]
 
-// Aliveness signal (per #875, wired in #1678). Per-customer "where is the
-// agent right now" header: idle / running / sticky_stop / offline +
-// last-action timestamp, derived from this customer's fleet_status
-// heartbeat row (ADR 0023 Wave 1). A customer with no row yet resolves to
-// null and the AlivenessHeader renders nothing (empty-state pattern).
-// Surfaced for any role so operators and compliance see the same posture
-// the principal sees; access to the surface is already role-gated upstream.
+// STATUS — persona identity + the real aliveness signal (brief §5). Both are real
+// from the config projection / fleet_status; the block is honest-empty when the
+// runtime bridge has no data (never a fabricated "healthy").
 let alivenessSignal: AlivenessSignal | null = null
 if (access) {
   alivenessSignal = await resolveAlivenessSignal(env.DB, access.subscription)
 }
-
-// "Meet your operator" hero (ADR 0069 Slice 2): identity (active persona) +
-// status (aliveness), composed by the shared resolver. Both facets are Tier-1
-// real from the config projection / fleet_status; nothing fabricated.
 const heroModel = resolveOperatorHero(customerConfig, alivenessSignal)
 
-// Promotion recommendation cards (per #811). Principal-only because the
-// trust-ceiling promotion is the firm's decision per §11.3 — operator
-// and compliance roles do not see the prompt. The resolver returns an
-// empty list today (Hermes stats bridge not wired); when it does the
-// PromotionCardList wrapper renders nothing, so no fabricated copy
-// reaches the page. The dismissals table is wired so the empty case is
-// honest: even when bridge data lands later, a dismissed card stays
-// suppressed for the cooldown.
-let promotionCandidates: PromotionCandidate[] = []
-if (access?.roles.includes('principal')) {
-  promotionCandidates = await listPromotionReadySkills(env.DB, client.id)
-}
+// The operator's facet map (brief §5). Scope/Skills/Governance/Voice deep-link to
+// today's Configure page until each is split into its own briefed surface; the
+// facets with no page yet (Persona, Schedule, Workflows, Memory) carry href: null.
+const CONFIGURE = '/portal/products/operator/configure'
+const roleDoors: FacetDoor[] = [
+  {
+    label: 'Persona',
+    desc: 'Who it is: its name, role, and the identities it can operate as.',
+    href: null,
+  },
+  { label: 'Scope', desc: 'What it handles for you, and the shape of its job.', href: CONFIGURE },
+  {
+    label: 'Skills',
+    desc: 'Everything it can do: authored, bundled, and the ones it wrote itself.',
+    href: CONFIGURE,
+  },
+  {
+    label: 'Schedule',
+    desc: 'The recurring jobs it runs, and the hours it works.',
+    href: null,
+  },
+  {
+    label: 'Workflows',
+    desc: 'The multi-step processes it follows to get work done.',
+    href: null,
+  },
+]
+const manageDoors: FacetDoor[] = [
+  {
+    label: 'Governance',
+    desc: 'What it may do on its own vs. what needs your sign-off.',
+    href: CONFIGURE,
+  },
+  { label: 'Voice', desc: 'How it sounds when it writes on your behalf.', href: CONFIGURE },
+  {
+    label: 'Connections',
+    desc: 'The systems and channels it works through.',
+    href: '/portal/products/operator/connections',
+  },
+  {
+    label: 'Team',
+    desc: 'People on the account and who gets alerted.',
+    href: '/portal/products/operator/team',
+  },
+  { label: 'Memory', desc: 'What it knows about your business, to view or export.', href: null },
+  {
+    label: 'Activity',
+    desc: 'The full record of everything it has done.',
+    href: '/portal/products/operator/activity',
+  },
+]
+const accountDoors: FacetDoor[] = [
+  {
+    label: 'Account',
+    desc: 'Subscription, data export, and cancellation.',
+    href: '/portal/products/operator/account',
+  },
+]
 
-// Home/Today runtime feeds (client-portal §5.1, wired in #1678): recent
-// activity + escalations from ONE live runtime read (ADR 0043, kind
-// audit_log — the same frozen seam the Activity page uses), and
-// needsAttentionCount from the Machine-pushed draft_queue_depth in this
-// customer's summary-mirror row. Every source fails closed to an honest
-// empty; Home never fabricates a review queue the Machine did not report
-// (ADR 0035).
-const customerSlug = customerConfig?.customer_slug ?? client.id
-const homeActorRole = access?.roles.includes('principal')
-  ? 'principal'
-  : access?.roles.includes('compliance')
-    ? 'compliance'
-    : 'staff'
-const homeFeeds: HomeFeeds | null = access
-  ? await loadHomeFeeds({ db: env.DB, env, actorUserId: user.id }, customerSlug, {
-      actor: user.email,
-      actorRole: homeActorRole,
-    })
-  : null
-
-// Change-request filing outcome (client-portal §3). The dual-mode "Request a
-// change" form 303s back with ?cr=filed|invalid|error so the surface it returned
-// to can show a banner.
+// Change-request filing outcome (returns via ?cr=filed|invalid|error).
 const crStatus = Astro.url.searchParams.get('cr')
 const crMessage =
   crStatus === 'filed'
@@ -247,6 +150,27 @@ const crMessage =
         ? 'Something went wrong filing your request. Please try again.'
         : null
 const crTone = crStatus === 'filed' ? 'complete' : 'error'
+
+const seclabelClass =
+  'font-mono text-label uppercase tracking-[0.14em] text-[color:var(--color-text-muted)]'
+
+// Honest non-active states (empty-state pattern).
+const EMPTY: Record<Exclude<SurfaceState, 'active'>, { title: string; body: string }> = {
+  no_subscription: {
+    title: 'Not subscribed',
+    body: "Your account doesn't include the Operator product. Contact us if you'd like to talk about adding it.",
+  },
+  provisioning: { title: 'Setup in progress', body: 'Your Operator is being configured.' },
+  paused: {
+    title: 'Paused',
+    body: 'Your Operator subscription is paused. Audit history remains accessible; new drafts are suspended until the subscription resumes.',
+  },
+  no_role: {
+    title: 'Access pending',
+    body: "The Operator is set up for your firm, but you haven't been granted a role yet. Contact your firm's principal to be added.",
+  },
+}
+const empty = surfaceState !== 'active' ? EMPTY[surfaceState] : null
 ---
 
 <PortalShell
@@ -256,11 +180,6 @@ const crTone = crStatus === 'filed' ? 'complete' : 'error'
   entityId={client.id}
   pathname={Astro.url.pathname}
 >
-  {
-    /* A console lead, not a marketing masthead: the nav tab and the hero below
-      already say "Operator", so we keep only a quiet breadcrumb. Calm register
-      (UI-PATTERNS Rule 8): a text-label crumb, no black-weight arrow. */
-  }
   <a
     href="/portal"
     class="mt-6 -mx-1 inline-flex min-h-11 items-center gap-2 px-1 text-label uppercase text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2"
@@ -285,48 +204,10 @@ const crTone = crStatus === 'filed' ? 'complete' : 'error'
   }
 
   {
-    surfaceState === 'no_subscription' && (
+    empty && (
       <Card class="mt-10 text-center">
-        <p class="text-title text-[color:var(--color-text-primary)]">Not subscribed</p>
-        <p class="mt-2 text-body text-[color:var(--color-text-secondary)]">
-          Your account doesn't include the Operator product. Contact us if you'd like to talk about
-          adding it.
-        </p>
-      </Card>
-    )
-  }
-
-  {
-    surfaceState === 'provisioning' && (
-      <Card class="mt-10 text-center">
-        <p class="text-title text-[color:var(--color-text-primary)]">Setup in progress</p>
-        <p class="mt-2 text-body text-[color:var(--color-text-secondary)]">
-          Your Operator is being configured.
-        </p>
-      </Card>
-    )
-  }
-
-  {
-    surfaceState === 'paused' && (
-      <Card class="mt-10 text-center">
-        <p class="text-title text-[color:var(--color-text-primary)]">Paused</p>
-        <p class="mt-2 text-body text-[color:var(--color-text-secondary)]">
-          Your Operator subscription is paused. Audit history remains accessible; new drafts are
-          suspended until the subscription resumes.
-        </p>
-      </Card>
-    )
-  }
-
-  {
-    surfaceState === 'no_role' && (
-      <Card class="mt-10 text-center">
-        <p class="text-title text-[color:var(--color-text-primary)]">Access pending</p>
-        <p class="mt-2 text-body text-[color:var(--color-text-secondary)]">
-          The Operator is set up for your firm, but you haven't been granted a role yet. Contact
-          your firm's principal to be added.
-        </p>
+        <p class="text-title text-[color:var(--color-text-primary)]">{empty.title}</p>
+        <p class="mt-2 text-body text-[color:var(--color-text-secondary)]">{empty.body}</p>
       </Card>
     )
   }
@@ -334,114 +215,23 @@ const crTone = crStatus === 'filed' ? 'complete' : 'error'
   {
     surfaceState === 'active' && (
       <>
-        <OperatorHero model={heroModel} />
+        <p class={`mt-8 ${seclabelClass}`}>Status</p>
+        <div class="mt-3">
+          <OperatorHero model={heroModel} />
+        </div>
 
-        {/* Home / Today (client-portal §5.1): what needs you, what it did,
-                escalations. Runtime-fed (#1678); fails closed to honest empty
-                on any transport failure. "What needs you" appears ONLY when
-                the Machine reported work genuinely routed to a human for this
-                client — never a fabricated queue (ADR 0035). */}
-        {homeFeeds && (
-          <section class="mt-8 flex flex-col gap-8" aria-label="What's happening">
-            {homeFeeds.needsAttentionCount > 0 && (
-              <Card href="/portal/products/operator/activity" ariaLabel="Items need your review">
-                <p class="text-label uppercase text-[color:var(--color-action)]">What needs you</p>
-                <p class="mt-1 text-heading text-[color:var(--color-text-primary)]">
-                  {homeFeeds.needsAttentionCount}{' '}
-                  {homeFeeds.needsAttentionCount === 1 ? 'item needs' : 'items need'} your review
-                </p>
-              </Card>
-            )}
+        <p class={`mt-10 ${seclabelClass}`}>Role</p>
+        <div class="mt-3">
+          <FacetDoorList doors={roleDoors} />
+        </div>
 
-            <Card>
-              <CardHeader
-                title="Recent activity"
-                actionLabel="Full record"
-                actionHref="/portal/products/operator/activity"
-              />
-              {homeFeeds.recentActivity.length === 0 ? (
-                <p class="mt-stack text-caption text-[color:var(--color-text-secondary)]">
-                  No activity to show yet.
-                </p>
-              ) : (
-                <ul role="list" class="mt-stack">
-                  {homeFeeds.recentActivity.map((item, i) => (
-                    <li
-                      class={`py-3 ${i > 0 ? 'border-t border-[color:var(--color-border-subtle)]' : ''}`}
-                    >
-                      <p class="text-body text-[color:var(--color-text-primary)]">{item.summary}</p>
-                      <p class="mt-1 text-caption text-[color:var(--color-text-muted)]">
-                        {formatAuditTimestamp(item.at)}
-                      </p>
-                    </li>
-                  ))}
-                </ul>
-              )}
-            </Card>
+        <p class={`mt-10 ${seclabelClass}`}>Management</p>
+        <div class="mt-3">
+          <FacetDoorList doors={manageDoors} />
+        </div>
 
-            {homeFeeds.escalations.length > 0 && (
-              <Card ariaLabel="Escalations">
-                <CardHeader title="Escalations" />
-                <ul role="list" class="mt-stack">
-                  {homeFeeds.escalations.map((item, i) => (
-                    <li
-                      class={`py-3 ${i > 0 ? 'border-t border-[color:var(--color-border-subtle)]' : ''}`}
-                    >
-                      <p class="text-body text-[color:var(--color-text-primary)]">{item.summary}</p>
-                      <p class="mt-1 text-caption text-[color:var(--color-text-muted)]">
-                        {formatAuditTimestamp(item.at)}
-                      </p>
-                    </li>
-                  ))}
-                </ul>
-              </Card>
-            )}
-          </section>
-        )}
-
-        <div class="mt-10 flex flex-col gap-8">
-          <PromotionCardList candidates={promotionCandidates} />
-
-          <section aria-label="Manage your operator" class="flex flex-col gap-8">
-            {SECTION_GROUPS.map((grp) => {
-              const items = sectionCards.filter((s) => s.group === grp.key)
-              if (items.length === 0) return null
-              return (
-                <div>
-                  <p class="mb-2 text-label uppercase text-[color:var(--color-text-muted)]">
-                    {grp.label}
-                  </p>
-                  <Card padded={false}>
-                    <ul role="list">
-                      {items.map((s, i) => (
-                        <li>
-                          <a
-                            href={s.href}
-                            class={`group flex items-center justify-between gap-6 p-card transition-colors hover:bg-[color:var(--color-border-subtle)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-inset ${i > 0 ? 'border-t border-[color:var(--color-border-subtle)]' : ''}`}
-                          >
-                            <div class="min-w-0">
-                              <p class="text-body font-semibold text-[color:var(--color-text-primary)]">
-                                {s.label}
-                              </p>
-                              <p class="mt-0.5 text-caption text-[color:var(--color-text-secondary)]">
-                                {s.description}
-                              </p>
-                            </div>
-                            <span
-                              aria-hidden="true"
-                              class="text-[color:var(--color-text-muted)] transition-transform group-hover:translate-x-0.5"
-                            >
-                              →
-                            </span>
-                          </a>
-                        </li>
-                      ))}
-                    </ul>
-                  </Card>
-                </div>
-              )
-            })}
-          </section>
+        <div class="mt-8">
+          <FacetDoorList doors={accountDoors} />
         </div>
       </>
     )


### PR DESCRIPTION
First surface built under the new **Surface Brief** process (Core Model). The operator landing becomes the operator's legible front door, not a work dashboard.

## The reframe (signed-off brief)

This console is about the **operator itself**, not the work it produces — business work flows through the mailbox/alerts, never here. The landing answers three questions:

- **STATUS** — is it OK? Health-led: persona as a small line, the real aliveness signal as the headline. Only operator problems (paused/offline) surface here; **no business-work queue**. Honest-empty when the runtime bridge has no data.
- **ROLE** — what does it do? Persona · Scope · Skills · Schedule · Workflows.
- **MANAGEMENT** — fix, change, or retrieve. Governance · Voice · Connections · Team · Memory · Activity. Account (commercial layer) last.

Every client-facing facet from the registry has a home; **"Configure" is dissolved** into top-level facets — nothing floating.

## Honest doors

- Live: Connections · Team · Activity · Account.
- Deep-link to today's Configure page until split out: Scope · Skills · Governance · Voice.
- Present-but-not-yet-built (honest, never "coming soon"): Persona · Schedule · Workflows · Memory. Each becomes its own briefed surface.
- No fabricated content; connection health is **not** asserted (no real probe yet).

## New

- `docs/style/surface-brief.md` — the per-surface Core Model exercise (the process, locked in).
- `docs/design/operator/surface-briefs/operator-landing.md` — this signed-off brief.
- `FacetDoorList.astro` + `facet-doors.ts` — the calm-register door primitive.

`OperatorHero` reworked persona-led → health-led. Removed the recent-activity preview, the "what needs you" work-queue, and promotion cards from the landing.

## Verify

`npm run verify` green — 3365 passed, 0 errors. Calm-register guard passes; the landing was already off PENDING from #1817 and stays clean. Em-dash / copy guardrails pass.

Note: the portal is auth-gated, so live rendering should be eyeballed post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)