### PR TITLE
fix(security): patch npm audit high vulns (astro 6.4.8, js-yaml, brace-expansion)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@formepdf/react": "^0.10.4",
         "@sentry/cloudflare": "^10.64.0",
         "@venturecrane/tokens": "0.0.2-alpha.0",
-        "astro": "^6.3.5",
+        "astro": "^6.4.8",
         "date-fns": "^4.4.0",
         "date-fns-tz": "^3.2.0",
         "ics": "^3.12.0",
@@ -4012,9 +4012,9 @@
       }
     },
     "node_modules/astro": {
-      "version": "6.4.7",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-6.4.7.tgz",
-      "integrity": "sha512-5vsXx0H52u23Jpshs9tM81D03Tb3Oh2Vt2Zo0bpqjXN+njkAWjFyGjTfmWJLAcrCQd9Q+iWB1eqfhR1sZJEaUA==",
+      "version": "6.4.8",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-6.4.8.tgz",
+      "integrity": "sha512-KK5lX90uU9EeVaTjINyj3sy9/NFXVa59aowaqbWBDDKLXZh4rr7GwIaCFYVetE22MJtsCNFerQXn0vlCLmpP/Q==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/compiler": "^4.0.0",
@@ -4233,9 +4233,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5919,9 +5919,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@formepdf/react": "^0.10.4",
     "@sentry/cloudflare": "^10.64.0",
     "@venturecrane/tokens": "0.0.2-alpha.0",
-    "astro": "^6.3.5",
+    "astro": "^6.4.8",
     "date-fns": "^4.4.0",
     "date-fns-tz": "^3.2.0",
     "ics": "^3.12.0",
@@ -66,6 +66,8 @@
     "js-cookie": "^3.0.7",
     "esbuild": "0.28.1",
     "ws": "8.21.0",
-    "yaml": "2.8.3"
+    "yaml": "2.8.3",
+    "brace-expansion": "^5.0.7",
+    "js-yaml": "^4.3.0"
   }
 }


### PR DESCRIPTION
## Why

The nightly **Security** workflow began failing 2026-07-21 (green through 07-20) after three advisories landed against transitive deps. `npm audit --audit-level=high` flagged three HIGH findings, failing the `npm audit (high+)` job and the `Security Summary`.

This is advisory-driven, not a code regression — the scheduled run surfaced newly-published CVEs.

## The three HIGH findings

| Package | Advisory | Fix |
|---|---|---|
| **astro** `<6.4.8` | [GHSA-vj59-8hwv-xxmv](https://github.com/advisories/GHSA-vj59-8hwv-xxmv) — Authorization Bypass via Rewrite Path Canonicalization Mismatch | → **6.4.8** (patch within our 6.x line) |
| **js-yaml** `<4.3.0` | [GHSA-52cp-r559-cp3m](https://github.com/advisories/GHSA-52cp-r559-cp3m) — quadratic CPU via YAML merge-key chains | → **4.3.0** (override) |
| **brace-expansion** `<5.0.7` | [GHSA-3jxr-9vmj-r5cp](https://github.com/advisories/GHSA-3jxr-9vmj-r5cp) — exponential-time expansion DoS | → **5.0.7** (override) |

The astro authz-bypass advisory is the notable one: it concerns **rewrite path canonicalization**, and our entire subdomain auth model (`admin.` / `portal.` gating in `src/middleware.ts`) is built on middleware path rewrites. 6.4.8 is a patch release in our existing 6.x line and satisfies `@astrojs/cloudflare@13`'s `^6.0.0` peer — no major upgrade.

`js-yaml` and `brace-expansion` are pinned via the existing security-overrides block, matching the established pattern (`undici`, `ws`, `yaml`, …).

## What's deliberately *not* here

Three remaining astro advisories ([GHSA-4g3v](https://github.com/advisories/GHSA-4g3v-8h47-v7g6), [GHSA-f48w](https://github.com/advisories/GHSA-f48w-9m4c-m7f5), [GHSA-7pw4](https://github.com/advisories/GHSA-7pw4-f3q4-r2p2)) are **moderate/low** and only patched in **Astro 7.x**. They sit below the `high` gate and do not block CI. A full Astro 6 → 7 major upgrade is a separate, larger effort — not bundled into a security hotfix.

## Verification

- `npm audit --audit-level=high` exits **0** at repo root and in all `workers/*` subdirs (was exit 1 / 5 vulns).
- Diff is three version bumps in `package.json` + `package-lock.json`. No source changes.
- All fix versions are >20 days old — outside the repo's 7-day supply-chain cooldown.
- CI (this PR) runs the full `verify` + `Security` suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)