### PR TITLE
docs(ashton-price): canonical correspondence archive (single source of truth)

### DIFF
--- a/operator/customers/ashton-price/correspondence/02_2026-06-24_christa-to-scott_hopes-and-tools.md
+++ b/operator/customers/ashton-price/correspondence/02_2026-06-24_christa-to-scott_hopes-and-tools.md
@@ -1,0 +1,34 @@
+---
+date: 2026-06-24T21:44:36Z
+from: Christa@ashtonandprice.com
+to: smdurgan@smdurgan.com
+subject: RE: Intro meeting with Scott Durgan
+gmail_message_id: 19efb97b2e449e82
+status: context (post-intro-call; her first written statement of what they hope AI can do)
+---
+
+# Christa → Scott: what they hope AI helps with + CoCounsel/BriefPoint links
+
+_Verbatim body (signature image omitted; quoted prior messages trimmed). Sent the day of the intro call._
+
+Hi,
+
+Great chatting with you today! Here's the link to CoCounsel we talked about: https://www.thomsonreuters.com/en/cocounsel. The other platform is https://briefpoint.ai/
+
+We're excited about bringing in AI to streamline and automate our litigation work. The main things we're hoping it can help with:
+
+- Drafting and responding to written discovery, plus reviewing responses to spot deficiencies
+- Motions to compel and separate statements, meet-and-confer letters, oppositions, replies, motions in limine, and trial briefs
+- Medical chronologies and treatment timelines from records
+- Summarizing depositions and case documents, and building case timelines and litigation summaries
+- Mediation briefs, settlement conference statements, case valuation, damages, and liability/comparative-fault analysis
+- Reviewing and analyzing expert reports, and tracking discovery deadlines and tasks
+
+Ideally, it would pull from the documents already in a Smokeball matter — pleadings, discovery, depositions, medical and billing records, expert reports, and correspondence — to produce attorney-ready first drafts that counsel can review and finalize.
+
+We're especially interested in building Agents for California personal injury workflows that can consistently generate work product aligned with California procedure and practice.
+
+Let me know if you have any questions or need anything else.
+
+Thanks,
+[C. Barrera signature]

