### PR TITLE
feat(portal): coverage slice 1A — outbound roster, authority view, identity + voice posture (blueprint §4)

### DIFF
--- a/docs/design/operator/surface-briefs/coverage-slice-1.md
+++ b/docs/design/operator/surface-briefs/coverage-slice-1.md
@@ -1,0 +1,39 @@
+# Surface Brief — Coverage slice 1 (blueprint §4 gaps, part A)
+
+Cites: [05-console-blueprint.md](../05-console-blueprint.md) (LOCKED 2026-07-14)
+§4 coverage contract + §8 slice 1.
+Status: built 2026-07-14. Read-only additions to three existing shared viewers;
+no new pages, no new doors, no interaction mechanics.
+
+## What this slice closes
+
+Three of the five §4 coverage gaps, each rendered where the blueprint's chapter
+mapping already puts it:
+
+| §4 gap                             | Where it now renders                                            | Data                                                                                                                                                       |
+| ---------------------------------- | --------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Outbound roster (who it writes to) | Scope viewer, new "Who it writes to for the firm" group         | `scope_json.outbound_roster` (ADR 0075), class labels via closed map                                                                                       |
+| Entitlements as one honest view    | Work surface, new "What it may do on its own" authority block   | active persona `entitlements.exposure` (sparse; unauthored never renders as a row — fail-closed stays invisible, stated once by the fixed footer sentence) |
+| Persona identity + voice posture   | Hero "who it is" lines: Sounds / Writes from / Also operates as | persona `tone` (humanized), `send_as`, other active personas (ADR 0011)                                                                                    |
+
+Occasions served (§3): #1 agreement (the config reads more completely) and
+#2 confirmation ("will it act alone?" now has one page answering globally).
+
+## Deliberately out (remain open §4 rows)
+
+- **Schedule** — plane `config_unprojected`; needs the projection extension
+  first (its own slice, next).
+- **Voice library/samples** — persona tone is the authored voice POSTURE;
+  the library stays a later slice (registry `voice` unchanged).
+
+## Vocabulary note
+
+The authority block's ceiling sentences ("Handles it on its own / Asks first /
+Prepares it for a person / Never") extend the locked tier-sentence register.
+Block heading "What it may do on its own". These join the blueprint §6 table
+at the vocabulary pass (slice 3) for guard enforcement.
+
+## Registry
+
+`entitlements` flips `planned(3)` → `has_viewer` at the work resolver. `scope`
+note gains the outbound group; `voice` unchanged (posture ≠ library).

--- a/src/components/portal/operator/facets/OperatorHero.astro
+++ b/src/components/portal/operator/facets/OperatorHero.astro
@@ -26,6 +26,14 @@ const { model, escalationHref = null } = Astro.props
 const displayName = model.name ?? 'Your operator'
 const personaLine = model.title ? `${displayName} · ${model.title}` : displayName
 
