### PR TITLE
fix(auth): case-insensitive Clerk email auto-link (first-client lockout risk)

### DIFF
--- a/src/lib/auth/clerk-bridge.ts
+++ b/src/lib/auth/clerk-bridge.ts
@@ -75,10 +75,20 @@ export async function ensureLocalUser(
   // this Clerk identity instead. Only links when clerk_user_id IS NULL
   // so we never overwrite an existing binding. Email comes from Clerk's
   // verified primary email, which is the trust anchor.
+  //
+  // Matched case-INSENSITIVELY. The `users.email` column carries no
+  // COLLATE NOCASE, so a seeded row's casing had to match Clerk's byte for
+  // byte or the link silently missed — the JIT INSERT below would then
+  // succeed (UNIQUE(org_id,email) is case-sensitive too), stranding the
+  // person on a second, entity-less row: signed in, "not connected to a
+  // customer", locked out of a seat that was waiting for them. Nobody
+  // controls which casing an IdP returns (Microsoft/Google OAuth echo the
+  // directory's own), and email addresses are treated case-insensitively in
+  // practice, so the lookup must be too.
   const emailMatch = await db
     .prepare(
       `SELECT * FROM users
-       WHERE org_id = ? AND email = ? AND clerk_user_id IS NULL
+       WHERE org_id = ? AND lower(email) = lower(?) AND clerk_user_id IS NULL
        LIMIT 1`
     )
     .bind(ORG_ID, profile.email)

--- a/tests/clerk-bridge.test.ts
+++ b/tests/clerk-bridge.test.ts
@@ -69,6 +69,30 @@ describe('ensureLocalUser', () => {
     expect(result.role).toBe('client')
   })
 
+  it('auto-links regardless of email CASE (IdP casing must never strand a seeded seat)', async () => {
+    // The bug this guards: users.email carries no COLLATE NOCASE, so an
+    // exact-match lookup missed when the seeded casing differed from what
+    // Clerk returned (Microsoft/Google OAuth echo the directory's casing).
+    // The JIT INSERT then succeeded — UNIQUE(org_id,email) is case-sensitive
+    // too — stranding the person on a second, entity-less row: signed in but
+    // "not connected to a customer", locked out of a waiting seat.
+    const newClerkId = 'user_uppercase_idp'
+    const upper = PRE_CLERK_EMAIL.toUpperCase()
+    expect(upper).not.toBe(PRE_CLERK_EMAIL)
+
+    const result = await ensureLocalUser(db, newClerkId, { email: upper, name: 'Pre Clerk Client' })
+
+    // Linked the SEEDED row (with its entity binding) — not a new orphan.
+    expect(result.id).toBe(PRE_CLERK_USER_ID)
+    expect(result.entity_id).toBe(PRE_CLERK_ENTITY_ID)
+
+    const rows = await db
+      .prepare('SELECT id FROM users WHERE lower(email) = lower(?)')
+      .bind(PRE_CLERK_EMAIL)
+      .all<{ id: string }>()
+    expect(rows.results).toHaveLength(1)
+  })
+
   it('auto-links a pre-Clerk row by email when clerk_user_id is NULL', async () => {
     // The bug this guards: ensureLocalUser used to only match on
     // clerk_user_id, then INSERT a new row. UNIQUE(org_id, email) made


### PR DESCRIPTION
## What

Found while tracing exactly how the first real client signs in tomorrow morning — before sending her the link, not after.

`users.email` has no `COLLATE NOCASE`, so `ensureLocalUser`'s auto-link matched **exact bytes**. A seat seeded as `Christa@firm.com` that Clerk reports as `christa@firm.com` misses the link — and the JIT `INSERT` below then **succeeds**, because `UNIQUE(org_id, email)` is case-sensitive too. Result: the person lands on a second, entity-less row and sees *"You're signed in, but your account isn't connected to a customer yet"* — locked out of a seat that was waiting for them, with no error anywhere to explain it.

This is not hypothetical for tomorrow: the live Clerk instance (`clerk.smd.services`, `pk_live_`) has **Google, Microsoft, and Apple OAuth enabled**, and OAuth providers echo the directory's own casing. The archived address for the pilot's principal is capitalized (`Christa@ashtonandprice.com`).

**Fix:** `WHERE org_id = ? AND lower(email) = lower(?) AND clerk_user_id IS NULL`.

**Test:** proves the failure — it fails against the old exact-match query (links a fresh orphan instead of the seeded seat) and passes with the fix, asserting exactly one row survives.

Follow-up worth considering separately: a migration adding `COLLATE NOCASE` to `users.email` so the UNIQUE constraint agrees with the lookup. Not needed to unblock tomorrow.

## Verification

`npm run verify` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R16YQuNvLvM16AswxGPwJw