### PR TITLE
fix(portal): one-pager typography — section-h headings, actionable rail (round 4)

### DIFF
--- a/src/components/portal/operator/facets/OperatorPeople.astro
+++ b/src/components/portal/operator/facets/OperatorPeople.astro
@@ -28,7 +28,7 @@ const { model, team } = Astro.props
 const { people } = model
 
 const groupLabel =
-  'font-mono text-label font-bold uppercase tracking-[0.18em] text-[color:var(--color-text-primary)]'
+  'font-mono text-caption font-bold uppercase tracking-[0.18em] text-[color:var(--color-text-primary)]'
 const rowValue = 'mt-1 font-body text-sm leading-snug text-[color:var(--color-text-primary)]'
 const noteText = 'mt-2 font-body text-sm leading-snug text-[color:var(--color-text-secondary)]'
 ---

--- a/src/components/portal/operator/facets/OperatorWork.astro
+++ b/src/components/portal/operator/facets/OperatorWork.astro
@@ -40,7 +40,7 @@ const { model } = Astro.props
       class="mb-8 border-[3px] border-[color:var(--color-text-primary)] bg-[color:var(--color-background)]"
       aria-label="Operator authority"
     >
-      <p class="px-5 pt-5 md:px-7 font-mono text-label font-bold uppercase tracking-[0.18em] text-[color:var(--color-text-primary)] m-0">
+      <p class="px-5 pt-5 md:px-7 font-mono text-caption font-bold uppercase tracking-[0.18em] text-[color:var(--color-text-primary)] m-0">
         What it's allowed to do
       </p>
       <div class="px-5 py-5 md:px-7">
@@ -106,7 +106,7 @@ const { model } = Astro.props
           class="border-[3px] border-[color:var(--color-text-primary)] bg-[color:var(--color-background)]"
           aria-label={section.name}
         >
-          <p class="px-5 pt-5 md:px-7 font-mono text-label font-bold uppercase tracking-[0.18em] text-[color:var(--color-text-primary)] m-0">
+          <p class="px-5 pt-5 md:px-7 font-mono text-caption font-bold uppercase tracking-[0.18em] text-[color:var(--color-text-primary)] m-0">
             {section.name}
           </p>
           <div class="px-5 py-2 md:px-7">

--- a/src/pages/portal/products/operator/[instance]/index.astro
+++ b/src/pages/portal/products/operator/[instance]/index.astro
@@ -229,8 +229,11 @@ const crMessage =
         : null
 const crTone = crStatus === 'filed' ? 'complete' : 'error'
 
-const seclabelClass =
-  'font-mono text-label font-bold uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)]'
+// Section headings use the design system's section-h register (Archivo 900,
+// 36px — the Plainspoken "§ block heading"), NOT the mono metadata label:
+// structural headings draw the eye, mono is reserved for metadata (Captain,
+// 2026-07-15 round 4).
+const sectionHeadClass = 'font-body text-section-h uppercase text-[color:var(--color-text-primary)]'
 
 // Honest non-active states (empty-state pattern).
 const EMPTY: Record<Exclude<SurfaceState, 'active'>, { title: string; body: string }> = {
@@ -304,8 +307,7 @@ const empty = surfaceState !== 'active' ? EMPTY[surfaceState] : null
       <>
         {/* Header row: status label left, the single Settings entry right —
             Settings is the act surface and never appears in the reading flow. */}
-        <div class="mt-8 flex items-center justify-between gap-4">
-          <p class={seclabelClass}>Status</p>
+        <div class="mt-8 flex items-center justify-end gap-4">
           <a
             href={`${operatorBase}/settings`}
             class="inline-flex min-h-11 items-center gap-2 px-1 font-mono text-label font-semibold uppercase tracking-[0.18em] text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2"
@@ -328,7 +330,7 @@ const empty = surfaceState !== 'active' ? EMPTY[surfaceState] : null
         )}
         <p class="mt-3 font-body text-sm leading-snug text-[color:var(--color-text-secondary)]">
           This page is how your operator is set up today. Any of it can be changed. Each section
