### PR TITLE
fix(operator): landing readability (tight column, full-strength rows, firmer cards)

### DIFF
--- a/src/components/portal/Card.astro
+++ b/src/components/portal/Card.astro
@@ -32,7 +32,7 @@ const {
 } = Astro.props
 
 const Tag: HTMLTag = href ? 'a' : as
-const base = 'bg-surface-raised rounded-card border border-[color:var(--color-border)]'
+const base = 'bg-surface-raised rounded-card border border-[color:var(--color-border-strong)]'
 const pad = padded ? 'p-card' : ''
 const interactive = href
   ? 'block transition-colors hover:border-[color:var(--color-text-muted)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2'

--- a/src/components/portal/operator/FacetDoorList.astro
+++ b/src/components/portal/operator/FacetDoorList.astro
@@ -17,7 +17,7 @@ interface Props {
 const { doors } = Astro.props
 ---
 
-<div class="border border-[color:var(--color-border)] bg-surface-raised">
+<div class="border border-[color:var(--color-border-strong)] bg-surface-raised">
   {
     doors.map((d, i) => {
       const divider = i > 0 ? 'border-t border-[color:var(--color-border-subtle)]' : ''
@@ -47,12 +47,10 @@ const { doors } = Astro.props
       ) : (
         <div class={`flex items-center justify-between gap-6 p-card ${divider}`}>
           <div class="min-w-0">
-            <p class="text-body font-semibold text-[color:var(--color-text-secondary)]">
-              {d.label}
-            </p>
-            <p class="mt-0.5 text-caption text-[color:var(--color-text-muted)]">{d.desc}</p>
+            <p class="text-body font-semibold text-[color:var(--color-text-primary)]">{d.label}</p>
+            <p class="mt-0.5 text-caption text-[color:var(--color-text-secondary)]">{d.desc}</p>
           </div>
-          <span class="flex-none font-mono text-label uppercase tracking-[0.1em] text-[color:var(--color-text-muted)]">
+          <span class="flex-none whitespace-nowrap border border-[color:var(--color-border-subtle)] px-2 py-1 font-mono text-[10px] uppercase tracking-[0.12em] text-[color:var(--color-text-muted)]">
             Not yet available
           </span>
         </div>

--- a/src/pages/portal/products/operator/index.astro
+++ b/src/pages/portal/products/operator/index.astro
@@ -180,60 +180,66 @@ const empty = surfaceState !== 'active' ? EMPTY[surfaceState] : null
   entityId={client.id}
   pathname={Astro.url.pathname}
 >
-  <a
-    href="/portal"
-    class="mt-6 -mx-1 inline-flex min-h-11 items-center gap-2 px-1 text-label uppercase text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2"
-  >
-    <span aria-hidden="true" class="text-[color:var(--color-text-muted)]">←</span>
-    Home
-  </a>
-
   {
-    crMessage && (
-      <div
-        role="status"
-        class={`mt-6 rounded-card border p-4 text-caption font-medium ${
-          crTone === 'complete'
-            ? 'border-[color:var(--color-complete)] text-[color:var(--color-complete)]'
-            : 'border-[color:var(--color-error)] text-[color:var(--color-error)]'
-        }`}
-      >
-        {crMessage}
-      </div>
-    )
+    /* Tight reading column — the calm cards wash out stretched to full portal
+      width (UI-PATTERNS Rule 8 readability pass). */
   }
+  <div class="mx-auto max-w-2xl">
+    <a
+      href="/portal"
+      class="mt-6 -mx-1 inline-flex min-h-11 items-center gap-2 px-1 text-label uppercase text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2"
+    >
+      <span aria-hidden="true" class="text-[color:var(--color-text-muted)]">←</span>
+      Home
+    </a>
 
-  {
-    empty && (
-      <Card class="mt-10 text-center">
-        <p class="text-title text-[color:var(--color-text-primary)]">{empty.title}</p>
-        <p class="mt-2 text-body text-[color:var(--color-text-secondary)]">{empty.body}</p>
-      </Card>
-    )
-  }
-
-  {
-    surfaceState === 'active' && (
-      <>
-        <p class={`mt-8 ${seclabelClass}`}>Status</p>
-        <div class="mt-3">
-          <OperatorHero model={heroModel} />
+    {
+      crMessage && (
+        <div
+          role="status"
+          class={`mt-6 rounded-card border p-4 text-caption font-medium ${
+            crTone === 'complete'
+              ? 'border-[color:var(--color-complete)] text-[color:var(--color-complete)]'
+              : 'border-[color:var(--color-error)] text-[color:var(--color-error)]'
+          }`}
+        >
+          {crMessage}
         </div>
+      )
+    }
 
-        <p class={`mt-10 ${seclabelClass}`}>Role</p>
-        <div class="mt-3">
-          <FacetDoorList doors={roleDoors} />
-        </div>
+    {
+      empty && (
+        <Card class="mt-10 text-center">
+          <p class="text-title text-[color:var(--color-text-primary)]">{empty.title}</p>
+          <p class="mt-2 text-body text-[color:var(--color-text-secondary)]">{empty.body}</p>
+        </Card>
+      )
+    }
 
-        <p class={`mt-10 ${seclabelClass}`}>Management</p>
-        <div class="mt-3">
-          <FacetDoorList doors={manageDoors} />
-        </div>
+    {
+      surfaceState === 'active' && (
+        <>
+          <p class={`mt-8 ${seclabelClass}`}>Status</p>
+          <div class="mt-3">
+            <OperatorHero model={heroModel} />
+          </div>
 
-        <div class="mt-8">
-          <FacetDoorList doors={accountDoors} />
-        </div>
-      </>
-    )
-  }
+          <p class={`mt-10 ${seclabelClass}`}>Role</p>
+          <div class="mt-3">
+            <FacetDoorList doors={roleDoors} />
+          </div>
+
+          <p class={`mt-10 ${seclabelClass}`}>Management</p>
+          <div class="mt-3">
+            <FacetDoorList doors={manageDoors} />
+          </div>
+
+          <div class="mt-8">
+            <FacetDoorList doors={accountDoors} />
+          </div>
+        </>
+      )
+    }
+  </div>
 </PortalShell>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -30,6 +30,10 @@
    * marketing surfaces on cream. */
   --color-surface-raised: #ffffff;
   --color-border: var(--ss-color-border);
+  /* Firmer hairline for calm-register cards — the default 16% ink border reads
+   * as washed on wide white cards (UI-PATTERNS Rule 8 readability pass). Still a
+   * hairline, just enough to seat the card on the cream. */
+  --color-border-strong: rgba(26, 21, 18, 0.22);
   --color-border-subtle: var(--ss-color-border-subtle);
 
   --color-text-primary: var(--ss-color-text-primary);


### PR DESCRIPTION
The deployed landing (#1818) rendered **washed**: stretched to the full ~1024px portal width, with the not-yet-built facet rows greyed so hard that half of Role looked switched off. Same calm register, wrong execution. Captain-approved fix:

- **Tight reading column** (`max-w-2xl` ~672px) instead of full portal width — the cards hold together instead of stretching thin.
- **Not-yet-available rows at full strength** (label `text-primary`, desc `text-secondary`) with a small bordered tag, instead of greyed into the background.
- **`--color-border-strong`** (ink at 22%) for calm cards; the default 16% hairline read as washed on wide white cards. `Card` + `FacetDoorList` adopt it.

Register and headers untouched (per Captain: fix the wash before touching those).

`npm run verify` green — 3365 passed, 0 errors. Auth-gated, so eyeball post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)