### PR TITLE
feat(portal): Operator › Skills facet — real inventory + initiation

### DIFF
--- a/docs/design/operator/surface-briefs/operator-skills.md
+++ b/docs/design/operator/surface-briefs/operator-skills.md
@@ -1,8 +1,14 @@
 # Surface Brief — Operator › Skills
 
-Route: `portal.smd.services/portal/products/operator/skills`
+Route: `portal.smd.services/portal/products/operator/<instance>/skills`
+(instance-addressed under the multi-operator model — the pre-multi-operator
+brief drafted this as the flat `/operator/skills`)
 Facet: `skills` (facet registry `src/lib/portal/operator/facet-registry.ts`)
-Status: **DRAFT — awaiting Captain sign-off** (drafted 2026-07-08)
+Status: **SIGNED OFF — BUILT 2026-07-08.** All three sign-off questions resolved
+as recommended: (1) show the honest cut (inventory + initiation only, no
+always-"On" state); (2) initiation labels "On request" / "On a schedule" /
+"When something happens"; (3) loud register (match siblings), registered in
+`CALM_REGISTER_PENDING`.
 
 The second facet made real under the content/functionality pass (ADR 0069). The
 landing's "Skills" door currently deep-links to the legacy Configure page; this

--- a/src/components/portal/operator/facets/OperatorSkills.astro
+++ b/src/components/portal/operator/facets/OperatorSkills.astro
@@ -1,0 +1,65 @@
+---
+/**
+ * Operator SKILLS viewer — the shared inventory + initiation view (ADR 0069
+ * Slice 3; signed-off brief docs/design/operator/surface-briefs/operator-skills.md).
+ * One shared component, both portals mount (Lock 4); the facet registry points
+ * `skills` at the resolver this consumes.
+ *
+ * Shows each configured skill (humanized slug) and HOW it is set in motion (its
+ * initiation labels) in authored order — the informative payload the legacy
+ * Configure list throws away. Deliberately NOT enable/disable (the projection
+ * dropped it; Configure's "On" is a hardcoded constant), ceilings, versions, or
+ * costs (brief §5). Honest empty state when the list is empty.
+ *
+ * Loud register to match its siblings (Configure, the landing, OperatorHero)
+ * while the calm migration is parked; registered in CALM_REGISTER_PENDING so the
+ * whole operator area flips to calm together, not one lone page at a time.
+ */
+import type { OperatorSkillsModel } from '../../../../lib/portal/operator/facets/skills/skills'
+
+interface Props {
+  model: OperatorSkillsModel
+}
+
+const { model } = Astro.props
+const { skills } = model
+---
+
+<section
+  class="border-[3px] border-[color:var(--color-text-primary)] bg-[color:var(--color-background)]"
+  aria-label="Operator skills"
+>
+  <div
+    class="bg-[color:var(--color-text-primary)] px-5 py-2.5 font-mono text-label font-bold uppercase tracking-[0.18em] text-[color:var(--color-background)]"
+  >
+    Skills
+  </div>
+  <div class="px-5 py-6 md:px-7">
+    {
+      skills.length === 0 ? (
+        <p class="font-mono text-label uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)]">
+          Your operator's skills appear here once they're configured.
+        </p>
+      ) : (
+        <ul role="list" class="flex flex-col">
+          {skills.map((s, i) => (
+            <li
+              class={`flex flex-col gap-1 py-3 md:flex-row md:items-baseline md:justify-between md:gap-6 ${
+                i > 0 ? 'border-t-[2px] border-[color:var(--color-border)]' : ''
+              }`}
+            >
+              <span class="font-body text-base font-semibold text-[color:var(--color-text-primary)]">
+                {s.name}
+              </span>
+              {s.initiation.length > 0 && (
+                <span class="shrink-0 font-mono text-label uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)]">
+                  {s.initiation.join(' · ')}
+                </span>
+              )}
+            </li>
+          ))}
+        </ul>
+      )
+    }
+  </div>
+</section>

