### PR TITLE
feat(operator): routine-tier enforcement compiler + close two unauthored exposure gaps on the A&P seat (#2003)

### DIFF
--- a/operator/customers/ashton-price/customer.yaml
+++ b/operator/customers/ashton-price/customer.yaml
@@ -113,6 +113,17 @@ personas:
         # authorizes nothing outside it. Client- and tribunal-bound mail stays
         # governed by external_send above. Pinned by customer-commitments (g).
         external_send_internal: autonomous
+        # Recipient-class exposures the routine grid says enforce the letter's
+        # prepare-and-route tiers (letter 07: client verification, records
+        # chase). resolve_ceiling does NO fallback from a recipient class to
+        # the base external_send — unauthored is REFUSED (ADR 0056), so
+        # without these two keys the firm's #1 named routine (verification
+        # chase) and the records chase would refuse instead of drafting.
+        # Found by the #2003 compiler build; the A&P grid had no traceability
+        # gate (the commitments suite pointed only at pilot-smokeball) — gate
+        # (h) now covers it.
+        external_send_client: draft_for_review
+        external_send_vendor: draft_for_review
     skills:
       # spine
       - name: matter-inbox-router

--- a/src/lib/operator/entitlement-compiler.ts
+++ b/src/lib/operator/entitlement-compiler.ts
@@ -1,0 +1,304 @@
+/**
+ * Routine-tier → enforcement compiler (#2003, ADR 0075 + ADR 0069 Lock 3).
+ *
+ * The routine grid RECORDS how each routine's CURRENT tier is enforced
+ * (`enforcement.exposure_keys`); it does not DERIVE the enforcement for a
+ * different tier. Nothing in the repo did — which is why the portal's
+ * entitlement control could not be built: a tier change had no compilable
+ * meaning. This module is that missing piece.
+ *
+ * Given a seat's grid + live config and a requested (routine, target tier),
+ * it returns either a typed config delta (the exact exposure/initiation
+ * changes the seat must author) or a typed list of rejections. It is PURE —
+ * no I/O, no D1, no git. Persisting the delta and delivering it to the
+ * running Machine are separate, sequenced concerns (ADR 0012: git is the
+ * source of truth; ADR 0044's live-apply path is REVERTED and unbuilt).
+ *
+ * ## What a tier means, derived not invented
+ *
+ * The tier vocabulary is the client letter's (ADR 0075). Its enforcement
+ * meaning is read off the grid's own authored rows rather than assumed:
+ *
+ *   - `flag-only`        — the routine only surfaces. Its send action class
+ *                          carries NO authored exposure (fail-closed per ADR
+ *                          0035: unauthored = refused, never defaulted).
+ *   - `prepare-and-route` — the routine prepares work a person sends:
+ *                          send class = `draft_for_review`.
+ *   - `auto-handle`      — the routine completes on its own:
+ *                          send class = `autonomous`.
+ *
+ * The routine's send action class is discovered from the row's own authored
+ * exposure keys (e.g. `external_send_client`, `external_send_vendor`,
+ * `external_send`). A row with no send key has NO graduation path — matching
+ * what those rows' notes already say ("The skill carries no draft or send
+ * tool, so there is no path above flag-only"). Such a row is rejected rather
+ * than silently synthesizing a send capability its skills do not have.
+ *
+ * ## The ceilings, in precedence order
+ *
+ * 1. **Letter ceiling** (`row.ceiling_tier`) — the client commitment the grid
+ *    compiles from a dated letter. NON-RAISABLE here: raising it is a
+ *    commitment change, which is the Captain's call and a letter, not a
+ *    portal click.
+ * 2. **Vertical floor** (ADR 0025, `VERTICAL_FLOORS`) — regulation-compelled,
+ *    non-raisable. Empty today (ADR 0073) but checked, so re-adding a floor
+ *    binds this path automatically.
+ * 3. **No-op** — a request already at its live value compiles to no delta and
+ *    is reported as such (never audited as a change that did not happen).
+ */
+
+import {
+  changeDirection,
+  getVerticalFloor,
+  restrictiveness,
+  type Ceiling,
+  type ChangeDirection,
+} from '../portal/operator/config-governance'
+import type { RoutineGrid, RoutineGridRow, RoutineTier } from './routine-grid'
+import { ROUTINE_TIERS } from './routine-grid'
+
+/** Ordering of the tier vocabulary, least → most autonomous. */
+const TIER_RANK: Readonly<Record<RoutineTier, number>> = {
+  'flag-only': 0,
+  'prepare-and-route': 1,
+  'auto-handle': 2,
+}
+
+/**
+ * Exposure ceiling a tier implies for a routine's SEND action class.
+ * `null` = the class carries no authored exposure at this tier (fail-closed,
+ * ADR 0035) — the flag-only posture.
+ */
+const TIER_SEND_CEILING: Readonly<Record<RoutineTier, Ceiling | null>> = {
+  'flag-only': null,
+  'prepare-and-route': 'draft_for_review',
+  'auto-handle': 'autonomous',
+}
+
+/** Action classes that are NOT a routine's send class (internal bookkeeping). */
+const NON_SEND_CLASSES: ReadonlySet<string> = new Set(['internal_write'])
+
+export type RejectionCode =
+  | 'unknown_routine'
+  | 'invalid_tier'
+  | 'above_letter_ceiling'
+  | 'no_graduation_path'
+  | 'below_vertical_floor'
+  | 'persona_missing'
+
+export interface Rejection {
+  code: RejectionCode
+  message: string
+}
+
+export interface ExposureChange {
+  /** Persona whose entitlements carry the key. */
+  personaSlug: string
+  /** Exposure action class, e.g. `external_send_client`. */
+  actionClass: string
+  /** Live authored value; null when the class is currently unauthored. */
+  from: Ceiling | null
+  /** Target value; null means REMOVE the key (return to fail-closed). */
+  to: Ceiling | null
+  direction: ChangeDirection | 'authorize' | 'deauthorize'
+}
+
+export interface TierChangeDelta {
+  routine: string
+  skills: readonly string[]
+  fromTier: RoutineTier
+  toTier: RoutineTier
+  /** Empty when the request is a no-op at the config layer. */
+  exposureChanges: readonly ExposureChange[]
+  /** True when live config already satisfies the target. */
+  noop: boolean
+}
+
+export type TierChangeResult =
+  { ok: true; delta: TierChangeDelta } | { ok: false; rejections: readonly Rejection[] }
+
+/** Live exposure map for the seat's persona, as authored (may be sparse). */
+export interface LiveExposure {
+  personaSlug: string
+  exposure: Readonly<Record<string, string>>
+}
+
+function isTier(v: string): v is RoutineTier {
+  return (ROUTINE_TIERS as readonly string[]).includes(v)
+}
+
+function asCeiling(v: string | undefined): Ceiling | null {
+  if (v === 'autonomous' || v === 'confirm' || v === 'draft_for_review' || v === 'refused') {
+    return v
+  }
+  return null
+}
+
+/**
+ * The routine's send action class, discovered from its authored enforcement
+ * keys. Returns null when the routine authors no send class at all — the
+ * structural signal that it has no graduation path.
+ */
+export function sendActionClassOf(row: RoutineGridRow): string | null {
+  for (const key of Object.keys(row.enforcement.exposure_keys)) {
+    if (!NON_SEND_CLASSES.has(key)) return key
+  }
+  return null
+}
+
+/**
+ * The tier a routine is CURRENTLY at, derived from live config rather than
+ * from the grid's recorded `start_tier` (which is the letter's starting
+ * point, not necessarily today's state after a prior change).
+ */
+export function liveTierOf(row: RoutineGridRow, live: LiveExposure): RoutineTier {
+  const sendClass = sendActionClassOf(row)
+  if (sendClass === null) return 'flag-only'
+  const authored = asCeiling(live.exposure[sendClass])
+  if (authored === null) return 'flag-only'
+  if (authored === 'autonomous') return 'auto-handle'
+  return 'prepare-and-route'
+}
+
+/**
+ * Compile a requested tier change into a config delta, or reject it.
+ *
+ * `vertical` feeds the ADR 0025 floor check; pass the seat's authored
+ * vertical (null when unknown — no floor then applies, matching
+ * `getVerticalFloor`).
+ */
+/**
+ * Structural + ceiling guards, split out to keep `compileTierChange` inside
+ * the 75-line function ceiling. Returns the resolved row/target on success.
+ */
+function guardRequest(
+  grid: RoutineGrid,
+  live: LiveExposure,
+  request: { routine: string; targetTier: string }
+): { ok: true; row: RoutineGridRow; target: RoutineTier } | { ok: false; rejections: Rejection[] } {
+  const row = grid.rows.find((r) => r.routine === request.routine)
+  if (!row) {
+    return {
+      ok: false,
+      rejections: [
+        { code: 'unknown_routine', message: `no routine "${request.routine}" in this seat's grid` },
+      ],
+    }
+  }
+  if (!isTier(request.targetTier)) {
+    return {
+      ok: false,
+      rejections: [
+        { code: 'invalid_tier', message: `tier must be one of: ${ROUTINE_TIERS.join(', ')}` },
+      ],
+    }
+  }
+  const target: RoutineTier = request.targetTier
+  const rejections: Rejection[] = []
+
+  if (live.personaSlug !== grid.persona) {
+    rejections.push({
+      code: 'persona_missing',
+      message: `grid targets persona "${grid.persona}" but live config carries "${live.personaSlug}"`,
+    })
+  }
+  // Ceiling 1: the letter commitment. Non-raisable from this path.
+  if (TIER_RANK[target] > TIER_RANK[row.ceiling_tier]) {
+    rejections.push({
+      code: 'above_letter_ceiling',
+      message: `"${row.routine}" is committed at a ceiling of ${row.ceiling_tier} (${row.ceiling_verbatim}); raising it is a commitment change, not a settings change`,
+    })
+  }
+  if (sendActionClassOf(row) === null && TIER_RANK[target] > TIER_RANK['flag-only']) {
+    rejections.push({
+      code: 'no_graduation_path',
+      message: `"${row.routine}" authors no send action class — its skills carry no draft or send tool, so there is no path above flag-only`,
+    })
+  }
+  return rejections.length > 0 ? { ok: false, rejections } : { ok: true, row, target }
+}
+
+export function compileTierChange(
+  grid: RoutineGrid,
+  live: LiveExposure,
+  request: { routine: string; targetTier: string; vertical: string | null }
+): TierChangeResult {
+  const guard = guardRequest(grid, live, request)
+  if (!guard.ok) return { ok: false, rejections: guard.rejections }
+  const { row, target } = guard
+  const sendClass = sendActionClassOf(row)
+
+  const fromTier = liveTierOf(row, live)
+  if (fromTier === target) {
+    return {
+      ok: true,
+      delta: {
+        routine: row.routine,
+        skills: row.skills,
+        fromTier,
+        toTier: target,
+        exposureChanges: [],
+        noop: true,
+      },
+    }
+  }
+
+  // sendClass is non-null here: a null sendClass forces fromTier === 'flag-only'
+  // and rejects any target above it, so an equal-tier no-op already returned.
+  const actionClass = sendClass as string
+  const fromValue = asCeiling(live.exposure[actionClass])
+  const toValue = TIER_SEND_CEILING[target]
+
+  // Ceiling 2: the vertical floor (non-raisable, ADR 0025). A floor binds the
+  // TARGET value; an unauthored target (flag-only) is always at-or-below any
+  // floor because unauthored is fail-closed.
+  if (toValue !== null) {
+    const floor = getVerticalFloor(request.vertical, actionClass as never)
+    if (floor !== null && restrictiveness(toValue) < restrictiveness(floor)) {
+      return {
+        ok: false,
+        rejections: [
+          {
+            code: 'below_vertical_floor',
+            message: `${actionClass} may not be less restrictive than the ${request.vertical} floor (${floor})`,
+          },
+        ],
+      }
+    }
+  }
+
+  const direction: ExposureChange['direction'] =
+    fromValue === null
+      ? 'authorize'
+      : toValue === null
+        ? 'deauthorize'
+        : changeDirection(fromValue, toValue)
+
+  return {
+    ok: true,
+    delta: {
+      routine: row.routine,
+      skills: row.skills,
+      fromTier,
+      toTier: target,
+      exposureChanges: [
+        { personaSlug: live.personaSlug, actionClass, from: fromValue, to: toValue, direction },
+      ],
+      noop: false,
+    },
+  }
+}
+
+/**
+ * Every tier a routine may legally be set to from the portal, given its
+ * letter ceiling and whether it has a send class at all. Drives the control's
+ * option list so a client is never offered a choice the compiler will reject.
+ */
+export function selectableTiers(row: RoutineGridRow): readonly RoutineTier[] {
+  const hasSend = sendActionClassOf(row) !== null
+  return ROUTINE_TIERS.filter((t) => {
+    if (TIER_RANK[t] > TIER_RANK[row.ceiling_tier]) return false
+    if (!hasSend && TIER_RANK[t] > TIER_RANK['flag-only']) return false
+    return true
+  })
+}

--- a/tests/customer-commitments.test.ts
+++ b/tests/customer-commitments.test.ts
@@ -27,6 +27,7 @@ import { resolve, join } from 'path'
 import { parse as parseYaml } from 'yaml'
 import { validate, type CustomerYaml } from '../src/lib/operator/customer-yaml'
 import { validateRoutineGrid, type RoutineGridRow } from '../src/lib/operator/routine-grid'
+import { isCeiling, restrictiveness } from '../src/lib/portal/operator/config-governance'
 
 const SEAT_YAML_PATH = resolve('operator/customers/pilot-smokeball/customer.yaml')
 const GRID_YAML_PATH = resolve('operator/customers/pilot-smokeball/routine-grid.yaml')
@@ -211,6 +212,64 @@ describe('pilot-smokeball commitments contract (ADR 0075)', () => {
       byName('medical-chronology-maintainer')?.settings?.['treatment_gap_flag_days'],
       'medical-chronology-maintainer must author treatment_gap_flag_days: 45 (correspondence 09)'
     ).toBe(45)
+  })
+
+  // (h) A&P GRID TRACEABILITY. The (c) gate above checks the pilot seat
+  // against the pilot grid; the CLIENT seat's own grid was checked by
+  // nothing, and the gap it hid was real: ashton-price authored neither
+  // external_send_client nor external_send_vendor, the two keys its grid
+  // says enforce the letter's prepare-and-route tiers for client
+  // verification (the firm's #1 named routine) and records chase.
+  // resolve_ceiling does NO recipient-class fallback — unauthored is
+  // REFUSED (ADR 0056), so those routines would have refused instead of
+  // drafting. This gate makes the client seat's grid binding.
+  it('(h) every ashton-price grid row traces to the ashton-price seat config', () => {
+    const raw = parseYaml(readFileSync(join(AP_DIR, 'customer.yaml'), 'utf-8')) as Record<
+      string,
+      unknown
+    >
+    const seat = validate(raw)
+    if (!seat.ok) {
+      throw new Error(
+        `ashton-price customer.yaml no longer validates:\n${JSON.stringify(seat.errors, null, 2)}`
+      )
+    }
+    const gridResult = validateRoutineGrid(
+      parseYaml(readFileSync(join(AP_DIR, 'routine-grid.yaml'), 'utf-8'))
+    )
+    if (!gridResult.ok) {
+      throw new Error(
+        `ashton-price routine-grid.yaml no longer validates:\n${JSON.stringify(gridResult.errors, null, 2)}`
+      )
+    }
+    const exposure = seat.value.personas.find((p) => p.slug === gridResult.value.persona)
+      ?.entitlements.exposure
+    expect(exposure, `persona ${gridResult.value.persona} must exist on the seat`).toBeTruthy()
+    const seatSkills = new Set(seat.value.personas.flatMap((p) => p.skills.map((s) => s.name)))
+
+    // Direction matters. A grid-claimed key the seat does not author is a
+    // DEFECT (unauthored = REFUSED, so the routine cannot do what the letter
+    // says). A seat value MORE restrictive than the grid claims is the
+    // client's own posture and is allowed — running tighter than committed is
+    // always the firm's right (ADR 0035). Only absence, or a value LESS
+    // restrictive than the grid claims, fails.
+    for (const row of gridResult.value.rows) {
+      for (const [key, claimed] of Object.entries(row.enforcement.exposure_keys)) {
+        const authored = exposure![key as keyof typeof exposure] as string | undefined
+        expect(
+          authored,
+          `${row.routine}: grid says ${key}=${claimed} enforces this row, but the seat authors no ${key} (unauthored = REFUSED, ADR 0056 — the routine would refuse instead of acting)`
+        ).toBeTruthy()
+        if (!authored || !isCeiling(authored) || !isCeiling(claimed)) continue
+        expect(
+          restrictiveness(authored) >= restrictiveness(claimed),
+          `${row.routine}: seat authors ${key}=${authored}, LESS restrictive than the grid's ${claimed} — the seat exceeds what the letter committed`
+        ).toBe(true)
+      }
+      for (const skill of row.skills) {
+        expect(seatSkills.has(skill), `${row.routine}: skill "${skill}" not on the seat`).toBe(true)
+      }
+    }
   })
 
   // (g) Per-matter alert routing (#2004, correspondence 09): case-level alerts

