### PR TITLE
feat(portal): per-skill client summaries on Operator › Skills

### DIFF
--- a/src/components/portal/operator/facets/OperatorSkills.astro
+++ b/src/components/portal/operator/facets/OperatorSkills.astro
@@ -44,15 +44,22 @@ const { skills } = model
         <ul role="list" class="flex flex-col">
           {skills.map((s, i) => (
             <li
-              class={`flex flex-col gap-1 py-3 md:flex-row md:items-baseline md:justify-between md:gap-6 ${
+              class={`flex flex-col gap-2 py-4 md:flex-row md:items-start md:justify-between md:gap-8 ${
                 i > 0 ? 'border-t-[2px] border-[color:var(--color-border)]' : ''
               }`}
             >
-              <span class="font-body text-base font-semibold text-[color:var(--color-text-primary)]">
-                {s.name}
-              </span>
+              <div class="min-w-0 md:max-w-[46rem]">
+                <p class="font-body text-base font-semibold text-[color:var(--color-text-primary)]">
+                  {s.name}
+                </p>
+                {s.summary && (
+                  <p class="mt-1 font-body text-sm leading-snug text-[color:var(--color-text-secondary)]">
+                    {s.summary}
+                  </p>
+                )}
+              </div>
               {s.initiation.length > 0 && (
-                <span class="shrink-0 font-mono text-label uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)]">
+                <span class="shrink-0 font-mono text-label uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)] md:pt-0.5">
                   {s.initiation.join(' · ')}
                 </span>
               )}

--- a/src/lib/portal/operator/facets/skills/skill-summaries.ts
+++ b/src/lib/portal/operator/facets/skills/skill-summaries.ts
@@ -1,0 +1,114 @@
+/**
+ * Client-facing skill summaries - the one-line "what it does" shown per skill on
+ * the Operator › Skills facet (ADR 0069 Slice 3; brief §5 follow-on, Captain call
+ * 2026-07-08: names alone don't tell a client what a skill does).
+ *
+ * WHY A SEPARATE, HAND-AUTHORED CATALOG (not the SKILL.md `description`):
+ * Each skill's `description` frontmatter is authored for the AGENT - Hermes reads
+ * it to select skills - so it is uneven for a client list (some are 150-word
+ * paragraphs; ~40% carry em dashes the house style bans on client surfaces). The
+ * summaries below are compressed faithfully from those authored descriptions -
+ * reviewed, client-legible, em-dash-free, each preserving the skill's key "never
+ * does X" boundary. This is authored client copy (agents ARE the voice per
+ * content-policy), NOT runtime paraphrase and NOT invented capability: every line
+ * is a reduction of the real authored description, reviewed by Captain before
+ * ship. Kept OUT of the SKILL.md files so it never touches the agent runtime
+ * (which keys on `description`).
+ *
+ * Maintenance contract (guarded by tests/skill-summaries.test.ts): every skill
+ * under operator/skills/ MUST have an entry here - a new skill cannot reach the
+ * client surface without a reviewed client summary - and no summary may contain
+ * an em dash. A skill configured on a persona but absent here renders name-only
+ * (honest degradation), never a fabricated line.
+ */
+
+export const SKILL_SUMMARIES: Record<string, string> = {
+  'ar-chaser': 'Drafts accounts-receivable follow-ups from QuickBooks for your review.',
+  'assessment-findings-draft':
+    'Drafts evidence-bound findings from an assessment interview transcript.',
+  'asset-collection-follower':
+    'Drafts the new-client onboarding checklist and chases the missing items.',
+  'client-matter-digest':
+    'Drafts a per-matter status update for a client, in your voice. Reports status, never advises.',
+  'client-verification-tracker':
+    'Tracks discovery-response verifications and chases the signer until signed. Never signs or sends without attorney approval.',
+  'conflict-intake-router':
+    'Captures conflict checks and routes them to the person who must clear them. Surfaces conflicts, never clears them.',
+  'consult-scheduler':
+    'Offers consult times within your rules and drafts the confirmation for a human to send.',
+  'daily-needs-you-digest':
+    'One batched daily digest of what across your matters genuinely needs attention. Never acts, never manufactures urgency.',
+  'deadline-and-sol-tracker':
+    'Surfaces your court dates, filing deadlines, and statute-of-limitations dates by urgency. Reflects dates you entered, never computes them.',
+  'deadline-miss-escalator':
+    'Escalates an approaching or missed deadline up a ladder so it never slips silently. Internal only.',
+  'discovery-response-staging':
+    'Stages a served discovery request and its documents so a response can be drafted, then files the finished draft for attorney review. Never drafts the response.',
+  'discovery-response-tracker':
+    'Tracks California discovery response deadlines in both directions and brings the decision to your attorney. Never computes a deadline as final.',
+  'discovery-served-watch':
+    'Spots served discovery, reads the service date, and surfaces the deadline input for attorney confirmation. Never computes the deadline.',
+  'document-receipt-logger':
+    'Logs an inbound document against the right matter and drafts a receipt entry. Records arrival, never interprets contents.',
+  'email-reply':
+    'Handles inbound email from allow-listed senders and drafts replies in your voice.',
+  'engagement-letter-chaser':
+    "Tracks an unsigned engagement letter and drafts nudges until it's signed. Never interprets the terms.",
+  'health-monitor': 'Checks system health and records degraded status.',
+  'inbox-triage': 'Triages your inbox daily and drafts categorized replies for your review.',
+  'intake-to-system-sync':
+    'Syncs a converted lead from your intake CRM into Smokeball, with dedupe and conflict checks.',
+  'lien-ledger-tracker':
+    'Keeps the matter lien ledger current and chases open payoffs. Logs figures you provide, never computes a reduction or moves money.',
+  'matter-document-review':
+    "Reads a matter's documents and surfaces highlights, timelines, and gaps for an attorney. Never drafts legal work product.",
+  'matter-inbox-router':
+    'Routes inbound matter mail to the skill that handles it and replies to colleagues. Never decides legal substance.',
+  'matter-initiation-setup':
+    'Sets up a new matter at day one: folders, standard tasks, and the deadlines in view for attorney confirmation. Never computes a final SOL, never files.',
+  'matter-memo-on-update':
+    'Logs a short factual internal memo whenever a matter changes in Smokeball. Passive supervision, never analysis.',
+  'matter-status-digest':
+    'Assembles a periodic internal digest of your matters from Smokeball. Reports state, never decides next steps.',
+  'matter-status-responder':
+    'Answers a client\'s routine "where are we" with a factual status from the system of record. Status only, no opinion.',
+  'mediation-settlement-tracker':
+    'Assembles the input packet for a mediation or settlement brief and tracks settlement deadlines. Never writes the brief, never asserts a deadline as final.',
+  'medical-chronology-maintainer':
+    'Keeps a cited medical chronology current on a PI matter as records land. Extractive only, never characterizes causation.',
+  'medical-records-chaser':
+    "Watches for the plaintiff's medical records to land and chases outstanding providers. Never diagnoses, never drafts a demand.",
+  'meet-and-confer-drafter':
+    'Drafts a meet-and-confer letter, for internal review, about discovery deficiencies your attorney flagged. Never sends to opposing counsel.',
+  'minors-compromise-packet':
+    "Fills the minor's-compromise court forms from authored figures for your attorney to finalize and file. Never computes amounts, never advises.",
+  'motion-calendar-tracker':
+    "Keeps each matter's motion calendar current from Smokeball. Reads and organizes, never computes a deadline or files a motion.",
+  'motion-package-assembler':
+    'Assembles and stages a law-and-motion filing package from components already drafted in the matter. Never drafts the motion, never reserves a hearing date.',
+  'new-matter-intake':
+    'Turns a new-client inquiry into a structured matter draft and a non-committal acknowledgment, after a read-only conflict check.',
+  'opposing-response-deficiency-review':
+    "Reads the opposing side's discovery responses and surfaces candidate gaps for an attorney. An assist, never a legal finding.",
+  'paid-media-anomaly-watcher': 'Scans paid-media accounts daily for anomalies and alerts you.',
+  'proposal-drafter': 'Drafts a proposal from a meeting transcript and your SOW templates.',
+  'referral-source-acknowledgment':
+    'Drafts a courtesy thank-you to whoever referred a new matter. Never discloses client identity. Drafted for review, never auto-sent.',
+  'retainer-hours-reconciler': 'Reconciles tracked hours against retainer caps for your review.',
+  'scope-creep-flagger': 'Flags out-of-scope requests in Slack or email for your reply.',
+  'separate-statement-assembler':
+    'Assembles the Rule 3.1345 separate statement for a motion to compel by collating requests and responses. Staged for your attorney, authors no argument.',
+  'service-confirmation-watcher':
+    'Watches for the proof of service to sync in, reads the served date, and surfaces the responsive-pleading deadline for confirmation. Never computes it.',
+  'settlement-statement-feeder':
+    'Assembles the settlement-statement and disbursement figures when a case settles, for a person to execute in Smokeball. Never moves trust money.',
+  'stalled-matter-nudge':
+    'Surfaces matters with no recent activity and drafts a neutral follow-up. Flags inactivity, never decides what a matter needs.',
+  'status-report-assembler':
+    'Assembles a weekly client status report from your PM tools and analytics.',
+  'trial-binder-assembler':
+    'Assembles the trial binder from authored components and tracks pre-trial deadlines. Organizes and stages, never authors or argues.',
+  'trust-balance-nudge':
+    'Watches your IOLTA trust balance and drafts a top-up request. Read-only on funds, never moves money.',
+  workspace: 'Reads and writes Google Workspace through trust-classified tools.',
+}

--- a/src/lib/portal/operator/facets/skills/skills.ts
+++ b/src/lib/portal/operator/facets/skills/skills.ts
@@ -26,6 +26,7 @@
 
 import type { CustomerConfigRow, PersonaSkill } from '../../../customer-config'
 import type { SkillInitiation } from '../../../../operator/customer-yaml/types'
+import { SKILL_SUMMARIES } from './skill-summaries'
 
 /**
  * Reformat a skill slug into a client-legible display name — SENTENCE case
@@ -48,6 +49,12 @@ export interface OperatorSkillView {
   name: string
   /** The raw authored slug — stable key / title, never shown as prose. */
   slug: string
+  /**
+   * Client-facing one-line "what it does", from the reviewed SKILL_SUMMARIES
+   * catalog. null when the skill has no authored summary (renders name-only —
+   * honest degradation, never a fabricated line).
+   */
+  summary: string | null
   /** Client-legible initiation labels; empty when no mode is set (show nothing). */
   initiation: string[]
 }
@@ -80,6 +87,7 @@ export function resolveOperatorSkills(config: CustomerConfigRow | null): Operato
   const skills: OperatorSkillView[] = (persona?.skills ?? []).map((s: PersonaSkill) => ({
     name: humanizeSkillName(s.name),
     slug: s.name,
+    summary: SKILL_SUMMARIES[s.name] ?? null,
     initiation: initiationLabels(s.initiation),
   }))
   return { skills }

--- a/tests/operator-skills-facet.test.ts
+++ b/tests/operator-skills-facet.test.ts
@@ -3,6 +3,7 @@ import {
   initiationLabels,
   resolveOperatorSkills,
 } from '../src/lib/portal/operator/facets/skills/skills'
+import { SKILL_SUMMARIES } from '../src/lib/portal/operator/facets/skills/skill-summaries'
 import type {
   CustomerConfigRow,
   PersonaConfig,
@@ -66,7 +67,7 @@ describe('initiationLabels', () => {
 })
 
 describe('resolveOperatorSkills', () => {
-  it('humanizes each skill slug for display and keeps the raw slug', () => {
+  it('humanizes each skill slug for display, keeps the raw slug, and attaches the authored summary', () => {
     const model = resolveOperatorSkills(
       config([persona({ skills: [skill('matter-inbox-router', { webhook: true })] })])
     )
@@ -74,9 +75,17 @@ describe('resolveOperatorSkills', () => {
       {
         name: 'Matter inbox router',
         slug: 'matter-inbox-router',
+        summary: SKILL_SUMMARIES['matter-inbox-router'],
         initiation: ['When something happens'],
       },
     ])
+  })
+
+  it('attaches null summary for a skill with no catalog entry (honest degradation, never fabricated)', () => {
+    const model = resolveOperatorSkills(
+      config([persona({ skills: [skill('a-skill-with-no-summary', { manual: true })] })])
+    )
+    expect(model.skills[0].summary).toBeNull()
   })
 
   it('preserves authored order', () => {

--- a/tests/skill-summaries.test.ts
+++ b/tests/skill-summaries.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest'
+import { readdirSync, existsSync, statSync } from 'node:fs'
+import { resolve, join } from 'node:path'
+import { SKILL_SUMMARIES } from '../src/lib/portal/operator/facets/skills/skill-summaries'
+
+/**
+ * Maintenance contract for the client-facing skill summaries (ADR 0069 Slice 3
+ * follow-on). The summaries are authored client copy shown on Operator › Skills;
+ * these guards keep them honest and complete:
+ *
+ *   1. Every skill under operator/skills/ has a summary — a new skill cannot
+ *      reach the client surface without a reviewed client-facing line.
+ *   2. No stale entries — every SKILL_SUMMARIES key maps to a real skill.
+ *   3. No em dashes (house style, mirrors forbidden-strings' user-facing rule).
+ *   4. Concise — a summary is a one-liner, not a pasted paragraph.
+ */
+
+const SKILLS_DIR = resolve('operator/skills')
+
+/** Skill slugs = every subdirectory of operator/skills/ that carries a SKILL.md. */
+function skillSlugsOnDisk(): string[] {
+  return readdirSync(SKILLS_DIR).filter((name) => {
+    const dir = join(SKILLS_DIR, name)
+    return statSync(dir).isDirectory() && existsSync(join(dir, 'SKILL.md'))
+  })
+}
+
+describe('skill summaries — maintenance contract', () => {
+  const slugs = skillSlugsOnDisk()
+
+  it('finds skills on disk (sanity)', () => {
+    expect(slugs.length).toBeGreaterThan(0)
+  })
+
+  it('every skill under operator/skills/ has a client summary', () => {
+    const missing = slugs.filter((slug) => !SKILL_SUMMARIES[slug])
+    expect(
+      missing,
+      `these skills have no client summary in skill-summaries.ts — add a reviewed one-liner:\n  ${missing.join('\n  ')}`
+    ).toEqual([])
+  })
+
+  it('has no stale entries (every summary key maps to a real skill)', () => {
+    const onDisk = new Set(slugs)
+    const stale = Object.keys(SKILL_SUMMARIES).filter((slug) => !onDisk.has(slug))
+    expect(stale, `summaries for skills that no longer exist:\n  ${stale.join('\n  ')}`).toEqual([])
+  })
+
+  it('no summary contains an em dash (house style — user-facing surface)', () => {
+    const offenders = Object.entries(SKILL_SUMMARIES)
+      .filter(([, text]) => text.includes('—'))
+      .map(([slug]) => slug)
+    expect(offenders, `em dash in: ${offenders.join(', ')}`).toEqual([])
+  })
+
+  it('every summary is a concise one-liner (<= 200 chars)', () => {
+    const tooLong = Object.entries(SKILL_SUMMARIES)
+      .filter(([, text]) => text.length > 200)
+      .map(([slug, text]) => `${slug} (${text.length})`)
+    expect(tooLong, `over-length summaries:\n  ${tooLong.join('\n  ')}`).toEqual([])
+  })
+})


### PR DESCRIPTION
Adds a one-line 'what it does' under each skill on Operator › Skills. Each summary is compressed faithfully from the skill's authored SKILL.md description (reviewed client copy, em-dash-free, safety boundary preserved) - not runtime paraphrase, not invented capability. Kept in a portal-side catalog so it never touches the agent runtime. 48 summaries + guard test (every operator/skills/ skill must have one, no em dashes, <=200 chars). npm run verify green; Captain reviewing copy live on pilot-smokeball post-deploy.

https://claude.ai/code/session_01MJF9rQDhVKLv2ADbbApPgi