### PR TITLE
feat(operator): add `confirm` trust-ceiling value + external_send enforcement (ADR 0071 #1804)

### DIFF
--- a/operator/adapter/tests/test_inbound_envelope.py
+++ b/operator/adapter/tests/test_inbound_envelope.py
@@ -130,3 +130,24 @@ def test_injected_send_refused_even_with_autonomous_skill_scalar():
         current_turn_approval=False,
     )
     assert not decision.allowed
+
+
+def test_confirm_send_refused_on_tainted_turn_even_with_approval():
+    # ADR 0071: the `confirm` ceiling is the one exposure value that consults
+    # current_turn_approval — but the taint-gate DOMINATES and sits before the
+    # send branch. A turn that ingested untrusted inbound content cannot reach the
+    # confirm allow-path, even with the approval flag set: an inbound/injected
+    # "reply yes" must never turn into a send. This is the load-bearing invariant
+    # for confirm-over-channel (the approval must come from a trusted path, not the
+    # tainted inbound turn).
+    decision = enforce(
+        ceiling=Ceiling.DRAFT_FOR_REVIEW,
+        action=ActionClass.EXTERNAL_SEND,
+        skill_name="inbox-triage",
+        tool_name="gmail.send",
+        current_turn_approval=True,
+        action_ceilings={ActionClass.EXTERNAL_SEND: Ceiling.CONFIRM},
+        inbound_trust_class="external_untrusted",
+    )
+    assert not decision.allowed
+    assert decision.audit_action == "refuse"

--- a/operator/adapter/trust_ceiling.py
+++ b/operator/adapter/trust_ceiling.py
@@ -35,6 +35,7 @@ from dataclasses import dataclass
 
 class Ceiling(str, enum.Enum):
     AUTONOMOUS = "autonomous"
+    CONFIRM = "confirm"  # external_send: execute after an explicit current-turn approval (ADR 0071)
     DRAFT_FOR_REVIEW = "draft_for_review"
     REFUSED = "refused"
 
@@ -66,7 +67,7 @@ _TRUST_CLASS_INTERNAL = "internal"
 class EnforcementDecision:
     allowed: bool
     reason: str
-    audit_action: str  # "allow" | "draft" | "refuse"
+    audit_action: str  # "allow" | "draft" | "refuse" | "await_approval"
 
 
 # Restrictiveness ordering: higher number == more restrictive. Used to pick
@@ -74,8 +75,9 @@ class EnforcementDecision:
 # vertical-pack floor (a floor can only narrow, never widen — ADR 0025).
 _RESTRICTIVENESS: dict[Ceiling, int] = {
     Ceiling.AUTONOMOUS: 0,
-    Ceiling.DRAFT_FOR_REVIEW: 1,
-    Ceiling.REFUSED: 2,
+    Ceiling.CONFIRM: 1,
+    Ceiling.DRAFT_FOR_REVIEW: 2,
+    Ceiling.REFUSED: 3,
 }
 
 