--- a/tests/entitlement-compiler.test.ts
+++ b/tests/entitlement-compiler.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Routine-tier → enforcement compiler (#2003).
+ *
+ * Exercised against the LIVE ashton-price grid + customer.yaml (not fixtures):
+ * the compiler's whole job is to be correct about this seat's committed
+ * ceilings, so the client artifacts are the test inputs. Synthetic rows cover
+ * the floor path (no vertical floor exists today, ADR 0073).
+ */
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { parse as parseYaml } from 'yaml'
+import { validate } from '../src/lib/operator/customer-yaml'
+import {
+  validateRoutineGrid,
+  type RoutineGrid,
+  type RoutineGridRow,
+} from '../src/lib/operator/routine-grid'
+import {
+  compileTierChange,
+  liveTierOf,
+  selectableTiers,
+  sendActionClassOf,
+  type LiveExposure,
+} from '../src/lib/operator/entitlement-compiler'
+
+const AP = resolve('operator/customers/ashton-price')
+
+function grid(): RoutineGrid {
+  const result = validateRoutineGrid(
+    parseYaml(readFileSync(resolve(AP, 'routine-grid.yaml'), 'utf-8'))
+  )
+  if (!result.ok) throw new Error(`grid invalid: ${JSON.stringify(result.errors)}`)
+  return result.value
+}
+
+function liveExposure(): LiveExposure {
+  const raw = parseYaml(readFileSync(resolve(AP, 'customer.yaml'), 'utf-8')) as Record<
+    string,
+    unknown
+  >
+  const result = validate(raw)
+  if (!result.ok) throw new Error(`customer.yaml invalid: ${JSON.stringify(result.errors)}`)
+  const persona = result.value.personas.find((p) => p.slug === 'operator')
+  if (!persona) throw new Error('operator persona missing')
+  return {
+    personaSlug: persona.slug,
+    exposure: persona.entitlements.exposure,
+  }
+}
+
+const rowNamed = (g: RoutineGrid, name: string): RoutineGridRow => {
+  const row = g.rows.find((r) => r.routine === name)
+  if (!row) throw new Error(`row "${name}" not in grid`)
+  return row
+}
+
+describe('send-class discovery + live tier', () => {
+  it('a flag-only row authors no send class (structural: no draft/send tool)', () => {
+    const row = rowNamed(grid(), 'Served discovery caught')
+    expect(sendActionClassOf(row)).toBeNull()
+    expect(liveTierOf(row, liveExposure())).toBe('flag-only')
+  })
+
+  it('a graduating row authors its own send class', () => {
+    const row = rowNamed(grid(), 'Client verification')
+    expect(sendActionClassOf(row)).toBe('external_send_client')
+  })
+
+  it('live tier derives from live config, never from the grid start_tier', () => {
+    const row = rowNamed(grid(), 'Client verification')
+    // The seat now authors external_send_client: draft_for_review, so live
+    // tier and the letter's start_tier agree. They are still computed
+    // independently — this build FOUND them disagreeing (the key was
+    // unauthored, so the routine sat at fail-closed flag-only while the
+    // letter said prepare-and-route). A seat whose key is removed drops to
+    // flag-only again, which is what the fail-closed assertion below pins.
+    expect(liveTierOf(row, liveExposure())).toBe('prepare-and-route')
+    expect(row.start_tier).toBe('prepare-and-route')
+
+    const stripped: LiveExposure = {
+      personaSlug: 'operator',
+      exposure: { internal_write: 'draft_for_review' },
+    }
+    expect(liveTierOf(row, stripped)).toBe('flag-only')
+  })
+})
+
+describe('letter ceiling is non-raisable from this path', () => {
+  it('rejects a target above the committed ceiling', () => {
+    const g = grid()
+    const row = g.rows.find((r) => r.ceiling_tier === 'prepare-and-route' && sendActionClassOf(r))
+    expect(row, 'grid must carry a send-bearing row capped at prepare-and-route').toBeTruthy()
+    const result = compileTierChange(g, liveExposure(), {
+      routine: row!.routine,
+      targetTier: 'auto-handle',
+      vertical: 'law-firm',
+    })
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.rejections.map((r) => r.code)).toContain('above_letter_ceiling')
+    expect(result.rejections[0].message).toContain('commitment change')
+  })
+
+  it('rejects any raise on a routine with no send class', () => {
+    const result = compileTierChange(grid(), liveExposure(), {
+      routine: 'Served discovery caught',
+      targetTier: 'prepare-and-route',
+      vertical: 'law-firm',
+    })
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.rejections.map((r) => r.code)).toContain('no_graduation_path')
+  })
+
+  it('selectableTiers never offers a tier the compiler would reject', () => {
+    const g = grid()
+    const live = liveExposure()
+    for (const row of g.rows) {
+      for (const tier of selectableTiers(row)) {
+        const result = compileTierChange(g, live, {
+          routine: row.routine,
+          targetTier: tier,
+          vertical: 'law-firm',
+        })
+        expect(result.ok, `${row.routine} → ${tier} was offered but rejected`).toBe(true)
+      }
+    }
+  })
+})
+
+describe('compiled deltas', () => {
+  it('graduating a routine to its ceiling emits one exposure change', () => {
+    const g = grid()
+    const row = g.rows.find((r) => r.ceiling_tier === 'auto-handle' && sendActionClassOf(r))!
+    const result = compileTierChange(g, liveExposure(), {
+      routine: row.routine,
+      targetTier: 'auto-handle',
+      vertical: 'law-firm',
+    })
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.delta.noop).toBe(false)
+    expect(result.delta.exposureChanges).toHaveLength(1)
+    const change = result.delta.exposureChanges[0]
+    expect(change.actionClass).toBe(sendActionClassOf(row))
+    expect(change.from).toBe('draft_for_review')
+    expect(change.to).toBe('autonomous')
+    expect(change.direction).toBe('raise')
+    expect(change.personaSlug).toBe('operator')
+  })
+
+  it('the seat now sits at the letter start tier for its graduating routines', () => {
+    const g = grid()
+    const live = liveExposure()
+    for (const row of g.rows) {
+      if (sendActionClassOf(row) === null) continue
+      expect(liveTierOf(row, live), `${row.routine} live tier`).toBe(row.start_tier)
+    }
+  })
+
+  it('a request already satisfied compiles to a no-op with no changes', () => {
+    const result = compileTierChange(grid(), liveExposure(), {
+      routine: 'Served discovery caught',
+      targetTier: 'flag-only',
+      vertical: 'law-firm',
+    })
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.delta.noop).toBe(true)
+    expect(result.delta.exposureChanges).toEqual([])
+  })
+
+  it('lowering back to flag-only REMOVES the key (fail-closed, ADR 0035)', () => {
+    const g = grid()
+    const row = g.rows.find((r) => r.ceiling_tier === 'auto-handle' && sendActionClassOf(r))!
+    const sendClass = sendActionClassOf(row)!
+    // Simulate a seat that has already graduated this routine.
+    const graduated: LiveExposure = {
+      personaSlug: 'operator',
+      exposure: { internal_write: 'draft_for_review', [sendClass]: 'autonomous' },
+    }
+    const result = compileTierChange(g, graduated, {
+      routine: row.routine,
+      targetTier: 'flag-only',
+      vertical: 'law-firm',
+    })
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    const change = result.delta.exposureChanges[0]
+    expect(result.delta.fromTier).toBe('auto-handle')
+    expect(change.from).toBe('autonomous')
+    expect(change.to).toBeNull()
+    expect(change.direction).toBe('deauthorize')
+  })
+})
+
+describe('input guards', () => {
+  it('rejects an unknown routine', () => {
+    const result = compileTierChange(grid(), liveExposure(), {
+      routine: 'Nonexistent routine',
+      targetTier: 'flag-only',
+      vertical: 'law-firm',
+    })
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.rejections[0].code).toBe('unknown_routine')
+  })
+
+  it('rejects a tier outside the closed vocabulary', () => {
+    const result = compileTierChange(grid(), liveExposure(), {
+      routine: 'Client verification',
+      targetTier: 'full-autonomy',
+      vertical: 'law-firm',
+    })
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.rejections[0].code).toBe('invalid_tier')
+  })
+
+  it('rejects when the live persona is not the grid persona', () => {
+    const result = compileTierChange(
+      grid(),
+      { personaSlug: 'someone-else', exposure: {} },
+      { routine: 'Client verification', targetTier: 'flag-only', vertical: 'law-firm' }
+    )
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.rejections.map((r) => r.code)).toContain('persona_missing')
+  })
+})


