### PR TITLE
feat(operator): provisioning refuses a build source that is not what you think (#2095)

### DIFF
--- a/operator/bin/provision-customer.sh
+++ b/operator/bin/provision-customer.sh
@@ -99,6 +99,85 @@ BIN_DIR="${REPO_ROOT}/operator/bin"
 log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [provision/${SLUG}] $*"; }
 die() { log "FATAL: $*"; exit 1; }
 
+# ---------- Step 0-: the build source is what you think it is ----------
+#
+# REPO_ROOT is derived from THIS SCRIPT'S OWN LOCATION, so the image is built
+# from whichever checkout you invoked — not from a canonical one. That is easy
+# to state and easy to forget, because runbooks, muscle memory, and shell
+# history all say `~/dev/ss-console/operator/bin/reprovision.sh` while an
+# agent's verified work is usually sitting in a worktree under
+# `.claude/worktrees/`.
+#
+# WHAT THIS COSTS WHEN IT GOES WRONG (2026-07-31). The primary checkout sat two
+# commits behind origin/main carrying thirty staged entries that reverted a
+# whole merged programme — the config publisher, both CI guards, a migration,
+# the Dockerfile and entrypoint changes — with OVERLAY_REF still on the previous
+# pin. A reprovision in that state builds an image containing none of the work,
+# pins the wrong overlay, and EXITS ZERO. Every observation taken afterwards is
+# then a true statement about the wrong artifact, which is worse than a failure,
+# because a failure gets investigated and a green run gets believed.
+#
+# So: refuse by default, and print the resolved source on every run so a
+# reprovision can never leave doubt about which tree produced the image.
+# Escape hatch is deliberate, named, and loud — the same shape as
+# SS_ALLOW_PRIMARY_WRITES and SS_ALLOW_UNREAD_ENGAGEMENT_WRITES.
+assert_build_source_is_current() {
+  log "Build source: ${REPO_ROOT}"
+
+  if ! git -C "${REPO_ROOT}" rev-parse --git-dir >/dev/null 2>&1; then
+    log "WARN: ${REPO_ROOT} is not a git checkout; source currency cannot be verified"
+    return 0
+  fi
+
+  local head_sha upstream_sha dirty behind pin manifest_pin
+  head_sha="$(git -C "${REPO_ROOT}" rev-parse --short HEAD)"
+  log "Build source HEAD: ${head_sha}"
+
+  # A stale index reverting merged work is exactly the incident above, and it
+  # presents as ordinary dirt. Report the paths — "dirty" alone sends people
+  # looking for their own edits rather than at a damaged index.
+  dirty="$(git -C "${REPO_ROOT}" status --porcelain 2>/dev/null | head -20)"
+  if [ -n "${dirty}" ] && [ "${SS_ALLOW_DIVERGENT_SOURCE:-}" != "1" ]; then
+    echo "${dirty}" >&2
+    die "build source ${REPO_ROOT} has uncommitted changes (above). An image built from a \
+dirty tree is not the code you reviewed. Commit, stash, or reset it — or set \
+SS_ALLOW_DIVERGENT_SOURCE=1 if you deliberately mean to build from these exact bytes."
+  fi
+
+  # Non-fatal: an offline operator should not be blocked, but they should know
+  # the comparison below is against whatever origin/main was last fetched.
+  git -C "${REPO_ROOT}" fetch origin --quiet 2>/dev/null \
+    || log "WARN: could not fetch origin; comparing against the last-known origin/main"
+
+  if git -C "${REPO_ROOT}" rev-parse --verify origin/main >/dev/null 2>&1; then
+    upstream_sha="$(git -C "${REPO_ROOT}" rev-parse --short origin/main)"
+    behind="$(git -C "${REPO_ROOT}" rev-list --count HEAD..origin/main 2>/dev/null || echo 0)"
+    if [ "${behind}" != "0" ] && [ "${SS_ALLOW_DIVERGENT_SOURCE:-}" != "1" ]; then
+      die "build source is ${behind} commit(s) behind origin/main (HEAD ${head_sha}, \
+origin/main ${upstream_sha}). Whatever landed in those commits will NOT be in this image. \
+Update it, or set SS_ALLOW_DIVERGENT_SOURCE=1 to build this ref on purpose."
+    fi
+  fi
+
+  # The vitest drift gate proves these agree at MERGE time. Nothing proved it at
+  # BUILD time, which is the only moment it protects an actual image.
+  pin="$(sed -n 's/^ARG OVERLAY_REF="\([0-9a-f]*\)".*/\1/p' "${TEMPLATE_DIR}/Dockerfile" | head -1)"
+  manifest_pin="$(sed -n 's/.*"overlayRef"[[:space:]]*:[[:space:]]*"\([0-9a-f]*\)".*/\1/p' \
+    "${REPO_ROOT}/operator/contracts/overlay-pairs.json" | head -1)"
+  if [ -n "${pin}" ] && [ -n "${manifest_pin}" ] && [ "${pin}" != "${manifest_pin}" ]; then
+    die "OVERLAY_REF mismatch: Dockerfile pins ${pin}, overlay-pairs.json pins ${manifest_pin}. \
+The image would ship an overlay the pair manifest does not describe."
+  fi
+  [ -n "${pin}" ] && log "Overlay pin: ${pin}"
+
+  if [ "${SS_ALLOW_DIVERGENT_SOURCE:-}" = "1" ]; then
+    log "WARN: SS_ALLOW_DIVERGENT_SOURCE=1 — source currency checks bypassed BY REQUEST. \
+The image is being built from ${REPO_ROOT} at ${head_sha} exactly as it stands."
+  fi
+}
+
+assert_build_source_is_current
+
 # ---------- Step 0: verify operator R2 credentials ----------
 # These live in the operator's local shell (e.g., direnv / .envrc); they are
 # used by `aws s3 cp` for the customer.yaml upload below. The same logical

--- a/tests/provision-source-guard.test.ts
+++ b/tests/provision-source-guard.test.ts
@@ -1,0 +1,202 @@
+/**
+ * The build source must be the code you think it is (ss #2095).
+ *
+ * `provision-customer.sh` derives `REPO_ROOT` from its own location, so the
+ * image is built from whichever checkout you invoked. That is easy to state and
+ * easy to forget: runbooks, muscle memory, and shell history all point at
+ * `~/dev/ss-console/operator/bin/reprovision.sh`, while an agent's verified work
+ * usually sits in a worktree under `.claude/worktrees/`.
+ *
+ * WHAT IT COST (2026-07-31). The primary checkout sat two commits behind
+ * origin/main carrying thirty staged entries that reverted a whole merged
+ * programme, with `OVERLAY_REF` still on the previous pin. A reprovision in that
+ * state builds an image containing none of the work, pins the wrong overlay, and
+ * exits zero. Every observation taken afterwards is a true statement about the
+ * wrong artifact — worse than a failure, because a failure gets investigated and
+ * a green run gets believed.
+ *
+ * Each refusal arm is DRIVEN here rather than read, because a guard nobody has
+ * watched refuse is a guard nobody knows the shape of.
+ *
+ * The guard runs before the script's R2-credential checks, so a fixture that
+ * gets past it dies on a different, identifiable message. That distinction is
+ * what lets the pass-through case assert "the guard allowed this" without
+ * needing R2, `aws`, or `pbpaste`.
+ *
+ * GIT_* IS STRIPPED FROM EVERY CHILD. `cwd` does not isolate a git subprocess:
+ * `GIT_DIR`, `GIT_WORK_TREE`, and `GIT_INDEX_FILE` win over it, and git hooks
+ * export them. A fixture that omits this initialises and commits into the REAL
+ * repository — which is how a branch got its index clobbered the same week this
+ * guard was written.
+ */
+import { execFileSync } from 'node:child_process'
+import { cpSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+const REPO_ROOT = fileURLToPath(new URL('..', import.meta.url))
+const SLUG = 'probe-seat'
+
+/**
+ * Env with every `GIT_*` and every `R2_*` removed.
+ *
+ * `GIT_*` for the reason in the header. `R2_*` for two reasons: the developer
+ * shell often carries real credentials (via direnv or an `infisical run`
+ * wrapper), which would let a fixture past the credential check and — worse —
+ * run a provisioning script holding live credentials; and the R2 check is the
+ * sentinel these tests use to mean "the guard allowed this", so it has to fail
+ * deterministically rather than depending on whose shell is running.
+ */
+function cleanEnv(extra: Record<string, string> = {}): Record<string, string> {
+  return {
+    ...Object.fromEntries(
+      Object.entries({ ...process.env, HUSKY: '0' }).filter(
+        ([k]) => !k.startsWith('GIT_') && !k.startsWith('R2_')
+      )
+    ),
+    ...extra,
+  }
+}
+
+function git(dir: string, ...args: string[]): void {
+  execFileSync('git', ['-C', dir, ...args], { env: cleanEnv(), stdio: 'pipe' })
+}
+
+const PIN = 'a'.repeat(40)
+
+/**
+ * A checkout shaped like this repo, far enough for the guard to run: the real
+ * script, a Dockerfile carrying a pin, a matching pair manifest, and a customer
+ * directory. Nothing beyond the guard's reach is built.
+ */
+function makeCheckout(): { root: string; script: string } {
+  const root = mkdtempSync(join(tmpdir(), 'provision-source-'))
+  mkdirSync(join(root, 'operator', 'bin'), { recursive: true })
+  mkdirSync(join(root, 'operator', 'templates'), { recursive: true })
+  mkdirSync(join(root, 'operator', 'contracts'), { recursive: true })
+  mkdirSync(join(root, 'operator', 'customers', SLUG), { recursive: true })
+
+  cpSync(
+    join(REPO_ROOT, 'operator', 'bin', 'provision-customer.sh'),
+    join(root, 'operator', 'bin', 'provision-customer.sh')
+  )
+  writeFileSync(join(root, 'operator', 'templates', 'Dockerfile'), `ARG OVERLAY_REF="${PIN}"\n`)
+  writeFileSync(
+    join(root, 'operator', 'contracts', 'overlay-pairs.json'),
+    `${JSON.stringify({ overlayRef: PIN, pairs: [] }, null, 2)}\n`
+  )
+  writeFileSync(
+    join(root, 'operator', 'customers', SLUG, 'customer.yaml'),
+    `customer_id: ${SLUG}\n`
+  )
+
+  git(root, 'init', '--quiet', '--initial-branch=main')
+  git(root, 'config', 'user.email', 'probe@example.invalid')
+  git(root, 'config', 'user.name', 'probe')
+  git(root, 'add', '-A')
+  git(root, 'commit', '--quiet', '-m', 'baseline')
+  // A local `origin/main` so the behind-check has something to compare against
+  // without any network.
+  git(root, 'update-ref', 'refs/remotes/origin/main', 'HEAD')
+
+  return { root, script: join(root, 'operator', 'bin', 'provision-customer.sh') }
+}
+
+/** Run the script and return combined output plus whether it exited zero. */
+function run(script: string, env: Record<string, string> = {}): { out: string; ok: boolean } {
+  try {
+    const out = execFileSync('bash', [script, SLUG], {
+      env: cleanEnv(env),
+      encoding: 'utf8',
+      stdio: 'pipe',
+    })
+    return { out, ok: true }
+  } catch (err) {
+    const e = err as { stdout?: string; stderr?: string }
+    return { out: `${e.stdout ?? ''}${e.stderr ?? ''}`, ok: false }
+  }
+}
+
+const checkouts: string[] = []
+afterEach(() => {
+  while (checkouts.length) rmSync(checkouts.pop()!, { recursive: true, force: true })
+})
+
+function checkout(): { root: string; script: string } {
+  const made = makeCheckout()
+  checkouts.push(made.root)
+  return made
+}
+
+describe('provision refuses a build source that is not what you think it is', () => {
+  it('prints the resolved build source and pin on every run', () => {
+    const { root, script } = checkout()
+    const { out } = run(script)
+    expect(out).toContain(`Build source: ${root}`)
+    expect(out).toContain(`Overlay pin: ${PIN}`)
+  })
+
+  it('a clean, current checkout gets PAST the guard', () => {
+    // Proves the refusals below are the guard and not the fixture. Past the
+    // guard the script dies on R2 credentials, which is a different failure.
+    const { script } = checkout()
+    const { out } = run(script)
+    expect(out).toContain('R2_ENDPOINT_URL not set')
+    expect(out).not.toContain('uncommitted changes')
+    expect(out).not.toContain('behind origin/main')
+  })
+
+  it('refuses a dirty checkout, naming the files', () => {
+    const { root, script } = checkout()
+    writeFileSync(join(root, 'operator', 'templates', 'entrypoint.sh'), 'echo drift\n')
+    const { out, ok } = run(script)
+    expect(ok).toBe(false)
+    expect(out).toContain('uncommitted changes')
+    expect(out).toContain('entrypoint.sh')
+    expect(out).not.toContain('R2_ENDPOINT_URL not set')
+  })
+
+  it('refuses a checkout behind origin/main, naming the gap', () => {
+    const { root, script } = checkout()
+    writeFileSync(join(root, 'operator', 'customers', SLUG, 'customer.yaml'), 'customer_id: x\n')
+    git(root, 'add', '-A')
+    git(root, 'commit', '--quiet', '-m', 'ahead')
+    git(root, 'update-ref', 'refs/remotes/origin/main', 'HEAD')
+    git(root, 'reset', '--hard', '--quiet', 'HEAD~1')
+
+    const { out, ok } = run(script)
+    expect(ok).toBe(false)
+    expect(out).toContain('behind origin/main')
+    expect(out).toContain('1 commit(s)')
+    expect(out).not.toContain('R2_ENDPOINT_URL not set')
+  })
+
+  it('refuses an OVERLAY_REF that disagrees with the pair manifest, naming both', () => {
+    const { root, script } = checkout()
+    const other = 'b'.repeat(40)
+    writeFileSync(join(root, 'operator', 'templates', 'Dockerfile'), `ARG OVERLAY_REF="${other}"\n`)
+    git(root, 'add', '-A')
+    git(root, 'commit', '--quiet', '-m', 'drift the pin')
+    git(root, 'update-ref', 'refs/remotes/origin/main', 'HEAD')
+
+    const { out, ok } = run(script)
+    expect(ok).toBe(false)
+    expect(out).toContain('OVERLAY_REF mismatch')
+    expect(out).toContain(other)
+    expect(out).toContain(PIN)
+  })
+
+  it('SS_ALLOW_DIVERGENT_SOURCE=1 bypasses, and says so loudly', () => {
+    // The escape hatch must exist — an operator sometimes means to build
+    // exactly these bytes — but it must never be quiet about it.
+    const { root, script } = checkout()
+    writeFileSync(join(root, 'operator', 'templates', 'entrypoint.sh'), 'echo drift\n')
+    const { out } = run(script, { SS_ALLOW_DIVERGENT_SOURCE: '1' })
+    expect(out).toContain('SS_ALLOW_DIVERGENT_SOURCE=1')
+    expect(out).toContain('bypassed BY REQUEST')
+    expect(out).toContain('R2_ENDPOINT_URL not set')
+  })
+})


### PR DESCRIPTION
Closes #2095.

## The asymmetry

`provision-customer.sh:89` derives `REPO_ROOT` from its **own** `BASH_SOURCE`, so the image is built from whichever checkout you invoked — not from a canonical one. Easy to state, easy to forget: runbooks, shell history, and muscle memory all point at `~/dev/ss-console/operator/bin/reprovision.sh`, while an agent's verified work is usually sitting in a worktree under `.claude/worktrees/`.

You verify the pin in the tree you are looking at. The build reads a different tree. Nothing connected the two.

## What it cost, hours before this PR

`vfy_01KYWKMS7RRK58DYH06C9WM5SJ` — the primary checkout sat **2 commits behind** `origin/main` carrying **30 staged entries** that reverted a whole merged programme: the config publisher, both CI guards, migration 0100, the Dockerfile and entrypoint changes, `OVERLAY_REF` still on the previous pin.

A reprovision in that state builds an image containing **none** of the work, pins the **wrong overlay**, and **exits zero**. Every observation taken afterwards would then be a true statement about the wrong artifact — worse than a failure, because a failure gets investigated and a green run gets believed. It was caught by hand, minutes before the run that would have believed it.

This is the third time the build-source asymmetry has cost something, and "remember to check" has not held. It cannot: the failure is silent by construction.

## The guard

Refuses by default when the build source is **dirty**, **behind `origin/main`**, or carrying an **`OVERLAY_REF` the pair manifest does not describe** — naming the offending files, the commit gap, or both pins, rather than just saying no. A stale index reverting merged work presents as ordinary dirt, and "dirty" alone sends people hunting for their own edits instead of at a damaged index.

Prints the **resolved source path and overlay pin on every run**, so a reprovision can never leave doubt about which tree produced the image.

The `git fetch` is non-fatal — an offline operator is warned that the comparison is against the last-known `origin/main`, not blocked.

`SS_ALLOW_DIVERGENT_SOURCE=1` bypasses and **says so loudly**, matching `SS_ALLOW_PRIMARY_WRITES` and `SS_ALLOW_UNREAD_ENGAGEMENT_WRITES`. Sometimes you do mean to build exactly those bytes; you should never do it quietly.

The `OVERLAY_REF` check is worth calling out separately: a vitest gate already proves the two pins agree at **merge** time. Nothing proved it at **build** time, which is the only moment it protects an actual image.

## Driven, not read

Six arms, each exercised. The pass-through case is there to prove the refusals are the guard and not the fixture — past the guard the script dies on R2 credentials, a different and identifiable failure.

| Arm | Result |
|---|---|
| Source path + pin printed every run | asserted |
| Clean, current checkout passes through | reaches the R2 check |
| Dirty checkout | refused, names the files |
| Behind `origin/main` | refused, names the gap |
| `OVERLAY_REF` ≠ manifest | refused, names both pins |
| `SS_ALLOW_DIVERGENT_SOURCE=1` | bypasses, warns loudly |

**Also kill-tested against this live worktree** (`vfy_01KYWS76H945WNA7NKANGPH0DT`), not only fixtures: run while dirty it named the source, the HEAD, and the two offending files and refused; run after commit it printed source, HEAD, and pin `151d1340` and proceeded.

## A fixture note that cost a branch this week

Fixtures strip **`GIT_*`** *and* **`R2_*`** from the child env.

`GIT_*` because `cwd` does not isolate a git subprocess — `GIT_DIR`, `GIT_WORK_TREE`, and `GIT_INDEX_FILE` win over it, and hooks export them. A fixture without the strip initialises and commits into the *real* repository.

`R2_*` because the developer shell often carries live credentials via direnv or an `infisical run` wrapper. The first run of this suite sailed past the credential check and into the validator on inherited real creds — which both defeated the sentinel the tests use for "the guard allowed this" and meant a test fixture was executing a provisioning script while holding production credentials.

## Status

| AC | Layer | Met |
|---|---|---|
| Refuses a dirty checkout, naming the files | repo | yes |
| Refuses when behind `origin/main`, naming the gap | repo | yes |
| Refuses on `OVERLAY_REF` / manifest mismatch, naming both | repo | yes |
| Build-source path printed on every run | repo | yes |
| A test drives each refusal arm | repo | yes |
| Reprovision against a deliberately-stale primary refuses; running image unchanged | runtime | **no** — not observed |

The runtime row needs a real reprovision attempt and is not closed here.

## Test plan

- [x] `npm run verify` — 3889 passed, 0 type errors, 0 lint errors, exit 0
- [x] Six guard arms driven in fixtures
- [x] Guard exercised against a real checkout, dirty and clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)