### PR TITLE
feat(operator): msgraph config layer — msgraph_auth, provider-neutral send identity, provisioning (slice 2, #1978)

### DIFF
--- a/operator/bin/lib/secret_custody.py
+++ b/operator/bin/lib/secret_custody.py
@@ -83,6 +83,16 @@ _CUSTOMER_EXACT: frozenset[str] = frozenset(
         # Smokeball webhook ingress (provision-customer.sh:611-616).
         "WEBHOOK_SECRET_SMOKEBALL",
         "WEBHOOK_SMOKEBALL_CLIENT_ID",
+        # Microsoft Graph mail connector, app-only (provision-customer.sh:554-557;
+        # email-channel-seam spec D5, ADR 0078). All four are per-seat values for
+        # the CLIENT's tenant: their tenant id, the app id consented into their
+        # tenant, the client secret to that consent, and the pinned operator
+        # mailbox. Only CLIENT_SECRET is sensitive; the identifiers ride along
+        # so the completeness check classifies every staged name.
+        "MSGRAPH_TENANT_ID",
+        "MSGRAPH_CLIENT_ID",
+        "MSGRAPH_CLIENT_SECRET",
+        "MSGRAPH_MAILBOX",
     }
 )
 
@@ -98,6 +108,9 @@ _CUSTOMER_PREFIX: tuple[str, ...] = (
     "CLIO_",
     "SMOKEBALL_STAGING_",
     "SMOKEBALL_PROD_",
+    # Per-seat override form MSGRAPH_CLIENT_SECRET__<CID> (provision-customer.sh
+    # msgraph branch) + any future family member.
+    "MSGRAPH_",
 )
 
 # Infra-owned staged/derived names NOT in env-consumption. These are SMD-owned

--- a/operator/bin/provision-customer.sh
+++ b/operator/bin/provision-customer.sh
@@ -507,6 +507,58 @@ if grep -qE 'adapter:[[:space:]]*agentmail|backend:[[:space:]]*mcp:agentmail' \
   unset _AGENTMAIL_WH_KEY _AGENTMAIL_WH_SECRET
 fi
 
+# Microsoft Graph app-only mail (adapter: msgraph, backend: mcp:msgraph-mail —
+# email-channel-seam ADR 0078 / spec D5). The connector authenticates app-only
+# (tenant + client id + client secret) against a mailbox pinned by config, tenant-
+# scoped by ApplicationAccessPolicy. Staged ONLY for a customer whose customer.yaml
+# binds the msgraph Email adapter. tenant_id / client_id / mailbox are non-secret
+# and read straight from the msgraph_auth block; the client SECRET is client-
+# custodied (ADR 0010) and never in the yaml — msgraph_auth.secret_ref names the
+# Fly secret (fly-secret:<NAME>), whose VALUE is sourced from the operator env,
+# preferring the per-customer <NAME>__<CUSTOMER_ID> so a reprovision of one seat
+# never pulls another tenant's secret. The connector reads all four as env vars
+# (MSGRAPH_TENANT_ID / MSGRAPH_CLIENT_ID / MSGRAPH_CLIENT_SECRET / MSGRAPH_MAILBOX).
+if grep -qE 'adapter:[[:space:]]*msgraph|backend:[[:space:]]*mcp:msgraph-mail' \
+    "${CUSTOMER_DIR}/customer.yaml" 2>/dev/null; then
+  MSG_PARSE_PY="
+import yaml
+with open('${CUSTOMER_YAML}') as f:
+    c = yaml.safe_load(f) or {}
+auth = {}
+for conn in (c.get('connectors') or {}).values():
+    if isinstance(conn, dict) and str(conn.get('adapter', '')) == 'msgraph':
+        auth = conn.get('msgraph_auth') or {}
+        break
+print(str(auth.get('tenant_id') or '').strip())
+print(str(auth.get('client_id') or '').strip())
+print(str(auth.get('mailbox') or '').strip())
+print(str(auth.get('secret_ref') or '').strip())
+"
+  MSG_FIELDS=()
+  while IFS= read -r _line; do MSG_FIELDS+=("${_line}"); done \
+    < <(uv run --quiet --with pyyaml python3 -c "${MSG_PARSE_PY}")
+  _MSG_TENANT="${MSG_FIELDS[0]:-}"
+  _MSG_CLIENT="${MSG_FIELDS[1]:-}"
+  _MSG_MAILBOX="${MSG_FIELDS[2]:-}"
+  _MSG_SECRET_REF="${MSG_FIELDS[3]:-}"
+  # Derive the Fly/operator-env secret NAME from the secret_ref (strip the
+  # fly-secret: prefix). Defaults to MSGRAPH_CLIENT_SECRET when unauthored.
+  _MSG_SECRET_NAME="${_MSG_SECRET_REF#fly-secret:}"
+  [ -n "${_MSG_SECRET_NAME}" ] && [ "${_MSG_SECRET_NAME}" != "${_MSG_SECRET_REF}" ] \
+    || _MSG_SECRET_NAME="MSGRAPH_CLIENT_SECRET"
+  # Per-customer source for the client secret, else the global by that name.
+  _MSG_SECRET_CID_KEY="${_MSG_SECRET_NAME}__$(printf '%s' "${CUSTOMER_ID}" | tr '[:lower:]-' '[:upper:]_' | tr -cd 'A-Z0-9_')"
+  _MSG_SECRET_VALUE="${!_MSG_SECRET_CID_KEY:-${!_MSG_SECRET_NAME:-}}"
+
+  log "Microsoft Graph mail seat: mailbox=${_MSG_MAILBOX} (client secret from ${_MSG_SECRET_CID_KEY}, else ${_MSG_SECRET_NAME})"
+  stage_secret_from_env MSGRAPH_TENANT_ID     "${_MSG_TENANT}"        "Microsoft Graph tenant id (from msgraph_auth.tenant_id)"
+  stage_secret_from_env MSGRAPH_CLIENT_ID     "${_MSG_CLIENT}"        "Microsoft Graph app client id (from msgraph_auth.client_id)"
+  stage_secret_from_env MSGRAPH_MAILBOX       "${_MSG_MAILBOX}"       "Microsoft Graph pinned operator mailbox (from msgraph_auth.mailbox)"
+  stage_secret_from_env MSGRAPH_CLIENT_SECRET "${_MSG_SECRET_VALUE}"  "Microsoft Graph app client secret (per-customer ${_MSG_SECRET_CID_KEY}, else ${_MSG_SECRET_NAME})"
+  unset MSG_PARSE_PY MSG_FIELDS _MSG_TENANT _MSG_CLIENT _MSG_MAILBOX _MSG_SECRET_REF \
+    _MSG_SECRET_NAME _MSG_SECRET_CID_KEY _MSG_SECRET_VALUE
+fi
+
 # Brave Search (native:brave-free, ADR 0070). BRAVE_SEARCH_API_KEY is the env var
 # Hermes' native brave-free provider reads. The Hosted-Agent tier uses Brave's
 # FREE tier (one shared, SMD-owned key; $0, no runaway spend; keeps "your only

