### PR TITLE
docs(operator): sharpen the A&P voice-sample onboarding step (#1851 AC2)

### DIFF
--- a/operator/customers/ashton-price/IMPLEMENTATION-PLAN.md
+++ b/operator/customers/ashton-price/IMPLEMENTATION-PLAN.md
@@ -185,8 +185,14 @@ principal) to correct the model and lock what only the firm can give:
    this unilaterally; it sets the deadline-lane shape).
 5. **CoCounsel / drafting division** — outcome of her Thomson Reuters
    meeting; sets motion/response orchestration.
-6. **Voice samples** — firm letters/templates into the voice library
-   (path is set, library is empty).
+6. **Voice samples** — ~30 firm-authored letters/templates (the ADR 0028
+   anchor-pack size) into the voice library, so Layer 2 has a real corpus to
+   transform toward instead of the general fallback. Christa provides the
+   samples; we ingest them through the leak-guarded differ
+   (`operator/bin/voice-ingest-corpus.py`) to content-free structural-diff
+   cohort JSONs in the seat vault — raw letter text never lands in the vault
+   or logs. The portal self-serve upload path (#1851) is a later
+   convenience; at onboarding we ingest the pack directly.
 7. **Monitored-inbox decision** — owned address vs forwarding vs Graph watch
    (feeds M6).
 8. **Starting matter set** — which live matters observation watches first.


### PR DESCRIPTION
Refs #1851 (AC 2). The firm-input register already carried the voice-sample ask (row 7); this sharpens M2 item 6 with the concrete shape: ~30 firm-authored samples (the ADR 0028 anchor-pack size), ingested through the leak-guarded differ (`voice-ingest-corpus.py`) to content-free structural-diff cohort JSONs — raw letter text never lands in the vault or logs. Notes that the portal self-serve upload (#1851 AC1) is a later convenience; at onboarding we ingest the pack directly.

Doc-only. Part of closing #1851's readily-completable ACs; AC1 (portal capture pipeline) has an architecture decision surfaced separately, and AC3 (live-fire) is gated on the first send-capable wave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EcUe7ViLSA73UwJ2SajH7E