### PR TITLE
fix(operator): close the reprovision silent-revert gap — R2 divergence guard + adopt-R2 mode + scheduled reconciler (ADR 0044, #1840)

### DIFF
--- a/.github/workflows/r2-config-reconcile.yml
+++ b/.github/workflows/r2-config-reconcile.yml
@@ -1,0 +1,55 @@
+# R2 -> git customer.yaml reconciler — ADR 0044 Decision 4 (#1840).
+#
+# R2 is the operational source of truth for live Operator config; git is the
+# reviewed record, reconciled FROM R2 on this schedule so divergence is
+# bounded ("owned and runs on a schedule", per the ADR) instead of waiting
+# on someone remembering. On divergence the script opens a
+# `reconcile/r2-<slug>` PR carrying the live R2 version for review.
+#
+# Requires repo secrets (READ access to the config bucket suffices):
+#   R2_ENDPOINT_URL, R2_RECONCILE_ACCESS_KEY_ID, R2_RECONCILE_SECRET_ACCESS_KEY
+# The job FAILS LOUDLY when they are absent — a silently-skipping reconciler
+# would be paper compliance.
+name: R2 config reconcile
+
+on:
+  schedule:
+    - cron: '23 16 * * *' # daily, 09:23 America/Phoenix — off the :00 herd
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  reconcile:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+      - name: Verify reconciler credentials are provisioned
+        env:
+          R2_ENDPOINT_URL: ${{ secrets.R2_ENDPOINT_URL }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_RECONCILE_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_RECONCILE_SECRET_ACCESS_KEY }}
+        run: |
+          missing=""
+          [ -n "$R2_ENDPOINT_URL" ] || missing="$missing R2_ENDPOINT_URL"
+          [ -n "$R2_ACCESS_KEY_ID" ] || missing="$missing R2_RECONCILE_ACCESS_KEY_ID"
+          [ -n "$R2_SECRET_ACCESS_KEY" ] || missing="$missing R2_RECONCILE_SECRET_ACCESS_KEY"
+          if [ -n "$missing" ]; then
+            echo "::error::R2 reconciler secrets not provisioned:$missing — the ADR 0044 Decision 4 reconciler cannot run. Add them (scoped READ key for the smd-customer-config bucket) or the silent-revert window is unbounded."
+            exit 1
+          fi
+      - name: Configure git author
+        run: |
+          git config user.name "r2-config-reconciler"
+          git config user.email "team@smd.services"
+      - name: Reconcile
+        env:
+          R2_ENDPOINT_URL: ${{ secrets.R2_ENDPOINT_URL }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_RECONCILE_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_RECONCILE_SECRET_ACCESS_KEY }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: operator/bin/reconcile-r2-config.sh --pr

--- a/docs/adr/0044-r2-authoritative-live-reconfig.md
+++ b/docs/adr/0044-r2-authoritative-live-reconfig.md
@@ -73,6 +73,37 @@ Therefore, **before the R2-authoritative apply path ships on any `execute_code`-
 - ADR 0012's git-first invariant is relaxed to git-reviewed; the reconciler and the reprovision-reads-R2 change are load-bearing and ship in the same wave.
 - The control/data-plane separation of ADR 0026 is preserved by construction (root applier + no agent-reachable config-bucket write credential), not by added checks — **contingent on Decision 8 (OP-P2-1) for any `execute_code`-enabled customer**. The gateway env is already clean; the apply path must not ship on an `execute_code` customer while the account-wide R2 key is still reachable from a sibling process's environ.
 
+## Realized (2026-07-13, #1840)
+
+Decisions 2 and 4 shipped with one deliberate reshaping, recorded here so the
+ADR matches what runs:
+
+- **Decision 2 is realized as a provenance-stamped divergence guard + an
+  explicit adopt-R2 mode, not an unconditional read-from-R2.** While the
+  portal write-back spine is unbuilt, git PRs are the only reviewed authoring
+  path, and the git → R2 projection _is_ how a merged config change deploys —
+  an unconditional reads-from-R2 reprovision would make merged changes
+  undeployable. Instead: every git projection stamps the uploaded object with
+  `projected-sha256` user metadata; `provision-customer.sh` (Step 0.5)
+  classifies the current R2 object before overwriting (`absent` /
+  `identical` / `clean-projection` → proceed; anything else → **fail closed**
+  with the diff that would be lost). A missing or mismatched stamp can never
+  allow a clobber — live-apply writes carry no stamp, so they are always
+  guarded. `SS_CONFIG_SOURCE=r2` provisions from the live R2 config (the
+  Decision 2 read path, on demand), and `SS_CONFIG_FORCE_GIT=1` is the
+  explicit revert. Verdict logic: `operator/bin/lib/config_divergence.py`;
+  tests: `operator/bin/tests/test_config_divergence.py`. The silent-revert
+  primitive in Context fact 1 is closed either way.
+- **Decision 4 reconciler:** `operator/bin/reconcile-r2-config.sh` (local via
+  Infisical, or CI) compares every provisioned customer's live R2 config
+  against git and, in `--pr` mode, opens a `reconcile/r2-<slug>` PR carrying
+  the R2 version as the reviewed record. Scheduled daily by
+  `.github/workflows/r2-config-reconcile.yml`, which **fails loudly** until
+  its scoped read credentials (`R2_ENDPOINT_URL`,
+  `R2_RECONCILE_ACCESS_KEY_ID`, `R2_RECONCILE_SECRET_ACCESS_KEY`) are
+  provisioned as repo secrets — a silently-skipping reconciler would be
+  paper compliance.
+
 ## Out of scope
 
 Portal client self-serve apply (admin-driven first); proactive entitlement-promotion nudges.