--- a/src/lib/portal/operator/facet-registry.ts
+++ b/src/lib/portal/operator/facet-registry.ts
@@ -115,9 +115,12 @@ export const OPERATOR_FACETS: readonly OperatorFacet[] = [
     id: 'skills',
     label: 'Skills (authored)',
     plane: 'config_projection',
-    surface: { kind: 'planned', slice: 3 },
+    surface: {
+      kind: 'has_viewer',
+      viewerModule: 'src/lib/portal/operator/facets/skills/skills.ts',
+    },
     mounts: ['client', 'admin'],
-    note: 'personas_json narrowed — enabled/version/cost dropped from projection.',
+    note: 'Slice 3: inventory (humanized slug) + initiation, in authored order. enabled/version/cost dropped from projection and deliberately not shown; per-skill autonomy is the Governance facet (Lock 4).',
   },
   {
     id: 'agent-skills',

--- a/src/lib/portal/operator/facets/skills/skills.ts
+++ b/src/lib/portal/operator/facets/skills/skills.ts
@@ -1,0 +1,86 @@
+/**
+ * Operator SKILLS facet — the shared inventory + initiation view model (ADR 0069
+ * Slice 3; signed-off brief docs/design/operator/surface-briefs/operator-skills.md).
+ *
+ * Answers the console's central "what can it do?" question: the skills configured
+ * on the active persona, in authored order, plus HOW each one gets set in motion
+ * (its initiation modes). One shared resolver + one shared viewer
+ * (`components/portal/operator/facets/OperatorSkills.astro`), mounted in both
+ * portals per Lock 4 — the facet registry points `skills` here.
+ *
+ * Honesty (brief §5): only what the projection carries. The portal holds the
+ * skill SLUG, never the `SKILL.md` prose, so a display name is a REFORMAT of the
+ * slug (`humanizeSlug`), never an invented description sentence. We deliberately
+ * do NOT surface:
+ *   - enabled / on-off — the projection dropped `enabled`; Configure's "On" is a
+ *     hardcoded constant (settings.ts::skillToggleRowsFromPersona), not real
+ *     state, so reproducing it would be theater;
+ *   - version / cost / scope — dropped from the projection;
+ *   - trust ceiling / exposure / autonomy — that is the Governance facet (Lock 4:
+ *     one viewer per facet; Skills is inventory + initiation only).
+ *
+ * Pure and total: a null config, no active persona, or an empty skills list all
+ * yield an empty list, and the viewer renders the honest empty state
+ * (docs/style/empty-state-pattern.md) — never a fabricated placeholder row.
+ */
+
+import type { CustomerConfigRow, PersonaSkill } from '../../../customer-config'
+import type { SkillInitiation } from '../../../../operator/customer-yaml/types'
+
+/**
+ * Reformat a skill slug into a client-legible display name — SENTENCE case
+ * (brief §5: `matter-inbox-router` → "Matter inbox router"), so a skill reads
+ * like a capability, not a shouting label. This is a pure reformat of the slug,
+ * never an invented description sentence; the portal holds only the slug. Kept
+ * separate from `offerings.humanizeSlug` (Title case, for operator display
+ * NAMES) because these are different concerns: a name is a proper noun, a skill
+ * is a description of a capability.
+ */
+export function humanizeSkillName(slug: string): string {
+  const words = slug.split('-').filter(Boolean)
+  if (words.length === 0) return ''
+  const [first, ...rest] = words
+  return [first.charAt(0).toUpperCase() + first.slice(1), ...rest].join(' ')
+}
+
+export interface OperatorSkillView {
+  /** Humanized display name, e.g. "matter-inbox-router" → "Matter inbox router". */
+  name: string
+  /** The raw authored slug — stable key / title, never shown as prose. */
+  slug: string
+  /** Client-legible initiation labels; empty when no mode is set (show nothing). */
+  initiation: string[]
+}
+
+export interface OperatorSkillsModel {
+  skills: OperatorSkillView[]
+}
+
+/**
+ * Map the three initiation booleans to client-legible labels, in a stable order
+ * (request → schedule → event). When every mode is false, returns [] so the
+ * viewer shows nothing rather than imply a trigger the skill does not carry.
+ */
+export function initiationLabels(init: SkillInitiation): string[] {
+  const labels: string[] = []
+  if (init.manual) labels.push('On request')
+  if (init.scheduled) labels.push('On a schedule')
+  if (init.webhook) labels.push('When something happens')
+  return labels
+}
+
+/**
+ * Compose the Skills view model from the config projection. Selects the active
+ * persona (mirrors `getActivePersona`) and maps its authored skill list,
+ * preserving order. No second DB read — the caller passes the already-projected,
+ * typed config.
+ */
+export function resolveOperatorSkills(config: CustomerConfigRow | null): OperatorSkillsModel {
+  const persona = config?.personas.find((p) => p.status === 'active') ?? null
+  const skills: OperatorSkillView[] = (persona?.skills ?? []).map((s: PersonaSkill) => ({
+    name: humanizeSkillName(s.name),
+    slug: s.name,
+    initiation: initiationLabels(s.initiation),
+  }))
+  return { skills }
+}

--- a/src/pages/portal/products/operator/[instance]/index.astro
+++ b/src/pages/portal/products/operator/[instance]/index.astro
@@ -116,8 +116,8 @@ const roleDoors: FacetDoor[] = [
   { label: 'Scope', desc: 'What it handles for you, and the shape of its job.', href: CONFIGURE },
   {
     label: 'Skills',
-    desc: 'Everything it can do: authored, bundled, and the ones it wrote itself.',
-    href: CONFIGURE,
+    desc: 'Everything it can do, and how each one gets set in motion.',
+    href: `${operatorBase}/skills`,
   },
   {
     label: 'Schedule',

--- a/src/pages/portal/products/operator/[instance]/skills/index.astro
+++ b/src/pages/portal/products/operator/[instance]/skills/index.astro
@@ -1,0 +1,106 @@
+---
+import PortalShell from '../../../../../../layouts/PortalShell.astro'
+import { resolveOperatorAccess } from '../../../../../../lib/portal/operator-access'
+import { resolveOperatorSkills } from '../../../../../../lib/portal/operator/facets/skills/skills'
+import PortalPageHead from '../../../../../../components/portal/PortalPageHead.astro'
+import DomainSurface from '../../../../../../components/portal/operator/DomainSurface.astro'
+import OperatorSkills from '../../../../../../components/portal/operator/facets/OperatorSkills.astro'
+import { env } from 'cloudflare:workers'
+
+/**
+ * Operator — Skills (ADR 0069 Slice 3; signed-off brief
+ * docs/design/operator/surface-briefs/operator-skills.md). The concrete answer
+ * to the console's central "what can it do?" question: a real, honest inventory
+ * of the skills configured on the active persona and HOW each gets set in
+ * motion. Replaces the landing's Skills → Configure deep-link.
+ *
+ * URL: portal.smd.services/portal/products/operator/<instance>/skills
+ *
+ * Read for all account roles (principal / staff / compliance), matching
+ * Configure's read posture. The one forward action is "Request a change" via the
+ * same <DomainSurface> (configuration domain) mechanism Configure uses — never
+ * the legacy enable/disable toggle, whose state the projection can't back.
+ *
+ * The view model is the one shared resolver; the list renders through the one
+ * shared <OperatorSkills> viewer both portals mount (Lock 4). Reads the
+ * customer_configs projection (real authored data); nothing fabricated.
+ */
+
+const instance = Astro.params.instance
+if (!instance) return Astro.redirect('/portal/products/operator')
+const operatorBase = `/portal/products/operator/${instance}`
+
+const access = await resolveOperatorAccess(env.DB, Astro.locals, {
+  allowedRoles: ['principal', 'staff', 'compliance'],
+  customerSlug: instance,
+})
+if (access.kind === 'redirect') {
+  return Astro.redirect(access.to)
+}
+const { client, roles } = access
+
+const model = resolveOperatorSkills(access.config)
+
+const RETURN_TO = `${operatorBase}/skills`
+
+const cr = Astro.url.searchParams.get('cr')
+const crMessage =
+  cr === 'filed'
+    ? 'Your request was sent.'
+    : cr === 'invalid'
+      ? "That request couldn't be filed. Please add a short description and try again."
+      : cr === 'error'
+        ? 'Something went wrong filing your request. Please try again.'
+        : null
+---
+
+<PortalShell
+  title="Operator · Skills"
+  clientName={client.name}
+  orgId={client.org_id}
+  entityId={client.id}
+  pathname={Astro.url.pathname}
+>
+  <PortalPageHead
+    crumbHref={operatorBase}
+    crumbLabel="Operator"
+    tag="Section"
+    h1="Skills"
+    meta={null}
+  />
+
+  {
+    crMessage && (
+      <div
+        role="status"
+        class={`mt-6 border-[3px] px-5 py-3 font-mono text-label uppercase tracking-[0.14em] font-bold ${
+          cr === 'filed'
+            ? 'border-[color:var(--ss-color-complete)] text-[color:var(--ss-color-complete)]'
+            : 'border-[color:var(--ss-color-error)] text-[color:var(--ss-color-error)]'
+        }`}
+      >
+        {crMessage}
+      </div>
+    )
+  }
+
+  <p
+    class="mt-8 font-mono text-label uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)]"
+  >
+    Everything your operator can do, and how each one gets set in motion.
+  </p>
+
+  <div class="mt-4">
+    <DomainSurface
+      authority={access.config?.authority ?? null}
+      domain="configuration"
+      roles={roles}
+      returnTo={RETURN_TO}
+      domainLabel="skills"
+    >
+      <div slot="read">
+        <OperatorSkills model={model} />
+      </div>
+    </DomainSurface>
+  </div>
+</PortalShell>

--- a/tests/forbidden-strings.test.ts
+++ b/tests/forbidden-strings.test.ts
@@ -816,6 +816,7 @@ const CALM_REGISTER_PENDING: string[] = [
   'src/pages/portal/products/operator/index.astro',
   'src/pages/portal/products/operator/[instance]/index.astro',
   'src/components/portal/operator/facets/OperatorHero.astro',
+  'src/components/portal/operator/facets/OperatorSkills.astro',
   'src/components/portal/operator/FacetDoorList.astro',
   'src/components/admin/EntityContactRow.astro',
   'src/components/admin/EntityIdentityStrip.astro',
@@ -862,6 +863,7 @@ const CALM_REGISTER_PENDING: string[] = [
   'src/pages/portal/products/operator/[instance]/settings/advanced/index.astro',
   'src/pages/portal/products/operator/[instance]/settings/index.astro',
   'src/pages/portal/products/operator/[instance]/settings/users.astro',
+  'src/pages/portal/products/operator/[instance]/skills/index.astro',
   'src/pages/portal/products/operator/[instance]/team/index.astro',
 ]
 

--- a/tests/operator-skills-facet.test.ts
+++ b/tests/operator-skills-facet.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest'
+import {
+  initiationLabels,
+  resolveOperatorSkills,
+} from '../src/lib/portal/operator/facets/skills/skills'
+import type {
+  CustomerConfigRow,
+  PersonaConfig,
+  PersonaSkill,
+} from '../src/lib/portal/customer-config'
+import type { SkillInitiation } from '../src/lib/operator/customer-yaml/types'
+
+/**
+ * Operator Skills facet resolver (ADR 0069 Slice 3; brief
+ * docs/design/operator/surface-briefs/operator-skills.md). Inventory + initiation
+ * from the config projection, in authored order — nothing fabricated.
+ */
+
+function init(p: Partial<SkillInitiation> = {}): SkillInitiation {
+  return { manual: false, scheduled: false, webhook: false, ...p }
+}
+
+function skill(name: string, i: Partial<SkillInitiation> = {}): PersonaSkill {
+  return { name, initiation: init(i) }
+}
+
+/** Minimal persona fixture — only the fields the resolver reads matter. */
+function persona(p: Partial<PersonaConfig>): PersonaConfig {
+  return {
+    slug: 'p',
+    status: 'active',
+    name: 'X',
+    title: null,
+    signature_html: null,
+    tone: [],
+    send_as: null,
+    entitlements: {} as PersonaConfig['entitlements'],
+    skills: [],
+    channel_bindings: [],
+    ...p,
+  }
+}
+
+function config(personas: PersonaConfig[]): CustomerConfigRow {
+  return { personas } as unknown as CustomerConfigRow
+}
+
+describe('initiationLabels', () => {
+  it('maps each mode to its client-legible label', () => {
+    expect(initiationLabels(init({ manual: true }))).toEqual(['On request'])
+    expect(initiationLabels(init({ scheduled: true }))).toEqual(['On a schedule'])
+    expect(initiationLabels(init({ webhook: true }))).toEqual(['When something happens'])
+  })
+
+  it('returns labels in a stable order (request → schedule → event), not input order', () => {
+    expect(initiationLabels(init({ webhook: true, manual: true, scheduled: true }))).toEqual([
+      'On request',
+      'On a schedule',
+      'When something happens',
+    ])
+  })
+
+  it('returns [] when no mode is set — the viewer shows nothing, never a fabricated trigger', () => {
+    expect(initiationLabels(init())).toEqual([])
+  })
+})
+
+describe('resolveOperatorSkills', () => {
+  it('humanizes each skill slug for display and keeps the raw slug', () => {
+    const model = resolveOperatorSkills(
+      config([persona({ skills: [skill('matter-inbox-router', { webhook: true })] })])
+    )
+    expect(model.skills).toEqual([
+      {
+        name: 'Matter inbox router',
+        slug: 'matter-inbox-router',
+        initiation: ['When something happens'],
+      },
+    ])
+  })
+
+  it('preserves authored order', () => {
+    const model = resolveOperatorSkills(
+      config([
+        persona({
+          skills: [
+            skill('new-matter-intake'),
+            skill('consult-scheduler'),
+            skill('trust-balance-nudge'),
+          ],
+        }),
+      ])
+    )
+    expect(model.skills.map((s) => s.slug)).toEqual([
+      'new-matter-intake',
+      'consult-scheduler',
+      'trust-balance-nudge',
+    ])
+  })
+
+  it('reads only the ACTIVE persona', () => {
+    const model = resolveOperatorSkills(
+      config([
+        persona({ status: 'archived', skills: [skill('old-skill', { manual: true })] }),
+        persona({ status: 'active', skills: [skill('live-skill', { manual: true })] }),
+      ])
+    )
+    expect(model.skills.map((s) => s.slug)).toEqual(['live-skill'])
+  })
+
+  it('is empty when config is null', () => {
+    expect(resolveOperatorSkills(null).skills).toEqual([])
+  })
+
+  it('is empty when there is no active persona', () => {
+    const model = resolveOperatorSkills(
+      config([persona({ status: 'archived', skills: [skill('x', { manual: true })] })])
+    )
+    expect(model.skills).toEqual([])
+  })
+
+  it('is empty when the active persona has no skills', () => {
+    expect(resolveOperatorSkills(config([persona({ skills: [] })])).skills).toEqual([])
+  })
+})


### PR DESCRIPTION
## What

Turns the Operator **Skills** door into a real, briefed surface. The landing's Skills door deep-linked to the legacy **Configure** dump — a flat list of ~33 skill slugs each with a hardcoded **ON** toggle (screenshot below). This replaces it with an honest inventory that answers the console's central "what can it do?" question.

Second facet made real under the content/functionality pass (ADR 0069 Slice 3; signed-off brief `docs/design/operator/surface-briefs/operator-skills.md`).

## The honest cut (brief §5)

Inventory **+ initiation only**, from the config projection:

- **Shown:** each skill on the active persona, humanized to sentence case (`matter-inbox-router` → "Matter inbox router"), in **authored order**, plus **how it gets set in motion** — `On request` / `On a schedule` / `When something happens` (the payload Configure throws away). No initiation shown when no mode is set.
- **Deliberately NOT shown:** enable/disable (the projection dropped `enabled`; Configure's "On" is a hardcoded constant, not real state), version, cost, and per-skill trust ceiling/autonomy (dropped from the projection, or the **Governance** facet per Lock 4 — one viewer per facet).
- **Honest empty state** when config is null, no active persona, or the skills list is empty — never a placeholder row.

## Shape (ADR 0069 Lock 4 — one viewer, two mounts)

- `src/lib/portal/operator/facets/skills/skills.ts` — shared, pure resolver (projection → view model).
- `src/components/portal/operator/facets/OperatorSkills.astro` — shared viewer, both portals mount.
- `src/pages/portal/products/operator/[instance]/skills/index.astro` — instance-addressed page; read for `principal`/`staff`/`compliance`; the one forward action is **Request a change** via the existing `<DomainSurface>` (never the legacy toggle).
- Facet registry: `skills` flipped `planned` → `has_viewer`.
- Landing Skills door: `Configure` → `/skills`; description tightened to what the page delivers.

## Guards / tests

- Both new loud files registered in `CALM_REGISTER_PENDING` (flip to calm with the rest of the operator area).
- New resolver unit test: humanization, initiation-label order, active-persona selection, three empty branches.
- `npm run verify` green (typecheck + workers typecheck + format + lint + build + all test suites).

## Deploy / verify

Read-only projection surface; no migration, no seed. Renders against the live `pilot-smokeball` law-firm config once deployed — I'll confirm the door lands on the new page (not Configure) and the ~33 skills render with initiation on the running seat post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MJF9rQDhVKLv2ADbbApPgi