### PR TITLE
feat(portal): pre-go-live operator clients land on the operator, not Home

### DIFF
--- a/src/lib/portal/nav.ts
+++ b/src/lib/portal/nav.ts
@@ -28,9 +28,14 @@ export interface PortalNavDestination {
 }
 
 export function buildPortalNav(offerings: PortalOfferings): PortalNavDestination[] {
-  const destinations: Omit<PortalNavDestination, 'anchor'>[] = [
-    { href: '/portal', label: 'Home', matchPrefix: '/portal', exact: true },
-  ]
+  const destinations: Omit<PortalNavDestination, 'anchor'>[] = []
+  // Home is hidden for a pre-go-live operator-only client: they land in the
+  // operator area and have no hub to return to (Captain, 2026-07-16). Same
+  // shape as the Billing gate below — a tab appears only when it has a purpose.
+  // (Billing is already absent in this state: hasBillingRelationship is false.)
+  if (!offerings.preGoLiveLanding) {
+    destinations.push({ href: '/portal', label: 'Home', matchPrefix: '/portal', exact: true })
+  }
   if (offerings.engagement.present) {
     destinations.push({
       href: '/portal/engagement',

--- a/src/lib/portal/offerings.ts
+++ b/src/lib/portal/offerings.ts
@@ -68,6 +68,24 @@ export interface PortalOfferings {
    */
   hasBillingRelationship: boolean
   subscriptions: SubscriptionRow[]
+  /**
+   * When set, the client lands directly on the operator area instead of the
+   * Home hub, and the Home tab is hidden (Captain, 2026-07-16). Non-null ONLY
+   * while the client is pre-go-live and their whole relationship is operators:
+   * nothing initiated yet (`hasBillingRelationship` false), no engagement or
+   * proposal, and at least one operator. In that window the portal exists to
+   * review and configure, so we skip the empty Home hub:
+   *   - one operator   → its instance page, deep-linked (skips the
+   *                      list→instance redirect hop that caused a visible delay)
+   *   - many operators → the operator list, to pick one (standing up several
+   *                      operators at once, mid-onboarding, is a valid state)
+   * The instant ANY subscription goes live (`hasBillingRelationship` flips true)
+   * or an engagement appears, this is null again — Home and the full tab set
+   * (including Billing) return. Hosted-agent never triggers it: a hosted-agent
+   * client only receives portal access after implementation, when the
+   * subscription is already initiated, so they are never in this window.
+   */
+  preGoLiveLanding: string | null
 }
 
 /** Title-case a kebab slug for a fallback display name (e.g. "pilot-smokeball" → "Pilot Smokeball"). */
@@ -110,9 +128,24 @@ export function deriveOfferings(input: {
       status: s.status,
     }))
 
+  const engagementPresent =
+    activeEngagement !== null || pastEngagements.length > 0 || input.quotes.length > 0
+  const hasBillingRelationship =
+    input.hasInvoices || input.subscriptions.some((s) => s.status !== 'provisioning')
+
+  // Pre-go-live operator shortcut (see preGoLiveLanding on PortalOfferings).
+  // Fires only when nothing is live and the client's whole world is operators:
+  // one → deep-link its instance (skipping the list hop); many → the list.
+  const preGoLiveLanding =
+    !hasBillingRelationship && !engagementPresent && operators.length > 0
+      ? operators.length === 1
+        ? `/portal/products/operator/${operators[0].slug}`
+        : '/portal/products/operator'
+      : null
+
   return {
     engagement: {
-      present: activeEngagement !== null || pastEngagements.length > 0 || input.quotes.length > 0,
+      present: engagementPresent,
       activeEngagement,
       openProposal,
       pastEngagements,
@@ -120,9 +153,9 @@ export function deriveOfferings(input: {
     operators,
     hostedAgent: bySlug('hosted-agent'),
     hasInvoices: input.hasInvoices,
-    hasBillingRelationship:
-      input.hasInvoices || input.subscriptions.some((s) => s.status !== 'provisioning'),
+    hasBillingRelationship,
     subscriptions: input.subscriptions,
+    preGoLiveLanding,
   }
 }
 

--- a/src/pages/portal/index.astro
+++ b/src/pages/portal/index.astro
@@ -44,6 +44,12 @@ let completedMilestones: PortalHomeMilestone[] = []
 const offerings = await resolvePortalOfferings(env.DB, user.org_id, client.id).catch(() => null)
 if (!offerings) {
   dashboardError = true
+} else if (offerings.preGoLiveLanding && Astro.url.searchParams.get('home') !== '1') {
+  // Pre-go-live operator clients land in the operator area, not this hub
+  // (Captain, 2026-07-16): before anything goes live the portal exists to
+  // review and configure the operator, and this Home page is an empty box.
+  // ?home=1 is a QA escape hatch to reach Home directly in this state.
+  return Astro.redirect(offerings.preGoLiveLanding)
 }
 
 if (offerings) {

--- a/tests/portal-offerings.test.ts
+++ b/tests/portal-offerings.test.ts
@@ -151,14 +151,15 @@ describe('buildPortalNav', () => {
     expect(nav.map((d) => d.label)).toEqual(['Home', 'Billing'])
   })
 
-  it('a provisioning-only subscription does NOT light up Billing (no billing relationship pre-go-live)', () => {
+  it('a provisioning-only operator: no Billing, and Home is hidden (pre-go-live lands on the operator)', () => {
     const o = deriveOfferings({
       ...NOTHING,
       subscriptions: [subscription('operator', 'provisioning')],
     })
     expect(o.hasBillingRelationship).toBe(false)
+    expect(o.preGoLiveLanding).toBe('/portal/products/operator/operator')
     const nav = buildPortalNav(o)
-    expect(nav.map((d) => d.label)).toEqual(['Home', 'Operator'])
+    expect(nav.map((d) => d.label)).toEqual(['Operator'])
   })
 
   it('prior invoices keep Billing visible even while an operator is provisioning', () => {
@@ -197,6 +198,63 @@ describe('buildPortalNav', () => {
     expect(operatorTabs[0].href).toBe('/portal/products/operator')
     // The whole nav stays the small category set regardless of operator count.
     expect(nav.map((d) => d.label)).toEqual(['Home', 'Operator', 'Billing'])
+  })
+})
+
+describe('preGoLiveLanding (pre-go-live operator shortcut)', () => {
+  const op = (slug: string, status = 'provisioning') =>
+    ({
+      id: `sub-${slug}`,
+      product_slug: 'operator',
+      instance_slug: slug,
+      status,
+      service_id: null,
+    }) as unknown as SubscriptionRow
+
+  it('single provisioning operator, nothing else → deep-links the instance', () => {
+    const o = deriveOfferings({ ...NOTHING, subscriptions: [op('ashton-price')] })
+    expect(o.preGoLiveLanding).toBe('/portal/products/operator/ashton-price')
+  })
+
+  it('many provisioning operators → the operator list (pick one)', () => {
+    const o = deriveOfferings({ ...NOTHING, subscriptions: [op('ashton-price'), op('second-op')] })
+    expect(o.preGoLiveLanding).toBe('/portal/products/operator')
+    // Home is hidden; the single Operator tab remains.
+    expect(buildPortalNav(o).map((d) => d.label)).toEqual(['Operator'])
+  })
+
+  it('go-live of ANY operator dissolves it → Home and Billing return', () => {
+    const o = deriveOfferings({ ...NOTHING, subscriptions: [op('a', 'active'), op('b')] })
+    expect(o.hasBillingRelationship).toBe(true)
+    expect(o.preGoLiveLanding).toBeNull()
+    expect(buildPortalNav(o).map((d) => d.label)).toEqual(['Home', 'Operator', 'Billing'])
+  })
+
+  it('an engagement suppresses it (Home has content to show)', () => {
+    const o = deriveOfferings({
+      ...NOTHING,
+      engagements: [engagement('in_progress')],
+      subscriptions: [op('ashton-price')],
+    })
+    expect(o.preGoLiveLanding).toBeNull()
+  })
+
+  it('prior invoices suppress it (a billing relationship already exists)', () => {
+    const o = deriveOfferings({
+      ...NOTHING,
+      subscriptions: [op('ashton-price')],
+      hasInvoices: true,
+    })
+    expect(o.preGoLiveLanding).toBeNull()
+  })
+
+  it('no operators → null (nothing-owned shows the welcome Home; hosted-agent never pre-go-live)', () => {
+    expect(deriveOfferings(NOTHING).preGoLiveLanding).toBeNull()
+    const ha = deriveOfferings({
+      ...NOTHING,
+      subscriptions: [subscription('hosted-agent', 'provisioning')],
+    })
+    expect(ha.preGoLiveLanding).toBeNull()
   })
 })
 


### PR DESCRIPTION
## What

Extends the Billing-tab gate pattern to the **Home** tab. Before any subscription goes live, a client whose whole relationship is operators skips the Home hub and lands directly in the operator area. Home is hidden until go-live; Billing is already hidden pre-go-live.

**Motivation (Captain, 2026-07-16):** on first login a pre-go-live client hits a Home page that is just one "setting up" card with a confusing click-delay — she doesn't know to go to the operator. Remove the friction: take her to the thing she's there to review.

## The rule (single-sourced)

Computed once in `deriveOfferings` as `preGoLiveLanding`, consumed by the Home redirect and the nav builder so they can't drift:

Fires only when **all** hold:
- nothing is live yet — `hasBillingRelationship` is false (no initiated subscription, no invoices)
- no engagement or proposal
- at least one operator owned

Destination:
- **one operator** → deep-link its instance (`/portal/products/operator/<slug>`), skipping the `list → instance` redirect hop that caused the visible delay
- **many operators** → the operator list, to pick one (standing up several operators mid-onboarding is a valid state)

The moment **any** subscription goes live (`hasBillingRelationship` flips true) or an engagement appears, it's null again — Home and the full tab set (incl. Billing) return. **Hosted-agent never triggers it**: a hosted-agent client only gets portal access after implementation, when the subscription is already initiated, so they're never in this window.

## Changes
- `src/lib/portal/offerings.ts` — `preGoLiveLanding` field + derivation
- `src/pages/portal/index.astro` — redirect to it (with `?home=1` QA escape hatch)
- `src/lib/portal/nav.ts` — omit Home when it's set
- `tests/portal-offerings.test.ts` — 6 new cases + 1 updated (the provisioning-only case now hides Home)

## Verification
- `npm run verify` green — 3578 passed
- Verified against **A&P live data**: `inv_visible:0, engagements:0, quotes:0, subs_live:0, op_provisioning:1` → resolves to `/portal/products/operator/ashton-price`. The rule fires for the real first-client seat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)