--- a/docs/handbook/deployment-release.md
+++ b/docs/handbook/deployment-release.md
@@ -97,6 +97,15 @@ customer's Machine image against a new overlay commit. The flow:
    `yes s | operator/bin/reprovision.sh <slug>` to skip the secret prompts
    non-interactively (Machine secrets persist across deploy, so there is nothing
    to re-enter).
+
+   **Divergence guard (ADR 0044, #1840).** R2 is the operational source of
+   truth for the live config, so the provisioner refuses to project git over
+   an R2 customer.yaml that carries live-applied changes (it prints the diff
+   that would be lost). Resolve deliberately: `SS_CONFIG_SOURCE=r2` provisions
+   FROM the live R2 config (reconcile it into git afterwards with
+   `operator/bin/reconcile-r2-config.sh`), or `SS_CONFIG_FORCE_GIT=1`
+   knowingly reverts the live change. The daily `r2-config-reconcile.yml`
+   workflow PRs any R2-only state back into git as the reviewed record.
 4. **Pass the verify gate.** Confirm the runtime came up against the live read
    seam (a correct key returns 200; a wrong key or wrong slug returns 401) and
    the boot smoke test passed - not just that the config validated.

--- a/operator/bin/lib/config_divergence.py
+++ b/operator/bin/lib/config_divergence.py
@@ -1,0 +1,129 @@
+"""R2 customer.yaml divergence guard — ADR 0044 Decision 2, issue #1840.
+
+The silent-revert primitive: ``provision-customer.sh`` projects the git
+working copy's customer.yaml over ``vaults/<slug>/customer.yaml`` in R2. R2
+is the operational source of truth (ADR 0044 Decision 1) — the console
+live-apply path writes it and the root config applier pulls from it — so a
+git-read projection over a live-applied config silently reverts the live
+change. Proven live 2026-07-13: two sessions' checkouts at different commits
+each projected over R2 mid-deploy and crash-looped pilot-smokeball.
+
+The guard distinguishes the two divergence cases using a provenance stamp:
+every git projection uploads with user metadata ``projected-sha256`` set to
+the digest of the uploaded bytes. On the next provision run:
+
+- R2 object ABSENT ............... first provision, project.
+- R2 digest == git digest ........ IDENTICAL, project (idempotent).
+- R2 digest == its own stamp ..... CLEAN_PROJECTION: the object is an
+  untouched previous git projection; the divergence is a newly merged git
+  change. Projecting is the normal deploy path — proceed.
+- otherwise ...................... DIVERGED: the object was written by
+  something other than a git projection (console live-apply, manual edit),
+  or modified after projection. Projecting would silently revert it —
+  fail closed (exit 3) and print the diff that would be lost.
+
+The stamp is load-bearing in one direction only: a MISSING or MISMATCHED
+stamp can never allow a clobber (it fails toward DIVERGED). The console
+live-apply writer does not set the stamp, so its writes are always guarded.
+
+Exit codes (consumed by provision-customer.sh):
+    0  safe to project (ABSENT / IDENTICAL / CLEAN_PROJECTION)
+    2  usage / IO error
+    3  DIVERGED — do not project without an explicit human decision
+       (SS_CONFIG_FORCE_GIT=1 to revert, SS_CONFIG_SOURCE=r2 to adopt R2)
+"""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import hashlib
+import sys
+from pathlib import Path
+
+ABSENT = "absent"
+IDENTICAL = "identical"
+CLEAN_PROJECTION = "clean-projection"
+DIVERGED = "diverged"
+
+
+def classify(git_sha256: str, r2_sha256: str | None, projected_sha256: str | None) -> str:
+    """Pure verdict from the three digests. ``r2_sha256`` is None when the R2
+    object does not exist; ``projected_sha256`` is None when the object
+    carries no provenance stamp (pre-guard uploads, live-apply writes)."""
+    if r2_sha256 is None:
+        return ABSENT
+    if r2_sha256 == git_sha256:
+        return IDENTICAL
+    if projected_sha256 is not None and projected_sha256 == r2_sha256:
+        return CLEAN_PROJECTION
+    return DIVERGED
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--git-file", required=True, help="git working-copy customer.yaml")
+    parser.add_argument(
+        "--r2-file", default=None, help="downloaded current R2 object (omit when absent)"
+    )
+    parser.add_argument(
+        "--projected-sha256",
+        default=None,
+        help="the R2 object's projected-sha256 user metadata (omit or pass '' / 'None' when unset)",
+    )
+    args = parser.parse_args(argv)
+
+    git_path = Path(args.git_file)
+    if not git_path.is_file():
+        print(f"config-divergence: git file not found: {git_path}", file=sys.stderr)
+        return 2
+    git_sha = _sha256(git_path)
+
+    r2_sha: str | None = None
+    r2_path: Path | None = None
+    if args.r2_file:
+        r2_path = Path(args.r2_file)
+        if not r2_path.is_file():
+            print(f"config-divergence: r2 file not found: {r2_path}", file=sys.stderr)
+            return 2
+        r2_sha = _sha256(r2_path)
+
+    stamp = (args.projected_sha256 or "").strip()
+    # `aws --output text` prints the literal string "None" for absent metadata.
+    projected = stamp if stamp and stamp != "None" else None
+
+    verdict = classify(git_sha, r2_sha, projected)
+    print(verdict)
+    if verdict != DIVERGED:
+        return 0
+
+    assert r2_path is not None  # DIVERGED implies an R2 object exists
+    print(
+        "\nconfig-divergence: R2 carries a live-applied customer.yaml that a git\n"
+        "projection would SILENTLY REVERT (ADR 0044 / #1840). The change that\n"
+        "would be lost (R2 -> git, i.e. what disappears if you project):\n",
+        file=sys.stderr,
+    )
+    diff = difflib.unified_diff(
+        r2_path.read_text().splitlines(keepends=True),
+        git_path.read_text().splitlines(keepends=True),
+        fromfile="R2 (live, would be lost)",
+        tofile="git (would be projected)",
+    )
+    sys.stderr.writelines(diff)
+    print(
+        "\nResolve deliberately:\n"
+        "  SS_CONFIG_SOURCE=r2      reprovision FROM the live R2 config (ADR 0044 Decision 2);\n"
+        "                           reconcile it into git afterwards (reconcile-r2-config.sh)\n"
+        "  SS_CONFIG_FORCE_GIT=1    knowingly revert the live change to the git version\n",
+        file=sys.stderr,
+    )
+    return 3
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/operator/bin/provision-customer.sh
+++ b/operator/bin/provision-customer.sh
@@ -109,6 +109,62 @@ R2_HINT="R2 creds missing. Run via: operator/bin/reprovision.sh ${SLUG}  (= infi
 command -v aws >/dev/null 2>&1 || die "aws CLI not found (required for R2 customer.yaml upload)"
 command -v pbpaste >/dev/null 2>&1 || die "pbpaste not found (macOS-only; required for secret entry flow)"
 
+# ---------- Step 0.5: config source + divergence guard (ADR 0044, #1840) ----------
+# R2 is the operational source of truth (ADR 0044 Decision 1): the console
+# live-apply writes it and the root config applier pulls from it. Projecting
+# the git working copy over a live-applied R2 config silently reverts the
+# live change (the exact primitive that crash-looped pilot-smokeball on
+# 2026-07-13 when two checkouts raced). Every git projection therefore
+# carries a provenance stamp (user metadata `projected-sha256`), and this
+# guard classifies the current R2 object before anything overwrites it:
+#   absent / identical / clean-projection -> proceed (normal deploy)
+#   diverged (live-applied content)       -> FAIL CLOSED with the diff
+# Overrides, both explicit human decisions:
+#   SS_CONFIG_SOURCE=r2    provision FROM the live R2 config (Decision 2's
+#                          read path): the R2 copy becomes the materialized
+#                          yaml for this run; R2 is not touched; reconcile it
+#                          into git afterwards (reconcile-r2-config.sh).
+#   SS_CONFIG_FORCE_GIT=1  knowingly revert the live change to git's version.
+R2_CONFIG_KEY="vaults/${SLUG}/customer.yaml"
+R2_CURRENT_TMP="$(mktemp -t "ss-r2-current-${SLUG}")"
+trap 'rm -f "${R2_CURRENT_TMP}"' EXIT
+HAVE_R2_CURRENT=0
+if AWS_ACCESS_KEY_ID="${R2_ACCESS_KEY_ID}" AWS_SECRET_ACCESS_KEY="${R2_SECRET_ACCESS_KEY}" \
+    aws s3 cp "s3://${R2_BUCKET_CONFIG}/${R2_CONFIG_KEY}" "${R2_CURRENT_TMP}" \
+      --endpoint-url "${R2_ENDPOINT_URL}" --only-show-errors >/dev/null 2>&1; then
+  HAVE_R2_CURRENT=1
+fi
+R2_PROJECTED_STAMP=""
+if [ "${HAVE_R2_CURRENT}" = "1" ]; then
+  R2_PROJECTED_STAMP="$(AWS_ACCESS_KEY_ID="${R2_ACCESS_KEY_ID}" AWS_SECRET_ACCESS_KEY="${R2_SECRET_ACCESS_KEY}" \
+    aws s3api head-object --bucket "${R2_BUCKET_CONFIG}" --key "${R2_CONFIG_KEY}" \
+      --endpoint-url "${R2_ENDPOINT_URL}" \
+      --query 'Metadata."projected-sha256"' --output text 2>/dev/null || true)"
+fi
+SKIP_R2_UPLOAD=0
+if [ "${SS_CONFIG_SOURCE:-git}" = "r2" ]; then
+  [ "${HAVE_R2_CURRENT}" = "1" ] || die "SS_CONFIG_SOURCE=r2 but no R2 config exists at s3://${R2_BUCKET_CONFIG}/${R2_CONFIG_KEY}"
+  CUSTOMER_YAML="${R2_CURRENT_TMP}"
+  SKIP_R2_UPLOAD=1
+  log "Config source: R2 (live operative config; git working copy IGNORED this run — reconcile afterwards)"
+elif [ "${HAVE_R2_CURRENT}" = "1" ]; then
+  GUARD_ARGS=(--git-file "${CUSTOMER_YAML}" --r2-file "${R2_CURRENT_TMP}")
+  [ -n "${R2_PROJECTED_STAMP}" ] && GUARD_ARGS+=(--projected-sha256 "${R2_PROJECTED_STAMP}")
+  GUARD_STATUS=0
+  GUARD_VERDICT="$(python3 "${BIN_DIR}/lib/config_divergence.py" "${GUARD_ARGS[@]}")" || GUARD_STATUS=$?
+  case "${GUARD_STATUS}" in
+    0) log "Divergence guard: ${GUARD_VERDICT} — safe to project git -> R2" ;;
+    3)
+      if [ "${SS_CONFIG_FORCE_GIT:-0}" = "1" ]; then
+        log "WARNING: SS_CONFIG_FORCE_GIT=1 — REVERTING the live R2 config to git's version (diff above shows what is being lost)"
+      else
+        die "R2 config has live-applied changes git would revert (see diff above). Rerun with SS_CONFIG_SOURCE=r2 to deploy the live config, or SS_CONFIG_FORCE_GIT=1 to knowingly revert it."
+      fi
+      ;;
+    *) die "divergence guard failed (exit ${GUARD_STATUS}); refusing to project blind" ;;
+  esac
+fi
+
 # ---------- Step 1: validate customer.yaml ----------
 # The canonical pre-merge gate is the TS validator in
 # src/lib/operator/customer-yaml/ (per ADR 0019). The retired in-tree