+// "Who it is" detail (console blueprint §4 coverage: persona identity + voice
+// posture). All authored config; each line renders only when authored.
+const toneLine = model.tone.length > 0 ? model.tone.join(' · ') : null
+const alsoLine =
+  model.alsoOperatesAs.length > 0
+    ? model.alsoOperatesAs.map((p) => (p.title ? `${p.name} (${p.title})` : p.name)).join(', ')
+    : null
+
 const HEALTH: Record<AlivenessLevel, { headline: string; dot: string; problem: boolean }> = {
   idle: { headline: 'Running normally', dot: 'bg-[color:var(--color-complete)]', problem: false },
   running: { headline: 'Working now', dot: 'bg-[color:var(--color-complete)]', problem: false },
@@ -61,6 +69,28 @@ const escalationTarget = escalationHref ?? '/portal/products/operator/settings'
   >
     {personaLine}
   </p>
+
+  {
+    (toneLine || model.sendAs || alsoLine) && (
+      <div class="mt-1 flex flex-col gap-0.5">
+        {toneLine && (
+          <p class="font-body text-sm leading-snug text-[color:var(--color-text-secondary)]">
+            Sounds: {toneLine}
+          </p>
+        )}
+        {model.sendAs && (
+          <p class="font-body text-sm leading-snug text-[color:var(--color-text-secondary)]">
+            Writes from: {model.sendAs}
+          </p>
+        )}
+        {alsoLine && (
+          <p class="font-body text-sm leading-snug text-[color:var(--color-text-secondary)]">
+            Also operates as: {alsoLine}
+          </p>
+        )}
+      </div>
+    )
+  }
 
   {
     health ? (

--- a/src/components/portal/operator/facets/OperatorScope.astro
+++ b/src/components/portal/operator/facets/OperatorScope.astro
@@ -82,6 +82,37 @@ const rowValue = 'mt-1 font-body text-sm leading-snug text-[color:var(--color-te
           </div>
 
           <div>
+            <p class={groupLabel}>Who it writes to for the firm</p>
+            {scope.writesTo.length > 0 ? (
+              <>
+                <div class="mt-3 flex flex-col gap-3">
+                  {scope.writesTo.map((w) => (
+                    <div>
+                      <p class={rowValue}>
+                        {w.address}
+                        <span class="ml-2 font-mono text-label uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)]">
+                          {w.classLabel}
+                        </span>
+                      </p>
+                      {w.note && (
+                        <p class="mt-0.5 font-body text-sm leading-snug text-[color:var(--color-text-secondary)]">
+                          {w.note}
+                        </p>
+                      )}
+                    </div>
+                  ))}
+                </div>
+                <p class="mt-2 font-body text-sm leading-snug text-[color:var(--color-text-secondary)]">
+                  Standing recipients a person has authorized for outbound work. This list never
+                  grows on its own.
+                </p>
+              </>
+            ) : (
+              <p class={rowValue}>No standing outside recipients are configured.</p>
+            )}
+          </div>
+
+          <div>
             <p class={groupLabel}>What's off limits</p>
             <div class="mt-3 flex flex-col gap-4">
               <div>

--- a/src/components/portal/operator/facets/OperatorWork.astro
+++ b/src/components/portal/operator/facets/OperatorWork.astro
@@ -34,6 +34,36 @@ const { model } = Astro.props
 ---
 
 {
+  model.authority.length > 0 && (
+    <section
+      class="mb-8 border-[3px] border-[color:var(--color-text-primary)] bg-[color:var(--color-background)]"
+      aria-label="Operator authority"
+    >
+      <div class="bg-[color:var(--color-text-primary)] px-5 py-2.5 font-mono text-label font-bold uppercase tracking-[0.18em] text-[color:var(--color-background)]">
+        What it may do on its own
+      </div>
+      <div class="px-5 py-6 md:px-7">
+        <ul role="list" class="flex flex-col gap-3">
+          {model.authority.map((row) => (
+            <li class="flex flex-col gap-0.5 md:flex-row md:items-baseline md:justify-between md:gap-8">
+              <span class="font-body text-base font-semibold text-[color:var(--color-text-primary)]">
+                {row.label}
+              </span>
+              <span class="font-mono text-label uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)]">
+                {row.sentence}
+              </span>
+            </li>
+          ))}
+        </ul>
+        <p class="mt-4 font-body text-sm leading-snug text-[color:var(--color-text-secondary)]">
+          Anything not listed here does not happen on its own.
+        </p>
+      </div>
+    </section>
+  )
+}
+
+{
   model.mode === 'gridless' ? (
     <section
       class="border-[3px] border-[color:var(--color-text-primary)] bg-[color:var(--color-background)]"

--- a/src/lib/portal/operator/facet-registry.ts
+++ b/src/lib/portal/operator/facet-registry.ts
@@ -134,9 +134,12 @@ export const OPERATOR_FACETS: readonly OperatorFacet[] = [
     id: 'entitlements',
     label: 'Entitlements / exposure',
     plane: 'config_projection',
-    surface: { kind: 'planned', slice: 3 },
+    surface: {
+      kind: 'has_viewer',
+      viewerModule: 'src/lib/portal/operator/facets/work/work.ts',
+    },
     mounts: ['client', 'admin'],
-    note: "Persona-level exposure × per-skill initiation; vertical floors non-raisable. Rendered on The work (ADR 0076) from the routine grid: each row's start/ceiling tier is the authored per-routine autonomy dial, with permanent caps read verbatim. Coarse-vs-rich matrix is an open decision.",
+    note: "Persona-level exposure × per-skill initiation; vertical floors non-raisable. Rendered on the work surface (console blueprint §4): the authority block is the one honest view of the active persona's authored exposure map (sparse; unauthored fails closed and never renders as a row), and on grid seats each row's start/ceiling tier is the authored per-routine autonomy dial with permanent caps read verbatim.",
   },
   {
     id: 'schedule',

--- a/src/lib/portal/operator/facets/identity/hero.ts
+++ b/src/lib/portal/operator/facets/identity/hero.ts
@@ -20,10 +20,34 @@ export interface OperatorHeroModel {
   name: string | null
   /** Persona title / role, e.g. "AI Case Coordinator". */
   title: string | null
+  /**
+   * The active persona's authored tone descriptors (customer.yaml
+   * persona.tone), humanized for display ("warm-but-professional" → "warm but
+   * professional"). Empty when unauthored — the line simply doesn't render.
+   * Closes the voice-posture half of the blueprint §4 coverage gap; the voice
+   * LIBRARY (samples) stays a later slice.
+   */
+  tone: string[]
+  /**
+   * The mailbox identity the active persona sends as (persona.send_as), or
+   * null when unauthored. Authored config, rendered verbatim.
+   */
+  sendAs: string | null
+  /**
+   * Every OTHER authored persona (ADR 0011 multi-persona) — the identities
+   * this operator can also operate as. Empty for single-persona seats; the
+   * component renders the line only when non-empty.
+   */
+  alsoOperatesAs: { name: string; title: string | null }[]
   /** The live aliveness signal, or null when the customer has no fleet_status
    *  row yet (the component renders the silent empty state — never a fabricated
    *  "healthy" chip). */
   aliveness: AlivenessSignal | null
+}
+
+/** "warm-but-professional" → "warm but professional" (display only). */
+function humanizeTone(t: string): string {
+  return t.replace(/-/g, ' ')
 }
 
 /**
@@ -39,9 +63,13 @@ export function resolveOperatorHero(
   // second DB read, no reparse of personas_json (the projection already parsed
   // it). Mirrors the selection in customer-config.ts::getActivePersona.
   const persona = config?.personas.find((p) => p.status === 'active') ?? null
+  const others = (config?.personas ?? []).filter((p) => p.status === 'active' && p !== persona)
   return {
     name: persona?.name ?? null,
     title: persona?.title ?? null,
+    tone: (persona?.tone ?? []).map(humanizeTone),
+    sendAs: persona?.send_as?.agentmail_identity ?? null,
+    alsoOperatesAs: others.map((p) => ({ name: p.name, title: p.title })),
     aliveness,
   }
 }

--- a/src/lib/portal/operator/facets/scope/scope.ts
+++ b/src/lib/portal/operator/facets/scope/scope.ts
@@ -4,7 +4,7 @@
  * chapter per ADR 0076).
  *
  * Answers "what are the limits?" from the `scope_json` projection, grouped as
- * three client-legible questions:
+ * four client-legible questions:
  *   - what it can see        — email_folders_visible / email_folders_blind
  *   - who it responds to     — inbound_allow_from, the ADR 0055 organization
  *                              roster (addresses and @domains). The single most
@@ -14,21 +14,50 @@
  *                              the operator drafts but never responds on its
  *                              own — and the viewer says so plainly, never as
  *                              an error.
+ *   - who it writes to       — outbound_roster (ADR 0075), the human-authored
+ *                              standing outbound recipients with their class
+ *                              rendered through the closed label map. Coverage
+ *                              gap closed per the console blueprint §4 (the
+ *                              resolver predated `outbound_roster`). Empty is
+ *                              the honest default: no standing recipients are
+ *                              configured.
  *   - what's off limits      — the three block lists, separately labeled
  *                              (Configure mashes them into one line, losing
  *                              which kind each is). matter_blocks is vertical
  *                              vocabulary and renders only when non-empty.
  *
- * Deliberately NOT surfaced (brief §5): the external-send ceiling (Governance
- * facet, Lock 4), business hours (Schedule facet), and the unvalidated
- * `trusted_sender_domains` yaml key (never reaches the projection).
+ * Deliberately NOT surfaced (brief §5): the external-send ceiling (rendered on
+ * The work as the authority view, Lock 4), business hours (Schedule facet), and
+ * the unvalidated `trusted_sender_domains` yaml key (never reaches the
+ * projection).
  *
  * Pure and total: a null config or missing scope blob yields `scope: null` and
  * the viewer renders the honest empty state (docs/style/empty-state-pattern.md).
  */
 
 import type { CustomerConfigRow } from '../../../customer-config'
+import type { OutboundRosterClass } from '../../../../operator/customer-yaml/types'
 import { parseScope } from '../../configure'
+
+/**
+ * Closed plain-language labels for the outbound-roster class vocabulary
+ * (OUTBOUND_ROSTER_CLASSES). Display-only; the authored class token never
+ * reaches the page.
+ */
+const OUTBOUND_CLASS_LABEL: Record<OutboundRosterClass, string> = {
+  client: 'Client',
+  records_vendor: 'Records vendor',
+}
+
+/** One standing outbound recipient, rendered from the authored roster entry. */
+export interface OutboundRosterView {
+  /** The authored address or @domain grant, verbatim. */
+  address: string
+  /** Plain-language class label from the closed map. */
+  classLabel: string
+  /** The authored free-text note, or null. */
+  note: string | null
+}
 
 export interface OperatorScopeModel {
   /** null when the projection carries no scope blob — page-level empty state. */
@@ -39,6 +68,12 @@ export interface OperatorScopeModel {
     neverSees: string[]
     /** The ADR 0055 roster: who gets real replies and action (inbound_allow_from). */
     respondsTo: string[]
+    /**
+     * The ADR 0075 outbound roster: the standing recipients a person authored
+     * for outbound work, each with its plain-language class. Empty means no
+     * standing outside recipients are configured.
+     */
+    writesTo: OutboundRosterView[]
     /** email_keyword_blocks — topics it must not touch. */
     blockedTopics: string[]
     /** domain_blocks — senders and domains it must not engage. */
@@ -68,6 +103,11 @@ export function resolveOperatorScope(config: CustomerConfigRow | null): Operator
       sees: scope.email_folders_visible,
       neverSees: scope.email_folders_blind,
       respondsTo: scope.inbound_allow_from,
+      writesTo: scope.outbound_roster.map((e) => ({
+        address: e.address,
+        classLabel: OUTBOUND_CLASS_LABEL[e.class],
+        note: e.note ?? null,
+      })),
       blockedTopics: scope.email_keyword_blocks,
       blockedSenders: scope.domain_blocks,
       blockedWork: scope.matter_blocks,

--- a/src/lib/portal/operator/facets/work/work.ts
+++ b/src/lib/portal/operator/facets/work/work.ts
@@ -31,6 +31,11 @@
 
 import type { CustomerConfigRow } from '../../../customer-config'
 import type { RoutineGridRow, RoutineTier } from '../../../../operator/routine-grid'
+import {
+  ACCEPTED_ACTION_CLASSES,
+  type AuthoredExposureActionClass,
+  type ExposureCeiling,
+} from '../../../../operator/customer-yaml/types'
 import { humanizeSkillName, resolveOperatorSkills, type OperatorSkillView } from '../skills/skills'
 import { SKILL_SUMMARIES } from '../skills/skill-summaries'
 
@@ -44,6 +49,59 @@ const TIER_SENTENCE: Record<RoutineTier, string> = {
   'flag-only': 'Surfaces it',
   'prepare-and-route': 'Prepares it for you',
   'auto-handle': 'Handles it',
+}
+
+/**
+ * THE AUTHORITY VIEW (console blueprint §4 — the "entitlements as one honest
+ * view" coverage gap). The active persona's authored exposure map, rendered as
+ * one block: each authored action class in plain language with its ceiling as
+ * a plain sentence. Sparse by design — an UNAUTHORED class fails closed at
+ * runtime (ADR 0035) and renders only through the fixed footer sentence in the
+ * viewer, never as an invented row. Both display maps are closed and
+ * display-only; the authored tokens never reach the page.
+ */
+const AUTHORITY_CLASS_LABEL: Record<AuthoredExposureActionClass, string> = {
+  internal_write: 'Writing inside your systems',
+  external_send: 'Sending outside the firm',
+  external_send_internal: 'Email to your own team',
+  external_send_client: 'Email to your clients',
+  external_send_vendor: 'Email to your vendors',
+  commitment: 'Making commitments for the firm',
+  destructive: 'Deleting or changing records',
+  code_execution: 'Running code',
+}
+
+const CEILING_SENTENCE: Record<ExposureCeiling, string> = {
+  autonomous: 'Handles it on its own',
+  confirm: 'Asks first',
+  draft_for_review: 'Prepares it for a person',
+  refused: 'Never',
+}
+
+/** One authority row: an authored exposure ceiling in plain language. */
+export interface WorkAuthorityRow {
+  /** Plain-language action-class label from the closed map. */
+  label: string
+  /** The authored ceiling as a plain sentence. */
+  sentence: string
+}
+
+/**
+ * Map the active persona's sparse exposure map into authority rows, in the
+ * stable ACCEPTED_ACTION_CLASSES order. Only authored keys render; `read` is
+ * never authored (it is not an exposure class).
+ */
+function resolveAuthority(config: CustomerConfigRow | null): WorkAuthorityRow[] {
+  const persona = config?.personas.find((p) => p.status === 'active') ?? null
+  const exposure = persona?.entitlements.exposure ?? {}
+  const rows: WorkAuthorityRow[] = []
+  for (const ac of ACCEPTED_ACTION_CLASSES) {
+    if (ac === 'read') continue
+    const ceiling = exposure[ac]
+    if (!ceiling) continue
+    rows.push({ label: AUTHORITY_CLASS_LABEL[ac], sentence: CEILING_SENTENCE[ceiling] })
+  }
+  return rows
 }
 
 /** One implementing skill on a routine: humanized name + its reviewed summary. */
@@ -102,7 +160,8 @@ export interface WorkSection {
  * viewer flags which introduction sentence to show.
  */
 export type OperatorWorkModel =
-  { mode: 'grid'; sections: WorkSection[] } | { mode: 'gridless'; skills: OperatorSkillView[] }
+  | { mode: 'grid'; sections: WorkSection[]; authority: WorkAuthorityRow[] }
+  | { mode: 'gridless'; skills: OperatorSkillView[]; authority: WorkAuthorityRow[] }
 
 /**
  * Parse the authored free-text initiation string into the established plain
@@ -167,9 +226,10 @@ function group(rows: readonly RoutineGridRow[]): WorkSection[] {
  * today's Skills page.
  */
 export function resolveOperatorWork(config: CustomerConfigRow | null): OperatorWorkModel {
+  const authority = resolveAuthority(config)
   const grid = config?.routine_grid ?? null
   if (!grid) {
-    return { mode: 'gridless', skills: resolveOperatorSkills(config).skills }
+    return { mode: 'gridless', skills: resolveOperatorSkills(config).skills, authority }
   }
-  return { mode: 'grid', sections: group(grid.rows) }
+  return { mode: 'grid', sections: group(grid.rows), authority }
 }

--- a/tests/operator-hero.test.ts
+++ b/tests/operator-hero.test.ts
@@ -37,7 +37,14 @@ describe('resolveOperatorHero (ADR 0069 Slice 2 — identity + status)', () => {
       config([persona({ status: 'active', name: 'Avery', title: 'AI Case Coordinator' })]),
       signal
     )
-    expect(m).toEqual({ name: 'Avery', title: 'AI Case Coordinator', aliveness: signal })
+    expect(m).toEqual({
+      name: 'Avery',
+      title: 'AI Case Coordinator',
+      tone: [],
+      sendAs: null,
+      alsoOperatesAs: [],
+      aliveness: signal,
+    })
   })
 
   it('ignores archived personas — no fabricated identity', () => {
@@ -51,7 +58,14 @@ describe('resolveOperatorHero (ADR 0069 Slice 2 — identity + status)', () => {
 
   it('null config yields null identity but still carries the signal (honest empty)', () => {
     const m = resolveOperatorHero(null, signal)
-    expect(m).toEqual({ name: null, title: null, aliveness: signal })
+    expect(m).toEqual({
+      name: null,
+      title: null,
+      tone: [],
+      sendAs: null,
+      alsoOperatesAs: [],
+      aliveness: signal,
+    })
   })
 
   it('an active persona with no title yields a null title (component falls back)', () => {
@@ -61,5 +75,40 @@ describe('resolveOperatorHero (ADR 0069 Slice 2 — identity + status)', () => {
     )
     expect(m.name).toBe('Crane')
     expect(m.title).toBeNull()
+  })
+
+  it('humanizes authored tone descriptors for display (dashes to spaces, order kept)', () => {
+    const m = resolveOperatorHero(
+      config([persona({ tone: ['plainspoken', 'warm-but-professional', 'concise'] })]),
+      null
+    )
+    expect(m.tone).toEqual(['plainspoken', 'warm but professional', 'concise'])
+  })
+
+  it('carries the authored send-as identity verbatim, null when unauthored', () => {
+    const withSendAs = resolveOperatorHero(
+      config([persona({ send_as: { agentmail_identity: 'ops@firm.example' } })]),
+      null
+    )
+    expect(withSendAs.sendAs).toBe('ops@firm.example')
+    expect(resolveOperatorHero(config([persona({})]), null).sendAs).toBeNull()
+  })
+
+  it('lists OTHER active personas as also-operates-as (ADR 0011); archived never appear', () => {
+    const m = resolveOperatorHero(
+      config([
+        persona({ slug: 'a', name: 'Crane', title: 'Coordinator' }),
+        persona({ slug: 'b', name: 'Ledger', title: 'Bookkeeper' }),
+        persona({ slug: 'c', status: 'archived', name: 'Old' }),
+      ]),
+      null
+    )
+    expect(m.name).toBe('Crane')
+    expect(m.alsoOperatesAs).toEqual([{ name: 'Ledger', title: 'Bookkeeper' }])
+  })
+
+  it('single-persona seats have an empty also-operates-as (the line never renders)', () => {
+    const m = resolveOperatorHero(config([persona({ name: 'Crane' })]), null)
+    expect(m.alsoOperatesAs).toEqual([])
   })
 })

--- a/tests/operator-scope-facet.test.ts
+++ b/tests/operator-scope-facet.test.ts
@@ -30,6 +30,7 @@ describe('resolveOperatorScope', () => {
       sees: ['Inbox', 'Sent'],
       neverSees: ['Legal'],
       respondsTo: ['scott@smd.services', '@smd.services'],
+      writesTo: [],
       blockedTopics: ['payroll'],
       blockedSenders: ['competitor.com'],
       blockedWork: ['Smith v. Jones'],
@@ -55,6 +56,44 @@ describe('resolveOperatorScope', () => {
     expect(model.scope?.respondsTo).toEqual([])
   })
 
+  it('maps outbound_roster entries to plain class labels, address verbatim, note carried (ADR 0075)', () => {
+    const model = resolveOperatorScope(
+      config({
+        ...FULL_SCOPE,
+        outbound_roster: [
+          { address: 'records@vendor.example', class: 'records_vendor', note: 'chase inbox' },
+          { address: 'owner@client.example', class: 'client' },
+        ],
+      })
+    )
+    expect(model.scope?.writesTo).toEqual([
+      { address: 'records@vendor.example', classLabel: 'Records vendor', note: 'chase inbox' },
+      { address: 'owner@client.example', classLabel: 'Client', note: null },
+    ])
+  })
+
+  it('drops malformed outbound entries (unknown class, missing address) — parser is lenient, never throws', () => {
+    const model = resolveOperatorScope(
+      config({
+        ...FULL_SCOPE,
+        outbound_roster: [
+          { address: 'ok@client.example', class: 'client' },
+          { address: 'bad@x.example', class: 'opposing_counsel' },
+          { class: 'client' },
+          'not-an-object',
+        ],
+      })
+    )
+    expect(model.scope?.writesTo).toEqual([
+      { address: 'ok@client.example', classLabel: 'Client', note: null },
+    ])
+  })
+
+  it('an absent outbound_roster renders the honest empty ([] — no standing recipients configured)', () => {
+    const model = resolveOperatorScope(config(FULL_SCOPE))
+    expect(model.scope?.writesTo).toEqual([])
+  })
+
   it('is null when config is null (page-level honest empty state)', () => {
     expect(resolveOperatorScope(null).scope).toBeNull()
   })
@@ -75,6 +114,7 @@ describe('resolveOperatorScope', () => {
       sees: ['Inbox'],
       neverSees: [],
       respondsTo: [],
+      writesTo: [],
       blockedTopics: [],
       blockedSenders: [],
       blockedWork: [],

--- a/tests/operator-work-facet.test.ts
+++ b/tests/operator-work-facet.test.ts
@@ -249,3 +249,56 @@ describe('resolveOperatorWork — gridless fallback', () => {
     expect(model.skills).toEqual([])
   })
 })
+
+describe('authority view (console blueprint §4 — entitlements as one honest view)', () => {
+  it('renders the active persona exposure map as plain rows in stable action-class order', () => {
+    const model = resolveOperatorWork(
+      gridlessConfig([
+        persona({
+          entitlements: {
+            exposure: {
+              external_send_client: 'draft_for_review',
+              internal_write: 'autonomous',
+              destructive: 'refused',
+              external_send: 'confirm',
+            },
+          },
+        }),
+      ])
+    )
+    expect(model.authority).toEqual([
+      { label: 'Writing inside your systems', sentence: 'Handles it on its own' },
+      { label: 'Sending outside the firm', sentence: 'Asks first' },
+      { label: 'Email to your clients', sentence: 'Prepares it for a person' },
+      { label: 'Deleting or changing records', sentence: 'Never' },
+    ])
+  })
+
+  it('unauthored classes NEVER render as rows (fail-closed stays invisible, not invented)', () => {
+    const model = resolveOperatorWork(
+      gridlessConfig([persona({ entitlements: { exposure: { internal_write: 'autonomous' } } })])
+    )
+    expect(model.authority).toHaveLength(1)
+  })
+
+  it('is empty for a null config, no active persona, or an empty exposure map', () => {
+    expect(resolveOperatorWork(null).authority).toEqual([])
+    expect(
+      resolveOperatorWork(gridlessConfig([persona({ status: 'archived' })])).authority
+    ).toEqual([])
+    expect(
+      resolveOperatorWork(gridlessConfig([persona({ entitlements: { exposure: {} } })])).authority
+    ).toEqual([])
+  })
+
+  it('grid mode carries the same authority block', () => {
+    const model = resolveOperatorWork({
+      routine_grid: { adr: '0075', seat: 's', persona: 'p', source_letter: 'x', rows: [row()] },
+      personas: [persona({ entitlements: { exposure: { internal_write: 'draft_for_review' } } })],
+    } as unknown as CustomerConfigRow)
+    expect(model.mode).toBe('grid')
+    expect(model.authority).toEqual([
+      { label: 'Writing inside your systems', sentence: 'Prepares it for a person' },
+    ])
+  })
+})


### PR DESCRIPTION
## What

**Slice 1 (part A) of the locked console blueprint** — closes three of the five §4 coverage gaps with read-only additions to the three existing shared viewers. No new pages, no new doors, no interaction mechanics.

| §4 gap | Where it renders now | Data |
|---|---|---|
| **Outbound roster** | Scope viewer: "Who it writes to for the firm" | `scope_json.outbound_roster` (ADR 0075); address verbatim, class via closed label map, note carried; honest empty when unauthored |
| **Entitlements as one honest view** | Work surface: "What it may do on its own" authority block | Active persona's authored exposure map — plain action-class labels × plain ceiling sentences ("Handles it on its own / Asks first / Prepares it for a person / Never"); sparse — unauthored classes fail closed and never render as rows, one fixed footer sentence states it. Both modes; admin mounts it free (Lock 4) |
| **Persona identity + voice posture** | Hero "who it is" lines | Sounds (tone, humanized) · Writes from (send_as) · Also operates as (other active personas, ADR 0011); each only when authored |

Registry: `entitlements` flips `planned(3)` → `has_viewer` at the work resolver. Voice facet unchanged (tone = authored voice posture; the library stays a later slice). **Schedule stays open** — it needs the projection extension first; that's the next slice.

Brief: `docs/design/operator/surface-briefs/coverage-slice-1.md` (cites blueprint §4/§8).

## Why

The blueprint's diagnosis: three build rounds reorganized structure while ~a third of the authored config had no rendering. This is the first coverage slice against the §4 contract; occasions served are agreement (#1) and confirmation (#2 — "will it act alone?" now has one page answering globally).

## Verify

`npm run verify` green (EXIT=0): typecheck, workers typecheck, prettier, eslint, build, all suites — including the extended `operator-scope-facet` (11), `operator-work-facet` (18), `operator-hero` (8) and the registry legibility guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R16YQuNvLvM16AswxGPwJw