--- a/src/lib/operator/customer-yaml/secret-detector.ts
+++ b/src/lib/operator/customer-yaml/secret-detector.ts
@@ -114,6 +114,16 @@ const PROVIDER_PATTERNS: ReadonlyArray<{
  * fields belong in Infisical, not in git. Matched case-insensitively as a
  * substring of the full key name.
  */
+/**
+ * Field names that legitimately contain a banned substring but are the permitted
+ * secret-REFERENCE channels — they carry a pointer, never a literal:
+ *   - `token_ref` — an `infisical:` path (the Infisical reference channel).
+ *   - `secret_ref` — a `fly-secret:<NAME>` reference to a per-seat Fly secret
+ *     (ADR 0010 custody for the msgraph client secret; email-channel-seam D5).
+ * Both scanners skip the field-name ban for these keys.
+ */
+const SECRET_REFERENCE_FIELD_NAMES: ReadonlySet<string> = new Set(['token_ref', 'secret_ref'])
+
 const BANNED_FIELD_NAME_SUBSTRINGS: ReadonlyArray<string> = [
   'password',
   'passwd',
@@ -141,6 +151,11 @@ const SHAPE_HEURISTIC_ALLOWLIST_PATHS: ReadonlyArray<string> = [
   'personas[*].signature_html',
   'personas[*].avatar_url',
   'personas[*].send_as.agentmail_identity',
+  'personas[*].send_as.send_identity.address',
+  // msgraph_auth carries a mailbox address, two GUIDs, and a fly-secret: ref
+  // (all references / identifiers, never literals — the GUIDs can brush the
+  // high-entropy heuristic, and the secret is custodied out-of-band per ADR 0010).
+  'connectors.Email.msgraph_auth',
   'users[*].email',
   'users[*].full_name',
   // Clerk user IDs are public stable identifiers, not credentials.
@@ -317,9 +332,9 @@ function visit(
     for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
       const keyLower = key.toLowerCase()
       const banned = BANNED_FIELD_NAME_SUBSTRINGS.find((s) => keyLower.includes(s))
-      // `token_ref` is the explicitly permitted Infisical-reference field,
-      // even though the name contains "token". Skip the field-name ban for it.
-      if (banned !== undefined && key !== 'token_ref') {
+      // token_ref / secret_ref are the explicitly permitted secret-reference
+      // fields (they carry a pointer, not a literal). Skip the field-name ban.
+      if (banned !== undefined && !SECRET_REFERENCE_FIELD_NAMES.has(key)) {
         findings.push({
           category: 'banned_field_name',
           line: null,
@@ -374,7 +389,7 @@ export function scanRawYaml(text: string, options: ScanOptions = {}): SecretFind
       const keyName = fieldName.replace(/^["']|["']$/g, '')
       const keyLower = keyName.toLowerCase()
       const banned = BANNED_FIELD_NAME_SUBSTRINGS.find((s) => keyLower.includes(s))
-      if (banned !== undefined && keyName !== 'token_ref') {
+      if (banned !== undefined && !SECRET_REFERENCE_FIELD_NAMES.has(keyName)) {
         findings.push({
           category: 'banned_field_name',
           line: i + 1,

--- a/src/lib/operator/customer-yaml/sections-connectors.ts
+++ b/src/lib/operator/customer-yaml/sections-connectors.ts
@@ -13,8 +13,12 @@ import {
 import {
   ACCEPTED_BACKEND_PREFIXES,
   ACCEPTED_CAPABILITY_NAMES,
+  MSGRAPH_ADAPTER,
+  MSGRAPH_GUID_PATTERN,
+  MSGRAPH_SECRET_REF_PATTERN,
   WEBHOOK_URL_PATTERN,
   type Connector,
+  type MsgraphAuth,
   type ValidationError,
 } from './types'
 import { isPlainObject, optionalEnum } from './helpers'
@@ -95,6 +99,8 @@ function checkOneConnector(
   if (scopes === null) return null
   const webhookUrl = checkWebhookUrl(key, value['webhook_url'], customerId, errors)
   if (webhookUrl === undefined) return null
+  const msgraph = checkMsgraph(key, adapter, value, errors)
+  if (msgraph === null) return null
   const enabled = typeof value['enabled'] === 'boolean' ? value['enabled'] : true
   const tokenRef = typeof value['token_ref'] === 'string' ? value['token_ref'] : null
   // ADR 0042: optional per-connector custody; null ⇒ inherit the client-level
@@ -116,7 +122,142 @@ function checkOneConnector(
     webhook_url: webhookUrl,
     credential_custody: custody,
     auth_mode: authMode,
+    msgraph_auth: msgraph.msgraph_auth,
+    poll_seconds: msgraph.poll_seconds,
   }
+}
+
+/**
+ * Validate the msgraph-specific knobs on a connector (email-channel-seam spec D5).
+ *
+ * When `adapter === MSGRAPH_ADAPTER`, `msgraph_auth` is REQUIRED and validated,
+ * and `poll_seconds` (optional) must be a positive integer. On any other adapter,
+ * both blocks MUST be absent — a present block is a hard error (no dead config),
+ * consistent with the schema's fail-closed posture.
+ *
+ * Returns the resolved `{ msgraph_auth, poll_seconds }` pair, or null to signal a
+ * hard failure that drops the whole connector.
+ */
+function checkMsgraph(
+  key: string,
+  adapter: string,
+  value: Record<string, unknown>,
+  errors: ValidationError[]
+): { msgraph_auth: MsgraphAuth | null; poll_seconds: number | null } | null {
+  const rawAuth = value['msgraph_auth']
+  const rawPoll = value['poll_seconds']
+  if (adapter !== MSGRAPH_ADAPTER) {
+    let ok = true
+    if (rawAuth !== undefined && rawAuth !== null) {
+      errors.push({
+        code: 'InvalidFormat',
+        path: `connectors.${key}.msgraph_auth`,
+        message: `msgraph_auth is only valid when adapter is "${MSGRAPH_ADAPTER}" (adapter is "${adapter}")`,
+      })
+      ok = false
+    }
+    if (rawPoll !== undefined && rawPoll !== null) {
+      errors.push({
+        code: 'InvalidFormat',
+        path: `connectors.${key}.poll_seconds`,
+        message: `poll_seconds is only valid when adapter is "${MSGRAPH_ADAPTER}" (adapter is "${adapter}")`,
+      })
+      ok = false
+    }
+    return ok ? { msgraph_auth: null, poll_seconds: null } : null
+  }
+  const msgraphAuth = checkMsgraphAuth(key, rawAuth, errors)
+  const pollSeconds = checkPollSeconds(key, rawPoll, errors)
+  if (msgraphAuth === null || pollSeconds === undefined) return null
+  return { msgraph_auth: msgraphAuth, poll_seconds: pollSeconds }
+}
+
+/**
+ * Validate the required `msgraph_auth` block (adapter is msgraph). Fail-closed:
+ * absent or malformed ⇒ null (drops the connector), never a partial block.
+ */
+function checkMsgraphAuth(
+  key: string,
+  raw: unknown,
+  errors: ValidationError[]
+): MsgraphAuth | null {
+  const path = `connectors.${key}.msgraph_auth`
+  if (raw === undefined || raw === null) {
+    errors.push({
+      code: 'MissingField',
+      path,
+      message: `${path} is required when adapter is "${MSGRAPH_ADAPTER}"`,
+    })
+    return null
+  }
+  if (!isPlainObject(raw)) {
+    errors.push({ code: 'TypeMismatch', path, message: `${path} must be an object` })
+    return null
+  }
+  let ok = true
+  const tenantId = checkGuid(raw['tenant_id'], `${path}.tenant_id`, errors)
+  if (tenantId === null) ok = false
+  const clientId = checkGuid(raw['client_id'], `${path}.client_id`, errors)
+  if (clientId === null) ok = false
+  const mailbox = raw['mailbox']
+  if (typeof mailbox !== 'string' || !mailbox.includes('@')) {
+    errors.push({
+      code: 'InvalidFormat',
+      path: `${path}.mailbox`,
+      message: `${path}.mailbox must be the operator mailbox email address`,
+    })
+    ok = false
+  }
+  const secretRef = raw['secret_ref']
+  if (typeof secretRef !== 'string' || !MSGRAPH_SECRET_REF_PATTERN.test(secretRef)) {
+    errors.push({
+      code: 'InvalidFormat',
+      path: `${path}.secret_ref`,
+      message: `${path}.secret_ref must reference a per-seat Fly secret as "fly-secret:<ENV_NAME>" (ADR 0010 custody)`,
+    })
+    ok = false
+  }
+  if (!ok) return null
+  return {
+    tenant_id: tenantId as string,
+    mailbox: mailbox as string,
+    client_id: clientId as string,
+    secret_ref: secretRef as string,
+  }
+}
+
+function checkGuid(raw: unknown, path: string, errors: ValidationError[]): string | null {
+  if (typeof raw !== 'string' || !MSGRAPH_GUID_PATTERN.test(raw)) {
+    errors.push({
+      code: 'InvalidFormat',
+      path,
+      message: `${path} must be a GUID (8-4-4-4-12 hex)`,
+    })
+    return null
+  }
+  return raw
+}
+
+/**
+ * Validate the optional `poll_seconds` cadence (adapter is msgraph). Returns the
+ * positive integer, null when absent (overlay applies the default), or undefined
+ * to signal a hard failure that drops the connector.
+ */
+function checkPollSeconds(
+  key: string,
+  raw: unknown,
+  errors: ValidationError[]
+): number | null | undefined {
+  if (raw === undefined || raw === null) return null
+  if (typeof raw !== 'number' || !Number.isInteger(raw) || raw <= 0) {
+    errors.push({
+      code: 'TypeMismatch',
+      path: `connectors.${key}.poll_seconds`,
+      message: 'poll_seconds must be a positive integer (seconds)',
+    })
+    return undefined
+  }
+  return raw
 }
 
 /**

--- a/src/lib/operator/customer-yaml/sections-personas-send-as.ts
+++ b/src/lib/operator/customer-yaml/sections-personas-send-as.ts
@@ -1,0 +1,111 @@
+/**
+ * Persona `send_as` validator — split from sections-personas.ts to keep that
+ * file under the 500-line ceiling (same convention as sections-google-auth.ts:
+ * one focused module per grown sub-block).
+ */
+
+import {
+  ACCEPTED_SEND_PROVIDERS,
+  type PersonaSendAs,
+  type SendIdentity,
+  type SendProvider,
+  type ValidationError,
+} from './types'
+import { isPlainObject } from './helpers'
+
+/**
+ * Validate + normalize a persona `send_as` block into the provider-neutral
+ * {@link PersonaSendAs} shape (ADR 0078 §4 / email-channel-seam spec D5).
+ *
+ * Two authored forms are accepted:
+ *   - `send_identity: { provider, address }` — the current shape.
+ *   - `agentmail_identity: <address>` — the deprecated AgentMail-only field,
+ *     normalized to `{ provider: 'agentmail', address }`.
+ *
+ * Authoring BOTH is a hard error (ambiguous intent — the repo fails closed on
+ * ambiguity rather than silently picking one). On success the output carries
+ * ONLY `send_identity` (the deprecated field is never emitted), so the output is
+ * idempotent as input — re-validating a normalized value never trips the both-set
+ * guard. Downstream readers consume `send_identity`; pre-migration projected D1
+ * rows keep resolving via the read-side `agentmail_identity` fallback.
+ */
+export function checkSendAs(
+  raw: unknown,
+  path: string,
+  errors: ValidationError[]
+): PersonaSendAs | null {
+  if (raw === undefined || raw === null) return null
+  if (!isPlainObject(raw)) {
+    errors.push({ code: 'TypeMismatch', path, message: `${path} must be an object` })
+    return null
+  }
+  const hasSendIdentity = raw['send_identity'] !== undefined && raw['send_identity'] !== null
+  const hasLegacy = raw['agentmail_identity'] !== undefined && raw['agentmail_identity'] !== null
+  if (hasSendIdentity && hasLegacy) {
+    errors.push({
+      code: 'InvalidFormat',
+      path,
+      message:
+        `${path} sets both send_identity and the deprecated agentmail_identity — ` +
+        'author exactly one (send_identity is preferred; agentmail_identity is back-compat only)',
+    })
+    return null
+  }
+  if (hasSendIdentity) {
+    const identity = checkSendIdentity(raw['send_identity'], `${path}.send_identity`, errors)
+    if (identity === null) return null
+    return { send_identity: identity }
+  }
+  if (hasLegacy) {
+    const legacy = raw['agentmail_identity']
+    if (typeof legacy !== 'string' || legacy.length === 0) {
+      errors.push({
+        code: 'MissingField',
+        path: `${path}.agentmail_identity`,
+        message: 'send_as.agentmail_identity must be a non-empty string when set',
+      })
+      return null
+    }
+    return { send_identity: { provider: 'agentmail', address: legacy } }
+  }
+  errors.push({
+    code: 'MissingField',
+    path: `${path}.send_identity`,
+    message: 'send_as requires send_identity { provider, address } (or legacy agentmail_identity)',
+  })
+  return null
+}
+
+/** Validate a `send_identity: { provider, address }` sub-block. */
+function checkSendIdentity(
+  raw: unknown,
+  path: string,
+  errors: ValidationError[]
+): SendIdentity | null {
+  if (!isPlainObject(raw)) {
+    errors.push({ code: 'TypeMismatch', path, message: `${path} must be an object` })
+    return null
+  }
+  const provider = raw['provider']
+  if (
+    typeof provider !== 'string' ||
+    !(ACCEPTED_SEND_PROVIDERS as readonly string[]).includes(provider)
+  ) {
+    errors.push({
+      code: 'EnumViolation',
+      path: `${path}.provider`,
+      message: `${path}.provider must be one of: ${ACCEPTED_SEND_PROVIDERS.join(', ')}`,
+    })
+    return null
+  }
+  const address = raw['address']
+  if (typeof address !== 'string' || address.length === 0) {
+    errors.push({
+      code: 'MissingField',
+      path: `${path}.address`,
+      message: `${path}.address must be a non-empty string`,
+    })
+    return null
+  }
+  return { provider: provider as SendProvider, address }
+}

--- a/src/lib/operator/customer-yaml/sections-personas.ts
+++ b/src/lib/operator/customer-yaml/sections-personas.ts
@@ -17,13 +17,13 @@ import {
   type Persona,
   type PersonaChannelBinding,
   type PersonaEntitlements,
-  type PersonaSendAs,
   type PersonaSkill,
   type PersonaStatus,
   type SkillInitiation,
   type ValidationError,
 } from './types'
 import { isPlainObject, optionalEnum, optionalString, optionalStringList } from './helpers'
+import { checkSendAs } from './sections-personas-send-as'
 import { checkBundles, checkCron } from './sections-bundles-cron'
 
 export function checkPersonas(root: Record<string, unknown>, errors: ValidationError[]): Persona[] {
@@ -462,24 +462,6 @@ function checkCostEstimate(
     }
   }
   return ok ? (out as CostEstimate) : null
-}
-
-function checkSendAs(raw: unknown, path: string, errors: ValidationError[]): PersonaSendAs | null {
-  if (raw === undefined || raw === null) return null
-  if (!isPlainObject(raw)) {
-    errors.push({ code: 'TypeMismatch', path, message: `${path} must be an object` })
-    return null
-  }
-  const id = raw['agentmail_identity']
-  if (typeof id !== 'string' || id.length === 0) {
-    errors.push({
-      code: 'MissingField',
-      path: `${path}.agentmail_identity`,
-      message: 'send_as.agentmail_identity is required when send_as is set',
-    })
-    return null
-  }
-  return { agentmail_identity: id }
 }
 
 export function checkChannelBindings(

--- a/src/lib/operator/customer-yaml/types.ts
+++ b/src/lib/operator/customer-yaml/types.ts
@@ -396,8 +396,46 @@ export interface PersonaSkill {
   scope: string[]
 }
 
+/**
+ * Provider vocabulary for a persona's send-as identity (ADR 0078 §4 / email-
+ * channel-seam spec D5). Closed set, grows by mail adapter. AgentMail is
+ * adapter #1 behind the provider-neutral seam; msgraph is the client-custody
+ * Microsoft 365 adapter.
+ */
+export const ACCEPTED_SEND_PROVIDERS = ['agentmail', 'msgraph'] as const
+export type SendProvider = (typeof ACCEPTED_SEND_PROVIDERS)[number]
+
+/**
+ * Provider-neutral send-as identity. The one shape every downstream reader
+ * consumes — nothing branches on provider except the matching send transport.
+ */
+export interface SendIdentity {
+  provider: SendProvider
+  address: string
+}
+
+/**
+ * Persona send-as identity (ADR 0078 §4). Generalized 2026-07-24 from the
+ * AgentMail-hardcoded `agentmail_identity` string to a provider-neutral
+ * `send_identity`.
+ *
+ * `send_identity` is ALWAYS populated after validation: an authored yaml that
+ * still uses the deprecated `agentmail_identity` field is normalized into
+ * `{ provider: 'agentmail', address: <value> }` at parse time so downstream
+ * readers see exactly one shape. The validated OUTPUT carries only
+ * `send_identity` — the deprecated field is never emitted — so a normalized
+ * value re-validates cleanly (idempotent). Pre-migration projected D1 rows keep
+ * resolving via the read-side `agentmail_identity` fallback in
+ * src/lib/portal/customer-config.ts.
+ */
 export interface PersonaSendAs {
-  agentmail_identity: string
+  send_identity: SendIdentity
+  /**
+   * @deprecated Legacy AgentMail-only field. Accepted as authored INPUT for
+   * back-compat (normalized into `send_identity`), never emitted on output.
+   * Read `send_identity` instead.
+   */
+  agentmail_identity?: string
 }
 
 export interface PersonaChannelBinding {
@@ -498,12 +536,70 @@ export interface User {
   voice_profile_id: string | null
 }
 
+/**
+ * The Email-connector adapter slug that binds Microsoft 365 app-only mail
+ * behind the provider-neutral seam (email-channel-seam spec D5). When
+ * `connectors.Email.adapter === MSGRAPH_ADAPTER`, the `msgraph_auth` block is
+ * required and validated; on any other adapter it must be absent (no dead config).
+ */
+export const MSGRAPH_ADAPTER = 'msgraph'
+
+/**
+ * Microsoft app-registration GUID shape (tenant_id / client_id). Standard
+ * 8-4-4-4-12 hex, case-insensitive.
+ */
+export const MSGRAPH_GUID_PATTERN =
+  /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/
+
+/**
+ * Custody reference shape for the Graph client secret (ADR 0010). Unlike the
+ * `infisical:` token_ref channel, the msgraph secret lives as a per-seat Fly
+ * secret (client-custodied), referenced as `fly-secret:<ENV_NAME>`. The
+ * provisioning script derives the Fly secret name from the suffix, so the name
+ * must be a valid environment-variable identifier.
+ */
+export const MSGRAPH_SECRET_REF_PATTERN = /^fly-secret:[A-Za-z_][A-Za-z0-9_]*$/
+
+/**
+ * Delta-poll cadence default (seconds) for the msgraph inbound poller
+ * (spec D1/D5). Applied by the overlay poller when `poll_seconds` is unauthored.
+ */
+export const DEFAULT_MSGRAPH_POLL_SECONDS = 45
+
+/**
+ * Microsoft Graph app-only mail auth (email-channel-seam spec D5). Parallel in
+ * structure to {@link GoogleAuth}, but per-connector (the Email connector binds
+ * one mailbox) rather than a top-level identity. Custody of the client secret
+ * is a per-seat Fly secret referenced by `secret_ref` (ADR 0010) — never a
+ * literal, never an `infisical:` token_ref.
+ */
+export interface MsgraphAuth {
+  tenant_id: string
+  mailbox: string
+  client_id: string
+  secret_ref: string
+}
+
 export interface Connector {
   adapter: string
   backend: string
   enabled: boolean
   scopes: string[]
   token_ref: string | null
+  /**
+   * Microsoft Graph app-only mail auth (spec D5). Non-null ONLY on the Email
+   * connector when `adapter === MSGRAPH_ADAPTER`; null on every other connector
+   * (a block present on a non-msgraph adapter is a validation error — no dead
+   * config). See {@link MsgraphAuth}.
+   */
+  msgraph_auth: MsgraphAuth | null
+  /**
+   * Delta-poll cadence in seconds for the msgraph inbound poller (spec D5).
+   * Only valid when `adapter === MSGRAPH_ADAPTER`; null on every other connector.
+   * Null under msgraph too ⇒ the overlay poller applies
+   * {@link DEFAULT_MSGRAPH_POLL_SECONDS}.
+   */
+  poll_seconds: number | null
   /**
    * Outbound webhook URL the connector's vendor pushes events to. ADR 0021
    * Stream E wires Filevine/Clio matter-created and document-added webhooks
@@ -1070,4 +1166,5 @@ export interface ValidationError {
 }
 
 export type ValidationResult =
-  { ok: true; value: CustomerYaml } | { ok: false; errors: ValidationError[] }
+  | { ok: true; value: CustomerYaml }
+  | { ok: false; errors: ValidationError[] }

--- a/src/lib/operator/customer-yaml/types.ts
+++ b/src/lib/operator/customer-yaml/types.ts
@@ -1166,5 +1166,4 @@ export interface ValidationError {
 }
 
 export type ValidationResult =
-  | { ok: true; value: CustomerYaml }
-  | { ok: false; errors: ValidationError[] }
+  { ok: true; value: CustomerYaml } | { ok: false; errors: ValidationError[] }

--- a/src/lib/portal/customer-config.ts
+++ b/src/lib/portal/customer-config.ts
@@ -40,7 +40,25 @@ import {
 export type PersonaStatus = 'active' | 'archived'
 
 export interface PersonaSendAs {
-  agentmail_identity: string
+  /**
+   * Provider-neutral send-as identity (ADR 0078 §4). Populated on every row
+   * projected after 2026-07-24; OPTIONAL here because pre-migration projected
+   * rows carry only `agentmail_identity` (the read side casts JSON without
+   * re-validating the sub-shape). Readers fall back to `agentmail_identity`.
+   */
+  send_identity?: { provider: 'agentmail' | 'msgraph'; address: string }
+  /** @deprecated Legacy AgentMail-only field. Read `send_identity`. */
+  agentmail_identity?: string
+}
+
+/**
+ * Resolve a persona's send-as email address from the provider-neutral
+ * `send_identity` (ADR 0078 §4), falling back to the deprecated
+ * `agentmail_identity` so pre-migration projected rows still resolve. The one
+ * place readers should ask "what does this persona send from?".
+ */
+export function personaSendAsAddress(sendAs: PersonaSendAs | null | undefined): string | null {
+  return sendAs?.send_identity?.address ?? sendAs?.agentmail_identity ?? null
 }
 
 export interface PersonaSkill {

--- a/src/lib/portal/operator/customer-yaml-editor.ts
+++ b/src/lib/portal/operator/customer-yaml-editor.ts
@@ -250,7 +250,13 @@ function projectPersona(p: Persona): EditablePersona {
     title: p.title,
     tone: p.tone,
     pronouns: p.pronouns,
-    send_as: p.send_as,
+    // The Advanced editor edits an AgentMail identity string only; read it from
+    // the normalized send_identity. A non-agentmail (msgraph) identity has no
+    // agentmail identity to surface here → null.
+    send_as:
+      p.send_as && p.send_as.send_identity.provider === 'agentmail'
+        ? { agentmail_identity: p.send_as.send_identity.address }
+        : null,
     skills: p.skills.map((s: PersonaSkill) => ({
       name: s.name,
       initiation: s.initiation,
@@ -536,6 +542,11 @@ function mergeConnectors(
       // auth_mode locked — set at provisioning with the OAuth flow itself;
       // the portal only READS it (connection care note).
       auth_mode: existing.auth_mode,
+      // msgraph_auth / poll_seconds locked — Microsoft Graph mail credentials
+      // and poll cadence (ADR 0078 D5) are set at provisioning, never via the
+      // general config editor. Preserved verbatim from the current connector.
+      msgraph_auth: existing.msgraph_auth,
+      poll_seconds: existing.poll_seconds,
     }
   }
   return merged
@@ -557,7 +568,12 @@ function mergePersona(current: Persona, update: EditablePersona): Persona {
     title: update.title,
     tone: update.tone,
     pronouns: update.pronouns,
-    send_as: update.send_as,
+    // Normalize the editor's AgentMail-only field back into the provider-neutral
+    // send_as shape (ADR 0078 §4). Emit only send_identity — the idempotent shape
+    // the validator itself produces, so this merged config re-validates cleanly.
+    send_as: update.send_as
+      ? { send_identity: { provider: 'agentmail', address: update.send_as.agentmail_identity } }
+      : null,
     entitlements: current.entitlements,
     channel_bindings: update.channel_bindings,
     skills: mergedSkills,

--- a/src/lib/portal/operator/facets/identity/hero.ts
+++ b/src/lib/portal/operator/facets/identity/hero.ts
@@ -12,7 +12,7 @@
  * branch, per docs/style/empty-state-pattern.md.
  */
 
-import type { CustomerConfigRow } from '../../../customer-config'
+import { personaSendAsAddress, type CustomerConfigRow } from '../../../customer-config'
 import type { AlivenessSignal } from '../../aliveness'
 
 export interface OperatorHeroModel {
@@ -112,7 +112,7 @@ export function resolveOperatorHero(
     name: persona?.name ?? null,
     title: persona?.title ?? null,
     tone: (persona?.tone ?? []).map(humanizeTone),
-    sendAs: persona?.send_as?.agentmail_identity ?? null,
+    sendAs: personaSendAsAddress(persona?.send_as),
     alsoOperatesAs: others.map((p) => ({ name: p.name, title: p.title })),
     aliveness,
   }

--- a/src/pages/portal/products/operator/[instance]/connections/index.astro
+++ b/src/pages/portal/products/operator/[instance]/connections/index.astro
@@ -3,6 +3,7 @@ import PortalShell from '../../../../../../layouts/PortalShell.astro'
 import { resolveOperatorAccess } from '../../../../../../lib/portal/operator-access'
 import { buildConnectionRows } from '../../../../../../lib/portal/operator/connections'
 import { resolveOperatorScope } from '../../../../../../lib/portal/operator/facets/scope/scope'
+import { personaSendAsAddress } from '../../../../../../lib/portal/customer-config'
 import PortalPageHead from '../../../../../../components/portal/PortalPageHead.astro'
 import DomainSurface from '../../../../../../components/portal/operator/DomainSurface.astro'
 import ConnectionRowCard from '../../../../../../components/portal/operator/ConnectionRowCard.astro'
@@ -62,8 +63,7 @@ const rows = buildConnectionRows(
 // identity it writes from. All authored config; the block renders only when
 // any of it is authored.
 const scopeView = resolveOperatorScope(config).scope
-const sendAs =
-  config?.personas.find((p) => p.status === 'active')?.send_as?.agentmail_identity ?? null
+const sendAs = personaSendAsAddress(config?.personas.find((p) => p.status === 'active')?.send_as)
 const emailAccess =
   scopeView && (scopeView.sees.length > 0 || scopeView.neverSees.length > 0 || sendAs)
     ? { sees: scopeView.sees, neverSees: scopeView.neverSees, sendAs }

--- a/src/pages/portal/products/operator/[instance]/index.astro
+++ b/src/pages/portal/products/operator/[instance]/index.astro
@@ -18,6 +18,7 @@ import {
 import {
   getCustomerConfigBySlug,
   listCustomerConfigsForEntity,
+  personaSendAsAddress,
 } from '../../../../../lib/portal/customer-config'
 import DomainSurface from '../../../../../components/portal/operator/DomainSurface.astro'
 import OperatorAuthorityRows from '../../../../../components/portal/operator/facets/OperatorAuthorityRows.astro'
@@ -163,8 +164,9 @@ const connectionRows = buildConnectionRows(
   customerConfig?.credential_custody_default ?? 'delegated'
 )
 const scopeView = resolveOperatorScope(customerConfig).scope
-const sendAs =
-  customerConfig?.personas.find((p) => p.status === 'active')?.send_as?.agentmail_identity ?? null
+const sendAs = personaSendAsAddress(
+  customerConfig?.personas.find((p) => p.status === 'active')?.send_as
+)
 const emailAccess =
   scopeView && (scopeView.sees.length > 0 || scopeView.neverSees.length > 0 || sendAs)
     ? { sees: scopeView.sees, neverSees: scopeView.neverSees, sendAs }

--- a/tests/customer-yaml-validator.test.ts
+++ b/tests/customer-yaml-validator.test.ts
@@ -3073,3 +3073,225 @@ describe('validate — send exposure classes (ADR 0075)', () => {
     if (!r.ok) expect(codesOf(r.errors)).toContain('InvalidActionCeiling')
   })
 })
+
+// -----------------------------------------------------------------------------
+// Email connector: msgraph_auth + poll_seconds (ADR 0078 / email-channel-seam D5)
+// -----------------------------------------------------------------------------
+
+describe('validate — connectors.Email msgraph_auth (ADR 0078 D5)', () => {
+  const TENANT = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'
+  const CLIENT = '11111111-2222-3333-4444-555555555555'
+
+  function validMsgraphAuth(): Record<string, unknown> {
+    return {
+      tenant_id: TENANT,
+      client_id: CLIENT,
+      mailbox: 'operator@clientdomain.com',
+      secret_ref: 'fly-secret:MSGRAPH_CLIENT_SECRET',
+    }
+  }
+
+  /** Replace the fixture Email connector with an msgraph-bound one. */
+  function withMsgraphEmail(
+    mutate?: (auth: Record<string, unknown>, conn: Record<string, unknown>) => void
+  ): Record<string, unknown> {
+    const f = validFixture()
+    const auth = validMsgraphAuth()
+    const conn: Record<string, unknown> = {
+      adapter: 'msgraph',
+      backend: 'mcp:msgraph-mail',
+      enabled: true,
+      msgraph_auth: auth,
+    }
+    mutate?.(auth, conn)
+    ;(f['connectors'] as Record<string, unknown>)['Email'] = conn
+    return f
+  }
+
+  it('accepts a valid msgraph Email connector and carries the block through', () => {
+    const r = validate(withMsgraphEmail())
+    expect(r.ok).toBe(true)
+    if (!r.ok) return
+    expect(r.value.connectors.Email?.msgraph_auth).toEqual(validMsgraphAuth())
+    // poll_seconds unauthored ⇒ null (overlay applies the 45s default)
+    expect(r.value.connectors.Email?.poll_seconds).toBeNull()
+  })
+
+  it('accepts an authored poll_seconds and carries it through', () => {
+    const r = validate(withMsgraphEmail((_a, c) => (c['poll_seconds'] = 30)))
+    expect(r.ok).toBe(true)
+    if (r.ok) expect(r.value.connectors.Email?.poll_seconds).toBe(30)
+  })
+
+  it('requires msgraph_auth when the adapter is msgraph', () => {
+    const r = validate(withMsgraphEmail((_a, c) => delete c['msgraph_auth']))
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(codesOf(r.errors)).toContain('MissingField')
+    expect(r.errors.some((e) => e.path === 'connectors.Email.msgraph_auth')).toBe(true)
+  })
+
+  it('rejects an msgraph_auth block on a non-msgraph adapter (no dead config)', () => {
+    const f = validFixture()
+    // fixture Email adapter is "microsoft-graph", not "msgraph"
+    ;(f['connectors'] as Record<string, Record<string, unknown>>)['Email']['msgraph_auth'] =
+      validMsgraphAuth()
+    const r = validate(f)
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(codesOf(r.errors)).toContain('InvalidFormat')
+    expect(r.errors.some((e) => e.path === 'connectors.Email.msgraph_auth')).toBe(true)
+  })
+
+  it('rejects poll_seconds on a non-msgraph adapter (no dead config)', () => {
+    const f = validFixture()
+    ;(f['connectors'] as Record<string, Record<string, unknown>>)['Email']['poll_seconds'] = 45
+    const r = validate(f)
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(r.errors.some((e) => e.path === 'connectors.Email.poll_seconds')).toBe(true)
+  })
+
+  it('rejects a non-integer / non-positive poll_seconds under msgraph', () => {
+    for (const bad of [0, -1, 2.5, '30']) {
+      const r = validate(withMsgraphEmail((_a, c) => (c['poll_seconds'] = bad)))
+      expect(r.ok).toBe(false)
+    }
+  })
+
+  it('rejects a malformed tenant_id / client_id (must be a GUID)', () => {
+    for (const key of ['tenant_id', 'client_id']) {
+      const r = validate(withMsgraphEmail((a) => (a[key] = 'not-a-guid')))
+      expect(r.ok).toBe(false)
+      if (r.ok) continue
+      expect(codesOf(r.errors)).toContain('InvalidFormat')
+      expect(r.errors.some((e) => e.path === `connectors.Email.msgraph_auth.${key}`)).toBe(true)
+    }
+  })
+
+  it('rejects a mailbox that is not an email address', () => {
+    const r = validate(withMsgraphEmail((a) => (a['mailbox'] = 'operator-no-domain')))
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(r.errors.some((e) => e.path === 'connectors.Email.msgraph_auth.mailbox')).toBe(true)
+  })
+
+  it('rejects a secret_ref that is not a fly-secret reference', () => {
+    // infisical: is the token_ref channel; msgraph custody is a per-seat Fly secret
+    for (const bad of ['infisical:/operator/x/y', 'MSGRAPH_CLIENT_SECRET', 'fly-secret:']) {
+      const r = validate(withMsgraphEmail((a) => (a['secret_ref'] = bad)))
+      expect(r.ok).toBe(false)
+      if (r.ok) continue
+      expect(r.errors.some((e) => e.path === 'connectors.Email.msgraph_auth.secret_ref')).toBe(true)
+    }
+  })
+
+  it('rejects a partial msgraph_auth block (fail-closed, never a silent default)', () => {
+    const r = validate(withMsgraphEmail((a) => delete a['secret_ref']))
+    expect(r.ok).toBe(false)
+  })
+})
+
+// -----------------------------------------------------------------------------
+// Persona send_as: provider-neutral send_identity + agentmail_identity back-compat
+// (ADR 0078 §4 / email-channel-seam D5)
+// -----------------------------------------------------------------------------
+
+describe('validate — persona send_as normalization (ADR 0078 §4)', () => {
+  function withSendAs(sendAs: unknown): Record<string, unknown> {
+    const f = validFixture()
+    ;(f['personas'] as Record<string, unknown>[])[0]['send_as'] = sendAs
+    return f
+  }
+
+  it('accepts a provider-neutral send_identity (msgraph) and carries it verbatim', () => {
+    const r = validate(
+      withSendAs({ send_identity: { provider: 'msgraph', address: 'operator@clientdomain.com' } })
+    )
+    expect(r.ok).toBe(true)
+    if (!r.ok) return
+    expect(r.value.personas[0].send_as?.send_identity).toEqual({
+      provider: 'msgraph',
+      address: 'operator@clientdomain.com',
+    })
+    // no agentmail mirror for a non-agentmail provider
+    expect(r.value.personas[0].send_as?.agentmail_identity).toBeUndefined()
+  })
+
+  it('emits an idempotent send_identity-only shape for an agentmail identity', () => {
+    const r = validate(
+      withSendAs({
+        send_identity: { provider: 'agentmail', address: 'ops@firm.agents.smd.services' },
+      })
+    )
+    expect(r.ok).toBe(true)
+    if (!r.ok) return
+    // output carries ONLY send_identity — the deprecated field is never emitted
+    // (the toEqual asserts the exact shape), so re-validating never trips the
+    // both-set guard.
+    expect(r.value.personas[0].send_as).toEqual({
+      send_identity: { provider: 'agentmail', address: 'ops@firm.agents.smd.services' },
+    })
+  })
+
+  it('normalizes a legacy agentmail_identity into send_identity (back-compat)', () => {
+    const r = validate(
+      withSendAs({ agentmail_identity: 'marcus@smith-pi-firm.agents.smd.services' })
+    )
+    expect(r.ok).toBe(true)
+    if (!r.ok) return
+    expect(r.value.personas[0].send_as).toEqual({
+      send_identity: { provider: 'agentmail', address: 'marcus@smith-pi-firm.agents.smd.services' },
+    })
+  })
+
+  it('re-validating a normalized value is idempotent (no both-set error)', () => {
+    const first = validate(
+      withSendAs({ agentmail_identity: 'marcus@smith-pi-firm.agents.smd.services' })
+    )
+    expect(first.ok).toBe(true)
+    if (!first.ok) return
+    const roundTrip = withSendAs(first.value.personas[0].send_as)
+    expect(validate(roundTrip).ok).toBe(true)
+  })
+
+  it('rejects authoring both send_identity and the legacy field (ambiguous)', () => {
+    const r = validate(
+      withSendAs({
+        send_identity: { provider: 'agentmail', address: 'a@b.c' },
+        agentmail_identity: 'a@b.c',
+      })
+    )
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(codesOf(r.errors)).toContain('InvalidFormat')
+    expect(r.errors.some((e) => e.path === 'personas[0].send_as')).toBe(true)
+  })
+
+  it('rejects an unknown send_identity.provider', () => {
+    const r = validate(withSendAs({ send_identity: { provider: 'gmail', address: 'a@b.c' } }))
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(codesOf(r.errors)).toContain('EnumViolation')
+    expect(r.errors.some((e) => e.path === 'personas[0].send_as.send_identity.provider')).toBe(true)
+  })
+
+  it('rejects a send_identity missing its address', () => {
+    const r = validate(withSendAs({ send_identity: { provider: 'msgraph' } }))
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(r.errors.some((e) => e.path === 'personas[0].send_as.send_identity.address')).toBe(true)
+  })
+
+  it('rejects a send_as with neither send_identity nor agentmail_identity', () => {
+    const r = validate(withSendAs({}))
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(codesOf(r.errors)).toContain('MissingField')
+  })
+
+  it('rejects an empty agentmail_identity string', () => {
+    const r = validate(withSendAs({ agentmail_identity: '' }))
+    expect(r.ok).toBe(false)
+  })
+})


### PR DESCRIPTION
## What

Slice 2 of the ADR 0078 / email-channel-seam build (#1978) — spec **D5**, config layer only:

- **`msgraph_auth` block** on the Email connector: `tenant_id`/`client_id` (GUID-validated), `mailbox`, `secret_ref` anchored to `fly-secret:<NAME>` (ADR 0010 custody). Required when `adapter: msgraph`; present on any other adapter = validation error (no dead config). `poll_seconds` sibling key gated the same way (absent → overlay default 45s).
- **Provider-neutral send identity**: `PersonaSendAs` gains `send_identity { provider, address }`; deprecated `agentmail_identity` is accepted input-only and normalized (both-set = hard error; validator output idempotent — never re-emits the legacy field). All shape readers routed via `personaSendAsAddress()`; pre-migration D1 rows resolve via read-side fallback. `send_as` validation extracted to `sections-personas-send-as.ts` (500-line ceiling).
- **secret-detector**: `secret_ref` joins `token_ref` as a permitted secret-*reference* field (name-ban skip only — a literal value can never validate past the `fly-secret:` anchor); `msgraph_auth` path shape-allowlisted (GUIDs brush the entropy heuristic).
- **provision-customer.sh**: msgraph branch staging `MSGRAPH_TENANT_ID/CLIENT_ID/CLIENT_SECRET/MAILBOX` per-seat — names match what the slice-1 connector reads.

## Verification

- 19 new validator tests; validator + parity-contract + forbidden-strings suites re-run independently: **554 passed**
- `npm run typecheck`: 0 errors (830 files)
- Projection confirmed verbatim pass-through (no changes needed)

## Known follow-ons (overlay side, slices 3–4)

- Overlay `bootstrap/validate.py` must gain the same `send_identity` + `msgraph_auth` acceptance before any seat authors them (cross-repo parity).
- `sections-custody-guard.ts` maps any `send_as` to the 'agentmail' custody surface — needs provider-awareness when the first msgraph send identity is authored (noted, deliberately not widened here).

Refs #1978 · ADR 0078 · spec `docs/specs/operator/email-channel-seam.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)