### PR TITLE
fix(operator): boot-smoke gate for customer-disabled bundled skills (#1198)

### DIFF
--- a/operator/bin/boot-smoke-test.sh
+++ b/operator/bin/boot-smoke-test.sh
@@ -107,6 +107,17 @@ ssh_exec "hermes-plugins-installed" "/opt/hermes/.venv/bin/hermes plugins list |
 # curator.enabled:false in every profile config; --check re-verifies it held.
 ssh_exec "curator-disabled" "/opt/hermes/.venv/bin/python3 /app/ensure-curator-disabled.py --check /opt/data"
 
+# ---------- Step 8b: customer-disabled bundled skills stayed off the menu (#1198) ----------
+# customer.yaml personas[].skills_disabled is the per-customer authority over
+# Hermes' bundled catalog (e.g. google-workspace + himalaya, which the DWD-broker
+# model replaces — ADR 0045). bootstrap step 7b.1 prunes them from the profile
+# skill tree + prompt snapshot, and a startup reconciler re-prunes after Hermes'
+# gateway sync. This --check FAILS the boot if any disabled skill reappeared —
+# the fail-closed guard against a Hermes-upgrade rehydration regression (a
+# re-exposed google-workspace skill is a governance-bypass path back to the raw
+# credential, exactly what ADR 0045 closes). No-op when no skills_disabled authored.
+ssh_exec "disabled-skills-pruned" "/opt/hermes/.venv/bin/python3 /app/ensure-disabled-skills.py --check /var/lib/smd-config/customer.yaml /opt/data"
+
 # ---------- Step 9: audit ledger is broker-owned and NOT agent-writable (OP-P1-4) ----------
 # The immutable ledger must be owned by the broker uid (workspace-broker), the
 # dir setgid 2750, and the agent uid (hermes) must be physically unable to write


### PR DESCRIPTION
Closes #1198 — the suppress half of native-skill disabling.

## Where #1198 already stood
The materialization was built (#1218): `operator/templates/ensure-disabled-skills.py` prunes `personas[].skills_disabled` entries from the profile skill tree + `.skills_prompt_snapshot.json` at boot (bootstrap step 7b.1) plus a 6× startup reconciler that re-prunes after Hermes' gateway sync. This sidesteps the `skills` list-vs-mapping shape conflict the issue flagged — it removes the skill artifacts rather than fighting Hermes' disable knob.

**Live-proven on pilot-smokeball** (vfy pending in comment): the pinned Hermes bundles `google-workspace` (`/opt/hermes/skills/productivity/google-workspace`) and `himalaya` (`/opt/hermes/skills/email/himalaya`) — so the guard is load-bearing — and both are **absent** from the profile skill dir and the prompt snapshot on the running seat.

## The gap this PR closes
The AC "a boot/CI check fails if either reappears" was unmet: `--check` mode exists and is unit-tested (`test_check_fails_when_disabled_skills_are_exposed`, returncode 1) but was never wired into the boot smoke test. This adds the `disabled-skills-pruned` check to `boot-smoke-test.sh`, mirroring the `curator-disabled` gate.

It guards the real regression class: a Hermes upgrade whose gateway sync rehydrates a bundled skill dir re-exposes `google-workspace` to the model — a governance-bypass path straight back to the raw DWD credential that ADR 0045 exists to close. Fail-closed: the boot fails if it reappears.

## Verification
- Live: `ensure-disabled-skills.py --check /var/lib/smd-config/customer.yaml /opt/data` on pilot-smokeball → `0 disabled skill artifacts`, exit 0.
- Suites: templates + bin tests 188 passed; smoke script syntax clean.

ss-only (boot-smoke wiring); no overlay change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EcUe7ViLSA73UwJ2SajH7E