### PR TITLE
feat(operator): entitlement control — compiled tier change → reviewable PR → governance ledger (#2003)

### DIFF
--- a/docs/handbook/secrets-access.md
+++ b/docs/handbook/secrets-access.md
@@ -72,6 +72,13 @@ not secrets, and are set in the build/deploy environment - see
   tokens (ADR 0007, ADR 0010); a credential for one customer never reaches another.
 - **Never grant or change access controls casually.** Modifying auth flows, sharing
   permissions, or access controls is a Captain decision, not an agent one.
+- **Client-reachable credentials are scoped to one action.** `OPERATOR_CONFIG_PR_TOKEN`
+  (the entitlement control's git transport, #2003) is a fine-grained GitHub token limited
+  to this one repository with `contents: write` + `pull_requests: write`. It sits in a
+  request path a client admin can reach, so its blast radius is deliberately bounded to
+  opening a pull request: branch protection keeps it off the default branch, and it can
+  touch no other repository. It is never the fleet `GH_TOKEN`. Unset means the control
+  fails closed, which is the correct posture until the token is minted.
 
 ## Related
 

--- a/migrations/0097_operator_entitlement_changes.sql
+++ b/migrations/0097_operator_entitlement_changes.sql
@@ -1,0 +1,37 @@
+-- 0097: operator_entitlement_changes — the entitlement control's governance
+-- ledger (#2003, A&P diligence reply Q7).
+--
+-- Every routine-tier change a client admin (or SMD on their behalf) submits,
+-- with who/when/why, the compiled delta, and the pull request that carries it
+-- to the source of truth. Companion to operator_pause_events (0096): same
+-- control plane, same "every change, yours or ours, lands in the same audit
+-- record" commitment.
+--
+-- STATUS SEMANTICS, deliberately honest: a submitted change is NOT applied.
+-- The PR must merge (re-projecting config) and the Machine must reprovision
+-- before the runtime changes. `submitted` is the only status this console
+-- writes; `applied` exists for a future merge-webhook to set, and nothing
+-- fabricates it in the meantime.
+
+CREATE TABLE IF NOT EXISTS operator_entitlement_changes (
+  id             TEXT PRIMARY KEY,
+  entity_id      TEXT NOT NULL,
+  customer_slug  TEXT NOT NULL,
+  routine        TEXT NOT NULL,
+  from_tier      TEXT NOT NULL,
+  to_tier        TEXT NOT NULL,
+  -- Compiled delta as JSON (exposure action class, from, to, direction).
+  delta_json     TEXT NOT NULL,
+  actor_user_id  TEXT NOT NULL,
+  actor_email    TEXT NOT NULL,
+  actor_role     TEXT NOT NULL,
+  source         TEXT NOT NULL CHECK (source IN ('portal', 'admin')),
+  reason         TEXT NOT NULL,
+  status         TEXT NOT NULL CHECK (status IN ('submitted', 'applied', 'abandoned')),
+  pr_url         TEXT,
+  pr_number      INTEGER,
+  created_at     TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_entitlement_changes_customer
+  ON operator_entitlement_changes (customer_slug, created_at DESC);

--- a/migrations/rollbacks/0097_operator_entitlement_changes_down.sql
+++ b/migrations/rollbacks/0097_operator_entitlement_changes_down.sql
@@ -1,0 +1,10 @@
+-- Rollback for 0097: drop the entitlement-control governance ledger.
+--
+-- Dropping the table removes the client-readable record of tier changes. The
+-- tier-change route and the audit-viewer union must be reverted in the same
+-- breath — without the table a submitted change throws at the record step
+-- AFTER its pull request already exists, leaving an unaudited open PR against
+-- a client's config.
+
+DROP INDEX IF EXISTS idx_entitlement_changes_customer;
+DROP TABLE IF EXISTS operator_entitlement_changes;

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -246,6 +246,19 @@ declare namespace Cloudflare {
      */
     OPERATOR_MCP_WEBHOOK_SECRET?: string
     /**
+     * FINE-GRAINED GitHub token, scoped to venturecrane/ss-console ONLY with
+     * `contents: write` + `pull_requests: write`. Opens the reviewable pull
+     * request that carries a client-submitted entitlement change to the
+     * source of truth (#2003, ADR 0012 + ADR 0069 Lock 3).
+     *
+     * Deliberately NOT the fleet `GH_TOKEN`: this credential sits in a
+     * client-reachable request path, so its blast radius is bounded to
+     * opening a PR on one repo — it can never push to a default branch
+     * (branch protection) or touch another repository. Unset = the
+     * entitlement control fails closed with an honest error.
+     */
+    OPERATOR_CONFIG_PR_TOKEN?: string
+    /**
      * Sentry Internal Integration Client Secret used to verify
      * `Sentry-Hook-Signature` headers on inbound alert-rule webhook
      * deliveries to `/api/webhooks/sentry`. Pulled from the SMD-owned

--- a/src/lib/operator/config-pr.ts
+++ b/src/lib/operator/config-pr.ts
@@ -1,0 +1,178 @@
+/**
+ * Config pull-request transport (#2003 slice 2).
+ *
+ * A compiled entitlement delta becomes a REVIEWABLE PULL REQUEST against the
+ * customer.yaml in git — never a direct push to the default branch. Captain
+ * decision, 2026-07-27: the change must be real (ADR 0069 Lock 3 — a handler
+ * that only records intent is not done) and persisted to the source of truth
+ * (ADR 0012 — git; ADR 0044's live-apply path is reverted and unbuilt), while
+ * the venture's all-changes-through-PRs rule keeps a human between a client
+ * click and the default branch.
+ *
+ * What the client's action therefore does: opens a PR carrying a one-line
+ * diff and the full governance context in its body. Merging it re-projects
+ * the config (deploy.yml sync) and the running Machine picks it up at its
+ * next reprovision. The portal must say exactly that — a submitted change is
+ * "submitted", never "applied".
+ *
+ * ## Credential
+ *
+ * `OPERATOR_CONFIG_PR_TOKEN` — a FINE-GRAINED GitHub token scoped to this one
+ * repository with `contents: write` + `pull_requests: write` and nothing else.
+ * Deliberately NOT the fleet `GH_TOKEN`: this credential lives in a
+ * client-reachable request path, so its blast radius is bounded to opening a
+ * PR on one repo. Unset → every call fails closed with an honest error; there
+ * is no degraded "record it and hope" mode.
+ */
+
+export interface ConfigPrEnv {
+  OPERATOR_CONFIG_PR_TOKEN?: string
+}
+
+export interface ConfigPrRequest {
+  /** Repo-relative path, e.g. operator/customers/ashton-price/customer.yaml */
+  path: string
+  /** Full new file content (produced by the surgical exposure editor). */
+  content: string
+  branch: string
+  title: string
+  body: string
+}
+
+export interface ConfigPrResult {
+  url: string
+  number: number
+  branch: string
+}
+
+const OWNER = 'venturecrane'
+const REPO = 'ss-console'
+const BASE = 'main'
+const API = 'https://api.github.com'
+
+/** True when the PR transport is configured. Callers must check and refuse. */
+export function isConfigPrConfigured(env: ConfigPrEnv): boolean {
+  return typeof env.OPERATOR_CONFIG_PR_TOKEN === 'string' && env.OPERATOR_CONFIG_PR_TOKEN.length > 0
+}
+
+function headers(token: string): Record<string, string> {
+  return {
+    Authorization: `Bearer ${token}`,
+    Accept: 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+    'Content-Type': 'application/json',
+    'User-Agent': 'ss-console-operator-config',
+  }
+}
+
+async function gh<T>(
+  token: string,
+  method: string,
+  path: string,
+  body?: unknown
+): Promise<{ ok: true; data: T } | { ok: false; status: number; detail: string }> {
+  const resp = await fetch(`${API}${path}`, {
+    method,
+    headers: headers(token),
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+  })
+  if (!resp.ok) {
+    const detail = await resp.text().catch(() => '')
+    return { ok: false, status: resp.status, detail: detail.slice(0, 300) }
+  }
+  return { ok: true, data: (await resp.json()) as T }
+}
+
+/** base64 for a UTF-8 string in the Workers runtime (no Buffer). */
+function toBase64(text: string): string {
+  const bytes = new TextEncoder().encode(text)
+  let binary = ''
+  for (const b of bytes) binary += String.fromCharCode(b)
+  return btoa(binary)
+}
+
+/**
+ * Read a repo file at the base branch. The Worker has no filesystem, so this
+ * is the ONLY honest source of the current authored text — and it is the same
+ * bytes the PR will be based on, which removes any drift between a bundled
+ * copy and git HEAD.
+ */
+export async function readConfigFile(env: ConfigPrEnv, path: string): Promise<string> {
+  if (!isConfigPrConfigured(env)) {
+    throw new Error('config PR transport not configured (OPERATOR_CONFIG_PR_TOKEN unset)')
+  }
+  const resp = await gh<{ content: string; encoding: string }>(
+    env.OPERATOR_CONFIG_PR_TOKEN!,
+    'GET',
+    `/repos/${OWNER}/${REPO}/contents/${path}?ref=${BASE}`
+  )
+  if (!resp.ok) throw new Error(`config read failed: ${resp.status} ${resp.detail}`)
+  if (resp.data.encoding !== 'base64') {
+    throw new Error(`unexpected content encoding: ${resp.data.encoding}`)
+  }
+  const binary = atob(resp.data.content.replace(/\n/g, ''))
+  const bytes = Uint8Array.from(binary, (c) => c.charCodeAt(0))
+  return new TextDecoder().decode(bytes)
+}
+
+/**
+ * Open a PR carrying the new file content. Throws on any failure so the
+ * caller records nothing and surfaces an honest error — the same
+ * remote-first-then-record ordering the pause control uses. A partially
+ * created branch is left in place rather than silently deleted; it is inert
+ * without a PR and visible to whoever investigates.
+ */
+export async function openConfigPr(
+  env: ConfigPrEnv,
+  request: ConfigPrRequest
+): Promise<ConfigPrResult> {
+  if (!isConfigPrConfigured(env)) {
+    throw new Error('config PR transport not configured (OPERATOR_CONFIG_PR_TOKEN unset)')
+  }
+  const token = env.OPERATOR_CONFIG_PR_TOKEN!
+
+  const baseRef = await gh<{ object: { sha: string } }>(
+    token,
+    'GET',
+    `/repos/${OWNER}/${REPO}/git/ref/heads/${BASE}`
+  )
+  if (!baseRef.ok) throw new Error(`base ref read failed: ${baseRef.status} ${baseRef.detail}`)
+
+  const existing = await gh<{ sha: string }>(
+    token,
+    'GET',
+    `/repos/${OWNER}/${REPO}/contents/${request.path}?ref=${BASE}`
+  )
+  if (!existing.ok) throw new Error(`file read failed: ${existing.status} ${existing.detail}`)
+
+  const branchCreate = await gh<unknown>(token, 'POST', `/repos/${OWNER}/${REPO}/git/refs`, {
+    ref: `refs/heads/${request.branch}`,
+    sha: baseRef.data.object.sha,
+  })
+  if (!branchCreate.ok) {
+    throw new Error(`branch create failed: ${branchCreate.status} ${branchCreate.detail}`)
+  }
+
+  const commit = await gh<unknown>(
+    token,
+    'PUT',
+    `/repos/${OWNER}/${REPO}/contents/${request.path}`,
+    {
+      message: request.title,
+      content: toBase64(request.content),
+      sha: existing.data.sha,
+      branch: request.branch,
+    }
+  )
+  if (!commit.ok) throw new Error(`commit failed: ${commit.status} ${commit.detail}`)
+
+  const pr = await gh<{ html_url: string; number: number }>(
+    token,
+    'POST',
+    `/repos/${OWNER}/${REPO}/pulls`,
+    { title: request.title, head: request.branch, base: BASE, body: request.body }
+  )
+  if (!pr.ok) throw new Error(`pull request failed: ${pr.status} ${pr.detail}`)
+
+  return { url: pr.data.html_url, number: pr.data.number, branch: request.branch }
+}

--- a/src/lib/operator/exposure-yaml-edit.ts
+++ b/src/lib/operator/exposure-yaml-edit.ts
@@ -1,0 +1,162 @@
+/**
+ * Surgical exposure-key editing on a customer.yaml TEXT (#2003 slice 2).
+ *
+ * A compiled tier delta has to land in `customer.yaml` as a reviewable diff.
+ * A parse → mutate → stringify round-trip is not usable here: the `yaml`
+ * Document API reflows the file (measured: 383 changed lines on the
+ * ashton-price seat) and drops the comments that carry WHY each entitlement
+ * is authored — the reviewer's whole context, and load-bearing under the
+ * repo's no-fabrication rules. So this module edits the text directly and
+ * produces a ONE-LINE diff per key.
+ *
+ * Scope is deliberately narrow: it only ever touches
+ * `personas[<slug>].entitlements.exposure.<key>`. It never rewrites, reorders,
+ * reindents, or re-serializes anything else, and it refuses (never guesses)
+ * when the block it expects is not exactly where the schema says it is.
+ */
+
+export type ExposureEditResult =
+  { ok: true; text: string; changed: boolean } | { ok: false; error: string }
+
+interface BlockBounds {
+  /** Index of the `exposure:` line itself. */
+  header: number
+  /** First line index INSIDE the block. */
+  start: number
+  /** One past the last line inside the block. */
+  end: number
+  /** Indent (in spaces) of the block's entries. */
+  indent: number
+}
+
+function indentOf(line: string): number {
+  return line.length - line.trimStart().length
+}
+
+function isBlank(line: string): boolean {
+  return line.trim() === ''
+}
+
+function isComment(line: string): boolean {
+  return line.trimStart().startsWith('#')
+}
+
+/**
+ * Locate the exposure block for one persona slug. Walks the personas list by
+ * its `- slug:` entries so a second persona's block can never be edited by
+ * accident.
+ */
+function personaEndIndex(
+  lines: readonly string[],
+  personaIdx: number,
+  personaIndent: number
+): number {
+  for (let i = personaIdx + 1; i < lines.length; i++) {
+    const line = lines[i]
+    if (isBlank(line) || isComment(line)) continue
+    const ind = indentOf(line)
+    if (ind < personaIndent) return i
+    if (ind <= personaIndent && /^\s*-\s/.test(line)) return i
+  }
+  return lines.length
+}
+
+function findExposureBlock(lines: readonly string[], personaSlug: string): BlockBounds | string {
+  const personaIdx = lines.findIndex(
+    (l) => /^\s*-\s+slug:\s*/.test(l) && l.split(':').slice(1).join(':').trim() === personaSlug
+  )
+  if (personaIdx < 0) return `persona "${personaSlug}" not found in customer.yaml`
+  const personaIndent = indentOf(lines[personaIdx])
+  const personaEnd = personaEndIndex(lines, personaIdx, personaIndent)
+
+  let header = -1
+  for (let i = personaIdx + 1; i < personaEnd; i++) {
+    if (/^\s*exposure:\s*$/.test(lines[i])) {
+      header = i
+      break
+    }
+  }
+  if (header < 0) return `persona "${personaSlug}" has no entitlements.exposure block`
+
+  const headerIndent = indentOf(lines[header])
+  const start = header + 1
+  let end = start
+  let indent = -1
+  for (let i = start; i < personaEnd; i++) {
+    const line = lines[i]
+    if (isBlank(line)) {
+      end = i + 1
+      continue
+    }
+    const ind = indentOf(line)
+    if (ind <= headerIndent) break
+    if (!isComment(line) && indent < 0) indent = ind
+    end = i + 1
+  }
+  if (indent < 0) return `persona "${personaSlug}" exposure block is empty`
+
+  // Trim trailing blank/comment lines back out of the block so an inserted key
+  // lands after the last real entry, not after a trailing comment that belongs
+  // to the NEXT block.
+  while (end > start && (isBlank(lines[end - 1]) || isComment(lines[end - 1]))) end--
+
+  return { header, start, end, indent }
+}
+
+/**
+ * Set, change, or remove one exposure key.
+ *
+ * `value === null` REMOVES the key — the fail-closed posture (ADR 0035:
+ * unauthored is refused; there is no "off" value to write). Removing a key
+ * that is not present, or setting a key to the value it already holds, is a
+ * no-op with `changed: false`, never an error.
+ *
+ * Any authored comment lines attached to the key are left in place: a removal
+ * takes only the `key: value` line. A reviewer therefore sees the comment
+ * explaining an entitlement that is no longer authored, which is the correct
+ * prompt to update or delete it in the same PR.
+ */
+export function setExposureKey(
+  yamlText: string,
+  personaSlug: string,
+  key: string,
+  value: string | null
+): ExposureEditResult {
+  if (!/^[a-z][a-z0-9_]*$/.test(key)) {
+    return { ok: false, error: `refusing to edit unsafe exposure key "${key}"` }
+  }
+  if (value !== null && !/^[a-z_]+$/.test(value)) {
+    return { ok: false, error: `refusing to write unsafe exposure value "${value}"` }
+  }
+
+  const lines = yamlText.split('\n')
+  const bounds = findExposureBlock(lines, personaSlug)
+  if (typeof bounds === 'string') return { ok: false, error: bounds }
+
+  const keyRe = new RegExp(`^\\s*${key}:\\s`)
+  let keyIdx = -1
+  for (let i = bounds.start; i < bounds.end; i++) {
+    if (!isComment(lines[i]) && keyRe.test(lines[i])) {
+      keyIdx = i
+      break
+    }
+  }
+
+  if (value === null) {
+    if (keyIdx < 0) return { ok: true, text: yamlText, changed: false }
+    const next = [...lines.slice(0, keyIdx), ...lines.slice(keyIdx + 1)]
+    return { ok: true, text: next.join('\n'), changed: true }
+  }
+
+  const pad = ' '.repeat(bounds.indent)
+  if (keyIdx >= 0) {
+    const current = lines[keyIdx].split(':').slice(1).join(':').trim()
+    if (current === value) return { ok: true, text: yamlText, changed: false }
+    const next = [...lines]
+    next[keyIdx] = `${pad}${key}: ${value}`
+    return { ok: true, text: next.join('\n'), changed: true }
+  }
+
+  const next = [...lines.slice(0, bounds.end), `${pad}${key}: ${value}`, ...lines.slice(bounds.end)]
+  return { ok: true, text: next.join('\n'), changed: true }
+}

--- a/src/lib/portal/operator/entitlement-change.ts
+++ b/src/lib/portal/operator/entitlement-change.ts
@@ -1,0 +1,206 @@
+/**
+ * Entitlement tier change — orchestration + governance ledger (#2003 slice 2).
+ *
+ * One governed path from a client's click to the source of truth:
+ *
+ *   compile (ceilings + floors)  →  surgical customer.yaml edit
+ *                                →  reviewable pull request
+ *                                →  governance row
+ *
+ * Ordering is remote-first, record-second — the same rule the pause control
+ * follows: a change whose PR did not open is never recorded as submitted.
+ *
+ * What a submitted change IS and IS NOT: the PR carries the one-line diff to
+ * `customer.yaml`; merging it re-projects config; the running Machine adopts
+ * it at its next reprovision. Nothing here changes a live runtime, and no
+ * surface may say it did (letter 10 Q7 commits access + audit, not instant
+ * self-serve — that is Q6's kill-switch promise, and only that).
+ */
+
+import type { D1Database } from '@cloudflare/workers-types'
+import {
+  compileTierChange,
+  type LiveExposure,
+  type Rejection,
+  type TierChangeDelta,
+} from '../../operator/entitlement-compiler'
+import type { RoutineGrid } from '../../operator/routine-grid'
+import { setExposureKey } from '../../operator/exposure-yaml-edit'
+import { openConfigPr, type ConfigPrEnv } from '../../operator/config-pr'
+
+export interface TierChangeActor {
+  userId: string
+  email: string
+  role: string
+}
+
+export interface TierChangeInput {
+  entityId: string
+  customerSlug: string
+  routine: string
+  targetTier: string
+  reason: string
+  vertical: string | null
+  actor: TierChangeActor
+  source: 'portal' | 'admin'
+}
+
+export type TierChangeOutcome =
+  | { kind: 'submitted'; prUrl: string; prNumber: number; delta: TierChangeDelta }
+  | { kind: 'noop'; delta: TierChangeDelta }
+  | { kind: 'rejected'; rejections: readonly Rejection[] }
+  | { kind: 'failed'; error: string }
+
+/** Repo path of a seat's authored config. */
+export function customerYamlPath(slug: string): string {
+  return `operator/customers/${slug}/customer.yaml`
+}
+
+/**
+ * Branch name for one submission. Deterministic in its inputs except for the
+ * caller-supplied `nonce` (a request id / timestamp the caller owns) — this
+ * module never reads the clock, so it stays pure enough to test.
+ */
+export function changeBranchName(slug: string, routine: string, nonce: string): string {
+  const slugified = routine
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')
+    .slice(0, 40)
+  return `operator-entitlement/${slug}/${slugified}-${nonce}`
+}
+
+function prBody(input: TierChangeInput, delta: TierChangeDelta): string {
+  const changes = delta.exposureChanges
+    .map(
+      (c) =>
+        `- \`${c.actionClass}\`: ${c.from ?? '(unauthored)'} → ${c.to ?? '(unauthored — fail-closed)'} (${c.direction})`
+    )
+    .join('\n')
+  return [
+    `Entitlement tier change submitted from the ${input.source === 'portal' ? 'client portal' : 'admin console'}.`,
+    '',
+    `**Routine:** ${delta.routine}`,
+    `**Tier:** ${delta.fromTier} → ${delta.toTier}`,
+    `**Skills affected:** ${delta.skills.join(', ')}`,
+    '',
+    '**Compiled exposure delta**',
+    changes,
+    '',
+    `**Requested by:** ${input.actor.email} (${input.actor.role})`,
+    `**Reason given:** ${input.reason}`,
+    '',
+    'Compiled by `src/lib/operator/entitlement-compiler.ts`: the target is at or below',
+    "this routine's committed letter ceiling and clears every vertical floor.",
+    'Merging re-projects the config; the running Machine adopts it at its next reprovision.',
+  ].join('\n')
+}
+
+/**
+ * Execute one tier change end to end. `readYaml` supplies the current file
+ * text (injected so this is testable without git); `nonce` makes the branch
+ * unique.
+ */
+export async function submitTierChange(
+  db: D1Database,
+  env: ConfigPrEnv,
+  deps: { grid: RoutineGrid; live: LiveExposure; readYaml: () => Promise<string>; nonce: string },
+  input: TierChangeInput
+): Promise<TierChangeOutcome> {
+  const compiled = compileTierChange(deps.grid, deps.live, {
+    routine: input.routine,
+    targetTier: input.targetTier,
+    vertical: input.vertical,
+  })
+  if (!compiled.ok) return { kind: 'rejected', rejections: compiled.rejections }
+  const delta = compiled.delta
+  if (delta.noop) return { kind: 'noop', delta }
+
+  let nextYaml: string
+  try {
+    let text = await deps.readYaml()
+    for (const change of delta.exposureChanges) {
+      const edited = setExposureKey(text, change.personaSlug, change.actionClass, change.to)
+      if (!edited.ok) return { kind: 'failed', error: edited.error }
+      text = edited.text
+    }
+    nextYaml = text
+  } catch (err) {
+    return { kind: 'failed', error: err instanceof Error ? err.message : 'config read failed' }
+  }
+
+  const branch = changeBranchName(input.customerSlug, delta.routine, deps.nonce)
+  const title = `config(${input.customerSlug}): ${delta.routine} → ${delta.toTier}`
+
+  let pr
+  try {
+    pr = await openConfigPr(env, {
+      path: customerYamlPath(input.customerSlug),
+      content: nextYaml,
+      branch,
+      title,
+      body: prBody(input, delta),
+    })
+  } catch (err) {
+    return { kind: 'failed', error: err instanceof Error ? err.message : 'pull request failed' }
+  }
+
+  await db
+    .prepare(
+      'INSERT INTO operator_entitlement_changes ' +
+        '(id, entity_id, customer_slug, routine, from_tier, to_tier, delta_json, actor_user_id, ' +
+        'actor_email, actor_role, source, reason, status, pr_url, pr_number) ' +
+        'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
+    )
+    .bind(
+      crypto.randomUUID(),
+      input.entityId,
+      input.customerSlug,
+      delta.routine,
+      delta.fromTier,
+      delta.toTier,
+      JSON.stringify(delta.exposureChanges),
+      input.actor.userId,
+      input.actor.email,
+      input.actor.role,
+      input.source,
+      input.reason,
+      'submitted',
+      pr.url,
+      pr.number
+    )
+    .run()
+
+  return { kind: 'submitted', prUrl: pr.url, prNumber: pr.number, delta }
+}
+
+export interface EntitlementChangeRow {
+  id: string
+  routine: string
+  from_tier: string
+  to_tier: string
+  actor_email: string
+  actor_role: string
+  source: string
+  reason: string
+  status: string
+  pr_url: string | null
+  created_at: string
+}
+
+/** Submitted changes for one customer, newest first (audit + portal surface). */
+export async function listEntitlementChanges(
+  db: D1Database,
+  customerSlug: string,
+  limit = 50
+): Promise<EntitlementChangeRow[]> {
+  const res = await db
+    .prepare(
+      'SELECT id, routine, from_tier, to_tier, actor_email, actor_role, source, reason, ' +
+        'status, pr_url, created_at FROM operator_entitlement_changes ' +
+        'WHERE customer_slug = ? ORDER BY created_at DESC LIMIT ?'
+    )
+    .bind(customerSlug, limit)
+    .all<EntitlementChangeRow>()
+  return res.results ?? []
+}

--- a/src/pages/api/portal/products/operator/[instance]/entitlement.ts
+++ b/src/pages/api/portal/products/operator/[instance]/entitlement.ts
@@ -1,0 +1,145 @@
+import type { APIRoute } from 'astro'
+import { env } from 'cloudflare:workers'
+import { resolveOperatorAccess } from '../../../../../../lib/portal/operator-access'
+import { getCustomerConfigBySlug } from '../../../../../../lib/portal/customer-config'
+import { clientRolePermits } from '../../../../../../lib/portal/operator/client-rbac'
+import { resolveDomainSurfaceMode } from '../../../../../../lib/portal/operator/domain-surface'
+import { readConfigFile } from '../../../../../../lib/operator/config-pr'
+import type { LiveExposure } from '../../../../../../lib/operator/entitlement-compiler'
+import {
+  customerYamlPath,
+  submitTierChange,
+} from '../../../../../../lib/portal/operator/entitlement-change'
+
+/**
+ * POST /api/portal/products/operator/[instance]/entitlement — the entitlement
+ * control (#2003, A&P diligence reply Q7).
+ *
+ * Form fields: routine, targetTier, reason (all required).
+ *
+ * Q7 commits ACCESS + AUDIT ("the portal gives authorized users access to...
+ * the entitlement settings... every change is logged with who made it and
+ * when"), NOT instant self-serve — that is Q6's kill-switch promise alone.
+ * So a submitted change opens a reviewable pull request against the seat's
+ * customer.yaml; merging re-projects it and the Machine adopts it at its next
+ * reprovision. Every status string this route returns says "submitted",
+ * never "applied".
+ *
+ * Enforcement chain:
+ *  1. resolveOperatorAccess — Clerk session, entity binding, live
+ *     subscription, role ∈ {principal}
+ *  2. `trust` authority domain must be client-operable AND the role matrix
+ *     must permit; unauthored authority = managed = refused (fail-closed)
+ *  3. compileTierChange — letter ceiling + vertical floor, both non-raisable
+ *  4. PR first, governance row second (never record an unopened change)
+ */
+
+const OPERATOR_LANDING = '/portal/products/operator'
+
+function redirectWithStatus(instance: string, status: string): Response {
+  return new Response(null, {
+    status: 303,
+    headers: {
+      Location: `${OPERATOR_LANDING}/${instance}/settings?status=${encodeURIComponent(status)}`,
+    },
+  })
+}
+
+export const POST: APIRoute = async ({ params, request, locals }) => {
+  const instance = typeof params.instance === 'string' ? params.instance : ''
+  if (instance === '') return new Response('Not found', { status: 404 })
+
+  const access = await resolveOperatorAccess(env.DB, locals, {
+    allowedRoles: ['principal'],
+    customerSlug: instance,
+  })
+  if (access.kind === 'redirect') return new Response('Forbidden', { status: 403 })
+
+  const config = await getCustomerConfigBySlug(env.DB, instance)
+  const mode = resolveDomainSurfaceMode(
+    config?.authority ?? null,
+    'trust',
+    clientRolePermits(access.roles, 'trust')
+  )
+  if (mode !== 'operable') return redirectWithStatus(instance, 'entitlement_not_operable')
+
+  const formData = await request.formData()
+  const field = (name: string): string => {
+    const v = formData.get(name)
+    return typeof v === 'string' ? v.trim() : ''
+  }
+  const routine = field('routine')
+  const targetTier = field('targetTier')
+  const reason = field('reason')
+  if (routine === '' || targetTier === '') {
+    return redirectWithStatus(instance, 'entitlement_invalid_request')
+  }
+  if (reason === '') return redirectWithStatus(instance, 'entitlement_reason_required')
+
+  // A Worker has no filesystem: the grid and the live exposure come from the
+  // D1 projection, and the authored TEXT comes from git at the base branch
+  // (the same bytes the PR is based on — no bundled-copy drift).
+  const resolved = resolveGridAndExposure(config)
+  if (!resolved) return redirectWithStatus(instance, 'entitlement_config_unreadable')
+
+  // Narrow the Worker env to exactly the transport's credential surface.
+  const prEnv = { OPERATOR_CONFIG_PR_TOKEN: env.OPERATOR_CONFIG_PR_TOKEN }
+
+  const outcome = await submitTierChange(
+    env.DB,
+    prEnv,
+    {
+      grid: resolved.grid,
+      live: resolved.live,
+      readYaml: () => readConfigFile(prEnv, customerYamlPath(instance)),
+      nonce: crypto.randomUUID().slice(0, 8),
+    },
+    {
+      entityId: access.client.id,
+      customerSlug: instance,
+      routine,
+      targetTier,
+      reason,
+      vertical: config?.vertical ?? null,
+      actor: { userId: access.user.id, email: access.user.email, role: 'principal' },
+      source: 'portal',
+    }
+  )
+
+  return redirectWithStatus(instance, statusFor(outcome))
+}
+
+/**
+ * Grid + live persona exposure from the projection, or null when either is
+ * absent (a seat whose grid has never been projected cannot be configured
+ * from here — refuse rather than guess).
+ */
+function resolveGridAndExposure(
+  config: Awaited<ReturnType<typeof getCustomerConfigBySlug>>
+): { grid: NonNullable<NonNullable<typeof config>['routine_grid']>; live: LiveExposure } | null {
+  const grid = config?.routine_grid ?? null
+  if (!grid) return null
+  const persona = config?.personas.find((p) => p.slug === grid.persona)
+  if (!persona) return null
+  return {
+    grid,
+    live: {
+      personaSlug: persona.slug,
+      exposure: persona.entitlements.exposure,
+    },
+  }
+}
+
+/** Outcome → status slug the settings page renders as client copy. */
+function statusFor(outcome: Awaited<ReturnType<typeof submitTierChange>>): string {
+  switch (outcome.kind) {
+    case 'submitted':
+      return 'entitlement_submitted'
+    case 'noop':
+      return 'entitlement_no_change'
+    case 'rejected':
+      return `entitlement_rejected_${outcome.rejections[0].code}`
+    default:
+      return 'entitlement_failed'
+  }
+}

--- a/src/pages/portal/products/operator/[instance]/settings/index.astro
+++ b/src/pages/portal/products/operator/[instance]/settings/index.astro
@@ -12,6 +12,7 @@ import DomainSurface from '../../../../../../components/portal/operator/DomainSu
 import { hasPortalVisibleInvoices } from '../../../../../../lib/portal/offerings'
 import { env } from 'cloudflare:workers'
 import { readPausePosture } from '../../../../../../lib/portal/operator/pause-control'
+import { liveTierOf, selectableTiers } from '../../../../../../lib/operator/entitlement-compiler'
 
 /**
  * Operator — Settings, the ACT surface (console blueprint §5, amended
@@ -68,6 +69,15 @@ const showPlanBilling = subscriptionLive || (await hasPortalVisibleInvoices(env.
 
 const RETURN_TO = `${operatorBase}/settings`
 
+// Client language for the tier vocabulary. The internal terms (flag-only /
+// prepare-and-route / auto-handle) are ours; the client reads what the level
+// DOES, in the letter's own framing.
+const TIER_LABELS: Record<string, string> = {
+  'flag-only': 'Surfaces it for you',
+  'prepare-and-route': 'Prepares it for someone to send',
+  'auto-handle': 'Handles it end to end',
+}
+
 // Connect-status banner — set by the OAuth callback / initiate on redirect.
 const status = Astro.url.searchParams.get('status')
 const reason = Astro.url.searchParams.get('reason')
@@ -107,6 +117,20 @@ function resolveBanner(status: string | null, reason: string | null): Banner | n
 // switch).
 const pausedNow = await readPausePosture(env.DB, instance ?? '')
 
+// Entitlement control (#2003 Q7): the seat's routine grid, each row with the
+// tiers it may legally be set to (compiler-derived, so the control can never
+// offer a choice the route would reject).
+const routineRows = (config?.routine_grid?.rows ?? []).map((row) => ({
+  routine: row.routine,
+  liveTier: liveTierOf(row, {
+    personaSlug: config?.routine_grid?.persona ?? '',
+    exposure: (config?.personas.find((p) => p.slug === config?.routine_grid?.persona)?.entitlements
+      .exposure ?? {}) as Record<string, string>,
+  }),
+  ceiling: row.ceiling_tier,
+  options: selectableTiers(row),
+}))
+
 const PAUSE_BANNERS: Record<string, Banner> = {
   paused: { text: 'The Operator is paused. It stays off until an admin resumes it.', tone: 'info' },
   resumed: { text: 'The Operator is resumed and running.', tone: 'success' },
@@ -120,6 +144,32 @@ const PAUSE_BANNERS: Record<string, Banner> = {
     tone: 'error',
   },
   pause_invalid_action: { text: 'Invalid pause action.', tone: 'error' },
+  entitlement_submitted: {
+    text: 'Change submitted for review. It takes effect once approved and rolled out; the record below tracks it.',
+    tone: 'success',
+  },
+  entitlement_no_change: { text: 'That routine is already set that way.', tone: 'info' },
+  entitlement_reason_required: { text: 'A reason is required to change a setting.', tone: 'error' },
+  entitlement_not_operable: {
+    text: 'Changing autonomy settings is not enabled for your account yet.',
+    tone: 'error',
+  },
+  entitlement_rejected_above_letter_ceiling: {
+    text: 'That level is above what this routine is set up to do. Changing it is a scope conversation with us, not a settings change.',
+    tone: 'error',
+  },
+  entitlement_rejected_no_graduation_path: {
+    text: 'This routine only surfaces work; it has no drafting or sending step to raise.',
+    tone: 'error',
+  },
+  entitlement_config_unreadable: {
+    text: 'We could not read this Operator configuration. Nothing was changed.',
+    tone: 'error',
+  },
+  entitlement_failed: {
+    text: 'We could not submit that change. Nothing was changed. Try again, or contact us if the problem persists.',
+    tone: 'error',
+  },
 }
 
 const banner = (status && PAUSE_BANNERS[status]) || resolveBanner(status, reason)
@@ -252,6 +302,94 @@ const SETTINGS_LINKS: ReadonlyArray<{ href: string; label: string; description: 
       </div>
     </DomainSurface>
   </section>
+
+  <!-- Autonomy per routine — the entitlement control (#2003, trust domain).
+       Operable only when the seat authors authority.trust: client AND the
+       role matrix permits. A submitted change opens a reviewable change to
+       the authored configuration; it is never applied by the click. -->
+  {
+    routineRows.length > 0 && (
+      <section class="mt-10" aria-label="Autonomy per routine">
+        <p class={sectionLabelClass}>Autonomy per routine</p>
+        <DomainSurface
+          authority={config?.authority ?? null}
+          domain="trust"
+          roles={roles}
+          returnTo={RETURN_TO}
+          domainLabel="how much each routine does on its own"
+        >
+          <div slot="operable" class={cardClass}>
+            <p class="m-0 font-body text-sm leading-snug text-[color:var(--ss-color-text-secondary)]">
+              Each routine runs at one of three levels: it can surface work, prepare it for someone
+              to send, or handle it end to end. Raising a level is submitted for review and takes
+              effect once approved and rolled out. Every change is logged with who made it and when.
+            </p>
+            <ul class="mt-4 flex flex-col gap-4 list-none p-0">
+              {routineRows.map((row) => (
+                <li class="border-t-[2px] border-[color:var(--ss-color-border-subtle)] pt-4">
+                  <p class="m-0 font-body font-bold text-[color:var(--ss-color-text-primary)]">
+                    {row.routine}
+                  </p>
+                  <form
+                    method="POST"
+                    action={`/api/portal/products/operator/${instance}/entitlement`}
+                    class="mt-2 flex flex-col gap-2 md:flex-row md:items-end"
+                  >
+                    <input type="hidden" name="routine" value={row.routine} />
+                    <label class="flex flex-col gap-1">
+                      <span class={emptyNoteClass}>Level</span>
+                      <select
+                        name="targetTier"
+                        class="border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)] px-3 py-2 font-body text-sm"
+                      >
+                        {row.options.map((tier) => (
+                          <option value={tier} selected={tier === row.liveTier}>
+                            {TIER_LABELS[tier]}
+                          </option>
+                        ))}
+                      </select>
+                    </label>
+                    <label class="flex flex-1 flex-col gap-1">
+                      <span class={emptyNoteClass}>Reason (required, kept in the log)</span>
+                      <input
+                        type="text"
+                        name="reason"
+                        required
+                        maxlength="300"
+                        class="border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)] px-3 py-2 font-body text-sm"
+                      />
+                    </label>
+                    <button
+                      type="submit"
+                      class="w-fit px-5 py-2.5 border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)] font-bold uppercase tracking-[0.08em] font-body hover:bg-[color:var(--ss-color-text-primary)] hover:text-[color:var(--ss-color-background)] transition-colors"
+                    >
+                      Submit
+                    </button>
+                  </form>
+                </li>
+              ))}
+            </ul>
+          </div>
+          <div slot="read" class={cardClass}>
+            <p class="m-0 font-body text-sm leading-snug text-[color:var(--ss-color-text-secondary)]">
+              Each routine runs at one of three levels: it can surface work, prepare it for someone
+              to send, or handle it end to end.
+            </p>
+            <ul class="mt-4 flex flex-col gap-2 list-none p-0">
+              {routineRows.map((row) => (
+                <li class="flex flex-wrap items-baseline justify-between gap-2 border-t-[2px] border-[color:var(--ss-color-border-subtle)] pt-2">
+                  <span class="font-body text-sm text-[color:var(--ss-color-text-primary)]">
+                    {row.routine}
+                  </span>
+                  <span class={emptyNoteClass}>{TIER_LABELS[row.liveTier]}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </DomainSurface>
+      </section>
+    )
+  }
 
   <!-- Plan & billing — provisioning domain: SMD-only, read-only, no request
        form. Absent entirely pre-go-live (billing-relationship gate above). -->

--- a/tests/entitlement-change.test.ts
+++ b/tests/entitlement-change.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Entitlement tier-change orchestration + governance ledger (#2003 slice 2).
+ *
+ * The invariants that matter:
+ *  - a rejected or no-op request opens NO pull request and writes NO row
+ *  - a PR failure records NOTHING (never "submitted" for a change that isn't)
+ *  - a submitted change writes exactly one row carrying the compiled delta
+ *  - status is `submitted`, never `applied` — merging + reprovision is what
+ *    applies it, and nothing here may claim otherwise
+ */
+
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+import {
+  createTestD1,
+  discoverNumericMigrations,
+  runMigrations,
+} from '@venturecrane/crane-test-harness'
+import { readFileSync } from 'fs'
+import path, { resolve } from 'path'
+import { parse as parseYaml } from 'yaml'
+import type { D1Database } from '@cloudflare/workers-types'
+import { validate } from '../src/lib/operator/customer-yaml'
+import { validateRoutineGrid, type RoutineGrid } from '../src/lib/operator/routine-grid'
+import { sendActionClassOf, type LiveExposure } from '../src/lib/operator/entitlement-compiler'
+import {
+  changeBranchName,
+  customerYamlPath,
+  listEntitlementChanges,
+  submitTierChange,
+} from '../src/lib/portal/operator/entitlement-change'
+
+const migrationsDir = path.resolve(__dirname, '../migrations')
+const AP = resolve('operator/customers/ashton-price')
+const yamlText = () => readFileSync(resolve(AP, 'customer.yaml'), 'utf-8')
+
+function grid(): RoutineGrid {
+  const r = validateRoutineGrid(parseYaml(readFileSync(resolve(AP, 'routine-grid.yaml'), 'utf-8')))
+  if (!r.ok) throw new Error('grid invalid')
+  return r.value
+}
+function live(): LiveExposure {
+  const r = validate(parseYaml(yamlText()) as Record<string, unknown>)
+  if (!r.ok) throw new Error('yaml invalid')
+  const p = r.value.personas.find((x) => x.slug === 'operator')!
+  return { personaSlug: p.slug, exposure: p.entitlements.exposure }
+}
+/** A routine that can legally graduate on this seat. */
+function graduatingRoutine(): string {
+  return grid().rows.find((r) => r.ceiling_tier === 'auto-handle' && sendActionClassOf(r))!.routine
+}
+
+const ENV = { OPERATOR_CONFIG_PR_TOKEN: 'test-token' }
+const ACTOR = { userId: 'u1', email: 'admin@firm.example', role: 'principal' }
+
+function inputFor(routine: string, targetTier: string) {
+  return {
+    entityId: 'e1',
+    customerSlug: 'ashton-price',
+    routine,
+    targetTier,
+    reason: 'firm is comfortable after clean cycles',
+    vertical: 'law-firm',
+    actor: ACTOR,
+    source: 'portal' as const,
+  }
+}
+
+function deps(nonce = 'abc123') {
+  return { grid: grid(), live: live(), readYaml: async () => yamlText(), nonce }
+}
+
+/** Mock the four GitHub calls openConfigPr makes, in order. */
+function mockGitHubOk() {
+  return vi.spyOn(globalThis, 'fetch').mockImplementation(async (url, init) => {
+    const u = String(url)
+    const method = init?.method ?? 'GET'
+    if (u.includes('/git/ref/heads/main')) {
+      return new Response(JSON.stringify({ object: { sha: 'basesha' } }), { status: 200 })
+    }
+    if (u.includes('/contents/') && method === 'GET') {
+      return new Response(JSON.stringify({ sha: 'filesha' }), { status: 200 })
+    }
+    if (u.includes('/git/refs') && method === 'POST') {
+      return new Response(JSON.stringify({}), { status: 201 })
+    }
+    if (u.includes('/contents/') && method === 'PUT') {
+      return new Response(JSON.stringify({}), { status: 200 })
+    }
+    if (u.includes('/pulls') && method === 'POST') {
+      return new Response(JSON.stringify({ html_url: 'https://github.com/pr/1', number: 1 }), {
+        status: 201,
+      })
+    }
+    return new Response('unexpected', { status: 500 })
+  })
+}
+
+describe('tier-change orchestration', () => {
+  let db: D1Database
+
+  beforeEach(async () => {
+    db = createTestD1()
+    await runMigrations(db, { files: discoverNumericMigrations(migrationsDir) })
+  })
+  afterEach(() => vi.restoreAllMocks())
+
+  it('submits a legal graduation: one PR, one row, status submitted', async () => {
+    const fetchSpy = mockGitHubOk()
+    const routine = graduatingRoutine()
+    const outcome = await submitTierChange(db, ENV, deps(), inputFor(routine, 'auto-handle'))
+
+    expect(outcome.kind).toBe('submitted')
+    if (outcome.kind !== 'submitted') return
+    expect(outcome.prUrl).toBe('https://github.com/pr/1')
+
+    const rows = await listEntitlementChanges(db, 'ashton-price')
+    expect(rows).toHaveLength(1)
+    expect(rows[0].routine).toBe(routine)
+    expect(rows[0].to_tier).toBe('auto-handle')
+    expect(rows[0].status).toBe('submitted')
+    expect(rows[0].pr_url).toBe('https://github.com/pr/1')
+    expect(rows[0].actor_email).toBe('admin@firm.example')
+
+    // The committed content carries the compiled one-line edit.
+    const put = fetchSpy.mock.calls.find(([, init]) => init?.method === 'PUT')
+    const body = JSON.parse(put![1]!.body as string) as { content: string }
+    const committed = atob(body.content)
+    expect(committed).toContain('autonomous')
+    const parsed = validate(parseYaml(committed) as Record<string, unknown>)
+    expect(parsed.ok, 'committed yaml must still validate').toBe(true)
+  })
+
+  it('a raise above the letter ceiling opens no PR and writes no row', async () => {
+    const fetchSpy = mockGitHubOk()
+    const capped = grid().rows.find(
+      (r) => r.ceiling_tier === 'prepare-and-route' && sendActionClassOf(r)
+    )!
+    const outcome = await submitTierChange(db, ENV, deps(), inputFor(capped.routine, 'auto-handle'))
+    expect(outcome.kind).toBe('rejected')
+    expect(fetchSpy).not.toHaveBeenCalled()
+    expect(await listEntitlementChanges(db, 'ashton-price')).toEqual([])
+  })
+
+  it('a no-op opens no PR and writes no row', async () => {
+    const fetchSpy = mockGitHubOk()
+    const outcome = await submitTierChange(
+      db,
+      ENV,
+      deps(),
+      inputFor(graduatingRoutine(), 'prepare-and-route')
+    )
+    expect(outcome.kind).toBe('noop')
+    expect(fetchSpy).not.toHaveBeenCalled()
+    expect(await listEntitlementChanges(db, 'ashton-price')).toEqual([])
+  })
+
+  it('a PR failure records NOTHING (never "submitted" for a change that is not)', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('boom', { status: 403 }))
+    const outcome = await submitTierChange(
+      db,
+      ENV,
+      deps(),
+      inputFor(graduatingRoutine(), 'auto-handle')
+    )
+    expect(outcome.kind).toBe('failed')
+    expect(await listEntitlementChanges(db, 'ashton-price')).toEqual([])
+  })
+
+  it('an unconfigured token fails closed, opening nothing', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch')
+    const outcome = await submitTierChange(
+      db,
+      {},
+      deps(),
+      inputFor(graduatingRoutine(), 'auto-handle')
+    )
+    expect(outcome.kind).toBe('failed')
+    if (outcome.kind !== 'failed') return
+    expect(outcome.error).toContain('not configured')
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+})
+
+describe('naming helpers', () => {
+  it('branch names are namespaced, slugified, and bounded', () => {
+    const b = changeBranchName('ashton-price', 'Client verification & records (chase)', 'n1')
+    expect(b.startsWith('operator-entitlement/ashton-price/')).toBe(true)
+    expect(b).toMatch(/^[a-z0-9/_-]+$/)
+    expect(b.endsWith('-n1')).toBe(true)
+  })
+
+  it('the config path targets the seat the change belongs to', () => {
+    expect(customerYamlPath('ashton-price')).toBe('operator/customers/ashton-price/customer.yaml')
+  })
+})

--- a/tests/exposure-yaml-edit.test.ts
+++ b/tests/exposure-yaml-edit.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Surgical exposure editing (#2003 slice 2).
+ *
+ * Run against the REAL ashton-price customer.yaml: the contract is that a
+ * client's config file survives an edit with a one-line diff and every
+ * authored comment intact. A fixture would not prove that.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { parse as parseYaml } from 'yaml'
+import { validate } from '../src/lib/operator/customer-yaml'
+import { setExposureKey } from '../src/lib/operator/exposure-yaml-edit'
+
+const AP_YAML = resolve('operator/customers/ashton-price/customer.yaml')
+const source = () => readFileSync(AP_YAML, 'utf-8')
+
+function diffLines(a: string, b: string): { added: string[]; removed: string[] } {
+  const aLines = a.split('\n')
+  const bLines = b.split('\n')
+  const added = bLines.filter((l, i) => l !== aLines[i] && !aLines.includes(l))
+  const removed = aLines.filter((l, i) => l !== bLines[i] && !bLines.includes(l))
+  return { added, removed }
+}
+
+describe('one-line diffs on a real client config', () => {
+  it('changing a value touches exactly one line and keeps every comment', () => {
+    const src = source()
+    const result = setExposureKey(src, 'operator', 'external_send_client', 'autonomous')
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.changed).toBe(true)
+
+    const { added, removed } = diffLines(src, result.text)
+    expect(added).toEqual(['        external_send_client: autonomous'])
+    expect(removed).toEqual(['        external_send_client: draft_for_review'])
+    expect(result.text.split('\n')).toHaveLength(src.split('\n').length)
+
+    // Every comment line survives byte-for-byte.
+    const comments = (t: string) => t.split('\n').filter((l) => l.trimStart().startsWith('#'))
+    expect(comments(result.text)).toEqual(comments(src))
+  })
+
+  it('the edited file still validates through the canonical validator', () => {
+    const result = setExposureKey(source(), 'operator', 'external_send_client', 'autonomous')
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    const parsed = validate(parseYaml(result.text) as Record<string, unknown>)
+    expect(parsed.ok).toBe(true)
+    if (!parsed.ok) return
+    const persona = parsed.value.personas.find((p) => p.slug === 'operator')
+    expect(persona?.entitlements.exposure['external_send_client']).toBe('autonomous')
+  })
+
+  it('adding a new key appends one line inside the block', () => {
+    const src = source()
+    const result = setExposureKey(src, 'operator', 'destructive', 'draft_for_review')
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.text.split('\n')).toHaveLength(src.split('\n').length + 1)
+    const parsed = validate(parseYaml(result.text) as Record<string, unknown>)
+    expect(parsed.ok).toBe(true)
+    if (!parsed.ok) return
+    expect(
+      parsed.value.personas.find((p) => p.slug === 'operator')?.entitlements.exposure['destructive']
+    ).toBe('draft_for_review')
+  })
+
+  it('removing a key (fail-closed) drops exactly that line', () => {
+    const src = source()
+    const result = setExposureKey(src, 'operator', 'external_send_vendor', null)
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.text.split('\n')).toHaveLength(src.split('\n').length - 1)
+    const parsed = validate(parseYaml(result.text) as Record<string, unknown>)
+    expect(parsed.ok).toBe(true)
+    if (!parsed.ok) return
+    expect(
+      parsed.value.personas.find((p) => p.slug === 'operator')?.entitlements.exposure[
+        'external_send_vendor'
+      ]
+    ).toBeUndefined()
+  })
+})
+
+describe('no-ops and refusals', () => {
+  it('setting a key to its current value is a no-op, not a diff', () => {
+    const src = source()
+    const result = setExposureKey(src, 'operator', 'external_send_client', 'draft_for_review')
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.changed).toBe(false)
+    expect(result.text).toBe(src)
+  })
+
+  it('removing an absent key is a no-op', () => {
+    const src = source()
+    const result = setExposureKey(src, 'operator', 'code_execution', null)
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.changed).toBe(false)
+    expect(result.text).toBe(src)
+  })
+
+  it('refuses an unknown persona rather than editing the wrong block', () => {
+    const result = setExposureKey(source(), 'not-a-persona', 'external_send', 'autonomous')
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.error).toContain('not found')
+  })
+
+  it('refuses unsafe key/value shapes (no YAML injection through the edit path)', () => {
+    for (const key of ['external_send\nrogue: x', 'a b', 'KEY', '']) {
+      expect(setExposureKey(source(), 'operator', key, 'autonomous').ok).toBe(false)
+    }
+    for (const value of ['autonomous\n      rogue: x', 'a b', '{}', '']) {
+      expect(setExposureKey(source(), 'operator', 'external_send', value).ok).toBe(false)
+    }
+  })
+
+  it('edits only the addressed persona (multi-persona safety)', () => {
+    const twoPersonas = source().replace(
+      /^personas:$/m,
+      'personas:\n  - slug: decoy\n    status: archived\n    name: Decoy\n    tone: [plain]\n    entitlements:\n      exposure:\n        external_send: autonomous\n    skills: []\n'
+    )
+    const result = setExposureKey(twoPersonas, 'operator', 'external_send', 'autonomous')
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    // The decoy's identical key is untouched: exactly one line changed overall.
+    const changedCount = result.text
+      .split('\n')
+      .filter((l, i) => l !== twoPersonas.split('\n')[i]).length
+    expect(changedCount).toBe(1)
+  })
+})


