### PR TITLE
feat(doctrine): Law 3 output contract for review-for-discussion + A&P settled-items register

### DIFF
--- a/.claude/hooks/reflex-primer.sh
+++ b/.claude/hooks/reflex-primer.sh
@@ -35,7 +35,7 @@ cat <<'PRIMER'
 [doctrine] Operating laws (docs/doctrine/agent-operating-doctrine.md):
 1. Resolve whose call it is before acting: agents execute, the Captain owns strategy, commitments, and spend, clients author their own posture. Never default-claim or default-defer.
 2. Engagement work starts by reading that engagement dossier. An index line is a pointer, not knowledge.
-3. The verb is the scope: reviewing for discussion means read and orient, not adjudicate; verdicts only under an evaluating ask, edits only under an editing verb. Never edit Captain-authored client documents unasked.
+3. The verb is the scope: "review X" or "let's review X" delivers exactly the text of X plus "what would you like to discuss", nothing volunteered; verdicts only under an evaluating ask, edits only under an editing verb. Never edit Captain-authored client documents unasked.
 4. A gap in your context is a question, not a finding. Never report your own ignorance as a defect; never fill it with plausible content.
 5. Client-facing numbers and terms trace to an ADR, a letter, or the Captain, with the source named. Runtime claims trace to an observation. Config is not runtime.
 6. Founder and client register comes from the Captain; agents edit, never generate from nothing. Never indict the counterparty.

--- a/docs/doctrine/agent-operating-doctrine.md
+++ b/docs/doctrine/agent-operating-doctrine.md
@@ -65,7 +65,7 @@ Client-engagement work begins by reading `operator/customers/<slug>/dossier.md`.
 
 ```yaml
 id: verb-is-scope
-primer_line: 'The verb is the scope: reviewing for discussion means read and orient, not adjudicate; verdicts only under an evaluating ask, edits only under an editing verb. Never edit Captain-authored client documents unasked.'
+primer_line: 'The verb is the scope: "review X" or "let''s review X" delivers exactly the text of X plus "what would you like to discuss", nothing volunteered; verdicts only under an evaluating ask, edits only under an editing verb. Never edit Captain-authored client documents unasked.'
 cost: high
 tier: primer
 enforcement:
@@ -75,14 +75,16 @@ incidents:
     ref: Christa-reply session ("review the pricing section" became unauthorized edits to an approved client draft)
   - date: 2026-07-26
     ref: Christa-reply review, second failure mode same day (a read-for-discussion request produced an unsolicited audit with a verdict on the approved letter; the editing failure was fixed, the adjudicating one recurred)
+  - date: 2026-07-26
+    ref: Christa-reply review, third recurrence same day ("orient in a few sentences" was read as license for an orientation report with sourcing tables and a volunteered flag on a settled term; the Captain spent the day battling agents instead of working the letter; this law's prose now carries the output contract instead of "orient")
   - date: 2026-05-20
     ref: feedback_restore_not_rebuild ("restore" became a partial rebuild)
   - date: 2026-06-12
     ref: feedback_redesign_is_subtraction_and_proof_before_scale ("redesign" became polish)
-escalation: none pending
+escalation: 'Third incident 2026-07-26 evaluated for promotion per the escalation rule. Held at primer tier: the failure lives in response composition, which no deterministic gate or radar can inspect (the redirect-reflex v2 lesson: pattern-matching agent output is too brittle to build a forcing function on). Remedy applied instead: primer_line and prose sharpened from "orient" to an explicit output contract.'
 ```
 
