### PR TITLE
fix(operator): the build-source guard no longer trips on .claude/ markers (#2101)

### DIFF
--- a/operator/bin/provision-customer.sh
+++ b/operator/bin/provision-customer.sh
@@ -136,7 +136,34 @@ assert_build_source_is_current() {
   # A stale index reverting merged work is exactly the incident above, and it
   # presents as ordinary dirt. Report the paths — "dirty" alone sends people
   # looking for their own edits rather than at a damaged index.
-  dirty="$(git -C "${REPO_ROOT}" status --porcelain 2>/dev/null | head -20)"
+  #
+  # `.claude/` is excluded, and ONLY `.claude/`. It holds agent session markers
+  # and the worktrees themselves, so it is dirty in essentially every working
+  # checkout; it is in `.dockerignore` and no COPY in the Dockerfile names it,
+  # so it cannot reach the image this guard protects. On the guard's FIRST real
+  # use it refused a rebuild over a lone `parallel-isolation-required-<uuid>`
+  # marker (#2101). That matters more than the nuisance: a guard that trips on
+  # ordinary working conditions teaches people to reach for
+  # SS_ALLOW_DIVERGENT_SOURCE by reflex, and a reflexive bypass is worse than no
+  # guard — it is one everybody believes is protecting them while it is waved
+  # through unread. Reaching for the flag has to stay a decision.
+  #
+  # Narrow ON PURPOSE. The tempting widening is "exclude whatever .dockerignore
+  # excludes", which is wrong: an untracked source file elsewhere in the tree
+  # genuinely can change the image, and .dockerignore also excludes paths whose
+  # presence in git still matters. `.claude/` is the one directory that is
+  # session state by definition — the repo already treats it specially, since
+  # .claude/hooks/worktree-guard.mjs exempts it from the read-only primary rule
+  # for exactly this reason.
+  #
+  # The pattern anchors to porcelain's `XY ` prefix (two status chars plus a
+  # space) so it matches a top-level `.claude/` and not some nested
+  # `src/.claude/` that would be a genuine surprise worth refusing.
+  # `|| true` is load-bearing: grep exits 1 when it emits nothing, which under
+  # `set -euo pipefail` aborts the script on a CLEAN tree — the guard would kill
+  # every well-formed build while letting dirty ones through to the next check.
+  dirty="$(git -C "${REPO_ROOT}" status --porcelain 2>/dev/null | grep -v '^...\.claude/' || true)"
+  dirty="$(printf '%s' "${dirty}" | head -20)"
   if [ -n "${dirty}" ] && [ "${SS_ALLOW_DIVERGENT_SOURCE:-}" != "1" ]; then
     echo "${dirty}" >&2
     die "build source ${REPO_ROOT} has uncommitted changes (above). An image built from a \

--- a/tests/provision-source-guard.test.ts
+++ b/tests/provision-source-guard.test.ts
@@ -149,6 +149,31 @@ describe('provision refuses a build source that is not what you think it is', ()
     expect(out).not.toContain('behind origin/main')
   })
 
+  it('a .claude/ session marker alone does NOT trip the dirty check', () => {
+    // The guard's first real use refused a rebuild over a lone
+    // `parallel-isolation-required-<uuid>` marker (#2101). `.claude/` is in
+    // .dockerignore and no COPY names it, so it cannot reach the image — and a
+    // guard that trips on ordinary working conditions trains people to reach
+    // for the bypass by reflex, which is worse than no guard at all.
+    const { root, script } = checkout()
+    mkdirSync(join(root, '.claude'), { recursive: true })
+    writeFileSync(join(root, '.claude', 'parallel-isolation-required-abc123'), '')
+    const { out } = run(script)
+    expect(out).not.toContain('uncommitted changes')
+    expect(out).toContain('R2_ENDPOINT_URL not set') // reached the next step
+  })
+
+  it('still refuses an untracked file OUTSIDE .claude/', () => {
+    // The exclusion must stay narrow. An untracked source file genuinely can
+    // change the image, so only `.claude/` is forgiven.
+    const { root, script } = checkout()
+    writeFileSync(join(root, 'operator', 'templates', 'stowaway.sh'), 'echo hi\n')
+    const { out, ok } = run(script)
+    expect(ok).toBe(false)
+    expect(out).toContain('uncommitted changes')
+    expect(out).toContain('stowaway.sh')
+  })
+
   it('refuses a dirty checkout, naming the files', () => {
     const { root, script } = checkout()
     writeFileSync(join(root, 'operator', 'templates', 'entrypoint.sh'), 'echo drift\n')


### PR DESCRIPTION
Closes #2101. Defect in #2095, found on the guard's **first real use** — the right time to find it, the wrong behaviour to leave in.

## What happened

A rebuild of `smd-staging` was refused:

```
[provision/smd-staging] Build source: /Users/scottdurgan/dev/ss-console
[provision/smd-staging] Build source HEAD: 91b7c816
?? .claude/parallel-isolation-required-4e12192a-a811-42e4-8e32-2a3bc10e41e7
[provision/smd-staging] FATAL: build source ... has uncommitted changes (above).
```

A session marker written by the agent harness. It cannot reach the image — `.dockerignore:18` excludes `.claude` and no `COPY` in the Dockerfile names it. The guard refused a build over a file structurally incapable of changing the artifact it protects.

## Why fix it rather than live with it

The bypass got used, correctly — paths inspected and `.dockerignore` confirmed first. That is precisely the reason this had to be fixed.

`.claude/` is present in essentially every working checkout. Left alone, `SS_ALLOW_DIVERGENT_SOURCE=1` becomes part of the normal invocation within a week, and **a reflexive bypass is worse than no guard**: it is one everybody believes is protecting them while it is waved through unread. Reaching for that flag has to stay a decision.

## Narrow on purpose

Excludes `.claude/` and only `.claude/`. The tempting widening is "exclude whatever `.dockerignore` excludes", which is wrong — an untracked source file elsewhere in the tree genuinely can change the image, and `.dockerignore` also excludes paths whose presence *in git* still matters.

`.claude/` is the one directory that is session state by definition, and the repo already treats it specially: `.claude/hooks/worktree-guard.mjs` exempts it from the read-only primary rule for the same reason. The pattern anchors to porcelain's `XY ` prefix, so a nested `src/.claude/` — which would be a genuine surprise — still refuses.

## The `|| true` is load-bearing, and running the suite is what found it

`grep` exits 1 when it emits nothing, which under `set -euo pipefail` aborts the script on a **clean** tree.

The first cut of this fix inverted the guard: it killed every well-formed build while letting dirty ones fall through to the next check. Four previously-green tests caught it immediately. Reading the one-line change would not have.

## Kill-tested

| Injected fault | Result |
|---|---|
| Remove the exclusion | `.claude/`-marker test fails; other 7 pass |
| Untracked file **outside** `.claude/` | still refuses, names the file |
| Tracked-file modification | still refuses |
| Restored | 8 pass |

## Status

| AC | Layer | Met |
|---|---|---|
| A `.claude/` marker alone does not trip the dirty check | repo | yes |
| An untracked file outside `.claude/` still trips it — kill-tested | repo | yes |
| A tracked-file modification still trips it | repo | yes |
| A reprovision with only a `.claude/` marker proceeds without the bypass | runtime | **no** — needs the next real reprovision |

## Test plan

- [x] `npm run verify` — 3917 passed, 0 type errors, 0 lint errors, exit 0
- [x] Guard suite: 8 arms, each driven
- [x] Exclusion kill-tested in both directions

🤖 Generated with [Claude Code](https://claude.com/claude-code)