--- a/operator/customers/ashton-price/correspondence/03_2026-06-25_scott-to-christa_discovery-workflow_SUPERSEDED.md
+++ b/operator/customers/ashton-price/correspondence/03_2026-06-25_scott-to-christa_discovery-workflow_SUPERSEDED.md
@@ -1,0 +1,121 @@
+---
+date: 2026-06-25T08:22:45Z
+from: smdurgan@smdurgan.com
+to: Christa@ashtonandprice.com
+subject: Re: Intro meeting with Scott Durgan
+gmail_message_id: 19efde0043b0d533
+status: SUPERSEDED by CLIENT-PROPOSAL.md (the Litigation Lifecycle Solution, 2026-06-26)
+---
+
+# Scott → Christa: the discovery-only workflow ("Doc 0")
+
+_This is the discovery-only picture, sent 2026-06-25. It is the message Christa's
+scope-expansion reply (04) reacts to ("the discovery workflow you mapped is largely right").
+It was **superseded** two days later by the full-lifecycle proposal (`../CLIENT-PROPOSAL.md`).
+The near-identical draft on `~/Desktop/christa-discovery-email.txt` is the same content — do
+not cite either as current. Verbatim body; quoted prior message trimmed._
+
+Hi Christa,
+
+Excited to work with you on this. Here is some feedback on the discovery process you described and where we may be able to provide value.
+
+Rather than just say "yes, we can do that," we put together a concrete picture of how the Operator would work inside your discovery process, step by step, so you have something specific to react to. The most useful thing you can do is mark where we have it right and where it should bend to fit how A&P actually runs.
+
+Two things we were deliberate about, because they matter most for something like this actually getting used:
+
+- Keeping it quiet. The Operator is meant to take work off your team's plate, not become one more system pinging everyone. It comes to people with things already prepared, and batches routine items into a single short summary.
+
+- Being honest about what we would test and tune. A few parts depend on reading your documents and matching your firm's rules, so we have called out where we would validate against your real matters first, and what the Operator does in the meantime if it is not yet sure.
+
+Here is the workflow.
+
+WHAT THE OPERATOR DOES
+
+The Operator is an always-on team member that works inside Smokeball and alongside the tools you already use (CoCounsel, Briefpoint). Its job in discovery is to carry the process so your people don't have to hold it in their heads: it watches every matter, knows every deadline, prepares the documents, and chases what is outstanding.
+
+When it needs a person to do their part, it emails them with everything already prepared, so their part is usually a single reply or a one-click button. If a step does not get done, it follows up rather than letting it slip. Every piece of work product goes to an attorney to review and finalize; the Operator never sends anything to another party and never signs on its own.
+
+It does not replace CoCounsel or Briefpoint. Those are the drafting engines. The Operator prepares their inputs, routes their outputs, and does the work between and around them.
+
+THE DISCOVERY WORKFLOW, STEP BY STEP
+
+1. Discovery is served on a matter
+   - Operator: spots the served document in the Smokeball matter, identifies the type (interrogatories, requests for production or admission, deposition notice), reads the service date and method, and tells the responsible attorney it arrived.
+   - Your part: nothing, unless it asks you to confirm.
+   - If it is not done: re-flags if unacknowledged.
+
+2. Response deadline
+   - Operator: computes the California response deadline and the downstream dates, calendars them in Smokeball, and emails the attorney a one-click confirm.
+   - Your part: click confirm, or correct the date.
+   - If it is not done: reminds before the date.
+
+3. Draft the response
+   - Operator: places the served request and the supporting documents (prior verified responses, relevant records) into the Smokeball matter folder that Briefpoint or CoCounsel draws from, then emails a ready-to-go nudge with the link.
+   - Your part: generate the draft in the tool.
+   - If it is not done: follows up if the draft has not landed back in the matter.
+
+4. Client verification
+   - Operator: drafts the plain-language verification request and emails the attorney an approve-and-send button; once approved it sends, then tracks the signature.
+   - Your part: click approve; client signs.
+   - If it is not done: chases the client for the signature, and tells you only if it stalls.
+
+5. Opposing side's responses
+   - Operator: reviews them for gaps (boilerplate objections, non-answers, missing verifications), drafts the meet-and-confer letter, and emails it for review with the 45-day deadline to compel noted.
+   - Your part: review, click send, or edit.
+   - If it is not done: reminds as the deadline nears.
+
+6. Motion to compel, if needed
+   - Operator: assembles the separate statement (the item-by-item table California requires) and the supporting pieces.
+   - Your part: attorney finalizes and files.
+   - If it is not done: reminds before the deadline.
+
+7. Records and chronology
+   - Operator: maintains a running medical chronology and case timeline as records arrive.
+   - Your part: use it for demands, mediation, valuation.
+
+8. What needs you
+   - Operator: sends one short summary of what needs attention (due soon, unsigned, deadline near).
+   - Your part: react to the few items.
+   - If it is not done: re-surfaces anything missed.
+
+WORKING THROUGH THE MATTER FOLDER
+
+The Operator hands off to the drafting tools the way those tools already connect to Smokeball. It places the served request and the supporting documents into the Smokeball matter folder that Briefpoint and CoCounsel draw from, so the draft can be generated with everything in place. When the finished draft lands back in the matter, the Operator picks it up there, files it, and routes it to the attorney to review. Nothing has to be emailed around or re-uploaded by hand.
+
+QUIET BY DESIGN
+
+The Operator is built to reduce load, not add to it. Routine items are gathered into a single short summary rather than a stream of notifications, and it reaches out directly only when something genuinely needs a person. The goal is that your team feels work coming off their plate, not one more system pinging them.
+
+BUILT AROUND HOW YOU WORK
+
+The steps above are one picture of the process. The Operator is configured to fit your firm, not the other way around. We can adjust where it watches for new discovery, how much it does on its own versus surfaces for a person, which tools it routes to, and how it matches each attorney's preferences. Where you want it to do more, it does more; where you want a person in the loop, it stays in a supporting role.
+
+WHAT WE WOULD TEST AND TUNE WITH YOU
+
+A few parts of this depend on reading your documents and matching your firm's rules and habits, so we would validate them on your real matters before relying on them. The guiding rule: where accuracy is not yet proven, the Operator surfaces what it found and asks, rather than acting on its own. We widen how much it does on its own only as it proves accurate on your work.
+
+- Reading the served discovery. The deadline math is only as good as what the Operator reads off the document, especially the service method and date. We would test this against a sample of your actual served-discovery documents. Until it is consistently accurate, it proposes the deadline next to the document it read it from, for a quick attorney confirm, rather than calendaring silently.
+
+- Deadlines and local rules. California's base deadlines are clear, but counties and departments add their own. We tune the deadline logic to the courts you actually practice in, and computed dates are always presented for attorney confirmation, never treated as final on their own.
+
+- Spotting deficiencies in opposing responses. This is a judgment task. We would calibrate it against matters you have already handled, comparing what it flags to what your attorneys would, and start it as an assist the attorney reviews rather than an authority.
+
+- Medical chronologies. With clean records this works well; with messy or scanned records it is a strong first draft and an accelerator, not a replacement for careful review. We would test it on your real records and scope how far it goes to what proves reliable.
+
+- Tracking client verifications. How well the Operator can track a signature depends on how you collect them today. We fit it to your process; where there is no automatic signal, it follows up by asking rather than assuming.
+
+- Catching discovery as it arrives. The Operator can only act on discovery it can see. We confirm where served discovery lands first and set up watching accordingly, including the path where it arrives by email before it reaches the matter.
+
+1. Does this match how A&P actually runs discovery? Where is it off?
+2. Which parts of discovery cost your team the most time or cause the most things to slip? Those are where the Operator can help most.
+3. When discovery is served, where does it land first: in Smokeball, or in an email that someone then files to the matter?
+4. How do you collect a client's verification today (e-signature, paper)?
+5. Which tool do you use for which document, Briefpoint or CoCounsel, and how is each connected to your Smokeball matters today (for example, which folder Briefpoint draws from)?
+6. Where do you keep discovery deadlines: Smokeball tasks, an Outlook calendar, or both?
+7. Which California courts and counties do you practice in most?
+
+Hopefully this is roughly the right shape. The intent is to give is a starting point to explore how this solution can fit the firm's workflow and provide value. Nothing is prescribed. Everything is configurable.
+
+Thanks again, Christa. This is a great place to start.
+
+Scott

