### PR TITLE
fix(validate): accept poll-driven msgraph as a webhook_triggers source (ss#1978)

### DIFF
--- a/src/lib/operator/customer-yaml/sections-webhook-triggers.ts
+++ b/src/lib/operator/customer-yaml/sections-webhook-triggers.ts
@@ -62,10 +62,20 @@ export function checkWebhookTriggers(
   return out
 }
 
+// Adapters whose inbound is driven by a POLLER, not a registered webhook_url.
+// They legitimately carry no webhook_url but are still valid webhook_triggers
+// sources: the delta poller injects each new message through the same
+// gate→router loopback that a push webhook uses, so fence/taint/roster apply
+// identically (ADR 0078 / email-channel-seam D1 — msgraph).
+const POLL_DRIVEN_INBOUND_ADAPTERS: ReadonlySet<string> = new Set(['msgraph'])
+
 function collectAdapterSlugs(connectors: Partial<Record<CapabilityName, Connector>>): Set<string> {
   const out = new Set<string>()
   for (const c of Object.values(connectors)) {
-    if (c && c.webhook_url !== null) {
+    if (!c) continue
+    // A connector is a valid inbound source either via a registered webhook_url
+    // (push) or as a poll-driven adapter (the poller is its inbound driver).
+    if (c.webhook_url !== null || POLL_DRIVEN_INBOUND_ADAPTERS.has(c.adapter)) {
       out.add(c.adapter)
     }
   }

--- a/tests/customer-yaml-validator.test.ts
+++ b/tests/customer-yaml-validator.test.ts
@@ -2145,6 +2145,50 @@ function withWebhooks(): Record<string, unknown> {
   return f
 }
 
+describe('webhook_triggers source — poll-driven adapters (ADR 0078 msgraph)', () => {
+  // A msgraph Email connector is inbound via the delta POLLER, so it carries no
+  // webhook_url yet is a valid trigger source. Regression for the smd-staging
+  // live-fire find (2026-07-25): collectAdapterSlugs required webhook_url and
+  // rejected the poll-driven source.
+  function withMsgraphPoll(): Record<string, unknown> {
+    const f = withBundlesAndCron()
+    const persona = (f['personas'] as unknown[])[0] as Record<string, unknown>
+    ;(persona['skills'] as Array<{ initiation: { webhook: boolean } }>)[0].initiation.webhook = true
+    const skillName = (persona['skills'] as Array<{ name: string }>)[0].name
+    const personaSlug = persona['slug'] as string
+    const connectors = f['connectors'] as Record<string, Record<string, unknown>>
+    connectors['Email'] = {
+      adapter: 'msgraph',
+      backend: 'mcp:msgraph-mail',
+      enabled: true,
+      msgraph_auth: {
+        tenant_id: 'f11d2887-b7f2-4464-a9c6-d4db2166b43c',
+        client_id: '83a044a4-0b43-4cb4-b989-370aa711af20',
+        mailbox: 'operator@smdopslab.onmicrosoft.com',
+        secret_ref: 'fly-secret:MSGRAPH_CLIENT_SECRET',
+      },
+    }
+    f['webhook_triggers'] = [
+      { source: 'msgraph', event_type: 'message.received', skill: skillName, persona: personaSlug },
+    ]
+    return f
+  }
+
+  it('accepts a trigger whose source is a poll-driven msgraph connector (no webhook_url)', () => {
+    const r = validate(withMsgraphPoll())
+    if (!r.ok) throw new Error(`expected ok; got: ${JSON.stringify(r.errors)}`)
+    expect(r.value.webhook_triggers[0].source).toBe('msgraph')
+  })
+
+  it('still rejects a trigger source matching no bound connector', () => {
+    const f = withMsgraphPoll()
+    ;(f['webhook_triggers'] as Record<string, unknown>[])[0]['source'] = 'nonexistent'
+    const r = validate(f)
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(codesOf(r.errors)).toContain('UnknownWebhookSource')
+  })
+})
+
 describe('validate — ADR 0021 webhook_url', () => {
   it('accepts a valid connector webhook_url', () => {
     const r = validate(withWebhooks())


### PR DESCRIPTION
## The gap (smd-staging live-fire find)

The provisioner's TS validator rejected the smd-staging msgraph config with `UnknownWebhookSource`: `collectAdapterSlugs` only accepted connectors that have a `webhook_url` (the push model). The **msgraph Email adapter is inbound via the delta poller** (ADR 0078 D1) — it deliberately has no `webhook_url` — so its valid `message.received` trigger was flagged. Fail-closed *before* deploy, exactly as the live-fire is meant to surface.

## Fix

A connector is a valid inbound source via a registered `webhook_url` (push) **or** as a poll-driven adapter (`POLL_DRIVEN_INBOUND_ADAPTERS = {msgraph}`) — the poller injects through the same gate→router loopback, so fence/taint/roster apply identically. Also improves cross-validator parity (the overlay `bootstrap/validate.py` already accepts this file). +2 regression tests; validator suite 275 green; the provisioner's exact validator now passes on the staging yaml.

Refs #1978 · ADR 0078

🤖 Generated with [Claude Code](https://claude.com/claude-code)