### PR TITLE
feat(operator): merged config reaches the seat, and every cited runtime path is guarded (#2082, #2083)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -24,3 +24,17 @@ test-results
 .env.*
 .dev.vars
 operator/.rendered
+
+# Python bytecode (ss-console #2083). Until now nothing under operator/ that
+# gets COPYed was ever executed locally, so no cache existed to leak. Shipping
+# operator/templates/drafting/ changes that: a developer running the gate checker
+# or its pytest suite leaves a __pycache__ in that tree, compiled by whichever
+# Python that machine has, and the COPY would carry it into a customer's image.
+#
+# Harmless in the narrow sense — a magic-number mismatch is ignored, and
+# drafting_gate_check.py is invoked as a script (`python3 <path>`) so its cache is
+# never consulted — but an image should carry what the repo says it carries and
+# nothing a developer left behind. `git ls-files operator/templates/drafting`
+# tracks zero .pyc files; the image should agree.
+**/__pycache__
+**/*.py[cod]

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -154,3 +154,51 @@ jobs:
           BEFORE_SHA: ${{ github.event.before }}
           AFTER_SHA: ${{ github.sha }}
         run: bash scripts/ci-sync-customer-configs.sh
+
+  # git → R2 projection auto-publish (ss #2082). The D1 sync above feeds the
+  # PORTAL; this feeds the SEAT. They are deliberately separate jobs: the two
+  # projections have different credentials, different failure modes, and one
+  # flaking must not stop the other from landing. A wrangler hiccup on the D1
+  # side should never be the reason a merged persona register fails to reach a
+  # running Machine.
+  publish-customer-configs:
+    name: Publish customer.yaml → R2 (seat source of truth)
+    runs-on: ubuntu-latest
+    needs: deploy
+    if: ${{ vars.DEPLOY_ENABLED == 'true' }}
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Full history: the publisher diffs the push range.
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '22'
+          cache: 'npm'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@venturecrane'
+
+      # The publisher validates every config with the canonical TS validator
+      # before it touches the seat's source of truth, so it needs the deps.
+      - name: Install dependencies
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npm ci
+
+      - name: Publish changed customer configs to R2
+        env:
+          # No R2_* secrets: the R2 S3 credentials are derived from these two
+          # inside the script. R2's S3 API accepts a Cloudflare API token
+          # directly, so minting and storing a second credential would add
+          # exposure without adding capability.
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          BEFORE_SHA: ${{ github.event.before }}
+          AFTER_SHA: ${{ github.sha }}
+        run: bash scripts/ci-publish-customer-configs.sh

--- a/operator/templates/Dockerfile
+++ b/operator/templates/Dockerfile
@@ -594,6 +594,31 @@ COPY operator/adapter/ /app/adapter/
 # Canonical skill library (markdown + references)
 COPY operator/skills/ /app/skills/
 
+# Drafting discipline + the mechanical gate checker (ss-console #2083).
+#
+# The destination mirrors the repo path on purpose. Four work-product skills
+# (demand-letter-drafter, discovery-response-drafter, follow-up-discovery-drafter,
+# mediation-brief-drafter) load `operator/templates/drafting/drafting-discipline.md`
+# verbatim into every drafting run, and their SKILL.md bodies invoke
+# `python3 operator/templates/drafting/drafting_gate_check.py` by that literal
+# relative path. The final WORKDIR below is /app, so ONLY this destination makes
+# the cited path resolve. A tidier /app/drafting/ would put both files in the
+# image and still leave every citation dangling, which is the same defect wearing
+# a better filename.
+#
+# Absent from this COPY set until 2026-07-30: a whole-filesystem `find` on the
+# live seat hermes-pilot-smokeball returned neither drafting-discipline.md nor
+# drafting_gate_check.py (vfy_01KYTXF76E1QHWQ2FQ9CYRGQBV), so the drafting lane
+# ran on every seat with neither its discipline nor its gates while four SKILL.md
+# files asserted both were loaded. The checker is stdlib-only, so the apt
+# `python3` above is the whole runtime dependency.
+#
+# Presence is the instance. The class is guarded by
+# tests/shipped-runtime-paths.test.ts, which derives the shipped set from the
+# COPY lines in this file and fails on any runtime path a shipped SKILL.md cites
+# but the image does not carry.
+COPY operator/templates/drafting/ /app/operator/templates/drafting/
+
 # Tier-1 custom MCP wrappers (one subdir per connector)
 COPY operator/connectors/ /app/connectors/
 
@@ -698,11 +723,20 @@ RUN chmod -R a+rX /opt/hermes /app \
 # above). NOTE: /app/safety-substrate is intentionally NOT re-owned — its
 # run_invariants.py writes a boot log under that tree, so it must stay
 # hermes-writable (a smaller, separately-tracked residual).
+#
+# /app/operator/templates/drafting is in this set for the same reason (#2083):
+# drafting_gate_check.py is the mechanical gate a draft must pass before it
+# reaches the attorney, and drafting-discipline.md is the rule it enforces. An
+# agent that owns its own gate checker can rewrite the check it is graded by.
+# Nothing writes under that tree at runtime: the checker is INVOKED as a script
+# (`python3 <path>`), never imported, so no __pycache__ write depends on the
+# agent owning it, and a+rX below keeps it readable and traversable.
 RUN chown -R root:root \
       /app/overlay-pack \
+      /app/operator/templates/drafting \
       /app/_env-arrays.generated.sh \
  && chown root:root /app/*.sh /app/*.py \
- && chmod -R a+rX /app/overlay-pack
+ && chmod -R a+rX /app/overlay-pack /app/operator/templates/drafting
 
 ENV HERMES_WEB_DIST=/opt/hermes/hermes_cli/web_dist
 

--- a/operator/templates/entrypoint.sh
+++ b/operator/templates/entrypoint.sh
@@ -44,6 +44,43 @@ if [ -f /opt/data/customer.yaml ] && [ ! -f "${LIVE_CUSTOMER_YAML}" ]; then
   mv /opt/data/customer.yaml "${LIVE_CUSTOMER_YAML}"
   log "migrated legacy /opt/data/customer.yaml -> ${LIVE_CUSTOMER_YAML} (keystone relocation)"
 fi
+# Validate a CANDIDATE customer.yaml before it becomes the live one, using the
+# SAME on-box validator the ADR 0044 live applier uses. Until ss #2082 the boot
+# fetch did a bare `cp` then `mv -f` with no check at all, and only the poller
+# validated. That asymmetry was survivable while the R2 object was written by
+# hand at provision time; auto-publish arms it. An object the poller REJECTS
+# stays in R2, and the next restart (a Fly migration, an OOM, an unrelated
+# redeploy) adopted it unvalidated, hours or days after the merge that put it
+# there and with nothing tying the crash to that merge.
+#
+# Structural validation ONLY. The applier's safety layer (config_applier.safety)
+# is deliberately NOT run here: it enforces live-apply transition rules, and the
+# rebuild-class fields it refuses on the live path (persona tone, vertical,
+# model) are precisely the ones a RESTART exists to deliver. Running it here
+# would refuse the changes this path is for.
+#
+# Exit 2 means the validator itself is unimportable. That is treated exactly
+# like an invalid config: a substrate we cannot check is not a substrate we
+# adopt from (the standing fail-closed posture, same as the invariant_7 gate
+# further down, which refuses boot on a missing module rather than skipping).
+validate_candidate_config() {
+  /opt/hermes/.venv/bin/python3 - "$1" <<'PY'
+import sys
+from pathlib import Path
+
+try:
+    from bootstrap.validate import validate_customer_yaml
+except Exception as exc:  # noqa: BLE001 - any import failure is a refusal
+    print(f"candidate config validator unimportable: {exc}", file=sys.stderr)
+    raise SystemExit(2)
+
+errors = validate_customer_yaml(Path(sys.argv[1]))
+for err in errors:
+    print(f"  {err}", file=sys.stderr)
+raise SystemExit(1 if errors else 0)
+PY
+}
+
 _seed_endpoint="${R2_ENDPOINT_URL:-https://${R2_ACCOUNT_ID:-}.r2.cloudflarestorage.com}"
 if AWS_ACCESS_KEY_ID="${R2_ACCESS_KEY_ID:?}" \
      AWS_SECRET_ACCESS_KEY="${R2_SECRET_ACCESS_KEY:?}" \
@@ -52,13 +89,41 @@ if AWS_ACCESS_KEY_ID="${R2_ACCESS_KEY_ID:?}" \
          --only-show-errors \
          "s3://${R2_BUCKET_CONFIG}/vaults/${CUSTOMER_SLUG}/customer.yaml" \
          "${LIVE_CUSTOMER_YAML}.r2.tmp"; then
+  _r2_fetched=1
+else
+  _r2_fetched=0
+fi
+
+_r2_usable=0
+if [ "${_r2_fetched}" -eq 1 ]; then
+  if validate_candidate_config "${LIVE_CUSTOMER_YAML}.r2.tmp"; then
+    _r2_usable=1
+  elif [ $? -eq 2 ]; then
+    log "WARN: cannot validate the R2 customer.yaml (validator unimportable); refusing to adopt it"
+  else
+    log "WARN: R2 customer.yaml REFUSED by the on-box validator (errors above); refusing to adopt it"
+  fi
+fi
+
+if [ "${_r2_usable}" -eq 1 ]; then
   mv -f "${LIVE_CUSTOMER_YAML}.r2.tmp" "${LIVE_CUSTOMER_YAML}"
   log "customer.yaml refreshed from R2 (source of truth) into ${CONFIG_DIR}"
 elif [ -f "${LIVE_CUSTOMER_YAML}" ]; then
+  # Fail-static: the Machine comes up on the config it was already serving. A
+  # bad publish costs the seat its update, never its uptime.
   rm -f "${LIVE_CUSTOMER_YAML}.r2.tmp" 2>/dev/null || true
-  log "WARN: R2 fetch failed; using existing root-owned customer.yaml"
+  if [ "${_r2_fetched}" -eq 1 ]; then
+    log "WARN: keeping the existing root-owned customer.yaml (the R2 object was not adopted)"
+  else
+    log "WARN: R2 fetch failed; using existing root-owned customer.yaml"
+  fi
 else
-  log "FATAL: customer.yaml not present and R2 fetch failed (${R2_BUCKET_CONFIG}/vaults/${CUSTOMER_SLUG})"
+  rm -f "${LIVE_CUSTOMER_YAML}.r2.tmp" 2>/dev/null || true
+  if [ "${_r2_fetched}" -eq 1 ]; then
+    log "FATAL: no local customer.yaml and the R2 object was refused (${R2_BUCKET_CONFIG}/vaults/${CUSTOMER_SLUG}); nothing valid to boot on"
+  else
+    log "FATAL: customer.yaml not present and R2 fetch failed (${R2_BUCKET_CONFIG}/vaults/${CUSTOMER_SLUG})"
+  fi
   exit 1
 fi
 # Root owns it; the agent reads (0644) but cannot write or rename it (the parent

--- a/scripts/ci-publish-customer-configs.sh
+++ b/scripts/ci-publish-customer-configs.sh
@@ -1,0 +1,230 @@
+#!/usr/bin/env bash
+# CI auto-publish: customer.yaml (git source of truth) → the R2 object the
+# running Machine actually reads (s3://${R2_BUCKET_CONFIG}/vaults/<slug>/customer.yaml).
+#
+# The sibling ci-sync-customer-configs.sh projects a merged config into D1, which
+# is what the PORTAL reads. Nothing projected it to R2, which is what the SEAT
+# reads. The only writer of that object was operator/bin/provision-customer.sh
+# (step 2), run by hand, so merged config sat in git indefinitely while the live
+# Machine kept serving whatever the last reprovision happened to upload. That is
+# how origin/main carried A&P's authored persona register (#2077) while the seat's
+# SOUL.md still said `plainspoken / warm-but-professional / concise` (ss #2082).
+#
+# Behavior per changed slug:
+#   - Object exists in R2  → validate, upload, read the bytes back and prove they
+#     match. The seat adopts it on its next boot (entrypoint.sh re-fetches every
+#     boot); live-writable fields are picked up sooner by the ADR 0044 poller.
+#   - No object (never provisioned) → WARN and skip. See "never create" below.
+#
+# Two guards, both load-bearing:
+#
+#   NEVER CREATE. A merge must not be able to conjure config for a seat nobody
+#   provisioned. Provisioning binds a config to a Machine, a volume, and a secret
+#   set; that binding is Captain-gated, exactly as the D1 sync leaves the FIRST
+#   projection manual. A HEAD that fails for any reason OTHER than 404 (bad
+#   credential, network, bucket typo) is a hard error, never a skip. "Cannot
+#   tell" must not read as "no object here, move along".
+#
+#   ONE KEY SPACE. This publisher writes customer.yaml and nothing else. The
+#   `output-classes.json` key beside it belongs to the portal (ADR 0083): two
+#   writers, two key spaces, never the same object. That is structural here, not
+#   a matter of restraint: the basename is a literal constant, the slug is
+#   charset-constrained, and assert_config_key re-checks the assembled key
+#   against a whole-string pattern before any write. There is no input to this
+#   script that produces any other key. (#1898: R2 must never diverge from git
+#   out of band.)
+#
+# Inputs (env): BEFORE_SHA, AFTER_SHA, the push range from the workflow.
+# R2 auth: R2_ACCESS_KEY_ID / R2_SECRET_ACCESS_KEY / R2_ENDPOINT_URL if set
+# (the operator-local path, e.g. `infisical run --env=prod --path=/ss -- ...`),
+# otherwise derived from CLOUDFLARE_API_TOKEN + CLOUDFLARE_ACCOUNT_ID, which CI
+# already holds. R2's S3 API accepts a Cloudflare API token directly: the key id
+# is the token's own id and the secret is the sha256 of the token value. Deriving
+# is the venture's documented mechanism (derive, never mint) and keeps this job
+# on the secrets the repo already has.
+set -euo pipefail
+
+BEFORE="${BEFORE_SHA:?BEFORE_SHA required}"
+AFTER="${AFTER_SHA:?AFTER_SHA required}"
+
+# The ONLY object name this publisher may write. Deliberately a constant: see
+# "ONE KEY SPACE" above.
+R2_CONFIG_BASENAME="customer.yaml"
+R2_BUCKET_CONFIG="${R2_BUCKET_CONFIG:-smd-customer-config}"
+
+# A force-push or branch-create event has a zero BEFORE sha; fall back to the
+# single pushed commit so we never diff against nothing.
+if [[ "$BEFORE" =~ ^0+$ ]]; then
+  BEFORE="${AFTER}~1"
+fi
+
+# Only customer.yaml. The sibling routine-grid.yaml is a D1-only artifact. It is
+# projected into the customer_configs row, never uploaded as its own R2 object,
+# so a grid-only merge has nothing to publish here.
+#
+# Portable line-array read: unlike the D1 sync (CI-only), this script is
+# exercised by tests/config-publish-guards.test.ts on an operator box, and macOS
+# ships bash 3.2, which has neither mapfile nor associative arrays.
+changed=()
+while IFS= read -r _line; do
+  [[ -n "$_line" ]] && changed+=("$_line")
+done < <(git diff --name-only "$BEFORE" "$AFTER" -- \
+  'operator/customers/*/customer.yaml' || true)
+
+if [[ ${#changed[@]} -eq 0 ]]; then
+  echo "No customer.yaml changes in ${BEFORE}..${AFTER}; nothing to publish."
+  exit 0
+fi
+
+command -v aws >/dev/null 2>&1 || {
+  echo "::error::aws CLI not found (required for the R2 upload)"
+  exit 1
+}
+
+# ---------- R2 credentials ----------
+# Never echoed, never logged, never passed on a command line: they reach the aws
+# CLI as env vars on the invocation itself.
+if [[ -z "${R2_ACCESS_KEY_ID:-}" || -z "${R2_SECRET_ACCESS_KEY:-}" ]]; then
+  : "${CLOUDFLARE_API_TOKEN:?R2_ACCESS_KEY_ID/R2_SECRET_ACCESS_KEY unset and CLOUDFLARE_API_TOKEN not available to derive them}"
+  # `|| true` so a curl/parse failure lands on the explicit message below rather
+  # than a bare set -e abort with no explanation.
+  token_id=$(curl -sS -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+    https://api.cloudflare.com/client/v4/user/tokens/verify 2>/dev/null |
+    node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>{try{const r=JSON.parse(s);process.stdout.write(r.success&&r.result&&r.result.id?r.result.id:'')}catch{process.stdout.write('')}})" || true)
+  if [[ -z "$token_id" ]]; then
+    echo "::error::could not derive the R2 key id from CLOUDFLARE_API_TOKEN (/user/tokens/verify did not return a token id)"
+    exit 1
+  fi
+  # sha256sum on the runner, shasum on a macOS operator box.
+  if command -v sha256sum >/dev/null 2>&1; then
+    token_digest=$(printf %s "${CLOUDFLARE_API_TOKEN}" | sha256sum | awk '{print $1}')
+  else
+    token_digest=$(printf %s "${CLOUDFLARE_API_TOKEN}" | shasum -a 256 | awk '{print $1}')
+  fi
+  R2_ACCESS_KEY_ID="$token_id"
+  R2_SECRET_ACCESS_KEY="$token_digest"
+fi
+if [[ -z "${R2_ENDPOINT_URL:-}" ]]; then
+  : "${CLOUDFLARE_ACCOUNT_ID:?R2_ENDPOINT_URL unset and CLOUDFLARE_ACCOUNT_ID not available to build it}"
+  R2_ENDPOINT_URL="https://${CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com"
+fi
+
+# ---------- helpers ----------
+
+# The last gate before any write. Belt to the constant basename's braces: even if
+# a future edit made the slug or the basename variable, a key outside this one
+# shape aborts the run rather than writing to a neighbouring key space.
+assert_config_key() {
+  local key="$1"
+  if [[ ! "$key" =~ ^vaults/[a-z0-9-]+/customer\.yaml$ ]]; then
+    echo "::error::refusing to write R2 key outside the customer.yaml key space: ${key}"
+    exit 1
+  fi
+}
+
+r2() {
+  AWS_ACCESS_KEY_ID="${R2_ACCESS_KEY_ID}" \
+  AWS_SECRET_ACCESS_KEY="${R2_SECRET_ACCESS_KEY}" \
+    aws "$@" --endpoint-url "${R2_ENDPOINT_URL}"
+}
+
+# Dedupe to unique slugs. A space-delimited seen-list rather than an associative
+# array, for the bash 3.2 reason above.
+seen_slugs=" "
+slugs=()
+for path in "${changed[@]}"; do
+  slug=$(basename "$(dirname "$path")")
+  case "${seen_slugs}" in *" ${slug} "*) continue ;; esac
+  seen_slugs="${seen_slugs}${slug} "
+  slugs+=("$slug")
+done
+
+work_dir=$(mktemp -d)
+trap 'rm -rf "${work_dir}"' EXIT
+
+fail=0
+for slug in "${slugs[@]}"; do
+  cfg="operator/customers/${slug}/customer.yaml"
+
+  # Template/staging dirs are not live customers. They also carry deliberate
+  # placeholder values that fail validation, so they must be skipped BEFORE the
+  # validator runs, not after.
+  if [[ "$slug" == _* ]]; then
+    echo "Skipping template dir: $slug"
+    continue
+  fi
+
+  # customer.yaml gone → the customer dir was retired. Retirement is a manual,
+  # Captain-gated operation; a merge never deletes the object a live Machine
+  # boots from.
+  if [[ ! -f "$cfg" ]]; then
+    echo "::warning::$cfg is absent; customer retirement is manual (no automatic R2 delete)."
+    continue
+  fi
+
+  # The slug becomes part of the R2 key; constrain it hard.
+  if [[ ! "$slug" =~ ^[a-z0-9-]+$ ]]; then
+    echo "::error::Refusing to publish suspicious slug: $slug"
+    fail=1
+    continue
+  fi
+
+  key="vaults/${slug}/${R2_CONFIG_BASENAME}"
+  assert_config_key "$key"
+
+  echo "── Publishing $slug ──"
+
+  # Validate against the canonical pre-merge gate (ADR 0019). An invalid config
+  # reaching this object is a seat kill on the next restart: the boot fetch and
+  # the ADR 0044 poller both refuse it, and a Machine on a fresh volume has
+  # nothing to fall back to.
+  if ! npx --quiet tsx scripts/validate-customer-yaml.ts "$cfg"; then
+    echo "::error::$slug: customer.yaml failed validation; not publishing"
+    fail=1
+    continue
+  fi
+
+  # NEVER CREATE. Distinguish "no such object" from "could not tell": only a 404
+  # is a skip.
+  head_err="${work_dir}/${slug}.head.err"
+  if r2 s3api head-object --bucket "${R2_BUCKET_CONFIG}" --key "$key" \
+       >/dev/null 2>"$head_err"; then
+    :
+  elif grep -q '(404)' "$head_err"; then
+    echo "::warning::$slug has no object at s3://${R2_BUCKET_CONFIG}/${key}; first publish is Captain-gated; run operator/bin/provision-customer.sh."
+    continue
+  else
+    echo "::error::$slug: could not read s3://${R2_BUCKET_CONFIG}/${key} (not a 404); refusing to guess whether the seat is provisioned"
+    sed 's/^/    /' "$head_err"
+    fail=1
+    continue
+  fi
+
+  if ! r2 s3 cp "$cfg" "s3://${R2_BUCKET_CONFIG}/${key}" --only-show-errors; then
+    echo "::error::$slug: R2 upload failed"
+    fail=1
+    continue
+  fi
+
+  # Prove the write landed by reading the object back and comparing bytes. The
+  # D1 sync can verify with a stamped git_sha because it controls the row's
+  # columns; the R2 object is the authored file verbatim (stamping it would make
+  # R2 diverge from git, which is the thing #1898 forbids), so the proof is
+  # byte identity.
+  readback="${work_dir}/${slug}.readback.yaml"
+  if ! r2 s3 cp "s3://${R2_BUCKET_CONFIG}/${key}" "$readback" --only-show-errors; then
+    echo "::error::$slug: published but could not read the object back to verify"
+    fail=1
+    continue
+  fi
+  if cmp -s "$cfg" "$readback"; then
+    file_sha=$(git rev-list -1 "$AFTER" -- "$cfg" || true)
+    echo "$slug published: s3://${R2_BUCKET_CONFIG}/${key} (git ${file_sha:-unknown})"
+    echo "  the seat adopts this on its next restart; live-writable fields apply sooner via the ADR 0044 poller"
+  else
+    echo "::error::$slug: R2 object does not match the file that was uploaded"
+    fail=1
+  fi
+done
+
+exit "$fail"

--- a/tests/config-publish-guards.test.ts
+++ b/tests/config-publish-guards.test.ts
@@ -1,0 +1,401 @@
+/**
+ * Guard coverage for the git -> R2 config publisher (ss #2082).
+ *
+ * `scripts/ci-publish-customer-configs.sh` writes the object a running Machine
+ * boots from. Two of its behaviors are load-bearing enough that a regression
+ * would be silent and expensive, so they are exercised here rather than trusted:
+ *
+ *  1. NEVER CREATE. A merge must not conjure config for a seat nobody
+ *     provisioned, and "I could not tell whether an object exists" must not
+ *     collapse into "there is none". Only a 404 is a skip.
+ *  2. ONE KEY SPACE. The publisher writes `vaults/<slug>/customer.yaml` and
+ *     nothing else. The `output-classes.json` key beside it belongs to the
+ *     portal (ADR 0083).
+ *
+ * Plus the boot half: `operator/templates/entrypoint.sh` must validate the
+ * fetched candidate BEFORE it becomes the live config.
+ *
+ * No live R2. The `aws` and `npx` the script invokes are replaced by stubs on
+ * PATH, backed by a directory that stands in for the bucket, so the read-back
+ * verification is a real byte comparison against what the script actually
+ * uploaded.
+ */
+import { execFileSync } from 'node:child_process'
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+const REPO_ROOT = fileURLToPath(new URL('..', import.meta.url))
+const PUBLISHER = join(REPO_ROOT, 'scripts', 'ci-publish-customer-configs.sh')
+const ENTRYPOINT = join(REPO_ROOT, 'operator', 'templates', 'entrypoint.sh')
+
+/** Minimal well-formed config body. The stub validator decides pass/fail. */
+function configBody(slug: string): string {
+  return `customer_id: ${slug}\nvertical: law-firm\n`
+}
+
+const FAKE_AWS = `#!/usr/bin/env bash
+# Stand-in for the aws CLI. Logs every invocation, and backs s3 cp with a
+# directory so the publisher's read-back comparison is a real one.
+echo "$*" >> "\${FAKE_AWS_LOG}"
+BUCKET_DIR="\${FAKE_AWS_BUCKET_DIR}"
+
+if [ "$1" = "s3api" ] && [ "$2" = "head-object" ]; then
+  key=""
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --key) key="$2"; shift 2 ;;
+      *) shift ;;
+    esac
+  done
+  if [ -n "\${FAKE_AWS_HEAD_ERROR:-}" ]; then
+    echo "An error occurred (403) when calling the HeadObject operation: Forbidden" >&2
+    exit 254
+  fi
+  if [ -f "\${BUCKET_DIR}/\${key}" ]; then exit 0; fi
+  echo "An error occurred (404) when calling the HeadObject operation: Not Found" >&2
+  exit 254
+fi
+
+if [ "$1" = "s3" ] && [ "$2" = "cp" ]; then
+  src="$3"; dst="$4"
+  case "\${dst}" in
+    s3://*)
+      key="\${dst#s3://}"; key="\${key#*/}"
+      mkdir -p "$(dirname "\${BUCKET_DIR}/\${key}")"
+      cp "\${src}" "\${BUCKET_DIR}/\${key}"
+      exit 0
+      ;;
+    *)
+      key="\${src#s3://}"; key="\${key#*/}"
+      [ -f "\${BUCKET_DIR}/\${key}" ] || { echo "no such object" >&2; exit 254; }
+      cp "\${BUCKET_DIR}/\${key}" "\${dst}"
+      exit 0
+      ;;
+  esac
+fi
+
+echo "unexpected aws invocation: $*" >&2
+exit 99
+`
+
+const FAKE_NPX = `#!/usr/bin/env bash
+# Stand-in for the validator invocation. The real validator has its own suite;
+# what matters here is that the publisher gates the upload on its exit code.
+cfg=""
+for a in "$@"; do cfg="$a"; done
+echo "\${cfg}" >> "\${FAKE_NPX_LOG}"
+case " \${FAKE_VALIDATOR_FAIL:-} " in
+  *" \${cfg} "*) echo "validation failed" >&2; exit 1 ;;
+esac
+exit 0
+`
+
+interface Fixture {
+  root: string
+  binDir: string
+  bucketDir: string
+  awsLog: string
+  npxLog: string
+  before: string
+  after: string
+}
+
+const fixtures: string[] = []
+
+function git(root: string, args: string[]): string {
+  return execFileSync('git', ['-c', 'user.email=t@example.com', '-c', 'user.name=t', ...args], {
+    cwd: root,
+    encoding: 'utf8',
+  })
+}
+
+/**
+ * A throwaway repo whose HEAD commit changes `customer.yaml` for each of
+ * `slugs`, so the publisher's push-range diff has something to find.
+ */
+function makeFixture(slugs: string[], opts: { deleted?: string[] } = {}): Fixture {
+  const root = mkdtempSync(join(tmpdir(), 'config-publish-'))
+  fixtures.push(root)
+
+  git(root, ['init', '-q'])
+  // A baseline commit so BEFORE..AFTER is a real range. Pre-create any config
+  // the test wants DELETED in the second commit.
+  writeFileSync(join(root, 'README.md'), 'fixture\n')
+  for (const slug of opts.deleted ?? []) {
+    mkdirSync(join(root, 'operator', 'customers', slug), { recursive: true })
+    writeFileSync(join(root, 'operator', 'customers', slug, 'customer.yaml'), configBody(slug))
+  }
+  git(root, ['add', '-A'])
+  git(root, ['commit', '-q', '-m', 'baseline'])
+  const before = git(root, ['rev-parse', 'HEAD']).trim()
+
+  for (const slug of slugs) {
+    mkdirSync(join(root, 'operator', 'customers', slug), { recursive: true })
+    writeFileSync(join(root, 'operator', 'customers', slug, 'customer.yaml'), configBody(slug))
+  }
+  for (const slug of opts.deleted ?? []) {
+    rmSync(join(root, 'operator', 'customers', slug, 'customer.yaml'))
+  }
+  git(root, ['add', '-A'])
+  // --allow-empty: the no-op case below deliberately commits nothing.
+  git(root, ['commit', '-q', '--allow-empty', '-m', 'change configs'])
+  const after = git(root, ['rev-parse', 'HEAD']).trim()
+
+  const binDir = join(root, '.fakebin')
+  mkdirSync(binDir)
+  writeFileSync(join(binDir, 'aws'), FAKE_AWS)
+  writeFileSync(join(binDir, 'npx'), FAKE_NPX)
+  chmodSync(join(binDir, 'aws'), 0o755)
+  chmodSync(join(binDir, 'npx'), 0o755)
+
+  const bucketDir = join(root, '.bucket')
+  mkdirSync(bucketDir)
+
+  return {
+    root,
+    binDir,
+    bucketDir,
+    awsLog: join(root, 'aws.log'),
+    npxLog: join(root, 'npx.log'),
+    before,
+    after,
+  }
+}
+
+/** Mark a key as already present in the stand-in bucket (i.e. provisioned). */
+function seedObject(fx: Fixture, key: string, body: string): void {
+  const dest = join(fx.bucketDir, key)
+  mkdirSync(join(dest, '..'), { recursive: true })
+  writeFileSync(dest, body)
+}
+
+interface RunResult {
+  code: number
+  stdout: string
+  stderr: string
+  awsCalls: string[]
+  npxCalls: string[]
+}
+
+function runPublisher(fx: Fixture, env: Record<string, string> = {}): RunResult {
+  const childEnv = {
+    ...process.env,
+    PATH: `${fx.binDir}:${process.env.PATH ?? ''}`,
+    BEFORE_SHA: fx.before,
+    AFTER_SHA: fx.after,
+    // Explicit creds so the script never reaches the Cloudflare derivation path.
+    R2_ACCESS_KEY_ID: 'test-key-id',
+    R2_SECRET_ACCESS_KEY: 'test-secret',
+    R2_ENDPOINT_URL: 'https://example.invalid',
+    FAKE_AWS_LOG: fx.awsLog,
+    FAKE_NPX_LOG: fx.npxLog,
+    FAKE_AWS_BUCKET_DIR: fx.bucketDir,
+    ...env,
+  }
+
+  let outcome: { code: number; stdout: string; stderr: string }
+  try {
+    const stdout = execFileSync('bash', [PUBLISHER], {
+      cwd: fx.root,
+      encoding: 'utf8',
+      env: childEnv,
+    })
+    outcome = { code: 0, stdout, stderr: '' }
+  } catch (err) {
+    const e = err as { status?: number; stdout?: Buffer | string; stderr?: Buffer | string }
+    outcome = {
+      code: e.status ?? 1,
+      stdout: String(e.stdout ?? ''),
+      stderr: String(e.stderr ?? ''),
+    }
+  }
+
+  const readLog = (path: string): string[] => {
+    try {
+      return readFileSync(path, 'utf8').split('\n').filter(Boolean)
+    } catch {
+      return []
+    }
+  }
+  return { ...outcome, awsCalls: readLog(fx.awsLog), npxCalls: readLog(fx.npxLog) }
+}
+
+/** Writes only. `s3 cp s3://... <local>` is the publisher's read-back verify. */
+const uploads = (calls: string[]): string[] =>
+  calls.filter((c) => c.startsWith('s3 cp ') && !c.startsWith('s3 cp s3://'))
+
+afterEach(() => {
+  while (fixtures.length > 0) {
+    const dir = fixtures.pop()
+    if (dir) rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+describe('ci-publish-customer-configs: never-create guard', () => {
+  it('publishes a changed config when the slug already has an object', () => {
+    const fx = makeFixture(['ashton-price'])
+    seedObject(fx, 'vaults/ashton-price/customer.yaml', 'stale: true\n')
+
+    const res = runPublisher(fx)
+
+    expect(res.code).toBe(0)
+    expect(uploads(res.awsCalls)).toHaveLength(1)
+    expect(uploads(res.awsCalls)[0]).toContain(
+      's3://smd-customer-config/vaults/ashton-price/customer.yaml'
+    )
+    // The read-back comparison passed against real bytes, not a stubbed OK.
+    expect(readFileSync(join(fx.bucketDir, 'vaults/ashton-price/customer.yaml'), 'utf8')).toBe(
+      configBody('ashton-price')
+    )
+    expect(res.stdout).toContain('ashton-price published')
+  })
+
+  it('never creates an object for a slug that has none', () => {
+    const fx = makeFixture(['never-provisioned'])
+
+    const res = runPublisher(fx)
+
+    expect(uploads(res.awsCalls)).toHaveLength(0)
+    expect(res.stdout).toContain('first publish is Captain-gated')
+    // A skipped unprovisioned slug is not a pipeline failure.
+    expect(res.code).toBe(0)
+  })
+
+  it('refuses to guess when the existence check fails for any reason but 404', () => {
+    const fx = makeFixture(['ashton-price'])
+    seedObject(fx, 'vaults/ashton-price/customer.yaml', 'stale: true\n')
+
+    const res = runPublisher(fx, { FAKE_AWS_HEAD_ERROR: '1' })
+
+    expect(uploads(res.awsCalls)).toHaveLength(0)
+    expect(res.code).not.toBe(0)
+    expect(res.stdout + res.stderr).toContain('refusing to guess whether the seat is provisioned')
+  })
+
+  it('does not delete the object a live Machine boots from when the file is removed', () => {
+    const fx = makeFixture([], { deleted: ['retired-seat'] })
+    seedObject(fx, 'vaults/retired-seat/customer.yaml', 'live: true\n')
+
+    const res = runPublisher(fx)
+
+    expect(res.code).toBe(0)
+    expect(res.awsCalls).toHaveLength(0)
+    expect(res.stdout).toContain('customer retirement is manual')
+    expect(readFileSync(join(fx.bucketDir, 'vaults/retired-seat/customer.yaml'), 'utf8')).toBe(
+      'live: true\n'
+    )
+  })
+})
+
+describe('ci-publish-customer-configs: one key space', () => {
+  it('writes only vaults/<slug>/customer.yaml, never a neighbouring key', () => {
+    const fx = makeFixture(['ashton-price', 'pilot-law'])
+    seedObject(fx, 'vaults/ashton-price/customer.yaml', 'a\n')
+    seedObject(fx, 'vaults/pilot-law/customer.yaml', 'b\n')
+
+    const res = runPublisher(fx)
+
+    expect(res.code).toBe(0)
+    for (const call of res.awsCalls) {
+      expect(call).not.toContain('output-classes')
+      if (call.includes('s3://')) {
+        expect(call).toMatch(/s3:\/\/smd-customer-config\/vaults\/[a-z0-9-]+\/customer\.yaml/)
+      }
+    }
+  })
+
+  it('constructs the key from a constant basename and a charset-bounded slug', () => {
+    const source = readFileSync(PUBLISHER, 'utf8')
+    // One assignment, one literal. If a future edit made the object name an
+    // input, these two assertions are what fail.
+    const basenameAssignments = source.match(/^R2_CONFIG_BASENAME=.*$/gm) ?? []
+    expect(basenameAssignments).toEqual(['R2_CONFIG_BASENAME="customer.yaml"'])
+    const keyAssignments = source.match(/^[ \t]*key=.*$/gm) ?? []
+    expect(keyAssignments).toEqual(['  key="vaults/${slug}/${R2_CONFIG_BASENAME}"'])
+    expect(source).toContain('^vaults/[a-z0-9-]+/customer\\.yaml$')
+  })
+
+  it('refuses a slug that could name any other object', () => {
+    // `.` is the character that separates `customer.yaml` from
+    // `output-classes.json`; the slug charset cannot carry one.
+    const fx = makeFixture(['bad.slug'])
+    seedObject(fx, 'vaults/bad.slug/customer.yaml', 'x\n')
+
+    const res = runPublisher(fx)
+
+    expect(res.code).not.toBe(0)
+    expect(res.awsCalls).toHaveLength(0)
+    expect(res.stdout + res.stderr).toContain('Refusing to publish suspicious slug')
+  })
+})
+
+describe('ci-publish-customer-configs: validation and template dirs', () => {
+  it('skips _template dirs before the validator runs', () => {
+    // The templates carry deliberate placeholder values and fail validation;
+    // reaching the validator at all would fail the whole job.
+    const fx = makeFixture(['_template', '_hosted-template'])
+
+    const res = runPublisher(fx)
+
+    expect(res.code).toBe(0)
+    expect(res.awsCalls).toHaveLength(0)
+    expect(res.npxCalls).toHaveLength(0)
+    expect(res.stdout).toContain('Skipping template dir: _template')
+    expect(res.stdout).toContain('Skipping template dir: _hosted-template')
+  })
+
+  it('does not publish a config that fails validation', () => {
+    const fx = makeFixture(['ashton-price'])
+    seedObject(fx, 'vaults/ashton-price/customer.yaml', 'good: true\n')
+
+    const res = runPublisher(fx, {
+      FAKE_VALIDATOR_FAIL: 'operator/customers/ashton-price/customer.yaml',
+    })
+
+    expect(res.code).not.toBe(0)
+    expect(uploads(res.awsCalls)).toHaveLength(0)
+    // The object a live seat boots from is untouched.
+    expect(readFileSync(join(fx.bucketDir, 'vaults/ashton-price/customer.yaml'), 'utf8')).toBe(
+      'good: true\n'
+    )
+  })
+
+  it('publishes nothing when the push range touched no customer.yaml', () => {
+    const fx = makeFixture([])
+
+    const res = runPublisher(fx)
+
+    expect(res.code).toBe(0)
+    expect(res.awsCalls).toHaveLength(0)
+    expect(res.stdout).toContain('nothing to publish')
+  })
+})
+
+describe('entrypoint boot fetch validates before adopting', () => {
+  const source = readFileSync(ENTRYPOINT, 'utf8')
+
+  it('validates the fetched candidate before it replaces the live config', () => {
+    const validateIdx = source.indexOf('validate_candidate_config "${LIVE_CUSTOMER_YAML}.r2.tmp"')
+    const moveIdx = source.indexOf('mv -f "${LIVE_CUSTOMER_YAML}.r2.tmp" "${LIVE_CUSTOMER_YAML}"')
+    expect(validateIdx).toBeGreaterThan(-1)
+    expect(moveIdx).toBeGreaterThan(-1)
+    expect(validateIdx).toBeLessThan(moveIdx)
+  })
+
+  it('uses the same on-box validator the live applier uses', () => {
+    expect(source).toContain('from bootstrap.validate import validate_customer_yaml')
+  })
+
+  it('keeps the existing config when the candidate is refused', () => {
+    expect(source).toContain('keeping the existing root-owned customer.yaml')
+  })
+
+  it('treats an unimportable validator as a refusal, not a skip', () => {
+    expect(source).toContain('validator unimportable')
+    expect(source).toContain('refusing to adopt it')
+  })
+})

--- a/tests/config-publish-guards.test.ts
+++ b/tests/config-publish-guards.test.ts
@@ -107,10 +107,40 @@ interface Fixture {
 const fixtures: string[] = []
 
 function git(root: string, args: string[]): string {
-  return execFileSync('git', ['-c', 'user.email=t@example.com', '-c', 'user.name=t', ...args], {
-    cwd: root,
-    encoding: 'utf8',
-  })
+  return execFileSync(
+    'git',
+    [
+      '-c',
+      'user.email=t@example.com',
+      '-c',
+      'user.name=t',
+      // Fixture repos must not inherit this repo's hooks: husky points
+      // core.hooksPath at .husky/, and it is inherited, so a fixture commit
+      // would run the real pre-commit hook against a temp dir with none of its
+      // tooling installed.
+      '-c',
+      'core.hooksPath=/dev/null',
+      ...args,
+    ],
+    {
+      cwd: root,
+      encoding: 'utf8',
+      // The load-bearing half. `cwd` does NOT make a git invocation
+      // self-contained: GIT_DIR, GIT_WORK_TREE and GIT_INDEX_FILE win over it,
+      // and git EXPORTS them to every hook it runs. So under `git push` these
+      // fixtures were committing into the parent repository's git dir rather
+      // than their own, and all eight assertions failed on a truncated
+      // "Command failed: git commit" that named neither the cause nor the repo.
+      //
+      // The tell was that they passed standalone and failed only inside a hook.
+      // A test whose result depends on who invoked it is measuring its
+      // environment rather than its subject; stripping GIT_* is what makes the
+      // fixture actually throwaway.
+      env: Object.fromEntries(
+        Object.entries({ ...process.env, HUSKY: '0' }).filter(([k]) => !k.startsWith('GIT_'))
+      ),
+    }
+  )
 }
 
 /**
@@ -182,8 +212,17 @@ interface RunResult {
 }
 
 function runPublisher(fx: Fixture, env: Record<string, string> = {}): RunResult {
+  // Strip GIT_* for the same reason the `git` helper above does, and it matters
+  // more here: the publisher's first act is a `git diff` of the push range, so
+  // an inherited GIT_DIR points it at the parent repository and it reports the
+  // real repo's changed files instead of the fixture's. `cwd` does not override
+  // those variables, and git exports them to every hook, which is why this only
+  // failed under `git push`.
+  const inherited = Object.fromEntries(
+    Object.entries(process.env).filter(([k]) => !k.startsWith('GIT_'))
+  ) as Record<string, string>
   const childEnv = {
-    ...process.env,
+    ...inherited,
     PATH: `${fx.binDir}:${process.env.PATH ?? ''}`,
     BEFORE_SHA: fx.before,
     AFTER_SHA: fx.after,

--- a/tests/shipped-runtime-paths.test.ts
+++ b/tests/shipped-runtime-paths.test.ts
@@ -1,0 +1,455 @@
+/**
+ * Regression guard: a shipped SKILL.md must not cite a runtime path the image
+ * does not carry.
+ *
+ * The incident (2026-07-30, ss-console #2083, vfy_01KYTXF76E1QHWQ2FQ9CYRGQBV):
+ * `operator/templates/drafting/` was absent from the Dockerfile COPY set. A
+ * whole-filesystem `find` on the live seat hermes-pilot-smokeball returned
+ * neither `drafting-discipline.md` nor `drafting_gate_check.py`. Four
+ * work-product skills assert the discipline is "loaded verbatim into every
+ * drafting run", and the discipline itself says no draft reaches the attorney
+ * without passing the mechanical checker. Neither file was on any seat. The
+ * skills were right about what they needed and the image simply did not have it.
+ *
+ * Adding the COPY closes that instance. This file closes the class, which is the
+ * actual deliverable: shipping the two files and calling it done is a `built`
+ * claim, and the plan this came from turns entirely on `built` and `wired` being
+ * different claims (CLAUDE.md, "Done means the client can do it").
+ *
+ * Two properties, both derived from the Dockerfile rather than a hardcoded list,
+ * so the guard cannot rot the moment someone adds a COPY:
+ *
+ *   1. PRESENCE. Every repo-relative path cited by a shipped skill is either
+ *      inside the COPY set or classified in CITED_TREE_POLICY as authoring canon
+ *      with the reason written down. An unclassified tree fails loudly, which
+ *      forces the decision to be made by a person rather than by omission.
+ *   2. RESOLVABILITY. For a tree the agent actually reads or executes, the COPY
+ *      destination must make the CITED path resolve from the container WORKDIR.
+ *      Presence at some other path is what a `COPY .../drafting/ /app/drafting/`
+ *      would have bought: both files in the image, every citation still dangling.
+ *
+ * @see operator/templates/Dockerfile
+ * @see tests/operator-dockerfile.test.ts
+ * @see operator/templates/drafting/drafting-discipline.md
+ */
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync, existsSync, readdirSync, statSync } from 'fs'
+import { resolve, join, basename } from 'path'
+
+const DOCKERFILE_PATH = 'operator/templates/Dockerfile'
+const DOCKERFILE = readFileSync(resolve(DOCKERFILE_PATH), 'utf8')
+
+// ---------------------------------------------------------------------------
+// Dockerfile parsing: the shipped set is whatever this file says it is.
+// ---------------------------------------------------------------------------
+
+interface CopyDirective {
+  readonly src: string
+  readonly dest: string
+  readonly line: number
+}
+
+/**
+ * COPY directives that read from the BUILD CONTEXT (the repo root). `--from=`
+ * stages copy between images, not from the repo, so they ship nothing this
+ * guard reasons about.
+ */
+function parseBuildContextCopies(dockerfile: string): CopyDirective[] {
+  const out: CopyDirective[] = []
+  dockerfile.split('\n').forEach((raw, i) => {
+    if (!/^COPY\s/.test(raw)) return
+    if (/\\\s*$/.test(raw)) {
+      // A continued COPY would be read half-way and silently under-report the
+      // shipped set, which is the failure mode this whole file exists to stop.
+      throw new Error(
+        `${DOCKERFILE_PATH}:${i + 1}: line-continued COPY is not parsed by ` +
+          `tests/shipped-runtime-paths.test.ts. Write it on one line or teach ` +
+          `the parser, but do not leave the shipped set half-read.`
+      )
+    }
+    const tokens = raw.trim().split(/\s+/).slice(1)
+    const args = tokens.filter((t) => !t.startsWith('--'))
+    if (tokens.some((t) => t.startsWith('--from='))) return
+    if (args.length < 2) return
+    const dest = args[args.length - 1]
+    for (const src of args.slice(0, -1)) out.push({ src, dest, line: i + 1 })
+  })
+  return out
+}
+
+const COPIES = parseBuildContextCopies(DOCKERFILE)
+
+/** The last WORKDIR wins; it is the CWD the entrypoint chain inherits. */
+function finalWorkdir(dockerfile: string): string {
+  const matches = [...dockerfile.matchAll(/^WORKDIR\s+(\S+)\s*$/gm)]
+  if (matches.length === 0) throw new Error(`${DOCKERFILE_PATH}: no WORKDIR found`)
+  return matches[matches.length - 1][1]
+}
+
+const WORKDIR = finalWorkdir(DOCKERFILE)
+
+const posixJoin = (...parts: string[]): string => parts.join('/').replace(/\/{2,}/g, '/')
+
+/**
+ * Where a repo path lands in the image under a given COPY, or null if that COPY
+ * does not carry it. Follows Docker's semantics: `COPY src/ dest/` copies the
+ * CONTENTS of src into dest, so the `src/` prefix is stripped, not preserved.
+ */
+function containerPathFor(repoPath: string, copy: CopyDirective): string | null {
+  if (copy.src.endsWith('/')) {
+    if (!repoPath.startsWith(copy.src)) return null
+    return posixJoin(copy.dest, repoPath.slice(copy.src.length))
+  }
+  if (repoPath !== copy.src) return null
+  return copy.dest.endsWith('/') ? posixJoin(copy.dest, basename(copy.src)) : copy.dest
+}
+
+const containerPaths = (repoPath: string): string[] =>
+  COPIES.map((c) => containerPathFor(repoPath, c)).filter((p): p is string => p !== null)
+
+// ---------------------------------------------------------------------------
+// The runtime surface of a skill.
+// ---------------------------------------------------------------------------
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal -- dir is a repo path from the Dockerfile COPY set; entry is readdirSync output, not user input.
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) walk(full, out)
+    else out.push(full)
+  }
+  return out
+}
+
+/**
+ * SKILL.md and its `references/*.md` only. A skill's `tests/` dir ships too (the
+ * COPY takes the whole tree) but it is an AUTHORING artifact: it cites graded
+ * fixtures and canonical sources for a human running a grading pass in the repo,
+ * never a path the agent opens on a seat. Scanning it would drag the fixture and
+ * grading trees into a guard about what the agent can reach at runtime.
+ */
+function shippedSkillDocs(): string[] {
+  const skillCopy = COPIES.find((c) => c.src === 'operator/skills/')
+  expect(skillCopy, 'the Dockerfile must still ship operator/skills/').toBeDefined()
+  return walk(skillCopy!.src.replace(/\/$/, ''))
+    .filter((p) => p.endsWith('/SKILL.md') || /\/references\/[^/]+\.md$/.test(p))
+    .sort()
+}
+
+const SKILL_DOCS = shippedSkillDocs()
+
+/**
+ * Repo-relative citations, e.g. `operator/templates/drafting/drafting_gate_check.py`.
+ * The lookbehind keeps the match anchored at a path boundary so a longer path
+ * that merely contains the token is not split.
+ */
+const REPO_CITATION = /(?<![\w./-])operator\/[A-Za-z0-9_./-]*[A-Za-z0-9_-]/g
+
+/** Skill-relative citations, e.g. `references/output-format.md`. */
+const SKILL_RELATIVE_CITATION = /(?<![\w./-])references\/[A-Za-z0-9_.-]+\.[A-Za-z0-9]+/g
+
+interface Citation {
+  readonly path: string
+  readonly citedBy: string
+  readonly line: number
+}
+
+function collectCitations(re: RegExp, mapPath: (raw: string, file: string) => string): Citation[] {
+  const out: Citation[] = []
+  for (const file of SKILL_DOCS) {
+    readFileSync(file, 'utf8')
+      .split('\n')
+      .forEach((text, i) => {
+        for (const raw of text.match(re) ?? []) {
+          out.push({ path: mapPath(raw, file), citedBy: file, line: i + 1 })
+        }
+      })
+  }
+  return out
+}
+
+const REPO_CITATIONS = collectCitations(REPO_CITATION, (raw) => raw.replace(/\/+$/, ''))
+
+const SKILL_RELATIVE_CITATIONS = collectCitations(SKILL_RELATIVE_CITATION, (raw, file) =>
+  posixJoin(file.split('/').slice(0, 3).join('/'), raw)
+)
+
+// ---------------------------------------------------------------------------
+// Citation roles.
+// ---------------------------------------------------------------------------
+
+/**
+ * `runtime-read` - the skill tells the agent to open or execute this path on a
+ *   seat. It must be in the image AND must resolve at the cited spelling.
+ *
+ * `authoring-canon` - the path is a source-of-truth pointer. The rule it holds
+ *   is duplicated into the SKILL.md body, so the agent never opens the file; the
+ *   citation exists so a human editing the skill knows where the rule is owned.
+ *   These are deliberately NOT shipped, and are not required to exist on disk at
+ *   all: several point at another repo (client material moved to
+ *   venturecrane/engagements, ADR 0081) or at fixtures not yet generated.
+ *
+ * A tree with no entry here fails the guard. That is the point: the choice
+ * between the two roles is a judgment about what the agent can reach, and it
+ * should be made deliberately, once, in writing, rather than inferred from
+ * whichever verb the sentence happened to use.
+ */
+type CitationRole = 'runtime-read' | 'authoring-canon'
+
+interface TreePolicy {
+  readonly prefix: string
+  readonly role: CitationRole
+  readonly reason: string
+}
+
+const CITED_TREE_POLICY: readonly TreePolicy[] = [
+  {
+    prefix: 'operator/templates/drafting/',
+    role: 'runtime-read',
+    reason:
+      'The four work-product drafters load drafting-discipline.md VERBATIM into every drafting ' +
+      'run and invoke drafting_gate_check.py by its literal relative path; the skeletons are the ' +
+      'fallback shells they render from. This is the tree #2083 found missing from every seat.',
+  },
+  {
+    prefix: 'operator/verticals/',
+    role: 'authoring-canon',
+    reason:
+      'Deliberate, and documented at operator/verticals/law-firm/addons/pi/references/' +
+      '_shared-delivery-channels.md: the pack duplicates each shared rule into every SKILL.md ' +
+      'body BECAUSE only operator/skills/ ships. The citation names where the rule is owned so ' +
+      'the two copies stay in step. Shipping this tree instead would not be a fix, it would ' +
+      'reverse a design decision.',
+  },
+  {
+    prefix: 'operator/references/',
+    role: 'authoring-canon',
+    reason:
+      'send-posture.md is the one source every skill DEFERS to (ADR 0025/0035). Each citing ' +
+      'skill states its own authored ceiling inline and then points here, so the runtime rule ' +
+      'is already in the SKILL.md. The doc itself links out with repo-relative ../../docs/adr ' +
+      'paths, which only resolve in the repo.',
+  },
+  {
+    prefix: 'operator/fixtures/',
+    role: 'authoring-canon',
+    reason:
+      'Graded input/expected pairs, cited only from references/test-cases.md. They are read by a ' +
+      'human or a grading harness in the repo. An agent on a seat that read its own frozen ' +
+      'expected output would be grading itself.',
+  },
+  {
+    prefix: 'operator/grading/',
+    role: 'authoring-canon',
+    reason: 'Rubrics and archived grading runs. Repo-side evaluation artifacts, never seat input.',
+  },
+  {
+    prefix: 'operator/workspace_broker/',
+    role: 'authoring-canon',
+    reason:
+      'Cited as "canonical at" / "byte-identical to" for escalation_ledger.py, whose working copy ' +
+      'ships INSIDE the skill dir. Provenance for a twin-file sync, not a path to read. The same ' +
+      'stamped-copy pattern as operator/templates/pre_run_gate.py. This tree DOES ship, but to ' +
+      '/opt/workspace-broker/ for the broker uid, which is not where the citation points and is ' +
+      'not a path the agent may read.',
+  },
+  {
+    prefix: 'operator/customers/',
+    role: 'authoring-canon',
+    reason:
+      'Per-engagement material. It lives in venturecrane/engagements (ADR 0081), so these ' +
+      'citations are cross-repo pointers and several do not resolve in this tree by design. A ' +
+      'seat reads its engagement config from the volume, never from the image.',
+  },
+]
+
+function policyFor(citedPath: string): TreePolicy | undefined {
+  return CITED_TREE_POLICY.filter((p) => citedPath.startsWith(p.prefix)).sort(
+    (a, b) => b.prefix.length - a.prefix.length
+  )[0]
+}
+
+const describeCite = (c: Citation): string => `${c.citedBy}:${c.line} cites ${c.path}`
+
+/**
+ * Skill-relative citations with no file behind them. Every path here is built
+ * from a repo file's own text plus the repo dir it was found in, never from
+ * caller input.
+ */
+function missingSkillReferences(): Set<string> {
+  const out = new Set<string>()
+  for (const c of SKILL_RELATIVE_CITATIONS) {
+    // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal -- c.path is derived from a checked-in skill doc under operator/skills, not from user input.
+    if (!existsSync(resolve(c.path))) out.add(c.path)
+  }
+  return out
+}
+
+// ---------------------------------------------------------------------------
+
+describe('shipped skills cite only runtime paths the image carries', () => {
+  it('classifies every repo tree a shipped skill cites', () => {
+    // An unclassified tree is the open end of the guard. Failing here is the
+    // mechanism that stops a new citation from inheriting a waiver it was never
+    // weighed against.
+    const unclassified = REPO_CITATIONS.filter((c) => !policyFor(c.path))
+    expect(
+      unclassified.map(describeCite).sort(),
+      'Add an entry to CITED_TREE_POLICY. runtime-read means the agent opens or ' +
+        'executes it on a seat, so it must ship at the cited spelling; ' +
+        'authoring-canon means the rule is duplicated into the SKILL.md and the ' +
+        'citation only records where it is owned. Write the reason down.'
+    ).toEqual([])
+  })
+
+  it('ships every runtime-read path, at the spelling the skill cites', () => {
+    // The #2083 assertion. `present in the image` is necessary and not
+    // sufficient: the skills invoke `python3 operator/templates/drafting/
+    // drafting_gate_check.py`, so a copy parked at /app/drafting/ resolves to
+    // nothing. Both halves are checked against the Dockerfile, so re-pointing a
+    // COPY breaks this test rather than the seat.
+    const failures: string[] = []
+    const runtimeReads = new Map<string, Citation>()
+    for (const c of REPO_CITATIONS) {
+      if (policyFor(c.path)?.role !== 'runtime-read') continue
+      if (!runtimeReads.has(c.path)) runtimeReads.set(c.path, c)
+    }
+
+    for (const [path, cite] of [...runtimeReads].sort()) {
+      if (!existsSync(resolve(path))) {
+        failures.push(`${describeCite(cite)} - no such file in this repo`)
+        continue
+      }
+      const landings = containerPaths(path)
+      if (landings.length === 0) {
+        failures.push(
+          `${describeCite(cite)} - not in the ${DOCKERFILE_PATH} COPY set, so it is on no seat`
+        )
+        continue
+      }
+      const expectedAtWorkdir = posixJoin(WORKDIR, path)
+      if (!landings.includes(expectedAtWorkdir)) {
+        failures.push(
+          `${describeCite(cite)} - lands at ${landings.join(', ')} but the skill spells it ` +
+            `relative, and WORKDIR is ${WORKDIR}, so it must also land at ${expectedAtWorkdir}`
+        )
+      }
+    }
+
+    expect(failures, 'a runtime-read citation must resolve on the seat').toEqual([])
+  })
+
+  it('keeps the authoring-canon waivers honest', () => {
+    // A waiver whose premise has quietly changed is worse than no waiver: it
+    // reads as a considered decision while describing a world that no longer
+    // exists. The premise being checked is not "this tree ships nowhere" but the
+    // narrower and truer one: it does not land AT THE CITED SPELLING. The
+    // distinction is load-bearing. operator/workspace_broker/ ships to
+    // /opt/workspace-broker/ for the broker uid, which leaves its citations
+    // provenance; a COPY landing a waived tree under WORKDIR would turn every
+    // citation of it into a resolvable read and the role would need re-deciding.
+    const probe = '__waiver_probe__'
+    const landsAtCitedSpelling = CITED_TREE_POLICY.filter(
+      (p) =>
+        p.role === 'authoring-canon' &&
+        containerPaths(p.prefix + probe).includes(posixJoin(WORKDIR, p.prefix + probe))
+    ).map((p) => p.prefix)
+    expect(
+      landsAtCitedSpelling,
+      'These trees are waived because a citation of them resolves to nothing on a ' +
+        'seat. They now land where the citation points. Re-decide the role rather ' +
+        'than leaving a stale reason in place.'
+    ).toEqual([])
+
+    const deliveryChannels =
+      'operator/verticals/law-firm/addons/pi/references/_shared-delivery-channels.md'
+    expect(
+      readFileSync(resolve(deliveryChannels), 'utf8'),
+      `${deliveryChannels} is the written basis for the operator/verticals/ waiver`
+    ).toContain('only `operator/skills/` ships to the Machine image')
+  })
+
+  it('has no new skill-relative reference citation without a file', () => {
+    // A skill pointing at its own `references/<file>` that does not exist is the
+    // same class one layer down: the SKILL.md instructs a read of something the
+    // image cannot carry because nothing authored it. The pre-existing gaps are
+    // frozen in KNOWN_MISSING_SKILL_REFERENCES below; this assertion is the
+    // ratchet that stops the list from growing.
+    const missing = [...missingSkillReferences()].sort()
+    const known = new Set(KNOWN_MISSING_SKILL_REFERENCES)
+    expect(
+      missing.filter((p) => !known.has(p)),
+      'Author the reference file, or fix the citation. Do not extend the frozen ' +
+        'list: it is a record of debt that predates the guard, not a place to put more.'
+    ).toEqual([])
+  })
+
+  it('has no stale entry in the frozen missing-reference list', () => {
+    // The other half of the ratchet. Authoring one of these files must delete
+    // its line, so the list can only ever shrink and always reads as true.
+    const stillMissing = missingSkillReferences()
+    expect(
+      KNOWN_MISSING_SKILL_REFERENCES.filter((p) => !stillMissing.has(p)),
+      'These files now exist. Remove them from KNOWN_MISSING_SKILL_REFERENCES.'
+    ).toEqual([])
+  })
+})
+
+/**
+ * Skill-relative `references/<file>` citations with no file behind them, as
+ * found when this guard was written (ss-console #2083, 2026-07-30).
+ *
+ * These are AUTHORING gaps, not plumbing: the fix for each is to write the
+ * reference the SKILL.md already promises, or to drop the promise. #2083 named
+ * six skills missing `references/output-format.md`; the guard found twelve, plus
+ * a wider set of missing rubric/voice/test-case references, plus three skills
+ * pointing at a `references/_shared-training-output.md` that lives in the
+ * verticals pack and was never copied down. The list is deliberately literal so
+ * the debt is greppable and shrinks one line at a time.
+ */
+const KNOWN_MISSING_SKILL_REFERENCES: readonly string[] = [
+  'operator/skills/ar-chaser/references/categorization-rubric.md',
+  'operator/skills/ar-chaser/references/output-format.md',
+  'operator/skills/ar-chaser/references/test-cases.md',
+  'operator/skills/ar-chaser/references/voice.md',
+  'operator/skills/assessment-findings-draft/references/coverage-model.md',
+  'operator/skills/asset-collection-follower/references/categorization-rubric.md',
+  'operator/skills/asset-collection-follower/references/output-format.md',
+  'operator/skills/asset-collection-follower/references/test-cases.md',
+  'operator/skills/asset-collection-follower/references/voice.md',
+  'operator/skills/client-matter-digest/references/output-format.md',
+  'operator/skills/client-matter-digest/references/test-cases.md',
+  'operator/skills/client-matter-digest/references/voice.md',
+  'operator/skills/conflict-intake-router/references/output-format.md',
+  'operator/skills/conflict-intake-router/references/test-cases.md',
+  // The three _shared-training-output.md entries are a different mistake from
+  // the rest: that file exists, but in the verticals pack. These SKILL.md bodies
+  // spell it as if it had been copied down into their own references/ dir.
+  'operator/skills/daily-needs-you-digest/references/_shared-training-output.md',
+  'operator/skills/demand-letter-drafter/references/_shared-training-output.md',
+  'operator/skills/document-receipt-logger/references/output-format.md',
+  'operator/skills/document-receipt-logger/references/test-cases.md',
+  'operator/skills/intake-to-system-sync/references/output-format.md',
+  'operator/skills/intake-to-system-sync/references/test-cases.md',
+  'operator/skills/matter-inbox-router/references/output-format.md',
+  'operator/skills/matter-inbox-router/references/test-cases.md',
+  'operator/skills/matter-status-digest/references/output-format.md',
+  'operator/skills/matter-status-digest/references/test-cases.md',
+  'operator/skills/meet-and-confer-drafter/references/_shared-training-output.md',
+  'operator/skills/paid-media-anomaly-watcher/references/categorization-rubric.md',
+  'operator/skills/paid-media-anomaly-watcher/references/output-format.md',
+  'operator/skills/paid-media-anomaly-watcher/references/test-cases.md',
+  'operator/skills/paid-media-anomaly-watcher/references/voice.md',
+  'operator/skills/proposal-drafter/references/categorization-rubric.md',
+  'operator/skills/proposal-drafter/references/output-format.md',
+  'operator/skills/proposal-drafter/references/test-cases.md',
+  'operator/skills/proposal-drafter/references/voice.md',
+  'operator/skills/referral-source-acknowledgment/references/output-format.md',
+  'operator/skills/referral-source-acknowledgment/references/test-cases.md',
+  'operator/skills/referral-source-acknowledgment/references/voice.md',
+  'operator/skills/scope-creep-flagger/references/categorization-rubric.md',
+  'operator/skills/scope-creep-flagger/references/output-format.md',
+  'operator/skills/scope-creep-flagger/references/test-cases.md',
+  'operator/skills/scope-creep-flagger/references/voice.md',
+]


### PR DESCRIPTION
Contract A, streams 1 and 2. Closes #2082 and #2083. Built by two agents on disjoint paths; S3 (the spec loader) follows rather than joining, because it forks `entrypoint.sh` where S1 is adding boot-fetch validation.

## Two instances of one defect

An artifact is authored and never arrives at the runtime meant to obey it.

**Merged config never reached a seat** (`vfy_01KYTX7R6SQ7HNX6GWNR607QDF`). `origin/main` carried A&P's authored persona register; the live seat's config and `SOUL.md` still said `plainspoken / warm-but-professional / concise`. CI synced to D1 only; the sole writer to the object the seat actually reads was `provision-customer.sh`, run by hand.

**The drafting discipline and its checker were on no seat** (`vfy_01KYTXF76E1QHWQ2FQ9CYRGQBV`). Four skills assert the discipline is "loaded verbatim into every drafting run", and the discipline says no draft reaches the attorney without passing the mechanical checker. A whole-filesystem `find` on the pilot returned neither file.

## S1 — the publisher, and the hole auto-publish would arm

Diffs the push range, validates with the canonical pre-merge validator, uploads, reads the bytes back. R2 credentials derived from `CLOUDFLARE_API_TOKEN` (the venture's documented mechanism), so no second credential is minted.

**Never create.** A HEAD that fails for any reason other than 404 is a hard error, never a skip: *cannot tell* must not read as *no object here, move along*. First publish stays Captain-gated.

**One key space.** `output-classes.json` belongs to the portal (ADR 0083). Structural, not restraint: literal basename constant, charset-constrained slug, and `assert_config_key` re-checks the assembled key against a whole-string pattern. Exercised against `output-classes.json`, a voice subkey, path traversal, uppercase, and a `.bak` suffix — all refused.

**The boot fetch now validates.** `entrypoint.sh` did `cp` then `mv -f` with no check; only the poller validated. Survivable while the object was written by hand; auto-publish arms it. An object the poller rejects stays in R2, and the next restart — a Fly migration, an OOM, an unrelated redeploy — adopted it unvalidated, hours after the merge that put it there.

Structural validation **only**, deliberately: the applier's safety layer refuses rebuild-class fields, and those (persona tone among them) are precisely what a restart exists to deliver. Fail-static — a refused object leaves the Machine on the config it was already serving, so a bad publish costs the seat its update and never its uptime. An unimportable validator is treated as an invalid config, because a substrate we cannot check is not one we adopt from.

Verified against real configs (`vfy_01KYV4YD75HFYZM3HHK2QA3YQ3`): A&P's live `customer.yaml` passes, a mismatched `customer_id` is refused with named errors, malformed YAML is refused rather than crashing the boot.

**The acceptance criterion is a restart, not a poll** — `personas.*.tone` is never live-writable (overlay#201), since it renders into `SOUL.md` at boot and the applier does not re-run translate.

## S2 — ship it, then guard the class

The COPY destination mirrors the repo path on purpose: `WORKDIR` is `/app` and skills invoke `python3 operator/templates/drafting/drafting_gate_check.py` by that literal relative path, so a tidier `/app/drafting/` would put both files in the image and leave every citation dangling. Root-owned, joining the SEC-31 set — an agent that owns its own gate checker can rewrite the check it is graded by.

**The guard is the deliverable.** Shipping two files and calling it done is a `built` claim, from a plan that turns on `built` and `wired` being different claims. `tests/shipped-runtime-paths.test.ts` derives the shipped set from the Dockerfile's COPY lines and the WORKDIR from its last directive, so it cannot rot, and asserts **presence** plus **resolvability at the spelling the skill uses**. Every cited tree must be classified `runtime-read` or `authoring-canon` with the reason in code; an unclassified tree fails, so a new citation cannot inherit a waiver it was never weighed against.

**It found seven times what the issue described.** The issue named six skills missing `references/output-format.md`. It is twelve, and the wider class is **40 promised reference files that do not exist**. Three are a different bug and the cheapest real fixes: `daily-needs-you-digest`, `demand-letter-drafter` and `meet-and-confer-drafter` cite `_shared-training-output.md` as if it sat in their own directory, when it lives in the verticals pack. None authored here — that is content, not plumbing. All 40 frozen behind a two-way ratchet, so the list only shrinks and always reads as true.

The stream also corrected its own first draft: it had waived `operator/workspace_broker/` as "does not ship", and its own guard proved that false (it ships to `/opt/workspace-broker/`). That is what narrowed the honesty check to the truer property, *does not land at the cited spelling*.

## A test that was measuring its environment

The publisher guards passed standalone and failed inside `git push`. Git exports `GIT_DIR` / `GIT_WORK_TREE` / `GIT_INDEX_FILE` to every hook, and those win over `cwd` — so each fixture committed into the parent repository, and the publisher's opening `git diff` read the real repo's changed files instead of the fixture's. Fixed at both spawn sites; verified under three environments (clean, `GIT_DIR` alone, all three set), 14 passed in each.

`.dockerignore` gains a bytecode rule: an untracked `drafting_gate_check.cpython-314.pyc` sits in that tree right now and would have ridden into every customer image. Excludes zero tracked files.

## Verification

`npm run verify` green: 235 test files passed / 3 skipped, 0 lint errors. 200 operator conformance tests. Kill-tests: `vfy_01KYV4S0CJ8N55B02EN16CKH52` (guard fails on unresolvable path and on unclassified tree, verified independently of the authoring agent), plus six more in the stream's own report covering the waiver-premise break and both directions of the ratchet.

**Runtime ACs are NOT ticked.** Both issues carry `(runtime)` rows needing an image rebuild and observation on a live seat, and this PR is a repo-layer claim.