### PR TITLE
feat(ap): author send_policy — the firm is rostered INTERNAL, 60/hr reply backstop

### DIFF
--- a/operator/customers/ashton-price/customer.yaml
+++ b/operator/customers/ashton-price/customer.yaml
@@ -617,6 +617,38 @@ scope:
   # not a fixed floor (ADR 0035). Recipient-locked replies to rostered senders are
   # governed by the roster above, not by this ceiling (ADR 0055 §3).
 
+# ---- REPLY-CHANNEL SEND POLICY (ss#2070) ----
+# Chris asked for something he can talk to. The platform default — 3 replies to
+# one sender per 10 minutes, hardcoded until #2070 — cuts a conversation off at
+# the fourth exchange and, before the auto-release landed, never resumed: the
+# Operator simply went quiet mid-thread with no notice to either side. On this
+# engagement that is the "one mistake" failure mode, not a missing feature.
+#
+# The roster above is domain-wide (`@ashtonandprice.com`), so everyone at the
+# firm classifies INTERNAL and is exempt from the per-sender window. What still
+# bounds the channel is the reply backstop: 60 replies an hour, every class
+# counted. Two people in a working conversation are nowhere near it; a stuck
+# loop trips it inside the hour instead of mailing the firm all day. Senders NOT
+# on the roster keep the tight platform caps, unchanged.
+#
+# Values are the settled platform decision (Captain, 2026-07-30), authored
+# identically on pilot-smokeball (#2076) and proven there before landing here:
+# leg 1 ran ten exchanges on one thread with zero rate holds
+# (vfy_01KYV9QEEEVB1H9G3YPMFYZJ5E). Held replies release automatically within
+# the TTL rather than being dropped.
+send_policy:
+  reply:
+    internal_exempt: true # the whole firm is rostered INTERNAL
+    per_sender_max: 3 # non-roster senders: platform default, unchanged
+    per_sender_window_seconds: 600
+    global_max: 20 # non-roster aggregate: platform default, unchanged
+    global_window_seconds: 3600
+    backstop_max: 60 # the runaway bound, all classes
+    backstop_window_seconds: 3600
+  held_release:
+    enabled: true
+    ttl_seconds: 86400
+
 # ---- ESCALATION ----
 
 # ---- BUSINESS HOURS ----


### PR DESCRIPTION
Closes the config half of the gap between the A&P seat and the sustained-dialogue capability Chris asked for on the 2026-07-29 call ("we ought to at least get it up and running").

## Why

Without `send_policy` the seat runs the platform default — **3 replies to one sender per 10 minutes**. A working conversation dies at the fourth exchange, and before the auto-release landed it never resumed: the Operator went quiet mid-thread with no notice to either side. On this engagement that is the "one mistake costs more than ten missing features" failure mode, not a missing feature.

A&P's roster is domain-wide (`@ashtonandprice.com`), so everyone at the firm classifies INTERNAL and is exempt from the per-sender window. What still bounds the channel is the reply backstop — 60 replies an hour, all classes counted. Two people in a real conversation are nowhere near it; a stuck loop trips it inside the hour instead of mailing the firm all day. Non-roster senders keep the tight platform caps unchanged.

## Provenance of the numbers

Settled platform decision (Captain, 2026-07-30), authored identically on pilot-smokeball in #2076 and **proven there before landing here** — leg 1 ran ten exchanges on one thread with zero rate holds, `vfy_01KYV9QEEEVB1H9G3YPMFYZJ5E`. Fixtures → pilot → client, in that order.

Config only. No code path changes.

## What this PR does NOT do

Merging authors the config; it does not move the seat. **The A&P Machine is on overlay `23ff1575` — two bumps behind**, so it also lacks the Phase-1 work (#2070) and the two reply-channel fixes from #2078: a failed `create_draft` still emails the client and the retry sends a duplicate, and a matter-naming answer is held silently as `fabrication:tier2_citation`. For a PI firm whose matters are captioned *X v. Y*, that second one makes a whole class of question unanswerable by email.

No client mail has reached the seat yet — the audit shows scheduled-routine traffic only, zero `INBOUND_RECEIVED` and zero `REPLY_SENT` since 2026-07-29 — so neither defect has touched a real person. The reprovision is the next step and is a separate, Captain-visible action on a live client seat.

## Test plan

- [x] `npm run verify` — 3824 passed, 2 skipped, 7 todo
- [ ] Reprovision `hermes-ashton-price`, then confirm the seat reports the current overlay ref and the authored `send_policy` via the runtime read seam
- [ ] No test mail to client addresses — the roster is real people; behaviour is proven on pilot-smokeball, which is the same class (law-firm + agentmail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XrXGrbhg96SuhdCRcffryV