### PR TITLE
fix(operator): chase config-missing surface re-fires until dials are authored

### DIFF
--- a/operator/skills/client-verification-tracker/SKILL.md
+++ b/operator/skills/client-verification-tracker/SKILL.md
@@ -257,12 +257,16 @@ matter for the chase:
   signed-document close) is likewise terminal.
 
 The **internal escalation-to-a-person** (both the ceiling hand-off and the
-single "cadence/attempt-count not authored" surface) therefore follows the same
-fire-once, terminal-aware rule the deadline lane uses — it never re-sends the
-same alert on a later wake. When `chase_cadence_days` or `escalate_after_attempts`
-is unauthored, the pre_run surfaces the missing-config note **once** (recorded on
-a config sentinel in the ledger) and then holds quiet, rather than either
-defaulting to an interval or re-surfacing daily.
+"cadence/attempt-count not authored" surface) therefore follows the same
+fire-once + re-fire-window, terminal-aware rule the deadline lane uses — it
+never re-sends the same alert on the next wake. When `chase_cadence_days` or
+`escalate_after_attempts` is unauthored, the pre_run surfaces the missing-config
+note (recorded on a config sentinel in the ledger), holds quiet through the
+re-fire window, and then **re-surfaces every `escalation.refire_days`** until
+the dials are authored (#1899) — a held chase must not go permanently dark on
+one missed notice. An `acked` on the sentinel snoozes it for the same window;
+authoring the dials ends the loop. It never defaults to an interval and never
+re-surfaces daily.
 
 If the ledger cannot be read, the pre_run **fires open** (wakes) rather than going
 silent — a chase watcher that goes quiet is the dangerous failure. If the config
@@ -310,8 +314,9 @@ surface), never a silent default.
      ledger event so the hand-off fires once; the client chase is done, the open item
      moves to a person.
    - `chase_cadence_days` or `escalate_after_attempts` unauthored → send no chase;
-     surface the missing-config note once (recorded on the ledger config sentinel),
-     then hold quiet.
+     surface the missing-config note (append a `fired` event on the ledger config
+     sentinel so the raise is remembered), hold quiet through the re-fire window,
+     and re-surface every `escalation.refire_days` until the dials are authored.
 6. **Escalate** — two independent triggers, either of which fires on its own; the
    chase's own trigger is the attempt count, and it points to the deadline lane for
    the other rather than duplicating it:

--- a/operator/skills/client-verification-tracker/pre_run.py
+++ b/operator/skills/client-verification-tracker/pre_run.py
@@ -31,9 +31,12 @@ Plus one seat-level condition:
 
   (c) CONFIG MISSING — ``chase_cadence_days`` or ``escalate_after_attempts`` is
       not authored: these are client-commitment numbers (File 07), so there is NO
