### PR TITLE
fix(operator): landing column literal max-width (var-based utility failed on portal)

### DIFF
--- a/src/pages/portal/products/operator/index.astro
+++ b/src/pages/portal/products/operator/index.astro
@@ -184,7 +184,7 @@ const empty = surfaceState !== 'active' ? EMPTY[surfaceState] : null
     /* Tight reading column — the calm cards wash out stretched to full portal
       width (UI-PATTERNS Rule 8 readability pass). */
   }
-  <div class="mx-auto max-w-2xl">
+  <div class="mx-auto max-w-[640px]">
     <a
       href="/portal"
       class="mt-6 -mx-1 inline-flex min-h-11 items-center gap-2 px-1 text-label uppercase text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2"


### PR DESCRIPTION
The `max-w-2xl` wrapper compiled to `max-width: var(--container-2xl)`, and that container var isn't in scope in the portal's CSS bundle — the declaration evaluated to nothing and the column went full-width (the washed page you saw). Switched to a literal `max-w-[640px]` so it can't silently fail. Verified the build emits `.max-w-[640px]{max-width:640px}` and the portal chunk uses it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)