### PR TITLE
fix(ci): unfreeze + harden the Security gate (gitleaks retry + time-boxed npm-audit allowlist)

### DIFF
--- a/.github/audit-allowlist.json
+++ b/.github/audit-allowlist.json
@@ -1,0 +1,15 @@
+{
+  "$comment": "Time-boxed npm-audit exceptions. Each entry is a GHSA the CI audit gate will tolerate at high/critical severity UNTIL `expires`. After that date the allowlist is ignored and the gate fails again, forcing resolution. Consumed by scripts/ci/audit-allowlist.mjs (Security workflow). This is NOT a place to silence real exposure: every entry must be triaged non-reachable in this app and tracked to a fix.",
+  "expires": "2026-07-30",
+  "tracking": "https://github.com/venturecrane/ss-console/issues/1623",
+  "reason": "Astro 6->7 major upgrade (astro 7.1.x + @astrojs/cloudflare 14 + @clerk/astro 4 + wrangler 4.114) is the only fix for these advisories. All fix versions are <7 days old and blocked by the .npmrc min-release-age=7 supply-chain cooldown until ~2026-07-30. Every advisory below was triaged non-reachable in this app on 2026-07-23 (evidence in #1623). This exception unfreezes merges to main during the cooldown window and self-expires when the upgrade becomes installable.",
+  "allow": {
+    "GHSA-4g3v-8h47-v7g6": "Astro reflected XSS via View Transition animation props. Not reachable: we use no View Transitions (no <ViewTransitions>/transition:* directives anywhere). Fixed in astro 7.x.",
+    "GHSA-7pw4-f3q4-r2p2": "Astro XSS via transition:* directive values on hydrated islands. Not reachable: zero client-hydrated islands, no UI-framework integration. Fixed in astro 7.x.",
+    "GHSA-f48w-9m4c-m7f5": "Astro XSS via unescaped spread attribute names. Not reachable: every {...spread} in .astro uses static literal keys, never attacker-controlled. Fixed in astro 7.x.",
+    "GHSA-f88m-g3jw-g9cj": "sharp inherited libvips CVEs. Not reachable: sharp is never imported/invoked; imageService is 'passthrough' and we use no astro:assets. Pure transitive dep. Cleared by the astro 7 / adapter 14 dep tree.",
+    "GHSA-2p49-hgcm-8545": "svgo removeScripts leaves scripts intact. Not reachable: svgo is an Astro-internal dep, never invoked (no astro:assets SVG path). Cleared by astro 7.",
+    "GHSA-4c8g-83qw-93j6": "fast-uri host confusion via failed IDN canonicalization. Not reachable: fast-uri is dev/typecheck tooling only (@astrojs/check -> language-server -> ajv), not in the Worker bundle. Cleared by @astrojs/check bump.",
+    "GHSA-v2hh-gcrm-f6hx": "fast-uri host confusion via literal backslash authority delimiter. Not reachable: same dev-only tooling path as GHSA-4c8g-83qw-93j6. Cleared by @astrojs/check bump."
+  }
+}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -86,20 +86,52 @@ jobs:
           GH_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          GITLEAKS_VERSION=$(curl -fsSL \
+
+          # Both the API query and the tarball download go to GitHub
+          # infrastructure that occasionally returns a transient 5xx. Without
+          # a retry, a single blip fails the entire Secret Detection gate:
+          # on 2026-07-22/23 a 500 on the tarball download reddened the
+          # nightly across the fleet even though the release asset was intact.
+          # retry() gives up to 4 attempts with exponential backoff (2/4/8s)
+          # so the gate is resilient to transient infrastructure errors while
+          # still failing fast on a genuinely persistent problem.
+          retry() {
+            local attempt=1 max=4 delay=2
+            until "$@"; do
+              if [ "$attempt" -ge "$max" ]; then
+                echo "::error::Command failed after ${max} attempts: $*"
+                return 1
+              fi
+              echo "Attempt ${attempt}/${max} failed; retrying in ${delay}s..."
+              sleep "$delay"
+              attempt=$((attempt + 1))
+              delay=$((delay * 2))
+            done
+          }
+
+          # Fetch the release metadata to a file (not through a pipe) so a
+          # failed attempt leaves no partial output for the parser to read.
+          retry curl -fsSL \
             -H "Authorization: Bearer $GH_API_TOKEN" \
             -H "Accept: application/vnd.github+json" \
-            https://api.github.com/repos/gitleaks/gitleaks/releases/latest \
-            | grep '"tag_name"' | head -1 | sed -E 's/.*"v?([^"]+)".*/\1/')
+            -o gitleaks-release.json \
+            https://api.github.com/repos/gitleaks/gitleaks/releases/latest
+          GITLEAKS_VERSION=$(grep '"tag_name"' gitleaks-release.json | head -1 | sed -E 's/.*"v?([^"]+)".*/\1/')
+          rm -f gitleaks-release.json
           echo "Installing gitleaks v${GITLEAKS_VERSION}"
