### PR TITLE
fix(operator/smokeball): compose matter caption so the citation gate exempts the matter's own caption

### DIFF
--- a/operator/connectors/smokeball/smokeball_connector/server.py
+++ b/operator/connectors/smokeball/smokeball_connector/server.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import base64
 import os
+import re
 from typing import Any
 
 from operator_connector_sdk.server import ConnectorServer
@@ -56,6 +57,145 @@ def _body(**fields: Any) -> dict[str, Any]:
     return {k: v for k, v in fields.items() if v is not None}
 
 
+# ---- Matter caption composition -------------------------------------------
+#
+# WHY (ss churn fix): the overlay's tier-2 citation gate refuses agent output
+# containing a case-name pattern ("Alvarez v. Draper") to block FABRICATED case
+# law, with an allowlist escape for any caption the agent actually READ this
+# session (ss #1758). But Smokeball matter reads carry parties only as
+# ``clientIds``/``otherSideIds`` UUID refs — never a joined "X v. Y" string — so
+# the overlay's regex harvester finds nothing, the allowlist stays empty, and the
+# agent's memo naming the matter by its OWN caption is blocked → refuse-and-redraft
+# churn (~25-35% of active-day tokens; graders confirmed the blocked memos carry
+# the matter's own caption). We compose the caption HERE from the matter's own
+# structured party contacts and return it as a ``caption`` field, so the existing
+# harvester catches it and the gate exempts the matter's own caption. This never
+# weakens the fabrication protection: the allowlist exempts only the case-name
+# pattern for these exact parties; reporter-cite/statute/rule patterns are NEVER
+# allowlisted, so a poisoned party label cannot smuggle a cite through. Composition
+# is best-effort — provenance enrichment must never break a read (a loud rollout
+# assertion on the seat, not a raise here, catches a genuine happy-path failure).
+
+# Max distinct contact lookups per ``list_matters`` call (bounds the bulk-list
+# path: up to 500 matters x 2 parties would be untenable). ``get_matter`` (one
+# matter) always resolves fully.
+_CAPTION_MAX_LOOKUPS = 40
+
+
+def _party_surname(contact: Any) -> str | None:
+    """Resolve a contact object to a single plain party label (person surname or
+    company name). Tolerates the nested (``person``/``company``) shape confirmed
+    live 2026-07-08 and a flat fallback. Structured fields only, never free text;
+    stripped and length-bounded; rejects a label that itself looks like a caption
+    or a cite so the emitted caption stays a clean single "X v. Y"."""
+    if not isinstance(contact, dict):
+        return None
+    label: str | None = None
+    person = contact.get("person")
+    company = contact.get("company")
+    if isinstance(person, dict):
+        label = (person.get("lastName") or "").strip() or None
+    elif isinstance(company, dict):
+        label = (company.get("name") or "").strip() or None
+    if label is None:  # flat fallback
+        label = (contact.get("lastName") or contact.get("name") or "").strip() or None
+    if not label:
+        return None
+    # A party label is a name, not a caption or citation. If it already contains a
+    # " v. " join or a reporter-cite-shaped number run, drop it (fail-safe: no
+    # caption rather than a malformed/poisoned one).
+    if re.search(r"\bv\.?\s", label, re.IGNORECASE) or re.search(r"\d{2,}", label):
+        return None
+    return label[:60]
+
+
+def _orient_parties(matter: dict[str, Any]) -> tuple[str, list[str]] | None:
+    """Return ``(plaintiff_contact_id, defendant_contact_ids)`` for the caption, or
+    None when the matter has no two-sided caption (lead / missing party).
+
+    The caption convention is *Plaintiff v. Defendant*. Orientation is derived from
+    the matter-type side suffix ("... - Plaintiff" / "... - Defendant", present on
+    both ``get_matter`` and ``list_matters`` items), NOT a hardcoded client=plaintiff
+    assumption: for a plaintiff-side matter the firm's client is the plaintiff; for
+    a defense-side matter the client is the defendant, so the caption flips."""
+    clients = [c for c in (matter.get("clientIds") or []) if c]
+    others = [o for o in (matter.get("otherSideIds") or []) if o]
+    if not clients or not others:
+        return None
+    mt_name = ((matter.get("matterType") or {}).get("name") or "").strip().lower()
+    if mt_name.endswith("defendant"):
+        return others[0], clients  # firm defends; plaintiff is the other side
+    return clients[0], others  # plaintiff-side (default): client is the plaintiff
+
+
+def _resolve_surname(
+    client: Any, contact_id: str, cache: dict[str, str | None], budget: list[int] | None
+) -> str | None:
+    """get_contact -> surname, memoized in ``cache``; ``budget`` (a 1-elem list)
+    caps live lookups on the list path. Best-effort: a failed fetch yields None."""
+    if contact_id in cache:
+        return cache[contact_id]
+    if budget is not None:
+        if budget[0] <= 0:
+            return None
+        budget[0] -= 1
+    label: str | None = None
+    try:
+        label = _party_surname(client.get(f"/contacts/{contact_id}"))
+    except Exception:  # noqa: BLE001 — enrichment must never break the read path
+        label = None
+    cache[contact_id] = label
+    return label
+
+
+def _attach_caption(
+    client: Any,
+    matter: Any,
+    *,
+    cache: dict[str, str | None] | None = None,
+    budget: list[int] | None = None,
+) -> None:
+    """Mutate ``matter`` in place, adding a ``caption`` ("Plaintiff v. Defendant"
+    surname form) composed from its own party contacts. No-op (no ``caption`` key)
+    for party-less matters or unresolved parties — fail-safe: a missing caption can
+    only fail to exempt, never help a fabricated cite. The surname-v-surname form is
+    required so the overlay harvester (which expands the right party from its first
+    token) registers the exact string the agent writes."""
+    if not isinstance(matter, dict):
+        return
+    try:
+        orient = _orient_parties(matter)
+        if orient is None:
+            return
+        plaintiff_id, defendant_ids = orient
+        if cache is None:
+            cache = {}
+        plaintiff = _resolve_surname(client, plaintiff_id, cache, budget)
+        defendant = _resolve_surname(client, defendant_ids[0], cache, budget)
+        if not plaintiff or not defendant:
+            return
+        caption = f"{plaintiff} v. {defendant}"
+        if len(defendant_ids) > 1:
+            caption += " et al."
+        matter["caption"] = caption
+    except Exception:  # noqa: BLE001 — enrichment must never break the read path
+        return
+
+
+def _attach_captions_to_list(client: Any, resp: Any) -> None:
+    """Best-effort caption enrichment over a ``list_matters`` HATEOAS envelope,
+    bounded to ``_CAPTION_MAX_LOOKUPS`` distinct contact lookups (shared cache)."""
+    if not isinstance(resp, dict):
+        return
+    items = resp.get("value")
+    if not isinstance(items, list):
+        return
+    cache: dict[str, str | None] = {}
+    budget = [_CAPTION_MAX_LOOKUPS]
+    for item in items:
+        _attach_caption(client, item, cache=cache, budget=budget)
+
+
 # ---- Auth -----------------------------------------------------------------
 @server.tool()
 def auth_status() -> dict[str, Any]:
