### PR TITLE
feat(operator): declare output_classes on smd-staging, so the spec gate binds (#2094)

### DIFF
--- a/operator/customers/smd-staging/customer.yaml
+++ b/operator/customers/smd-staging/customer.yaml
@@ -39,6 +39,28 @@ seat:
   kind: preprod
   product: operator
 
+# ---- AUTHORED OUTPUT SPECS (ADR 0083) ----
+# The first seat in the fleet to declare anything here, and deliberately the
+# preprod one: declaring `expected` BINDS the spec gate, and a bound class whose
+# spec is not yet installed fails closed to draft. That is the correct behavior
+# and the entire point of the declaration existing — but it is behavior to
+# observe on a seat that serves nobody before it reaches one that serves a firm.
+#
+# `staff` first because persona voice needs no customer corpus, so it is
+# provable from day one; because it is the highest-volume class by a wide
+# margin; and because its recipients are the firm's own people, so the cost of
+# a fail-closed draft is a human reading it a moment later rather than a client
+# waiting. `format_spec: none` is an authored choice, not an omission — the
+# convention in the skill's own output-format reference governs the shape.
+#
+# Every other class stays undeclared until someone authors its spec. An absent
+# class is not `none`; it is a class nobody has decided about yet, and the
+# registry is built so those cannot be confused (sections-output-classes.ts).
+output_classes:
+  staff:
+    voice_spec: expected
+    format_spec: none
+
 vertical: mixed
 fly_region: lax
 

--- a/tests/output-class-declarations.test.ts
+++ b/tests/output-class-declarations.test.ts
@@ -1,0 +1,137 @@
+/**
+ * A declared spec expectation must be one somebody can actually satisfy.
+ *
+ * WHY THIS GATE EXISTS. `output_classes.<class>.voice_spec: expected` is not a
+ * preference — it BINDS the overlay's spec gate. A bound class whose spec is
+ * absent or whose hash does not match the root manifest fails closed: that
+ * class's autonomous sends downgrade to draft, and they stay downgraded until
+ * someone installs a spec. That is correct, and it is the whole reason the
+ * declaration exists (see sections-output-classes.ts).
+ *
+ * It also means a declaration nobody can satisfy is not a harmless typo. It is
+ * a silent, permanent downgrade of a class of output, with no error anywhere
+ * and nothing on the seat to explain it. A class slug misspelled here, or one
+ * the portal writer cannot address, produces exactly that.
+ *
+ * So this asserts the loop closes: every class declared `expected` on any seat
+ * exists in the class registry, and the console → vault writer can produce a
+ * key and a document body for it. The producer and the expectation are checked
+ * against each other rather than each against its own idea of the vocabulary.
+ *
+ * This is the repo half of #2094. The runtime half — the spec installing
+ * root-owned, the gate passing on a read turn and downgrading on a turn that
+ * did not read — is observed on a seat and cannot be closed here.
+ */
+
+import { readFileSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { parse as parseYaml } from 'yaml'
+
+import {
+  buildSpecDocument,
+  specObjectKey,
+  SPEC_PROPERTIES,
+  type SpecProperty,
+} from '../src/lib/operator/output-class-specs'
+
+const CUSTOMERS_DIR = join(process.cwd(), 'operator', 'customers')
+const REGISTRY_PATH = join(process.cwd(), 'operator', 'contracts', 'output-classes.yaml')
+
+interface Declaration {
+  slug: string
+  outputClass: string
+  property: SpecProperty
+}
+
+function registryClasses(): Set<string> {
+  const parsed = parseYaml(readFileSync(REGISTRY_PATH, 'utf8')) as {
+    classes?: Record<string, unknown>
+  }
+  const classes = parsed?.classes
+  if (!classes || typeof classes !== 'object') {
+    throw new Error(`${REGISTRY_PATH} has no classes: block`)
+  }
+  return new Set(Object.keys(classes))
+}
+
+/** Every (seat, class, property) declared `expected` anywhere in the tree. */
+function expectedDeclarations(): Declaration[] {
+  const found: Declaration[] = []
+  for (const slug of readdirSync(CUSTOMERS_DIR).sort()) {
+    const path = join(CUSTOMERS_DIR, slug, 'customer.yaml')
+    let raw: string
+    try {
+      raw = readFileSync(path, 'utf8')
+    } catch {
+      continue
+    }
+    const doc = (parseYaml(raw) ?? {}) as { output_classes?: Record<string, unknown> }
+    const declared = doc.output_classes
+    if (!declared || typeof declared !== 'object') continue
+    for (const [outputClass, entry] of Object.entries(declared)) {
+      if (!entry || typeof entry !== 'object') continue
+      for (const property of SPEC_PROPERTIES) {
+        if ((entry as Record<string, unknown>)[`${property}_spec`] === 'expected') {
+          found.push({ slug, outputClass, property })
+        }
+      }
+    }
+  }
+  return found
+}
+
+describe('declared spec expectations are satisfiable', () => {
+  it('at least one seat declares output_classes', () => {
+    // Without this, every assertion below passes vacuously and the spec loader
+    // stays shipped-but-bound-to-nothing — which is the state #2094 exists to
+    // end, and precisely the failure class this programme indicts.
+    const anyDeclared = readdirSync(CUSTOMERS_DIR).some((slug) => {
+      try {
+        const doc = parseYaml(readFileSync(join(CUSTOMERS_DIR, slug, 'customer.yaml'), 'utf8')) as {
+          output_classes?: unknown
+        }
+        return doc?.output_classes != null
+      } catch {
+        return false
+      }
+    })
+    expect(
+      anyDeclared,
+      'no customer.yaml declares output_classes, so the overlay spec gate binds on nothing ' +
+        'fleet-wide and the shipped spec loader governs no output at all'
+    ).toBe(true)
+  })
+
+  it('every class declared expected exists in the class registry', () => {
+    const known = registryClasses()
+    for (const { slug, outputClass, property } of expectedDeclarations()) {
+      expect(
+        known.has(outputClass),
+        `${slug} declares ${property}_spec: expected for output class '${outputClass}', which is ` +
+          `not in operator/contracts/output-classes.yaml. A class the registry does not know is a ` +
+          `class the gate resolves to nothing — the expectation silently governs no send.`
+      ).toBe(true)
+    }
+  })
+
+  it('the console writer can produce a key and a body for every expected class', async () => {
+    for (const { slug, outputClass, property } of expectedDeclarations()) {
+      expect(() => specObjectKey(slug)).not.toThrow()
+
+      const built = await buildSpecDocument([
+        { outputClass, property, body: 'probe body for the declaration gate' },
+      ])
+      expect(
+        built.ok,
+        `${slug} declares ${property}_spec: expected for '${outputClass}', but the console → vault ` +
+          `writer refuses to build a document for it: ` +
+          `${built.ok ? '' : built.errors.join('; ')}. A declaration the producer cannot satisfy is ` +
+          `a permanent fail-closed downgrade of that class with nothing anywhere to explain it.`
+      ).toBe(true)
+      if (built.ok) {
+        expect(built.doc.classes[outputClass]?.[property]?.sha256).toMatch(/^[0-9a-f]{64}$/)
+      }
+    }
+  })
+})


### PR DESCRIPTION
Closes the `(repo)` rows of #2094.

## The gap this closes

The spec loader merged in #2088 is **bound to nothing on every seat**. `output_classes:` landed in W0′ as optional and default-absent — correct for a seams PR — and no customer declared it, so `spec_gate` resolves every send to a class nobody has an expectation for and stays silent fleet-wide.

Built, shipped into the image, root-owned on the volume, gated on a verified per-turn read, and governing no output at all. That is the failure class this programme exists to end, arriving inside the programme's own work (`vfy_01KYWJKEHY68DHW3NV29QDE813`).

## What this changes

`staff.voice_spec: expected` on `smd-staging`, plus the gate that keeps a declaration honest.

**Why this seat.** `expected` binds, and a bound class whose spec is not yet installed **fails closed to draft**. That is correct and is the entire reason the declaration exists — but it is behavior to observe on a `seat.kind: preprod` seat that serves nobody before it reaches one that serves a firm. `ashton-price` is `kind: customer`; declaring there is a Captain call, not an agent one.

**Why this class.** Persona voice needs no customer corpus, so `staff` is provable from day one. It is the highest-volume class by a wide margin. And its recipients are the firm's own people, so the cost of a fail-closed draft is a human reading it a moment later rather than a client waiting. `format_spec: none` is an authored choice, not an omission — the skill's own `output-format.md` convention governs the shape.

Every other class stays undeclared. An absent class is not `none`; it is a class nobody has decided about, and the registry is built so those cannot be confused.

## Expected behavior change on merge

Config auto-publishes on merge (#2082), so `smd-staging` adopts this on its **next restart**, not immediately. From then, until a spec is installed for `staff`, that class's autonomous sends downgrade to draft with reason `spec_not_read`.

Stating it plainly because it is a behavior change on a live seat, and because "the gate now downgrades" is one of #2094's own runtime ACs rather than a regression.

## The gate

`tests/output-class-declarations.test.ts`, three arms:

1. **Some seat declares something.** Without this, every other assertion passes vacuously and we are back at bound-to-nothing while the suite reports green.
2. **Every class declared `expected` exists in the class registry.** A class the registry does not know is a class the gate resolves to nothing.
3. **The console → vault writer can produce a key and a hashed body for it.** A declaration the producer cannot satisfy is a silent, permanent downgrade of a class of output with nothing on the seat to explain it.

**Kill-tested, not assumed:**

| Injected fault | Result |
|---|---|
| Class slug misspelled (`staaff`) | registry arm fails |
| Slug the writer cannot produce (`STAFF_UPPER`) | registry + writer arms fail |
| Declaration removed entirely | vacuity arm fails |
| Restored | all three pass, tree clean |

## Status

| AC | Layer | Met | Evidence |
|---|---|---|---|
| A proving seat declares `output_classes` with one class `expected` | repo | yes | `smd-staging/customer.yaml` |
| A test asserts a declared `expected` class has a producible spec key | repo | yes | kill-tested, 4 arms above |
| Spec installs root-owned under `SMD_SPEC_DIR`, manifest names it | runtime | **no** | not observed |
| `spec_gate` PASSES an autonomous send on a turn that read the spec | runtime | **no** | not observed |
| `spec_gate` DOWNGRADES on a turn that did not | runtime | **no** | not observed |
| Both behaviors identical after a restart | runtime | **no** | not observed |

**Not end-to-end.** This makes the gate bindable; nothing here has been observed on a seat. The runtime rows need an image rebuild on the current pin and a restart of `smd-staging`.

## Test plan

- [x] `npm run verify` — 3883 passed, 0 type errors, 0 lint errors, exit 0
- [x] Declaration gate kill-tested across three fault injections, clean restore verified
- [x] Projection carries the block (`customer-config-projection.ts:106`, migration 0100)

🤖 Generated with [Claude Code](https://claude.com/claude-code)