### PR TITLE
feat(admin): Clients shows the whole book, honestly (ADR 0077 Part 2 PR1)

### DIFF
--- a/docs/design/admin/surface-briefs/clients.md
+++ b/docs/design/admin/surface-briefs/clients.md
@@ -1,0 +1,118 @@
+# Surface Brief: Clients (`/admin/clients` + `/admin/clients/[id]`)
+
+Status: **LOCKED** 2026-07-15 (Captain sign-off). Governs the Part 2 build of
+ADR 0077 (admin portal mirrors the client portal). Follows the Core Model
+surface-brief process in `docs/style/surface-brief.md`.
+
+## The build-vs-buy decision behind this brief
+
+Before locking, we asked whether a flat Clients surface means "building our own
+CRM," and whether an off-the-shelf CRM (HubSpot / Pipedrive / Attio / Folk)
+would be the intentional choice. It would not, for one structural reason: SMD
+already runs a single, non-optional system of record. The `entities` row is
+what a booking writes to, what `quotes.entity_id` points at, what a signed SOW
+and every invoice hang off, what the client portal authenticates a person into,
+and what Operator provisioning keys on. A prospect who signs is not "converted";
+the same row walks the whole lifecycle from first contact to a portal login to a
+running Operator machine.
+
+An external CRM cannot be that record (it cannot own our portal, our SOW
+generation, our billing, or Operator). So a CRM would sit _beside_ the record,
+not replace it, forcing re-keying at exactly the signing moment and two truths
+kept in sync forever. For a business whose product _is_ a system of record, a
+second system of record is the expensive mistake. Decision: keep one record;
+put the thinnest honest surface over it. Revisit only if SMD runs real outbound
+at volume, adds a second person on the pipeline, or wants email sequencing as a
+sales motion, at which point a funnel CRM feeds _into_ the record.
+
+## 1. Target user
+
+The Captain, running SMD. One user. He has landed a conversation (networking,
+referral) or someone booked an assessment, and he needs to see and move the
+people he is working with, from first contact through signed client through
+delivery.
+
+## 2. User tasks
+
+- "I met someone worth pursuing. Add them so I can work them toward an assessment."
+- "Someone booked an assessment. I need to see them, run the call, send a quote, get them signed."
+- "Show me everyone I am working with and where each stands, so I know who needs me next."
+- "Open one and give me their whole story (contact, what we discussed, quotes/SOW, what they owe) so I can act without digging."
+
+## 3. Business objective
+
+This is the venture's book of business, cradle to grave. It must keep any booked
+assessment or live client from falling through a crack, carry the
+assessment to quote to SOW to signed conversion (the money path), and show what
+is owed. It replaces the Leads funnel with an honest record list.
+
+## 4. Inward paths
+
+Nav "Clients." Booking-confirmation emails deep-link to a record. Assessment and
+engagement pages hand off here. Those links point at `/admin/entities/[id]`
+today; Part 2 leaves a 301 stub so in-flight emails still resolve, and repoints
+the handful of user-facing breadcrumbs.
+
+## 5. Core content
+
+- **List:** one flat list of every business we are working with, newest first.
+  Each row: name, vertical, stage badge, outstanding balance, Operator badge if
+  provisioned. No funnel tabs, no buckets.
+- **Record:** identity (name plus stage, honestly labeled), contact(s), the
+  conversation/timeline, assessment/meeting (with live notes), quotes/SOW,
+  invoices and what is owed, Operator card if present.
+
+## 6. Forward paths
+
+- **List:** add a client; open a record.
+- **Record:** add/edit contact; log a note; schedule/run the assessment; draft a
+  quote from the meeting; send for signature (existing SignWell flow); set
+  Operator price. The record becomes a client automatically when a quote is
+  accepted; that is the invariant, not a button.
+
+## 7. Verdict and locked decisions
+
+- **A. Flat list with stage badges, not two buckets.** LOCKED. A
+  stage-partitioned two-section list is the funnel wearing a Clients costume.
+  Badge labels map the canonical stages to honest words (`clientStageBadge` in
+  `src/lib/admin/client-hub.ts`): Prospect, Assessment (`meetings`), Proposing,
+  Client (`engaged`), Delivered, Ongoing, with Lost behind an optional "show
+  lost" filter and `signal` never shown. Placement is a total function over all
+  eight stages, so no record silently disappears.
+- **B. One record cockpit.** LOCKED. Make `clients/[id]` stage-aware (it must
+  stop labeling a pre-signature record "Client" — that is mislabeling under the
+  no-fabricated-content rule) and retire `entities/[id]` to a 301 stub. Inventory
+  field-by-field what `entities/[id]` renders that `clients/[id]` lacks before
+  cutting over.
+- **C. Add-a-client is minimal.** LOCKED. Name plus vertical plus optional
+  contact, created as a `prospect`. Verified against a real created row, not
+  types. No pipeline-intake form.
+- **D. Meetings/quotes subtree stays in place.** LOCKED (floor scope). Do not
+  re-home `entities/[id]/meetings/*` or `entities/[id]/quotes/*`; the 301 stub on
+  the parent absorbs the path, and re-homing buys no user-visible gain for real
+  churn. Repoint only the few user-facing breadcrumb hrefs inside the surviving
+  pages.
+
+## Stage enum
+
+Keep the eight values (`signal|prospect|meetings|proposing|engaged|delivered|ongoing|lost`);
+do not migrate. Retire only the dead `signal` cold-origin (new records start
+`prospect`). Preserve the two invariants in `transitionStage`
+(`src/lib/db/entities.ts`): `proposing to engaged` requires an accepted quote;
+`delivered to ongoing` requires a paid completion invoice.
+
+## Out of scope
+
+Follow-ups subsystem (untouched); the deeper "is the whole booking/SOW apparatus
+over-built for pre-launch" question (parked); Settings rework.
+
+## Build sequence
+
+1. **New front (no deletion):** Clients list flat + stage badges + add-client +
+   `clients/[id]` made stage-aware. Highest value, lowest risk, ships first.
+2. **Cut over + tear down:** 301 stubs at `/admin/entities` and
+   `/admin/entities/[id]`; repoint user-facing breadcrumbs; delete the Leads list
+   and pure-theater apparatus (dismiss/merge/reply-log/EntityListRow/list-sort),
+   each deletion carrying its own test surgery.
+
+Nothing ships against an unsigned brief. This brief is signed.

