### PR TITLE
fix(operator): provision step 6c KeyError SLUG — first run with HEALTHCHECKS_API_KEY armed

### DIFF
--- a/operator/bin/provision-customer.sh
+++ b/operator/bin/provision-customer.sh
@@ -775,7 +775,11 @@ HC_CHECK_NAME="hermes-${SLUG}"
 HC_PING_URL=""
 if [ -n "${HEALTHCHECKS_API_KEY:-}" ]; then
   log "Creating/finding healthchecks.io check '${HC_CHECK_NAME}'..."
-  HC_PAYLOAD=$(python3 -c "
+  # SLUG is a script-local shell variable — it must be passed into the python
+  # subprocess env explicitly. (Latent since Wave 1: this branch only runs
+  # when HEALTHCHECKS_API_KEY exists, which first happened 2026-07-25; the
+  # unexported read KeyError'd and killed the whole provision.)
+  HC_PAYLOAD=$(SLUG="${SLUG}" python3 -c "
 import json, os
 slug = os.environ['SLUG']
 admin = os.environ.get('ADMIN_BASE_URL', 'https://admin.smd.services')


### PR DESCRIPTION
## Summary
- Step 6c's inline python reads `os.environ['SLUG']` but `SLUG` is a script-local (unexported) shell variable — the branch only executes when `HEALTHCHECKS_API_KEY` is present, which first happened tonight (key vaulted 2026-07-25), so the latent bug killed the smd-staging reprovision mid-flight at step 6c. One-line fix: pass `SLUG` into the subprocess env explicitly.

## Test plan
- [x] `bash -n` + payload subprocess reproduced and verified with the fix shape
- [ ] smd-staging reprovision re-run completes through step 6c (immediately follows merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)