### PR TITLE
fix(portal): operator Duties readable on a phone (mobile legibility)

### DIFF
--- a/src/components/portal/operator/OperatorLimits.astro
+++ b/src/components/portal/operator/OperatorLimits.astro
@@ -22,7 +22,7 @@ const anyBlocks = Boolean(
 )
 
 const groupLabel =
-  'font-mono text-label uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)] m-0'
+  'font-mono text-label uppercase tracking-[0.08em] text-[color:var(--color-text-secondary)] m-0'
 const groupValue = 'mt-1 font-body text-sm leading-snug text-[color:var(--color-text-primary)] m-0'
 ---
 
@@ -30,11 +30,11 @@ const groupValue = 'mt-1 font-body text-sm leading-snug text-[color:var(--color-
   class="mt-8 border-[3px] border-[color:var(--color-text-primary)] bg-[color:var(--color-background)]"
 >
   <p
-    class="px-5 pt-5 md:px-7 font-mono text-caption font-bold uppercase tracking-[0.18em] text-[color:var(--color-text-primary)] m-0"
+    class="px-4 pt-5 md:px-7 font-mono text-caption font-bold uppercase tracking-[0.14em] text-[color:var(--color-text-primary)] m-0"
   >
     What it must leave alone
   </p>
-  <div class="px-5 py-5 md:px-7">
+  <div class="px-4 py-5 md:px-7">
     {
       standingCaps.length > 0 && (
         <div class="mb-5">

--- a/src/components/portal/operator/facets/InitiationChips.astro
+++ b/src/components/portal/operator/facets/InitiationChips.astro
@@ -1,0 +1,54 @@
+---
+/**
+ * Initiation chips + schedule line — the shared "how a duty starts" metadata,
+ * mounted by both the routine-grid rows (OperatorWorkRow) and the gridless
+ * skills list (OperatorWork), per ADR 0069 Lock 4 / Pattern 07 shared
+ * primitives.
+ *
+ * Replaces the former single wide-tracked uppercase run
+ * ("ON REQUEST · ON A SCHEDULE (WEEKDAYS AT 7:17 A.M.)"), which applied eyebrow
+ * styling to a full sentence and wrapped badly mid-parenthetical on a phone
+ * (mobile-legibility fix, 2026-07-16). Each initiation MODE becomes a short
+ * square mono chip; the schedule detail, when present, drops to its own readable
+ * line. Loud register kept — chips stay uppercase mono (JetBrains Mono is the
+ * canonical chip face per the typography ruling), only the long tracked run is
+ * gone. Every string is authored data passed in; this component invents nothing.
+ */
+interface Props {
+  /** Client-legible initiation labels ("On request" / "On a schedule" / …). */
+  labels: string[]
+  /** Plain schedule prose ("Weekdays at 7:17 a.m."), or null when none. */
+  scheduleDetail?: string | null
+}
+const { labels, scheduleDetail = null } = Astro.props
+---
+
+{
+  labels.length > 0 && (
+    <div class="mt-2 flex flex-wrap gap-1.5">
+      {labels.map((label) => (
+        <span class="inline-flex items-center whitespace-nowrap border-[1.5px] border-[color:rgba(26,21,18,0.34)] px-[7px] py-[3px] font-mono text-[11px] font-semibold uppercase leading-none tracking-[0.06em] text-[color:var(--color-text-secondary)]">
+          {label}
+        </span>
+      ))}
+    </div>
+  )
+}
+{
+  scheduleDetail && (
+    <p class="mt-2 flex items-center gap-1.5 font-mono text-caption leading-snug text-[color:var(--color-text-secondary)]">
+      <svg
+        class="h-3.5 w-3.5 shrink-0 opacity-70"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="1.8"
+        aria-hidden="true"
+      >
+        <circle cx="12" cy="12" r="9" />
+        <path d="M12 7v5l3 2" />
+      </svg>
+      {scheduleDetail}
+    </p>
+  )
+}

--- a/src/components/portal/operator/facets/OperatorAuthorityRows.astro
+++ b/src/components/portal/operator/facets/OperatorAuthorityRows.astro
@@ -25,7 +25,7 @@ const { rows } = Astro.props
         <span class="font-body text-base font-semibold text-[color:var(--color-text-primary)]">
           {row.label}
         </span>
-        <span class="font-mono text-label uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)]">
+        <span class="font-mono text-label uppercase tracking-[0.08em] text-[color:var(--color-text-secondary)]">
           {row.sentence}
         </span>
       </li>

--- a/src/components/portal/operator/facets/OperatorWork.astro
+++ b/src/components/portal/operator/facets/OperatorWork.astro
@@ -26,6 +26,7 @@
 import type { OperatorWorkModel } from '../../../../lib/portal/operator/facets/work/work'
 import OperatorAuthorityRows from './OperatorAuthorityRows.astro'
 import OperatorWorkRow from './OperatorWorkRow.astro'
+import InitiationChips from './InitiationChips.astro'
 
 interface Props {
   model: OperatorWorkModel
@@ -40,10 +41,10 @@ const { model } = Astro.props
       class="mb-8 border-[3px] border-[color:var(--color-text-primary)] bg-[color:var(--color-background)]"
       aria-label="Operator authority"
     >
-      <p class="px-5 pt-5 md:px-7 font-mono text-caption font-bold uppercase tracking-[0.18em] text-[color:var(--color-text-primary)] m-0">
+      <p class="px-4 pt-5 md:px-7 font-mono text-caption font-bold uppercase tracking-[0.14em] text-[color:var(--color-text-primary)] m-0">
         What it's allowed to do
       </p>
-      <div class="px-5 py-5 md:px-7">
+      <div class="px-4 py-5 md:px-7">
         <p class="mb-4 font-body text-sm leading-snug text-[color:var(--color-text-secondary)]">
           Each kind of action your operator may take, and how much of it happens without a person.
         </p>
@@ -59,9 +60,9 @@ const { model } = Astro.props
       class="border-[3px] border-[color:var(--color-text-primary)] bg-[color:var(--color-background)]"
       aria-label="Operator duties"
     >
-      <div class="px-5 py-6 md:px-7">
+      <div class="px-4 py-6 md:px-7">
         {model.skills.length === 0 ? (
-          <p class="font-mono text-label uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)]">
+          <p class="font-mono text-label uppercase tracking-[0.08em] text-[color:var(--color-text-secondary)]">
             Your operator's duties appear here once they're configured.
           </p>
         ) : (
@@ -72,26 +73,17 @@ const { model } = Astro.props
             <ul role="list" class="flex flex-col">
               {model.skills.map((s, i) => (
                 <li
-                  class={`flex flex-col gap-2 py-4 md:flex-row md:items-start md:justify-between md:gap-8 ${
-                    i > 0 ? 'border-t-[2px] border-[color:var(--color-border)]' : ''
-                  }`}
+                  class={`py-4 ${i > 0 ? 'border-t-[2px] border-[color:var(--color-border)]' : ''}`}
                 >
-                  <div class="min-w-0 md:max-w-[46rem]">
-                    <p class="font-body text-base font-semibold text-[color:var(--color-text-primary)]">
-                      {s.name}
+                  <p class="font-body text-base font-semibold text-[color:var(--color-text-primary)]">
+                    {s.name}
+                  </p>
+                  {s.summary && (
+                    <p class="mt-1 font-body text-sm leading-snug text-[color:var(--color-text-secondary)]">
+                      {s.summary}
                     </p>
-                    {s.summary && (
-                      <p class="mt-1 font-body text-sm leading-snug text-[color:var(--color-text-secondary)]">
-                        {s.summary}
-                      </p>
-                    )}
-                  </div>
-                  {s.initiation.length > 0 && (
-                    <span class="shrink-0 font-mono text-label uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)] md:pt-0.5">
-                      {s.initiation.join(' · ')}
-                      {s.scheduleDetail ? ` (${s.scheduleDetail})` : ''}
-                    </span>
                   )}
+                  <InitiationChips labels={s.initiation} scheduleDetail={s.scheduleDetail} />
                 </li>
               ))}
             </ul>
@@ -106,10 +98,10 @@ const { model } = Astro.props
           class="border-[3px] border-[color:var(--color-text-primary)] bg-[color:var(--color-background)]"
           aria-label={section.name}
         >
-          <p class="px-5 pt-5 md:px-7 font-mono text-caption font-bold uppercase tracking-[0.18em] text-[color:var(--color-text-primary)] m-0">
+          <p class="px-4 pt-5 md:px-7 font-mono text-caption font-bold uppercase tracking-[0.14em] text-[color:var(--color-text-primary)] m-0">
             {section.name}
           </p>
-          <div class="px-5 py-2 md:px-7">
+          <div class="px-4 py-2 md:px-7">
             <ul role="list" class="flex flex-col">
               {section.routines.map((r, i) => (
                 <OperatorWorkRow routine={r} divided={i > 0} />

--- a/src/components/portal/operator/facets/OperatorWorkRow.astro
+++ b/src/components/portal/operator/facets/OperatorWorkRow.astro
@@ -10,6 +10,7 @@
  * resolver — no invented copy, no vertical vocabulary.
  */
 import type { WorkRoutineView } from '../../../../lib/portal/operator/facets/work/work'
+import InitiationChips from './InitiationChips.astro'
 
 interface Props {
   routine: WorkRoutineView
@@ -18,44 +19,36 @@ interface Props {
 }
 
 const { routine: r, divided } = Astro.props
+
+// One quiet mono eyebrow for the autonomy labels — tightened to the system's own
+// 0.08em label tracking (was 0.14em) so the sentence that follows reads as the
+// row's headline status, not the label. Kept at text-secondary (AA) not muted.
+const microLabel =
+  'mb-0.5 block font-mono text-label font-bold uppercase tracking-[0.08em] text-[color:var(--color-text-secondary)]'
 ---
 
 <li class={`py-5 ${divided ? 'border-t-[2px] border-[color:var(--color-border)]' : ''}`}>
-  <div class="flex flex-col gap-2 md:flex-row md:items-start md:justify-between md:gap-8">
-    <p class="min-w-0 font-body text-base font-semibold text-[color:var(--color-text-primary)]">
-      {r.routine}
-    </p>
-    {
-      r.startsLabels.length > 0 && (
-        <span
-          class="shrink-0 font-mono text-label uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)] md:pt-0.5"
-          title={r.scheduleDetail ?? undefined}
-        >
-          {r.startsLabels.join(' · ')}
-          {r.scheduleDetail ? ` (${r.scheduleDetail})` : ''}
-        </span>
-      )
-    }
-  </div>
+  <p class="font-body text-base font-semibold text-[color:var(--color-text-primary)]">
+    {r.routine}
+  </p>
 
-  <div class="mt-2 flex flex-col gap-1">
+  <InitiationChips labels={r.startsLabels} scheduleDetail={r.scheduleDetail} />
+
+  <div class="mt-3 flex flex-col gap-2">
     <p class="font-body text-sm text-[color:var(--color-text-primary)]">
-      <span
-        class="font-mono text-label font-bold uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)]"
-      >
-        Autonomy:{' '}
-      </span>
-      {r.todaySentence}
+      <span class={microLabel}>Autonomy</span>
+      <span class="font-semibold">{r.todaySentence}</span>
     </p>
     {
       r.canBecomeSentence && (
         <p class="font-body text-sm text-[color:var(--color-text-primary)]">
-          <span class="font-mono text-label font-bold uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)]">
-            Can be raised to:{' '}
-          </span>
+          <span class={microLabel}>Can be raised to</span>
           {r.canBecomeSentence}
           {r.canBecomeVerbatim && (
-            <span class="text-[color:var(--color-text-secondary)]"> ({r.canBecomeVerbatim})</span>
+            <span class="text-[color:var(--color-text-secondary)]">
+              {' · '}
+              {r.canBecomeVerbatim}
+            </span>
           )}
         </p>
       )


### PR DESCRIPTION
## What & why

Christa reviews A&P's operator configuration on her phone. On the **§02 Operator → Duties** section, each routine's "how it starts" metadata was rendered as one uppercase JetBrains Mono string at 0.14em tracking — eyebrow styling applied to a full initiation + schedule sentence. At ~50 characters (`ON REQUEST · ON A SCHEDULE (WEEKDAYS AT 7:17 A.M.)`) it overflowed the ~312px mobile content column and wrapped mid-parenthetical, on all 19 rows.

This is **Option A** — a typographic fix that keeps the loud register (heavy 3px boxes, big §-headings, short mono eyebrows) and only stops forcing long strings into label styling. Captain-approved via phone mockup before implementation.

## Changes

- **New shared `InitiationChips.astro`** (Pattern 07 shared primitive): each initiation *mode* renders as a short square mono chip; the schedule detail drops to its own readable line with a small clock. Mounted by both the routine-grid rows and the gridless skills list, so the **client duties page and the admin config surface stay in lockstep** (ADR 0069 Lock 4).
- **`OperatorWorkRow`**: `Autonomy` / `Can be raised to` become quiet block eyebrows (tracking 0.14em → 0.08em, the system's own label spec) so the status sentence reads as the row's headline — today-sentence semibold, can-be-raised regular.
- **Ceiling verbatim kept exact** (authored contract language) and shown after a middot instead of wrapped in a second set of parens — removes the `(Auto-handle (once you are comfortable))` nesting **without altering the words** (no-fabrication compliance).
- **Consistent mobile box padding** (px-5 → px-4; desktop `md:px-7` unchanged) and section-title tracking (0.18em → 0.14em) across the Duties boxes (`OperatorWork` sections + authority box, `OperatorLimits`) so their left edges align.

Presentation only — no resolver, schema, or authored-content change.

## Notes / calls made
- **Chips for initiation** are slightly more than a pure type tweak, but they kill the wrap for good and stay square/loud/on-register. Chips use ink (not burnt-orange) to hold single-accent discipline.
- **Desktop**: routine rows now stack metadata under the name (dropped the `md:` two-column split) for one consistent shape at all widths; also improves the admin config mount.
- Two intentional deviations from the approved mockup, both toward correctness: micro-labels use `text-secondary` (AA) rather than the mockup's `muted` (fails AA for text); the ceiling verbatim stays exact rather than the mockup's lightly-cleaned wording.

## Verification
`typecheck`, `typecheck:workers`, `format:check`, `lint`, `build`, unit tests (3572 passed), workers tests (12 passed) — all green locally (pre-push `npm run verify` passed). Live proof after deploy: the shared component also renders on `admin.smd.services/admin/operator/ashton-price/config` at mobile width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)