### PR TITLE
docs(ap): voice samples are read in place, never handed over — align plan with letters 07/10 (#2036)

### DIFF
--- a/operator/customers/ashton-price/IMPLEMENTATION-PLAN.md
+++ b/operator/customers/ashton-price/IMPLEMENTATION-PLAN.md
@@ -187,12 +187,19 @@ principal) to correct the model and lock what only the firm can give:
    meeting; sets motion/response orchestration.
 6. **Voice samples** — ~30 firm-authored letters/templates (the ADR 0028
    anchor-pack size) into the voice library, so Layer 2 has a real corpus to
-   transform toward instead of the general fallback. Christa provides the
-   samples; we ingest them through the leak-guarded differ
+   transform toward instead of the general fallback. The firm never
+   assembles or provides documents (letter 07 "Getting set up": "You do not
+   need to send us anything"; letter 10 item 4: "We don't keep a copy of
+   your matter files"). Christa points at sample matters, letters, or
+   folders in Smokeball (or the firm's directory); we read each document in
+   place through the authorized connector and pass the text transiently
+   through the leak-guarded differ
    (`operator/bin/voice-ingest-corpus.py`) to content-free structural-diff
-   cohort JSONs in the seat vault — raw letter text never lands in the vault
-   or logs. The portal self-serve upload path (#1851) is a later
-   convenience; at onboarding we ingest the pack directly.
+   cohort JSONs in the seat vault — raw letter text is discarded after
+   extraction and never lands in the vault, logs, or any SMD store. The
+   Smokeball-fetch front end for the differ is #2036; the portal
+   self-serve upload path (#1851) is a later convenience for firms without
+   a readable document source.
 7. **Monitored-inbox decision** — owned address vs forwarding vs Graph watch
    (feeds M6).
 8. **Starting matter set** — which live matters observation watches first.
@@ -347,7 +354,7 @@ is the artifact to speak from (in its client-facing shape,
 | 4   | Markup + 7 proposal questions                                                                                                   | Christa          | Lane final shapes                                                                                                       |
 | 5   | Deadline-fork answer                                                                                                            | Christa          | Deadline-lane shape                                                                                                     |
 | 6   | CoCounsel division (post-TR meeting)                                                                                            | Christa          | Motion/response lane                                                                                                    |
-| 7   | Voice samples (letters/templates)                                                                                               | Christa          | Firm-voice drafting                                                                                                     |
+| 7   | Voice-sample pointers (which matters/letters to read in Smokeball; no documents handed over)                                    | Christa          | Firm-voice drafting                                                                                                     |
 | 8   | Inbox decision + M365 admin consent                                                                                             | Christa + IT     | M6                                                                                                                      |
 | 9   | Starting matter set                                                                                                             | Christa          | M4 shadow scope                                                                                                         |
 | 10  | Lifecycle sign-off (per-lane acceptance)                                                                                        | Chris + Christa  | Gate (a) → M5+                                                                                                          |

--- a/operator/customers/ashton-price/dossier.md
+++ b/operator/customers/ashton-price/dossier.md
@@ -37,6 +37,7 @@ Closed facts an agent relies on without comment. Surfacing any of these as a fla
 
 - **The stand-up waiver.** Rationale recorded in Commercial rationale above, Captain-confirmed 2026-07-26. Letter 10 states the waiver in one clause without justification by design; the omission is the approved posture, not a gap. Needs no comment in any review.
 - **Claude direct access.** A deliverable Chris himself requested; we built it and we provide it. The firm's own Claude Enterprise account carries the seats; SMD sets up and maintains the access for the people the firm chooses. Letter 10's wording is correct as written. The 07-26 account fact creates no tension with the 07-24 approval.
+- **Voice-sample sourcing.** The firm never assembles or hands over documents (letter 07 "Getting set up": "You do not need to send us anything"; letter 10 item 4: "We don't keep a copy of your matter files"). Christa at most points at specific matters, letters, or folders; we read them in place through the authorized connector and persist only content-free structural fingerprints. Any plan or issue language asking the firm to "provide samples" is drift from the sent commitment — it re-triggered her retention/destruction concerns once (letter 09 cycle) and must not resurface. Build item: #2036. (Captain re-affirmed 2026-07-27.)
 
 ## Firm research
 


### PR DESCRIPTION
## What

Corrects the A&P implementation plan's voice-sample sourcing to match the sent client commitment, and records the posture as a settled item in the dossier.

- **IMPLEMENTATION-PLAN step 6**: "Christa provides the samples" → Christa points at sample matters/letters/folders in Smokeball; we read each document in place through the authorized connector; only content-free structural fingerprints persist. Build item cited: #2036.
- **IMPLEMENTATION-PLAN prerequisite 7**: deliverable from Christa is now pointers, not documents.
- **dossier.md**: new settled-item line so the "firm provides documents" framing cannot resurface (it re-triggered Christa's retention/destruction concerns in the letter 09 cycle).

## Why

Letters 07 ("Getting set up": "You do not need to send us anything… We do not take a separate copy of your files to keep") and 10 (item 4: "We don't keep a copy of your matter files") are the sent, binding posture. The plan language predated letter 07 and was never reconciled. Captain re-affirmed the alignment 2026-07-27 (this session).

Related: #2036 (Smokeball-fetch ingestion front end, filed this session), #1851 (scope correction commented).

## Verification

- `npm run verify` green locally (and re-run by the pre-push hook).
- Docs-only change; no runtime seams.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0128md6aGuTrPyck5EJ8AfUH