-          below has a request link.
+          below has a change request link.
         </p>
 
         {/* Sticky anchor rail — in-page navigation over the one-pager's
@@ -341,7 +343,7 @@ const empty = surfaceState !== 'active' ? EMPTY[surfaceState] : null
             {railSections.map((s) => (
               <a
                 href={`#${s.id}`}
-                class="font-mono text-label font-semibold uppercase tracking-[0.18em] text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2"
+                class="font-mono text-label font-bold uppercase tracking-[0.18em] text-[color:var(--ss-color-primary)] hover:text-[color:var(--ss-color-primary-hover)] hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2"
               >
                 {s.label}
               </a>
@@ -352,7 +354,7 @@ const empty = surfaceState !== 'active' ? EMPTY[surfaceState] : null
         <div class="mt-10 flex flex-col gap-12">
           {showPersona && (
             <section id="persona" aria-label="Persona" class="scroll-mt-16">
-              <p class={seclabelClass}>Persona</p>
+              <h2 class={sectionHeadClass}>Persona</h2>
               <p class="mt-2 font-body text-sm leading-snug text-[color:var(--color-text-secondary)]">
                 Who your operator is and how it carries itself in writing.
               </p>
@@ -408,7 +410,7 @@ const empty = surfaceState !== 'active' ? EMPTY[surfaceState] : null
 
           {showDuties && workModel && (
             <section id="duties" aria-label="Duties" class="scroll-mt-16">
-              <p class={seclabelClass}>Duties</p>
+              <h2 class={sectionHeadClass}>Duties</h2>
               <p class="mt-2 font-body text-sm leading-snug text-[color:var(--color-text-secondary)]">
                 Everything your operator does, and how much it does on its own.
               </p>
@@ -450,7 +452,7 @@ const empty = surfaceState !== 'active' ? EMPTY[surfaceState] : null
               </div>
               {blocks && (
                 <div class="mt-8 border-[3px] border-[color:var(--color-text-primary)] bg-[color:var(--color-background)]">
-                  <p class="px-5 pt-5 md:px-7 font-mono text-label font-bold uppercase tracking-[0.18em] text-[color:var(--color-text-primary)] m-0">
+                  <p class="px-5 pt-5 md:px-7 font-mono text-caption font-bold uppercase tracking-[0.18em] text-[color:var(--color-text-primary)] m-0">
                     What it must leave alone
                   </p>
                   <div class="px-5 py-5 md:px-7">
@@ -506,7 +508,7 @@ const empty = surfaceState !== 'active' ? EMPTY[surfaceState] : null
 
           {showAccess && (
             <section id="access" aria-label="Access" class="scroll-mt-16">
-              <p class={seclabelClass}>Access</p>
+              <h2 class={sectionHeadClass}>Access</h2>
               <p class="mt-2 font-body text-sm leading-snug text-[color:var(--color-text-secondary)]">
                 The systems your operator works in, and what it can see there.
               </p>
@@ -546,7 +548,7 @@ const empty = surfaceState !== 'active' ? EMPTY[surfaceState] : null
 
           {showPeople && (
             <section id="people" aria-label="People" class="scroll-mt-16">
-              <p class={seclabelClass}>People</p>
+              <h2 class={sectionHeadClass}>People</h2>
               <p class="mt-2 font-body text-sm leading-snug text-[color:var(--color-text-secondary)]">
                 Who your operator works with, and on what terms.
               </p>

--- a/src/pages/portal/products/operator/[instance]/settings/index.astro
+++ b/src/pages/portal/products/operator/[instance]/settings/index.astro
@@ -97,7 +97,7 @@ const statusToneClass =
 
 const cardClass = 'border-[3px] border-[color:var(--ss-color-text-primary)] p-6 md:p-8'
 const sectionLabelClass =
-  'mb-4 font-mono text-label uppercase tracking-[0.14em] font-bold text-[color:var(--ss-color-text-secondary)]'
+  'mb-4 font-body text-section-h uppercase text-[color:var(--ss-color-text-primary)]'
 const emptyNoteClass =
   'font-mono text-label uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)]'
 


### PR DESCRIPTION
## What

Captain's round-4 walk: the type hierarchy was scattered and inverted — section headers in the 12px mono metadata register while the content under them ran bigger and bolder, and the anchor rail gave no clickable affordance.

The design system already prescribed the fix: the **`section-h` token** (Archivo 900, 36px — documented as '§ block headings on detail pages'). Applied:

- **Section headers** (Persona / Duties / Access / People on the landing; Plan & billing / Operational alerts / Configuration on Settings) render as real `h2`s in `text-section-h`. Structural headings now draw the eye; mono stays reserved for metadata.
- **Anchor rail** links wear the actionable register — burnt-orange bold mono with hover underline, the same recipe as 'Request a change' — so they read as clickable.
- **In-box headings** ('What it's allowed to do', grid stage names, 'What it must leave alone', People group labels) step up to `text-caption` (14px): a clear middle tier between section-h and the 12px labels.
- The lone tiny STATUS label is gone (the hero states its own status); the Settings entry keeps its spot top-right.
- Copy: 'each section below has a **change request** link.'

## Verification

`npm run verify` green (full suite + workers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R16YQuNvLvM16AswxGPwJw