### PR TITLE
feat(voice): read-in-place bridge — named matter documents to voice corpus

### DIFF
--- a/operator/bin/tests/test_voice_fetch_corpus.py
+++ b/operator/bin/tests/test_voice_fetch_corpus.py
@@ -1,0 +1,285 @@
+"""Tests for bin/voice-fetch-corpus.py — the read-in-place bridge.
+
+Covers the four things that make this path safe and traceable:
+
+* Ambiguity is REFUSED, never guessed — a name matching several matters or
+  files raises with the candidates named, which is the same posture the
+  Operator takes when it cannot match a matter cleanly.
+* Cohorts are validated against the seat's authored vocabulary BEFORE any
+  fetch, so a typo cannot mint an orphan vault directory no loader reads.
+* The emitted JSONL is exactly what the (untouched) ingester consumes, split
+  one file per cohort, and provenance ties every fingerprint-to-be back to
+  the document it came from.
+* The markdown adapter strips frontmatter and EXCLUDES unmapped audiences
+  rather than defaulting them into the wrong cohort.
+
+Run::
+
+    cd operator && python -m pytest bin/tests/test_voice_fetch_corpus.py -v
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_HERE = Path(__file__).resolve()
+_OPERATOR = _HERE.parents[2]
+sys.path.insert(0, str(_OPERATOR))
+
+# The script is hyphenated (a CLI, not a module), so load it by path.
+_spec = importlib.util.spec_from_file_location(
+    "voice_fetch_corpus", _OPERATOR / "bin" / "voice-fetch-corpus.py"
+)
+assert _spec and _spec.loader
+vfc = importlib.util.module_from_spec(_spec)
+# Register before exec: @dataclass resolves its class's module out of
+# sys.modules, and a spec-loaded module that is not registered makes that
+# lookup return None (AttributeError at import time on 3.12+).
+sys.modules["voice_fetch_corpus"] = vfc
+_spec.loader.exec_module(vfc)
+
+
+# ---------------------------------------------------------------------------
+# Refusal posture
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_one_matches_by_id_exactly():
+    cands = [{"id": "m-1", "name": "Nakashima v. Cornerstone"}, {"id": "m-2", "name": "Boyle"}]
+    got = vfc.resolve_one(cands, "m-2", id_key="id", name_keys=("name",), kind="matter")
+    assert got["id"] == "m-2"
+
+
+def test_resolve_one_matches_by_case_insensitive_substring():
+    cands = [{"id": "m-1", "name": "Nakashima v. Cornerstone Market Holdings, LLC"}]
+    got = vfc.resolve_one(cands, "nakashima", id_key="id", name_keys=("name",), kind="matter")
+    assert got["id"] == "m-1"
+
+
+def test_ambiguous_name_refuses_and_names_candidates():
+    cands = [
+        {"id": "f-1", "name": "Client status letter June"},
+        {"id": "f-2", "name": "Client status letter August"},
+    ]
+    with pytest.raises(vfc.ResolutionError) as exc:
+        vfc.resolve_one(cands, "client status", id_key="id", name_keys=("name",), kind="file")
+    msg = str(exc.value)
+    assert "refusing to guess" in msg
+    assert "June" in msg and "August" in msg  # candidates named, so the caller can be specific
+
+
+def test_no_match_refuses():
+    cands = [{"id": "m-1", "name": "Boyle"}]
+    with pytest.raises(vfc.ResolutionError):
+        vfc.resolve_one(cands, "nakashima", id_key="id", name_keys=("name",), kind="matter")
+
+
+# ---------------------------------------------------------------------------
+# Cohort vocabulary
+# ---------------------------------------------------------------------------
+
+
+def test_unauthored_cohort_is_rejected_before_any_fetch():
+    entries = [vfc.ManifestEntry(matter="X", file="Y", cohort="adjustor")]  # typo
+    with pytest.raises(ValueError) as exc:
+        vfc.validate_cohorts(entries, vfc.BASE_COHORTS)
+    assert "adjustor" in str(exc.value)
+
+
+def test_authored_cohorts_replace_the_base_vocabulary(tmp_path: Path):
+    """Mirrors resolveCohortVocabulary: an authored list REPLACES the base set."""
+    yaml_path = tmp_path / "customer.yaml"
+    yaml_path.write_text(
+        "customer_id: pilot\n"
+        "voice_cohorts:\n"
+        "  cohorts:\n"
+        "    - client\n"
+        "    - adjuster       # comment tolerated\n"
+        "    - opposing-counsel\n"
+        "  min_samples_per_cohort: 5\n"
+        "memory:\n"
+        "  d1_namespace: pilot\n",
+        encoding="utf-8",
+    )
+    vocab = vfc.load_cohort_vocabulary(str(yaml_path))
+    assert vocab == frozenset({"client", "adjuster", "opposing-counsel"})
+    assert "court" not in vocab  # base member NOT authored -> not in the vocabulary
+    vfc.validate_cohorts([vfc.ManifestEntry("m", "f", "adjuster")], vocab)  # no raise
+    with pytest.raises(ValueError):
+        vfc.validate_cohorts([vfc.ManifestEntry("m", "f", "court")], vocab)
+
+
+def test_no_customer_yaml_falls_back_to_base_vocabulary():
+    assert vfc.load_cohort_vocabulary(None) == vfc.BASE_COHORTS
+
+
+# ---------------------------------------------------------------------------
+# Fetch (mocked client — no live calls in CI)
+# ---------------------------------------------------------------------------
+
+
+_DOCX_TEXT = b"Dear Errol,\n\nThe demand went out May 12.\n\nYours,\nLuisa"
+
+
+class _FakeClient:
+    """Minimal stand-in exposing the two methods the bridge uses."""
+
+    def __init__(self, matters, files, blob=_DOCX_TEXT):
+        self._matters = matters
+        self._files = files
+        self._blob = blob
+        self.downloaded: list[tuple[str, str]] = []
+
+    def get(self, path, **params):
+        if path == "/matters":
+            return {"value": self._matters}
+        return {"value": self._files}
+
+    def download_file(self, matter_id, file_id):
+        self.downloaded.append((matter_id, file_id))
+        return ({"name": "status.txt", "fileExtension": "txt"}, self._blob)
+
+
+def test_fetch_entries_resolves_downloads_and_extracts():
+    client = _FakeClient(
+        matters=[{"id": "m-1", "name": "Nakashima v. Cornerstone"}],
+        files=[{"id": "f-9", "name": "Client status letter June 8"}],
+    )
+    docs = vfc.fetch_entries(
+        [vfc.ManifestEntry(matter="Nakashima", file="Client status", cohort="client")],
+        client,
+    )
+    assert len(docs) == 1
+    d = docs[0]
+    assert client.downloaded == [("m-1", "f-9")]
+    assert "The demand went out May 12." in d.text
+    assert d.cohort == "client"
+    assert d.source == "smokeball:m-1/f-9"
+    assert d.matter_name == "Nakashima v. Cornerstone"
+
+
+def test_empty_extraction_refuses_rather_than_emitting_an_empty_sample():
+    client = _FakeClient(
+        matters=[{"id": "m-1", "name": "Boyle"}],
+        files=[{"id": "f-1", "name": "scan"}],
+        blob=b"   \n  ",
+    )
+    with pytest.raises(vfc.ResolutionError) as exc:
+        vfc.fetch_entries([vfc.ManifestEntry("Boyle", "scan", "client")], client)
+    assert "manual review" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# Markdown adapter
+# ---------------------------------------------------------------------------
+
+
+def _write_md(path: Path, audience: str, body: str) -> None:
+    path.write_text(
+        f"---\nsample_id: 04\ndoc_type: client_status_letter\n"
+        f"audience: {audience}\nmatter: Nakashima\nsynthetic: true\n---\n\n{body}\n",
+        encoding="utf-8",
+    )
+
+
+def test_strip_frontmatter_splits_fields_and_body(tmp_path: Path):
+    f = tmp_path / "04.md"
+    _write_md(f, "client (post-demand, pre-suit)", "Dear Errol,\n\nHere is where things stand.")
+    fields, body = vfc.strip_frontmatter(f.read_text(encoding="utf-8"))
+    assert fields["audience"].startswith("client")
+    assert fields["sample_id"] == "04"
+    assert body.startswith("Dear Errol,")
+    assert "---" not in body
+
+
+def test_audience_map_routes_by_prefix_and_excludes_unmapped(tmp_path: Path):
+    _write_md(tmp_path / "04.md", "client (post-demand, pre-suit)", "Dear Errol, one.")
+    _write_md(tmp_path / "01.md", "claims adjuster (commercial auto)", "Dear Adjuster, two.")
+    _write_md(tmp_path / "08.md", "neutral (mediator)", "Statement of facts, three.")
+    docs = vfc.load_markdown_dir(
+        str(tmp_path),
+        cohort="unassigned",
+        audience_map={"client": "client", "claims adjuster": "adjuster"},
+    )
+    cohorts = sorted(d.cohort for d in docs)
+    assert cohorts == ["adjuster", "client"]  # the mediator sample is EXCLUDED, not defaulted
+
+
+def test_frontmatterless_file_still_yields_its_body(tmp_path: Path):
+    f = tmp_path / "plain.md"
+    f.write_text("Dear Errol,\n\nNo frontmatter here.", encoding="utf-8")
+    docs = vfc.load_markdown_dir(str(f), cohort="client")
+    assert len(docs) == 1 and docs[0].text.startswith("Dear Errol,")
+
+
+# ---------------------------------------------------------------------------
+# Output contract (what the ingester consumes) + provenance
+# ---------------------------------------------------------------------------
+
+
+def test_write_corpus_splits_per_cohort_in_ingester_format(tmp_path: Path):
+    docs = [
+        vfc.FetchedDoc("id-1", "client", "Dear Errol, one.", "Nakashima", "m-1", "a.docx", "f-1", "smokeball:m-1/f-1"),
+        vfc.FetchedDoc("id-2", "client", "Dear Marguerite, two.", "Boyle", "m-2", "b.docx", "f-2", "smokeball:m-2/f-2"),
+        vfc.FetchedDoc("id-3", "adjuster", "Dear Adjuster, three.", "Duarte", "m-3", "c.docx", "f-3", "smokeball:m-3/f-3"),
+    ]
+    written = vfc.write_corpus(docs, str(tmp_path / "corpus.jsonl"))
+    assert set(written) == {"client", "adjuster"}
+
+    rows = [json.loads(ln) for ln in Path(written["client"]).read_text().splitlines() if ln.strip()]
+    assert len(rows) == 2
+    # The ingester reads `text` only, but id/source must be present for review.
+    assert set(rows[0]) == {"id", "source", "text"}
+    assert rows[0]["text"] == "Dear Errol, one."
+
+
+def test_provenance_ties_documents_to_corpus_ids(tmp_path: Path):
+    docs = [
+        vfc.FetchedDoc("id-1", "client", "Dear Errol.", "Nakashima", "m-1", "june.docx", "f-1", "smokeball:m-1/f-1")
+    ]
+    written = vfc.write_corpus(docs, str(tmp_path / "corpus.jsonl"))
+    prov_path = tmp_path / "prov.json"
+    vfc.write_provenance(docs, str(prov_path), written)
+    prov = json.loads(prov_path.read_text())
+    entry = prov["documents"][0]
+    assert entry["corpus_id"] == "id-1"
+    assert entry["file_name"] == "june.docx"
+    assert entry["matter_id"] == "m-1"
+    assert entry["chars"] == len("Dear Errol.")
+    assert prov["corpus_files"]["client"].endswith("corpus.client.jsonl")
+
+
+# ---------------------------------------------------------------------------
+# End of the bridge: the emitted corpus survives the real ingester's guard
+# ---------------------------------------------------------------------------
+
+
+def test_emitted_corpus_feeds_the_real_ingester_leak_guard(tmp_path: Path):
+    """The bridge's output must produce content-free samples through the REAL
+    differ + leak invariant — the join this whole script exists to make."""
+    from bin.lib.voice_corpus import build_sample
+
+    docs = [
+        vfc.FetchedDoc(
+            "id-1",
+            "client",
+            "Dear Errol,\n\nThe demand went out May 12. Bayline has it.\n\nYours,\nLuisa",
+            "Nakashima",
+            "m-1",
+            "june.docx",
+            "f-1",
+            "smokeball:m-1/f-1",
+        )
+    ]
+    written = vfc.write_corpus(docs, str(tmp_path / "corpus.jsonl"))
+    row = json.loads(Path(written["client"]).read_text().splitlines()[0])
+    sample = build_sample(row["text"], slug="pilot-smokeball", cohort="client")
+    assert sample.r2_key.startswith("vaults/pilot-smokeball/voice/cohort/client/")
+    blob = sample.diff_bytes.decode()
+    for leaked in ("Errol", "Bayline", "Luisa", "demand"):
+        assert leaked not in blob

--- a/operator/bin/voice-fetch-corpus.py
+++ b/operator/bin/voice-fetch-corpus.py
@@ -1,0 +1,588 @@
+#!/usr/bin/env python3
+"""Fetch named matter documents into a voice corpus JSONL (the read-in-place bridge).
+
+The missing link in the voice chain. The ingester
+(``bin/voice-ingest-corpus.py``) turns a corpus JSONL into content-free
+structural-diff samples, and the Smokeball connector can read a matter
+document's text (``client.download_file`` + ``extract.extract_text``), but
+nothing joined the two: there was no path from "the documents the firm points
+at" to a corpus the ingester accepts. This script is that path.
+
+The client commitment it serves (A&P letters 07/10): the firm never assembles
+or hands over writing samples. They NAME documents on their matters in plain
+English; we read them IN PLACE through the already-authorized connector. This
+script mechanizes exactly that naming step and nothing more.
+
+Two input modes
+---------------
+
+``--manifest FILE.yaml`` (the real path)
+    A list of ``{matter, file, cohort}`` entries. ``matter`` and ``file`` are
+    plain-English names (substring, case-insensitive) or ids. Each entry is
+    resolved against the live account, downloaded, and text-extracted.
+
+``--from-md DIR`` (the adapter)
+    Strips YAML frontmatter from repo-side markdown corpora and emits their
+    bodies. CI-testable and useful for fixtures; it is NOT a substitute for
+    the fetch path when proving the chain, because extraction output (PDF and
+    DOCX prose) differs materially from clean markdown.
+
+Refusal posture
+---------------
+
+A name that matches more than one matter or more than one file is NOT
+guessed. The script lists the candidates and exits non-zero, the same posture
+the Operator itself takes when a matter cannot be matched cleanly.
+
+Cohorts are validated against the seat's authored ``voice_cohorts`` vocabulary
+(``--customer-yaml``) before anything is fetched, so a typo cannot mint an
+orphan cohort directory in the vault that no profile loader will ever read.
+
+Provenance
+----------
+
+The ingester keys every emitted sample by a fresh uuid and drops the corpus
+``id``/``source`` fields, so a fingerprint in R2 cannot otherwise be tied back
+to the document it came from. ``--provenance FILE.json`` records the mapping
+(document -> corpus id, matter, file id, cohort, char count) locally so a
+verification artifact can state exactly which documents produced which
+samples.
+
+Usage::
+
+    cd operator
+    # 1. fetch (writes one JSONL per cohort next to --out)
+    infisical run --env=prod --path=/ss -- \\
+      python bin/voice-fetch-corpus.py --manifest /tmp/exemplars.yaml \\
+        --customer-yaml customers/pilot-smokeball/customer.yaml \\
+        --out /tmp/corpus.jsonl --provenance /tmp/provenance.json
+    # 2. ingest each cohort file (unmodified ingester)
+    python bin/voice-ingest-corpus.py --corpus /tmp/corpus.client.jsonl \\
+      --slug pilot-smokeball --cohort client --r2
+
+Manifest format::
+
+    entries:
+      - matter: Nakashima            # substring of the matter name, or a matter id
+        file: client status June     # substring of the file name, or a file id
+        cohort: client
+      - matter: Boyle
+        file: deposition prep letter
+        cohort: client
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable
+
+_HERE = Path(__file__).resolve()
+_OPERATOR = _HERE.parents[1]
+sys.path.insert(0, str(_OPERATOR))  # operator/ on sys.path
+# The Smokeball connector is a standalone installable package; put its source
+# root on the path so the REAL text extractor is reachable without installing
+# it. `smokeball_connector.extract` imports only stdlib at module level (PDF and
+# DOCX deps load lazily inside their branches), so this stays importable in a
+# bare pytest venv and the CI suite exercises the same extractor the agent uses.
+sys.path.insert(0, str(_OPERATOR / "connectors" / "smokeball"))
+
+
+class ResolutionError(Exception):
+    """A name matched zero or several candidates. Never resolved by guessing."""
+
+
+# ---------------------------------------------------------------------------
+# Cohort vocabulary (authored, not inferred)
+# ---------------------------------------------------------------------------
+
+# The vocabulary a seat accepts when it authors no `voice_cohorts:` block
+# (mirrors BASE_VOICE_COHORTS in src/lib/operator/customer-yaml/types.ts).
+BASE_COHORTS = frozenset({"client", "opposing-counsel", "court", "internal"})
+
+
+def load_cohort_vocabulary(customer_yaml: str | None) -> frozenset[str]:
+    """Read the seat's resolved cohort vocabulary.
+
+    Mirrors ``resolveCohortVocabulary`` (sections-voice.ts): an authored
+    ``voice_cohorts.cohorts`` list REPLACES the base vocabulary rather than
+    extending it, so a seat that authors the block must list every cohort it
+    intends to use. Absence means the base set.
+
+    Parsing is deliberately narrow — the flat slug list only. The console-side
+    validator owns the real schema; this is a pre-flight guard so a typo fails
+    before a fetch, not a competing validator.
+    """
+    if not customer_yaml:
+        return BASE_COHORTS
+    text = Path(customer_yaml).read_text(encoding="utf-8")
+    authored: list[str] = []
+    in_block = False
+    in_list = False
+    for line in text.splitlines():
+        if re.match(r"^voice_cohorts:\s*$", line):
+            in_block = True
+            continue
+        if not in_block:
+            continue
+        if line.strip() and not line.startswith((" ", "\t")):
+            break  # dedented to the next top-level key
+        if re.match(r"^\s+cohorts:\s*$", line):
+            in_list = True
+            continue
+        if in_list:
+            m = re.match(r"^\s*-\s*['\"]?([a-z0-9][a-z0-9-]{0,31})['\"]?\s*(?:#.*)?$", line)
+            if m:
+                authored.append(m.group(1))
+            elif line.strip() and not line.lstrip().startswith("#"):
+                in_list = False  # a sibling key (min_samples_per_cohort, etc.)
+    return frozenset(authored) if authored else BASE_COHORTS
+
+
+# ---------------------------------------------------------------------------
+# Manifest
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ManifestEntry:
+    matter: str
+    file: str
+    cohort: str
+
+
+def load_manifest(path: str) -> list[ManifestEntry]:
+    """Parse the manifest. YAML if PyYAML is importable, else JSON."""
+    raw = Path(path).read_text(encoding="utf-8")
+    data: Any
+    try:
+        import yaml  # type: ignore
+
+        data = yaml.safe_load(raw)
+    except ImportError:  # pragma: no cover - environment-dependent
+        data = json.loads(raw)
+    entries = data.get("entries") if isinstance(data, dict) else data
+    if not isinstance(entries, list) or not entries:
+        raise ValueError(f"{path}: no `entries` list found")
+    out: list[ManifestEntry] = []
+    for i, e in enumerate(entries):
+        if not isinstance(e, dict):
+            raise ValueError(f"{path}: entry {i} is not a mapping")
+        missing = [k for k in ("matter", "file", "cohort") if not e.get(k)]
+        if missing:
+            raise ValueError(f"{path}: entry {i} missing {', '.join(missing)}")
+        out.append(
+            ManifestEntry(
+                matter=str(e["matter"]), file=str(e["file"]), cohort=str(e["cohort"])
+            )
+        )
+    return out
+
+
+def validate_cohorts(
+    entries: Iterable[ManifestEntry], vocabulary: frozenset[str]
+) -> None:
+    """Fail before any fetch if a manifest names a cohort the seat has not authored."""
+    unknown = sorted({e.cohort for e in entries if e.cohort not in vocabulary})
+    if unknown:
+        raise ValueError(
+            f"cohort(s) {unknown} are not in the seat's authored vocabulary "
+            f"{sorted(vocabulary)}. Author them in customer.yaml `voice_cohorts:` "
+            "first — an unauthored cohort writes samples to a vault path no "
+            "profile loader reads."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Name resolution (refuses ambiguity)
+# ---------------------------------------------------------------------------
+
+
+def _items(resp: Any) -> list[dict]:
+    """Smokeball list responses nest under `value`/`items`/`results` by endpoint."""
+    if isinstance(resp, list):
+        return [r for r in resp if isinstance(r, dict)]
+    if isinstance(resp, dict):
+        for key in ("value", "items", "results", "data", "matters", "files"):
+            v = resp.get(key)
+            if isinstance(v, list):
+                return [r for r in v if isinstance(r, dict)]
+    return []
+
+
+def _label(rec: dict, keys: tuple[str, ...]) -> str:
+    for k in keys:
+        v = rec.get(k)
+        if isinstance(v, str) and v.strip():
+            return v
+    return ""
+
+
+def resolve_one(
+    candidates: list[dict],
+    needle: str,
+    *,
+    id_key: str,
+    name_keys: tuple[str, ...],
+    kind: str,
+) -> dict:
+    """Match exactly one candidate by id or case-insensitive name substring.
+
+    Never guesses. Zero matches and several matches are both errors, and the
+    several-matches error names the candidates so the caller can be specific.
+    """
+    for c in candidates:
+        if str(c.get(id_key, "")).strip() == needle.strip():
+            return c
+    n = needle.strip().lower()
+    hits = [c for c in candidates if n in _label(c, name_keys).lower()]
+    if len(hits) == 1:
+        return hits[0]
+    if not hits:
+        raise ResolutionError(
+            f"no {kind} matches {needle!r}. "
+            f"Available: {[_label(c, name_keys) for c in candidates][:12]}"
+        )
+    raise ResolutionError(
+        f"{needle!r} matches {len(hits)} {kind}s — refusing to guess. "
+        f"Candidates: {[_label(c, name_keys) for c in hits]}. "
+        "Name it more specifically (or pass the id)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Letter normalization (corpus hygiene before the differ sees the text)
+# ---------------------------------------------------------------------------
+
+# The differ classifies the greeting from the FIRST line and the signoff from
+# the LAST THREE non-empty lines (adapter/voice/diff.py :: _classify_greeting,
+# _classify_signoff) — correct for the email bodies it was built on. A law
+# firm's exemplars are LETTERS: letterhead, address block, date, and RE: line
+# sit above the salutation, and a contact block sits below the closer. Feed one
+# in raw and both classifiers return `none`, so the profile loses the two
+# fields the transform actually rewrites (verified on the rehearsal corpus
+# 2026-07-30: all five client samples came back greeting_style=none,
+# signoff_style=none).
+#
+# So the corpus step trims a letter to its voice-bearing body, the same way the
+# differ internally strips quoted replies from an email. Conservative by
+# construction: if no salutation or no closer is recognized, that end is left
+# exactly as it was rather than guessed at.
+
+_SALUTATION_RE = re.compile(
+    r"^\**\s*(dear|hi|hello|hey|good (morning|afternoon|evening))\b", re.I
+)
+_CLOSER_RE = re.compile(
+    r"^\**\s*(yours|sincerely|best|thanks|thank you|regards|warm(ly| regards)|"
+    r"cordially|respectfully|very truly yours)\b[\s,.]*\**\s*$",
+    re.I,
+)
+# How far in to look. A letterhead + address block + date + RE: line runs well
+# under 40 lines; scanning further would risk catching a "Dear" inside quoted
+# body text.
+_SALUTATION_SCAN_LINES = 40
+_CLOSER_SCAN_LINES = 15
+# Lines kept after the closer: the differ's own signoff window is the last
+# three non-empty lines, so keeping the printed-name line preserves the
+# NAMED/INITIAL fallback without dragging the contact block back in.
+_LINES_AFTER_CLOSER = 1
+
+
+def normalize_letter(text: str) -> str:
+    """Trim a letter document to the prose between salutation and closer.
+
+    Returns the text unchanged when neither marker is found — an unrecognized
+    shape is left alone rather than truncated on a guess.
+    """
+    lines = text.splitlines()
+    start = 0
+    for i, line in enumerate(lines[:_SALUTATION_SCAN_LINES]):
+        if _SALUTATION_RE.match(line.strip()):
+            start = i
+            break
+
+    end = len(lines)
+    tail_start = max(start, len(lines) - _CLOSER_SCAN_LINES)
+    for j in range(len(lines) - 1, tail_start - 1, -1):
+        if _CLOSER_RE.match(lines[j].strip()):
+            # Keep the closer plus the printed-name line that follows it.
+            kept = 0
+            k = j + 1
+            while k < len(lines) and kept < _LINES_AFTER_CLOSER:
+                if lines[k].strip():
+                    kept += 1
+                k += 1
+            end = k
+            break
+
+    trimmed = "\n".join(lines[start:end]).strip()
+    return trimmed or text.strip()
+
+
+# ---------------------------------------------------------------------------
+# Fetch
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FetchedDoc:
+    corpus_id: str
+    cohort: str
+    text: str
+    matter_name: str
+    matter_id: str
+    file_name: str
+    file_id: str
+    source: str = field(default="")
+
+
+def fetch_entries(entries: list[ManifestEntry], client: Any) -> list[FetchedDoc]:
+    """Resolve, download, and text-extract each manifest entry.
+
+    ``client`` is a SmokeballClient (or a test double exposing ``get`` and
+    ``download_file``). Extraction reuses the connector's own ``extract_text``
+    so this path and the agent's ``read_document`` path cannot diverge.
+    """
+    from smokeball_connector.extract import extract_text  # lazy: connector on path
+
+    out: list[FetchedDoc] = []
+    for entry in entries:
+        matters = _items(client.get("/matters", Search=entry.matter, Limit=100))
+        matter = resolve_one(
+            matters,
+            entry.matter,
+            id_key="id",
+            name_keys=("name", "title", "caption", "matterName"),
+            kind="matter",
+        )
+        matter_id = str(matter.get("id", ""))
+        files = _items(
+            client.get(f"/matters/{matter_id}/documents/files", Limit=500, Offset=0)
+        )
+        f = resolve_one(
+            files,
+            entry.file,
+            id_key="id",
+            name_keys=("name", "fileName", "title"),
+            kind="file",
+        )
+        file_id = str(f.get("id", ""))
+        info, blob = client.download_file(matter_id, file_id)
+        text = extract_text(
+            blob,
+            file_name=str(info.get("name", "")),
+            file_extension=str(info.get("fileExtension", "")),
+        )
+        if not text.strip():
+            raise ResolutionError(
+                f"{entry.file!r} on {entry.matter!r} extracted to empty text — "
+                "needs manual review rather than an empty voice sample"
+            )
+        out.append(
+            FetchedDoc(
+                corpus_id=uuid.uuid4().hex,
+                cohort=entry.cohort,
+                text=normalize_letter(text),
+                matter_name=_label(matter, ("name", "title", "caption", "matterName")),
+                matter_id=matter_id,
+                file_name=_label(f, ("name", "fileName", "title")),
+                file_id=file_id,
+                source=f"smokeball:{matter_id}/{file_id}",
+            )
+        )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Markdown adapter (fixtures / repo corpora)
+# ---------------------------------------------------------------------------
+
+_FRONTMATTER = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.S)
+
+
+def strip_frontmatter(raw: str) -> tuple[dict[str, str], str]:
+    """Split a frontmatter markdown file into (fields, body).
+
+    Deliberately a flat scalar reader: the seed corpora carry `key: value`
+    lines only, and a full YAML parse here would invite structure this path
+    has no use for.
+    """
+    m = _FRONTMATTER.match(raw)
+    if not m:
+        return {}, raw.strip()
+    fields: dict[str, str] = {}
+    for line in m.group(1).splitlines():
+        if ":" in line and not line.lstrip().startswith("#"):
+            k, _, v = line.partition(":")
+            fields[k.strip()] = v.strip().strip("'\"")
+    return fields, raw[m.end() :].strip()
+
+
+def load_markdown_dir(
+    path: str, *, cohort: str, audience_map: dict[str, str] | None = None
+) -> list[FetchedDoc]:
+    """Emit corpus docs from a directory (or single file) of frontmatter markdown.
+
+    ``audience_map`` maps a frontmatter ``audience`` value (or any prefix of
+    it) to a cohort id; entries whose audience maps to nothing fall back to
+    ``cohort``. Mapping is explicit by design — matching long audience phrases
+    on substring luck is how a corpus silently lands in the wrong cohort.
+    """
+    p = Path(path)
+    files = sorted(p.glob("*.md")) if p.is_dir() else [p]
+    out: list[FetchedDoc] = []
+    for f in files:
+        fields, body = strip_frontmatter(f.read_text(encoding="utf-8"))
+        if not body.strip():
+            continue
+        resolved = cohort
+        audience = fields.get("audience", "")
+        if audience_map:
+            for prefix, target in audience_map.items():
+                if audience.lower().startswith(prefix.lower()):
+                    resolved = target
+                    break
+            else:
+                continue  # unmapped audience: excluded on purpose, never defaulted
+        out.append(
+            FetchedDoc(
+                corpus_id=uuid.uuid4().hex,
+                cohort=resolved,
+                text=normalize_letter(body),
+                matter_name=fields.get("matter", ""),
+                matter_id="",
+                file_name=f.name,
+                file_id=fields.get("sample_id", ""),
+                source=f"file:{f.name}",
+            )
+        )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Output
+# ---------------------------------------------------------------------------
+
+
+def write_corpus(docs: list[FetchedDoc], out_path: str) -> dict[str, str]:
+    """Write one JSONL per cohort. Returns {cohort: path}.
+
+    Per-cohort files because the ingester takes a single ``--cohort`` per run
+    (its samples are keyed by cohort in the vault), so splitting here keeps
+    that script untouched.
+    """
+    base = Path(out_path)
+    stem = base.stem or "corpus"
+    written: dict[str, str] = {}
+    by_cohort: dict[str, list[FetchedDoc]] = {}
+    for d in docs:
+        by_cohort.setdefault(d.cohort, []).append(d)
+    for cohort, group in by_cohort.items():
+        dest = base.with_name(f"{stem}.{cohort}{base.suffix or '.jsonl'}")
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        with dest.open("w", encoding="utf-8") as fh:
+            for d in group:
+                fh.write(
+                    json.dumps(
+                        {"id": d.corpus_id, "source": d.source, "text": d.text},
+                        ensure_ascii=False,
+                    )
+                    + "\n"
+                )
+        written[cohort] = str(dest)
+    return written
+
+
+def write_provenance(docs: list[FetchedDoc], path: str, corpus_files: dict[str, str]) -> None:
+    """Record document -> corpus-id mapping so fingerprints stay traceable."""
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
+    Path(path).write_text(
+        json.dumps(
+            {
+                "corpus_files": corpus_files,
+                "documents": [
+                    {
+                        "corpus_id": d.corpus_id,
+                        "cohort": d.cohort,
+                        "matter_name": d.matter_name,
+                        "matter_id": d.matter_id,
+                        "file_name": d.file_name,
+                        "file_id": d.file_id,
+                        "source": d.source,
+                        "chars": len(d.text),
+                    }
+                    for d in docs
+                ],
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(
+        description="Fetch named matter documents into a voice corpus JSONL."
+    )
+    src = p.add_mutually_exclusive_group(required=True)
+    src.add_argument("--manifest", help="YAML/JSON manifest of {matter, file, cohort}.")
+    src.add_argument("--from-md", help="Directory (or file) of frontmatter markdown.")
+    p.add_argument("--out", required=True, help="Base path; one JSONL per cohort.")
+    p.add_argument("--provenance", help="Write the document -> corpus-id map here.")
+    p.add_argument("--customer-yaml", help="Seat customer.yaml for cohort validation.")
+    p.add_argument("--cohort", default="unassigned", help="Cohort for --from-md.")
+    p.add_argument(
+        "--audience-map",
+        help="JSON {audience-prefix: cohort} for --from-md; unmapped are EXCLUDED.",
+    )
+    args = p.parse_args(argv)
+
+    vocabulary = load_cohort_vocabulary(args.customer_yaml)
+
+    try:
+        if args.manifest:
+            entries = load_manifest(args.manifest)
+            validate_cohorts(entries, vocabulary)
+            from smokeball_connector.client import build_client_from_env
+
+            docs = fetch_entries(entries, build_client_from_env())
+        else:
+            amap = json.loads(args.audience_map) if args.audience_map else None
+            docs = load_markdown_dir(
+                args.from_md, cohort=args.cohort, audience_map=amap
+            )
+            validate_cohorts(
+                [ManifestEntry(matter="", file="", cohort=d.cohort) for d in docs],
+                vocabulary,
+            )
+    except (ResolutionError, ValueError) as e:
+        print(f"REFUSED: {e}", file=sys.stderr)
+        return 2
+
+    if not docs:
+        print("no documents produced (check the manifest or audience map)", file=sys.stderr)
+        return 2
+
+    written = write_corpus(docs, args.out)
+    if args.provenance:
+        write_provenance(docs, args.provenance, written)
+
+    for cohort, path in sorted(written.items()):
+        n = sum(1 for d in docs if d.cohort == cohort)
+        floor = "" if n >= 5 else "  <-- BELOW the 5-sample profile floor; will not shape drafts"
+        print(f"{cohort:20s} {n:3d} docs -> {path}{floor}")
+    print(
+        "\nNext: ingest each cohort file, then restart the Machine to adopt:\n"
+        "  python bin/voice-ingest-corpus.py --corpus <file> --slug <seat> "
+        "--cohort <cohort> --r2"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/operator/contracts/customer-yaml-blocks.yaml
+++ b/operator/contracts/customer-yaml-blocks.yaml
@@ -127,6 +127,21 @@ top_level:
   voice_library:
     status: implemented
     materializer: bootstrap Step 2a (R2 voice-vault sync) + translate _persona_config (config.yaml)
+  voice_cohorts:
+    status: inert
+    materializer: >-
+      console-side only — checkVoiceCohorts / resolveCohortVocabulary
+      (src/lib/operator/customer-yaml/sections-voice.ts) validate and resolve the
+      vocabulary, and bin/voice-fetch-corpus.py reads it as a pre-flight guard so
+      an unauthored cohort cannot mint an orphan vault directory at ingest.
+    note: >-
+      INERT AT RUNTIME BY DESIGN. The vocabulary partitions the vault keys
+      (vaults/<slug>/voice/cohort/<cohort>/) that the ingest step writes and the
+      runtime reader consumes; nothing in translate.py or bootstrap renders this
+      block into seat config, because the cohort is carried in the sample's own
+      recipient_cohort field, not in a config value. The runtime effect is
+      therefore real but indirect — the block governs WHERE samples land, not
+      what the Machine is told.
   telegram:
     status: implemented
     materializer: translate _materialize_telegram_platform (config.yaml platforms)

--- a/operator/customers/ashton-price/customer.yaml
+++ b/operator/customers/ashton-price/customer.yaml
@@ -637,8 +637,19 @@ escalation:
 # ---- VOICE LIBRARY ----
 # Empty until the firm's voice is read in place from documents they point at
 # (never handed over — letter 07); ships with the general voice until then.
+#
+# METADATA ONLY. Nothing reads this path at runtime: the Machine derives the
+# vault prefix from the customer slug and syncs `vaults/<slug>/voice/` to the
+# volume at BOOT (operator/templates/bootstrap.sh:157); ingested samples land
+# under `vaults/<slug>/voice/cohort/<cohort>/`. Kept for the config-plane
+# consumers (schema validation, the portal YAML editor, the D1 projection).
+#
+# `voice_cohorts:` is deliberately unauthored here: the firm's own audience
+# partition is set at onboarding from the documents they point at, not guessed
+# ahead of them. Absent the block, the seat accepts the base vocabulary
+# (client / opposing-counsel / court / internal).
 voice_library:
-  samples_path: 'r2://vaults/ashton-price/voice/samples/'
+  samples_path: 'r2://vaults/ashton-price/voice/'
 
 # ---- MEMORY (per-customer isolation invariants; must match customer_id) ----
 memory:

--- a/operator/customers/pilot-smokeball/customer.yaml
+++ b/operator/customers/pilot-smokeball/customer.yaml
@@ -693,11 +693,50 @@ escalation:
     fallback_recipients:
       - scott@smd.services
 
+# ---- VOICE COHORTS ----
+# The audience classes this seat's voice profiles are partitioned by. An
+# authored list REPLACES the base vocabulary (client / opposing-counsel /
+# court / internal) rather than extending it — resolveCohortVocabulary,
+# src/lib/operator/customer-yaml/sections-voice.ts — so every cohort this seat
+# uses is listed here, including the base members it keeps.
+#
+# The rehearsal corpus (seed/voice/) maps onto these by its `audience`
+# frontmatter. The mapping is EXPLICIT (passed to bin/voice-fetch-corpus.py
+# --audience-map), never substring luck, and an unmapped audience is excluded
+# from ingestion rather than defaulted into the wrong cohort:
+#
+#   "client (...)"           -> client      (04, 05, 10, 12, 13 = 5 samples)
+#   "claims adjuster (...)"  -> adjuster    (01, 02, 03, 06 = 4 samples)
+#   "opposing counsel (...)" -> opposing-counsel (07 = 1 sample)
+#   "neutral (mediator)"     -> UNMAPPED, excluded (08, 09 are greeting-less
+#                               brief excerpts; they would pollute modal
+#                               greeting/signoff stats)
+#   "prospective client (declined)" -> UNMAPPED, excluded (11: a declination
+#                               is a different register from client status)
+#
+# Only `client` clears the profile floor. That is deliberate: the hard floor is
+# MIN_PROFILE_SAMPLE_COUNT = 5, re-checked on the RESOLVED profile at
+# adapter/voice/transform.py:751 regardless of min_samples_per_cohort below, so
+# a sub-floor cohort yields PASSTHROUGH_INSUFFICIENT_PROFILE rather than a
+# thin profile. adjuster/opposing-counsel are ingested for realism and are
+# inert until their sample counts grow. Do NOT merge adjuster into client to
+# clear the floor — blending adversarial demand register into client-status
+# drafts is exactly the failure the cohort partition exists to prevent.
+voice_cohorts:
+  cohorts:
+    - client
+    - adjuster
+    - opposing-counsel
+  min_samples_per_cohort: 5
+
 # ---- VOICE LIBRARY ----
-# Empty until the firm supplies writing samples to tune the voice; ships with the
-# general voice meanwhile.
+# METADATA ONLY. Nothing reads this path at runtime: the Machine derives the
+# vault prefix from the customer slug and syncs `vaults/<slug>/voice/` to the
+# volume at BOOT (operator/templates/bootstrap.sh:157), and ingested samples
+# land under `vaults/<slug>/voice/cohort/<cohort>/`. Kept for the config-plane
+# consumers (schema validation, the portal YAML editor, the D1 projection).
 voice_library:
-  samples_path: 'r2://vaults/pilot-smokeball/voice/samples/'
+  samples_path: 'r2://vaults/pilot-smokeball/voice/'
 
 # ---- MEMORY (per-customer isolation invariants; must match customer_id) ----
 memory:

--- a/operator/customers/pilot-smokeball/seed/voice/12-client-status-duarte.md
+++ b/operator/customers/pilot-smokeball/seed/voice/12-client-status-duarte.md
@@ -1,0 +1,65 @@
+---
+sample_id: 12
+doc_type: client_status_letter
+audience: client (offer received, decision pending)
+matter: Duarte v. Brennan and Copperline Logistics, Inc.
+synthetic: true
+note: Fictional firm, fictional parties, fictional carrier. Authored as a voice-derivation sample to bring the client cohort to the five-sample profile floor.
+---
+
+**BRANNOCK & FERREIRA LLP**
+Trial Lawyers
+3400 E. Broadway, Suite 610
+Long Beach, California 90803
+(562) 555-0170
+
+July 14, 2026
+
+Reyna Duarte
+884 Obispo Avenue, Unit B
+Long Beach, CA 90804
+
+RE: Copperline's offer, and what I think of it
+
+Dear Reyna,
+
+Copperline's carrier came back Thursday with $88,000. I told them I would take it to you and give them an answer next week. Here is my honest read, and then the decision is yours.
+
+**What the number actually is**
+
+$88,000 sounds like a lot until you walk it through. Your medical bills are $47,300. The health plan's lien on those bills is $31,900 before we fight it, and I expect to get that down but not to zero. The fee and costs come off the top. If you took this offer today you would clear somewhere in the low thirties.
+
+That is the number to compare against, not the eighty-eight.
+
+**Why they offered it now**
+
+Their own driver's logs put him at nineteen hours on duty in a twenty-four hour window. They know that. The offer came four days after we produced the logs to them, which is not a coincidence.
+
+An adjuster who moves that fast after a bad document has been told to close the file before somebody sees the document in a deposition. That tells me the number goes up, not down, if we keep going.
+
+**What I recommend, and what it costs you**
+
+I would decline and counter at $210,000.
+
+The cost of that is time. If they move, we are talking about another two to four months. If they do not move, we file, and then you are looking at a year, maybe more, and a deposition where a defense lawyer asks you about the back injury from 2019. That deposition is not fun and I will not pretend otherwise. We would prepare you for it thoroughly.
+
+The cost of accepting is simpler. You are done in about six weeks and you take low thirties.
+
+**The part only you can weigh**
+
+I know the hours got cut at the warehouse and I know what that means at home right now. If certainty in six weeks is worth more to you than a bigger number a year from now, that is a legitimate answer and I will not argue with you about it. People take reasonable offers for reasonable reasons and I have never once thought less of a client for it.
+
+What I do not want is for you to take this number because you think it is the best we can do. It is not. It is the first thing they said.
+
+**What I need from you**
+
+Call Marcus this week and tell him yes or no. If you want to talk it through first, I have time Tuesday afternoon or Thursday morning, and there is no charge for the call, ever, on any day.
+
+If I do not hear from you by Friday I will hold the offer open rather than let it lapse, and I will keep working the file either way.
+
+Yours,
+
+**Luisa Ferreira**
+BRANNOCK & FERREIRA LLP
+lferreira@brannockferreira.com
+Direct: (562) 555-0173

--- a/operator/customers/pilot-smokeball/seed/voice/13-client-status-tolliver.md
+++ b/operator/customers/pilot-smokeball/seed/voice/13-client-status-tolliver.md
@@ -1,0 +1,63 @@
+---
+sample_id: 13
+doc_type: client_status_letter
+audience: client (guardian ad litem, minor's compromise pending)
+matter: Tolliver, a minor, by and through her guardian ad litem, v. Barre
+synthetic: true
+note: Fictional firm, fictional parties. Authored as a voice-derivation sample to bring the client cohort to the five-sample profile floor.
+---
+
+**BRANNOCK & FERREIRA LLP**
+Trial Lawyers
+3400 E. Broadway, Suite 610
+Long Beach, California 90803
+(562) 555-0170
+
+July 21, 2026
+
+Denise Tolliver
+6042 Gundry Avenue
+Long Beach, CA 90805
+
+RE: Where Amaya's case stands, and the court date
+
+Dear Denise,
+
+We have terms. Barre's homeowners carrier agreed to $145,000 on Tuesday. Nothing is final until a judge signs it, and I want to walk you through what that means because a case with a child in it does not settle the way an adult's does.
+
+**Why a judge has to approve this**
+
+Amaya is nine. She cannot agree to anything, and neither can you on her behalf without a court looking at it first. That is a protection for her, not a hurdle for us. A judge reads the medical records, reads what we are asking in fees, and decides whether the settlement is fair to her.
+
+The hearing is set for September 9 at 8:30 in Department 31. You should plan to be there. Amaya does not need to come, and in my experience it is better that she does not.
+
+**Where the money goes, and where it does not**
+
+This is the part that surprises people, so I will be direct about it.
+
+Most of the net will not come to your household. It goes into a blocked account in Amaya's name at a bank the court approves, and it stays there until she turns eighteen. Not you, not me, not anyone can withdraw from it before then without another judge's order. The bank will send you statements.
+
+What comes out before that account is funded: the medical liens, the case costs, and our fee. On a minor's case the court also reviews the fee itself and can reduce it. I am asking for twenty-five percent rather than the thirty-three in your agreement, because that is what this court expects on a minor's compromise and because I would rather ask for the number the judge will approve than argue for a bigger one.
+
+Her dental work is the one piece that can be paid out now. If the reconstruction Dr. Okwuosa recommended is scheduled before the hearing, we can ask the court to release that amount directly to the provider rather than blocking it. Get me the treatment plan and the estimate and I will put it in the petition.
+
+**One thing I need you to think about before September**
+
+The petition asks the court to find that this amount is fair to Amaya. That means telling the judge honestly what her scar looks like now and what Dr. Okwuosa expects it to look like at fifteen.
+
+I would like a short letter from you, in your own words, about what changed for her after the bite. Whether she stopped sleeping in her own room. Whether she crosses the street when there is a dog. Anything a doctor's chart does not hold.
+
+Write it plainly. Do not try to make it sound legal, and do not exaggerate anything. Judges read a lot of these and they can tell.
+
+**What happens after the hearing**
+
+The carrier has thirty days to fund. The blocked account gets opened, the liens get paid, and I send you a closing statement showing every dollar. Then this file closes, and the next thing that happens on it is Amaya walking into a bank on her eighteenth birthday.
+
+Call Marcus if anything about the September date is a problem, and send me that letter when you have it. There is no deadline on it other than mine, which is the end of August.
+
+Yours,
+
+**Luisa Ferreira**
+BRANNOCK & FERREIRA LLP
+lferreira@brannockferreira.com
+Direct: (562) 555-0173


### PR DESCRIPTION
## The gate this closes

A `/wired` contract run on the voice commitment (A&P letters 07/10: *the firm names exemplar documents, we read them in place, drafts come back in their voice*) found the chain unreachable at one row: **nothing connected Smokeball document text to the ingester's corpus format.** Everything downstream was built (leak-guarded fingerprints, `build_voice_profile`, the overlay transform hook, the outbound gate); everything upstream was built (`download_file` + `extract_text`). The join did not exist, so the capability was committed-but-not-built.

## What this adds

`operator/bin/voice-fetch-corpus.py`:
- **`--manifest`** — resolves plain-English matter/file names against the live account, downloads, extracts with the connector's **own** extractor (no second implementation to drift), emits ingester-format JSONL split per cohort.
- **Refuses ambiguity.** A name matching several matters or files lists the candidates and exits non-zero — the same posture the Operator takes when it cannot match a matter cleanly.
- **Validates cohorts before any fetch** against the seat's authored `voice_cohorts` vocabulary, mirroring `resolveCohortVocabulary` (an authored list *replaces* the base set). A typo cannot mint an orphan vault directory no profile loader reads.
- **Provenance manifest** — the ingester keys samples by fresh uuid and drops corpus `id`/`source`, so without this a fingerprint in R2 cannot be tied back to its document.
- **`normalize_letter()`** — trims letterhead/address/contact blocks. The differ classifies greeting from the FIRST line and signoff from the LAST THREE non-empty lines (correct for the email bodies it was built on); a law firm's exemplars are letters, and raw they hide both markers.
- **`--from-md`** — frontmatter adapter for repo corpora. CI-testable; explicitly *not* rehearsal evidence, since extraction output differs from clean markdown.

Supporting:
- Two synthetic client exemplars (`12`, `13`) bring the rehearsal client cohort to **five**, clearing `MIN_PROFILE_SAMPLE_COUNT` (re-checked on the resolved profile at `transform.py:751` regardless of `min_samples_per_cohort` — that knob governs bundle *selection* only). Merging adjuster into client to clear the floor instead would blend adversarial demand register into client-status drafts.
- Pilot `voice_cohorts` authored with the explicit audience→cohort mapping (unmapped audiences are **excluded**, never defaulted); declared inert-by-design in the block registry.
- `voice_library.samples_path` corrected on both seats to the real vault layout, labeled metadata-only (the runtime derives the prefix from the slug at `bootstrap.sh:157`).

## Proven

Dry-run over the real rehearsal corpus: 11 documents → correct cohort split (client 5, adjuster 4, opposing-counsel 1, mediator/declination excluded) → 5 content-free fingerprints through the **real** ingester and leak guard → a profile with live rhythm data (avg sentence 15.49 words, full length distribution, paragraph rhythm).

15 new unit tests; `bin/tests` + `adapter/voice/tests` = 235 passing.

## Known gap, filed separately

The differ's greeting/signoff vocabulary has **no formal-letter register**: `"Dear <first name>,"` matches no greeting pattern (`_FORMAL_NAMED_RE` requires an honorific), and `"Yours,"` / `"Cordially,"` / `"Respectfully,"` / `"Very truly yours,"` match no closer. Both fields resolve `none` for every letter — so the two fields the transform actually rewrites are dead for exactly the document type a law firm supplies.

Mapping them onto existing categories is **unsafe**: `_GREETING_TEMPLATES[FIRST_NAME]` renders `"Hi {name},"`, which would rewrite a firm's letters into a register they do not use. The fix needs new enum members with their own templates plus overlay-twin coordination (`operator/contracts/overlay-pairs.json`), which is a cross-repo change and out of this PR's scope.

Bridge merged ≠ voice synthesis proven. The rehearsal that walks the full chain is gated on that vocabulary fix.

## Acceptance criteria

- [x] (repo) Bridge resolves named documents, extracts via the connector's extractor, emits ingester-format JSONL
- [x] (repo) Ambiguity refused with candidates named; cohorts validated pre-fetch; provenance emitted
- [x] (repo) Real corpus produces a 5-sample client cohort clearing the profile floor, fingerprints content-free through the real leak guard
- [ ] (runtime) Documents fetched from a live staging matter via the connector — pending the rehearsal
- [ ] (runtime) Profile from fetched text adopted by the seat and observed shaping a draft — pending the register-vocabulary fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EdT6UDZ3koetuq7NgRZLpL