### PR TITLE
feat(operator): promote operator_pause to enforced + tenant ground truth in the routing rule (#2003 #2004)

### DIFF
--- a/operator/contracts/runtime-controls.yaml
+++ b/operator/contracts/runtime-controls.yaml
@@ -252,9 +252,9 @@ controls:
     # covering cron-fired wakes, which no pre_run gates). Resume is the
     # existing Captain clear surface.
     wired_via: 'pre_tool_call / hermes-smd-trust'
-    live_probe: ''
-    probe_surface: ''
-    status: unprobed
+    live_probe: operator_pause_negative_fire
+    probe_surface: staging
+    status: enforced
     owner: SMDurgan
     tracking: '#2003'
     note: >-
@@ -262,8 +262,16 @@ controls:
       pause/resume via portal -> console proxy -> gate POST /sticky-stop/set /
       /sticky-stop/clear (overlay#188, OVERLAY_REF 9d15c6a9). Governance rows
       in operator_pause_events (control-plane; broker PID-gates the Machine
-      ledger). UNPROBED until the live negative-fire probe runs on
-      pilot-smokeball at next reprovision: pause via portal route -> verify
-      /mcp/turn 503 + a cron-fired turn refuses at the tool wall -> resume ->
-      verify a turn completes. Promote to enforced with the probe name when
-      that run is recorded (crane_verify).
+      ledger). PROBED LIVE 2026-07-27 on pilot-smokeball
+      (vfy_01KYH5DV0VC9Q8WPKHMDW3T8HZ): baseline turn 200 -> set pins
+      HARD_STOP -> /mcp/turn 503 "operator paused" -> clear -> turn completes.
+      While paused, three forced cron fires plus a vendor task-create webhook
+      produced ZERO agent turns (audit-seam negative read) - every wake path
+      on the seat refused UPSTREAM of the tool wall (interactive at the gate,
+      cron at pre_run state starvation because the parked webhooks never fed
+      it, webhooks at the wake guard). The pre_tool_call wall itself is the
+      defense-in-depth backstop for a wake that slips those layers; its
+      refusal behavior is pinned by overlay integration tests
+      (test_trust_enforce.py: refuses a plain READ at HARD_STOP through the
+      real plugin + real state db) and has no live exercise yet precisely
+      because no live wake path survives to reach it.

--- a/operator/skills/deadline-miss-escalator/references/case-alert-routing.md
+++ b/operator/skills/deadline-miss-escalator/references/case-alert-routing.md
@@ -19,11 +19,18 @@ For each alert item (items already carry a `matter_id` — the ledger requires
 it):
 
 1. **Read the matter's assignment fields**: `get_matter(matter_id)` returns
-   `personResponsibleStaffId` (the responsible attorney) and
-   `personAssistingStaffId` (the assisting staff) directly on the matter.
-2. **Resolve each populated id through `get_staff(staff_id)`**. A staff record
-   that is deleted/disabled (`isDeleted`) is treated as UNPOPULATED — stale
-   assignment takes the fallback path, same as empty.
+   `personResponsibleStaffId` (the responsible attorney) and the
+   `personAssistingStaffs` list (assisting staff) on the matter. Tenant
+   ground truth (staging probe, 2026-07-27): these fields are **absent
+   entirely until populated** — treat absent and empty identically as
+   UNPOPULATED, never as an error.
+2. **Resolve each populated id through `get_staff(staff_id)`**. A staff
+   record that is disabled or departed (`enabled: false` or `former: true` —
+   the actual staff-record fields; there is no `isDeleted` on staff) is
+   treated as UNPOPULATED — stale assignment takes the fallback path, same
+   as empty. Staff records carry a top-level `email` field (verified on the
+   staging tenant), which is the delivery address candidate the roster check
+   in step 4 evaluates.
 3. **Recipient set**: the responsible attorney always; the assisting staff
    additionally where the skill's own body says paralegal-class work routes to
    assisting staff. At least one resolved, usable person = deliver to that

--- a/tests/case-alert-routing.test.ts
+++ b/tests/case-alert-routing.test.ts
@@ -59,7 +59,13 @@ describe('case-alert routing (#2004)', () => {
   it('the routing reference exists and carries the load-bearing rules', () => {
     const ref = readFileSync(ROUTING_REF, 'utf-8')
     expect(ref).toContain('personResponsibleStaffId')
-    expect(ref).toContain('personAssistingStaffId')
+    // Tenant ground truth (staging probe 2026-07-27): assisting staff is the
+    // personAssistingStaffs LIST, and staff usability is enabled/former (no
+    // isDeleted). The gate pins the corrected names so the doc cannot drift
+    // back to the published-docs shapes the probe disproved.
+    expect(ref).toContain('personAssistingStaffs')
+    expect(ref).toContain('enabled: false')
+    expect(ref).toContain('former: true')
     expect(ref).toContain('Never grow the roster from runtime data')
     expect(ref).toContain('Fail-closed floor')
     expect(ref).toContain('Ledger identity is routing-independent')


### PR DESCRIPTION
## What

Wiring close-out from tonight's live probe suite on the reprovisioned pilot (overlay `9d15c6a9` is now the running runtime — verified via boot smoke 22/22 + config greps on the volume).

**1. `operator_pause` → `enforced`.** Live negative-fire recorded (`vfy_01KYH5DV...`): baseline turn 200 → `/sticky-stop/set` pins HARD_STOP → `/mcp/turn` 503 "operator paused" → clear → turn returns "ok". While paused, three forced cron fires plus a vendor task-create webhook produced **zero agent turns** (audit-seam negative read) — every wake path refused *upstream* of the tool wall (gate, pre_run state starvation, wake guard). The registry note records the arms split honestly: the pre_tool_call wall is the defense-in-depth backstop, pinned by overlay integration tests, with no live exercise yet precisely because no live wake path survives to reach it.

**2. Routing rule corrected to tenant ground truth** (`vfy_01KYH3WD...`, `vfy_01KYH5DY...`): assisting staff is the `personAssistingStaffs` **list** (published docs' singular id is wrong); assignment fields are **absent until populated**; staff usability is `enabled`/`former` (**no `isDeleted`** on staff records); staff records **do** carry a top-level `email` — #2004's load-bearing unknown, resolved in favor of the design. The gate now pins the corrected names.

## Live rehearsals behind this (recorded)

- **Fallback leg**: unassigned matter → rule chain → authored fallback as sole recipient
- **Staffed leg**: `personResponsibleStaffId` authored via App 1 (PATCH 202, async-settled and observed on GET) → `get_staff` resolution with email/enabled/former → recipient set
- Both report-only through the live seat; nothing sent or written

## Verification

`npm run verify` exit 0; conformance registry 10/10; case-alert-routing gate 3/3 with the corrected pins.

Closes #2004 (routing now observed working on the runtime). #2003 remains open for the entitlement-control build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUsHocWqwBUbqpm8sjGFZY