### PR TITLE
feat(portal): schedule projection + plain-language prose (blueprint §4, slice 1B)

### DIFF
--- a/src/components/portal/operator/facets/OperatorSkills.astro
+++ b/src/components/portal/operator/facets/OperatorSkills.astro
@@ -61,6 +61,7 @@ const { skills } = model
               {s.initiation.length > 0 && (
                 <span class="shrink-0 font-mono text-label uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)] md:pt-0.5">
                   {s.initiation.join(' · ')}
+                  {s.scheduleDetail ? ` (${s.scheduleDetail})` : ''}
                 </span>
               )}
             </li>

--- a/src/components/portal/operator/facets/OperatorWork.astro
+++ b/src/components/portal/operator/facets/OperatorWork.astro
@@ -89,6 +89,7 @@ const { model } = Astro.props
                   {s.initiation.length > 0 && (
                     <span class="shrink-0 font-mono text-label uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)] md:pt-0.5">
                       {s.initiation.join(' · ')}
+                      {s.scheduleDetail ? ` (${s.scheduleDetail})` : ''}
                     </span>
                   )}
                 </li>

--- a/src/components/portal/operator/facets/OperatorWorkRow.astro
+++ b/src/components/portal/operator/facets/OperatorWorkRow.astro
@@ -27,8 +27,12 @@ const { routine: r, divided } = Astro.props
     </p>
     {
       r.startsLabels.length > 0 && (
-        <span class="shrink-0 font-mono text-label uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)] md:pt-0.5">
+        <span
+          class="shrink-0 font-mono text-label uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)] md:pt-0.5"
+          title={r.scheduleDetail ?? undefined}
+        >
           {r.startsLabels.join(' · ')}
+          {r.scheduleDetail ? ` (${r.scheduleDetail})` : ''}
         </span>
       )
     }

