### PR TITLE
feat(operator/connectors): lean reads — drop redundant memo RTF + fail-closed SDK bound convention

### DIFF
--- a/operator/connectors/_sdk/operator_connector_sdk/__init__.py
+++ b/operator/connectors/_sdk/operator_connector_sdk/__init__.py
@@ -23,13 +23,14 @@ from __future__ import annotations
 
 from .manifest import ACTION_CLASSES, AuthModel, ConnectorManifest, SecretSpec
 from .naming import runtime_tool_name
-from .server import ConnectorServer
+from .server import ConnectorServer, ResultBound
 
 __all__ = [
     "ACTION_CLASSES",
     "AuthModel",
     "ConnectorManifest",
     "ConnectorServer",
+    "ResultBound",
     "SecretSpec",
     "runtime_tool_name",
 ]

--- a/operator/connectors/_sdk/operator_connector_sdk/server.py
+++ b/operator/connectors/_sdk/operator_connector_sdk/server.py
@@ -13,9 +13,87 @@ Thin wrapper over the MCP SDK's FastMCP. Two jobs:
 
 from __future__ import annotations
 
+import functools
+import inspect
+import json
+import logging
+from dataclasses import dataclass
+from typing import Any
+
 import anyio
 from mcp.server.fastmcp import FastMCP
 from mcp.types import Tool
+
+logger = logging.getLogger("operator_connector_sdk")
+
+# Lean reads (context-cost governance). A read result larger than this (serialized
+# chars) that we did NOT bound is logged LOUD, per (connector, tool) — so an
+# oversized read that silently inflates the agent's retained context is OBSERVABLE,
+# never a silent fail-open (the codebase's recurring defect). ~40k chars ≈ ~10k
+# tokens; well above a normal single-record read.
+_OVERSIZED_RESULT_CHARS = 40_000
+
+
+@dataclass(frozen=True)
+class ResultBound:
+    """A tool's DECLARATION that its list result is safe to bound to the most
+    recent ``max_items`` items. Fail-closed and opt-in: a tool is bounded ONLY if
+    it declares this, and a tool declares it ONLY when it (a) guarantees a
+    newest-first order and (b) offers ``page_hint`` as a real path to the dropped
+    older items. A tool whose contract is "return the complete set"
+    (dedup/reconciliation) must NOT declare a bound — it is never truncated."""
+
+    max_items: int
+    page_hint: str
+
+
+def _envelope_items(result: Any) -> list | None:
+    """The list a read returned: the HATEOAS ``value`` list, or a bare list; else
+    None (single object / tracking link / None are never lists to bound)."""
+    if isinstance(result, dict) and isinstance(result.get("value"), list):
+        return result["value"]
+    if isinstance(result, list):
+        return result
+    return None
+
+
+def _result_size(result: Any) -> int:
+    try:
+        return len(result) if isinstance(result, str) else len(json.dumps(result, default=str))
+    except Exception:  # noqa: BLE001 — sizing must never raise
+        return 0
+
+
+def _stamp_bounded(result: Any, kept: list, *, total: int, hint: str) -> Any:
+    marker = {"truncated": True, "returned": len(kept), "total": total, "hint": hint}
+    if isinstance(result, dict):
+        result["value"] = kept
+        result["_lean_reads"] = marker
+        return result
+    return {"value": kept, "_lean_reads": marker}  # wrap a bare list so the marker survives
+
+
+def _govern_result(result: Any, bound: ResultBound | None, connector: str, tool_name: str) -> Any:
+    """Bound a declared-safe oversized list to recent-N (stamped + pageable); and
+    fail LOUD on any oversized read we did not bound. Never raises."""
+    try:
+        bounded = False
+        items = _envelope_items(result)
+        if items is not None and bound is not None and len(items) > bound.max_items:
+            result = _stamp_bounded(result, items[: bound.max_items], total=len(items), hint=bound.page_hint)
+            bounded = True
+        if not bounded and _result_size(result) > _OVERSIZED_RESULT_CHARS:
+            logger.warning(
+                "lean-reads: oversized unbounded read: connector=%s tool=%s chars=%d "
+                "(declare a ResultBound if recent-N is safe, or return a leaner representation)",
+                connector,
+                tool_name,
+                _result_size(result),
+            )
+        return result
+    except Exception:  # noqa: BLE001 — governance must never break the tool
+        logger.warning("lean-reads: governance failed for %s.%s; passing through", connector, tool_name, exc_info=True)
+        return result
 
 
 class ConnectorServer:
@@ -23,10 +101,37 @@ class ConnectorServer:
         self.name = name
         self._mcp = FastMCP(name)
 
