### PR TITLE
feat(portal): vocabulary pass — Duties, Autonomy, Can be raised to (blueprint §6, slice 3)

### DIFF
--- a/src/components/portal/operator/OperatorOverviewBlock.astro
+++ b/src/components/portal/operator/OperatorOverviewBlock.astro
@@ -1,0 +1,41 @@
+---
+/**
+ * One landing summary block (console blueprint §5 — the one-pager). A labeled
+ * bordered section whose CONTENT answers the question and whose footer link
+ * flows into the chapter for depth. Replaces the door pattern: the client
+ * learns by reading, not by choosing a door.
+ *
+ * Loud register to match its sibling viewers while the calm migration is
+ * parked; in CALM_REGISTER_PENDING with the rest of the operator area.
+ */
+interface Props {
+  label: string
+  href: string
+  linkLabel: string
+}
+
+const { label, href, linkLabel } = Astro.props
+---
+
+<section
+  class="border-[3px] border-[color:var(--color-text-primary)] bg-[color:var(--color-background)]"
+  aria-label={label}
+>
+  <div
+    class="bg-[color:var(--color-text-primary)] px-5 py-2.5 font-mono text-label font-bold uppercase tracking-[0.18em] text-[color:var(--color-background)]"
+  >
+    {label}
+  </div>
+  <div class="px-5 py-5 md:px-7">
+    <slot />
+    <a
+      href={href}
+      class="mt-4 inline-flex min-h-11 items-center gap-2 font-mono text-label font-bold uppercase tracking-[0.14em] text-[color:var(--color-text-primary)] hover:text-[color:var(--color-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2"
+    >
+      {linkLabel}
+      <span aria-hidden="true" class="font-body font-black text-[color:var(--color-primary)]"
+        >→</span
+      >
+    </a>
+  </div>
+</section>

--- a/src/components/portal/operator/facets/OperatorAuthorityRows.astro
+++ b/src/components/portal/operator/facets/OperatorAuthorityRows.astro
@@ -1,0 +1,37 @@
+---
+/**
+ * Authority rows — the shared rendering of the "what it may do on its own"
+ * view (console blueprint §4: entitlements as one honest view). One component,
+ * mounted by the work surface AND the landing's one-pager summary block, so the
+ * two can never disagree. Rows come from the work resolver's authority model;
+ * the fixed footer sentence states the fail-closed default once.
+ *
+ * Loud register with its siblings while the calm migration is parked
+ * (CALM_REGISTER_PENDING).
+ */
+import type { WorkAuthorityRow } from '../../../../lib/portal/operator/facets/work/work'
+
+interface Props {
+  rows: WorkAuthorityRow[]
+}
+
+const { rows } = Astro.props
+---
+
+<ul role="list" class="flex flex-col gap-2">
+  {
+    rows.map((row) => (
+      <li class="flex flex-col gap-0.5 md:flex-row md:items-baseline md:justify-between md:gap-8">
+        <span class="font-body text-base font-semibold text-[color:var(--color-text-primary)]">
+          {row.label}
+        </span>
+        <span class="font-mono text-label uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)]">
+          {row.sentence}
+        </span>
+      </li>
+    ))
+  }
+</ul>
+<p class="mt-4 font-body text-sm leading-snug text-[color:var(--color-text-secondary)]">
+  Anything not listed here does not happen on its own.
+</p>

--- a/src/components/portal/operator/facets/OperatorWork.astro
+++ b/src/components/portal/operator/facets/OperatorWork.astro
@@ -1,16 +1,16 @@
 ---
 /**
- * Operator "The work" viewer — the shared routine-grid view (ADR 0076; console
- * structure doc §3.2; signed-off brief
+ * Operator Duties viewer — the shared routine-grid view (ADR 0076; console
+ * blueprint §5/§6; original brief
  * docs/design/operator/surface-briefs/operator-the-work.md). One shared
- * component, both portals mount it (client work page + admin config surface),
+ * component, both portals mount it (client duties page + admin config surface),
  * per ADR 0069 Lock 4.
  *
  * GRID mode renders the lifecycle-grouped routine matrix: one section block per
  * authored `letter_section`, each row showing the routine name, how it starts,
- * the "Today" tier sentence, the "Can become" line (only where the ceiling
- * exceeds the start) or the standing cap verbatim, and the implementing skills
- * with their reviewed summaries. GRIDLESS mode renders the exact Skills
+ * the current autonomy sentence, the can-be-raised-to line (only where the
+ * ceiling exceeds the start) or the standing cap verbatim, and the implementing
+ * skills with their reviewed summaries. GRIDLESS mode renders the exact Skills
  * inventory the Skills page shows today (honest degradation), introduced by one
  * true sentence.
  *

--- a/src/components/portal/operator/facets/OperatorWork.astro
+++ b/src/components/portal/operator/facets/OperatorWork.astro
@@ -24,6 +24,7 @@
  * operator area flips to calm together.
  */
 import type { OperatorWorkModel } from '../../../../lib/portal/operator/facets/work/work'