--- a/src/lib/portal/customer-config-projection.ts
+++ b/src/lib/portal/customer-config-projection.ts
@@ -40,8 +40,12 @@ export interface ProjectionContext {
 /**
  * Narrow a full schema `Persona` to the read-side `PersonaConfig`. Drops the
  * fields the portal projection does not surface (version, enabled,
- * cost_estimate, scope, bundles, cron, avatar, pronouns, overrides). Nullable
+ * cost_estimate, scope, bundles, avatar, pronouns, overrides). Nullable
  * scalars are coerced to `null` so the serialized JSON always carries the key.
+ *
+ * `cron` projects skill + schedule only (console blueprint §4 — the schedule
+ * coverage gap): the portal renders WHEN things run; pre_run / wake_policy are
+ * runtime mechanics and stay unprojected.
  */
 function toPersonaConfig(p: Persona): PersonaConfig {
   return {
@@ -54,6 +58,7 @@ function toPersonaConfig(p: Persona): PersonaConfig {
     send_as: p.send_as ?? null,
     entitlements: p.entitlements,
     skills: (p.skills ?? []).map((s) => ({ name: s.name, initiation: s.initiation })),
+    cron: (p.cron ?? []).map((c) => ({ skill: c.skill, schedule: c.schedule })),
     channel_bindings: (p.channel_bindings ?? []).map((c) => ({
       integration: c.integration,
       channels: c.channels ?? [],

--- a/src/lib/portal/customer-config.ts
+++ b/src/lib/portal/customer-config.ts
@@ -53,6 +53,12 @@ export interface PersonaChannelBinding {
   channels: string[]
 }
 
+/** One projected cron entry: WHEN a skill runs (schedule detail only). */
+export interface PersonaCronEntry {
+  skill: string
+  schedule: string
+}
+
 export interface PersonaConfig {
   slug: string
   status: PersonaStatus
@@ -63,6 +69,11 @@ export interface PersonaConfig {
   send_as: PersonaSendAs | null
   entitlements: PersonaEntitlements
   skills: PersonaSkill[]
+  /**
+   * Projected cron schedules (console blueprint §4 schedule coverage). Rows
+   * projected before this field existed parse as [] (defensive read side).
+   */
+  cron?: PersonaCronEntry[]
   channel_bindings: PersonaChannelBinding[]
 }
 

--- a/src/lib/portal/operator/facet-registry.ts
+++ b/src/lib/portal/operator/facet-registry.ts
@@ -144,10 +144,13 @@ export const OPERATOR_FACETS: readonly OperatorFacet[] = [
   {
     id: 'schedule',
     label: 'Schedule / recurring jobs',
-    plane: 'config_unprojected',
-    surface: { kind: 'planned', slice: 7 },
+    plane: 'config_projection',
+    surface: {
+      kind: 'has_viewer',
+      viewerModule: 'src/lib/portal/operator/facets/schedule/schedule.ts',
+    },
     mounts: ['client', 'admin'],
-    note: 'The "starts on a schedule" signal is rendered on The work (ADR 0076) from each grid row\'s initiation. The concrete cron detail (personas[].cron[]) is authored but dropped from the projection — still pending a projection extension before the recurring-job specifics can show.',
+    note: 'Projected (personas[].cron -> skill+schedule, console blueprint §4) and rendered as plain-language prose on Duties rows and the Skills inventory via the deterministic cron describer; non-describable expressions render no prose (never mistranslated).',
   },
   {
     id: 'bundles',

--- a/src/lib/portal/operator/facets/schedule/schedule.ts
+++ b/src/lib/portal/operator/facets/schedule/schedule.ts
@@ -1,0 +1,58 @@
+/**
+ * Operator SCHEDULE facet helper — deterministic cron → plain-language
+ * translation (console blueprint §4: the schedule coverage gap; registry
+ * `schedule` facet). Consumed by the skills and work resolvers to attach
+ * "when it runs" prose to duties.
+ *
+ * Covers ONLY the shapes the seats author (fixed minute/hour with daily /
+ * weekday / single-weekday cadence); anything else returns null and no
+ * schedule prose renders — a wrong translation would be fabrication, a
+ * missing one is just less detail (the "On a schedule" label still shows).
+ * Times render in the seat's own clock: seat cron runs seat-local
+ * (business_hours.timezone → HERMES_TIMEZONE), so no zone math happens here.
+ */
+
+import type { PersonaCronEntry } from '../../../customer-config'
+
+const WEEKDAY_NAME: Record<string, string> = {
+  '0': 'Sunday',
+  '1': 'Monday',
+  '2': 'Tuesday',
+  '3': 'Wednesday',
+  '4': 'Thursday',
+  '5': 'Friday',
+  '6': 'Saturday',
+  '7': 'Sunday',
+}
+
+export function describeCronSchedule(expr: string): string | null {
+  const m = expr.trim().match(/^(\d{1,2}) (\d{1,2}) \* \* (\*|\d|1-5)$/)
+  if (!m) return null
+  const minute = Number(m[1])
+  const hour = Number(m[2])
+  if (minute > 59 || hour > 23) return null
+  const h12 = hour % 12 === 0 ? 12 : hour % 12
+  const ampm = hour < 12 ? 'a.m.' : 'p.m.'
+  const time = `${h12}:${String(minute).padStart(2, '0')} ${ampm}`
+  if (m[3] === '*') return `Daily at ${time}`
+  if (m[3] === '1-5') return `Weekdays at ${time}`
+  const day = WEEKDAY_NAME[m[3]]
+  return day ? `Weekly on ${day} at ${time}` : null
+}
+
+/**
+ * Build the skill → schedule-prose map from projected cron entries. A skill
+ * scheduled more than once keeps every describable entry, joined; entries
+ * whose expression is outside the describable shapes are omitted (never
+ * mistranslated).
+ */
+export function scheduleDetailBySkill(entries: readonly PersonaCronEntry[]): Map<string, string> {
+  const out = new Map<string, string>()
+  for (const entry of entries) {
+    const prose = describeCronSchedule(entry.schedule)
+    if (!prose) continue
+    const existing = out.get(entry.skill)
+    out.set(entry.skill, existing ? `${existing} · ${prose}` : prose)
+  }
+  return out
+}

--- a/src/lib/portal/operator/facets/skills/skills.ts
+++ b/src/lib/portal/operator/facets/skills/skills.ts
@@ -27,6 +27,7 @@
 import type { CustomerConfigRow, PersonaSkill } from '../../../customer-config'
 import type { SkillInitiation } from '../../../../operator/customer-yaml/types'
 import { SKILL_SUMMARIES } from './skill-summaries'
+import { scheduleDetailBySkill } from '../schedule/schedule'
 
 /**
  * Reformat a skill slug into a client-legible display name — SENTENCE case
@@ -57,6 +58,12 @@ export interface OperatorSkillView {
   summary: string | null
   /** Client-legible initiation labels; empty when no mode is set (show nothing). */
   initiation: string[]
+  /**
+   * Plain-language schedule prose from the projected cron entries via the
+   * work facet's deterministic describer ("Weekdays at 7:17 a.m."), or null
+   * (nothing scheduled / not describable — never mistranslated).
+   */
+  scheduleDetail: string | null
 }
 
 export interface OperatorSkillsModel {
@@ -84,11 +91,13 @@ export function initiationLabels(init: SkillInitiation): string[] {
  */
 export function resolveOperatorSkills(config: CustomerConfigRow | null): OperatorSkillsModel {
   const persona = config?.personas.find((p) => p.status === 'active') ?? null
+  const schedules = scheduleDetailBySkill(persona?.cron ?? [])
   const skills: OperatorSkillView[] = (persona?.skills ?? []).map((s: PersonaSkill) => ({
     name: humanizeSkillName(s.name),
     slug: s.name,
     summary: SKILL_SUMMARIES[s.name] ?? null,
     initiation: initiationLabels(s.initiation),
+    scheduleDetail: schedules.get(s.name) ?? null,
   }))
   return { skills }
 }

--- a/src/lib/portal/operator/facets/work/work.ts
+++ b/src/lib/portal/operator/facets/work/work.ts
@@ -37,6 +37,7 @@ import {
   type ExposureCeiling,
 } from '../../../../operator/customer-yaml/types'
 import { humanizeSkillName, resolveOperatorSkills, type OperatorSkillView } from '../skills/skills'
+import { scheduleDetailBySkill } from '../schedule/schedule'
 import { SKILL_SUMMARIES } from '../skills/skill-summaries'
 
 /**
@@ -145,6 +146,12 @@ export interface WorkRoutineView {
   capVerbatim: string | null
   /** The implementing skill(s), humanized + summarized. */
   skills: WorkRoutineSkill[]
+  /**
+   * Plain-language schedule prose for the routine's scheduled skills
+   * ("Weekdays at 7:17 a.m."), from the projected cron entries via the
+   * deterministic describer. Null when nothing scheduled or not describable.
+   */
+  scheduleDetail: string | null
 }
 
 /** A lifecycle section: the authored `letter_section` name and its routines. */
@@ -179,8 +186,11 @@ export function startsLabels(initiation: string): string[] {
   return labels
 }
 
-function toRoutineView(row: RoutineGridRow): WorkRoutineView {
+function toRoutineView(row: RoutineGridRow, schedules: Map<string, string>): WorkRoutineView {
   const graduates = row.ceiling_tier !== row.start_tier
+  const scheduleProse = row.skills
+    .map((slug) => schedules.get(slug))
+    .filter((s): s is string => !!s)
   return {
     routine: row.routine,
     startsLabels: startsLabels(row.enforcement.initiation),
@@ -195,6 +205,7 @@ function toRoutineView(row: RoutineGridRow): WorkRoutineView {
       slug,
       summary: SKILL_SUMMARIES[slug] ?? null,
     })),
+    scheduleDetail: scheduleProse.length > 0 ? scheduleProse.join(' · ') : null,
   }
 }
 
@@ -205,7 +216,7 @@ function toRoutineView(row: RoutineGridRow): WorkRoutineView {
  * insertion order for its keys; `order` records first appearance explicitly for
  * clarity.
  */
-function group(rows: readonly RoutineGridRow[]): WorkSection[] {
+function group(rows: readonly RoutineGridRow[], schedules: Map<string, string>): WorkSection[] {
   const order: string[] = []
   const bySection = new Map<string, WorkRoutineView[]>()
   for (const row of rows) {
@@ -213,7 +224,7 @@ function group(rows: readonly RoutineGridRow[]): WorkSection[] {
       bySection.set(row.letter_section, [])
       order.push(row.letter_section)
     }
-    bySection.get(row.letter_section)!.push(toRoutineView(row))
+    bySection.get(row.letter_section)!.push(toRoutineView(row, schedules))
   }
   return order.map((name) => ({ name, routines: bySection.get(name)! }))
 }
@@ -231,5 +242,7 @@ export function resolveOperatorWork(config: CustomerConfigRow | null): OperatorW
   if (!grid) {
     return { mode: 'gridless', skills: resolveOperatorSkills(config).skills, authority }
   }
-  return { mode: 'grid', sections: group(grid.rows), authority }
+  const persona = config?.personas.find((p) => p.status === 'active') ?? null
+  const schedules = scheduleDetailBySkill(persona?.cron ?? [])
+  return { mode: 'grid', sections: group(grid.rows, schedules), authority }
 }

--- a/tests/operator-schedule-facet.test.ts
+++ b/tests/operator-schedule-facet.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest'
+import {
+  describeCronSchedule,
+  scheduleDetailBySkill,
+} from '../src/lib/portal/operator/facets/schedule/schedule'
+import { resolveOperatorSkills } from '../src/lib/portal/operator/facets/skills/skills'
+import type { CustomerConfigRow, PersonaConfig } from '../src/lib/portal/customer-config'
+
+/**
+ * Schedule facet (console blueprint §4 — the schedule coverage gap). The cron
+ * describer is DETERMINISTIC and deliberately partial: only the shapes seats
+ * actually author translate; everything else returns null (a wrong translation
+ * would be fabrication, a missing one is just less detail).
+ */
+
+describe('describeCronSchedule', () => {
+  it('translates the three authored shapes (daily / weekdays / single weekday)', () => {
+    expect(describeCronSchedule('0 7 * * *')).toBe('Daily at 7:00 a.m.')
+    expect(describeCronSchedule('23 6 * * 1-5')).toBe('Weekdays at 6:23 a.m.')
+    expect(describeCronSchedule('9 8 * * 2')).toBe('Weekly on Tuesday at 8:09 a.m.')
+    expect(describeCronSchedule('0 12 * * *')).toBe('Daily at 12:00 p.m.')
+    expect(describeCronSchedule('30 0 * * *')).toBe('Daily at 12:30 a.m.')
+    expect(describeCronSchedule('15 17 * * 5')).toBe('Weekly on Friday at 5:15 p.m.')
+  })
+
+  it('returns null for anything outside the describable shapes (never mistranslates)', () => {
+    expect(describeCronSchedule('*/17 * * * *')).toBeNull()
+    expect(describeCronSchedule('0 7 1 * *')).toBeNull()
+    expect(describeCronSchedule('0 7 * 2 *')).toBeNull()
+    expect(describeCronSchedule('99 7 * * *')).toBeNull()
+    expect(describeCronSchedule('0 25 * * *')).toBeNull()
+    expect(describeCronSchedule('not cron')).toBeNull()
+  })
+})
+
+describe('scheduleDetailBySkill', () => {
+  it('maps skills to prose, joining multiple describable entries, omitting the rest', () => {
+    const map = scheduleDetailBySkill([
+      { skill: 'a', schedule: '0 7 * * *' },
+      { skill: 'a', schedule: '9 8 * * 2' },
+      { skill: 'b', schedule: '*/17 * * * *' },
+    ])
+    expect(map.get('a')).toBe('Daily at 7:00 a.m. · Weekly on Tuesday at 8:09 a.m.')
+    expect(map.has('b')).toBe(false)
+  })
+})
+
+function persona(p: Partial<PersonaConfig>): PersonaConfig {
+  return {
+    slug: 'p',
+    status: 'active',
+    name: 'X',
+    title: null,
+    signature_html: null,
+    tone: [],
+    send_as: null,
+    entitlements: { exposure: {} },
+    skills: [],
+    channel_bindings: [],
+    ...p,
+  }
+}
+
+describe('schedule prose on the skills inventory', () => {
+  it('attaches prose to scheduled skills from projected cron; null elsewhere', () => {
+    const config = {
+      personas: [
+        persona({
+          skills: [
+            { name: 'digest', initiation: { manual: false, scheduled: true, webhook: false } },
+            { name: 'router', initiation: { manual: true, scheduled: false, webhook: true } },
+          ],
+          cron: [{ skill: 'digest', schedule: '23 6 * * 1-5' }],
+        }),
+      ],
+    } as unknown as CustomerConfigRow
+    const { skills } = resolveOperatorSkills(config)
+    expect(skills[0].scheduleDetail).toBe('Weekdays at 6:23 a.m.')
+    expect(skills[1].scheduleDetail).toBeNull()
+  })
+
+  it('rows projected before the cron field existed parse with no prose (defensive)', () => {
+    const config = {
+      personas: [
+        persona({
+          skills: [{ name: 'x', initiation: { manual: true, scheduled: false, webhook: false } }],
+        }),
+      ],
+    } as unknown as CustomerConfigRow
+    expect(resolveOperatorSkills(config).skills[0].scheduleDetail).toBeNull()
+  })
+})

--- a/tests/operator-skills-facet.test.ts
+++ b/tests/operator-skills-facet.test.ts
@@ -77,6 +77,7 @@ describe('resolveOperatorSkills', () => {
         slug: 'matter-inbox-router',
         summary: SKILL_SUMMARIES['matter-inbox-router'],
         initiation: ['When something happens'],
+        scheduleDetail: null,
       },
     ])
   })


### PR DESCRIPTION
## What

**Slice 1B — the last actionable §4 coverage gap: WHEN things run.**

- `personas[].cron` projects skill + schedule into `personas_json` (runtime mechanics stay unprojected); read side is defensive for pre-extension rows
- New schedule facet module: a **deterministic** cron → plain-language describer covering only the authored shapes (daily / weekdays / single weekday); anything else renders no prose — never mistranslated
- Duties rows + the Skills inventory append it: "On a schedule (Weekdays at 6:23 a.m.)" — seat-local by construction
- Registry: schedule → `config_projection`, `has_viewer` at the facets-rooted module (Lock 4 shape)

Post-merge live step: re-project the seats so existing rows pick up cron (auto-sync only fires on yaml changes).

## Verify

`npm run verify` green (EXIT=0) incl. new `operator-schedule-facet` suite (describer shapes + refusal cases, per-skill joining, skills integration, defensive pre-extension parse).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R16YQuNvLvM16AswxGPwJw