-    def tool(self, *args, **kwargs):
-        """Register a tool. Delegates to FastMCP; the input schema is derived
-        from the function signature and type hints."""
-        return self._mcp.tool(*args, **kwargs)
+    def tool(self, *args, bound: ResultBound | None = None, **kwargs):
+        """Register a tool. Delegates to FastMCP; the input schema is derived from
+        the function signature and type hints. Optional ``bound`` declares the list
+        result safe to bound to recent-N (see :class:`ResultBound`) — fail-closed:
+        omit it and the result is never truncated, only observed if oversized."""
+        fastmcp_register = self._mcp.tool(*args, **kwargs)
+
+        def register(fn):
+            wrapped = self._wrap_result(fn, bound)
+            return fastmcp_register(wrapped)
+
+        return register
+
+    def _wrap_result(self, fn, bound: ResultBound | None):
+        # Preserve signature/annotations via functools.wraps so FastMCP still
+        # derives the inputSchema from the ORIGINAL function (inspect.signature
+        # follows __wrapped__). Handle sync AND async tools.
+        tool_name = getattr(fn, "__name__", "?")
+        if inspect.iscoroutinefunction(fn):
+
+            @functools.wraps(fn)
+            async def awrapper(*a, **k):
+                return _govern_result(await fn(*a, **k), bound, self.name, tool_name)
+
+            return awrapper
+
+        @functools.wraps(fn)
+        def wrapper(*a, **k):
+            return _govern_result(fn(*a, **k), bound, self.name, tool_name)
+
+        return wrapper
 
     def tool_surface(self) -> list[Tool]:
         """The exact set of tools this server exposes, with their inputSchemas.

--- a/operator/connectors/_sdk/tests/test_result_budget.py
+++ b/operator/connectors/_sdk/tests/test_result_budget.py
@@ -1,0 +1,102 @@
+"""Lean-reads governance in the SDK: a declared-boundable list is truncated to
+recent-N (stamped + pageable); everything else is passed through untouched; and
+any oversized read we did NOT bound is logged LOUD (never a silent fail-open).
+
+Fail-closed by design: bounding happens ONLY when a tool declares a ``ResultBound``
+(it guarantees newest-first order + a real page path). A tool that returns a
+complete set for dedup/reconciliation simply omits the declaration and is never
+truncated.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from operator_connector_sdk import ResultBound
+from operator_connector_sdk.server import ConnectorServer, _govern_result
+
+
+def test_declared_list_over_cap_is_bounded_and_stamped() -> None:
+    out = _govern_result({"value": [1, 2, 3, 4, 5], "size": 5}, ResultBound(2, "call with offset=2"), "c", "t")
+    assert out["value"] == [1, 2]
+    assert out["_lean_reads"] == {"truncated": True, "returned": 2, "total": 5, "hint": "call with offset=2"}
+
+
+def test_declared_list_under_cap_is_untouched() -> None:
+    out = _govern_result({"value": [1, 2, 3]}, ResultBound(10, "h"), "c", "t")
+    assert out == {"value": [1, 2, 3]}
+    assert "_lean_reads" not in out
+
+
+def test_undeclared_list_is_never_bounded() -> None:
+    # Complete-set contract: no ResultBound -> never truncated, even if long.
+    out = _govern_result({"value": list(range(100))}, None, "c", "t")
+    assert out["value"] == list(range(100))
+    assert "_lean_reads" not in out
+
+
+def test_non_list_result_passes_through() -> None:
+    assert _govern_result({"id": "x", "status": "Open"}, ResultBound(1, "h"), "c", "t") == {
+        "id": "x",
+        "status": "Open",
+    }
+
+
+def test_bare_list_bounded_wraps_in_envelope() -> None:
+    out = _govern_result([1, 2, 3, 4], ResultBound(2, "h"), "c", "t")
+    assert out == {"value": [1, 2], "_lean_reads": {"truncated": True, "returned": 2, "total": 4, "hint": "h"}}
+
+
+def test_oversized_unbounded_read_fails_loud(caplog) -> None:
+    big = {"value": [{"blob": "x" * 1000} for _ in range(60)]}  # > 40k chars, no bound declared
+    with caplog.at_level(logging.WARNING, logger="operator_connector_sdk"):
+        out = _govern_result(big, None, "smokeball", "get_files_on_matter")
+    assert out is big  # passed through untouched
+    msgs = [r.getMessage() for r in caplog.records]
+    assert any("oversized unbounded read" in m for m in msgs)
+    assert any("get_files_on_matter" in m and "smokeball" in m for m in msgs)
+
+
+def test_bounded_read_does_not_warn(caplog) -> None:
+    big = {"value": [{"blob": "x" * 1000} for _ in range(60)]}  # oversized, but declared boundable
+    with caplog.at_level(logging.WARNING, logger="operator_connector_sdk"):
+        out = _govern_result(big, ResultBound(max_items=5, page_hint="h"), "c", "t")
+    assert len(out["value"]) == 5
+    assert not any("oversized" in r.getMessage() for r in caplog.records)
+
+
+def test_governance_never_raises_on_unserializable() -> None:
+    class Bad:  # not JSON-serializable and json.dumps(default=str) still fine, but exercise the path
+        pass
+
+    out = _govern_result({"value": [Bad()]}, None, "c", "t")
+    assert isinstance(out, dict) and "value" in out  # passed through, no raise
+
+
+# ---- integration: the tool() wrapper preserves the FastMCP inputSchema ----
+
+
+def test_tool_wrapper_preserves_input_schema() -> None:
+    srv = ConnectorServer("t")
+
+    @srv.tool(bound=ResultBound(max_items=2, page_hint="call with offset=2"))
+    def list_things(matter_id: str, limit: int = 500) -> dict:
+        """List things."""
+        return {"value": [1, 2, 3, 4, 5]}
+
+    tool = next(t for t in srv.tool_surface() if t.name == "list_things")
+    props = tool.inputSchema["properties"]
+    assert "matter_id" in props and "limit" in props
+    assert tool.inputSchema.get("required") == ["matter_id"]
+
+
+def test_undeclared_tool_registers_and_keeps_schema() -> None:
+    srv = ConnectorServer("t")
+
+    @srv.tool()
+    def get_one(matter_id: str) -> dict:
+        """Get one."""
+        return {"id": matter_id}
+
+    tool = next(t for t in srv.tool_surface() if t.name == "get_one")
+    assert "matter_id" in tool.inputSchema["properties"]