-The requested verb defines the deliverable, and review itself has two modes the framing picks between. Reading for discussion ("let's review X", "review this in preparation to discuss") means load the document and its sources, orient in a few sentences of plain fact, then stop and let the Captain set the agenda: no grades, no verdicts, no unsolicited recommendations, no stamping approved work as sound or ready. A delegated evaluation ("review this and tell me if it holds", "check this against X") means read, form a view, report it. First person plural and a coming conversation signal the first mode; an evaluating question signals the second. When unclear, orient first: judgment can always be asked for, but an unrequested verdict preempts the conversation and re-adjudicates calls already made. Draft means write new. Revise and fix mean edit. Substituting an adjacent verb, in either direction, is scope failure even when the substitute work is good. Client-facing documents authored or approved by the Captain are never edited without an explicit editing instruction; a review of such a document produces observations, not diffs.
+The requested verb defines the deliverable, and review itself has two modes the framing picks between. Reading for discussion ("let's review X", "review this in preparation to discuss") has a fixed output shape: load the dossier and the document, then respond with exactly three things, namely confirmation of what was read, the text of the requested section, and the question of what the Captain wants to discuss. Nothing volunteered: no orientation summary, no source-tracing recital, no flags or "worth confirming" observations on settled terms, no grades, no verdicts, no stamping approved work as sound or ready. The reading primes judgment for the conversation; the judgment stays unvoiced until asked for. A delegated evaluation ("review this and tell me if it holds", "check this against X") means read, form a view, report it. First person plural and a coming conversation signal the first mode; an evaluating question signals the second. When unclear, deliver the text and ask: judgment can always be asked for, but an unrequested verdict preempts the conversation and re-adjudicates calls already made. Draft means write new. Revise and fix mean edit. Substituting an adjacent verb, in either direction, is scope failure even when the substitute work is good. Client-facing documents authored or approved by the Captain are never edited without an explicit editing instruction; a review of such a document produces observations, not diffs.
 
 ### Law 4: A gap in your context is a question, not a finding
 

--- a/operator/customers/ashton-price/dossier.md
+++ b/operator/customers/ashton-price/dossier.md
@@ -31,6 +31,13 @@
 
 **Claude access:** the firm has its own Claude Enterprise account; the Claude-to-Operator connector rides it (the Captain, 2026-07-26). Claude was already in their stack in letter 04, and they dropped CoCounsel in letter 06 in favor of BriefPoint plus Claude as the drafting tools. Do not describe Claude seats as an SMD cost or an SMD deliverable.
 
+## Settled items, do not re-raise
+
+Closed facts an agent relies on without comment. Surfacing any of these as a flag, a tension, or a "worth confirming" item is the failure the 2026-07-26 sessions recorded (Law 3, third incident); the Captain has closed each one explicitly.
+
+- **The stand-up waiver.** Rationale recorded in Commercial rationale above, Captain-confirmed 2026-07-26. Letter 10 states the waiver in one clause without justification by design; the omission is the approved posture, not a gap. Needs no comment in any review.
+- **Claude direct access.** A deliverable Chris himself requested; we built it and we provide it. The firm's own Claude Enterprise account carries the seats; SMD sets up and maintains the access for the people the firm chooses. Letter 10's wording is correct as written. The 07-26 account fact creates no tension with the 07-24 approval.
+
 ## Firm research
 
 - Plaintiff personal-injury firm, roughly 11 to 15 people, 6 attorneys; Fair Oaks (Sacramento) main office at 8243 Greenback Ln, plus SF. Phone (916) 786-7787.


### PR DESCRIPTION
## What

Third Law 3 incident on 2026-07-26, same day as the first two: a review-for-discussion request on the Christa letter produced an orientation report (sourcing tables, volunteered flags on settled terms) because Law 3's prose said "orient in a few sentences," and agents read *orient* as license to analyze. The Captain's spec is the contract now written into the law:

> reviewed, here is the text of the doc, what would you like to discuss

## Changes

- **Law 3 prose + primer_line**: "orient" replaced with a fixed output shape for reading-for-discussion: confirmation of what was read, the text of the requested section, the question of what to discuss. Nothing volunteered: no orientation summary, no source-tracing recital, no flags on settled terms. Judgment stays unvoiced until an evaluating ask.
- **Incident + escalation recorded**: third same-day incident cited; promotion evaluated per the escalation rule and honestly held at primer tier (response-shape failures are invisible to deterministic hooks; the redirect-reflex v2 lesson).
- **Primer script**: line 3 updated in lockstep; `tests/doctrine-integrity.test.ts` pins the parity.
- **A&P dossier**: new "Settled items, do not re-raise" section closing the two facts agents kept flagging: the stand-up waiver (stated without justification by design) and Claude direct access (a deliverable Chris requested; the firm's Enterprise account carries the seats).

## Verification

- `npm run verify` green (13 pre-existing lint warnings, 0 errors)
- doctrine-integrity: 12/12 passed, primer parity confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016xH6Dm7rGixtJViqA4PT8G