+import OperatorAuthorityRows from './OperatorAuthorityRows.astro'
 import OperatorWorkRow from './OperatorWorkRow.astro'
 
 interface Props {
@@ -43,21 +44,7 @@ const { model } = Astro.props
         What it may do on its own
       </div>
       <div class="px-5 py-6 md:px-7">
-        <ul role="list" class="flex flex-col gap-3">
-          {model.authority.map((row) => (
-            <li class="flex flex-col gap-0.5 md:flex-row md:items-baseline md:justify-between md:gap-8">
-              <span class="font-body text-base font-semibold text-[color:var(--color-text-primary)]">
-                {row.label}
-              </span>
-              <span class="font-mono text-label uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)]">
-                {row.sentence}
-              </span>
-            </li>
-          ))}
-        </ul>
-        <p class="mt-4 font-body text-sm leading-snug text-[color:var(--color-text-secondary)]">
-          Anything not listed here does not happen on its own.
-        </p>
+        <OperatorAuthorityRows rows={model.authority} />
       </div>
     </section>
   )

--- a/src/components/portal/operator/facets/OperatorWorkRow.astro
+++ b/src/components/portal/operator/facets/OperatorWorkRow.astro
@@ -1,13 +1,13 @@
 ---
 /**
- * One routine row of "The work" grid (ADR 0076; console structure doc §3.2).
- * Extracted from OperatorWork.astro so each component stays small; it renders a
- * single WorkRoutineView: the routine name, how it starts, the Today tier
- * sentence, the Can-become line (only where the ceiling exceeds the start) or
- * the standing cap verbatim, and the implementing skills with their reviewed
- * summaries. Every string traces to authored grid data, the reviewed skill
- * summaries, or the fixed tier / starts label maps in the resolver — no invented
- * copy, no vertical vocabulary.
+ * One routine row of the Duties grid (ADR 0076; console blueprint §6
+ * vocabulary). Extracted from OperatorWork.astro so each component stays small;
+ * it renders a single WorkRoutineView: the routine name, how it starts, the
+ * current autonomy sentence, the can-be-raised-to line (only where the ceiling
+ * exceeds the start) or the standing cap verbatim, and the implementing skills
+ * with their reviewed summaries. Every string traces to authored grid data, the
+ * reviewed skill summaries, or the fixed tier / starts label maps in the
+ * resolver — no invented copy, no vertical vocabulary.
  */
 import type { WorkRoutineView } from '../../../../lib/portal/operator/facets/work/work'
 
@@ -39,7 +39,7 @@ const { routine: r, divided } = Astro.props
       <span
         class="font-mono text-label font-bold uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)]"
       >
-        Today:{' '}
+        Autonomy:{' '}
       </span>
       {r.todaySentence}
     </p>