@@ -156,8 +158,11 @@ def enforce(
     `current_turn_approval` is True iff the operator explicitly approved this
     specific action in the current invocation. Approvals from prior turns or
     prior sessions are NOT valid (safety invariant #1). It gates the
-    reversibility classes (COMMITMENT, DESTRUCTIVE); `external_send` autonomy is
-    governed by the configured ceiling, not by an in-turn approval (ADR 0025).
+    reversibility classes (COMMITMENT, DESTRUCTIVE) and, per ADR 0071, a send
+    at the `confirm` ceiling — the one exposure value that DOES consult an
+    in-turn approval. `external_send` at an `autonomous` ceiling still sends
+    without one; at `confirm` it sends only with one (else the send is withheld
+    pending approval); at `draft_for_review` it drafts (ADR 0025/0071).
     """
     # REFUSED ceiling: nothing executes
     if ceiling == Ceiling.REFUSED:
@@ -248,16 +253,16 @@ def enforce(
         return EnforcementDecision(allowed=True, reason="destructive with current-turn approval", audit_action="allow")
 
     # EXTERNAL_SEND / EXTERNAL_SEND_INTERNAL: each governed by its OWN resolved
-    # per-action ceiling (ADR 0025/0035). The recipient axis is decided upstream
+    # per-action ceiling (ADR 0025/0035/0071). The recipient axis is decided upstream
     # (recipient_classifier) — by the time a send reaches here it is already typed
     # as the outside class (external_send) or the rostered class
     # (external_send_internal); an unclassifiable recipient never reaches here (it
-    # is a hard error at the router). autonomous → send; draft_for_review (an
-    # AUTHORED value) → draft; refused → block. Unauthored is fail-closed (refused),
-    # not draft (ADR 0035 — no imposed default). No in-turn-approval escape:
-    # exposure autonomy is configured, not approved per message. A rostered send is
-    # recipient-locked to the classified roster recipient — the classifier, not this
-    # branch, enforces that lock.
+    # is a hard error at the router). autonomous → send; confirm → send only with an
+    # explicit current-turn approval, else withhold pending approval (ADR 0071);
+    # draft_for_review (an AUTHORED value) → draft; refused → block. Unauthored is
+    # fail-closed (refused), not draft (ADR 0035 — no imposed default). A rostered
+    # send is recipient-locked to the classified roster recipient — the classifier,
+    # not this branch, enforces that lock.
     if action in (ActionClass.EXTERNAL_SEND, ActionClass.EXTERNAL_SEND_INTERNAL):
         eff = resolve_ceiling(action, ceiling, action_ceilings, vertical_floors)
         if eff == Ceiling.AUTONOMOUS:
@@ -265,6 +270,25 @@ def enforce(
                 allowed=True,
                 reason=f"{action.value} permitted: configured ceiling is autonomous",
                 audit_action="allow",
+            )
+        if eff == Ceiling.CONFIRM:
+            # confirm (ADR 0071): the send executes only with an explicit
+            # current-turn approval captured by a TRUSTED runtime path. Without
+            # one it is WITHHELD pending approval — not drafted, not refused. The
+            # taint-gate above already blocked this class on a tainted turn, so an
+            # inbound/injected "approval" can never reach here. The approval-capture
+            # round-trip is #1806; until it lands, confirm resolves to
+            # await_approval (fail-safe: nothing sends).
+            if current_turn_approval:
+                return EnforcementDecision(
+                    allowed=True,
+                    reason=f"{action.value} confirmed by explicit current-turn approval (ADR 0071)",
+                    audit_action="allow",
+                )
+            return EnforcementDecision(
+                allowed=False,
+                reason=f"{action.value} at authored confirm ceiling; withheld pending current-turn approval",
+                audit_action="await_approval",
             )
         if eff == Ceiling.REFUSED:
             return EnforcementDecision(

--- a/operator/safety-substrate/tests/test_invariant_2_no_external_send_without_confirmation.py
+++ b/operator/safety-substrate/tests/test_invariant_2_no_external_send_without_confirmation.py
@@ -153,11 +153,65 @@ def run() -> tuple[bool, str]:
             f"FAIL: refused-scalar skill should never execute anything, got allowed ({decision.reason})",
         )
 
+    # Scenario G (ADR 0071): authored external_send=confirm WITHOUT a current-turn
+    # approval is WITHHELD pending approval — not sent, not drafted, not refused.
+    decision = enforce(
+        ceiling=Ceiling.DRAFT_FOR_REVIEW,
+        action=ActionClass.EXTERNAL_SEND,
+        skill_name="ar-chaser",
+        tool_name="gmail.send",
+        current_turn_approval=False,
+        action_ceilings={ActionClass.EXTERNAL_SEND: Ceiling.CONFIRM},
+    )
+    if decision.allowed or decision.audit_action != "await_approval":
+        return (
+            False,
+            f"FAIL: external_send=confirm without approval must withhold pending approval, got "
+            f"allowed={decision.allowed} audit={decision.audit_action}",
+        )
+
+    # Scenario H (ADR 0071): authored external_send=confirm WITH a current-turn
+    # approval sends — the one exposure value that consults the approval flag.
+    decision = enforce(
+        ceiling=Ceiling.DRAFT_FOR_REVIEW,
+        action=ActionClass.EXTERNAL_SEND,
+        skill_name="ar-chaser",
+        tool_name="gmail.send",
+        current_turn_approval=True,
+        action_ceilings={ActionClass.EXTERNAL_SEND: Ceiling.CONFIRM},
+    )
+    if not decision.allowed or decision.audit_action != "allow":
+        return (
+            False,
+            f"FAIL: external_send=confirm with current-turn approval should send, got "
+            f"allowed={decision.allowed} audit={decision.audit_action} ({decision.reason})",
+        )
+
+    # Scenario I (ADR 0071 ordering): a vertical floor of draft_for_review NARROWS an
+    # authored confirm (confirm < draft_for_review) — even with approval it drafts,
+    # never sends. The regulated-vertical guarantee holds against confirm too.
+    decision = enforce(
+        ceiling=Ceiling.DRAFT_FOR_REVIEW,
+        action=ActionClass.EXTERNAL_SEND,
+        skill_name="ar-chaser",
+        tool_name="gmail.send",
+        current_turn_approval=True,
+        action_ceilings={ActionClass.EXTERNAL_SEND: Ceiling.CONFIRM},
+        vertical_floors={ActionClass.EXTERNAL_SEND: Ceiling.DRAFT_FOR_REVIEW},
+    )
+    if decision.allowed or decision.audit_action != "draft":
+        return (
+            False,
+            f"FAIL: vertical floor draft_for_review must narrow authored confirm to draft; "
+            f"expected draft, got allowed={decision.allowed} audit={decision.audit_action}",
+        )
+
     return (
         True,
         "PASS: invariant 2 holds — external send gated by configured ceiling; "
         "autonomous skill scalar does not auto-grant send; explicit override sends; "
-        "vertical floor narrows; refused scalar blocks all",
+        "vertical floor narrows; refused scalar blocks all; confirm withholds without "
+        "approval, sends with it, and is narrowed by a draft_for_review floor (ADR 0071)",
     )
 
 


### PR DESCRIPTION
Closes #1804. In-tree half of **ADR 0071** — pairs with **hermes-smd-overlay#151** (the live overlay gate). The two enforcement cores are updated in lockstep.

## What
Adds a fourth trust-ceiling value **`confirm`** between `autonomous` and `draft_for_review`. An `EXTERNAL_SEND` at `confirm` executes only with an explicit current-turn approval; otherwise it is **withheld pending approval** (`audit_action="await_approval"`) — not drafted, not refused.

- `Ceiling.CONFIRM` added; `_RESTRICTIVENESS` renumbered → `autonomous(0) < confirm(1) < draft_for_review(2) < refused(3)`. The renumber is **monotonic**: every existing pairwise ordering is preserved, so no authored ceiling's resolution changes.
- `EXTERNAL_SEND` / `EXTERNAL_SEND_INTERNAL` branch: `confirm` reuses the existing `current_turn_approval` param.
- A stray `confirm` on any non-send branch resolves safely (INTERNAL_WRITE → draft; CODE_EXECUTION / COMMITMENT / DESTRUCTIVE → refuse/approval-gated) — never a surprise allow. #1805's validator forbids authoring `confirm` off `external_send`.
- **Taint-gate unchanged and dominates**: a tainted turn cannot reach the confirm allow-path even with approval set (test asserts).

## Scope decisions (from the reviewed plan)
- **Audit vocab deferred to #1806.** `trust_ceiling_log.py` (`Decision` / `CeilingLevel` / `DecisionReason`) is the emitter — but it is **unwired** (nothing emits any decision today) and `refusal.py::_message_for` falls back gracefully for unmapped reasons. Adding `await_approval` vocab now would ripple into `refusal.py` + two tests for zero runtime benefit on a module #1806 will rewrite when it wires live emission. `await_approval` is also a non-refuse outcome that doesn't fit the refuse-side mapping.
- **`OVERLAY_REF` bump is a separate, staged step.** After overlay#151 merges, the ref is bumped to its merge SHA and rolled out **pilot-smokeball first → verify → then ashton-price** (the paid seat). Not in this PR.
- **Behavioral parity is by-convention.** `test_guard_hook_parity.py` checks hook-surface parity, not behavioral parity between the two `enforce()` cores; I've written matching `confirm` tests in each. A cross-repo behavioral-parity harness is a candidate follow-up.

## Safety
**Inert on live seats** — no `customer.yaml` can author `confirm` until #1805 lands, and the renumber changes no existing resolution. This PR adds capability without changing any running agent's posture. Full confirmed-send behavior (approval capture over channel) is proven in #1806 on pilot-smokeball, not here.

## Tests
Invariant-2 confirm scenarios (withhold / send-on-approval / floor-narrows-confirm) + taint-dominance test in `test_inbound_envelope`. **315 pytest pass** (adapter + safety-substrate); overlay#151 **1336 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)