@@ -174,15 +230,28 @@ log "Hermes upstream pin: ${HERMES_UPSTREAM_TAG} @ ${HERMES_UPSTREAM_SHA}"
 # first Machine boot can succeed (otherwise the boot would race against a
 # missing config). The customer-sync sidecar (from the overlay bootstrap/
 # package) polls this same key for non-structural updates.
-R2_CONFIG_KEY="vaults/${SLUG}/customer.yaml"
-log "Uploading customer.yaml to R2: s3://${R2_BUCKET_CONFIG}/${R2_CONFIG_KEY}"
-AWS_ACCESS_KEY_ID="${R2_ACCESS_KEY_ID}" \
-AWS_SECRET_ACCESS_KEY="${R2_SECRET_ACCESS_KEY}" \
-  aws s3 cp "${CUSTOMER_YAML}" "s3://${R2_BUCKET_CONFIG}/${R2_CONFIG_KEY}" \
-    --endpoint-url "${R2_ENDPOINT_URL}" \
-    --only-show-errors \
-  || die "R2 upload failed; bootstrap.sh would not be able to fetch customer.yaml"
-log "R2 upload OK"
+#
+# The upload carries the `projected-sha256` provenance stamp the Step 0.5
+# divergence guard reads: stamp == object digest marks an untouched git
+# projection (safe to overwrite on the next deploy); anything else the guard
+# treats as live-applied and refuses to clobber (ADR 0044, #1840). In
+# SS_CONFIG_SOURCE=r2 mode the upload is skipped entirely — R2 is already
+# the source being deployed, and re-stamping it would launder a live apply
+# into a "clean projection" the next run would silently overwrite.
+if [ "${SKIP_R2_UPLOAD}" = "1" ]; then
+  log "Skipping R2 upload (SS_CONFIG_SOURCE=r2 — R2 is the source this run)"
+else
+  CUSTOMER_YAML_SHA256="$(shasum -a 256 "${CUSTOMER_YAML}" | cut -d' ' -f1)"
+  log "Uploading customer.yaml to R2: s3://${R2_BUCKET_CONFIG}/${R2_CONFIG_KEY} (projected-sha256=${CUSTOMER_YAML_SHA256})"
+  AWS_ACCESS_KEY_ID="${R2_ACCESS_KEY_ID}" \
+  AWS_SECRET_ACCESS_KEY="${R2_SECRET_ACCESS_KEY}" \
+    aws s3 cp "${CUSTOMER_YAML}" "s3://${R2_BUCKET_CONFIG}/${R2_CONFIG_KEY}" \
+      --endpoint-url "${R2_ENDPOINT_URL}" \
+      --metadata "projected-sha256=${CUSTOMER_YAML_SHA256}" \
+      --only-show-errors \
+    || die "R2 upload failed; bootstrap.sh would not be able to fetch customer.yaml"
+  log "R2 upload OK"
+fi
 
 # ---------- Step 3: render fly.toml ----------
 log "Rendering fly.toml..."