@@ -83,8 +223,12 @@ def list_matters(
     `search` here is a PLAIN full-text keyword (live-verified 2026-07-03:
     "Johnson" matches the matter title; field-scoped syntax like
     "name:*Johnson*" is NOT an error but silently returns zero results —
-    the opposite of the /contacts contract)."""
-    return _get_client().get(
+    the opposite of the /contacts contract).
+
+    Each item is enriched with a composed ``caption`` ("Plaintiff v. Defendant")
+    from its own party contacts (best-effort, bounded) — see the caption block."""
+    client = _get_client()
+    resp = client.get(
         "/matters",
         Status=status,
         IsLead=is_lead,
@@ -96,12 +240,20 @@ def list_matters(
         Limit=limit,
         Offset=offset,
     )
+    _attach_captions_to_list(client, resp)
+    return resp
 
 
 @server.tool()
 def get_matter(matter_id: str) -> Any:
-    """Get one matter by id (includes personResponsibleStaffId, status, isLead)."""
-    return _get_client().get(f"/matters/{matter_id}")
+    """Get one matter by id (includes personResponsibleStaffId, status, isLead).
+
+    Enriched with a composed ``caption`` ("Plaintiff v. Defendant") from the
+    matter's own party contacts (best-effort; absent for party-less matters)."""
+    client = _get_client()
+    matter = client.get(f"/matters/{matter_id}")
+    _attach_caption(client, matter)
+    return matter
 
 
 @server.tool()

--- a/operator/connectors/smokeball/tests/test_caption_composition.py
+++ b/operator/connectors/smokeball/tests/test_caption_composition.py
@@ -1,0 +1,192 @@
+"""Unit coverage for the composed matter ``caption`` field (ss churn fix).
+
+The overlay's tier-2 citation gate blocks agent memos containing a case-name
+("Alvarez v. Draper") unless the caption was READ this session, but Smokeball
+matter reads carry parties only as UUID refs — so the caption never reaches the
+overlay harvester and the matter's OWN caption gets refused → redraft churn.
+``server._attach_caption`` composes the caption from the matter's own party
+contacts and returns it as a ``caption`` field so the harvester catches it.
+
+No live Smokeball calls: an ``httpx.MockTransport`` is injected so the real
+contact-resolution logic runs against scripted responses. A final test imports
+the byte-identical ``citation_filter`` twin and asserts the emitted string is
+BOTH catchable (the harvester will register it) AND exempting (a memo naming the
+matter by that caption is then allowed) — locking the emission form to the
+deployed allowlist contract.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import httpx
+
+from smokeball_connector import server as srv
+from smokeball_connector.client import SmokeballClient
+
+
+def _mock_client(handler, captured: list[httpx.Request] | None = None) -> SmokeballClient:
+    client = SmokeballClient(
+        region="us", environment="staging", client_id="cid", client_secret="sec", api_key="apikey"
+    )
+    client._http = httpx.Client(transport=httpx.MockTransport(handler))
+    return client
+
+
+def _contacts_handler(contacts: dict[str, dict], captured: list[httpx.Request] | None = None):
+    def handler(request: httpx.Request) -> httpx.Response:
+        if captured is not None:
+            captured.append(request)
+        path = request.url.path
+        if path.endswith("/oauth2/token"):
+            return httpx.Response(
+                200, json={"access_token": "tok", "expires_in": 3600, "token_type": "Bearer"}
+            )
+        if "/contacts/" in path:
+            cid = path.rsplit("/", 1)[-1]
+            if cid in contacts:
+                return httpx.Response(200, json=contacts[cid])
+            return httpx.Response(404, json={"error": "not found"})
+        return httpx.Response(200, json={"ok": True})
+
+    return handler
+
+
+def _person(last: str) -> dict:
+    return {"person": {"firstName": "Given", "lastName": last}}
+
+
+def _company(name: str) -> dict:
+    return {"company": {"name": name}}
+
+
+def _contact_gets(captured: list[httpx.Request]) -> list[httpx.Request]:
+    return [r for r in captured if "/contacts/" in r.url.path]
+
+
+# ---- get_matter composition ----------------------------------------------
+
+
+def test_person_v_person_plaintiff_side() -> None:
+    captured: list[httpx.Request] = []
+    client = _mock_client(_contacts_handler({"c1": _person("Alvarez"), "d1": _person("Draper")}, captured), captured)
+    matter = {"clientIds": ["c1"], "otherSideIds": ["d1"], "matterType": {"name": "Motor Vehicle Accident - Plaintiff"}}
+    srv._attach_caption(client, matter)
+    assert matter["caption"] == "Alvarez v. Draper"
+    assert len(_contact_gets(captured)) == 2
+
+
+def test_defense_side_flips_orientation() -> None:
+    # Firm's client is the defendant; the caption is still Plaintiff v. Defendant.
+    client = _mock_client(_contacts_handler({"cl": _person("Draper"), "op": _person("Alvarez")}))
+    matter = {"clientIds": ["cl"], "otherSideIds": ["op"], "matterType": {"name": "Motor Vehicle Accident - Defendant"}}
+    srv._attach_caption(client, matter)
+    assert matter["caption"] == "Alvarez v. Draper"
+
+
+def test_multidef_appends_et_al_and_resolves_only_first_defendant() -> None:
+    captured: list[httpx.Request] = []
+    contacts = {"c1": _person("Bell"), "d1": _company("Acme Corp"), "d2": _person("Roe"), "d3": _person("Doe")}
+    client = _mock_client(_contacts_handler(contacts, captured), captured)
+    matter = {"clientIds": ["c1"], "otherSideIds": ["d1", "d2", "d3"], "matterType": {"name": "Personal Injury - Plaintiff"}}
+    srv._attach_caption(client, matter)
+    assert matter["caption"] == "Bell v. Acme Corp et al."
+    assert len(_contact_gets(captured)) == 2  # plaintiff + first defendant only
+
+
+def test_lead_no_otherside_yields_no_caption() -> None:
+    client = _mock_client(_contacts_handler({"c1": _person("Alvarez")}))
+    matter = {"clientIds": ["c1"], "otherSideIds": [], "matterType": {"name": "Personal Injury - Plaintiff"}, "isLead": True}
+    srv._attach_caption(client, matter)
+    assert "caption" not in matter
+
+
+def test_missing_contact_yields_no_caption_no_raise() -> None:
+    client = _mock_client(_contacts_handler({"c1": _person("Alvarez")}))  # d1 -> 404
+    matter = {"clientIds": ["c1"], "otherSideIds": ["d1"], "matterType": {"name": "X - Plaintiff"}}
+    srv._attach_caption(client, matter)
+    assert "caption" not in matter
+
+
+def test_blank_lastname_yields_no_caption() -> None:
+    client = _mock_client(_contacts_handler({"c1": _person("Alvarez"), "d1": _person("   ")}))
+    matter = {"clientIds": ["c1"], "otherSideIds": ["d1"], "matterType": {"name": "X - Plaintiff"}}
+    srv._attach_caption(client, matter)
+    assert "caption" not in matter
+
+
+def test_poisoned_label_with_cite_shape_is_rejected() -> None:
+    # A party label that itself carries a reporter-cite-shaped number run is dropped
+    # (fail-safe: no caption rather than a poisoned one). Independent of this, the
+    # overlay never allowlists reporter-cite/statute/rule patterns.
+    client = _mock_client(_contacts_handler({"c1": _person("Alvarez"), "d1": _person("Draper 410 US 113")}))
+    matter = {"clientIds": ["c1"], "otherSideIds": ["d1"], "matterType": {"name": "X - Plaintiff"}}
+    srv._attach_caption(client, matter)
+    assert "caption" not in matter
+
+
+def test_company_flat_shape_fallback() -> None:
+    client = _mock_client(_contacts_handler({"c1": _person("Whitfield"), "d1": _company("Pacific Freight")}))
+    matter = {"clientIds": ["c1"], "otherSideIds": ["d1"], "matterType": {"name": "Personal Injury - Plaintiff"}}
+    srv._attach_caption(client, matter)
+    assert matter["caption"] == "Whitfield v. Pacific Freight"
+
+
+# ---- list_matters composition (bounded + deduped) -------------------------
+
+
+def test_list_lookup_cap_bounds_contact_gets() -> None:
+    captured: list[httpx.Request] = []
+    contacts: dict[str, dict] = {}
+    items = []
+    for i in range(50):  # 50 matters x 2 distinct parties = 100 potential lookups
+        suffix = chr(65 + i // 26) + chr(65 + i % 26)  # digit-free distinct surnames ("AA", "AB", ...)
+        contacts[f"c{i}"] = _person(f"Plaintiff{suffix}")
+        contacts[f"d{i}"] = _person(f"Defendant{suffix}")
+        items.append({"clientIds": [f"c{i}"], "otherSideIds": [f"d{i}"], "matterType": {"name": "X - Plaintiff"}})
+    client = _mock_client(_contacts_handler(contacts, captured), captured)
+    resp = {"value": items}
+    srv._attach_captions_to_list(client, resp)
+    assert len(_contact_gets(captured)) == srv._CAPTION_MAX_LOOKUPS  # capped at 40
+    assert sum(1 for m in items if "caption" in m) == srv._CAPTION_MAX_LOOKUPS // 2  # 20 fully resolved
+
+
+def test_list_shared_contacts_dedupe() -> None:
+    captured: list[httpx.Request] = []
+    client = _mock_client(_contacts_handler({"c1": _person("Alvarez"), "d1": _person("Draper")}, captured), captured)
+    items = [{"clientIds": ["c1"], "otherSideIds": ["d1"], "matterType": {"name": "X - Plaintiff"}} for _ in range(3)]
+    resp = {"value": items}
+    srv._attach_captions_to_list(client, resp)
+    assert len(_contact_gets(captured)) == 2  # deduped across all 3 matters
+    assert all(m["caption"] == "Alvarez v. Draper" for m in items)
+
+
+# ---- canonicalization proof vs the deployed citation-filter twin ----------
+
+
+def _load_citation_filter():
+    path = Path(__file__).resolve().parents[3] / "safety-substrate" / "citation_filter.py"
+    spec = importlib.util.spec_from_file_location("ss_citation_filter", path)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod  # dataclass field resolution needs the module registered
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_emitted_caption_is_catchable_and_exempting() -> None:
+    cf = _load_citation_filter()
+    caption = "Alvarez v. Draper"
+    # 1) The caption, as it appears embedded in a stringified read result, IS a
+    #    case-name hit — so the overlay harvester will register it.
+    assert cf.contains_citation(f"...'caption': '{caption}'...") is True
+    # 2) A memo naming the matter by that caption is blocked WITHOUT the allowlist,
+    #    and EXEMPT once the caption is registered — the whole point of the fix.
+    memo = "Discovery capture on Alvarez v. Draper: SROG set 1 served 2026-06-26."
+    assert cf.contains_citation(memo) is True
+    assert cf.contains_citation(memo, allowed_case_names=[cf.canonical_caption(caption)]) is False
+    # 3) Safety unchanged: a reporter cite is NEVER exempt, even allowlisted.
+    fabricated = "As held in Alvarez v. Draper, 410 U.S. 113 (1973)."
+    assert cf.contains_citation(fabricated, allowed_case_names=[cf.canonical_caption(caption)]) is True


### PR DESCRIPTION
## Summary
Kills the citation-gate **refuse-and-redraft churn** — graders measured it at ~25–35% of active-day tokens, and it will hit every active day of the A&P go-live.

- **Root cause (traced live):** the overlay tier-2 citation gate blocks agent memos containing a case-name ("Alvarez v. Draper") to prevent fabricated case law, with an allowlist escape for any caption the agent READ this session (#1758). But Smokeball matter reads carry parties only as `clientIds`/`otherSideIds` UUID refs — never a joined "X v. Y" string — so the overlay's regex harvester finds nothing, the allowlist stays empty (`register_was_empty` ~90% in the ledger), and the agent's memo naming the matter by its **own** caption is blocked → redraft.
- **Fix (connector-only, no overlay change):** compose the caption from the matter's own structured party contacts and return it as a `caption` field on `get_matter`/`list_matters`, so the **existing** overlay harvester catches it and the gate exempts the matter's own caption. The read tools are already `READ`-mapped; no `OVERLAY_REF` bump, no byte-pair twin touched.
- Orientation is derived from the matter-type side suffix (never a hardcoded client=plaintiff assumption); `get_matter` resolves fully (≤2 cached contact GETs), `list_matters` is best-effort capped at 40 lookups; party-less/unresolved → no caption (fail-safe).

## Safety
Unchanged. The allowlist exempts **only** the case-name pattern for these exact parties; reporter-cite/statute/rule patterns are **never** allowlisted. A canonicalization test asserts a reporter cite still blocks even when the caption is allowlisted.

## Test plan
- [x] 11 new unit tests (MockTransport): person-v-person, defense-side flip, multi-def "et al.", lead/blank/missing → no caption, poisoned-label rejection, list cap + dedupe
- [x] Canonicalization proof vs the byte-identical `citation_filter` twin (emitted caption catchable AND exempting; reporter cite still blocks)
- [x] Full connector suite green (96 tests); `npm run verify` green
- [x] Step 0 live-staging recon confirmed `list_matters` `value[]` carries the party arrays and `matterType.name` encodes the side
- [ ] Live proof on rebuilt pilot-smokeball: blank a matter's description (confound control), drive a memo skill, confirm `FABRICATION_FILTER_TRIGGERED` case-name blocks → ~0 and `register_was_empty` flips false in-session; fabricated cite still blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)