--- a/operator/customers/ashton-price/correspondence/04_2026-06-25_christa-to-scott_stack-answers-scope.md
+++ b/operator/customers/ashton-price/correspondence/04_2026-06-25_christa-to-scott_stack-answers-scope.md
@@ -1,0 +1,141 @@
+---
+date: 2026-06-25T18:28:44Z
+from: Christa@ashtonandprice.com
+to: smdurgan@smdurgan.com
+subject: RE: Intro meeting with Scott Durgan
+gmail_message_id: 19f000adae2d4d88
+status: CANONICAL inbound — the scope-defining email (mandates the full CA PI lifecycle)
+---
+
+# Christa → Scott: tech stack + answers to the 7 questions + EXPANDED SCOPE
+
+_Verbatim body (firm confidentiality footer and quoted prior message trimmed). This is the
+email that expanded the engagement from discovery-only to the full CA PI litigation lifecycle,
+and it is what the proposal (`../CLIENT-PROPOSAL.md`) was written to answer. **It contains no
+data-handling questions.**_
+
+Thank you for putting this together — this is exactly the kind of concrete picture we needed to react to, and it tells me you understand what we're actually trying to build. The discovery workflow you mapped is largely right. I want to use this reply to answer your questions, clarify our tech stack, and expand the scope so we're building the full Operator architecture from day one.
+
+## OUR TECH STACK
+
+Here is what we're working with so you can map integrations:
+
+- Smokeball — matter management, documents, tasks, deadlines (central hub)
+- Microsoft Office — Outlook (email + calendar), Word, Teams
+- Claude — AI drafting, summarization, document analysis
+- Adobe — PDF handling, Bates stamping, exhibit prep, e-signing
+- BriefPoint — written discovery responses and objections
+- InfoTrak — process serving, service of process tracking, e-filing, and direct document and invoice import into Smokeball per client matter; also provides E-Sign integrated within Smokeball
+- Greenfiling — e-filing
+- YoCierge — medical records vendor; automatically uploads ordered records and invoices directly into each Smokeball client matter
+- Dropbox — sharing exhibits, medical records, demands, and documents with clients and defense counsel
+- CoCounsel (Thomson Reuters) — meeting scheduled this Friday to evaluate; not yet onboarded
+
+Note on the Smokeball x Thomson Reuters partnership: I received the announcement this week and have a meeting scheduled to learn more about how the integration works in practice. I want to make sure the Operator architecture accounts for how CoCounsel ultimately connects to Smokeball once that picture is clearer.
+
+A few integration points I want to make sure are on your radar:
+
+- Discovery arrives by mail and email before being manually filed into Smokeball. Both channels need to be accounted for — the Operator needs to close that handoff gap regardless of how it arrives.
+- InfoTrak service confirmations should automatically trigger responsive pleading deadlines in Smokeball — this should not be a manual step.
+- Client verifications should route through Smokeball E-Sign (powered by InfoTrak) with the Operator tracking completion and chasing automatically if unsigned.
+- The Operator should trigger paralegal and attorney updates at defined case milestones, coordinating with YoCierge on records status where applicable.
+- Once we confirm how CoCounsel integrates, I want to discuss how to position Claude vs. CoCounsel vs. BriefPoint within the Operator's drafting logic to avoid redundancy and manage cost.
+
+## YOUR QUESTIONS — OUR ANSWERS
+
+1. Does this match how A&P actually runs discovery? Where is it off?
+   Broadly yes. A few nuances:
+
+- Discovery arrives by mail and email before being manually filed into Smokeball. Both paths need to be on the Operator's radar.
+- Meet-and-confer letters are sometimes handled informally before a formal letter goes out. The Operator should flag that decision point to the attorney rather than auto-drafting every time.
+- We want the Operator to track discovery we propound, not just respond to what is served on us — including following up on outstanding responses from opposing counsel and flagging when to move to compel.
+
+2. Which parts cost the most time or cause the most slippage?
+
+- Client verification tracking — falls through the cracks consistently.
+- Deadline calendaring — especially with extensions, stipulations, and amended service.
+- Drafting separate statements for motions to compel — extremely time-consuming.
+- Medical chronology maintenance as new records arrive throughout the case.
+
+3. Where does served discovery land first?
+   Mail and email, then manually filed into Smokeball. Closing this gap across both channels is a priority.
+
+4. How do we collect client verifications today?
+   Currently a mix of e-signature and manual. We want to standardize through Smokeball E-Sign and have the Operator own that process end to end.
+
+5. BriefPoint vs. CoCounsel — how are they used?
+
+- BriefPoint: written discovery responses and objections.
+- CoCounsel: we are meeting with Thomson Reuters this Friday and have not yet onboarded. We will have a clearer picture of the integration and use case after that meeting and the Smokeball partnership discussion next week.
+  Neither is fully integrated into a consistent Smokeball folder structure yet. We want the Operator to establish and enforce that structure once the CoCounsel integration picture is clear.
+
+6. Where do we keep discovery deadlines?
+   Currently split between Smokeball tasks and Outlook calendar. We want the Operator to consolidate into Smokeball as the single source of truth.
+
+7. Which courts do we practice in?
+   Primarily Sacramento County Superior Court, with matters across Northern California courts. The Operator will need to handle court-specific local rules, formatting requirements, and e-filing protocols across those venues. For e-filing we currently use InfoTrak and Greenfiling, and the Operator should integrate with or guide filing through those platforms and/or Odyssey/eCourt as applicable.
+
+## EXPANDED SCOPE — FULL CALIFORNIA PI LITIGATION LIFECYCLE
+
+The discovery workflow is the right place to start, but I want the architecture built to support the full case lifecycle from day one. Here is the complete scope:
+
+1. COMPLAINT FILING & CASE INITIATION
+
+- Draft complaint, summons, and cover sheet (CM-010)
+- Track defendant service deadlines; integrate with InfoTrak for service confirmation to auto-trigger responsive pleading deadlines in Smokeball
+- Calendar responsive pleading deadlines once service is confirmed
+- E-filing workflow via InfoTrak, Greenfiling, and/or Odyssey/eCourt depending on venue
+- Court-specific local rule compliance for Sacramento and Northern California courts
+
+2. FULL DISCOVERY LIFECYCLE
+
+- Everything in your mapped workflow, plus:
+- Track propounded discovery and follow up on outstanding opposing responses
+- Flag when to move to compel on our own propounded discovery
+
+3. MOTIONS PRACTICE
+
+- MSJ, opposition, reply
+- Motions in limine
+- Ex parte applications
+- Format and procedural compliance by court and department
+
+4. MINOR'S COMPROMISE WORKFLOW
+   This is a significant part of our practice and needs dedicated Operator support:
+
+- MC-350 and MC-351 preparation
+- Petition for approval of minor's compromise
+- Court hearing scheduling and follow-up
+- Guardian ad litem appointment tracking
+- Net settlement calculations and fee disclosures
+- California Probate Code compliance
+- Post-approval funding and structured settlement coordination where applicable
+
+5. TRIAL PREPARATION
+
+- Trial brief drafting
+- Exhibit and witness list preparation
+- Deposition summary integration
+- Trial binder organization in Smokeball
+
+6. MEDIATION & SETTLEMENT
+
+- Mediation brief and settlement conference statement drafting
+- Damages summary with liability and comparative fault analysis
+- Lien tracking and resolution workflow (ERISA, Medi-Cal, Medicare, provider liens)
+
+7. PARALEGAL TRAINING FUNCTION
+   This is a core requirement, not a nice-to-have. We want the Operator to function as an embedded training tool for litigation paralegals:
+
+- SOPs built into each workflow step so staff know what to do, why, and what comes next
+- Procedural checklists at each stage (e.g., how to file a complaint in Sacramento Superior, how to prepare an MC-350 packet)
+- Escalation logic that teaches staff when to involve the attorney versus proceed independently
+- A junior paralegal working alongside the Operator should be able to develop real competency in California civil litigation procedure through the work itself over time
+
+This has real potential to transform how our litigation team operates. Excited to see this in action!
+
+C. Barrera
+Operations Manager
+Ashton & Price, LLP
+(916) 727-9027 Direct
+(916) 726-0678 Fax