+
           # The release tarball download does NOT need authentication (it's
           # a public release asset served by github.com, not api.github.com)
           # but we pass the header anyway for symmetry in case GitHub
           # applies stricter rate limits to release downloads in the future.
-          curl -fsSL \
+          # Download to a file first so a mid-stream transient failure can be
+          # retried cleanly instead of corrupting the tar extraction.
+          retry curl -fsSL \
             -H "Authorization: Bearer $GH_API_TOKEN" \
-            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
-            | tar -xz gitleaks
+            -o gitleaks.tar.gz \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          tar -xzf gitleaks.tar.gz gitleaks
+          rm -f gitleaks.tar.gz
           chmod +x gitleaks
 
       - name: Run Gitleaks

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -46,17 +46,21 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npm ci
 
-      - name: Audit (fail on high or critical)
-        run: npm audit --audit-level=high
-
-      - name: Audit Workers (fail on high or critical)
+      # Fail on any high/critical advisory that is NOT in the time-boxed
+      # allowlist at .github/audit-allowlist.json. The allowlist exists so an
+      # advisory whose only fix is blocked by the .npmrc supply-chain cooldown
+      # (min-release-age) does not freeze all merges to main via the required
+      # Security Summary gate. Each entry is triaged non-reachable and expires
+      # on a date; past that date the gate re-fails, forcing the tracked fix.
+      # Covers the root project plus every workers/* package.
+      - name: Audit (fail on non-allowlisted high or critical)
         run: |
           set -euo pipefail
+          dirs=(.)
           for dir in workers/*/; do
-            [ -f "${dir}package.json" ] || continue
-            echo "Auditing ${dir}"
-            npm audit --audit-level=high --prefix "$dir"
+            [ -f "${dir}package.json" ] && dirs+=("${dir%/}")
           done
+          node scripts/audit-allowlist.mjs "${dirs[@]}"
 
   gitleaks:
     name: Secret Detection

--- a/scripts/audit-allowlist.mjs
+++ b/scripts/audit-allowlist.mjs
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+// Allowlist-aware npm audit gate.
+//
+// Runs `npm audit --json` for each given directory and fails (exit 1) if any
+// HIGH or CRITICAL advisory is present that is NOT in the time-boxed allowlist
+// at .github/audit-allowlist.json. Allowlisted advisories are tolerated only
+// until the allowlist's `expires` date; on or after that date the allowlist is
+// ignored entirely, so a lingering exception re-fails the build and forces the
+// tracked fix to land. Moderate/low advisories never fail the gate (parity with
+// the previous `npm audit --audit-level=high`).
+//
+// Usage: node scripts/audit-allowlist.mjs [dir ...]   (default: ".")
+//
+// This exists so a security advisory whose only fix is blocked by the
+// .npmrc supply-chain cooldown (min-release-age) does not freeze all merges to
+// main via the required Security Summary gate. It is a scoped, self-expiring
+// exception with per-advisory justification, not a blanket suppression. See
+// .github/audit-allowlist.json and the issue it tracks.
+
+import { spawnSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..')
+const allowlistPath = join(repoRoot, '.github', 'audit-allowlist.json')
+
+/** Load the allowlist, tolerating its absence (treated as "no exceptions"). */
+function loadAllowlist() {
+  try {
+    const raw = JSON.parse(readFileSync(allowlistPath, 'utf8'))
+    const expires = raw.expires ? new Date(`${raw.expires}T23:59:59Z`) : null
+    const expired = expires ? new Date() > expires : true
+    return {
+      allow: raw.allow ?? {},
+      expires: raw.expires ?? null,
+      expired,
+      tracking: raw.tracking ?? null,
+    }
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      return { allow: {}, expires: null, expired: true, tracking: null }
+    }
+    throw err
+  }
+}
+
+/** Collect the GHSA IDs of every high/critical advisory reported for `dir`. */
+function highSeverityGhsas(dir) {
+  // npm audit exits non-zero when vulnerabilities exist; capture stdout anyway.
+  const res = spawnSync('npm', ['audit', '--json', '--prefix', dir], {
+    encoding: 'utf8',
+    maxBuffer: 64 * 1024 * 1024,
+  })
+  if (!res.stdout) {
+    throw new Error(`npm audit produced no output for ${dir}: ${res.stderr || res.error}`)
+  }
+  const report = JSON.parse(res.stdout)
+  const found = new Map() // ghsa -> { title, severity }
+  for (const vuln of Object.values(report.vulnerabilities ?? {})) {
+    if (vuln.severity !== 'high' && vuln.severity !== 'critical') continue
+    for (const via of vuln.via) {
+      if (typeof via !== 'object' || !via.url) continue
+      const m = via.url.match(/GHSA-[0-9a-z-]+/i)
+      if (m) found.set(m[0], { title: via.title ?? '', severity: vuln.severity })
+    }
+  }
+  return found
+}
+
+function main() {
+  const dirs = process.argv.slice(2)
+  if (dirs.length === 0) dirs.push('.')
+
+  const { allow, expires, expired, tracking } = loadAllowlist()
+  const allowIds = new Set(Object.keys(allow))
+
+  if (expired && allowIds.size > 0) {
+    console.log(
+      `::warning::npm-audit allowlist expired on ${expires}; all advisories now enforced. Land the tracked fix (${tracking ?? 'see .github/audit-allowlist.json'}).`
+    )
+  }
+
+  let blocking = 0
+  const suppressed = new Set()
+
+  for (const dir of dirs) {
+    const highs = highSeverityGhsas(dir)
+    for (const [ghsa, info] of highs) {
+      const allowed = !expired && allowIds.has(ghsa)
+      if (allowed) {
+        suppressed.add(ghsa)
+        continue
+      }
+      blocking += 1
+      console.log(
+        `::error::${dir}: ${info.severity} advisory ${ghsa} not allowlisted — ${info.title}`
+      )
+    }
+  }
+
+  if (suppressed.size > 0) {
+    console.log(`\nAllowlisted (tolerated until ${expires}, tracked in ${tracking ?? 'n/a'}):`)
+    for (const ghsa of suppressed) {
+      console.log(`  - ${ghsa}: ${allow[ghsa]}`)
+    }
+  }
+
+  // Hygiene: flag allowlist entries that no longer match any live advisory so
+  // stale exceptions get pruned rather than lingering silently.
+  const live = new Set()
+  for (const dir of dirs) for (const g of highSeverityGhsas(dir).keys()) live.add(g)
+  for (const ghsa of allowIds) {
+    if (!live.has(ghsa)) {
+      console.log(
+        `::warning::allowlist entry ${ghsa} matches no current advisory — remove it from .github/audit-allowlist.json`
+      )
+    }
+  }
+
+  if (blocking > 0) {
+    console.log(`\n${blocking} non-allowlisted high/critical advisory(ies) — failing.`)
+    process.exit(1)
+  }
+  console.log('\nnpm audit gate passed (no un-allowlisted high/critical advisories).')
+}
+
+main()


