### PR TITLE
chore(deps): ignore @venturecrane/* in root npm Dependabot (internal private scope)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,6 +37,14 @@ updates:
         update-types:
           - minor
           - patch
+    # Our own packages on the private GitHub Packages registry. We cut and
+    # adopt their versions intentionally as part of coordinated changes —
+    # Dependabot is for external currency/security, not our internal releases,
+    # and it holds no credential for the private scope (the root npm job fails
+    # `private_source_authentication_failure` trying to resolve them). Managed
+    # by us, not Dependabot.
+    ignore:
+      - dependency-name: '@venturecrane/*'
     commit-message:
       prefix: chore(deps)
 


### PR DESCRIPTION
## What

Adds a Dependabot `ignore` for `@venturecrane/*` in the root npm ecosystem.

## Why

After the config-cleanup PR (#1900) merged, the full Dependabot re-run surfaced a pre-existing gap: the root npm job fails `private_source_authentication_failure` trying to resolve a new `@venturecrane/tokens` version from `npm.pkg.github.com`. Dependabot holds no credential for the private GitHub Packages scope — the repo authenticates via `.npmrc` + `NODE_AUTH_TOKEN`, which Dependabot doesn't read. (This produced 3 CI/CD notifications; the root npm job had succeeded as recently as 17:13 today, before a new internal version forced a registry lookup.)

`@venturecrane/tokens` (design tokens, feeding SMD's type/color system) and `@venturecrane/crane-test-harness` (test harness) are **enterprise-shared packages** — we cut and adopt their versions intentionally as part of coordinated changes. Dependabot is for external dependency currency/security, not our internal releases.

## Decision

Ignore the scope rather than mint a `read:packages` PAT for Dependabot. That fixes the auth failure permanently with **no new credential to manage**, and correctly scopes the tool (external currency, not internal release management). No worker depends on `@venturecrane/*`, so the root entry is the only one that needs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)