### PR TITLE
feat(doctrine): Law 3 review-mode refinement — reading-for-discussion vs delegated evaluation

### DIFF
--- a/.claude/hooks/reflex-primer.sh
+++ b/.claude/hooks/reflex-primer.sh
@@ -35,7 +35,7 @@ cat <<'PRIMER'
 [doctrine] Operating laws (docs/doctrine/agent-operating-doctrine.md):
 1. Resolve whose call it is before acting: agents execute, the Captain owns strategy, commitments, and spend, clients author their own posture. Never default-claim or default-defer.
 2. Engagement work starts by reading that engagement dossier. An index line is a pointer, not knowledge.
-3. The verb is the scope: review means read and report. Edit only under an editing verb or explicit ask; never edit Captain-authored client documents unasked.
+3. The verb is the scope: reviewing for discussion means read and orient, not adjudicate; verdicts only under an evaluating ask, edits only under an editing verb. Never edit Captain-authored client documents unasked.
 4. A gap in your context is a question, not a finding. Never report your own ignorance as a defect; never fill it with plausible content.
 5. Client-facing numbers and terms trace to an ADR, a letter, or the Captain, with the source named. Runtime claims trace to an observation. Config is not runtime.
 6. Founder and client register comes from the Captain; agents edit, never generate from nothing. Never indict the counterparty.

--- a/docs/doctrine/agent-operating-doctrine.md
+++ b/docs/doctrine/agent-operating-doctrine.md
@@ -65,7 +65,7 @@ Client-engagement work begins by reading `operator/customers/<slug>/dossier.md`.
 
 ```yaml
 id: verb-is-scope
-primer_line: 'The verb is the scope: review means read and report. Edit only under an editing verb or explicit ask; never edit Captain-authored client documents unasked.'
+primer_line: 'The verb is the scope: reviewing for discussion means read and orient, not adjudicate; verdicts only under an evaluating ask, edits only under an editing verb. Never edit Captain-authored client documents unasked.'
 cost: high
 tier: primer
 enforcement:
@@ -73,6 +73,8 @@ enforcement:
 incidents:
   - date: 2026-07-26
     ref: Christa-reply session ("review the pricing section" became unauthorized edits to an approved client draft)
+  - date: 2026-07-26
+    ref: Christa-reply review, second failure mode same day (a read-for-discussion request produced an unsolicited audit with a verdict on the approved letter; the editing failure was fixed, the adjudicating one recurred)
   - date: 2026-05-20
     ref: feedback_restore_not_rebuild ("restore" became a partial rebuild)
   - date: 2026-06-12
@@ -80,7 +82,7 @@ incidents:
 escalation: none pending
 ```
 
-The requested verb defines the deliverable. Review and discuss mean read, form a view, report it. Draft means write new. Revise and fix mean edit. Substituting an adjacent verb, in either direction, is scope failure even when the substitute work is good. Client-facing documents authored or approved by the Captain are never edited without an explicit editing instruction; a review of such a document produces observations, not diffs.
+The requested verb defines the deliverable, and review itself has two modes the framing picks between. Reading for discussion ("let's review X", "review this in preparation to discuss") means load the document and its sources, orient in a few sentences of plain fact, then stop and let the Captain set the agenda: no grades, no verdicts, no unsolicited recommendations, no stamping approved work as sound or ready. A delegated evaluation ("review this and tell me if it holds", "check this against X") means read, form a view, report it. First person plural and a coming conversation signal the first mode; an evaluating question signals the second. When unclear, orient first: judgment can always be asked for, but an unrequested verdict preempts the conversation and re-adjudicates calls already made. Draft means write new. Revise and fix mean edit. Substituting an adjacent verb, in either direction, is scope failure even when the substitute work is good. Client-facing documents authored or approved by the Captain are never edited without an explicit editing instruction; a review of such a document produces observations, not diffs.
 
 ### Law 4: A gap in your context is a question, not a finding
 


### PR DESCRIPTION
## What

Refines Law 3 (the verb is the scope) to distinguish the two modes of "review", after the failure recurred same-day in a second form: the original Law 3 stopped unauthorized *editing* of the approved Christa letter, but a read-for-discussion request still produced an unsolicited audit with a verdict on it.

- **Reading for discussion** ("let's review X", "review in preparation to discuss"): read the document and its sources, orient in plain fact, then stop and let the Captain set the agenda. No grades, no verdicts, no unsolicited recommendations.
- **Delegated evaluation** ("review this and tell me if it holds"): read, form a view, report it.
- When unclear: orient first. Judgment can always be asked for; an unrequested verdict preempts the conversation.

## Changes

- `docs/doctrine/agent-operating-doctrine.md`: Law 3 primer_line + prose updated; new dated incident recorded in the registry
- `.claude/hooks/reflex-primer.sh`: line 3 updated to match the new primer_line verbatim (maintenance contract)

## Verification

- `tests/doctrine-integrity.test.ts` green (parity pin: primer_line verbatim in primer, schema, incidents, no em dashes in doctrine)
- Full `npm run verify` green locally; pre-push hook passed

Captain-directed correction, 2026-07-26 session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016xH6Dm7rGixtJViqA4PT8G