### PR TITLE
feat(pilot-smokeball): author send_policy — staff exempt, 60/hr reply backstop (#2070)

### DIFF
--- a/operator/customers/pilot-smokeball/customer.yaml
+++ b/operator/customers/pilot-smokeball/customer.yaml
@@ -669,6 +669,31 @@ business_hours:
   start: '08:00'
   end: '18:00'
 
+# Reply-channel send policy (ss#2070). The Operator has to be usable the way a
+# person uses Claude on the web: someone at the firm emails it, gets an answer,
+# replies, gets another — for as long as the conversation lasts. The platform
+# default (3 replies per sender per 10 minutes, hardcoded until #2070) cut that
+# off at the fourth exchange and never resumed, which is exactly what the
+# 2026-07-30 burst rehearsal caught.
+#
+# So a rostered colleague is exempt from the per-sender window, and the bound
+# that remains is the reply backstop: 60 replies per hour across the whole
+# channel. No real conversation approaches that; a stuck loop hits it inside an
+# hour instead of mailing a client all day. Senders who are NOT on the roster
+# keep the tight default caps unchanged.
+send_policy:
+  reply:
+    internal_exempt: true
+    per_sender_max: 3 # non-roster senders: platform default, unchanged
+    per_sender_window_seconds: 600
+    global_max: 20 # non-roster aggregate: platform default, unchanged
+    global_window_seconds: 3600
+    backstop_max: 60 # the runaway bound, all classes
+    backstop_window_seconds: 3600
+  held_release:
+    enabled: true
+    ttl_seconds: 86400
+
 escalation:
   red_flag_recipients:
     - scott@smd.services


### PR DESCRIPTION
## Summary

Authors the Captain-decided send policy onto the pilot seat: rostered colleagues are exempt from the per-sender window so a sustained email conversation never rate-holds, bounded by a 60/hour reply backstop as the runaway guard. Non-roster senders keep today's platform defaults unchanged.

This is the config half of #2070 Phase 1 — the code merged earlier (overlay #196/#197/#198/#199, console #2073/#2074). Takes effect on the seat after reprovision onto overlay `12fea42b` plus an R2 `customer.yaml` sync; the block is live-read per reply thereafter.

## Test plan
- [x] `npm run verify` green
- [x] `shipped-customer-configs` + `customer-commitments` green (24 tests) — the seat validates against the schema that landed in #2073

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XrXGrbhg96SuhdCRcffryV