-      pack default. Fail-closed: wake ONCE to surface "chase cadence / escalation
-      attempt-count not authored", record that surface in the ledger, then stay
-      quiet. An unset dial holds the chase; it never releases it and never spams.
+      pack default. Fail-closed: wake to surface "chase cadence / escalation
+      attempt-count not authored", record that surface in the ledger, and then
+      re-surface on the shared fire-once + re-fire-window rule (every
+      ``refire_days``) until the dials are authored — a chase held dark must not
+      go permanently silent on one missed notice (#1899). An unset dial holds
+      the client chase; it never releases it and never daily-spams.
 
 Everything else -> a ``SUPPRESSED_WAKE`` heartbeat through the broker, then
 ``{"wakeAgent": false}``. The heartbeat IS the dead-man's-switch: a scheduled
@@ -58,8 +61,8 @@ Fail direction (per the plan)
   pre-graduation behavior. Never silently skip a chase.
 - Smokeball pull failure / unrecognized envelope -> FIRE-OPEN (wake).
 - Config file unreadable / unauthored -> treat as unauthored: fail-CLOSED hold
-  plus the single "config missing" surface (condition (c)), never a silent
-  default and never a spam loop.
+  plus the re-fired "config missing" surface (condition (c)), never a silent
+  default and never a daily spam loop.
 
 ``decide()`` is a pure function (no I/O), unit-tested with fake inputs.
 ``run_once()`` wires the real verification-task source + broker heartbeat + stdout.
@@ -85,7 +88,8 @@ from typing import Protocol, Sequence
 SKILL_NAME = "client-verification-tracker"
 
 # The config-missing surface is seat-level, not per-item. It is remembered in the
-# ledger under a stable sentinel item_key so it fires exactly once (then quiet).
+# ledger under a stable sentinel item_key so it fires on the re-fire window
+# (every refire_days until authored), never daily (#1899).
 _CONFIG_SENTINEL_SOURCE_ID = "__chase_config__"
 _CONFIG_SENTINEL_LABEL = "chase-config-missing"
 
@@ -136,7 +140,7 @@ class VerificationSource(Protocol):
 
 # ---------------------------------------------------------------------------
 # Chase config — CLIENT-COMMITMENT numbers (File 07). No pack default: unset is
-# fail-closed hold + single surface, never a silent interval (ADR 0035).
+# fail-closed hold + re-fired surface, never a silent interval (ADR 0035).
 # ---------------------------------------------------------------------------
 
 
@@ -277,7 +281,7 @@ def _load_ledger_module():
 # Per-item actions the decision can reach.
 ACTION_CHASE = "chase"  # a client nudge is due (attempt < ceiling)
 ACTION_HANDOFF = "handoff"  # ceiling reached; stop chasing, hand to the attorney (once)
-ACTION_SURFACE_CONFIG = "surface_config_missing"  # seat-level, once
+ACTION_SURFACE_CONFIG = "surface_config_missing"  # seat-level, on the refire window
 ACTION_SUPPRESS = "suppress"  # nothing due for this item
 
 
@@ -335,22 +339,27 @@ def decide(
     """
     states = ledger.derive_state(events)
 
-    # (c) Seat-level: config unauthored → fail-closed hold + single surface.
+    # (c) Seat-level: config unauthored → fail-closed hold + re-fired surface.
+    # The sentinel follows the same fire-once + re-fire-window rule as every
+    # other internal raise (never daily, but never once-ever either): a held
+    # chase re-surfaces every refire_days until the dials are authored (#1899).
     if not config.authored:
         sentinel_key = ledger.item_key(
             "", _CONFIG_SENTINEL_SOURCE_ID, _CONFIG_SENTINEL_LABEL, ""
         )
-        already_surfaced = sentinel_key in states  # any prior raise = surfaced once
-        if already_surfaced:
+        sentinel_state = states.get(sentinel_key)
+        if not ledger.should_fire(
+            sentinel_state, today, refire_days=refire_days, ack_snooze_days=refire_days
+        ):
             return WakeDecision(
                 wake=False,
-                decision_basis="chase_config_unauthored_already_surfaced",
+                decision_basis="chase_config_unauthored_within_refire_window",
                 pre_run_inputs_digest=raw_inputs_for_digest,
                 extra_metadata={"open_item_count": len(items)},
             )
         return WakeDecision(
             wake=True,
-            decision_basis="chase_config_unauthored_surface_once",
+            decision_basis="chase_config_unauthored_surface",
             pre_run_inputs_digest=raw_inputs_for_digest,
             plans=(
                 ItemPlan(
@@ -358,7 +367,7 @@ def decide(
                     task_id=None,
                     item_key=sentinel_key,
                     action=ACTION_SURFACE_CONFIG,
-                    attempt=0,
+                    attempt=ledger.next_attempt(sentinel_state),
                 ),
             ),
             extra_metadata={
@@ -487,7 +496,7 @@ async def run_once(
 
     Fail-open on ledger loss: if the ledger module cannot be loaded, wake (the
     pre-graduation behavior). Config-read is the unauthored path on failure, but
-    that is handled inside ``decide`` (surface-once), not here.
+    that is handled inside ``decide`` (re-fired surface), not here.
     ``config``/``refire_days``/``ledger_events`` default to the live config +
     on-disk ledger; tests inject them directly."""
     now = now or datetime.now(timezone.utc)

--- a/operator/skills/client-verification-tracker/test_verification_pre_run.py
+++ b/operator/skills/client-verification-tracker/test_verification_pre_run.py
@@ -261,39 +261,74 @@ def test_resolved_is_terminal_and_suppresses():
 
 
 # ---------------------------------------------------------------------------
-# decide() — unauthored config (condition c): single surface, then quiet
+# decide() — unauthored config (condition c): surface, hold, re-fire until
+# authored (#1899). Never daily, never once-ever.
 # ---------------------------------------------------------------------------
 
 
-def _config_sentinel_fired():
+def _config_sentinel_fired(*, ts="2026-07-10T09:00:00.000Z", attempt=1):
     key = _ledger.item_key("", "__chase_config__", "chase-config-missing", "")
     return _ledger.make_event(
         skill="client-verification-tracker",
         matter_id=None,
         item_key=key,
         event="fired",
-        attempt=1,
-        ts="2026-07-10T09:00:00.000Z",
+        attempt=attempt,
+        ts=ts,
     )
 
 
-def test_unauthored_config_surfaces_once():
-    # Cadence missing → surface once, no chase of the open item.
+def test_unauthored_config_surfaces():
+    # Cadence missing → surface, no chase of the open item.
     d = _decide([_item(next_chase_due=TODAY)], [], config=ChaseConfig(escalate_after_attempts=3))
     assert d.wake is True
     assert d.plans[0].action == ACTION_SURFACE_CONFIG
+    assert d.plans[0].attempt == 1  # first surface
     assert "chase_cadence_days" in d.extra_metadata["missing"]
 
 
-def test_unauthored_config_quiet_after_surface():
-    # A prior config-missing raise in the ledger → do not surface again.
+def test_unauthored_config_quiet_within_refire_window():
+    # Surfaced 2 days ago, refire window 3 → hold quiet, do not re-surface yet.
     d = _decide(
         [_item(next_chase_due=TODAY)],
-        [_config_sentinel_fired()],
+        [_config_sentinel_fired(ts="2026-07-12T09:00:00.000Z")],
         config=ChaseConfig(chase_cadence_days=5),  # ceiling missing
     )
     assert d.wake is False
-    assert d.decision_basis == "chase_config_unauthored_already_surfaced"
+    assert d.decision_basis == "chase_config_unauthored_within_refire_window"
+
+
+def test_unauthored_config_resurfaces_after_refire_window():
+    # Surfaced 4 days ago, refire window 3, dials still unauthored → re-surface
+    # (#1899: a held chase must not go permanently dark on one missed notice).
+    d = _decide(
+        [_item(next_chase_due=TODAY)],
+        [_config_sentinel_fired(ts="2026-07-10T09:00:00.000Z")],
+        config=ChaseConfig(chase_cadence_days=5),  # ceiling missing
+    )
+    assert d.wake is True
+    assert d.plans[0].action == ACTION_SURFACE_CONFIG
+    assert d.plans[0].attempt == 2  # second surface, numbered from the ledger
+
+
+def test_unauthored_config_ack_snoozes_the_surface():
+    # Staff acked the config notice yesterday → snoozed (ack window = refire
+    # window), not re-fired, and still no chase.
+    key = _ledger.item_key("", "__chase_config__", "chase-config-missing", "")
+    events = [
+        _config_sentinel_fired(ts="2026-07-10T09:00:00.000Z"),
+        _ledger.make_event(
+            skill="client-verification-tracker",
+            matter_id=None,
+            item_key=key,
+            event="acked",
+            attempt=1,
+            ts="2026-07-13T09:00:00.000Z",
+        ),
+    ]
+    d = _decide([_item(next_chase_due=TODAY)], events, config=ChaseConfig())
+    assert d.wake is False
+    assert d.decision_basis == "chase_config_unauthored_within_refire_window"
 
 
 def test_unauthored_config_never_chases():


### PR DESCRIPTION
Closes #1899. Follow-on from #1895 (Captain-directed).

**The gap.** When the firm's chase dials (`chase_cadence_days` / `escalate_after_attempts`) were unauthored, the internal "chase config missing" notice fired exactly once, ever. One missed notice left the chase dark indefinitely: no client reminders, no repeat nag — a client could correctly say they were never chased.

**The fix.** The config sentinel now follows the same fire-once + re-fire-window rule as every other internal raise, via the ledger's existing `should_fire()`: surface, hold quiet through `escalation.refire_days` (pack default 3), re-surface until the dials are authored. An `acked` on the sentinel snoozes it for the same window; authoring the dials ends the loop. Surfaces are attempt-numbered from the ledger. The fail-closed hold on client chasing is unchanged — no invented cadence (ADR 0035 / File 07).

Also updates the stale once-ever language in the module docstrings and SKILL.md (the `_DEFAULT_REFIRE_DAYS` comment already claimed this behavior; the implementation now matches it).

**Verification.** New tests: quiet within the window, re-fires after the window (attempt 2), ack snoozes. Substrate suite (exact CI invocation): 856 passed. Pre-push `npm run verify` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MM1hvcoHxjCDAQ56ZbfanM