--- a/src/lib/admin/client-hub.ts
+++ b/src/lib/admin/client-hub.ts
@@ -17,6 +17,44 @@ import type { Invoice } from '../db/invoices'
 import type { Engagement, EngagementStatus } from '../db/engagements'
 import { ENGAGEMENT_STATUSES } from '../db/engagements'
 import type { Quote } from '../db/quotes'
+import type { EntityStage } from '../db/entities'
+
+/**
+ * Admin-facing stage badge for the Clients surface: an honest label plus
+ * whether the record has crossed the signature line (drives badge tone).
+ *
+ * The eight canonical stages (`src/lib/db/entities.ts`) are unchanged; this
+ * only maps them to the labels Clients shows. Two labels differ from the raw
+ * enum on purpose: `meetings` reads "Assessment" (what the stage actually is),
+ * and `engaged` reads "Client" (a signed quote at `proposing → engaged` is the
+ * moment a record becomes one). `signed` is true from `engaged` onward.
+ */
+export interface ClientStageBadge {
+  label: string
+  signed: boolean
+}
+
+export function clientStageBadge(stage: EntityStage): ClientStageBadge {
+  switch (stage) {
+    case 'prospect':
+      return { label: 'Prospect', signed: false }
+    case 'meetings':
+      return { label: 'Assessment', signed: false }
+    case 'proposing':
+      return { label: 'Proposing', signed: false }
+    case 'engaged':
+      return { label: 'Client', signed: true }
+    case 'delivered':
+      return { label: 'Delivered', signed: true }
+    case 'ongoing':
+      return { label: 'Ongoing', signed: true }
+    case 'lost':
+      return { label: 'Lost', signed: false }
+    case 'signal':
+    default:
+      return { label: 'Signal', signed: false }
+  }
+}
 
 export interface BillingRollup {
   /** Sum of all non-draft, non-void invoice amounts. */

--- a/src/lib/db/entities.ts
+++ b/src/lib/db/entities.ts
@@ -101,6 +101,7 @@ export interface CreateEntityData {
   area?: string | null
   phone?: string | null
   website?: string | null
+  vertical?: string | null
   stage?: EntityStage
   source_pipeline?: string | null
 }
@@ -348,7 +349,7 @@ export async function createEntity(
   const now = new Date().toISOString()
   await db
     .prepare(
-      `INSERT INTO entities (id, org_id, name, slug, phone, website, area, stage, stage_changed_at, source_pipeline, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      `INSERT INTO entities (id, org_id, name, slug, phone, website, area, vertical, stage, stage_changed_at, source_pipeline, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
     )
     .bind(
       id,
@@ -358,6 +359,7 @@ export async function createEntity(
       data.phone ?? null,
       data.website ?? null,
       data.area ?? null,
+      data.vertical ?? null,
       data.stage ?? 'signal',
       now,
       data.source_pipeline ?? null,

--- a/src/pages/admin/clients/[id].astro
+++ b/src/pages/admin/clients/[id].astro
@@ -9,6 +9,7 @@
  * The `service` spine is deferred — this renders the unified view today.
  */
 import AdminLayout from '../../../layouts/AdminLayout.astro'
+import AdminFlashNotice from '../../../components/admin/AdminFlashNotice.astro'
 import EntityTimelineEntry from '../../../components/admin/EntityTimelineEntry.astro'
 import { loadEntityDetailPage, formatDate } from '../../../lib/admin/entity-detail-page'
 import { listFleetRoster, personaSummary, posturePill } from '../../../lib/admin/fleet-roster'
@@ -17,8 +18,9 @@ import {
   engagementToServiceRow,
   formatMoney,
   serviceToneDotClass,
+  clientStageBadge,
 } from '../../../lib/admin/client-hub'
-import { ENTITY_VERTICALS, ENTITY_STAGES } from '../../../lib/db/entities'
+import { ENTITY_VERTICALS } from '../../../lib/db/entities'
 import { getOperatorServiceForEntity } from '../../../lib/db/services'
 import { getSubscriptionForBilling } from '../../../lib/db/subscriptions'
 import { statusBadgeClass } from '../../../lib/ui/status-badge'
@@ -56,7 +58,8 @@ const serviceRows = engagements.map((eng) => engagementToServiceRow(eng, quotes)
 
 const verticalLabel =
   ENTITY_VERTICALS.find((v) => v.value === entity.vertical)?.label ?? entity.vertical ?? '—'
-const stageLabel = ENTITY_STAGES.find((s) => s.value === entity.stage)?.label ?? entity.stage
+const badge = clientStageBadge(entity.stage)
+const created = Astro.url.searchParams.get('created')
 const primaryContact = contacts[0] ?? null
 
 const earliestStart = engagements
@@ -79,6 +82,8 @@ const LINK_ACT =
   breadcrumbs={[{ label: 'Clients', href: '/admin/clients' }, { label: entity.name }]}
   maxWidth="max-w-6xl"
 >
+  {created && <AdminFlashNotice message={`${entity.name} added.`} />}
+
   <a
     href="/admin/clients"
     class="mb-5 inline-flex items-center gap-1 text-sm text-[color:var(--ss-color-text-secondary)] transition-colors hover:text-[color:var(--ss-color-primary)]"
@@ -98,11 +103,21 @@ const LINK_ACT =
       <span
         class="inline-flex items-center gap-2 border border-[color:var(--ss-color-border)] px-2 py-1 font-mono text-[11px] font-bold uppercase tracking-[0.1em]"
       >
-        <span class="h-[7px] w-[7px] rounded-full bg-[color:var(--ss-color-complete)]"></span>
-        Client · {stageLabel}
+        <span
+          class:list={[
+            'h-[7px] w-[7px] rounded-full',
+            entity.stage === 'lost'
+              ? 'bg-[color:var(--ss-color-text-muted)]'
+              : badge.signed
+                ? 'bg-[color:var(--ss-color-complete)]'
+                : 'bg-[color:var(--ss-color-primary)]',
+          ]}></span>
+        {badge.label}
       </span>
       {primaryContact && <div class="mt-2">Primary: {primaryContact.name}</div>}
-      <div>Client since {clientSince}</div>
+      <div>
+        {badge.signed ? `Client since ${clientSince}` : `Added ${formatDate(entity.created_at)}`}
+      </div>
     </div>
   </div>
 

--- a/src/pages/admin/clients/index.astro
+++ b/src/pages/admin/clients/index.astro
@@ -1,43 +1,51 @@
 ---
 /**
- * Clients list — the post-acceptance account directory (ADR 0046).
+ * Clients — the venture's book of business, cradle to grave (ADR 0077).
  *
- * Entities past the acceptance line (engaged / delivered / ongoing).
- * Pre-acceptance records live in Leads. Same `entities` table, split by
- * stage — the surface follows the record's current job.
+ * One flat list of every business we are working with, newest first, each row
+ * badged with its lifecycle stage. Not a post-acceptance directory and not a
+ * funnel: a prospect is an early client, shown as a plain record. `signal` (the
+ * dead cold-origin stage) is never shown; `lost` sits behind an opt-in filter.
  */
 import AdminLayout from '../../../layouts/AdminLayout.astro'
-import { listEntities, ENTITY_VERTICALS, ENTITY_STAGES } from '../../../lib/db/entities'
-import type { EntityStage } from '../../../lib/db/entities'
+import { listEntities, ENTITY_VERTICALS } from '../../../lib/db/entities'
 import { getInvoiceRollupForEntities } from '../../../lib/db/invoices'
 import { listFleetRoster } from '../../../lib/admin/fleet-roster'
-import { formatMoney } from '../../../lib/admin/client-hub'
+import { formatMoney, clientStageBadge } from '../../../lib/admin/client-hub'
 import { env } from 'cloudflare:workers'
 
 const session = Astro.locals.session!
 
-const CLIENT_STAGES: EntityStage[] = ['engaged', 'delivered', 'ongoing']
+const showLost = Astro.url.searchParams.get('show') === 'lost'
 
-const [clients, roster] = await Promise.all([
-  listEntities(env.DB, session.orgId, { stages: CLIENT_STAGES }),
+const [all, roster] = await Promise.all([
+  listEntities(env.DB, session.orgId),
   listFleetRoster(env.DB),
 ])
+
+// `signal` is the retired cold-origin stage — never a record we are working.
+// `lost` is reachable (it can re-engage to prospect) but hidden by default.
+const records = all.filter((e) => {
+  if (e.stage === 'signal') return false
+  if (e.stage === 'lost') return showLost
+  return true
+})
 
 const rollups = await getInvoiceRollupForEntities(
   env.DB,
   session.orgId,
-  clients.map((c) => c.id)
+  records.map((r) => r.id)
 )
 const operatorEntityIds = new Set(roster.map((r) => r.entity_id))
+const lostCount = all.filter((e) => e.stage === 'lost').length
 
 function verticalLabel(v: string | null): string {
   return ENTITY_VERTICALS.find((x) => x.value === v)?.label ?? v ?? '—'
 }
-function stageLabel(s: string): string {
-  return ENTITY_STAGES.find((x) => x.value === s)?.label ?? s
-}
 
 const COL = 'grid grid-cols-[1.6fr_1.4fr_0.9fr_0.9fr_1fr] gap-4 items-center'
+const ADD_BTN =
+  'inline-flex items-center gap-1.5 border border-[color:var(--ss-color-primary)] bg-[color:var(--ss-color-primary)] px-3.5 py-2 font-mono text-[11px] font-bold uppercase tracking-[0.12em] text-white transition-colors hover:bg-[color:var(--ss-color-primary-hover)]'
 ---
 
 <AdminLayout
@@ -45,34 +53,47 @@ const COL = 'grid grid-cols-[1.6fr_1.4fr_0.9fr_0.9fr_1fr] gap-4 items-center'
   breadcrumbs={[{ label: 'Clients' }]}
   maxWidth="max-w-6xl"
 >
-  <div class="mb-5 flex items-end justify-between">
-    <h1 class="text-2xl font-bold text-[color:var(--ss-color-text-primary)]">Clients</h1>
-    <span class="font-mono text-[13px] text-[color:var(--ss-color-text-muted)]">
-      {clients.length}
-      {clients.length === 1 ? 'client' : 'clients'}
-    </span>
+  <div class="mb-5 flex flex-wrap items-end justify-between gap-3">
+    <div class="flex items-baseline gap-3">
+      <h1 class="text-2xl font-bold text-[color:var(--ss-color-text-primary)]">Clients</h1>
+      <span class="font-mono text-[13px] text-[color:var(--ss-color-text-muted)]">
+        {records.length}
+        {records.length === 1 ? 'record' : 'records'}
+      </span>
+    </div>
+    <a href="/admin/clients/new" class={ADD_BTN}>+ Add a client</a>
   </div>
 
   {
-    clients.length === 0 ? (
-      <p class="border border-[color:var(--ss-color-border)] px-5 py-8 text-center text-[15px] italic text-[color:var(--ss-color-text-secondary)]">
-        No clients yet. A lead becomes a client when its first service is accepted.
-      </p>
+    records.length === 0 ? (
+      <div class="border border-[color:var(--ss-color-border)] px-5 py-10 text-center">
+        <p class="text-[15px] italic text-[color:var(--ss-color-text-secondary)]">
+          {showLost
+            ? 'No records to show.'
+            : 'No records yet. Add a business you are working with to start tracking it.'}
+        </p>
+        {!showLost && (
+          <a href="/admin/clients/new" class={`${ADD_BTN} mt-4`}>
+            + Add a client
+          </a>
+        )}
+      </div>
     ) : (
       <div>
         <div
           class={`${COL} border-b border-[color:var(--ss-color-text-primary)] px-3.5 pb-2.5 font-mono text-[11px] font-bold uppercase tracking-[0.12em] text-[color:var(--ss-color-text-secondary)]`}
         >
-          <span>Client</span>
+          <span>Business</span>
           <span>Vertical</span>
           <span>Stage</span>
           <span>Services</span>
           <span class="text-right">Outstanding</span>
         </div>
-        {clients.map((c) => {
+        {records.map((c) => {
           const rollup = rollups.get(c.id)
           const outstanding = rollup?.outstanding_amount ?? 0
           const hasOperator = operatorEntityIds.has(c.id)
+          const badge = clientStageBadge(c.stage)
           return (
             <a
               href={`/admin/clients/${c.id}`}
@@ -82,8 +103,17 @@ const COL = 'grid grid-cols-[1.6fr_1.4fr_0.9fr_0.9fr_1fr] gap-4 items-center'
               <span class="text-sm text-[color:var(--ss-color-text-secondary)]">
                 {verticalLabel(c.vertical)}
               </span>
-              <span class="font-mono text-[11px] font-bold uppercase tracking-[0.08em] text-[color:var(--ss-color-text-secondary)]">
-                {stageLabel(c.stage)}
+              <span
+                class:list={[
+                  'font-mono text-[11px] font-bold uppercase tracking-[0.08em]',
+                  c.stage === 'lost'
+                    ? 'text-[color:var(--ss-color-text-muted)]'
+                    : badge.signed
+                      ? 'text-[color:var(--ss-color-primary)]'
+                      : 'text-[color:var(--ss-color-text-secondary)]',
+                ]}
+              >
+                {badge.label}
               </span>
               <span>
                 {hasOperator && (
@@ -107,6 +137,19 @@ const COL = 'grid grid-cols-[1.6fr_1.4fr_0.9fr_0.9fr_1fr] gap-4 items-center'
             </a>
           )
         })}
+      </div>
+    )
+  }
+
+  {
+    lostCount > 0 && (
+      <div class="mt-5 text-right">
+        <a
+          href={showLost ? '/admin/clients' : '/admin/clients?show=lost'}
+          class="font-mono text-[11px] font-bold uppercase tracking-[0.12em] text-[color:var(--ss-color-text-muted)] underline underline-offset-4 hover:text-[color:var(--ss-color-primary)]"
+        >
+          {showLost ? 'Hide lost' : `Show lost (${lostCount})`}
+        </a>
       </div>
     )
   }

--- a/src/pages/admin/clients/new.astro
+++ b/src/pages/admin/clients/new.astro
@@ -1,0 +1,95 @@
+---
+/**
+ * Add a client (ADR 0077).
+ *
+ * The minimal create the Captain named as a real gap: name + vertical + an
+ * optional primary contact. The record is created at stage `prospect`. No
+ * pipeline-intake form — the record's story is built out on its detail page.
+ */
+import AdminLayout from '../../../layouts/AdminLayout.astro'
+import AdminFlashNotice from '../../../components/admin/AdminFlashNotice.astro'
+import { ENTITY_VERTICALS } from '../../../lib/db/entities'
+
+const error = Astro.url.searchParams.get('error')
+const errorMessage =
+  error === 'name_required'
+    ? 'A business name is required.'
+    : error === 'server'
+      ? 'Something went wrong. Try again.'
+      : null
+
+const FIELD_LABEL =
+  'mb-1.5 block font-mono text-[12px] font-bold uppercase tracking-[0.12em] text-[color:var(--ss-color-text-secondary)]'
+const INPUT =
+  'w-full border border-[color:var(--ss-color-border)] bg-[color:var(--ss-color-background)] px-3 py-2 text-sm text-[color:var(--ss-color-text-primary)]'
+---
+
+<AdminLayout
+  title="Add a client | SMD Services"
+  breadcrumbs={[{ label: 'Clients', href: '/admin/clients' }, { label: 'Add a client' }]}
+  maxWidth="max-w-5xl"
+>
+  <div class="max-w-xl">
+    <h1 class="mb-1 text-2xl font-bold text-[color:var(--ss-color-text-primary)]">Add a client</h1>
+    <p class="mb-6 text-sm text-[color:var(--ss-color-text-secondary)]">
+      Creates a record at the prospect stage. You can fill in the rest on its page.
+    </p>
+
+    {errorMessage && <AdminFlashNotice kind="error" message={errorMessage} />}
+
+    <form method="POST" action="/api/admin/clients" class="space-y-5">
+      <label class="block">
+        <span class={FIELD_LABEL}>Business name</span>
+        <input
+          type="text"
+          name="name"
+          required
+          autofocus
+          placeholder="Acme Plumbing"
+          class={INPUT}
+        />
+      </label>
+
+      <label class="block">
+        <span class={FIELD_LABEL}>Vertical</span>
+        <select name="vertical" class={INPUT}>
+          <option value="">Select a vertical</option>
+          {ENTITY_VERTICALS.map((v) => <option value={v.value}>{v.label}</option>)}
+        </select>
+      </label>
+
+      <fieldset class="border border-[color:var(--ss-color-border)] px-4 py-4">
+        <legend
+          class="px-1.5 font-mono text-[11px] font-bold uppercase tracking-[0.12em] text-[color:var(--ss-color-text-muted)]"
+        >
+          Primary contact (optional)
+        </legend>
+        <div class="space-y-4">
+          <label class="block">
+            <span class={FIELD_LABEL}>Name</span>
+            <input type="text" name="contact_name" placeholder="Jordan Rivera" class={INPUT} />
+          </label>
+          <label class="block">
+            <span class={FIELD_LABEL}>Email</span>
+            <input type="email" name="contact_email" placeholder="jordan@acme.com" class={INPUT} />
+          </label>
+        </div>
+      </fieldset>
+
+      <div class="flex items-center justify-end gap-3 pt-1">
+        <a
+          href="/admin/clients"
+          class="border border-[color:var(--ss-color-text-primary)] px-4 py-2 font-mono text-[11px] font-bold uppercase tracking-[0.14em] text-[color:var(--ss-color-text-primary)] transition-colors hover:bg-[color:var(--ss-color-text-primary)] hover:text-[color:var(--ss-color-background)]"
+        >
+          Cancel
+        </a>
+        <button
+          type="submit"
+          class="border border-[color:var(--ss-color-primary)] bg-[color:var(--ss-color-primary)] px-5 py-2 font-body text-sm font-semibold uppercase tracking-[0.04em] text-white transition-colors hover:bg-[color:var(--ss-color-primary-hover)] hover:border-[color:var(--ss-color-primary-hover)]"
+        >
+          Add client
+        </button>
+      </div>
+    </form>
+  </div>
+</AdminLayout>

--- a/src/pages/api/admin/clients/index.ts
+++ b/src/pages/api/admin/clients/index.ts
@@ -1,0 +1,52 @@
+import type { APIRoute } from 'astro'
+import { env } from 'cloudflare:workers'
+import { requireAdminSession } from '../../../../lib/auth/admin-session'
+import { createEntity } from '../../../../lib/db/entities'
+import { createContact } from '../../../../lib/db/contacts'
+
+/**
+ * POST /api/admin/clients
+ *
+ * Minimal add-a-client: create a record at stage `prospect` (the honest entry
+ * point — a business we have started working, not yet signed), with an optional
+ * primary contact. The record walks the lifecycle from here; signing is a stage
+ * transition gated on an accepted quote, never set at creation.
+ */
+export const POST: APIRoute = async ({ request, locals, redirect }) => {
+  const auth = requireAdminSession(locals)
+  if (!auth.ok) return auth.response
+  const { session } = auth
+
+  try {
+    const form = await request.formData()
+    const str = (key: string): string => {
+      const v = form.get(key)
+      return typeof v === 'string' ? v.trim() : ''
+    }
+    const name = str('name')
+    const vertical = str('vertical') || null
+    const contactName = str('contact_name')
+    const contactEmail = str('contact_email')
+
+    if (!name) return redirect('/admin/clients/new?error=name_required', 302)
+
+    const entity = await createEntity(env.DB, session.orgId, {
+      name,
+      vertical,
+      stage: 'prospect',
+      source_pipeline: 'admin_manual',
+    })
+
+    if (contactName) {
+      await createContact(env.DB, session.orgId, entity.id, {
+        name: contactName,
+        email: contactEmail || null,
+      })
+    }
+
+    return redirect(`/admin/clients/${entity.id}?created=1`, 302)
+  } catch (err) {
+    console.error('[api/admin/clients] POST Error:', err)
+    return redirect('/admin/clients/new?error=server', 302)
+  }
+}

--- a/tests/client-hub.test.ts
+++ b/tests/client-hub.test.ts
@@ -3,7 +3,9 @@ import {
   computeBillingRollup,
   engagementToServiceRow,
   formatMoney,
+  clientStageBadge,
 } from '../src/lib/admin/client-hub'
+import type { EntityStage } from '../src/lib/db/entities'
 import type { Invoice } from '../src/lib/db/invoices'
 import type { Engagement } from '../src/lib/db/engagements'
 import type { Quote } from '../src/lib/db/quotes'
@@ -90,5 +92,33 @@ describe('formatMoney', () => {
     expect(formatMoney(10500)).toBe('$10,500')
     expect(formatMoney(0)).toBe('$0')
     expect(formatMoney(1234.6)).toBe('$1,235')
+  })
+})
+
+describe('clientStageBadge (Clients surface, ADR 0077)', () => {
+  it('maps meetings to Assessment and engaged to Client', () => {
+    expect(clientStageBadge('meetings').label).toBe('Assessment')
+    expect(clientStageBadge('engaged').label).toBe('Client')
+  })
+
+  it('marks engaged/delivered/ongoing as signed and everything else as not', () => {
+    const signed: EntityStage[] = ['engaged', 'delivered', 'ongoing']
+    const unsigned: EntityStage[] = ['signal', 'prospect', 'meetings', 'proposing', 'lost']
+    for (const s of signed) expect(clientStageBadge(s).signed, s).toBe(true)
+    for (const s of unsigned) expect(clientStageBadge(s).signed, s).toBe(false)
+  })
+
+  it('gives every stage a non-empty label (total over the enum)', () => {
+    const all: EntityStage[] = [
+      'signal',
+      'prospect',
+      'meetings',
+      'proposing',
+      'engaged',
+      'delivered',
+      'ongoing',
+      'lost',
+    ]
+    for (const s of all) expect(clientStageBadge(s).label.length, s).toBeGreaterThan(0)
   })
 })

--- a/tests/entities-area-persisted.test.ts
+++ b/tests/entities-area-persisted.test.ts
@@ -71,3 +71,35 @@ describe('entities INSERT persists area column (regression for silent area-drop 
     expect(second.entity.area).toBe('Tempe, AZ')
   })
 })
+
+describe('entities INSERT persists vertical column (add-a-client, ADR 0077)', () => {
+  it('createEntity stores vertical and prospect stage on the row', async () => {
+    const db = await setup()
+    // Mirrors the add-a-client endpoint (POST /api/admin/clients): a manual
+    // record is created at stage `prospect` with its vertical. Before the DAL
+    // fix the INSERT silently dropped vertical (column existed, INSERT omitted
+    // it), so a new client always listed with no vertical.
+    const e = await createEntity(db, ORG, {
+      name: 'Acme Plumbing',
+      vertical: 'home_services',
+      stage: 'prospect',
+      source_pipeline: 'admin_manual',
+    })
+    expect(e.vertical).toBe('home_services')
+    expect(e.stage).toBe('prospect')
+
+    // Read back from the row, not the return value, to prove it persisted.
+    const row = await db
+      .prepare('SELECT vertical, stage FROM entities WHERE id = ?')
+      .bind(e.id)
+      .first<{ vertical: string | null; stage: string }>()
+    expect(row?.vertical).toBe('home_services')
+    expect(row?.stage).toBe('prospect')
+  })
+
+  it('createEntity stores null when vertical is omitted', async () => {
+    const db = await setup()
+    const e = await createEntity(db, ORG, { name: 'No Vertical Co' })
+    expect(e.vertical).toBeNull()
+  })
+})


### PR DESCRIPTION
## What & why

Part 2 of the admin-portal first-principles rebuild (ADR 0077). Before building, we asked the real question: does a flat Clients surface mean **building our own CRM**, and would an off-the-shelf CRM be the intentional choice? It would not — SMD already runs a single, non-optional system of record (the `entities` row is what booking writes to, what `quotes.entity_id` points at, what the portal authenticates into, and what Operator provisioning keys on). An external CRM can't *be* that record, so it would sit beside it and force re-keying at the signing moment. Decision: **keep one record, put the thinnest honest surface over it.** Full rationale in the locked Surface Brief.

This is the **"new front"** half — no deletions. The Leads-theater teardown + single-cockpit reconciliation is PR2.

## Changes

- **Clients list** (`/admin/clients`): drops the `engaged`-only filter → one flat list of every business we're working, newest first, each row badged with its lifecycle stage. `signal` (dead cold-origin) hidden; `lost` behind an opt-in "show lost" filter.
- **Add a client** (`/admin/clients/new` + `POST /api/admin/clients`): minimal create — name + vertical + optional primary contact — at stage `prospect`. Closes the "there's no way to add a client" gap.
  - `createEntity` now persists the `vertical` column (the INSERT silently dropped it before, though the column existed since migration 0008).
- **`clients/[id]` mislabeling fix**: stage-aware identity. Stops hardcoding "Client" / "Client since" / the green dot for a pre-signature record (a fabricated-content violation). Honest dot + stage label + "Added {date}" for unsigned records; "Client since" only once signed.
- **Surface Brief locked** at `docs/design/admin/surface-briefs/clients.md` (includes the build-vs-buy decision and the four locked forks).

## Guardrails held

- Both `transitionStage` invariants preserved (`proposing→engaged` needs an accepted quote; `delivered→ongoing` needs a paid completion invoice). No stage-enum migration.
- No em dashes in shipped copy.

## Verification

- `npm run typecheck` — 0 errors. `npm run lint` — 0 errors. Full `npm run test` — 3553 passed.
- New tests: `entities-area-persisted.test.ts` proves `vertical` + `prospect` stage persist on a **real created row** (read back from the row, not the return value); `client-hub.test.ts` covers `clientStageBadge` (meetings→Assessment, engaged→Client, signed set, total over the enum).

## Not in this PR (PR2)

Absorb the working tools (stage actions, send-booking, contacts-edit, add-note) into `clients/[id]`; 301-stub `/admin/entities[/id]`; repoint breadcrumbs; delete the Leads list + theater apparatus with per-suite test surgery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)