### PR TITLE
fix(portal): drop the § NN anchor prefixes from portal nav tabs

### DIFF
--- a/src/components/portal/PortalNav.astro
+++ b/src/components/portal/PortalNav.astro
@@ -33,7 +33,7 @@ const dense = destinations.length >= 5
         destinations.map((dest, i) => {
           const active = isNavDestinationActive(dest, pathname)
           const base =
-            'inline-flex items-baseline gap-2 px-5 py-3 min-h-[44px] font-mono text-sm font-bold uppercase tracking-[0.14em] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2'
+            'inline-flex items-center px-5 py-3 min-h-[44px] font-mono text-sm font-bold uppercase tracking-[0.14em] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2'
           const state = active
             ? 'bg-[color:var(--ss-color-primary)] text-[color:var(--ss-color-background)]'
             : 'bg-transparent text-[color:var(--ss-color-text-secondary)] hover:text-[color:var(--ss-color-text-primary)] hover:bg-[color:var(--ss-color-border-subtle)]'
@@ -46,12 +46,6 @@ const dense = destinations.length >= 5
                 aria-current={active ? 'page' : undefined}
                 class={`${base} ${state}`}
               >
-                <span
-                  aria-hidden="true"
-                  class={`font-mono text-xs tracking-[0.06em] ${active ? 'text-[color:var(--ss-color-background)]' : 'text-[color:var(--ss-color-primary)]'}`}
-                >
-                  § {dest.anchor}
-                </span>
                 <span>{dest.label}</span>
               </a>
             </li>
@@ -83,12 +77,6 @@ const dense = destinations.length >= 5
               aria-current={active ? 'page' : undefined}
               class={`${base} w-full ${state}`}
             >
-              <span
-                aria-hidden="true"
-                class={`font-mono text-[11px] leading-none tracking-[0.06em] ${active ? 'text-[color:var(--ss-color-background)]' : 'text-[color:var(--ss-color-primary)]'}`}
-              >
-                § {dest.anchor}
-              </span>
               <span class="leading-none">{dest.mobileLabel ?? dest.label}</span>
             </a>
           </li>

--- a/src/lib/portal/nav.ts
+++ b/src/lib/portal/nav.ts
@@ -4,14 +4,12 @@
  * Pure function from PortalOfferings to the ordered destination list —
  * offerings as destinations, fully composed (Captain decisions 1, 2, 10):
  *
- *   Home        always
+ *   Home        unless a pre-go-live operator-only client (then hidden; they
+ *               land on the operator itself — see offerings.preGoLiveLanding)
  *   Engagement  when any engagement or proposal exists
  *   Operator    ONE tab when the client owns any operator (the list lives inside)
  *   Agent       when a hosted-agent subscription exists
  *   Billing     once a billing relationship exists (invoice history or a live subscription)
- *
- * Section anchors are assigned sequentially at build time so there is no
- * conditional-anchor arithmetic anywhere.
  */
 
 import type { PortalOfferings } from './offerings'
@@ -21,14 +19,13 @@ export interface PortalNavDestination {
   label: string
   /** Escape hatch for narrow mobile cells; unused initially. */
   mobileLabel?: string
-  anchor: string
   matchPrefix: string
   /** Home matches exactly; everything else matches by prefix. */
   exact?: boolean
 }
 
 export function buildPortalNav(offerings: PortalOfferings): PortalNavDestination[] {
-  const destinations: Omit<PortalNavDestination, 'anchor'>[] = []
+  const destinations: PortalNavDestination[] = []
   // Home is hidden for a pre-go-live operator-only client: they land in the
   // operator area and have no hub to return to (Captain, 2026-07-16). Same
   // shape as the Billing gate below — a tab appears only when it has a purpose.
@@ -72,7 +69,7 @@ export function buildPortalNav(offerings: PortalOfferings): PortalNavDestination
       matchPrefix: '/portal/billing',
     })
   }
-  return destinations.map((d, i) => ({ ...d, anchor: String(i + 1).padStart(2, '0') }))
+  return destinations
 }
 
 export function isNavDestinationActive(dest: PortalNavDestination, pathname: string): boolean {

--- a/tests/portal-offerings.test.ts
+++ b/tests/portal-offerings.test.ts
@@ -124,7 +124,7 @@ describe('buildPortalNav', () => {
     expect(nav.map((d) => d.label)).toEqual(['Home'])
   })
 
-  it('everything owned: all five destinations in fixed order with sequential anchors', () => {
+  it('everything owned: all five destinations in fixed order', () => {
     const nav = buildPortalNav(
       deriveOfferings({
         engagements: [engagement('in_progress')],
@@ -135,7 +135,6 @@ describe('buildPortalNav', () => {
       })
     )
     expect(nav.map((d) => d.label)).toEqual(['Home', 'Engagement', 'Operator', 'Agent', 'Billing'])
-    expect(nav.map((d) => d.anchor)).toEqual(['01', '02', '03', '04', '05'])
   })
 
   it('agent-only subscriber: Home, Agent, Billing (subscription implies billing)', () => {
@@ -143,7 +142,6 @@ describe('buildPortalNav', () => {
       deriveOfferings({ ...NOTHING, subscriptions: [subscription('hosted-agent')] })
     )
     expect(nav.map((d) => d.label)).toEqual(['Home', 'Agent', 'Billing'])
-    expect(nav.map((d) => d.anchor)).toEqual(['01', '02', '03'])
   })
 
   it('invoices alone light up Billing', () => {


### PR DESCRIPTION
## Summary
- Removes the `§ 01` style anchor prefixes from every portal nav tab (desktop + mobile) — a decorative leftover that read as clutter, not wayfinding (Captain, 2026-07-16).
- Rips the now-purposeless `anchor` field from `PortalNavDestination` and `buildPortalNav` so no dead code is left behind.
- Tabs now show just the label (e.g. `OPERATOR`, not `§ 01 OPERATOR`).

## Scope
Portal nav only (PortalShell → PortalNav — the tabs a client actually sees). The legacy `PortalTabs.astro` carries the same `§ NN` treatment but is only imported by pre-IA-rebuild content components on old routes; left untouched here.

## Test plan
- [x] `npm run verify` green — 3578 passed
- [x] Two nav tests updated (dropped the anchor-sequence assertions; label assertions unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)