### PR TITLE
fix(portal): operators named 'Operator' to clients, never a persona name

### DIFF
--- a/src/lib/portal/offerings.ts
+++ b/src/lib/portal/offerings.ts
@@ -33,21 +33,30 @@ export interface EngagementOfferings {
 /**
  * One operator the client owns (multi-operator model). An operator instance is a
  * subscription row + its config, addressed by `slug` (the config's customer_slug,
- * carried on the subscription as instance_slug). `displayName` is the active
- * persona's name (fallback: humanized slug) — the label shown in nav/home.
+ * carried on the subscription as instance_slug).
+ *
+ * `displayName` is the neutral, client-facing product name — "Operator" — never
+ * the internal persona name (Crane, Quinn), by rule (Captain 2026-07-08). `role`
+ * (the persona title, e.g. "AI Case Coordinator") is the client-facing
+ * disambiguator when a client owns more than one.
  */
 export interface OperatorInstance {
   slug: string
   subscription: SubscriptionRow
   displayName: string
+  role: string | null
   status: string
 }
 
 /** Lite view of an operator config, passed into the pure derivation. */
 export interface OperatorConfigLite {
   customer_slug: string
-  displayName: string
+  /** Active persona title/role — the client-facing disambiguator. */
+  role: string | null
 }
+
+/** The neutral client-facing operator name. A client never sees a persona name. */
+const NEUTRAL_OPERATOR_NAME = 'Operator'
 
 export interface PortalOfferings {
   engagement: EngagementOfferings
@@ -57,15 +66,6 @@ export interface PortalOfferings {
   /** Any portal-visible invoice exists (drives the Billing destination). */
   hasInvoices: boolean
   subscriptions: SubscriptionRow[]
-}
-
-/** Title-case a kebab slug for a fallback display name (e.g. "pilot-smokeball" → "Pilot Smokeball"). */
-export function humanizeSlug(slug: string): string {
-  return slug
-    .split('-')
-    .filter(Boolean)
-    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
-    .join(' ')
 }
 
 /** Pure derivation from already-fetched rows; unit-tested in isolation. */
@@ -84,18 +84,20 @@ export function deriveOfferings(input: {
   const openProposal = input.quotes.find((q) => q.status === 'sent') ?? null
 
   const bySlug = (slug: string) => input.subscriptions.find((s) => s.product_slug === slug) ?? null
-  const displayNameFor = (slug: string) =>
-    input.operatorConfigs.find((c) => c.customer_slug === slug)?.displayName ?? humanizeSlug(slug)
+  const roleFor = (slug: string) =>
+    input.operatorConfigs.find((c) => c.customer_slug === slug)?.role ?? null
 
   // One entry per operator subscription. instance_slug is the instance identity;
   // a defensive filter drops any malformed operator sub with no instance_slug so
-  // it never renders a broken (slug-less) card/URL.
+  // it never renders a broken (slug-less) card/URL. displayName is the neutral
+  // product name; role disambiguates when there are several.
   const operators: OperatorInstance[] = input.subscriptions
     .filter((s) => s.product_slug === 'operator' && !!s.instance_slug)
     .map((s) => ({
       slug: s.instance_slug as string,
       subscription: s,
-      displayName: displayNameFor(s.instance_slug as string),
+      displayName: NEUTRAL_OPERATOR_NAME,
+      role: roleFor(s.instance_slug as string),
       status: s.status,
     }))
 
@@ -138,16 +140,18 @@ export async function resolvePortalOfferings(
   ])
   const operatorConfigs: OperatorConfigLite[] = configs.map((c) => ({
     customer_slug: c.customer_slug,
-    displayName: operatorDisplayName(c.personas, c.customer_slug),
+    role: operatorRole(c.personas),
   }))
   return deriveOfferings({ engagements, quotes, subscriptions, operatorConfigs, hasInvoices })
 }
 
 /**
- * The label an operator shows in nav/home: its active persona's name, falling
- * back to the humanized slug when no persona is active/authored. Never fabricated.
+ * The client-facing ROLE of an operator — its active persona's title (e.g. "AI
+ * Case Coordinator"). This is the disambiguator shown alongside the neutral
+ * "Operator" name; it is a role, never a persona name. Null when no active
+ * persona / no title.
  */
-function operatorDisplayName(personas: { status: string; name: string }[], slug: string): string {
+function operatorRole(personas: { status: string; title: string | null }[]): string | null {
   const active = personas.find((p) => p.status === 'active')
-  return active?.name?.trim() || humanizeSlug(slug)
+  return active?.title?.trim() || null
 }

--- a/src/lib/portal/operator/facets/identity/hero.ts
+++ b/src/lib/portal/operator/facets/identity/hero.ts
@@ -16,9 +16,15 @@ import type { CustomerConfigRow } from '../../../customer-config'
 import type { AlivenessSignal } from '../../aliveness'
 
 export interface OperatorHeroModel {
-  /** Persona display name, e.g. "Quinn". null when no active persona. */
+  /**
+   * Client-facing operator name. Defaults to the neutral "Operator" — a client
+   * never sees an internal persona name (Crane, Quinn). A client-chosen name
+   * would override this, but there is no rename mechanism yet, so it is "Operator"
+   * whenever a config exists, and null (→ "Your operator") when none does.
+   */
   name: string | null
-  /** Persona title / role, e.g. "AI Case Coordinator". */
+  /** Persona title / role, e.g. "AI Case Coordinator" — the client-facing
+   *  disambiguator (NOT a persona name). */
   title: string | null
   /** The live aliveness signal, or null when the customer has no fleet_status
    *  row yet (the component renders the silent empty state — never a fabricated
@@ -40,7 +46,9 @@ export function resolveOperatorHero(
   // it). Mirrors the selection in customer-config.ts::getActivePersona.
   const persona = config?.personas.find((p) => p.status === 'active') ?? null
   return {
-    name: persona?.name ?? null,
+    // Neutral by rule (Captain 2026-07-08): the client-facing name is "Operator",
+    // never the internal persona name. persona?.name is deliberately NOT surfaced.
+    name: config ? 'Operator' : null,
     title: persona?.title ?? null,
     aliveness,
   }

--- a/src/pages/portal/products/operator/index.astro
+++ b/src/pages/portal/products/operator/index.astro
@@ -81,6 +81,7 @@ const seclabelClass =
                 {op.displayName}
               </p>
               <p class="mt-0.5 font-mono text-label uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)]">
+                {op.role ? `${op.role} · ` : ''}
                 {op.status}
               </p>
             </div>

--- a/tests/operator-hero.test.ts
+++ b/tests/operator-hero.test.ts
@@ -32,20 +32,22 @@ const signal: AlivenessSignal = {
 }
 
 describe('resolveOperatorHero (ADR 0069 Slice 2 — identity + status)', () => {
-  it('surfaces the active persona name + title, passing the signal through', () => {
+  it('surfaces the NEUTRAL name + the active persona title, passing the signal through', () => {
     const m = resolveOperatorHero(
       config([persona({ status: 'active', name: 'Quinn', title: 'AI Case Coordinator' })]),
       signal
     )
-    expect(m).toEqual({ name: 'Quinn', title: 'AI Case Coordinator', aliveness: signal })
+    // The client-facing name is always "Operator" — the persona name (Quinn) is
+    // never surfaced. Only the title (role) comes from the persona.
+    expect(m).toEqual({ name: 'Operator', title: 'AI Case Coordinator', aliveness: signal })
   })
 
-  it('ignores archived personas — no fabricated identity', () => {
+  it('archived personas contribute no title; name stays the neutral "Operator"', () => {
     const m = resolveOperatorHero(
       config([persona({ status: 'archived', name: 'Old', title: 'stale' })]),
       null
     )
-    expect(m.name).toBeNull()
+    expect(m.name).toBe('Operator')
     expect(m.title).toBeNull()
   })
 
@@ -59,7 +61,7 @@ describe('resolveOperatorHero (ADR 0069 Slice 2 — identity + status)', () => {
       config([persona({ status: 'active', name: 'Crane', title: null })]),
       null
     )
-    expect(m.name).toBe('Crane')
+    expect(m.name).toBe('Operator')
     expect(m.title).toBeNull()
   })
 })

--- a/tests/portal-offerings.test.ts
+++ b/tests/portal-offerings.test.ts
@@ -109,12 +109,14 @@ describe('deriveOfferings', () => {
     const o = deriveOfferings({
       ...NOTHING,
       subscriptions: [smd, pilot],
-      operatorConfigs: [{ customer_slug: 'smd', displayName: 'Crane' }],
+      operatorConfigs: [{ customer_slug: 'smd', role: 'AI Case Coordinator' }],
     })
     expect(o.operators.map((op) => op.slug)).toEqual(['smd', 'pilot-smokeball'])
-    // displayName from config when present; humanized slug as the honest fallback.
-    expect(o.operators[0].displayName).toBe('Crane')
-    expect(o.operators[1].displayName).toBe('Pilot Smokeball')
+    // Client-facing name is ALWAYS the neutral "Operator" — never a persona name.
+    expect(o.operators.map((op) => op.displayName)).toEqual(['Operator', 'Operator'])
+    // role (the persona title) is the disambiguator; null when no config/title.
+    expect(o.operators[0].role).toBe('AI Case Coordinator')
+    expect(o.operators[1].role).toBeNull()
   })
 })
 


### PR DESCRIPTION
## Why
Captain rule (2026-07-08): an operator's client-facing name defaults to the neutral **"Operator"**. Persona names (Crane, Quinn) are internal config identities and must never be shown to a client; only a client-chosen name would override, and there's no rename mechanism yet. Operators are distinguished by their **role** (persona title, e.g. "AI Case Coordinator"), not a made-up name. Removes the last places "Quinn" leaked to the client (the operator's status header + the list).

## What
- `hero.ts`: status-header name = "Operator" (was persona name); title/role preserved → "Operator · AI Case Coordinator".
- `offerings.ts`: `OperatorInstance.displayName = "Operator"`; adds `role` as the client-facing disambiguator; drops the persona-name fallback + dead `humanizeSlug`.
- operator chooser rows: "Operator" + role · status.
- Admin keeps persona names (internal). Only client-facing output changes.

## Verification
`npm run verify` green (build + typecheck + lint + format + 3380 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)