### PR DESCRIPTION
## Slice 2: the delivery leg, built as approved

Captain decision 2026-07-27: the change must be **real** (ADR 0069 Lock 3 — intent-only is not done) and persisted to the **source of truth** (ADR 0012 — git; ADR 0044's live-apply is reverted), while the all-changes-through-PRs rule keeps a human between a client click and the default branch.

**One governed path:** compile (letter ceiling + vertical floor, both non-raisable) → surgical `customer.yaml` edit → reviewable pull request → governance row. **Remote-first, record-second**: a change whose PR did not open is never recorded as submitted — the same ordering the pause control uses.

## Pieces

- **`exposure-yaml-edit.ts`** — surgical line-level editing. A `yaml` Document round-trip was measured at **383 changed lines** on the A&P seat and drops the comments carrying *why* each entitlement is authored (the reviewer's whole context). This produces a **one-line diff per key**, refuses unsafe key/value shapes, and edits only the addressed persona (multi-persona test included).
- **`config-pr.ts`** — GitHub transport behind **`OPERATOR_CONFIG_PR_TOKEN`**: a fine-grained token scoped to this repo with `contents: write` + `pull_requests: write` only. Deliberately **not** the fleet `GH_TOKEN` — it sits in a client-reachable path, so blast radius is bounded to opening a PR on one repo, and branch protection keeps it off `main`. Unset = fail closed, no degraded mode. Documented in the secrets handbook.
- **`entitlement-change.ts`** + **migration 0097** — orchestration and the `operator_entitlement_changes` ledger. Status is **`submitted`, never `applied`** — merging re-projects and the Machine adopts at next reprovision; no surface may claim otherwise.
- **Portal route + settings control** on the `trust` authority domain. Options come from `selectableTiers()`, so the control cannot offer a choice the compiler would reject. Tier labels are client language ("Prepares it for someone to send"); the internal vocabulary stays ours.

## Platform honesty

A Worker has no filesystem, so the grid + live exposure come from the **D1 projection** and the authored **text comes from git at the base branch** — the same bytes the PR is based on, so there's no bundled-copy drift. (First cut used `readFileSync`; caught and replaced.)

## Scope trace

Letter 10 Q7 commits *access + audit* — "the portal gives authorized users access to... the entitlement settings... every change is logged with who made it and when." It does **not** promise instant self-serve; that is Q6's kill-switch promise alone. The client-facing copy says submitted-for-review and means it.

## Verification

`npm run verify` exit 0; operator substrate 299/299; new suites 16/16 (surgical-edit incl. one-line-diff + comment-preservation + validator-clean against the real client config; orchestration incl. rejected/no-op/PR-failure/unconfigured all opening nothing and recording nothing); handbook integrity green.

## Before it can be used

`OPERATOR_CONFIG_PR_TOKEN` must be minted and vaulted (fine-grained, this repo, contents+PR write). Until then the control fails closed — correct posture, and the honest state to leave it in.

Part of #2003.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUsHocWqwBUbqpm8sjGFZY