### PR TITLE
feat(operator): pilot-smokeball authors external_send: autonomous — ADR 0073 live proof

### DIFF
--- a/operator/customers/pilot-smokeball/customer.yaml
+++ b/operator/customers/pilot-smokeball/customer.yaml
@@ -68,7 +68,11 @@ personas:
     entitlements:
       exposure:
         internal_write: autonomous
-        external_send: draft_for_review
+        # autonomous on the STAGING seat to prove ADR 0073 (law external-send
+        # floor removed): an authored autonomous outside send must actually
+        # SEND. The content-sensitivity floor (ADR 0031) and taint gate still
+        # narrow; a real client seat authors its own posture.
+        external_send: autonomous
         external_send_internal: autonomous
         destructive: autonomous
     skills:
@@ -501,8 +505,9 @@ scope:
   inbound_allow_from:
     - scott@smd.services
     - smdurgan@smdurgan.com
-  # External send (to anyone OUTSIDE the roster / a chosen recipient) is drafted,
-  # never autonomous. Recipient-locked replies to rostered senders are governed by
+  # External send (to anyone OUTSIDE the roster) follows the authored
+  # external_send ceiling above — autonomous on this staging seat (ADR 0073
+  # proof). Recipient-locked replies to rostered senders are governed by
   # the roster above, not by this ceiling (ADR 0055 §3).
   #
   # This is SMD's own STAGING TEST seat (not a client). The Operator manages its


### PR DESCRIPTION
## Summary
- Raises the staging seat's authored `external_send` ceiling to `autonomous` — the live proof that ADR 0073 (law external-send floor removal, #1838 + overlay #152) actually delivers an autonomous outside send on a law-vertical seat
- Fixes the stale roster comment restating the retired always-drafted posture
- Staging seat only; a real client seat authors its own posture

## Test plan
- [x] `npm run verify` passes
- [ ] Reprovision pilot-smokeball (picks up OVERLAY_REF d5187194 + this config)
- [ ] Trusted trigger → outside send to team@smd.services SENDS (seat ledger + mailbox receipt)
- [ ] Money-content outbound still drafts (ADR 0031); trust-account write still refused

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L9agvEtkbqZEP6HAJRnLzu