### PR TITLE
fix(portal): Captain walk round 2 — honest status during setup, voice off the hero, nav dedupe, home honesty

### DIFF
--- a/src/components/portal/operator/OperatorOverviewBlock.astro
+++ b/src/components/portal/operator/OperatorOverviewBlock.astro
@@ -10,11 +10,13 @@
  */
 interface Props {
   label: string
-  href: string
-  linkLabel: string
+  /** Chapter link. Omit both for a block whose fact has no deeper chapter
+   *  (e.g. Voice until the voice-library slice lands). */
+  href?: string | null
+  linkLabel?: string | null
 }
 
-const { label, href, linkLabel } = Astro.props
+const { label, href = null, linkLabel = null } = Astro.props
 ---
 
 <section
@@ -28,14 +30,18 @@ const { label, href, linkLabel } = Astro.props
   </div>
   <div class="px-5 py-5 md:px-7">
     <slot />
-    <a
-      href={href}
-      class="mt-4 inline-flex min-h-11 items-center gap-2 font-mono text-label font-bold uppercase tracking-[0.14em] text-[color:var(--color-text-primary)] hover:text-[color:var(--color-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2"
-    >
-      {linkLabel}
-      <span aria-hidden="true" class="font-body font-black text-[color:var(--color-primary)]"
-        >→</span
-      >
-    </a>
+    {
+      href && linkLabel && (
+        <a
+          href={href}
+          class="mt-4 inline-flex min-h-11 items-center gap-2 font-mono text-label font-bold uppercase tracking-[0.14em] text-[color:var(--color-text-primary)] hover:text-[color:var(--color-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2"
+        >
+          {linkLabel}
+          <span aria-hidden="true" class="font-body font-black text-[color:var(--color-primary)]">
+            →
+          </span>
+        </a>
+      )
+    }
   </div>
 </section>

--- a/src/components/portal/operator/facets/OperatorHero.astro
+++ b/src/components/portal/operator/facets/OperatorHero.astro
@@ -5,6 +5,15 @@
  * headline) rendered in the original loud Plainspoken register (Captain call
  * 2026-07-08: keep the reshaped content, revert the calm register for now).
  *
+ * This block is STATUS ONLY (Captain walk, 2026-07-15): the persona's voice
+ * detail (tone / writes-from / also-operates-as) is configuration, not
+ * status — it renders in the landing's Voice block, not here.
+ *
+ * A provisioning subscription suppresses the aliveness alarm entirely: the
+ * operator is not in service, so "offline, needs your attention" would be a
+ * false flag (Captain finding, 2026-07-15). The hero states the setup posture
+ * instead, and the escalation affordance stays hidden.
+ *
  * Honesty unchanged: identity is authored config (falls back to "Your operator");
  * health is the real aliveness signal and says so plainly when the bridge has no
  * data (never a fabricated healthy state); only operator problems surface here.
@@ -20,19 +29,17 @@ import type { OperatorHeroModel } from '../../../../lib/portal/operator/facets/i
 interface Props {
   model: OperatorHeroModel
   escalationHref?: string | null
+  /** True while the subscription is still provisioning — renders the setup
+   *  posture instead of the aliveness signal. */
+  provisioning?: boolean
 }
 
-const { model, escalationHref = null } = Astro.props
+// "Contact your consultant" contacts a person (Captain finding, 2026-07-15:
+// it previously routed to the settings hub, which answers nothing when the
+// operator is down). team@smd.services is the operational-escalation address.
+const { model, escalationHref = 'mailto:team@smd.services', provisioning = false } = Astro.props
 const displayName = model.name ?? 'Your operator'
 const personaLine = model.title ? `${displayName} · ${model.title}` : displayName