--- a/operator/customers/ashton-price/correspondence/06_2026-07-08_christa-to-scott_section-by-section-markup.md
+++ b/operator/customers/ashton-price/correspondence/06_2026-07-08_christa-to-scott_section-by-section-markup.md
@@ -1,0 +1,63 @@
+---
+date: 2026-07-08T22:27:15Z
+from: Christa@ashtonandprice.com
+to: smdurgan@smdurgan.com
+subject: RE: Litigation Lifecycle Solution
+gmail_message_id: 19f43d7c650e482b
+status: CANONICAL inbound — async acceptance-with-refinements (the M2 working session, in writing)
+---
+
+# Christa → Scott: section-by-section markup of the proposal
+
+_Verbatim body. This is her markup of `../CLIENT-PROPOSAL.md`. It accepts the lifecycle model
+and refines it, and resolves several open forks (deadline engine, CoCounsel, intake inbox). She
+also asks for written answers on three open items: data handling/retention, the refusal-behavior
+spec, and confirmation of the permission-tier structure. See `README.md` note on the
+"data-handling questions" — they are not present in any prior email she sent._
+
+Hi Scott,
+
+This is a strong translation of what we walked through — you've got the shape of the practice right. Reacting section by section, plus the decisions on our end so you can keep moving.
+
+Overall structure
+The "you set the dial" framing is the right model, and I want it more granular than a single per-task setting. For each routine, I want three tiers available from day one: auto-handle, prepare-and-route-for-approval, and flag-only (no draft, just surface it). Discovery deadline calendaring and lien tracking start at flag-only or prepare-and-route across the board, full stop, regardless of how much trust it earns — nothing touching a deadline or money moves to auto-handle. Routine, non-time-sensitive items (folder setup, chronology entries, records intake logging) can graduate faster.
+
+Discovery — the deadline question
+We do not currently run Smokeball's court-rules calendaring tied to InfoTrack. Use that engine if it's available and accurate — I'd rather deadline math live in software built and maintained for that specific purpose than in a routine we're tuning by hand. If it doesn't cover a discovery type or service method cleanly, the Operator's own logic can fill the gap, but every date is confirmed by the attorney either way, no exceptions, and I want that confirmation logged with a timestamp and the attorney's name for the file.
+
+Client verification — own it end to end as described. This is the leak we most want closed. Confirm the follow-up cadence is configurable per matter and that after a set number of unanswered attempts it escalates to a person rather than nagging indefinitely.
+
+Separate statement — approved as described. Confirm the "reasons to compel" cells stay empty by default and there's no mode where it fills in an argument for the attorney.
+
+Discovery you propound / meet-and-confer — agreed the decision to send anything stays with the attorney. That holds permanently, not something that graduates to auto-handle as trust builds — meet-and-confer letters and anything addressed to opposing counsel always require an explicit send action from a person.
+
+Medical chronology — approved as described. One addition: flag treatment gaps over a set number of days automatically, since that's a recurring valuation and causation issue, not just a data-entry one.
+
+Case initiation — approved. Confirm the folder/task templates are configurable per matter type (auto, premises, product liability, etc.).
+
+Motions — approved for tracking and packet assembly. On drafting-tool division: we've opted not to move forward with CoCounsel, so that's no longer an open variable on our end. Proceed with BriefPoint and Claude as the drafting tools and build the routing accordingly.
+
+Minor's compromise — approved. Keep the posture from the rehearsal: name what's missing (a GAL, a blocked account), don't infer it.
+
+Trial prep — approved.
+
+Mediation and settlement / liens — approved as described. To confirm: it never computes a net-to-client figure or fee reduction, only lays out the inputs as recorded. That line doesn't move even as trust builds.
+
+Paralegal training layer — build the explanation visible by default, not a toggle someone forgets to turn on, at least for the first 90 days for anyone new to a task type.
+
+Access and setup
+
+- Smokeball connection: I'll coordinate the one-time authorization with our Smokeball owner.
+- Discovery intake routing: set up a dedicated monitored inbox rather than routing through an existing staff inbox, so there's a clean audit trail of what the Operator saw and when.
+- InfoTrack connection: approved to proceed.
+- Tuning documents: I'll pull a representative set of served discovery and 2-3 closed matters spanning our case types. Confirm in writing how those documents are stored/processed during tuning and whether they're retained afterward or purged — this ties to the data-handling questions from my last email, which still stand.
+
+Given my schedule, I'd rather not add a standing meeting right now. Please proceed on the items above and anything else that doesn't require my input, and send written answers on the open items (data handling/retention, the refusal-behavior spec, and confirmation on the permission-tier structure) so I can review and approve async. If something genuinely can't move without a live conversation, tell me specifically what it is and why, and I'll make time for that narrow item only.
+
+Thanks,
+
+C. Barrera
+Operations Manager
+Ashton & Price, LLP
+(916) 727-9027 Direct
+(916) 726-0678 Fax