--- a/operator/bin/reconcile-r2-config.sh
+++ b/operator/bin/reconcile-r2-config.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# R2 -> git customer.yaml reconciler — ADR 0044 Decision 4, issue #1840.
+#
+# R2 is the operational source of truth for the live config (Decision 1);
+# git is the reviewed/DR record, reconciled FROM R2. This script bounds the
+# divergence window: for every provisioned customer it compares the live R2
+# customer.yaml against the git working copy and, when they differ AND the
+# R2 object is not simply an untouched projection of git (provenance stamp,
+# see operator/bin/lib/config_divergence.py), surfaces the divergence.
+#
+# Modes:
+#   --check   (default) report divergences; exit 4 if any exist, 0 if clean.
+#   --pr      additionally, for each diverged slug, create a branch
+#             `reconcile/r2-<slug>` carrying the R2 version of the file and
+#             open (or update) a PR — the reviewed-record path. Requires gh.
+#
+# Credentials: R2_ENDPOINT_URL / R2_ACCESS_KEY_ID / R2_SECRET_ACCESS_KEY
+# (read access suffices). Locally: run under Infisical
+#   infisical run --env=prod --path=/ss -- operator/bin/reconcile-r2-config.sh
+# In CI: provided as repo secrets by .github/workflows/r2-config-reconcile.yml.
+set -euo pipefail
+
+MODE="${1:---check}"
+case "${MODE}" in --check|--pr) ;; *) echo "usage: $0 [--check|--pr]" >&2; exit 2 ;; esac
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BIN_DIR="${REPO_ROOT}/operator/bin"
+CUSTOMERS_DIR="${REPO_ROOT}/operator/customers"
+R2_BUCKET_CONFIG="${R2_BUCKET_CONFIG:-smd-customer-config}"
+
+log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [reconcile-r2] $*"; }
+[ -n "${R2_ENDPOINT_URL:-}" ] || { echo "FATAL: R2_ENDPOINT_URL not set (Infisical /ss prod, or CI secrets)" >&2; exit 2; }
+[ -n "${R2_ACCESS_KEY_ID:-}" ] || { echo "FATAL: R2_ACCESS_KEY_ID not set" >&2; exit 2; }
+[ -n "${R2_SECRET_ACCESS_KEY:-}" ] || { echo "FATAL: R2_SECRET_ACCESS_KEY not set" >&2; exit 2; }
+command -v aws >/dev/null 2>&1 || { echo "FATAL: aws CLI not found" >&2; exit 2; }
+[ "${MODE}" = "--check" ] || command -v gh >/dev/null 2>&1 || { echo "FATAL: gh CLI required for --pr" >&2; exit 2; }
+
+TMP_DIR="$(mktemp -d -t ss-reconcile-r2)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+DIVERGED_SLUGS=()
+for dir in "${CUSTOMERS_DIR}"/*/; do
+  slug="$(basename "${dir}")"
+  case "${slug}" in _*) continue ;; esac # templates are not provisioned customers
+  git_yaml="${dir}customer.yaml"
+  [ -f "${git_yaml}" ] || continue
+  key="vaults/${slug}/customer.yaml"
+  r2_yaml="${TMP_DIR}/${slug}.yaml"
+  if ! AWS_ACCESS_KEY_ID="${R2_ACCESS_KEY_ID}" AWS_SECRET_ACCESS_KEY="${R2_SECRET_ACCESS_KEY}" \
+      aws s3 cp "s3://${R2_BUCKET_CONFIG}/${key}" "${r2_yaml}" \
+        --endpoint-url "${R2_ENDPOINT_URL}" --only-show-errors >/dev/null 2>&1; then
+    log "${slug}: no R2 object (never provisioned) — skip"
+    continue
+  fi
+  stamp="$(AWS_ACCESS_KEY_ID="${R2_ACCESS_KEY_ID}" AWS_SECRET_ACCESS_KEY="${R2_SECRET_ACCESS_KEY}" \
+    aws s3api head-object --bucket "${R2_BUCKET_CONFIG}" --key "${key}" \
+      --endpoint-url "${R2_ENDPOINT_URL}" \
+      --query 'Metadata."projected-sha256"' --output text 2>/dev/null || true)"
+  GUARD_ARGS=(--git-file "${git_yaml}" --r2-file "${r2_yaml}")
+  [ -n "${stamp}" ] && GUARD_ARGS+=(--projected-sha256 "${stamp}")
+  status=0
+  verdict="$(python3 "${BIN_DIR}/lib/config_divergence.py" "${GUARD_ARGS[@]}" 2>/dev/null)" || status=$?
+  case "${status}" in
+    0)
+      # clean-projection means git moved ahead of R2 (a merged-but-undeployed
+      # change) — a deploy question, not a reconciliation one. identical/absent
+      # are clean by definition.
+      log "${slug}: ${verdict} — no reconciliation needed"
+      ;;
+    3)
+      log "${slug}: DIVERGED — live R2 config is not in git"
+      DIVERGED_SLUGS+=("${slug}")
+      if [ "${MODE}" = "--pr" ]; then
+        branch="reconcile/r2-${slug}"
+        (
+          cd "${REPO_ROOT}"
+          git fetch origin main --quiet
+          git checkout -B "${branch}" origin/main --quiet
+          cp "${r2_yaml}" "operator/customers/${slug}/customer.yaml"
+          if git diff --quiet -- "operator/customers/${slug}/customer.yaml"; then
+            log "${slug}: R2 already matches origin/main (local checkout was stale) — no PR"
+          else
+            git add "operator/customers/${slug}/customer.yaml"
+            git commit --quiet -m "chore(operator): reconcile ${slug} customer.yaml from live R2 (ADR 0044 Decision 4)"
+            git push --force-with-lease --set-upstream origin "${branch}" --quiet
+            gh pr create --title "chore(operator): reconcile ${slug} customer.yaml from live R2 (ADR 0044)" \
+              --body "Automated R2 -> git reconciliation (ADR 0044 Decision 4, #1840): the live R2 customer.yaml for \`${slug}\` diverged from git (a live apply landed). This PR makes git the reviewed record of the live state. Review the diff as you would any config change; merging does NOT redeploy anything." \
+              2>/dev/null || log "${slug}: PR already open for ${branch} (updated the branch)"
+          fi
+        )
+      fi
+      ;;
+    *)
+      log "${slug}: guard error (exit ${status})"
+      exit 2
+      ;;
+  esac
+done
+
+if [ "${#DIVERGED_SLUGS[@]}" -gt 0 ]; then
+  log "diverged: ${DIVERGED_SLUGS[*]}"
+  [ "${MODE}" = "--pr" ] || exit 4
+else
+  log "all customers reconciled (git is current with live R2 state)"
+fi

--- a/operator/bin/tests/test_config_divergence.py
+++ b/operator/bin/tests/test_config_divergence.py
@@ -1,0 +1,197 @@
+"""Divergence guard for the git -> R2 customer.yaml projection (ADR 0044
+Decision 2, issue #1840).
+
+The silent-revert primitive: provision-customer.sh projects the git working
+copy over the live R2 customer.yaml; any live-applied change not in git is
+silently reverted (proven live 2026-07-13 — two racing checkouts projected
+over R2 mid-deploy and crash-looped pilot-smokeball). These tests pin:
+
+  1. the pure verdict matrix (classify) — a missing/mismatched provenance
+     stamp can never allow a clobber;
+  2. the CLI contract provision-customer.sh consumes (exit 0 proceed /
+     exit 3 diverged, with the would-be-lost diff on stderr);
+  3. the shell wiring — the guard runs before the upload, the upload carries
+     the provenance stamp, and adopt-r2 mode never re-stamps R2.
+
+Run::
+
+    cd operator && python -m pytest bin/tests/test_config_divergence.py -v
+"""
+
+from __future__ import annotations
+
+import hashlib
+import sys
+from pathlib import Path
+
+import pytest
+
+_LIB = Path(__file__).resolve().parents[1] / "lib"
+sys.path.insert(0, str(_LIB.parent))
+
+from lib.config_divergence import (  # noqa: E402
+    ABSENT,
+    CLEAN_PROJECTION,
+    DIVERGED,
+    IDENTICAL,
+    classify,
+    main,
+)
+
+_SCRIPT = Path(__file__).resolve().parents[1] / "provision-customer.sh"
+_RECONCILER = Path(__file__).resolve().parents[1] / "reconcile-r2-config.sh"
+_WORKFLOW = (
+    Path(__file__).resolve().parents[3] / ".github" / "workflows" / "r2-config-reconcile.yml"
+)
+
+_GIT = "a" * 64
+_LIVE = "b" * 64
+
+
+# ---------------------------------------------------------------- classify
+
+
+def test_absent_r2_object_is_first_provision() -> None:
+    assert classify(_GIT, None, None) == ABSENT
+
+
+def test_identical_digests_are_idempotent() -> None:
+    assert classify(_GIT, _GIT, None) == IDENTICAL
+    # identical wins even with a stale stamp — bytes agree, nothing to lose
+    assert classify(_GIT, _GIT, _LIVE) == IDENTICAL
+
+
+def test_untouched_prior_projection_is_safe_to_overwrite() -> None:
+    """R2 == its own stamp != git: a newly merged git change deploying over
+    the previous projection — the normal deploy path."""
+    assert classify(_GIT, _LIVE, _LIVE) == CLEAN_PROJECTION
+
+
+def test_missing_stamp_fails_toward_diverged() -> None:
+    """No provenance stamp (live-apply write, pre-guard upload) can never
+    allow a clobber."""
+    assert classify(_GIT, _LIVE, None) == DIVERGED
+
+
+def test_mismatched_stamp_fails_toward_diverged() -> None:
+    """Object modified after projection (stamp is stale) — treat as live."""
+    assert classify(_GIT, _LIVE, "c" * 64) == DIVERGED
+
+
+# ---------------------------------------------------------------- CLI
+
+
+def _write(tmp_path: Path, name: str, body: str) -> Path:
+    p = tmp_path / name
+    p.write_text(body)
+    return p
+
+
+def test_cli_proceeds_on_absent_and_identical(tmp_path: Path, capsys) -> None:
+    git = _write(tmp_path, "git.yaml", "a: 1\n")
+    assert main(["--git-file", str(git)]) == 0
+    assert capsys.readouterr().out.strip() == ABSENT
+    r2 = _write(tmp_path, "r2.yaml", "a: 1\n")
+    assert main(["--git-file", str(git), "--r2-file", str(r2)]) == 0
+    assert capsys.readouterr().out.strip() == IDENTICAL
+
+
+def test_cli_proceeds_on_clean_projection(tmp_path: Path, capsys) -> None:
+    git = _write(tmp_path, "git.yaml", "a: 2\n")
+    r2 = _write(tmp_path, "r2.yaml", "a: 1\n")
+    stamp = hashlib.sha256(r2.read_bytes()).hexdigest()
+    assert main(["--git-file", str(git), "--r2-file", str(r2), "--projected-sha256", stamp]) == 0
+    assert capsys.readouterr().out.strip() == CLEAN_PROJECTION
+
+
+def test_cli_blocks_diverged_and_prints_the_lost_diff(tmp_path: Path, capsys) -> None:
+    git = _write(tmp_path, "git.yaml", "ceiling: draft_for_review\n")
+    r2 = _write(tmp_path, "r2.yaml", "ceiling: refused\n")
+    assert main(["--git-file", str(git), "--r2-file", str(r2)]) == 3
+    captured = capsys.readouterr()
+    assert captured.out.strip() == DIVERGED
+    assert "SILENTLY REVERT" in captured.err
+    assert "-ceiling: refused" in captured.err  # what would be lost
+    assert "+ceiling: draft_for_review" in captured.err  # what would replace it
+    assert "SS_CONFIG_SOURCE=r2" in captured.err
+    assert "SS_CONFIG_FORCE_GIT=1" in captured.err
+
+
+def test_cli_treats_aws_text_none_as_no_stamp(tmp_path: Path, capsys) -> None:
+    """`aws --output text` prints the literal 'None' for absent metadata —
+    it must not be mistaken for a real stamp value."""
+    git = _write(tmp_path, "git.yaml", "a: 2\n")
+    r2 = _write(tmp_path, "r2.yaml", "a: 1\n")
+    assert (
+        main(["--git-file", str(git), "--r2-file", str(r2), "--projected-sha256", "None"]) == 3
+    )
+    capsys.readouterr()
+
+
+def test_cli_errors_on_missing_files(tmp_path: Path, capsys) -> None:
+    assert main(["--git-file", str(tmp_path / "nope.yaml")]) == 2
+    git = _write(tmp_path, "git.yaml", "a: 1\n")
+    assert main(["--git-file", str(git), "--r2-file", str(tmp_path / "nope.yaml")]) == 2
+    capsys.readouterr()
+
+
+# ---------------------------------------------------------------- wiring
+
+
+def _code_lines(script: Path) -> list[str]:
+    out = []
+    for line in script.read_text(encoding="utf-8").splitlines():
+        out.append("" if line.lstrip().startswith("#") else line)
+    return out
+
+
+def _first_index(lines: list[str], needle: str) -> int:
+    for i, line in enumerate(lines):
+        if needle in line:
+            return i
+    pytest.fail(f"{needle!r} not found in script code lines")
+
+
+def test_guard_runs_before_the_r2_upload() -> None:
+    lines = _code_lines(_SCRIPT)
+    guard = _first_index(lines, "config_divergence.py")
+    upload = _first_index(lines, 'aws s3 cp "${CUSTOMER_YAML}"')
+    assert guard < upload, "divergence guard must run before the git -> R2 projection"
+
+
+def test_upload_carries_the_provenance_stamp() -> None:
+    lines = _code_lines(_SCRIPT)
+    upload = _first_index(lines, 'aws s3 cp "${CUSTOMER_YAML}"')
+    window = "\n".join(lines[upload : upload + 6])
+    assert "projected-sha256=" in window, "projection upload must stamp projected-sha256 metadata"
+
+
+def test_diverged_default_is_fail_closed() -> None:
+    body = _SCRIPT.read_text(encoding="utf-8")
+    assert "SS_CONFIG_FORCE_GIT" in body
+    assert 'die "R2 config has live-applied changes' in body, (
+        "the diverged verdict must die by default, not warn-and-continue"
+    )
+
+
+def test_adopt_r2_mode_skips_the_upload() -> None:
+    """SS_CONFIG_SOURCE=r2 must not re-stamp R2: re-uploading the live bytes
+    with a projection stamp would launder a live apply into a clean
+    projection the NEXT run would silently overwrite."""
+    body = _SCRIPT.read_text(encoding="utf-8")
+    assert "SS_CONFIG_SOURCE" in body
+    assert "SKIP_R2_UPLOAD" in body
+    lines = _code_lines(_SCRIPT)
+    skip = _first_index(lines, 'if [ "${SKIP_R2_UPLOAD}" = "1" ]')
+    upload = _first_index(lines, 'aws s3 cp "${CUSTOMER_YAML}"')
+    assert skip < upload, "the skip branch must gate the projection upload"
+
+
+def test_reconciler_exists_and_is_wired_to_the_schedule() -> None:
+    assert _RECONCILER.is_file(), "ADR 0044 Decision 4 reconciler script missing"
+    assert _RECONCILER.stat().st_mode & 0o111, "reconciler must be executable"
+    body = _RECONCILER.read_text(encoding="utf-8")
+    assert "config_divergence.py" in body, "reconciler must reuse the guard's verdict logic"
+    wf = _WORKFLOW.read_text(encoding="utf-8")
+    assert "schedule:" in wf and "reconcile-r2-config.sh --pr" in wf
+    assert "::error::" in wf, "missing-secrets case must fail loudly, never skip silently"


### PR DESCRIPTION
Closes #1840. Ships ADR 0044 Decisions 2 + 4 (the silent-revert primitive), reshaped to fit the real authoring path and recorded in a new ADR **Realized** section.

## The defect (proven live today)
`provision-customer.sh` projected the git working copy over the live R2 customer.yaml unconditionally. Any live-applied change (console apply, root config-applier state) — or simply a second session's checkout at a different commit — was silently reverted. This exact primitive crash-looped pilot-smokeball this afternoon when two sessions' deploys raced.

## The fix
1. **Provenance-stamped divergence guard (Step 0.5).** Every git projection stamps the uploaded R2 object with `projected-sha256` metadata. Before overwriting, the provisioner classifies the current object: `absent` / `identical` / `clean-projection` (untouched prior projection — the normal deploy) proceed; anything else is live-applied content and the run **fails closed**, printing the diff that would be lost. A missing/mismatched stamp can never allow a clobber — live-apply writes carry no stamp, so they're always guarded.
2. **Explicit resolutions.** `SS_CONFIG_SOURCE=r2` provisions FROM the live R2 config (Decision 2's read path; the upload is skipped so a live apply is never laundered into a clean projection). `SS_CONFIG_FORCE_GIT=1` knowingly reverts, logging what's lost.
3. **Decision 4 reconciler.** `operator/bin/reconcile-r2-config.sh` (`--check` / `--pr`) compares every provisioned customer's live R2 config to git and opens `reconcile/r2-<slug>` PRs. Scheduled daily by `r2-config-reconcile.yml`, which **fails loudly** until its scoped READ secrets are provisioned (`R2_ENDPOINT_URL`, `R2_RECONCILE_ACCESS_KEY_ID`, `R2_RECONCILE_SECRET_ACCESS_KEY`) — a silently-skipping reconciler would be paper compliance. **Captain step: add those repo secrets (read-only key on smd-customer-config).**

## Why not unconditional read-from-R2 (Decision 2 as written)
Git PRs are the only reviewed authoring path until the portal write-back spine (#1800, parked) exists — the git→R2 projection IS how a merged config change deploys. Unconditional R2 reads would make merged changes undeployable. The Realized section in ADR 0044 records this reshaping.

## First-run note for the fleet
Existing R2 objects predate the stamp, so the FIRST reprovision per seat after this merges will report DIVERGED (unprovable provenance). Read the diff; if it shows only your intended change, `SS_CONFIG_FORCE_GIT=1` once — every projection after that is stamped and the guard is fully armed.

## Verification
- 15 new tests (`operator/bin/tests/test_config_divergence.py`): verdict matrix, CLI contract incl. the aws `None`-metadata footgun, shell wiring order (guard before upload, stamp on upload, adopt-mode skip), reconciler presence + loud-fail.
- Full substrate suite: 786 passed. `npm run verify` green. Handbook deployment-release page updated in the same PR (maintenance contract).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EcUe7ViLSA73UwJ2SajH7E