### PR TITLE
revert(operator): landing back to loud register, keep the content

### DIFF
--- a/src/components/portal/operator/FacetDoorList.astro
+++ b/src/components/portal/operator/FacetDoorList.astro
@@ -1,10 +1,10 @@
 ---
 /**
- * FacetDoorList — the calm-register list of operator facet doors (ADR 0069;
- * landing brief 2026-07-08). One raised card, hairline-divided rows.
+ * FacetDoorList — the operator facet doors (ADR 0069; landing brief 2026-07-08),
+ * in the original loud Plainspoken register (Captain call 2026-07-08).
  *
- * A door with an `href` is a link (arrow + optional real status hint). A door
- * with `href: null` renders as a non-interactive, muted row marked "Not yet
+ * A door with an `href` is a link (orange arrow + optional real status hint). A
+ * door with `href: null` renders as a non-interactive row marked "Not yet
  * available" — the facet is on the map but its page isn't built, and we never
  * fabricate a destination or promise a date.
  */
@@ -17,40 +17,46 @@ interface Props {
 const { doors } = Astro.props
 ---
 
-<div class="border border-[color:var(--color-border-strong)] bg-surface-raised">
+<div
+  class="border-[3px] border-[color:var(--color-text-primary)] bg-[color:var(--color-background)]"
+>
   {
     doors.map((d, i) => {
-      const divider = i > 0 ? 'border-t border-[color:var(--color-border-subtle)]' : ''
+      const divider = i > 0 ? 'border-t-[2px] border-[color:var(--color-border)]' : ''
       return d.href ? (
         <a
           href={d.href}
-          class={`group flex items-center justify-between gap-6 p-card transition-colors hover:bg-[color:var(--color-border-subtle)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-inset ${divider}`}
+          class={`group flex items-center justify-between gap-6 px-5 py-4 transition-colors hover:bg-[color:var(--color-border-subtle)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-inset md:px-7 ${divider}`}
         >
           <div class="min-w-0">
-            <p class="text-body font-semibold text-[color:var(--color-text-primary)]">{d.label}</p>
-            <p class="mt-0.5 text-caption text-[color:var(--color-text-secondary)]">{d.desc}</p>
+            <p class="font-body text-base font-bold text-[color:var(--color-text-primary)]">
+              {d.label}
+            </p>
+            <p class="mt-0.5 text-sm text-[color:var(--color-text-secondary)]">{d.desc}</p>
           </div>
           <div class="flex flex-none items-center gap-3">
             {d.status && (
-              <span class="font-mono text-label uppercase tracking-[0.1em] text-[color:var(--color-error)]">
+              <span class="font-mono text-label font-bold uppercase tracking-[0.14em] text-[color:var(--color-error)]">
                 {d.status}
               </span>
             )}
             <span
               aria-hidden="true"
-              class="text-[color:var(--color-text-muted)] transition-transform group-hover:translate-x-0.5"
+              class="font-body font-black text-[color:var(--color-primary)] transition-transform group-hover:translate-x-1"
             >
               →
             </span>
           </div>
         </a>
       ) : (
-        <div class={`flex items-center justify-between gap-6 p-card ${divider}`}>
+        <div class={`flex items-center justify-between gap-6 px-5 py-4 md:px-7 ${divider}`}>
           <div class="min-w-0">
-            <p class="text-body font-semibold text-[color:var(--color-text-primary)]">{d.label}</p>
-            <p class="mt-0.5 text-caption text-[color:var(--color-text-secondary)]">{d.desc}</p>
+            <p class="font-body text-base font-bold text-[color:var(--color-text-primary)]">
+              {d.label}
+            </p>
+            <p class="mt-0.5 text-sm text-[color:var(--color-text-secondary)]">{d.desc}</p>
           </div>
-          <span class="flex-none whitespace-nowrap border border-[color:var(--color-border-subtle)] px-2 py-1 font-mono text-[10px] uppercase tracking-[0.12em] text-[color:var(--color-text-muted)]">
+          <span class="flex-none whitespace-nowrap font-mono text-label font-bold uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)]">
             Not yet available
           </span>
         </div>

--- a/src/components/portal/operator/facets/OperatorHero.astro
+++ b/src/components/portal/operator/facets/OperatorHero.astro
@@ -1,33 +1,24 @@
 ---
 /**
  * Operator STATUS block — the shared "is it OK?" lead (ADR 0069; landing brief
- * 2026-07-08). Health-led: the persona is a small line, the operator's health is
- * the headline. Answers the first of the landing's three questions at a glance.
+ * 2026-07-08). Health-led CONTENT (persona as a small line, health as the
+ * headline) rendered in the original loud Plainspoken register (Captain call
+ * 2026-07-08: keep the reshaped content, revert the calm register for now).
  *
- * ONE shared component, mounted in both portals per Lock 4; the facet registry
- * points the `identity` and `status` facets at the resolver this consumes
- * (lib/portal/operator/facets/identity/hero.ts).
- *
- * Honesty: identity is authored config (no fabrication; falls back to the generic
- * "Your operator" label). Health is the real aliveness signal — when the runtime
- * bridge has no data (`aliveness === null`) the block says so plainly rather than
- * fabricating a healthy state. Only operator problems surface here (paused /
- * offline); business work never does (landing brief §5).
+ * Honesty unchanged: identity is authored config (falls back to "Your operator");
+ * health is the real aliveness signal and says so plainly when the bridge has no
+ * data (never a fabricated healthy state); only operator problems surface here.
  */
-import Card from '../../Card.astro'
-import StatusDot from '../../StatusDot.astro'
 import {
   formatLastActionRelative,
   formatLastActionAbsolute,
   needsEscalationAffordance,
   type AlivenessLevel,
 } from '../../../../lib/portal/operator/aliveness'
-import type { Tone } from '../../../../lib/portal/status'
 import type { OperatorHeroModel } from '../../../../lib/portal/operator/facets/identity/hero'
 
 interface Props {
   model: OperatorHeroModel
-  /** Escalation target for the two unhealthy states; null falls back to settings. */
   escalationHref?: string | null
 }
 
@@ -35,13 +26,19 @@ const { model, escalationHref = null } = Astro.props
 const displayName = model.name ?? 'Your operator'
 const personaLine = model.title ? `${displayName} · ${model.title}` : displayName
 
-// Client-facing health headline for each aliveness level. Healthy states read as
-// reassurance; the two problem states name the problem and offer the fix.
-const HEALTH: Record<AlivenessLevel, { headline: string; tone: Tone; problem: boolean }> = {
-  idle: { headline: 'Running normally', tone: 'success', problem: false },
-  running: { headline: 'Working now', tone: 'success', problem: false },
-  sticky_stop: { headline: 'Paused, needs your attention', tone: 'danger', problem: true },
-  offline: { headline: 'Offline, needs your attention', tone: 'danger', problem: true },
+const HEALTH: Record<AlivenessLevel, { headline: string; dot: string; problem: boolean }> = {
+  idle: { headline: 'Running normally', dot: 'bg-[color:var(--color-complete)]', problem: false },
+  running: { headline: 'Working now', dot: 'bg-[color:var(--color-complete)]', problem: false },
+  sticky_stop: {
+    headline: 'Paused, needs your attention',
+    dot: 'bg-[color:var(--color-error)]',
+    problem: true,
+  },
+  offline: {
+    headline: 'Offline, needs your attention',
+    dot: 'bg-[color:var(--color-error)]',
+    problem: true,
+  },
 }
 
 const signal = model.aliveness
@@ -55,24 +52,33 @@ const showEscalation = level ? needsEscalationAffordance(level) : false
 const escalationTarget = escalationHref ?? '/portal/products/operator/settings'
 ---
 
-<Card ariaLabel="Operator status">
-  <p class="font-mono text-label uppercase tracking-[0.14em] text-[color:var(--color-text-muted)]">
+<section
+  class="mt-8 border-[3px] border-[color:var(--color-text-primary)] bg-[color:var(--color-background)] px-5 py-6 md:px-7"
+  aria-label="Operator status"
+>
+  <p
+    class="font-mono text-label font-bold uppercase tracking-[0.18em] text-[color:var(--color-text-secondary)]"
+  >
     {personaLine}
   </p>
 
   {
     health ? (
       <>
-        <div class="mt-2 flex items-center gap-2.5">
-          <StatusDot tone={health.tone} />
-          <h2 class="text-title text-[color:var(--color-text-primary)]">{health.headline}</h2>
+        <div class="mt-2 flex items-center gap-3">
+          <span class={`inline-block h-3 w-3 rounded-full ${health.dot}`} aria-hidden="true" />
+          <h2 class="font-body text-2xl font-black uppercase tracking-[-0.02em] text-[color:var(--color-text-primary)] md:text-3xl">
+            {health.headline}
+          </h2>
         </div>
         {stickyReason && (
-          <p class="mt-2 text-caption text-[color:var(--color-text-secondary)]">{stickyReason}</p>
+          <p class="mt-2 font-mono text-label uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)]">
+            {stickyReason}
+          </p>
         )}
         {(currentSkill || lastRel) && (
           <p
-            class="mt-2 text-caption text-[color:var(--color-text-secondary)]"
+            class="mt-2 font-mono text-label uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)]"
             title={lastAbs ?? undefined}
           >
             {currentSkill ? `${currentSkill} · ` : ''}
@@ -82,16 +88,16 @@ const escalationTarget = escalationHref ?? '/portal/products/operator/settings'
         {showEscalation && (
           <a
             href={escalationTarget}
-            class="mt-4 inline-flex min-h-11 items-center border border-[color:var(--color-text-primary)] bg-[color:var(--color-text-primary)] px-4 text-caption font-semibold text-[color:var(--color-background)] transition-colors hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2"
+            class="mt-4 inline-flex min-h-11 items-center border-[3px] border-[color:var(--color-text-primary)] bg-[color:var(--color-text-primary)] px-4 font-mono text-label font-bold uppercase tracking-[0.14em] text-[color:var(--color-background)] transition-colors hover:bg-[color:var(--color-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2"
           >
             Contact your consultant
           </a>
         )}
       </>
     ) : (
-      <p class="mt-2 text-caption text-[color:var(--color-text-secondary)]">
+      <p class="mt-2 font-mono text-label uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)]">
         Live status isn't reporting yet.
       </p>
     )
   }
-</Card>
+</section>

--- a/src/pages/portal/products/operator/index.astro
+++ b/src/pages/portal/products/operator/index.astro
@@ -13,7 +13,6 @@ import {
   type AlivenessSignal,
 } from '../../../../lib/portal/operator/aliveness'
 import { getCustomerConfig } from '../../../../lib/portal/customer-config'
-import Card from '../../../../components/portal/Card.astro'
 import FacetDoorList from '../../../../components/portal/operator/FacetDoorList.astro'
 import type { FacetDoor } from '../../../../lib/portal/operator/facet-doors'
 import { env } from 'cloudflare:workers'
@@ -152,7 +151,7 @@ const crMessage =
 const crTone = crStatus === 'filed' ? 'complete' : 'error'
 
 const seclabelClass =
-  'font-mono text-label uppercase tracking-[0.14em] text-[color:var(--color-text-muted)]'
+  'font-mono text-label font-bold uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)]'
 
 // Honest non-active states (empty-state pattern).
 const EMPTY: Record<Exclude<SurfaceState, 'active'>, { title: string; body: string }> = {
@@ -180,66 +179,64 @@ const empty = surfaceState !== 'active' ? EMPTY[surfaceState] : null
   entityId={client.id}
   pathname={Astro.url.pathname}
 >
+  <a
+    href="/portal"
+    class="mt-6 -mx-1 inline-flex min-h-11 items-center gap-2 px-1 font-mono text-label font-semibold uppercase tracking-[0.18em] text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2"
+  >
+    <span aria-hidden="true" class="font-body font-black text-[color:var(--color-primary)]">←</span>
+    Home
+  </a>
+
   {
-    /* Tight reading column — the calm cards wash out stretched to full portal
-      width (UI-PATTERNS Rule 8 readability pass). */
+    crMessage && (
+      <div
+        role="status"
+        class={`mt-6 border-[3px] px-5 py-3 font-mono text-label font-bold uppercase tracking-[0.14em] ${
+          crTone === 'complete'
+            ? 'border-[color:var(--color-complete)] text-[color:var(--color-complete)]'
+            : 'border-[color:var(--color-error)] text-[color:var(--color-error)]'
+        }`}
+      >
+        {crMessage}
+      </div>
+    )
   }
-  <div class="mx-auto max-w-2xl">
-    <a
-      href="/portal"
-      class="mt-6 -mx-1 inline-flex min-h-11 items-center gap-2 px-1 text-label uppercase text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2"
-    >
-      <span aria-hidden="true" class="text-[color:var(--color-text-muted)]">←</span>
-      Home
-    </a>
 
-    {
-      crMessage && (
-        <div
-          role="status"
-          class={`mt-6 rounded-card border p-4 text-caption font-medium ${
-            crTone === 'complete'
-              ? 'border-[color:var(--color-complete)] text-[color:var(--color-complete)]'
-              : 'border-[color:var(--color-error)] text-[color:var(--color-error)]'
-          }`}
-        >
-          {crMessage}
+  {
+    empty && (
+      <div class="mt-10 border-[3px] border-[color:var(--color-text-primary)] p-8 text-center md:p-12">
+        <p class="font-body text-2xl font-black uppercase tracking-[-0.02em] text-[color:var(--color-text-primary)] md:text-3xl">
+          {empty.title}
+        </p>
+        <p class="mt-3 font-mono text-label uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)]">
+          {empty.body}
+        </p>
+      </div>
+    )
+  }
+
+  {
+    surfaceState === 'active' && (
+      <>
+        <p class={`mt-8 ${seclabelClass}`}>Status</p>
+        <div class="mt-3">
+          <OperatorHero model={heroModel} />
         </div>
-      )
-    }
 
-    {
-      empty && (
-        <Card class="mt-10 text-center">
-          <p class="text-title text-[color:var(--color-text-primary)]">{empty.title}</p>
-          <p class="mt-2 text-body text-[color:var(--color-text-secondary)]">{empty.body}</p>
-        </Card>
-      )
-    }
+        <p class={`mt-10 ${seclabelClass}`}>Role</p>
+        <div class="mt-3">
+          <FacetDoorList doors={roleDoors} />
+        </div>
 
-    {
-      surfaceState === 'active' && (
-        <>
-          <p class={`mt-8 ${seclabelClass}`}>Status</p>
-          <div class="mt-3">
-            <OperatorHero model={heroModel} />
-          </div>
+        <p class={`mt-10 ${seclabelClass}`}>Management</p>
+        <div class="mt-3">
+          <FacetDoorList doors={manageDoors} />
+        </div>
 
-          <p class={`mt-10 ${seclabelClass}`}>Role</p>
-          <div class="mt-3">
-            <FacetDoorList doors={roleDoors} />
-          </div>
-
-          <p class={`mt-10 ${seclabelClass}`}>Management</p>
-          <div class="mt-3">
-            <FacetDoorList doors={manageDoors} />
-          </div>
-
-          <div class="mt-8">
-            <FacetDoorList doors={accountDoors} />
-          </div>
-        </>
-      )
-    }
-  </div>
+        <div class="mt-8">
+          <FacetDoorList doors={accountDoors} />
+        </div>
+      </>
+    )
+  }
 </PortalShell>

--- a/tests/forbidden-strings.test.ts
+++ b/tests/forbidden-strings.test.ts
@@ -811,6 +811,11 @@ const LOUD_MARKERS: { re: RegExp; label: string }[] = [
 // so a file that merely *documents* a loud marker — like the primitives' doc
 // blocks — is not flagged. Only real class usage should trip the guard.
 const CALM_REGISTER_PENDING: string[] = [
+  // Operator landing reverted to the loud register per Captain (2026-07-08):
+  // keep the Status/Role/Management content, drop the calm register for now.
+  'src/pages/portal/products/operator/index.astro',
+  'src/components/portal/operator/facets/OperatorHero.astro',
+  'src/components/portal/operator/FacetDoorList.astro',
   'src/components/admin/EntityContactRow.astro',
   'src/components/admin/EntityIdentityStrip.astro',
   'src/components/admin/HostedAgentQueueCard.astro',


### PR DESCRIPTION
Per Captain (2026-07-08): the calm migration became a styling rabbit-hole (a var-scoping bug rendered it washed/full-width). Revert the operator landing's **visual register** to the original loud Plainspoken styling for now, and **keep the reshaped content** (Status / Role / Management, facet map, health-led status, honest doors). Content/functionality is the priority; calm can return later.

- `OperatorHero`, `FacetDoorList`, `index.astro` re-styled to loud (3px ink rules, black uppercase, mono labels, full width); content/structure unchanged.
- Re-added those three to `CALM_REGISTER_PENDING`.
- `Card`/`CardHeader`/`StatusDot` kept as registered calm primitives (unused for now).

`npm run verify` green — 3362 passed, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)