### PR DESCRIPTION
## Slice 1 of the entitlement control: the compiler

The routine grid **records** how each routine's current tier is enforced; nothing **derived** enforcement for a *different* tier — so a portal tier change had no compilable meaning. This is that piece.

`compileTierChange(grid, liveExposure, request)` → typed delta or typed rejections. Pure, no I/O. Tier semantics are read off the grid's own authored rows rather than assumed:

| tier | send class exposure |
|---|---|
| `flag-only` | unauthored (fail-closed, ADR 0035) |
| `prepare-and-route` | `draft_for_review` |
| `auto-handle` | `autonomous` |

Two non-raisable ceilings, in order: **the letter commitment** (`row.ceiling_tier` — raising it is a commitment change, not a settings change) and the **ADR 0025 vertical floor** (empty today, checked so a future floor binds automatically). `selectableTiers()` drives the control's options, property-tested against every grid row so a client is never offered a choice the compiler would reject.

## Defect found while building — and fixed

Building against the real seat instead of a fixture surfaced this: **ashton-price authored neither `external_send_client` nor `external_send_vendor`** — the two keys its own grid says enforce the letter's prepare-and-route tiers for **client verification** (the firm's #1 named routine) and **records chase**.

`enforce.resolve_ceiling` does **no** recipient-class fallback — `base = exposure.get(action)`, unauthored → `REFUSED`. Both routines would have **refused instead of drafting**. Same defect class as the `external_send_internal` blocker found in #2004, in two more routines.

**Root cause:** the commitments suite's traceability gate (c) checks the *pilot* seat against the *pilot* grid. The client seat's grid was checked by nothing.

**New gate (h)** makes the A&P grid binding, with direction semantics that matter: an unauthored grid-claimed key **fails** (unauthored = refused); a seat value *more restrictive* than the grid claims **passes** (running tighter than committed is always the firm's right, ADR 0035 — this is why A&P's `internal_write: draft_for_review` against a grid claim of `autonomous` is correctly not flagged).

## Verification

`npm run verify` exit 0; operator substrate 299/299; compiler suite 13/13; commitments suite green including the new gate.

## Not in this PR (and not implied)

Persistence of a compiled delta to `customer.yaml` (git is source of truth, ADR 0012; ADR 0044's live-apply path is **reverted** and unbuilt) and the portal control surface. Those are the next slices — the delivery mechanism is a Captain decision, raised separately.

Part of #2003.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUsHocWqwBUbqpm8sjGFZY