### PR TITLE
fix(provision): stage msgraph poller loopback signing secrets (ss#1978)

### DIFF
--- a/operator/bin/lib/secret_custody.py
+++ b/operator/bin/lib/secret_custody.py
@@ -67,6 +67,11 @@ _CUSTOMER_EXACT: frozenset[str] = frozenset(
         # secret + the router forward-verify secret are per-customer.
         "WEBHOOK_SECRET_AGENTMAIL",
         "SMD_WEBHOOK_SIGNING_SECRET",
+        # Microsoft Graph delta-poller loopback signing secret (ADR 0078;
+        # provision-customer.sh msgraph branch). Per-seat, generated when no
+        # override is supplied — the poller signs its loopback with it and the
+        # in-Machine Hermes adapter re-verifies. Customer custody (per-seat).
+        "WEBHOOK_SECRET_MSGRAPH",
         # Smokeball connector (provision-customer.sh:560-575). Both the
         # environment-specific SOURCE names in /ss and the env-agnostic runtime
         # names the connector reads.
@@ -111,6 +116,8 @@ _CUSTOMER_PREFIX: tuple[str, ...] = (
     # Per-seat override form MSGRAPH_CLIENT_SECRET__<CID> (provision-customer.sh
     # msgraph branch) + any future family member.
     "MSGRAPH_",
+    # Per-seat override form WEBHOOK_SECRET_MSGRAPH__<CID>.
+    "WEBHOOK_SECRET_MSGRAPH__",
 )
 
 # Infra-owned staged/derived names NOT in env-consumption. These are SMD-owned

--- a/operator/bin/provision-customer.sh
+++ b/operator/bin/provision-customer.sh
@@ -555,8 +555,24 @@ print(str(auth.get('secret_ref') or '').strip())
   stage_secret_from_env MSGRAPH_CLIENT_ID     "${_MSG_CLIENT}"        "Microsoft Graph app client id (from msgraph_auth.client_id)"
   stage_secret_from_env MSGRAPH_MAILBOX       "${_MSG_MAILBOX}"       "Microsoft Graph pinned operator mailbox (from msgraph_auth.mailbox)"
   stage_secret_from_env MSGRAPH_CLIENT_SECRET "${_MSG_SECRET_VALUE}"  "Microsoft Graph app client secret (per-customer ${_MSG_SECRET_CID_KEY}, else ${_MSG_SECRET_NAME})"
+  # Loopback signing secrets for the delta poller (ADR 0078 / email-channel-seam
+  # D1). Unlike AgentMail's Svix secret these are NOT vendor-issued — the poller
+  # signs its own loopback POST with WEBHOOK_SECRET_MSGRAPH and the Hermes webhook
+  # adapter re-verifies it, all inside this one Machine. SMD_WEBHOOK_SIGNING_SECRET
+  # is what the overlay router verifies the gate's forwarded signature with, and
+  # the gate re-signs its forward hop with the ROUTE secret (same rule the
+  # AgentMail branch above relies on), so on an msgraph seat it MUST equal the
+  # msgraph route secret or polled mail never routes to a skill. Prefer a
+  # per-customer override so a reprovision is reproducible; otherwise generate a
+  # fresh per-seat value (safe — both ends read it from the same freshly-deployed
+  # env, so a rotation is atomic and touches no external party).
+  _MSG_WH_KEY="WEBHOOK_SECRET_MSGRAPH__$(printf '%s' "${CUSTOMER_ID}" | tr '[:lower:]-' '[:upper:]_' | tr -cd 'A-Z0-9_')"
+  _MSG_WH_SECRET="${!_MSG_WH_KEY:-${WEBHOOK_SECRET_MSGRAPH:-}}"
+  [ -n "${_MSG_WH_SECRET}" ] || _MSG_WH_SECRET="$(openssl rand -hex 32)"
+  stage_secret_from_env WEBHOOK_SECRET_MSGRAPH "${_MSG_WH_SECRET}" "msgraph delta-poller loopback signing secret (per-customer ${_MSG_WH_KEY}, else generated)"
+  stage_secret_from_env SMD_WEBHOOK_SIGNING_SECRET "${_MSG_WH_SECRET}" "router forward-verify secret (== msgraph route secret on an msgraph seat)"
   unset MSG_PARSE_PY MSG_FIELDS _MSG_TENANT _MSG_CLIENT _MSG_MAILBOX _MSG_SECRET_REF \
-    _MSG_SECRET_NAME _MSG_SECRET_CID_KEY _MSG_SECRET_VALUE
+    _MSG_SECRET_NAME _MSG_SECRET_CID_KEY _MSG_SECRET_VALUE _MSG_WH_KEY _MSG_WH_SECRET
 fi
 
 # Brave Search (native:brave-free, ADR 0070). BRAVE_SEARCH_API_KEY is the env var


### PR DESCRIPTION
## The gap

Tracing the `smd-staging` live-fire, I found the msgraph branch of `provision-customer.sh` (slice 2) staged the four `MSGRAPH_*` connector values but **not** the two signing secrets the slice-4 delta poller requires:

- `WEBHOOK_SECRET_MSGRAPH` — the poller signs its loopback POST with it; the in-Machine Hermes webhook adapter re-verifies.
- `SMD_WEBHOOK_SIGNING_SECRET` — the overlay router's forward-verify secret; the gate re-signs its forward hop with the route secret, so on an msgraph seat it must equal the msgraph route secret or polled mail never routes to a skill.

Result: an msgraph seat booted with a poller that couldn't sign its own loopback. Unit tests missed it because the requirement crystallized in slice 4. This is exactly the wiring gap the sandbox live-fire exists to catch — before A&P.

## Fix

Mirror the AgentMail branch: stage `WEBHOOK_SECRET_MSGRAPH` (prefer per-customer override `WEBHOOK_SECRET_MSGRAPH__<CID>`, else generate a fresh per-seat value — internal, not vendor-issued) and set `SMD_WEBHOOK_SIGNING_SECRET` equal to it. Classified the new name (+ override form) as customer custody. 11/11 custody tests green; `bash -n` clean.

Refs #1978 · ADR 0078

🤖 Generated with [Claude Code](https://claude.com/claude-code)