@@ -47,7 +47,7 @@ const { routine: r, divided } = Astro.props
       r.canBecomeSentence && (
         <p class="font-body text-sm text-[color:var(--color-text-primary)]">
           <span class="font-mono text-label font-bold uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)]">
-            Can become:{' '}
+            Can be raised to:{' '}
           </span>
           {r.canBecomeSentence}
           {r.canBecomeVerbatim && (

--- a/src/lib/portal/operator/facets/overview/overview.ts
+++ b/src/lib/portal/operator/facets/overview/overview.ts
@@ -1,0 +1,132 @@
+/**
+ * Operator landing OVERVIEW — the one-pager view model (console blueprint §5).
+ *
+ * The landing reads as a document, not a hall of doors: the whole operator
+ * summarized top to bottom, each block flowing into its chapter for depth. This
+ * resolver derives every summary from the SAME shared facet resolvers the
+ * chapters render (work, scope, connections) plus the projection's own currency
+ * fields — so the landing and its chapters can never disagree.
+ *
+ * Every rendered fact traces to authored/projected data or a pure derivation of
+ * it (the blueprint explicitly blesses derived counts: "19 duties across 8
+ * stages" is arithmetic over authored tiers, not invented copy). Blocks whose
+ * data is absent are absent — the empty-chapter rule extends to summary blocks.
+ */
+
+import type { CustomerConfigRow } from '../../../customer-config'
+import { resolveOperatorWork, type WorkAuthorityRow } from '../work/work'
+import { resolveOperatorScope } from '../scope/scope'
+import { connectorRowsFromCustomerYaml } from '../../settings'
+
+/** Derived job-in-numbers: grid seats get tier counts, gridless a skills count. */
+export type JobSummary =
+  | {
+      kind: 'grid'
+      duties: number
+      stages: number
+      /** Counts by start tier (today's setting), in fixed display order. */
+      handles: number
+      prepares: number
+      surfaces: number
+    }
+  | { kind: 'skills'; count: number }
+
+export interface OperatorOverviewModel {
+  /**
+   * The currency stamp: "Configuration as published <date>" (blueprint §5).
+   * Derived from the projection's synced_at — it states when the rendered
+   * configuration was published, never the live seat's runtime state. Null when
+   * the timestamp is missing/unparseable (the line simply doesn't render).
+   */
+  publishedOn: string | null
+  job: JobSummary
+  /** The same authority rows the work surface renders (shared derivation). */
+  authority: WorkAuthorityRow[]
+  /** Connected system display names, from the connectors map keys. */
+  systems: string[]
+  /** The inbound roster (who it responds to), from the scope projection. */
+  respondsTo: string[]
+  /** Standing outbound recipients count (who it writes to for the firm). */
+  writesToCount: number
+}
+
+/**
+ * The job-in-numbers lines (pure derivation over authored tiers — blueprint §5
+ * blesses derived counts). Null when there is nothing to summarize (the block
+ * is absent, per the empty-chapter rule).
+ */
+export function jobLines(job: JobSummary): { headline: string; detail: string | null } | null {
+  if (job.kind === 'skills') {
+    if (job.count === 0) return null
+    return {
+      headline: `${job.count} ${job.count === 1 ? 'duty' : 'duties'} configured.`,
+      detail: null,
+    }
+  }
+  if (job.duties === 0) return null
+  const fragments: string[] = []
+  if (job.handles > 0) fragments.push(`${job.handles} handled on its own`)
+  if (job.prepares > 0) fragments.push(`${job.prepares} prepared for a person`)
+  if (job.surfaces > 0) fragments.push(`${job.surfaces} surfaced for you`)
+  return {
+    headline: `${job.duties} ${job.duties === 1 ? 'duty' : 'duties'} across ${job.stages} ${
+      job.stages === 1 ? 'stage' : 'stages'
+    } of your work.`,
+    detail: fragments.length > 0 ? fragments.join(' · ') : null,
+  }
+}
+
+/** 'PracticeManagement' → 'Practice management' (display only). */
+function humanizeCapabilityName(name: string): string {
+  const spaced = name.replace(/([a-z0-9])([A-Z])/g, '$1 $2').replace(/[-_]/g, ' ')
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1).toLowerCase()
+}
+
+/** ISO timestamp → "July 14, 2026" (UTC date part; null when unparseable). */
+export function formatPublishedDate(syncedAt: string | null | undefined): string | null {
+  if (!syncedAt) return null
+  const d = new Date(syncedAt)
+  if (Number.isNaN(d.getTime())) return null
+  return new Intl.DateTimeFormat('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    timeZone: 'UTC',
+  }).format(d)
+}
+
+/**
+ * Compose the landing overview from the config projection, reusing the shared
+ * facet resolvers so every number and list matches its chapter exactly.
+ */
+export function resolveOperatorOverview(config: CustomerConfigRow | null): OperatorOverviewModel {
+  const work = resolveOperatorWork(config)
+
+  let job: JobSummary
+  if (work.mode === 'grid') {
+    const rows = work.sections.flatMap((s) => s.routines)
+    job = {
+      kind: 'grid',
+      duties: rows.length,
+      stages: work.sections.length,
+      handles: rows.filter((r) => r.todaySentence === 'Handles it').length,
+      prepares: rows.filter((r) => r.todaySentence === 'Prepares it for you').length,
+      surfaces: rows.filter((r) => r.todaySentence === 'Surfaces it').length,
+    }
+  } else {
+    job = { kind: 'skills', count: work.skills.length }
+  }
+
+  const scope = resolveOperatorScope(config).scope
+
+  return {
+    publishedOn: formatPublishedDate(config?.synced_at),
+    job,
+    authority: work.authority,
+    systems: connectorRowsFromCustomerYaml(config?.connectors ?? null).map((r) =>
+      humanizeCapabilityName(r.capabilityName)
+    ),
+    respondsTo: scope?.respondsTo ?? [],
+    writesToCount: scope?.writesTo.length ?? 0,
+  }
+}

--- a/src/pages/admin/operator/[customer]/config.astro
+++ b/src/pages/admin/operator/[customer]/config.astro
@@ -191,7 +191,7 @@ const workModel = config ? resolveOperatorWork(config) : null
 
             <div class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card">
               <h3 class="text-base font-semibold text-[color:var(--ss-color-text-primary)] mb-1">
-                The work
+                Duties
               </h3>
               <p class="text-sm text-[color:var(--ss-color-text-secondary)] mb-4">
                 What this operator does, stage by stage, and how much it does on its own — the same

--- a/src/pages/portal/products/operator/[instance]/index.astro
+++ b/src/pages/portal/products/operator/[instance]/index.astro
@@ -16,32 +16,31 @@ import {
   getCustomerConfigBySlug,
   listCustomerConfigsForEntity,
 } from '../../../../../lib/portal/customer-config'
-import FacetDoorList from '../../../../../components/portal/operator/FacetDoorList.astro'
-import type { FacetDoor } from '../../../../../lib/portal/operator/facet-doors'
+import OperatorOverviewBlock from '../../../../../components/portal/operator/OperatorOverviewBlock.astro'
+import OperatorAuthorityRows from '../../../../../components/portal/operator/facets/OperatorAuthorityRows.astro'
+import {
+  jobLines,
+  resolveOperatorOverview,
+} from '../../../../../lib/portal/operator/facets/overview/overview'
 import { env } from 'cloudflare:workers'
 
 /**
- * Operator landing — the operator's front door (ADR 0069; signed-off landing
- * brief docs/design/operator/surface-briefs/operator-landing.md, 2026-07-08).
+ * Operator landing — the ONE-PAGER (console blueprint
+ * docs/design/operator/05-console-blueprint.md §5, LOCKED 2026-07-14).
  *
- * This console is about the OPERATOR itself, not the work it produces. Business
- * work (a draft to review) flows through the real channels — the mailbox, the
- * alert — never here. The surface answers three questions:
- *   Status     — is it OK? (operator health only; no business-work queue)
- *   Role       — what does it do? (Persona · Scope · The work)
- *   Management — fix, change, or retrieve (Voice · Connections · Team · Memory ·
- *                Activity), with Account (the commercial layer) last.
+ * The landing reads as a document, not a hall of doors: the whole operator
+ * summarized top to bottom — identity + status, the currency stamp, the job in
+ * numbers, the authority posture, systems, people, plan — each block flowing
+ * into its chapter for depth. A first-time reader learns the operator by
+ * reading one screen; the chapters are where they verify detail.
  *
- * "The work" (ADR 0076; console structure doc §3.2) is the console spine — the
- * rendered routine grid, stage by stage, with how much the operator does on its
- * own per duty. It absorbs the former Skills, Schedule, Workflows (Role) and
- * Governance (Management) doors into one destination; the Skills page stays
- * routable as the grid's gridless fallback but no longer has a door.
- *
- * Every door leads to a facet's own page. Facets whose page isn't built yet carry
- * href: null and render as present-but-not-yet-built (honest, never "coming
- * soon"); each becomes its own Surface Brief. Access is gated per destination
- * (resolveOperatorAccess) — this landing only maps the doors.
+ * This console is about the OPERATOR itself, not the work it produces (ADR
+ * 0052). Business work flows through the real channels — the mailbox, the
+ * alert — never here. Every summary derives from the same shared facet
+ * resolvers the chapters render (overview resolver), so the landing and its
+ * chapters can never disagree; the empty-chapter rule means a block with no
+ * data is absent, never a hollow door. Access is gated per destination
+ * (resolveOperatorAccess).
  */
 
 const PRODUCT_SLUG = 'operator'
@@ -113,54 +112,17 @@ if (access) {
 }
 const heroModel = resolveOperatorHero(customerConfig, alivenessSignal)
 
-// The operator's facet map (brief §5). Voice deep-links to today's Configure
-// page until it is split into its own briefed surface; the facets with no page
-// yet (Persona, Memory) carry href: null. "The work" is the built spine that
-// absorbs Skills/Schedule/Workflows/Governance (structure doc §3.2).
-const CONFIGURE = `${operatorBase}/configure`
-const roleDoors: FacetDoor[] = [
-  {
-    label: 'Persona',
-    desc: 'Who it is: its name, role, and the identities it can operate as.',
-    href: null,
-  },
-  {
-    label: 'Scope',
-    desc: "What it can see, who it responds to, and what's off limits.",
-    href: `${operatorBase}/scope`,
-  },
-  {
-    label: 'The work',
-    desc: 'Everything it does, stage by stage, and how much it does on its own.',
-    href: `${operatorBase}/work`,
-  },
-]
-const manageDoors: FacetDoor[] = [
-  { label: 'Voice', desc: 'How it sounds when it writes on your behalf.', href: CONFIGURE },
-  {
-    label: 'Connections',
-    desc: 'The systems and channels it works through.',
-    href: `${operatorBase}/connections`,
-  },
-  {
-    label: 'Team',
-    desc: 'People on the account and who gets alerted.',
-    href: `${operatorBase}/team`,
-  },
-  { label: 'Memory', desc: 'What it knows about your business, to view or export.', href: null },
-  {
-    label: 'Activity',
-    desc: 'The full record of everything it has done.',
-    href: `${operatorBase}/activity`,
-  },
-]
-const accountDoors: FacetDoor[] = [
-  {
-    label: 'Account',
-    desc: 'Subscription, data export, and cancellation.',
-    href: `${operatorBase}/account`,
-  },
-]
+// THE ONE-PAGER (console blueprint §5). The landing reads as a document: the
+// whole operator summarized top to bottom, each block flowing into its chapter
+// for depth. Every number and list comes from the SAME shared facet resolvers
+// the chapters render (overview resolver), so the landing can never disagree
+// with a chapter. Blocks with no data are absent (empty-chapter rule) — which
+// also retires the dead Persona/Memory doors (persona identity renders on the
+// hero now), the Voice door (its authored posture renders on the hero; the
+// Configure page stays routable until its retirement slice), and the Activity
+// door (runtime seam unwired — it returns when the seam lands).
+const overview = resolveOperatorOverview(customerConfig)
+const job = jobLines(overview.job)
 
 // Change-request filing outcome (returns via ?cr=filed|invalid|error).
 const crStatus = Astro.url.searchParams.get('cr')
@@ -256,19 +218,82 @@ const empty = surfaceState !== 'active' ? EMPTY[surfaceState] : null
         <div class="mt-3">
           <OperatorHero model={heroModel} escalationHref={`${operatorBase}/settings`} />
         </div>
+        {overview.publishedOn && (
+          <p class="mt-2 font-mono text-label uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)]">
+            Configuration as published {overview.publishedOn}
+          </p>
+        )}
 
-        <p class={`mt-10 ${seclabelClass}`}>Role</p>
-        <div class="mt-3">
-          <FacetDoorList doors={roleDoors} />
-        </div>
+        <div class="mt-10 flex flex-col gap-8">
+          {job && (
+            <OperatorOverviewBlock
+              label="The job"
+              href={`${operatorBase}/work`}
+              linkLabel="The work"
+            >
+              <p class="font-body text-base font-semibold text-[color:var(--color-text-primary)]">
+                {job.headline}
+              </p>
+              {job.detail && (
+                <p class="mt-1 font-mono text-label uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)]">
+                  {job.detail}
+                </p>
+              )}
+            </OperatorOverviewBlock>
+          )}
 
-        <p class={`mt-10 ${seclabelClass}`}>Management</p>
-        <div class="mt-3">
-          <FacetDoorList doors={manageDoors} />
-        </div>
+          {overview.authority.length > 0 && (
+            <OperatorOverviewBlock
+              label="What it may do on its own"
+              href={`${operatorBase}/work`}
+              linkLabel="The work"
+            >
+              <OperatorAuthorityRows rows={overview.authority} />
+            </OperatorOverviewBlock>
+          )}
 
-        <div class="mt-8">
-          <FacetDoorList doors={accountDoors} />
+          {overview.systems.length > 0 && (
+            <OperatorOverviewBlock
+              label="Systems"
+              href={`${operatorBase}/connections`}
+              linkLabel="Connections"
+            >
+              <p class="font-body text-base text-[color:var(--color-text-primary)]">
+                {overview.systems.join(' · ')}
+              </p>
+            </OperatorOverviewBlock>
+          )}
+
+          <OperatorOverviewBlock label="People" href={`${operatorBase}/scope`} linkLabel="Scope">
+            {overview.respondsTo.length > 0 ? (
+              <p class="font-body text-base text-[color:var(--color-text-primary)]">
+                Responds to: {overview.respondsTo.join(', ')}
+              </p>
+            ) : (
+              <p class="font-body text-base text-[color:var(--color-text-primary)]">
+                No one yet. Until someone is added here, your operator drafts replies for review and
+                sends nothing on its own.
+              </p>
+            )}
+            {overview.writesToCount > 0 && (
+              <p class="mt-1 font-mono text-label uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)]">
+                {overview.writesToCount} standing outside{' '}
+                {overview.writesToCount === 1 ? 'recipient' : 'recipients'}
+              </p>
+            )}
+          </OperatorOverviewBlock>
+
+          <OperatorOverviewBlock label="The team" href={`${operatorBase}/team`} linkLabel="Team">
+            <p class="font-body text-base text-[color:var(--color-text-primary)]">
+              People on the account and who gets alerted.
+            </p>
+          </OperatorOverviewBlock>
+
+          <OperatorOverviewBlock label="Plan" href={`${operatorBase}/account`} linkLabel="Account">
+            <p class="font-body text-base text-[color:var(--color-text-primary)]">
+              Subscription, data export, and cancellation.
+            </p>
+          </OperatorOverviewBlock>
         </div>
       </>
     )

