### PR TITLE
chore(db): prune dead intake_conversation_meta table (schema evaluation)

### DIFF
--- a/migrations/0092_prune_dead_schema.sql
+++ b/migrations/0092_prune_dead_schema.sql
@@ -1,0 +1,21 @@
+-- Migration 0092: prune dead schema (schema evaluation 2026-07-15).
+--
+-- intake_conversation_meta was created by migration 0037 for an intake
+-- conversation feature that was never wired. Zero rows, and a whole-repo grep
+-- finds it nowhere outside its own creating migration -- no DAL, no page, no
+-- worker, no CLI. Safe to drop pre-production, and backward-compatible with the
+-- currently deployed app (nothing references it), which matters because
+-- deploy.yml applies migrations before publishing code.
+--
+-- Scoped deliberately narrow. Two adjacent items from the same evaluation are
+-- handled elsewhere on purpose:
+--   * entities.next_action / next_action_at / summary are vestigial, but still
+--     read by the Leads-list theater (EntityListRow / entity-row-view /
+--     list-sort). They drop together with that teardown (admin Part 2), not
+--     here, so the build never breaks mid-flight.
+--   * captain_time_events backs the `crane operator log-time` CLI (ADR 0062);
+--     its disposition is a separate decision.
+--
+-- Manual rollback: migrations/rollbacks/0092_prune_dead_schema_down.sql.
+
+DROP TABLE IF EXISTS intake_conversation_meta;

--- a/migrations/rollbacks/0092_prune_dead_schema_down.sql
+++ b/migrations/rollbacks/0092_prune_dead_schema_down.sql
@@ -1,0 +1,16 @@
+-- Down migration for 0092. Recreates intake_conversation_meta EMPTY -- the
+-- pruned data (dead by audit) is not recoverable. Schema-shape restoration
+-- only. Manual-only, matching the rollbacks/ convention (not auto-applied).
+
+CREATE TABLE IF NOT EXISTS intake_conversation_meta (
+  conversation_id TEXT PRIMARY KEY,
+  entity_id TEXT NOT NULL,
+  closed_at TEXT,
+  in_flight_until TEXT,
+  last_idempotency_key TEXT,
+  last_turn INTEGER,
+  last_ai_reply TEXT,
+  last_slot_picker_next INTEGER NOT NULL DEFAULT 0,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);


### PR DESCRIPTION
## What & why

Part of the pre-production **schema evaluation** — trimming detritus before money and customers are in play. This PR takes the one item that's unambiguously dead and fully independent.

**Migration 0092** drops `intake_conversation_meta`:
- Created by migration 0037 for an intake-conversation feature that was never wired.
- **0 rows** in prod; a whole-repo grep finds it **nowhere** outside its own creating migration (no DAL, page, worker, or CLI).
- Backward-compatible (nothing references it) — matters because `deploy.yml` applies migrations *before* publishing code.
- Ships with a manual down-migration (`migrations/rollbacks/`) that recreates the table empty.

## Scope discipline (what this PR deliberately does NOT do)

The evaluation surfaced two adjacent items, both handled elsewhere on purpose:

- **`entities.next_action` / `next_action_at` / `summary`** — vestigial CRM fields, but typecheck proved they're still read by the **Leads-list theater** (`EntityListRow` / `entity-row-view` / `list-sort`). They drop *with* that teardown (admin Part 2), not here, so the build never breaks mid-flight.
- **`captain_time_events`** — not a mistaken table: it backs the `crane operator log-time` CLI (ADR 0062 cost-plane). Its disposition is a separate decision (see the conversation).

## Verification

- `npm run typecheck` — 0 errors. `npm run test` — 3,556 passed. `npm run lint` — 0 errors.
- `npm run db:migrate:local` — 0092 applies ✅.
- Diff is only the two migration files; `entities.ts` untouched.

## Schema-evaluation headline (for context)

Of 57 tables, 54 are verified live. The DB is in better shape than a "detritus everywhere" scenario — most fields are wired to real surfaces (e.g. `consultant_*`, `next_touchpoint_*`, `outreach_events`, `fleet_alert_state` are all live, not cruft). Only this one table was cleanly droppable on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)