### PR TITLE
feat(portal): The work chapter — routine grid rendered on both portals (ADR 0076, structure doc §3.2)

### DIFF
--- a/src/components/portal/operator/facets/OperatorWork.astro
+++ b/src/components/portal/operator/facets/OperatorWork.astro
@@ -1,0 +1,105 @@
+---
+/**
+ * Operator "The work" viewer — the shared routine-grid view (ADR 0076; console
+ * structure doc §3.2; signed-off brief
+ * docs/design/operator/surface-briefs/operator-the-work.md). One shared
+ * component, both portals mount it (client work page + admin config surface),
+ * per ADR 0069 Lock 4.
+ *
+ * GRID mode renders the lifecycle-grouped routine matrix: one section block per
+ * authored `letter_section`, each row showing the routine name, how it starts,
+ * the "Today" tier sentence, the "Can become" line (only where the ceiling
+ * exceeds the start) or the standing cap verbatim, and the implementing skills
+ * with their reviewed summaries. GRIDLESS mode renders the exact Skills
+ * inventory the Skills page shows today (honest degradation), introduced by one
+ * true sentence.
+ *
+ * Every rendered string traces to authored grid data, the reviewed skill
+ * summaries, or the fixed tier / starts label maps in the resolver. No invented
+ * copy. This file carries NO vertical vocabulary — the section names, routine
+ * names, and verbatim tier language arrive as data.
+ *
+ * Loud register to match its sibling viewers (OperatorSkills, the landing) while
+ * the calm migration is parked; registered in CALM_REGISTER_PENDING so the whole
+ * operator area flips to calm together.
+ */
+import type { OperatorWorkModel } from '../../../../lib/portal/operator/facets/work/work'
+import OperatorWorkRow from './OperatorWorkRow.astro'
+
+interface Props {
+  model: OperatorWorkModel
+}
+
+const { model } = Astro.props
+---
+
+{
+  model.mode === 'gridless' ? (
+    <section
+      class="border-[3px] border-[color:var(--color-text-primary)] bg-[color:var(--color-background)]"
+      aria-label="Operator duties"
+    >
+      <div class="bg-[color:var(--color-text-primary)] px-5 py-2.5 font-mono text-label font-bold uppercase tracking-[0.18em] text-[color:var(--color-background)]">
+        Duties
+      </div>
+      <div class="px-5 py-6 md:px-7">
+        {model.skills.length === 0 ? (
+          <p class="font-mono text-label uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)]">
+            Your operator's duties appear here once they're configured.
+          </p>
+        ) : (
+          <>
+            <p class="mb-5 font-body text-sm text-[color:var(--color-text-secondary)]">
+              Your operator's duties are listed here as configured.
+            </p>
+            <ul role="list" class="flex flex-col">
+              {model.skills.map((s, i) => (
+                <li
+                  class={`flex flex-col gap-2 py-4 md:flex-row md:items-start md:justify-between md:gap-8 ${
+                    i > 0 ? 'border-t-[2px] border-[color:var(--color-border)]' : ''
+                  }`}
+                >
+                  <div class="min-w-0 md:max-w-[46rem]">
+                    <p class="font-body text-base font-semibold text-[color:var(--color-text-primary)]">
+                      {s.name}
+                    </p>
+                    {s.summary && (
+                      <p class="mt-1 font-body text-sm leading-snug text-[color:var(--color-text-secondary)]">
+                        {s.summary}
+                      </p>
+                    )}
+                  </div>
+                  {s.initiation.length > 0 && (
+                    <span class="shrink-0 font-mono text-label uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)] md:pt-0.5">
+                      {s.initiation.join(' · ')}
+                    </span>
+                  )}
+                </li>
+              ))}
+            </ul>
+          </>
+        )}
+      </div>
+    </section>
+  ) : (
+    <div class="flex flex-col gap-8">
+      {model.sections.map((section) => (
+        <section
+          class="border-[3px] border-[color:var(--color-text-primary)] bg-[color:var(--color-background)]"
+          aria-label={section.name}
+        >
+          <div class="bg-[color:var(--color-text-primary)] px-5 py-2.5 font-mono text-label font-bold uppercase tracking-[0.18em] text-[color:var(--color-background)]">
+            {section.name}
+          </div>
+          <div class="px-5 py-2 md:px-7">
+            <ul role="list" class="flex flex-col">
+              {section.routines.map((r, i) => (
+                <OperatorWorkRow routine={r} divided={i > 0} />
+              ))}
+            </ul>
+          </div>
+        </section>
+      ))}
+    </div>
+  )
+}