--- a/operator/customers/ashton-price/correspondence/README.md
+++ b/operator/customers/ashton-price/correspondence/README.md
@@ -1,0 +1,67 @@
+# Ashton & Price — Correspondence Archive
+
+**Purpose.** This folder is the **single source of truth** for the SMD ⇄ Ashton & Price
+engagement correspondence. Read from here — do **not** reconstruct the history from the
+mailbox. Every substantive email is captured verbatim as a dated file with a metadata
+header (date, from/to, Gmail message-id, status). When a new substantive email is sent or
+received, add it here in the same working session, and update the timeline below.
+
+**Why this exists.** The only authoritative copy used to be a mailbox (`smdurgan@smdurgan.com`),
+and reconstructing the thread by hand led to a miscount (the intro thread carries three of
+Christa's emails, not one — easy to miss when threads quote each other). This archive removes
+that failure mode.
+
+**Canonical vs. stale — read this before citing anything.**
+
+- The **canonical proposal** we are accountable to is
+  [`../CLIENT-PROPOSAL.md`](../CLIENT-PROPOSAL.md) (the "Litigation Lifecycle Solution", sent
+  2026-06-26). It is verbatim-identical to what Christa received (verified by word-level diff).
+- The file `~/Desktop/christa-discovery-email.txt` is the **discovery-only draft** — despite
+  the filename it is **Scott → Christa** and it is **superseded**. The version actually sent
+  (2026-06-25, `03_...`) is archived here for the record; the lifecycle proposal replaced it.
+- The two **scope-defining inbound emails** are `04` (Christa's stack + scope-expansion) and
+  `06` (Christa's section-by-section markup). These are the documents the build answers to.
+
+## Timeline (verified against the mailbox, 2026-07-08)
+
+| #   | Date       | From → To           | Subject                                                      | Status                                                                                        | File                                                                       |
+| --- | ---------- | ------------------- | ------------------------------------------------------------ | --------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| —   | 2026-06-17 | Scott → Christa     | Intro meeting                                                | logistics                                                                                     | (in thread `19ed77bb7e2d10bc`)                                             |
+| —   | 2026-06-23 | Christa → Scott     | "Sure, available today"                                      | logistics (scheduling)                                                                        | —                                                                          |
+| —   | 2026-06-24 | _phone call_        | intro call                                                   | verbal                                                                                        | —                                                                          |
+| 02  | 2026-06-24 | Christa → Scott     | what they hope AI helps with + CoCounsel/BriefPoint links    | context                                                                                       | [02\_...](02_2026-06-24_christa-to-scott_hopes-and-tools.md)               |
+| 03  | 2026-06-25 | Scott → Christa     | discovery-only workflow (the "Doc 0" draft)                  | **SUPERSEDED** by the proposal                                                                | [03\_...](03_2026-06-25_scott-to-christa_discovery-workflow_SUPERSEDED.md) |
+| 04  | 2026-06-25 | **Christa → Scott** | tech stack + answers to the 7 questions + **EXPANDED SCOPE** | **CANONICAL inbound** (defines the full-lifecycle mandate)                                    | [04\_...](04_2026-06-25_christa-to-scott_stack-answers-scope.md)           |
+| 05  | 2026-06-26 | Scott → Christa     | **Litigation Lifecycle Solution**                            | **CANONICAL proposal**                                                                        | [`../CLIENT-PROPOSAL.md`](../CLIENT-PROPOSAL.md)                           |
+| —   | 2026-06-30 | Christa → Scott     | "In NYC this week, back next week"                           | logistics                                                                                     | (thread `19f1a952c9b25638`)                                                |
+| —   | 2026-07-06 | Scott → Christa     | "Rehearsal Results: Running Your Litigation Lifecycle"       | status update                                                                                 | (msg `19f3977ecfad335e`, not yet archived)                                 |
+| —   | 2026-07-08 | Scott → Christa     | "Checking in"                                                | logistics                                                                                     | (msg `19f436a8beb1350b`)                                                   |
+| 06  | 2026-07-08 | **Christa → Scott** | **section-by-section markup** of the proposal                | **CANONICAL inbound** (async acceptance-with-refinements; the M2 working session, in writing) | [06\_...](06_2026-07-08_christa-to-scott_section-by-section-markup.md)     |
+
+## What the two canonical inbound emails established
+
+- **`04` (2026-06-25)** — the firm's tech stack (Smokeball, MS Office, Claude, Adobe, BriefPoint,
+  InfoTrak, Greenfiling, YoCierge, Dropbox, CoCounsel-under-eval), answers to our 7 questions, and
+  the mandate to build the **full CA PI lifecycle from day one** (not discovery-only). Contains
+  **no data-handling questions.**
+- **`06` (2026-07-08)** — accepts the lifecycle model and refines it: three-tier per-routine dial
+  (auto-handle / prepare-and-route / flag-only), permanent floors on deadlines & money, deadline
+  engine = Smokeball court-rules/InfoTrack, CoCounsel dropped (BriefPoint + Claude), dedicated
+  monitored intake inbox, InfoTrack approved, medical-chronology gap-flagging, training-explanation
+  default-on. Asks for written answers on three items: **data handling/retention**, the
+  **refusal-behavior spec**, and confirmation of the **permission-tier structure**.
+
+## Note on the "data-handling questions"
+
+In `06` Christa refers to "the data-handling questions from my last email, which still stand."
+Those questions are **not present in any email she sent** (verified: the terms never appear in
+the intro thread; they appear only inside `06` itself). Her prior substantive email (`04`) has
+none. They were most likely raised on the **2026-06-24 phone call**, or are being flagged fresh.
+When we answer, we state our standard data-handling posture and invite her to add any specific
+question we may have missed. Do not treat a data-handling questionnaire from her as existing in
+writing — it does not.
+
+---
+
+_Source of record: `smdurgan@smdurgan.com` mailbox. Message-ids are recorded per file so any
+item can be re-fetched if needed, but the archived copy here is authoritative for reference._


### PR DESCRIPTION
## Why

The only authoritative copy of the SMD ⇄ Ashton & Price engagement emails was a mailbox. Reconstructing the thread by hand during this session produced a miscount (the intro thread carries **three** of Christa's emails, not one — easy to miss when Outlook quotes prior messages inline). This removes that failure mode: from now on we reference the repo, not the mailbox.

## What

New folder `operator/customers/ashton-price/correspondence/`:

- **README.md** — verified timeline, canonical-vs-superseded markers, per-item Gmail message-ids, and a note documenting that Christa's referenced "data-handling questions" are **not present in any email she sent** (they appear only inside her 07-08 markup; likely raised on the 06-24 call).
- **02** (06-24) — Christa's post-call hopes + CoCounsel/BriefPoint links
- **03** (06-25) — Scott's discovery-only workflow, marked **SUPERSEDED** by the proposal
- **04** (06-25) — Christa's tech stack + 7-question answers + **EXPANDED SCOPE** — **CANONICAL inbound**
- **06** (07-08) — Christa's section-by-section markup — **CANONICAL inbound**

The sent proposal (05) stays `CLIENT-PROPOSAL.md`, verbatim-verified against what she received.

## Fidelity

Email bodies captured verbatim from the `smdurgan@smdurgan.com` mailbox; quoted history and the firm confidentiality footer trimmed. Prettier reconciled formatting only — a word-level diff confirmed the verbatim text is unchanged. Em dashes are preserved because these are authentic client emails; the forbidden-strings em-dash guard scans `src/` only, so the archive is out of its scope (227 targeted guard tests pass).

## Not a code change

Docs-only; no runtime surface. No customer.yaml, skill, or connector touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L9agvEtkbqZEP6HAJRnLzu