### PR TITLE
fix(operator): pre_run pulls read the nested Smokeball matter link object

### DIFF
--- a/operator/skills/client-verification-tracker/pre_run.py
+++ b/operator/skills/client-verification-tracker/pre_run.py
@@ -629,6 +629,15 @@ def _first_str(item: dict, keys: Sequence[str]) -> str:
 
 
 def _matter_id_of(item: dict) -> str:
+    # The live Smokeball /tasks payload carries the matter as a NESTED link
+    # object ({"matter": {"id": ..., "href": ...}}), not a flat matterId —
+    # found by the WP-D probe when the flat-key miss put "unknown-matter" into
+    # every item identity and forked the ledger join (ss #1915).
+    matter = item.get("matter") or item.get("Matter")
+    if isinstance(matter, dict):
+        nested = matter.get("id") or matter.get("Id")
+        if isinstance(nested, str) and nested:
+            return nested
     for key in _MATTER_ID_KEYS:
         value = item.get(key)
         if isinstance(value, str) and value:

--- a/operator/skills/client-verification-tracker/test_verification_pre_run.py
+++ b/operator/skills/client-verification-tracker/test_verification_pre_run.py
@@ -463,6 +463,27 @@ def test_run_once_falls_back_to_wake_when_no_writer():
 # ---------------------------------------------------------------------------
 
 
+def test_parse_pull_reads_nested_matter_link_object():
+    # The live Smokeball /tasks payload nests the matter as a link object —
+    # the flat-key miss put "unknown-matter" into every item identity and
+    # forked the ledger join (WP-D probe find, ss #1915).
+    raw = {
+        "tasks": {
+            "items": [
+                {
+                    "id": "t-1",
+                    "matter": {"id": "m-real", "href": "https://api/matters/m-real"},
+                    "subject": "Client verification outstanding",
+                    "dueDate": "2026-07-20",
+                }
+            ]
+        }
+    }
+    items, problem = parse_pull(raw, today=TODAY)
+    assert problem is None
+    assert items[0].matter_id == "m-real"
+
+
 def test_parse_pull_filters_to_verification_tasks():
     raw = {
         "tasks": {

--- a/operator/skills/deadline-miss-escalator/pre_run.py
+++ b/operator/skills/deadline-miss-escalator/pre_run.py
@@ -494,6 +494,16 @@ def _first_date(item: dict, keys: Sequence[str]) -> date | None:
 
 
 def _matter_id_of(item: dict) -> str:
+    # The live Smokeball /tasks payload carries the matter as a NESTED link
+    # object ({"matter": {"id": ..., "href": ...}}), not a flat matterId —
+    # found by the WP-D probe (ss #1915). The flat keys stay as fallbacks; the
+    # bare "id" fallback is last (it is the TASK's own id, kept only for the
+    # calendar-entry shapes that flatten differently).
+    matter = item.get("matter") or item.get("Matter")
+    if isinstance(matter, dict):
+        nested = matter.get("id") or matter.get("Id")
+        if isinstance(nested, str) and nested:
+            return nested
     for key in _MATTER_ID_KEYS:
         value = item.get(key)
         if isinstance(value, str) and value:

--- a/operator/skills/deadline-miss-escalator/test_escalator_pre_run.py
+++ b/operator/skills/deadline-miss-escalator/test_escalator_pre_run.py
@@ -268,6 +268,27 @@ def test_parse_pull_clean_tasks_and_events() -> None:
     }
 
 
+def test_parse_pull_reads_nested_matter_link_object() -> None:
+    # The live Smokeball /tasks payload nests the matter as a link object —
+    # the flat-key miss put "unknown-matter" (or worse, the task's own id via
+    # the bare-"id" fallback) into item identity (WP-D probe find, ss #1915).
+    raw = {
+        "tasks": {
+            "items": [
+                {
+                    "id": "t-1",
+                    "matter": {"id": "m-real", "href": "https://api/matters/m-real"},
+                    "dueDate": "2026-07-20T00:00:00Z",
+                }
+            ]
+        },
+        "events": [],
+    }
+    deadlines, problem = parse_pull(raw)
+    assert problem is None
+    assert deadlines[0].matter_id == "m-real"
+
+
 def test_parse_pull_bare_list_envelope() -> None:
     raw = {"tasks": [{"matterId": "m-1", "dueDate": "2026-07-20"}], "events": []}
     deadlines, problem = parse_pull(raw)


### PR DESCRIPTION
## Summary
- WP-D probe find (#1915): the live Smokeball `/tasks` payload nests the matter as a link object (`{"matter": {"id": …}}`). Both pre_run pulls only checked flat keys, so the chase pull stamped `unknown-matter` into every item identity — the ledger join forked and suppression could never engage (the escalator additionally risked mistaking the task's own id for the matter id via its bare-`id` fallback).
- Nested link object read first; flat keys stay as fallbacks. Parse tests added for both skills.

## Test plan
- [x] Substrate suite (exact CI invocation): 843 passed
- [ ] Post-merge: seat re-projection picks the scripts up on next reprovision; probe 2 (cadence/terminal suppression) verifies live

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MM1hvcoHxjCDAQ56ZbfanM