### PR TITLE
fix(operator): project auth_mode so the honest reconnect note actually fires

### DIFF
--- a/src/lib/operator/customer-yaml/sections-connectors.ts
+++ b/src/lib/operator/customer-yaml/sections-connectors.ts
@@ -106,6 +106,7 @@ function checkOneConnector(
     `connectors.${key}.credential_custody`,
     errors
   )
+  const authMode = typeof value['auth_mode'] === 'string' ? value['auth_mode'] : null
   return {
     adapter,
     backend,
@@ -114,6 +115,7 @@ function checkOneConnector(
     token_ref: tokenRef,
     webhook_url: webhookUrl,
     credential_custody: custody,
+    auth_mode: authMode,
   }
 }
 

--- a/src/lib/operator/customer-yaml/types.ts
+++ b/src/lib/operator/customer-yaml/types.ts
@@ -527,6 +527,14 @@ export interface Connector {
    * src/lib/operator/credential-custody.ts.
    */
   credential_custody: CredentialCustody | null
+  /**
+   * Authored OAuth flow for the connector (e.g. 'authorization_code' — the
+   * firm authorizes via login + Allow; SMD can only send a fresh
+   * authorization link, never re-establish alone). Free-form string, absent
+   * ⇒ null. The portal's connection care note keys on it (Captain,
+   * 2026-07-15: reconnect claims must match who can actually reconnect).
+   */
+  auth_mode: string | null
 }
 
 /**

--- a/src/lib/portal/operator/customer-yaml-editor.ts
+++ b/src/lib/portal/operator/customer-yaml-editor.ts
@@ -533,6 +533,9 @@ function mergeConnectors(
       // in the connectors authority domain, set via the dedicated custody flow,
       // never through the general config editor.
       credential_custody: existing.credential_custody,
+      // auth_mode locked — set at provisioning with the OAuth flow itself;
+      // the portal only READS it (connection care note).
+      auth_mode: existing.auth_mode,
     }
   }
   return merged


### PR DESCRIPTION
## What

Round 5 shipped an auth-mode-aware connection care note ('SMD sends a fresh authorization link and someone at your firm approves it' for authorization_code connections like Smokeball) — but the Captain's live walk showed Smokeball still claiming SMD 'can re-establish it for you.' Root cause: the typed customer.yaml connector parser (`sections-connectors.ts`) whitelists fields, and `auth_mode` wasn't among them, so the projection never carried it and `row.authMode` was always null. The note read a field that could not arrive.

- `Connector` type + entry parser now carry `auth_mode` (string, absent ⇒ null)
- The advanced-editor merge treats it as locked (provisioning-time fact, read-only via portal), like token_ref / webhook_url / custody
- The merge-triggered auto-sync re-projects every seat on merge, which is itself the live proof path

Also confirmed during diagnosis, no code change needed: the missing Brave Search row on the walked seat is correct data — web search (ADR 0070) is authored on pilot-smokeball only; the ashton-price seat has no WebSearch connector authored yet, and the row appears automatically when it is.

## Verification

`npm run verify` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R16YQuNvLvM16AswxGPwJw