### PR TITLE
fix(portal): operator detail breadcrumbs to the Operators list, not Home

### DIFF
--- a/src/pages/portal/products/operator/[instance]/index.astro
+++ b/src/pages/portal/products/operator/[instance]/index.astro
@@ -12,7 +12,10 @@ import {
   resolveAlivenessSignal,
   type AlivenessSignal,
 } from '../../../../../lib/portal/operator/aliveness'
-import { getCustomerConfigBySlug } from '../../../../../lib/portal/customer-config'
+import {
+  getCustomerConfigBySlug,
+  listCustomerConfigsForEntity,
+} from '../../../../../lib/portal/customer-config'
 import FacetDoorList from '../../../../../components/portal/operator/FacetDoorList.astro'
 import type { FacetDoor } from '../../../../../lib/portal/operator/facet-doors'
 import { env } from 'cloudflare:workers'
@@ -50,6 +53,13 @@ if (!portalData.client) {
 }
 
 const { user, client } = portalData
+
+// Breadcrumb parent (list → detail hierarchy): step back to the OPERATORS list
+// when the client owns more than one operator; otherwise Home, since a lone
+// operator's list just forwards straight back into this same page.
+const operatorCount = (await listCustomerConfigsForEntity(env.DB, client.id)).length
+const backHref = operatorCount > 1 ? '/portal/products/operator' : '/portal'
+const backLabel = operatorCount > 1 ? 'Operators' : 'Home'
 
 type SurfaceState = 'no_subscription' | 'provisioning' | 'paused' | 'no_role' | 'active'
 let surfaceState: SurfaceState
@@ -194,11 +204,11 @@ const empty = surfaceState !== 'active' ? EMPTY[surfaceState] : null
   pathname={Astro.url.pathname}
 >
   <a
-    href="/portal"
+    href={backHref}
     class="mt-6 -mx-1 inline-flex min-h-11 items-center gap-2 px-1 font-mono text-label font-semibold uppercase tracking-[0.18em] text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2"
   >
     <span aria-hidden="true" class="font-body font-black text-[color:var(--color-primary)]">←</span>
-    Home
+    {backLabel}
   </a>
 
   {

--- a/src/pages/portal/products/operator/index.astro
+++ b/src/pages/portal/products/operator/index.astro
@@ -46,14 +46,10 @@ const seclabelClass =
   entityId={client.id}
   pathname={Astro.url.pathname}
 >
-  <a
-    href="/portal"
-    class="mt-6 -mx-1 inline-flex min-h-11 items-center gap-2 px-1 font-mono text-label font-semibold uppercase tracking-[0.18em] text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2"
-  >
-    <span aria-hidden="true" class="font-body font-black text-[color:var(--color-primary)]">←</span>
-    Home
-  </a>
-
+  {
+    /* No "← Home" here: this is the top of the Operator section and Home is
+      already the adjacent nav tab — a back-to-Home breadcrumb would be redundant. */
+  }
   <p class={`mt-8 ${seclabelClass}`}>Operators</p>
 
   {


### PR DESCRIPTION
## Why
Standard list→detail navigation: from inside an operator you should be able to step back to the **operators list**, not skip to top-level Home (which is already the adjacent nav tab). Reported by Captain.

## What
- Operator landing: back-link is **← Operators** when the client owns >1 operator; **← Home** when they own only one (a lone operator's list just forwards straight back in, so Home is the right parent there).
- Operators list: drops the redundant **← Home** (section top; Home is the adjacent nav tab).
- Sub-pages already step back to the operator landing → full hierarchy **Home › Operators › ‹operator› › ‹facet›**.

## Verification
`npm run verify` green (build + typecheck + lint + format + 3380 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)