### PR TITLE
fix(portal): change-request filing notifies team@ (silent-drop fix)

### DIFF
--- a/src/lib/email/operator-templates.ts
+++ b/src/lib/email/operator-templates.ts
@@ -1,0 +1,38 @@
+/**
+ * Operator console transactional emails. Separate module (templates.ts sits
+ * near its 500-line ceiling); composes the same shared portal shell helpers
+ * so the emails render identically.
+ */
+
+import { actionButton, detailPanel, escapeEmailHtml, paragraph, portalDocument } from './templates'
+
+export interface ChangeRequestNotificationInput {
+  entityName: string
+  customerSlug: string
+  domainLabel: string
+  requestedByEmail: string
+  summary: string
+  adminInboxUrl: string
+}
+
+/**
+ * Operational alert to team@ when a client files an operator change request.
+ * Without it the request sits silently in `operator_change_requests` until
+ * someone happens to open the admin inbox (Captain finding, 2026-07-15: a
+ * request filed 06-23 went unnoticed for three weeks).
+ */
+export function operatorChangeRequestNotificationEmailHtml(
+  input: ChangeRequestNotificationInput
+): string {
+  return portalDocument(
+    [
+      paragraph('An operator change request was filed from the client portal.', '0 0 8px'),
+      detailPanel('Client', escapeEmailHtml(input.entityName)),
+      detailPanel('Operator', escapeEmailHtml(input.customerSlug)),
+      detailPanel('Domain', escapeEmailHtml(input.domainLabel)),
+      detailPanel('Filed by', escapeEmailHtml(input.requestedByEmail)),
+      detailPanel('Request', escapeEmailHtml(input.summary)),
+      actionButton(input.adminInboxUrl, 'Open the Request Inbox'),
+    ].join('\n')
+  )
+}

--- a/src/pages/api/portal/operator/change-request.ts
+++ b/src/pages/api/portal/operator/change-request.ts
@@ -3,6 +3,11 @@ import { env } from 'cloudflare:workers'
 import { resolveOperatorAccess } from '../../../../lib/portal/operator-access'
 import { createChangeRequest } from '../../../../lib/portal/operator/change-request'
 import { safeReturnTo, instanceFromOperatorPath } from '../../../../lib/portal/operator/return-to'
+import { changeRequestDomainLabel } from '../../../../lib/admin/change-request-inbox'
+import { isSwitchableDomain } from '../../../../lib/operator/authority'
+import { getAdminBaseUrl } from '../../../../lib/config/app-url'
+import { sendEmail } from '../../../../lib/email/resend'
+import { operatorChangeRequestNotificationEmailHtml } from '../../../../lib/email/operator-templates'
 
 /**
  * POST /api/portal/operator/change-request
@@ -75,6 +80,27 @@ export const POST: APIRoute = async ({ locals, request }) => {
 
   if (!result.ok) {
     return redirect(returnTo, 'invalid')
+  }
+
+  // Operational baton to team@ — without it the request sits silently in the
+  // admin inbox until someone happens to look (a request filed 2026-06-23 went
+  // unnoticed for three weeks). Best-effort: never blocks or fails the filing.
+  try {
+    const adminBase = getAdminBaseUrl(env) ?? 'https://admin.smd.services'
+    await sendEmail(env.RESEND_API_KEY, {
+      to: 'team@smd.services',
+      subject: `Operator change request: ${access.client.name} (${access.customerSlug})`,
+      html: operatorChangeRequestNotificationEmailHtml({
+        entityName: access.client.name,
+        customerSlug: access.customerSlug,
+        domainLabel: isSwitchableDomain(domain) ? changeRequestDomainLabel(domain) : domain,
+        requestedByEmail: access.user.email,
+        summary: summary.trim(),
+        adminInboxUrl: `${adminBase}/admin/operator/requests`,
+      }),
+    })
+  } catch (err) {
+    console.error('[operator/change-request] team notification failed:', err)
   }
   return redirect(returnTo, 'filed')
 }

--- a/tests/operator-change-request-notification.test.ts
+++ b/tests/operator-change-request-notification.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Tests for the operator change-request team notification email
+ * (src/lib/email/operator-templates.ts). The filing endpoint fires this to
+ * team@ so a request never again sits unnoticed in the admin inbox (the
+ * 2026-06-23 request went unseen for three weeks because filing was silent).
+ */
+
+import { describe, it, expect } from 'vitest'
+import { operatorChangeRequestNotificationEmailHtml } from '../src/lib/email/operator-templates'
+
+const input = {
+  entityName: 'Ashton & Price LLP',
+  customerSlug: 'ashton-price',
+  domainLabel: 'Trust & autonomy',
+  requestedByEmail: 'christa@ashtonprice.com',
+  summary: 'Please let it send intake confirmations on its own.',
+  adminInboxUrl: 'https://admin.smd.services/admin/operator/requests',
+}
+
+describe('operatorChangeRequestNotificationEmailHtml', () => {
+  it('carries every fact the inbox triage needs', () => {
+    const html = operatorChangeRequestNotificationEmailHtml(input)
+    expect(html).toContain('Ashton &amp; Price LLP')
+    expect(html).toContain('ashton-price')
+    expect(html).toContain('Trust &amp; autonomy')
+    expect(html).toContain('christa@ashtonprice.com')
+    expect(html).toContain('Please let it send intake confirmations on its own.')
+    expect(html).toContain('https://admin.smd.services/admin/operator/requests')
+  })
+
+  it('escapes client-authored request text', () => {
+    const html = operatorChangeRequestNotificationEmailHtml({
+      ...input,
+      summary: '<script>alert(1)</script> & more',
+    })
+    expect(html).not.toContain('<script>')
+    expect(html).toContain('&lt;script&gt;alert(1)&lt;/script&gt; &amp; more')
+  })
+})


### PR DESCRIPTION
## What

A portal change request wrote to `operator_change_requests` and showed the client a confirmation banner, but **notified no one**. The admin inbox (`/admin/operator/requests`) was the only consumer, and nothing prompts anyone to open it. Live proof of the failure: request id 1, filed **2026-06-23** by scott@smd.services ("advanced configuration is generating an error"), still `open` and unseen three weeks later.

## Fix

After a successful create, the filing endpoint sends a best-effort notification to `team@smd.services` — client, operator slug, domain, requester, request text, and a link to the admin request inbox. Mirrors the existing Hosted Agent intake baton (`api/portal/products/hosted-agent/intake.ts`); email failure never blocks or fails the filing.

- New `src/lib/email/operator-templates.ts` (templates.ts is near its 500-line ceiling), composing the shared portal email shell
- Tests: template carries every triage fact; client-authored text is HTML-escaped

## Verification

`npm run verify` green (218 test files + workers suites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R16YQuNvLvM16AswxGPwJw