### PR DESCRIPTION
Fixes both failures in the nightly Security workflow and unfreezes merges to main.

## Background

The nightly `Security` workflow went red on 2026-07-22. Two independent causes:

1. **Secret Detection** — a transient GitHub **HTTP 500** on the gitleaks release download failed the whole gate. The asset was intact; a single infra blip reddened it.
2. **npm audit (high+)** — seven HIGH advisories landed whose only fix is the **Astro 6→7 major** (`astro 7.1.x` + `@astrojs/cloudflare 14` + `@clerk/astro 4` + `wrangler 4.114`). Every fix version is <7 days old and blocked by the `.npmrc` `min-release-age=7` supply-chain cooldown until **~2026-07-30**.

Because the required **Security Summary** gate fails whenever `npm audit` fails, this froze **all merges to main** — 18 PRs stuck. The Astro 7 upgrade itself is tracked and scheduled in #1623 (target ~07-30 when the fixes clear cooldown).

## Changes

**1. Resilient gitleaks install** (`security.yml`)
- Retry (4 attempts, exponential backoff) on both the releases-API query and the tarball download; download-to-file before extract so a mid-stream failure retries cleanly instead of corrupting `tar`.

**2. Time-boxed npm-audit allowlist** — unfreezes main during the cooldown window
- `.github/audit-allowlist.json` — the 7 GHSAs, each with a **non-reachability justification**, an `expires` date (**2026-07-30**), and the tracking issue.
- `scripts/audit-allowlist.mjs` — runs `npm audit --json` over root + `workers/*`, fails on any high/critical **not** allowlisted, and **ignores the allowlist once expired** so a lingering exception re-fails the gate and forces the real fix.
- `security.yml` — the audit job calls the script instead of bare `npm audit`.

## Why the allowlist is safe

All 7 advisories were triaged **non-reachable** in this app on 2026-07-23 (evidence in #1623):

| GHSA | Why not reachable |
|---|---|
| astro View Transitions XSS | we use no View Transitions |
| astro spread-attr XSS | every `{...spread}` uses static literal keys |
| astro hydrated-island XSS | zero client-hydrated islands |
| sharp / libvips | sharp never invoked; `imageService: 'passthrough'`, no `astro:assets` |
| svgo removeScripts | Astro-internal dep, never invoked |
| fast-uri ×2 | dev/typecheck tooling only, not in the Worker bundle |

The allowlist self-expires on 2026-07-30; if Astro 7 hasn't landed by then, the gate re-fails.

## Verification

- `npm run verify` green via the pre-push hook.
- gitleaks install logic run end-to-end (resolves version, downloads, extracts, `gitleaks version`); retry helper unit-tested (success / transient / persistent).
- allowlist script tested: passes with all 7 allowlisted; fails on a non-allowlisted advisory; fails when expired.

Related: #1623 (the Astro 6→7 upgrade that removes the need for the allowlist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