--- a/src/components/portal/operator/facets/OperatorWorkRow.astro
+++ b/src/components/portal/operator/facets/OperatorWorkRow.astro
@@ -1,0 +1,87 @@
+---
+/**
+ * One routine row of "The work" grid (ADR 0076; console structure doc §3.2).
+ * Extracted from OperatorWork.astro so each component stays small; it renders a
+ * single WorkRoutineView: the routine name, how it starts, the Today tier
+ * sentence, the Can-become line (only where the ceiling exceeds the start) or
+ * the standing cap verbatim, and the implementing skills with their reviewed
+ * summaries. Every string traces to authored grid data, the reviewed skill
+ * summaries, or the fixed tier / starts label maps in the resolver — no invented
+ * copy, no vertical vocabulary.
+ */
+import type { WorkRoutineView } from '../../../../lib/portal/operator/facets/work/work'
+
+interface Props {
+  routine: WorkRoutineView
+  /** True for every row after the first in a section — draws the divider rule. */
+  divided: boolean
+}
+
+const { routine: r, divided } = Astro.props
+---
+
+<li class={`py-5 ${divided ? 'border-t-[2px] border-[color:var(--color-border)]' : ''}`}>
+  <div class="flex flex-col gap-2 md:flex-row md:items-start md:justify-between md:gap-8">
+    <p class="min-w-0 font-body text-base font-semibold text-[color:var(--color-text-primary)]">
+      {r.routine}
+    </p>
+    {
+      r.startsLabels.length > 0 && (
+        <span class="shrink-0 font-mono text-label uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)] md:pt-0.5">
+          {r.startsLabels.join(' · ')}
+        </span>
+      )
+    }
+  </div>
+
+  <div class="mt-2 flex flex-col gap-1">
+    <p class="font-body text-sm text-[color:var(--color-text-primary)]">
+      <span
+        class="font-mono text-label font-bold uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)]"
+      >
+        Today:{' '}
+      </span>
+      {r.todaySentence}
+    </p>
+    {
+      r.canBecomeSentence && (
+        <p class="font-body text-sm text-[color:var(--color-text-primary)]">
+          <span class="font-mono text-label font-bold uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)]">
+            Can become:{' '}
+          </span>
+          {r.canBecomeSentence}
+          {r.canBecomeVerbatim && (
+            <span class="text-[color:var(--color-text-secondary)]"> ({r.canBecomeVerbatim})</span>
+          )}
+        </p>
+      )
+    }
+    {
+      r.capVerbatim && (
+        <p class="font-body text-sm text-[color:var(--color-text-secondary)]">{r.capVerbatim}</p>
+      )
+    }
+  </div>
+
+  {
+    r.skills.length > 0 && (
+      <ul
+        role="list"
+        class="mt-3 flex flex-col gap-2 border-l-[2px] border-[color:var(--color-border)] pl-4"
+      >
+        {r.skills.map((s) => (
+          <li>
+            <p class="font-body text-sm font-semibold leading-snug text-[color:var(--color-text-primary)]">
+              {s.name}
+            </p>
+            {s.summary && (
+              <p class="font-body text-sm leading-snug text-[color:var(--color-text-secondary)]">
+                {s.summary}
+              </p>
+            )}
+          </li>
+        ))}
+      </ul>
+    )
+  }
+</li>

--- a/src/lib/portal/operator/facet-registry.ts
+++ b/src/lib/portal/operator/facet-registry.ts
@@ -120,7 +120,7 @@ export const OPERATOR_FACETS: readonly OperatorFacet[] = [
       viewerModule: 'src/lib/portal/operator/facets/skills/skills.ts',
     },
     mounts: ['client', 'admin'],