--- a/src/pages/portal/products/operator/[instance]/index.astro
+++ b/src/pages/portal/products/operator/[instance]/index.astro
@@ -226,11 +226,7 @@ const empty = surfaceState !== 'active' ? EMPTY[surfaceState] : null
 
         <div class="mt-10 flex flex-col gap-8">
           {job && (
-            <OperatorOverviewBlock
-              label="The job"
-              href={`${operatorBase}/work`}
-              linkLabel="The work"
-            >
+            <OperatorOverviewBlock label="The job" href={`${operatorBase}/work`} linkLabel="Duties">
               <p class="font-body text-base font-semibold text-[color:var(--color-text-primary)]">
                 {job.headline}
               </p>
@@ -246,7 +242,7 @@ const empty = surfaceState !== 'active' ? EMPTY[surfaceState] : null
             <OperatorOverviewBlock
               label="What it may do on its own"
               href={`${operatorBase}/work`}
-              linkLabel="The work"
+              linkLabel="Duties"
             >
               <OperatorAuthorityRows rows={overview.authority} />
             </OperatorOverviewBlock>
@@ -289,7 +285,11 @@ const empty = surfaceState !== 'active' ? EMPTY[surfaceState] : null
             </p>
           </OperatorOverviewBlock>
 
-          <OperatorOverviewBlock label="Plan" href={`${operatorBase}/account`} linkLabel="Account">
+          <OperatorOverviewBlock
+            label="Plan & billing"
+            href={`${operatorBase}/account`}
+            linkLabel="Plan & billing"
+          >
             <p class="font-body text-base text-[color:var(--color-text-primary)]">
               Subscription, data export, and cancellation.
             </p>

--- a/src/pages/portal/products/operator/[instance]/work/index.astro
+++ b/src/pages/portal/products/operator/[instance]/work/index.astro
@@ -56,13 +56,13 @@ const crMessage =
 ---
 
 <PortalShell
-  title="Operator · The work"
+  title="Operator · Duties"
   clientName={client.name}
   orgId={client.org_id}
   entityId={client.id}
   pathname={Astro.url.pathname}
 >
-  <PortalPageHead crumbHref={operatorBase} crumbLabel="Operator" h1="The work" meta={null} />
+  <PortalPageHead crumbHref={operatorBase} crumbLabel="Operator" h1="Duties" meta={null} />
 
   {
     crMessage && (

--- a/tests/forbidden-strings.test.ts
+++ b/tests/forbidden-strings.test.ts
@@ -819,6 +819,9 @@ const CALM_REGISTER_PENDING: string[] = [
   'src/components/portal/operator/facets/OperatorSkills.astro',
   'src/components/portal/operator/facets/OperatorWork.astro',
   'src/components/portal/operator/facets/OperatorScope.astro',
+  // One-pager landing summary block (console blueprint §5): matches its loud
+  // operator-area siblings until the whole area flips to calm together.
+  'src/components/portal/operator/OperatorOverviewBlock.astro',
   'src/components/portal/operator/FacetDoorList.astro',
   'src/components/admin/EntityContactRow.astro',
   'src/components/admin/EntityIdentityStrip.astro',

--- a/tests/forbidden-strings.test.ts
+++ b/tests/forbidden-strings.test.ts
@@ -1075,3 +1075,40 @@ describe('retired persona name stays retired (Captain directive 2026-07-13)', ()
     ).toEqual([])
   })
 })
+
+// ---------------------------------------------------------------------------
+// Console vocabulary guard (console blueprint §6 — locked once, then enforced).
+// The §6 table is decided by Captain exactly once; this guard keeps the retired
+// display labels from re-entering the operator console surfaces, so naming
+// stops being re-litigated per page. Comments are stripped first — only real
+// template text can trip it. Registry ids and route paths are deliberately NOT
+// scanned (labels rename; identifiers stay stable).
+// ---------------------------------------------------------------------------
+describe('console vocabulary guard (blueprint §6 — retired display labels)', () => {
+  const RETIRED_VOCAB: ReadonlyArray<{ re: RegExp; label: string }> = [
+    { re: /The work\b/, label: '"The work" (§6: renamed to Duties)' },
+    { re: /Today:/, label: '"Today:" autonomy row label (§6: renamed to Autonomy:)' },
+    { re: /Can become/, label: '"Can become" (§6: renamed to Can be raised to:)' },
+  ]
+  const VOCAB_ROOTS = [
+    resolve('src/components/portal/operator'),
+    resolve('src/pages/portal/products/operator'),
+    resolve('src/pages/admin/operator'),
+  ]
+  const files = VOCAB_ROOTS.flatMap((root) =>
+    existsSync(root) ? collectSourceFiles(root) : []
+  ).filter((f) => f.endsWith('.astro'))
+
+  it('finds console files to scan (sanity)', () => {
+    expect(files.length).toBeGreaterThan(0)
+  })
+
+  for (const file of files) {
+    const rel = relOf(file)
+    it(`${rel} — no retired vocabulary (§6)`, () => {
+      const src = stripComments(readFileSync(file, 'utf-8'))
+      const hits = RETIRED_VOCAB.filter(({ re }) => re.test(src)).map(({ label }) => label)
+      expect(hits, `${rel} uses retired labels: ${hits.join(', ')}`).toEqual([])
+    })
+  }
+})

--- a/tests/operator-landing-overview.test.ts
+++ b/tests/operator-landing-overview.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect } from 'vitest'
+import {
+  resolveOperatorOverview,
+  formatPublishedDate,
+  jobLines,
+} from '../src/lib/portal/operator/facets/overview/overview'
+import type { CustomerConfigRow, PersonaConfig } from '../src/lib/portal/customer-config'
+
+/**
+ * Operator landing overview resolver (console blueprint §5 — the one-pager).
+ * Every summary must derive from the same shared facet resolvers the chapters
+ * render; counts are pure arithmetic over authored tiers, never invented.
+ * Fixtures carry NO vertical vocabulary.
+ */
+
+function persona(p: Partial<PersonaConfig>): PersonaConfig {
+  return {
+    slug: 'p',
+    status: 'active',
+    name: 'X',
+    title: null,
+    signature_html: null,
+    tone: [],
+    send_as: null,
+    entitlements: { exposure: {} },
+    skills: [],
+    channel_bindings: [],
+    ...p,
+  }
+}
+
+function gridRow(p: Record<string, unknown>): Record<string, unknown> {
+  return {
+    routine: 'A routine',
+    letter_section: 'Section one',
+    skills: [],
+    start_tier: 'flag-only',
+    ceiling_tier: 'flag-only',
+    start_verbatim: 'x',
+    ceiling_verbatim: 'x',
+    enforcement: {
+      initiation: 'manual',
+      exposure_keys: {},
+      content_floor: false,
+      banned_tools: [],
+      notes: '',
+    },
+    ...p,
+  }
+}
+
+function config(p: Partial<Record<string, unknown>>): CustomerConfigRow {
+  return {
+    personas: [],
+    routine_grid: null,
+    connectors: null,
+    scope: null,
+    synced_at: '2026-07-14T23:59:59.000Z',
+    ...p,
+  } as unknown as CustomerConfigRow
+}
+
+describe('formatPublishedDate', () => {
+  it('formats the projection timestamp as a long UTC date', () => {
+    expect(formatPublishedDate('2026-07-14T23:59:59.000Z')).toBe('July 14, 2026')
+  })
+  it('is null for missing or unparseable input (the stamp line never fabricates)', () => {
+    expect(formatPublishedDate(null)).toBeNull()
+    expect(formatPublishedDate(undefined)).toBeNull()
+    expect(formatPublishedDate('not-a-date')).toBeNull()
+  })
+})
+
+describe('jobLines', () => {
+  it('derives grid counts into the headline + tier detail (zero tiers omitted)', () => {
+    const lines = jobLines({
+      kind: 'grid',
+      duties: 19,
+      stages: 8,
+      handles: 2,
+      prepares: 14,
+      surfaces: 3,
+    })
+    expect(lines).toEqual({
+      headline: '19 duties across 8 stages of your work.',
+      detail: '2 handled on its own · 14 prepared for a person · 3 surfaced for you',
+    })
+    expect(
+      jobLines({ kind: 'grid', duties: 1, stages: 1, handles: 0, prepares: 1, surfaces: 0 })
+    ).toEqual({
+      headline: '1 duty across 1 stage of your work.',
+      detail: '1 prepared for a person',
+    })
+  })
+  it('is null when there is nothing to summarize (block absent, empty-chapter rule)', () => {
+    expect(jobLines({ kind: 'skills', count: 0 })).toBeNull()
+    expect(
+      jobLines({ kind: 'grid', duties: 0, stages: 0, handles: 0, prepares: 0, surfaces: 0 })
+    ).toBeNull()
+  })
+  it('summarizes gridless seats by configured-duty count', () => {
+    expect(jobLines({ kind: 'skills', count: 7 })).toEqual({
+      headline: '7 duties configured.',
+      detail: null,
+    })
+  })
+})
+
+describe('resolveOperatorOverview', () => {
+  it('derives grid job numbers, authority, systems, and rosters from the shared resolvers', () => {
+    const model = resolveOperatorOverview(
+      config({
+        routine_grid: {
+          adr: '0075',
+          seat: 's',
+          persona: 'p',
+          source_letter: 'x',
+          rows: [
+            gridRow({ routine: 'One', start_tier: 'prepare-and-route' }),
+            gridRow({ routine: 'Two', letter_section: 'Section two', start_tier: 'auto-handle' }),
+            gridRow({ routine: 'Three', start_tier: 'flag-only' }),
+          ],
+        },
+        personas: [persona({ entitlements: { exposure: { internal_write: 'draft_for_review' } } })],
+        connectors: { PracticeManagement: { adapter: 'x' }, Email: { adapter: 'y' } },
+        scope: {
+          inbound_allow_from: ['@firm.example'],
+          outbound_roster: [{ address: 'a@b.example', class: 'client' }],
+        },
+      })
+    )
+    expect(model.job).toEqual({
+      kind: 'grid',
+      duties: 3,
+      stages: 2,
+      handles: 1,
+      prepares: 1,
+      surfaces: 1,
+    })
+    expect(model.authority).toEqual([
+      { label: 'Writing inside your systems', sentence: 'Prepares it for a person' },
+    ])
+    expect(model.systems).toEqual(['Email', 'Practice management'])
+    expect(model.respondsTo).toEqual(['@firm.example'])
+    expect(model.writesToCount).toBe(1)
+    expect(model.publishedOn).toBe('July 14, 2026')
+  })
+
+  it('is fully empty-safe for a null config (nothing fabricated)', () => {
+    const model = resolveOperatorOverview(null)
+    expect(model.job).toEqual({ kind: 'skills', count: 0 })
+    expect(model.authority).toEqual([])
+    expect(model.systems).toEqual([])
+    expect(model.respondsTo).toEqual([])
+    expect(model.writesToCount).toBe(0)
+    expect(model.publishedOn).toBeNull()
+  })
+})


### PR DESCRIPTION
## What

**Slice 3 of the locked console blueprint** — the §6 vocabulary table applied and guard-enforced:

- "The work" → **Duties** (page title/heading, landing links, admin config card); route `/work` and identifiers stay stable
- "Today:" → **Autonomy:** and "Can become:" → **Can be raised to:** on routine rows (tier value sentences unchanged — locked)
- Commercial block → **Plan & billing**
- New **console vocabulary guard** in `forbidden-strings.test.ts`: retired display labels are banned from operator console templates (comments stripped), so naming stops being re-litigated per page

## Verify

`npm run verify` green (EXIT=0); the new guard runs across all operator console .astro files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R16YQuNvLvM16AswxGPwJw