-
-// "Who it is" detail (console blueprint §4 coverage: persona identity + voice
-// posture). All authored config; each line renders only when authored.
-const toneLine = model.tone.length > 0 ? model.tone.join(' · ') : null
-const alsoLine =
-  model.alsoOperatesAs.length > 0
-    ? model.alsoOperatesAs.map((p) => (p.title ? `${p.name} (${p.title})` : p.name)).join(', ')
-    : null
 
 const HEALTH: Record<AlivenessLevel, { headline: string; dot: string; problem: boolean }> = {
   idle: { headline: 'Running normally', dot: 'bg-[color:var(--color-complete)]', problem: false },
@@ -56,8 +63,7 @@ const lastRel = signal ? formatLastActionRelative(signal.lastActionAt) : null
 const lastAbs = signal ? formatLastActionAbsolute(signal.lastActionAt) : null
 const currentSkill = signal?.level === 'running' ? signal.currentSkill : null
 const stickyReason = signal?.level === 'sticky_stop' ? signal.stickyStopReason : null
-const showEscalation = level ? needsEscalationAffordance(level) : false
-const escalationTarget = escalationHref ?? '/portal/products/operator/settings'
+const showEscalation = !provisioning && level ? needsEscalationAffordance(level) : false
 ---
 
 <section
@@ -71,29 +77,16 @@ const escalationTarget = escalationHref ?? '/portal/products/operator/settings'
   </p>
 
   {
-    (toneLine || model.sendAs || alsoLine) && (
-      <div class="mt-1 flex flex-col gap-0.5">
-        {toneLine && (
-          <p class="font-body text-sm leading-snug text-[color:var(--color-text-secondary)]">
-            Sounds: {toneLine}
-          </p>
-        )}
-        {model.sendAs && (
-          <p class="font-body text-sm leading-snug text-[color:var(--color-text-secondary)]">
-            Writes from: {model.sendAs}
-          </p>
-        )}
-        {alsoLine && (
-          <p class="font-body text-sm leading-snug text-[color:var(--color-text-secondary)]">
-            Also operates as: {alsoLine}
-          </p>
-        )}
-      </div>
-    )
-  }
-
-  {
-    health ? (
+    provisioning ? (
+      <>
+        <h2 class="mt-2 font-body text-2xl font-black uppercase tracking-[-0.02em] text-[color:var(--color-text-primary)] md:text-3xl">
+          Being set up
+        </h2>
+        <p class="mt-2 font-mono text-label uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)]">
+          Setup in progress. Your Operator is being configured.
+        </p>
+      </>
+    ) : health ? (
       <>
         <div class="mt-2 flex items-center gap-3">
           <span class={`inline-block h-3 w-3 rounded-full ${health.dot}`} aria-hidden="true" />
@@ -115,9 +108,9 @@ const escalationTarget = escalationHref ?? '/portal/products/operator/settings'
             {lastRel ? `Last action ${lastRel}` : ''}
           </p>
         )}
-        {showEscalation && (
+        {showEscalation && escalationHref && (
           <a
-            href={escalationTarget}
+            href={escalationHref}
             class="mt-4 inline-flex min-h-11 items-center border-[3px] border-[color:var(--color-text-primary)] bg-[color:var(--color-text-primary)] px-4 font-mono text-label font-bold uppercase tracking-[0.14em] text-[color:var(--color-background)] transition-colors hover:bg-[color:var(--color-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2"
           >
             Contact your consultant

--- a/src/lib/portal/home-cards.ts
+++ b/src/lib/portal/home-cards.ts
@@ -174,7 +174,10 @@ async function billingCard(
   if (!offerings.hasInvoices && offerings.subscriptions.length === 0) return null
 
   let needsYou: OfferingCard['needsYou'] = null
-  let statusLabel = 'Up to date'
+  // "Up to date" is a claim about invoice history — it needs history to be
+  // true of. A client who has never been invoiced sees the honest fact
+  // instead (Captain finding, 2026-07-15: the label read as a placeholder).
+  let statusLabel = offerings.hasInvoices ? 'Up to date' : 'No invoices yet'
   const meta: string[] = []
 
   try {

--- a/src/lib/portal/operator/account-read.ts
+++ b/src/lib/portal/operator/account-read.ts
@@ -89,11 +89,13 @@ export function parseEscalation(raw: unknown): EscalationView {
   }
 }
 
-/** One-line human label for a subscription status. */
+/** One-line human label for a subscription status. Client language, not
+ *  infrastructure language — "Being set up", never "Provisioning" (admin
+ *  surfaces keep their own internal vocabulary). */
 export function subscriptionStatusLabel(status: SubscriptionStatus): string {
   switch (status) {
     case 'provisioning':
-      return 'Provisioning'
+      return 'Being set up'
     case 'active':
       return 'Active'
     case 'paused':

--- a/src/lib/portal/operator/facets/identity/hero.ts
+++ b/src/lib/portal/operator/facets/identity/hero.ts
@@ -51,6 +51,27 @@ function humanizeTone(t: string): string {
 }
 
 /**
+ * The landing's VOICE block lines (Captain finding 2026-07-15: voice detail is
+ * configuration, not status — it renders in its own block, not on the health
+ * hero). Each line is present only when authored; an all-null result means the
+ * block is absent entirely (empty-chapter rule).
+ */
+export function voiceLines(model: OperatorHeroModel): {
+  tone: string | null
+  writesFrom: string | null
+  alsoOperatesAs: string | null
+} {
+  return {
+    tone: model.tone.length > 0 ? model.tone.join(' · ') : null,
+    writesFrom: model.sendAs,
+    alsoOperatesAs:
+      model.alsoOperatesAs.length > 0
+        ? model.alsoOperatesAs.map((p) => (p.title ? `${p.name} (${p.title})` : p.name)).join(', ')
+        : null,
+  }
+}
+
+/**
  * Compose the hero view model from the config projection + the resolved
  * aliveness signal. Pure and total: a null config or no-active-persona yields
  * null identity fields; the caller passes the already-resolved signal.

--- a/src/pages/portal/billing/index.astro
+++ b/src/pages/portal/billing/index.astro
@@ -89,9 +89,11 @@ const csMessage =
   pathname={Astro.url.pathname}
   offerings={offerings}
 >
+  {
+    /* No crumb: this page is the Billing nav tab's destination — a "← Home"
+      crumb would duplicate the Home tab directly above it. */
+  }
   <PortalPageHead
-    crumbHref="/portal"
-    crumbLabel="Home"
     tag="Ledger"
     h1="Billing"
     meta={invoices.length > 0

--- a/src/pages/portal/engagement/documents/index.astro
+++ b/src/pages/portal/engagement/documents/index.astro
@@ -137,8 +137,8 @@ function kindFor(doc: DocumentEntry): string {
   pathname={Astro.url.pathname}
 >
   <PortalPageHead
-    crumbHref="/portal"
-    crumbLabel="Home"
+    crumbHref="/portal/engagement"
+    crumbLabel="Engagement"
     tag="File room"
     h1="Documents"
     meta={`${documents.length} total`}

--- a/src/pages/portal/engagement/index.astro
+++ b/src/pages/portal/engagement/index.astro
@@ -77,9 +77,11 @@ const headMeta = engagement
   pathname={Astro.url.pathname}
   offerings={offerings}
 >
+  {
+    /* No crumb: this page is the Engagement nav tab's destination — a "← Home"
+      crumb would duplicate the Home tab directly above it. */
+  }
   <PortalPageHead
-    crumbHref="/portal"
-    crumbLabel="Home"
     tag={engagement ? `Engagement № ${engagement.id.slice(0, 2).toUpperCase()}` : 'Engagement'}
     h1="Engagement"
     meta={headMeta}

--- a/src/pages/portal/index.astro
+++ b/src/pages/portal/index.astro
@@ -252,15 +252,21 @@ const touchpointText: string | null = (() => {
           ))}
         </div>
 
-        <section class="mt-12 min-w-0">
-          <p class="font-mono text-label uppercase tracking-[0.18em] font-bold text-[color:var(--ss-color-text-secondary)]">
-            Recent activity
-          </p>
-          <h2 class="mt-2 font-body text-3xl md:text-4xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]">
-            Log
-          </h2>
+        {/* The log records engagement-lifecycle events (proposals sent/signed,
+            invoices sent/paid, milestones completed). When nothing has
+            happened yet — or the client owns only products that don't feed
+            it — the section is absent, not an empty frame (empty-chapter
+            rule; Captain finding 2026-07-15: the empty box read as filler,
+            and its old copy promised a "next touchpoint" nobody authored). */}
+        {timelineEntries.length > 0 && (
+          <section class="mt-12 min-w-0">
+            <p class="font-mono text-label uppercase tracking-[0.18em] font-bold text-[color:var(--ss-color-text-secondary)]">
+              Recent activity
+            </p>
+            <h2 class="mt-2 font-body text-3xl md:text-4xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]">
+              Log
+            </h2>
 
-          {timelineEntries.length > 0 ? (
             <div class="mt-6 border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)] p-5 md:p-7 space-y-6">
               {timelineEntries.map((entry) => (
                 <TimelineEntry
@@ -272,14 +278,8 @@ const touchpointText: string | null = (() => {
                 />
               ))}
             </div>
-          ) : (
-            <div class="mt-6 border-[3px] border-[color:var(--ss-color-text-primary)] p-6 md:p-8">
-              <p class="text-[color:var(--ss-color-text-secondary)]">
-                Nothing here yet. First entry lands after your next touchpoint.
-              </p>
-            </div>
-          )}
-        </section>
+          </section>
+        )}
       </>
     )
   }

--- a/src/pages/portal/products/hosted-agent/index.astro
+++ b/src/pages/portal/products/hosted-agent/index.astro
@@ -167,13 +167,11 @@ const stMessage =
   entityId={client.id}
   pathname={Astro.url.pathname}
 >
-  <PortalPageHead
-    crumbHref="/portal"
-    crumbLabel="Home"
-    tag="Product"
-    h1="Hosted Agent"
-    meta={null}
-  />
+  {
+    /* No crumb: this page is the Agent nav tab's destination — a "← Home"
+      crumb would duplicate the Home tab directly above it. */
+  }
+  <PortalPageHead tag="Product" h1="Hosted Agent" meta={null} />
 
   {
     stMessage && (

--- a/src/pages/portal/products/operator/[instance]/index.astro
+++ b/src/pages/portal/products/operator/[instance]/index.astro
@@ -7,7 +7,10 @@ import {
   type ProductAccess,
 } from '../../../../../lib/portal/product-access'
 import OperatorHero from '../../../../../components/portal/operator/facets/OperatorHero.astro'
-import { resolveOperatorHero } from '../../../../../lib/portal/operator/facets/identity/hero'
+import {
+  resolveOperatorHero,
+  voiceLines,
+} from '../../../../../lib/portal/operator/facets/identity/hero'
 import {
   resolveAlivenessSignal,
   type AlivenessSignal,
@@ -60,11 +63,12 @@ if (!portalData.client) {
 const { user, client } = portalData
 
 // Breadcrumb parent (list → detail hierarchy): step back to the OPERATORS list
-// when the client owns more than one operator; otherwise Home, since a lone
-// operator's list just forwards straight back into this same page.
+// only when the client owns more than one operator. With a single operator the
+// list forwards straight here, making this page the nav tab's destination — a
+// "← Home" crumb would duplicate the Home tab one inch above it (Captain
+// finding, 2026-07-15: top-level nav destinations carry no crumb).
 const operatorCount = (await listCustomerConfigsForEntity(env.DB, client.id)).length
-const backHref = operatorCount > 1 ? '/portal/products/operator' : '/portal'
-const backLabel = operatorCount > 1 ? 'Operators' : 'Home'
+const showCrumb = operatorCount > 1
 
 type SurfaceState = 'no_subscription' | 'paused' | 'no_role' | 'active'
 let surfaceState: SurfaceState
@@ -124,6 +128,14 @@ const heroModel = resolveOperatorHero(customerConfig, alivenessSignal)
 const overview = resolveOperatorOverview(customerConfig)
 const job = jobLines(overview.job)
 
+// VOICE — the persona's authored writing posture (tone descriptors, mailbox
+// identity, other authored identities). Configuration, not status: it moved
+// here from the status hero (Captain finding, 2026-07-15 — persona flavor
+// text has no business inside the health block). No chapter link yet; the
+// voice library is a later slice by design (blueprint §4).
+const voice = voiceLines(heroModel)
+const hasVoice = Boolean(voice.tone || voice.writesFrom || voice.alsoOperatesAs)
+
 // Change-request filing outcome (returns via ?cr=filed|invalid|error).
 const crStatus = Astro.url.searchParams.get('cr')
 const crMessage =
@@ -164,13 +176,19 @@ const empty = surfaceState !== 'active' ? EMPTY[surfaceState] : null
   entityId={client.id}
   pathname={Astro.url.pathname}
 >
-  <a
-    href={backHref}
-    class="mt-6 -mx-1 inline-flex min-h-11 items-center gap-2 px-1 font-mono text-label font-semibold uppercase tracking-[0.18em] text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2"
-  >
-    <span aria-hidden="true" class="font-body font-black text-[color:var(--color-primary)]">←</span>
-    {backLabel}
-  </a>
+  {
+    showCrumb && (
+      <a
+        href="/portal/products/operator"
+        class="mt-6 -mx-1 inline-flex min-h-11 items-center gap-2 px-1 font-mono text-label font-semibold uppercase tracking-[0.18em] text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2"
+      >
+        <span aria-hidden="true" class="font-body font-black text-[color:var(--color-primary)]">
+          ←
+        </span>
+        Operators
+      </a>
+    )
+  }
 
   {
     crMessage && (
@@ -201,22 +219,13 @@ const empty = surfaceState !== 'active' ? EMPTY[surfaceState] : null
   }
 
   {
-    surfaceState === 'active' && isProvisioning && (
-      <div
-        role="status"
-        class="mt-6 border-[3px] border-[color:var(--color-text-primary)] px-5 py-3 font-mono text-label font-bold uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)]"
-      >
-        Setup in progress. Your Operator is being configured.
-      </div>
-    )
-  }
-
-  {
     surfaceState === 'active' && (
       <>
         <p class={`mt-8 ${seclabelClass}`}>Status</p>
         <div class="mt-3">
-          <OperatorHero model={heroModel} escalationHref={`${operatorBase}/settings`} />
+          {/* One status signal: while provisioning, the hero itself states the
+              setup posture (no aliveness alarm, no separate banner). */}
+          <OperatorHero model={heroModel} provisioning={isProvisioning} />
         </div>
         {overview.publishedOn && (
           <p class="mt-2 font-mono text-label uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)]">
@@ -253,6 +262,28 @@ const empty = surfaceState !== 'active' ? EMPTY[surfaceState] : null
               linkLabel="Duties"
             >
               <OperatorAuthorityRows rows={overview.authority} />
+            </OperatorOverviewBlock>
+          )}
+
+          {hasVoice && (
+            <OperatorOverviewBlock label="Voice">
+              <div class="flex flex-col gap-1">
+                {voice.tone && (
+                  <p class="font-body text-base text-[color:var(--color-text-primary)]">
+                    Sounds: {voice.tone}
+                  </p>
+                )}
+                {voice.writesFrom && (
+                  <p class="font-body text-base text-[color:var(--color-text-primary)]">
+                    Writes from: {voice.writesFrom}
+                  </p>
+                )}
+                {voice.alsoOperatesAs && (
+                  <p class="font-body text-base text-[color:var(--color-text-primary)]">
+                    Also operates as: {voice.alsoOperatesAs}
+                  </p>
+                )}
+              </div>
             </OperatorOverviewBlock>
           )}
 

--- a/tests/operator-account.test.ts
+++ b/tests/operator-account.test.ts
@@ -54,7 +54,7 @@ describe('parseEscalation: defensive, never a fabricated contact', () => {
 
 describe('subscription status display', () => {
   it('labels every known status and falls back to Unknown', () => {
-    expect(subscriptionStatusLabel('provisioning')).toBe('Provisioning')
+    expect(subscriptionStatusLabel('provisioning')).toBe('Being set up')
     expect(subscriptionStatusLabel('active')).toBe('Active')
     expect(subscriptionStatusLabel('paused')).toBe('Paused')
     expect(subscriptionStatusLabel('unknown')).toBe('Unknown')


### PR DESCRIPTION
Six findings from the Captain's 2026-07-15 console walk, one batch:

1. **Provisioning is not an alarm.** The operator status hero now states **Being set up** while the subscription is provisioning — no red "Offline, needs your attention" false flag, no escalation button, and the separate setup banner is gone (one signal owns the posture). Client-facing subscription label `Provisioning` → `Being set up` (home card, billing, account); admin keeps internal vocabulary.
2. **"Contact your consultant" contacts a person** — `mailto:team@smd.services` — instead of routing to the settings hub, which answers nothing when the operator is down.
3. **Voice off the status hero.** Sounds / Writes from / Also operates as are configuration, not status: they render as a **Voice** block on the one-pager (new `voiceLines()` in the hero resolver; `OperatorOverviewBlock` link now optional — the voice library chapter is a later slice by design).
4. **No "← Home" crumb on nav-tab destinations** (operator landing with a single operator, Engagement, Billing, Hosted Agent). Operator landing keeps a crumb only when the client owns >1 operator (→ the list). Engagement › Documents crumbs to Engagement, not Home.
5. **Billing card honesty:** "No invoices yet" until invoice history exists; "Up to date" only when there is history for it to be a claim about.
6. **Recent-activity Log** renders only when it has entries (empty-chapter rule); the fabricated "first entry lands after your next touchpoint" empty copy is gone.

Verify green (typecheck, lint, format, build, 3552 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R16YQuNvLvM16AswxGPwJw