-    note: 'Slice 3: inventory (humanized slug) + initiation, in authored order. enabled/version/cost dropped from projection and deliberately not shown; per-skill autonomy is the Governance facet (Lock 4).',
+    note: 'Inventory (humanized slug) + initiation, in authored order. Now the DETAIL/FALLBACK of The work (ADR 0076, structure doc §3.2): implementing-skill rows within a grid routine, and the whole-page gridless fallback for seats with no routine-grid. Skills page stays routable, loses its landing door. enabled/version/cost dropped from projection and deliberately not shown.',
   },
   {
     id: 'agent-skills',
@@ -136,7 +136,7 @@ export const OPERATOR_FACETS: readonly OperatorFacet[] = [
     plane: 'config_projection',
     surface: { kind: 'planned', slice: 3 },
     mounts: ['client', 'admin'],
-    note: 'Persona-level exposure × per-skill initiation; vertical floors non-raisable. Coarse-vs-rich matrix is an open decision.',
+    note: "Persona-level exposure × per-skill initiation; vertical floors non-raisable. Rendered on The work (ADR 0076) from the routine grid: each row's start/ceiling tier is the authored per-routine autonomy dial, with permanent caps read verbatim. Coarse-vs-rich matrix is an open decision.",
   },
   {
     id: 'schedule',
@@ -144,7 +144,7 @@ export const OPERATOR_FACETS: readonly OperatorFacet[] = [
     plane: 'config_unprojected',
     surface: { kind: 'planned', slice: 7 },
     mounts: ['client', 'admin'],
-    note: 'personas[].cron[] authored but dropped from projection — needs projection extension.',
+    note: 'The "starts on a schedule" signal is rendered on The work (ADR 0076) from each grid row\'s initiation. The concrete cron detail (personas[].cron[]) is authored but dropped from the projection — still pending a projection extension before the recurring-job specifics can show.',
   },
   {
     id: 'bundles',
@@ -157,10 +157,13 @@ export const OPERATOR_FACETS: readonly OperatorFacet[] = [
   {
     id: 'workflow',
     label: 'Workflows / process',
-    plane: 'no_schema',
-    surface: { kind: 'planned', slice: 10 },
+    plane: 'config_projection',
+    surface: {
+      kind: 'has_viewer',
+      viewerModule: 'src/lib/portal/operator/facets/work/work.ts',
+    },
     mounts: ['client', 'admin'],
-    note: 'No config facet exists. Generic (vertical-neutral) schema must be designed first.',
+    note: 'The work chapter (ADR 0076, console structure doc §3.2). The routine grid (routine-grid.yaml, ADR 0075) is the schema that "no config facet exists" once anticipated — plane no_schema → config_projection now that the grid projects into customer_configs. Renders the lifecycle-grouped routine matrix; a seat with no grid degrades to the skills inventory fallback.',
   },
   {
     id: 'memory',

--- a/src/lib/portal/operator/facets/work/work.ts
+++ b/src/lib/portal/operator/facets/work/work.ts
@@ -1,0 +1,176 @@
+/**
+ * Operator "The work" facet — the shared routine-grid view model (ADR 0076,
+ * console structure doc §3.2; signed-off brief
+ * docs/design/operator/surface-briefs/operator-the-work.md).
+ *
+ * Chapter 2 of the console is the spine: the rendered job description crossed
+ * with an authority matrix. It answers the owner's three questions in one page —
+ * "what does it do", "how does each duty start", and "how much does it do on its
+ * own" — grouped by the lifecycle sections the authored grid names.
+ *
+ * This resolver is READ-ONLY and pure. It maps the projected routine grid
+ * (CustomerConfigRow.routine_grid, ADR 0075) into a two-mode view model:
+ *
+ *   - GRID mode (a validated grid is projected): sections in grid order, each
+ *     with its routines. Every rendered fact traces to an authored grid field —
+ *     the tier SENTENCES and the "starts" LABELS below are the only fixed maps,
+ *     and the skill summaries come from the existing reviewed catalog. No runtime
+ *     paraphrase, no invented copy (Captain reset 2026-07-14: accurate read-only
+ *     depiction only; graduation requests and a permanent-rules block are out).
+ *
+ *   - GRIDLESS mode (no grid — smd, Hosted Agent, any pre-grid seat, or a null
+ *     config): the honest degradation, the exact skills + initiation inventory
+ *     the Skills page renders today, reused via resolveOperatorSkills. No invented
+ *     tiers, no empty grid scaffolding.
+ *
+ * This module carries NO vertical vocabulary: the lifecycle section names, the
+ * routine names, and the letter's verbatim tier language all arrive as authored
+ * DATA at runtime (correct — the grid supplies the vertical, the code stays
+ * neutral).
+ */
+
+import type { CustomerConfigRow } from '../../../customer-config'
+import type { RoutineGridRow, RoutineTier } from '../../../../operator/routine-grid'
+import { humanizeSkillName, resolveOperatorSkills, type OperatorSkillView } from '../skills/skills'
+import { SKILL_SUMMARIES } from '../skills/skill-summaries'
+
+/**
+ * Closed tier → plain-sentence map (locked, Captain 2026-07-14). The reader is a
+ * colleague, not a technician: the internal token names never reach the page and
+ * may change freely in code. The letter's own verbatim phrasing stays available
+ * per row (start/ceiling verbatim) as the contract language.
+ */
+const TIER_SENTENCE: Record<RoutineTier, string> = {
+  'flag-only': 'Surfaces it',
+  'prepare-and-route': 'Prepares it for you',
+  'auto-handle': 'Handles it',
+}
+
+/** One implementing skill on a routine: humanized name + its reviewed summary. */
+export interface WorkRoutineSkill {
+  /** Humanized display name (e.g. "records-chaser" → "Records chaser"). */
+  name: string
+  /** The raw authored slug — stable key, never shown as prose. */
+  slug: string
+  /** Reviewed one-line summary from SKILL_SUMMARIES, or null (name-only). */
+  summary: string | null
+}
+
+/** One routine row, every field traced to authored grid data or a fixed map. */
+export interface WorkRoutineView {
+  /** `routine` verbatim. */
+  routine: string
+  /**
+   * Client-legible initiation labels parsed from the authored initiation string
+   * ("On request" / "On a schedule" / "When something happens"), in the stable
+   * order request → schedule → event. Empty when none detected.
+   */
+  startsLabels: string[]
+  /** The full authored initiation string — shown at the row's detail level. */
+  initiationDetail: string
+  /** `start_tier` as the locked plain sentence — the row's "Today" line. */
+  todaySentence: string
+  /** `start_verbatim` — the letter's contract language for today's tier. */
+  startVerbatim: string
+  /**
+   * `ceiling_tier` as the plain sentence, ONLY when the ceiling differs from the
+   * start (a real graduation headroom exists). Null when ceiling equals start.
+   */
+  canBecomeSentence: string | null
+  /** `ceiling_verbatim` — shown alongside canBecomeSentence. Null when no headroom. */
+  canBecomeVerbatim: string | null
+  /**
+   * `ceiling_verbatim` rendered as the row's STANDING rule when ceiling equals
+   * start (there is no graduation path; this is its maximum). Null otherwise.
+   * Exactly one of canBecomeSentence / capVerbatim is non-null.
+   */
+  capVerbatim: string | null
+  /** The implementing skill(s), humanized + summarized. */
+  skills: WorkRoutineSkill[]
+}
+
+/** A lifecycle section: the authored `letter_section` name and its routines. */
+export interface WorkSection {
+  /** `letter_section` verbatim (authored data — carries the vertical). */
+  name: string
+  routines: WorkRoutineView[]
+}
+
+/**
+ * The two-mode view model. GRID renders the lifecycle-grouped routine matrix;
+ * GRIDLESS renders the Skills inventory unchanged (honest degradation), and the
+ * viewer flags which introduction sentence to show.
+ */
+export type OperatorWorkModel =
+  | { mode: 'grid'; sections: WorkSection[] }
+  | { mode: 'gridless'; skills: OperatorSkillView[] }
+
+/**
+ * Parse the authored free-text initiation string into the established plain
+ * labels by substring detection of the three canonical modes. Order is fixed
+ * (request → schedule → event), independent of where the words appear in the
+ * string; empty array when none is present. The authored string itself is kept
+ * verbatim on the row (initiationDetail) for the detail level.
+ */
+export function startsLabels(initiation: string): string[] {
+  const s = initiation.toLowerCase()
+  const labels: string[] = []
+  if (s.includes('manual')) labels.push('On request')
+  if (s.includes('scheduled')) labels.push('On a schedule')
+  if (s.includes('webhook')) labels.push('When something happens')
+  return labels
+}
+
+function toRoutineView(row: RoutineGridRow): WorkRoutineView {
+  const graduates = row.ceiling_tier !== row.start_tier
+  return {
+    routine: row.routine,
+    startsLabels: startsLabels(row.enforcement.initiation),
+    initiationDetail: row.enforcement.initiation,
+    todaySentence: TIER_SENTENCE[row.start_tier],
+    startVerbatim: row.start_verbatim,
+    canBecomeSentence: graduates ? TIER_SENTENCE[row.ceiling_tier] : null,
+    canBecomeVerbatim: graduates ? row.ceiling_verbatim : null,
+    capVerbatim: graduates ? null : row.ceiling_verbatim,
+    skills: row.skills.map((slug) => ({
+      name: humanizeSkillName(slug),
+      slug,
+      summary: SKILL_SUMMARIES[slug] ?? null,
+    })),
+  }
+}
+
+/**
+ * Group rows into sections by `letter_section`, preserving each section's
+ * first-appearance order and each row's order within it (grid order — the way
+ * the client narrates the work to themselves, structure doc §2). The Map keeps
+ * insertion order for its keys; `order` records first appearance explicitly for
+ * clarity.
+ */
+function group(rows: readonly RoutineGridRow[]): WorkSection[] {
+  const order: string[] = []
+  const bySection = new Map<string, WorkRoutineView[]>()
+  for (const row of rows) {
+    if (!bySection.has(row.letter_section)) {
+      bySection.set(row.letter_section, [])
+      order.push(row.letter_section)
+    }
+    bySection.get(row.letter_section)!.push(toRoutineView(row))
+  }
+  return order.map((name) => ({ name, routines: bySection.get(name)! }))
+}
+
+/**
+ * Compose the "The work" view model from the config projection. When a validated
+ * routine grid is present, render it lifecycle-grouped (grid mode). Otherwise —
+ * no grid authored, or a null config — degrade to the Skills inventory
+ * (gridless mode), reusing the Skills resolver so the fallback is identical to
+ * today's Skills page.
+ */
+export function resolveOperatorWork(config: CustomerConfigRow | null): OperatorWorkModel {
+  const grid = config?.routine_grid ?? null
+  if (!grid) {
+    return { mode: 'gridless', skills: resolveOperatorSkills(config).skills }
+  }
+  return { mode: 'grid', sections: group(grid.rows) }
+}

--- a/src/pages/admin/operator/[customer]/config.astro
+++ b/src/pages/admin/operator/[customer]/config.astro
@@ -4,6 +4,8 @@ import { resolveEntityIdBySlug } from '../../../../lib/admin/operator-overview'
 import { sectionPresence, presenceBadge, toneSummary } from '../../../../lib/admin/config-view'
 import { personaStatusDisplay, skillCountLabel } from '../../../../lib/admin/operator-overview'
 import { getCustomerConfig, type CustomerConfigRow } from '../../../../lib/portal/customer-config'
+import { resolveOperatorWork } from '../../../../lib/portal/operator/facets/work/work'
+import OperatorWork from '../../../../components/portal/operator/facets/OperatorWork.astro'
 import { env } from 'cloudflare:workers'
 
 /**
@@ -45,6 +47,11 @@ const sections = config
       { label: 'Escalation', presence: sectionPresence(config.escalation) },
     ]
   : []
+
+// "The work" chapter (ADR 0076 / console structure doc §3.2) — the same shared
+// resolver + viewer the client portal mounts, reading the same routine-grid
+// projection. Admin gets the plain read (no DomainSurface / request path).
+const workModel = config ? resolveOperatorWork(config) : null
 ---
 
 <AdminLayout
@@ -180,6 +187,18 @@ const sections = config
                 These sections are shown as configured / not set; their detailed editors land with
                 the config-authoring write path.
               </p>
+            </div>
+
+            <div class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card">
+              <h3 class="text-base font-semibold text-[color:var(--ss-color-text-primary)] mb-1">
+                The work
+              </h3>
+              <p class="text-sm text-[color:var(--ss-color-text-secondary)] mb-4">
+                What this operator does, stage by stage, and how much it does on its own — the same
+                view the client sees. Grid-backed when a routine grid is projected; otherwise the
+                skills inventory.
+              </p>
+              {workModel && <OperatorWork model={workModel} />}
             </div>
           </>
         )

--- a/src/pages/portal/products/operator/[instance]/index.astro
+++ b/src/pages/portal/products/operator/[instance]/index.astro
@@ -28,9 +28,15 @@ import { env } from 'cloudflare:workers'
  * work (a draft to review) flows through the real channels — the mailbox, the
  * alert — never here. The surface answers three questions:
  *   Status     — is it OK? (operator health only; no business-work queue)
- *   Role       — what does it do? (Persona · Scope · Skills · Schedule · Workflows)
- *   Management — fix, change, or retrieve (Governance · Voice · Connections ·
- *                Team · Memory · Activity), with Account (the commercial layer) last.
+ *   Role       — what does it do? (Persona · Scope · The work)
+ *   Management — fix, change, or retrieve (Voice · Connections · Team · Memory ·
+ *                Activity), with Account (the commercial layer) last.
+ *
+ * "The work" (ADR 0076; console structure doc §3.2) is the console spine — the
+ * rendered routine grid, stage by stage, with how much the operator does on its
+ * own per duty. It absorbs the former Skills, Schedule, Workflows (Role) and
+ * Governance (Management) doors into one destination; the Skills page stays
+ * routable as the grid's gridless fallback but no longer has a door.
  *
  * Every door leads to a facet's own page. Facets whose page isn't built yet carry
  * href: null and render as present-but-not-yet-built (honest, never "coming
@@ -103,9 +109,10 @@ if (access) {
 }
 const heroModel = resolveOperatorHero(customerConfig, alivenessSignal)
 
-// The operator's facet map (brief §5). Governance/Voice deep-link to today's
-// Configure page until each is split into its own briefed surface; the facets
-// with no page yet (Persona, Schedule, Workflows, Memory) carry href: null.
+// The operator's facet map (brief §5). Voice deep-links to today's Configure
+// page until it is split into its own briefed surface; the facets with no page
+// yet (Persona, Memory) carry href: null. "The work" is the built spine that
+// absorbs Skills/Schedule/Workflows/Governance (structure doc §3.2).
 const CONFIGURE = `${operatorBase}/configure`
 const roleDoors: FacetDoor[] = [
   {
@@ -119,27 +126,12 @@ const roleDoors: FacetDoor[] = [
     href: `${operatorBase}/scope`,
   },
   {
-    label: 'Skills',
-    desc: 'Everything it can do, and how each one gets set in motion.',
-    href: `${operatorBase}/skills`,
-  },
-  {
-    label: 'Schedule',
-    desc: 'The recurring jobs it runs, and the hours it works.',
-    href: null,
-  },
-  {
-    label: 'Workflows',
-    desc: 'The multi-step processes it follows to get work done.',
-    href: null,
+    label: 'The work',
+    desc: 'Everything it does, stage by stage, and how much it does on its own.',
+    href: `${operatorBase}/work`,
   },
 ]
 const manageDoors: FacetDoor[] = [
-  {
-    label: 'Governance',
-    desc: 'What it may do on its own vs. what needs your sign-off.',
-    href: CONFIGURE,
-  },
   { label: 'Voice', desc: 'How it sounds when it writes on your behalf.', href: CONFIGURE },
   {
     label: 'Connections',

--- a/src/pages/portal/products/operator/[instance]/work/index.astro
+++ b/src/pages/portal/products/operator/[instance]/work/index.astro
@@ -1,0 +1,101 @@
+---
+import PortalShell from '../../../../../../layouts/PortalShell.astro'
+import { resolveOperatorAccess } from '../../../../../../lib/portal/operator-access'
+import { resolveOperatorWork } from '../../../../../../lib/portal/operator/facets/work/work'
+import PortalPageHead from '../../../../../../components/portal/PortalPageHead.astro'
+import DomainSurface from '../../../../../../components/portal/operator/DomainSurface.astro'
+import OperatorWork from '../../../../../../components/portal/operator/facets/OperatorWork.astro'
+import { env } from 'cloudflare:workers'
+
+/**
+ * Operator — The work (ADR 0076; console structure doc §3.2; signed-off brief
+ * docs/design/operator/surface-briefs/operator-the-work.md). Chapter 2, the
+ * console spine: the operator's whole job rendered stage by stage, with how each
+ * duty starts and how much it does on its own. Absorbs the Skills, Schedule,
+ * Workflows, and Governance doors from the landing.
+ *
+ * URL: portal.smd.services/portal/products/operator/<instance>/work
+ *
+ * Read for all account roles (principal / staff / compliance), matching the
+ * other operator surfaces. The one forward action is the generic "Request a
+ * change" via the same <DomainSurface> (configuration domain) the Skills page
+ * uses — no per-routine actions in this read-only build (Captain reset
+ * 2026-07-14).
+ *
+ * The view model is the one shared resolver; it renders through the one shared
+ * <OperatorWork> viewer both portals mount (Lock 4). Grid mode renders the
+ * projected routine grid; a gridless seat degrades to the Skills inventory.
+ */
+
+const instance = Astro.params.instance
+if (!instance) return Astro.redirect('/portal/products/operator')
+const operatorBase = `/portal/products/operator/${instance}`
+
+const access = await resolveOperatorAccess(env.DB, Astro.locals, {
+  allowedRoles: ['principal', 'staff', 'compliance'],
+  customerSlug: instance,
+})
+if (access.kind === 'redirect') {
+  return Astro.redirect(access.to)
+}
+const { client, roles } = access
+
+const model = resolveOperatorWork(access.config)
+
+const RETURN_TO = `${operatorBase}/work`
+
+const cr = Astro.url.searchParams.get('cr')
+const crMessage =
+  cr === 'filed'
+    ? 'Your request was sent.'
+    : cr === 'invalid'
+      ? "That request couldn't be filed. Please add a short description and try again."
+      : cr === 'error'
+        ? 'Something went wrong filing your request. Please try again.'
+        : null
+---
+
+<PortalShell
+  title="Operator · The work"
+  clientName={client.name}
+  orgId={client.org_id}
+  entityId={client.id}
+  pathname={Astro.url.pathname}
+>
+  <PortalPageHead crumbHref={operatorBase} crumbLabel="Operator" h1="The work" meta={null} />
+
+  {
+    crMessage && (
+      <div
+        role="status"
+        class={`mt-6 border-[3px] px-5 py-3 font-mono text-label uppercase tracking-[0.14em] font-bold ${
+          cr === 'filed'
+            ? 'border-[color:var(--ss-color-complete)] text-[color:var(--ss-color-complete)]'
+            : 'border-[color:var(--ss-color-error)] text-[color:var(--ss-color-error)]'
+        }`}
+      >
+        {crMessage}
+      </div>
+    )
+  }
+
+  <p
+    class="mt-8 font-mono text-label uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)]"
+  >
+    Everything your operator does, stage by stage, and how much it does on its own.
+  </p>
+
+  <div class="mt-4">
+    <DomainSurface
+      authority={access.config?.authority ?? null}
+      domain="configuration"
+      roles={roles}
+      returnTo={RETURN_TO}
+      domainLabel="the work"
+    >
+      <div slot="read">
+        <OperatorWork model={model} />
+      </div>
+    </DomainSurface>
+  </div>
+</PortalShell>

--- a/tests/forbidden-strings.test.ts
+++ b/tests/forbidden-strings.test.ts
@@ -817,6 +817,7 @@ const CALM_REGISTER_PENDING: string[] = [
   'src/pages/portal/products/operator/[instance]/index.astro',
   'src/components/portal/operator/facets/OperatorHero.astro',
   'src/components/portal/operator/facets/OperatorSkills.astro',
+  'src/components/portal/operator/facets/OperatorWork.astro',
   'src/components/portal/operator/facets/OperatorScope.astro',
   'src/components/portal/operator/FacetDoorList.astro',
   'src/components/admin/EntityContactRow.astro',
@@ -865,6 +866,7 @@ const CALM_REGISTER_PENDING: string[] = [
   'src/pages/portal/products/operator/[instance]/settings/index.astro',
   'src/pages/portal/products/operator/[instance]/settings/users.astro',
   'src/pages/portal/products/operator/[instance]/skills/index.astro',
+  'src/pages/portal/products/operator/[instance]/work/index.astro',
   'src/pages/portal/products/operator/[instance]/scope/index.astro',
   'src/pages/portal/products/operator/[instance]/team/index.astro',
 ]

--- a/tests/operator-work-facet.test.ts
+++ b/tests/operator-work-facet.test.ts
@@ -1,0 +1,251 @@
+import { describe, it, expect } from 'vitest'
+import { startsLabels, resolveOperatorWork } from '../src/lib/portal/operator/facets/work/work'
+import { SKILL_SUMMARIES } from '../src/lib/portal/operator/facets/skills/skill-summaries'
+import type {
+  CustomerConfigRow,
+  PersonaConfig,
+  PersonaSkill,
+} from '../src/lib/portal/customer-config'
+import type {
+  RoutineGrid,
+  RoutineGridRow,
+  RoutineGridEnforcement,
+  RoutineTier,
+} from '../src/lib/operator/routine-grid'
+import type { SkillInitiation } from '../src/lib/operator/customer-yaml/types'
+
+/**
+ * Operator "The work" facet resolver (ADR 0076; console structure doc §3.2).
+ * Read-only projection of the routine grid (ADR 0075) into the lifecycle-grouped
+ * view model, plus the gridless skills fallback. Every rendered fact traces to
+ * an authored grid field, the fixed tier / starts maps, or the reviewed skill
+ * summaries — nothing invented.
+ *
+ * Fixtures carry NO vertical vocabulary: the grid supplies the vertical as DATA
+ * at runtime, so the resolver (and these fixtures) stay neutral.
+ */
+
+// 'health-monitor' is a real, vertical-neutral entry in the reviewed summaries
+// catalog — used to prove a summary is attached from the catalog, never invented.
+const SUMMARIZED_SLUG = 'health-monitor'
+
+function enforcement(p: Partial<RoutineGridEnforcement> = {}): RoutineGridEnforcement {
+  return {
+    initiation: 'manual',
+    exposure_keys: {},
+    content_floor: false,
+    banned_tools: [],
+    notes: '',
+    ...p,
+  }
+}
+
+function row(p: Partial<RoutineGridRow> = {}): RoutineGridRow {
+  // Ceiling defaults to the start tier (no graduation headroom) unless the
+  // fixture sets it explicitly. Tiers are applied LAST so the computed defaults
+  // win over the base literals, without duplicating keys across the spread.
+  const start_tier: RoutineTier = p.start_tier ?? 'flag-only'
+  const ceiling_tier: RoutineTier = p.ceiling_tier ?? start_tier
+  return {
+    routine: 'A routine',
+    letter_section: 'Section one',
+    skills: [],
+    start_verbatim: 'We surface it.',
+    ceiling_verbatim: 'We surface it.',
+    enforcement: enforcement(),
+    ...p,
+    start_tier,
+    ceiling_tier,
+  }
+}
+
+function grid(rows: RoutineGridRow[]): RoutineGrid {
+  return {
+    adr: 'ADR 0075',
+    seat: 'test-seat',
+    persona: 'test-persona',
+    source_letter: 'test-letter',
+    rows,
+  }
+}
+
+/** Grid-mode config: only routine_grid is read in this branch. */
+function gridConfig(rows: RoutineGridRow[]): CustomerConfigRow {
+  return { routine_grid: grid(rows), personas: [] } as unknown as CustomerConfigRow
+}
+
+// --- gridless-mode fixtures (mirror the skills resolver's inputs) -------------
+
+function init(p: Partial<SkillInitiation> = {}): SkillInitiation {
+  return { manual: false, scheduled: false, webhook: false, ...p }
+}
+
+function skill(name: string, i: Partial<SkillInitiation> = {}): PersonaSkill {
+  return { name, initiation: init(i) }
+}
+
+function persona(p: Partial<PersonaConfig>): PersonaConfig {
+  return {
+    slug: 'p',
+    status: 'active',
+    name: 'X',
+    title: null,
+    signature_html: null,
+    tone: [],
+    send_as: null,
+    entitlements: {} as PersonaConfig['entitlements'],
+    skills: [],
+    channel_bindings: [],
+    ...p,
+  }
+}
+
+/** Gridless-mode config: no grid, skills read from the active persona. */
+function gridlessConfig(personas: PersonaConfig[]): CustomerConfigRow {
+  return { routine_grid: null, personas } as unknown as CustomerConfigRow
+}
+
+describe('startsLabels', () => {
+  it('maps each initiation mode to its client-legible label by substring detection', () => {
+    expect(startsLabels('manual')).toEqual(['On request'])
+    expect(startsLabels('scheduled')).toEqual(['On a schedule'])
+    expect(startsLabels('webhook')).toEqual(['When something happens'])
+  })
+
+  it('detects modes inside a free-text initiation string, in a stable order', () => {
+    // Words appear out of canonical order in the source string; output is fixed
+    // request → schedule → event regardless.
+    expect(startsLabels('webhook and scheduled; also manual')).toEqual([
+      'On request',
+      'On a schedule',
+      'When something happens',
+    ])
+  })
+
+  it('returns [] when no known mode is present (viewer shows nothing)', () => {
+    expect(startsLabels('')).toEqual([])
+    expect(startsLabels('something else entirely')).toEqual([])
+  })
+})
+
+describe('resolveOperatorWork — grid mode', () => {
+  it('groups rows into sections by letter_section in first-appearance order, preserving row order', () => {
+    const model = resolveOperatorWork(
+      gridConfig([
+        row({ routine: 'First', letter_section: 'Alpha' }),
+        row({ routine: 'Second', letter_section: 'Beta' }),
+        row({ routine: 'Third', letter_section: 'Alpha' }),
+      ])
+    )
+    expect(model.mode).toBe('grid')
+    if (model.mode !== 'grid') return
+    expect(model.sections.map((s) => s.name)).toEqual(['Alpha', 'Beta'])
+    expect(model.sections[0].routines.map((r) => r.routine)).toEqual(['First', 'Third'])
+    expect(model.sections[1].routines.map((r) => r.routine)).toEqual(['Second'])
+  })
+
+  it('renders each tier as its locked plain sentence for the Today line', () => {
+    const model = resolveOperatorWork(
+      gridConfig([
+        row({ routine: 'a', start_tier: 'flag-only' }),
+        row({ routine: 'b', start_tier: 'prepare-and-route' }),
+        row({ routine: 'c', start_tier: 'auto-handle' }),
+      ])
+    )
+    if (model.mode !== 'grid') throw new Error('expected grid mode')
+    const today = model.sections[0].routines.map((r) => r.todaySentence)
+    expect(today).toEqual(['Surfaces it', 'Prepares it for you', 'Handles it'])
+  })
+
+  it('surfaces a Can-become sentence + verbatim when the ceiling exceeds the start (headroom)', () => {
+    const model = resolveOperatorWork(
+      gridConfig([
+        row({
+          start_tier: 'prepare-and-route',
+          ceiling_tier: 'auto-handle',
+          ceiling_verbatim: 'You may authorize sending on its own.',
+        }),
+      ])
+    )
+    if (model.mode !== 'grid') throw new Error('expected grid mode')
+    const r = model.sections[0].routines[0]
+    expect(r.canBecomeSentence).toBe('Handles it')
+    expect(r.canBecomeVerbatim).toBe('You may authorize sending on its own.')
+    expect(r.capVerbatim).toBeNull()
+  })
+
+  it('renders the ceiling verbatim as the standing cap (no Can-become) when ceiling equals start', () => {
+    const model = resolveOperatorWork(
+      gridConfig([
+        row({
+          start_tier: 'flag-only',
+          ceiling_tier: 'flag-only',
+          ceiling_verbatim: 'It never acts on its own here.',
+        }),
+      ])
+    )
+    if (model.mode !== 'grid') throw new Error('expected grid mode')
+    const r = model.sections[0].routines[0]
+    expect(r.canBecomeSentence).toBeNull()
+    expect(r.canBecomeVerbatim).toBeNull()
+    expect(r.capVerbatim).toBe('It never acts on its own here.')
+  })
+
+  it('parses the row initiation into client-legible starts labels', () => {
+    const model = resolveOperatorWork(
+      gridConfig([row({ enforcement: enforcement({ initiation: 'manual, scheduled' }) })])
+    )
+    if (model.mode !== 'grid') throw new Error('expected grid mode')
+    expect(model.sections[0].routines[0].startsLabels).toEqual(['On request', 'On a schedule'])
+  })
+
+  it('humanizes implementing-skill slugs and attaches the reviewed summary, null when uncatalogued', () => {
+    const model = resolveOperatorWork(
+      gridConfig([row({ skills: [SUMMARIZED_SLUG, 'a-skill-with-no-summary'] })])
+    )
+    if (model.mode !== 'grid') throw new Error('expected grid mode')
+    const skills = model.sections[0].routines[0].skills
+    expect(skills[0]).toEqual({
+      name: 'Health monitor',
+      slug: SUMMARIZED_SLUG,
+      summary: SKILL_SUMMARIES[SUMMARIZED_SLUG],
+    })
+    expect(skills[1].summary).toBeNull()
+  })
+})
+
+describe('resolveOperatorWork — gridless fallback', () => {
+  it('degrades to the skills inventory (identical to the Skills resolver) when no grid is projected', () => {
+    const model = resolveOperatorWork(
+      gridlessConfig([
+        persona({
+          skills: [
+            skill('welcome-message', { webhook: true }),
+            skill('weekly-summary', { scheduled: true }),
+          ],
+        }),
+      ])
+    )
+    expect(model.mode).toBe('gridless')
+    if (model.mode !== 'gridless') return
+    expect(model.skills.map((s) => s.slug)).toEqual(['welcome-message', 'weekly-summary'])
+    expect(model.skills[0].name).toBe('Welcome message')
+    expect(model.skills[0].initiation).toEqual(['When something happens'])
+    expect(model.skills[1].initiation).toEqual(['On a schedule'])
+  })
+
+  it('is gridless with an empty skills list when config is null (honest empty state)', () => {
+    const model = resolveOperatorWork(null)
+    expect(model.mode).toBe('gridless')
+    if (model.mode !== 'gridless') return
+    expect(model.skills).toEqual([])
+  })
+
+  it('is gridless with an empty skills list when a gridless config has no active persona', () => {
+    const model = resolveOperatorWork(
+      gridlessConfig([persona({ status: 'archived', skills: [skill('x', { manual: true })] })])
+    )
+    if (model.mode !== 'gridless') throw new Error('expected gridless mode')
+    expect(model.skills).toEqual([])
+  })
+})


### PR DESCRIPTION
## What

Builds **Chapter 2 of the operator console — "The work"** (ADR 0076; console structure doc §3.2, LOCKED). It renders the authored routine grid (ADR 0075) as the console spine: every duty grouped by lifecycle section, one row per routine, with how each starts and how much the operator does on its own. It is a **read-only, accurate rendering** on **both portals** (client + admin) off the same projection — the job description crossed with a delegation-of-authority matrix.

Per the Captain reset (2026-07-14): **no** graduation buttons, **no** per-routine actions, **no** new change-request mechanics, **no** invented client-facing copy. Every rendered string traces to (a) authored grid data, (b) the reviewed skill-summaries catalog, or (c) the fixed tier / starts-label maps.

## Why

Three prior console pages were built from a config mechanism and failed a client question ("what's its job", "what can it see", "how much can it do alone"). The routine matrix is the one console-like artifact a real customer engaged with successfully. This chapter renders that artifact from `routine-grid.yaml`, projected into `customer_configs.routine_grid_json`, and collapses four planned pages (Skills, Schedule, Workflows, Governance) into one destination.

## Changes

- **Shared resolver** `src/lib/portal/operator/facets/work/work.ts` (pure): grid mode groups rows by `letter_section` in first-appearance order; tier map `flag-only`/`prepare-and-route`/`auto-handle` → "Surfaces it" / "Prepares it for you" / "Handles it"; Today from `start_tier`; Can-become only when `ceiling_tier` exceeds `start_tier`, else the ceiling verbatim renders as a standing cap; starts labels by substring detection on `enforcement.initiation`; implementing skills via the existing `humanizeSkillName` + `SKILL_SUMMARIES`. Gridless/null config reuses `resolveOperatorSkills`.
- **Shared viewer** `OperatorWork.astro` (+ extracted `OperatorWorkRow.astro` to keep each component small), loud register matching `OperatorSkills`.
- **Client page** `[instance]/work/index.astro` — mirrors the skills page (roles principal/staff/compliance, PortalPageHead crumb Operator, generic Request-a-change only).
- **Admin mount** — a "The work" card in `src/pages/admin/operator/[customer]/config.astro` mounting the **same shared resolver + viewer** off the same `getCustomerConfig` projection; plain read, no DomainSurface / request path.
- **Landing doors** `[instance]/index.astro` — Skills, Schedule, Workflows (Role) and Governance (Management) doors replaced by one Role door "The work". Persona and Scope unchanged; Skills page stays routable, loses its door.
- **Registry** `facet-registry.ts` — `workflow` → `has_viewer` at the work resolver, plane `no_schema` → `config_projection` (the grid is the schema, arrived via ADR 0075); `skills` (now detail/fallback of The work), `schedule`, `entitlements` notes updated. Nothing else touched.
- **Tests** `tests/operator-work-facet.test.ts` (14 cases: section grouping order, tier sentences, ceiling==start → capVerbatim, initiation parsing, gridless fallback, null config). New viewer + page added to `CALM_REGISTER_PENDING`. Fixtures carry zero vertical vocabulary (grid supplies the vertical as data at runtime).

## Verify

`npm run verify` fully green (EXIT=0):
- `astro check` — 0 errors, 0 warnings, 16 (pre-existing) hints
- `prettier --check .` — all files clean
- `eslint .` — clean (the `max-lines-per-function` error was resolved by extracting `OperatorWorkRow.astro`)
- test — main suite + all worker suites pass; `operator-work-facet`, `operator-facet-legibility`, and `forbidden-strings` guards all green

Grid-mode rendering is exercised by the unit tests against the real `RoutineGrid` type; the live pilot-smokeball 19-row grid renders on merge + deploy (projection auto-syncs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016UK3pbT62argSz7fS3ZZNU