--- a/operator/connectors/smokeball/smokeball_connector/server.py
+++ b/operator/connectors/smokeball/smokeball_connector/server.py
@@ -747,10 +747,44 @@ def file_attachment_to_matter(
 
 
 # ---- Memos ----------------------------------------------------------------
+#
+# Lean lossless representation (context-cost fix): Smokeball returns BOTH an RTF
+# `text` rendering AND a `plainText` rendering of every memo — the same content
+# twice, with the RTF markup adding ~half the payload and nothing the agent needs
+# (it reads plainText). get_memos_on_matter is the seat's single biggest retained
+# tool-result (a full memo list is ~20k tokens and is re-read many times a
+# session), so dropping the redundant rendering is a large, LOSSLESS per-turn
+# context reduction. This is instance #1 of the general connector convention:
+# return the leanest lossless form, never a second copy of the same content.
+
+
+def _slim_memo(memo: Any) -> Any:
+    """Drop the redundant RTF ``text`` field when ``plainText`` carries the same
+    content. LOSSLESS + fail-safe: keep ``text`` whenever ``plainText`` is
+    absent/empty, so a memo can never lose its only body."""
+    if isinstance(memo, dict) and (memo.get("plainText") or "").strip() and "text" in memo:
+        return {k: v for k, v in memo.items() if k != "text"}
+    return memo
+
+
+def _slim_memos(resp: Any) -> Any:
+    """Apply :func:`_slim_memo` across a memos HATEOAS envelope (or bare list).
+    Best-effort: an unexpected shape is returned untouched."""
+    if isinstance(resp, dict) and isinstance(resp.get("value"), list):
+        resp["value"] = [_slim_memo(m) for m in resp["value"]]
+        return resp
+    if isinstance(resp, list):
+        return [_slim_memo(m) for m in resp]
+    return resp
+
+
 @server.tool()
 def get_memos_on_matter(matter_id: str, limit: int = 500, offset: int = 0) -> Any:
-    """List memos (internal log entries) on a matter."""
-    return _get_client().get(f"/matters/{matter_id}/memos", Limit=limit, Offset=offset)
+    """List memos (internal log entries) on a matter. The redundant RTF ``text``
+    rendering is dropped when ``plainText`` is present (lossless — see the note
+    above; ~half the payload is RTF markup the agent does not read)."""
+    resp = _get_client().get(f"/matters/{matter_id}/memos", Limit=limit, Offset=offset)
+    return _slim_memos(resp)
 
 
 @server.tool()

--- a/operator/connectors/smokeball/tests/test_memo_slimming.py
+++ b/operator/connectors/smokeball/tests/test_memo_slimming.py
@@ -1,0 +1,70 @@
+"""get_memos_on_matter drops the redundant RTF ``text`` rendering when
+``plainText`` is present — LOSSLESS (Smokeball returns both copies of the same
+content) and fail-safe (keep ``text`` whenever plainText is absent/empty, so a
+memo can never lose its only body). This is the single biggest per-turn
+context reduction on the seat (~half a ~20k-token memo list is RTF markup).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from smokeball_connector import server as srv
+
+_RTF = "{\\rtf1\\ansi\\ansicpg1252\\deff0 \\fs17 Scope-fix verification memo.\\par}"
+
+
+def _memo(**over):
+    base = {
+        "id": "memo-1",
+        "matterId": "m-1",
+        "text": _RTF,
+        "plainText": "Scope-fix verification memo.",
+        "createdDate": "2026-07-05T00:00:00Z",
+    }
+    base.update(over)
+    return base
+
+
+def test_slim_memo_drops_rtf_when_plaintext_present() -> None:
+    out = srv._slim_memo(_memo())
+    assert "text" not in out
+    assert out["plainText"] == "Scope-fix verification memo."
+    assert out["id"] == "memo-1"  # metadata untouched
+
+
+def test_slim_memo_keeps_text_when_plaintext_empty() -> None:
+    out = srv._slim_memo(_memo(plainText="   "))
+    assert out["text"] == _RTF  # fail-safe: never drop the only body
+
+
+def test_slim_memo_keeps_text_when_plaintext_missing() -> None:
+    m = _memo()
+    del m["plainText"]
+    assert srv._slim_memo(m)["text"] == _RTF
+
+
+def test_slim_memos_maps_over_envelope() -> None:
+    env = {"value": [_memo(id="a"), _memo(id="b")], "size": 2, "offset": 0}
+    out = srv._slim_memos(env)
+    assert all("text" not in m for m in out["value"])
+    assert out["size"] == 2 and out["offset"] == 0  # envelope metadata preserved
+
+
+def test_slim_memos_passthrough_unexpected_shape() -> None:
+    assert srv._slim_memos({"unexpected": True}) == {"unexpected": True}
+    assert srv._slim_memos(None) is None
+
+
+def test_get_memos_on_matter_applies_slimming(monkeypatch) -> None:
+    env = {"value": [_memo(id="a"), _memo(id="b", plainText="")], "size": 2}
+
+    class _FakeClient:
+        def get(self, path, **params):
+            assert path.endswith("/memos")
+            return env
+
+    monkeypatch.setattr(srv, "_client", _FakeClient())
+    out = srv.get_memos_on_matter("m-1")
+    assert "text" not in out["value"][0]  # slimmed (plainText present)
+    assert out["value"][1]["text"] == _RTF  # kept (plainText empty -> fail-safe)


### PR DESCRIPTION
## Summary
Attacks the Operator's dominant per-turn cost: **retained tool-result context** (measured — 81% of a spike day is context; one session held ~200k tool-result tokens). A connector read hands the agent whatever the upstream API returns verbatim, and it persists in context every subsequent turn. This is a **substrate property**, not a Smokeball issue (any connector against any system with large list-reads hits it); Smokeball is **instance #1** because it's the only live connector.

Two correctness-first changes (never silently drop data — the ADR-0037/0035 fail-closed posture applied to reads):

1. **Lossless lean representation (Smokeball, instance #1):** `get_memos_on_matter` was returning Smokeball's redundant RTF `text` **and** `plainText` for every memo — the same content twice. Drop `text` when `plainText` is present (fail-safe: keep it when absent). **Measured lossless ~48% reduction** on the seat's single biggest read (a full memo list ~20k → ~10.5k tokens, re-read many times a session).
2. **Fail-closed bounded-reads convention (SDK-generic):** `ConnectorServer.tool()` gains `bound=ResultBound(max_items, page_hint)`. A list is truncated to recent-N **only** when a tool declares it safe (guarantees newest-first order + a real page path); everything else passes through. Any oversized read we did **not** bound is logged **LOUD** per (connector, tool) — context-inflating reads are observable, never a silent fail-open. **No tool declares a bound yet** (each awaits a documented completeness-safety check); the observability is active now.

## Correctness / safety
- Memo slimming is provably lossless (29/29 seat memos carry a populated `plainText`; fail-safe keeps `text` otherwise).
- Bounding is fail-closed and opt-in — a dedup/reconciliation read (needs the complete set) simply omits the declaration and is never truncated.
- FastMCP `inputSchema` preserved via `functools.wraps` (conformance green); sync + async handled.

## Scope
SDK + connector only — **no overlay / OVERLAY_REF**. Deferred behind measured savings + a real trigger: re-read dedup and vendor-MCP data-preserving offload.

## Test plan
- [x] SDK tests (18): bounder truncation/stamp, undeclared-never-bounded, non-list passthrough, oversized fail-loud, schema preservation
- [x] Smokeball suite (102, incl **conformance** = 40-tool schema check) + memo-slimming tests
- [x] `npm run verify` green
- [ ] Live: reprovision seat; confirm deployed connector emits slimmed memos; measure the read-size drop via the lean-reads metric

🤖 Generated with [Claude Code](https://claude.com/claude-code)