### PR TITLE
fix(operator): LF-normalise spec bodies before hashing; the ceiling is the server's (0.5, 0.6)

### DIFF
--- a/src/components/portal/operator/OutputClassSpecs.astro
+++ b/src/components/portal/operator/OutputClassSpecs.astro
@@ -3,6 +3,7 @@ import Field from '../form/Field.astro'
 import TextArea from '../form/TextArea.astro'
 import SubmitButton from '../form/SubmitButton.astro'
 import {
+  MAX_SPEC_BODY_BYTES,
   SPEC_PROPERTIES,
   specFieldName,
   type SpecDocument,
@@ -29,6 +30,18 @@ import type { OutputClasses } from '../../../lib/operator/customer-yaml/types'
  * docs/style/empty-state-pattern.md. It is a real and ordinary condition (a
  * seat whose engagement has not reached the point of declaring output classes)
  * and it must not be papered over with a specimen class list.
+ *
+ * THE LENGTH CAP IS THE SERVER'S, MIRRORED. `maxlength` is derived from
+ * `MAX_SPEC_BODY_BYTES` rather than picked, and the derivation is safe in one
+ * direction only: the attribute counts UTF-16 code units and the ceiling counts
+ * UTF-8 bytes, and a string is never fewer bytes than code units, so this
+ * attribute can only ever refuse text the server would also refuse. It cannot
+ * block a body the server would accept, which is the failure it used to have at
+ * 20,000: a longer body authored elsewhere would render into a field the browser
+ * then treated as over-limit, and constraint validation would make the whole
+ * form unsubmittable with nothing on screen saying why. The attribute is a
+ * courtesy either way. The ceiling that decides is in `buildSpecDocument`, over
+ * the bytes about to be written, and its refusal comes back as a banner.
  */
 
 interface Props {
@@ -111,7 +124,12 @@ const rows = Object.entries(declared)
               {row.properties.map((prop) => (
                 <div class="mt-5">
                   <Field label={prop.label}>
-                    <TextArea name={prop.field} rows={5} maxlength={20000} value={prop.body} />
+                    <TextArea
+                      name={prop.field}
+                      rows={5}
+                      maxlength={MAX_SPEC_BODY_BYTES}
+                      value={prop.body}
+                    />
                   </Field>
                   <p class="mt-1 mb-0 font-mono text-label uppercase tracking-[0.14em] text-[color:var(--ss-color-text-muted)]">
                     {prop.expected ? 'Spec expected' : 'No spec expected'}

--- a/src/lib/operator/output-class-specs.ts
+++ b/src/lib/operator/output-class-specs.ts
@@ -29,6 +29,17 @@
  * body/hash pair that verifies against itself while disagreeing with what they
  * typed.
  *
+ * THE STORED BYTES ARE LF-ONLY. A browser textarea submits its value with CRLF
+ * line endings, per the HTML form-submission spec. Nothing downstream converts
+ * them, and nothing would fail loudly if they survived: the digest computed here
+ * would match its own CRLF body and the applier would verify and install it. The
+ * seat would then hold a markdown file whose every line carries a trailing `\r` —
+ * different bytes from the LF file every existing proof was taken against, and
+ * a trailing character that any line-oriented format check would silently
+ * inherit. So `buildSpecDocument` normalises CRLF and lone CR to LF BEFORE
+ * trimming, hashing, and length-checking. The document, the digest, and the
+ * installed file therefore agree, and agree on LF.
+ *
  * FAIL-CLOSED ON THE EMPTY DOCUMENT. The applier refuses a document declaring
  * no bodies (`output-classes.json declares no spec bodies`) and, refusing it,
  * keeps the previously installed tree standing. So writing an empty document
@@ -116,6 +127,20 @@ export function assertSpecKey(key: string): void {
   if (!SPEC_KEY_PATTERN.test(key)) {
     throw new SpecKeyError(`refusing an R2 key outside the output-classes key space: ${key}`)
   }
+}
+
+// ---------------------------------------------------------------------------
+// Normalisation
+// ---------------------------------------------------------------------------
+
+/**
+ * Collapse CRLF and lone CR to LF.
+ *
+ * Called before trimming, hashing, and the byte-length check, so all three see
+ * the bytes that will actually be stored and installed. See the header note.
+ */
+export function normalizeLineEndings(text: string): string {
+  return text.replace(/\r\n?/g, '\n')
 }
 
 // ---------------------------------------------------------------------------
@@ -249,11 +274,29 @@ export interface AuthoredBody {
   body: string
 }
 
+/**
+ * Why a build was refused, as a value rather than a string to match on.
+ *
+ * The caller turns this into what a client reads, and the three reasons need
+ * three different sentences: one is "shorten it", one is "this surface cannot
+ * do that", and one is a defect they cannot act on. A caller that had to
+ * pattern-match `errors` to tell them apart would show the wrong one the first
+ * time an error string was reworded.
+ */
+export type SpecBuildFailure = 'body_too_long' | 'invalid_class' | 'no_bodies'
+
 export type SpecBuildResult =
-  { ok: true; doc: SpecDocument } | { ok: false; errors: readonly string[] }
+  | { ok: true; doc: SpecDocument }
+  | { ok: false; reason: SpecBuildFailure; errors: readonly string[] }
 
 /**
  * Build the document to write, hashing every body server-side.
+ *
+ * THE SERVER HOLDS THE CEILING. The authoring form carries a `maxlength`, but a
+ * browser attribute is a convenience, not an invariant — it is absent from a
+ * hand-crafted POST and it counts LF-normalised characters while the wire
+ * carries CRLF. The check that matters is this one, over the exact bytes about
+ * to be written, after line endings are normalised and the body trimmed.
  *
  * Bodies are trimmed and an empty one means "no spec for this property" — that
  * is how a class property is cleared, and the applier prunes the installed
@@ -262,6 +305,8 @@ export type SpecBuildResult =
  */
 export async function buildSpecDocument(bodies: readonly AuthoredBody[]): Promise<SpecBuildResult> {
   const errors: string[] = []
+  let invalidClass = false
+  let tooLong = false
   const classes: SpecDocument['classes'] = {}
   const encoder = new TextEncoder()
 
@@ -269,15 +314,17 @@ export async function buildSpecDocument(bodies: readonly AuthoredBody[]): Promis
     const slug = authored.outputClass
     if (!CLASS_SLUG_PATTERN.test(slug) || slug.length > 64) {
       errors.push(`${slug}: class slug must match [a-z0-9_-] and be at most 64 characters`)
+      invalidClass = true
       continue
     }
-    const body = authored.body.trim()
+    const body = normalizeLineEndings(authored.body).trim()
     if (body.length === 0) continue
     const byteLength = encoder.encode(body).length
     if (byteLength > MAX_SPEC_BODY_BYTES) {
       errors.push(
         `${slug}.${authored.property}: ${byteLength} bytes exceeds the ${MAX_SPEC_BODY_BYTES}-byte ceiling`
       )
+      tooLong = true
       continue
     }
     const entry = classes[slug] ?? {}
@@ -285,10 +332,14 @@ export async function buildSpecDocument(bodies: readonly AuthoredBody[]): Promis
     classes[slug] = entry
   }
 
-  if (errors.length > 0) return { ok: false, errors }
+  // A bad class slug outranks an over-long body: the first is a defect the
+  // client cannot act on and must not be told to shorten something for.
+  if (invalidClass) return { ok: false, reason: 'invalid_class', errors }
+  if (tooLong) return { ok: false, reason: 'body_too_long', errors }
   if (countBodies(classes) === 0) {
     return {
       ok: false,
+      reason: 'no_bodies',
       errors: [
         'the document would declare no spec bodies. A seat refuses an empty document and keeps ' +
           'the specs it already installed, so writing one would leave the portal and the ' +

--- a/src/pages/api/portal/operator/settings/output-class-specs.ts
+++ b/src/pages/api/portal/operator/settings/output-class-specs.ts
@@ -45,6 +45,7 @@ import {
   readSpecDocument,
   writeSpecDocument,
   SPEC_PROPERTIES,
+  type SpecBuildFailure,
   type SpecDocument,
 } from '../../../../../lib/operator/output-class-specs'
 import {
@@ -55,6 +56,25 @@ import {
 } from '../../../../../lib/portal/operator/voice-corrections'
 
 const OPERATOR_ROOT = '/portal/products/operator'
+
+/**
+ * One refusal, one sentence the person can act on.
+ *
+ * THE SERVER IS WHERE THE CEILING IS HELD. The form carries a `maxlength`, but
+ * that attribute is absent from a hand-crafted POST and it counts characters
+ * while the ceiling is in bytes, so it can only ever be a courtesy. When a body
+ * really is over the ceiling the client is told to shorten it — not shown the
+ * catch-all, which would leave them resubmitting the same text.
+ *
+ * Every value here has a matching banner in the Advanced page's
+ * `STATUS_BANNERS`; `tests/output-class-specs.test.ts` pins that parity, because
+ * a status with no banner renders as no message at all.
+ */
+const BUILD_FAILURE_STATUS: Record<SpecBuildFailure, string> = {
+  body_too_long: 'spec_too_long',
+  no_bodies: 'spec_empty',
+  invalid_class: 'spec_invalid',
+}
 
 function redirectWithStatus(instance: string | null, status: string): Response {
   const base = instance ? `${OPERATOR_ROOT}/${instance}/settings/advanced` : OPERATOR_ROOT
@@ -210,8 +230,8 @@ export const POST: APIRoute = async ({ request, locals }) => {
 
   const built = await buildSpecDocument(collectAuthoredBodies(form, classes))
   if (!built.ok) {
-    await recordAttempt(auth, 'rejected', { errors: built.errors })
-    return redirectWithStatus(auth.customerSlug, 'spec_invalid')
+    await recordAttempt(auth, 'rejected', { reason: built.reason, errors: built.errors })
+    return redirectWithStatus(auth.customerSlug, BUILD_FAILURE_STATUS[built.reason])
   }
 
   // Read before write. An unparseable existing document must not be

--- a/src/pages/portal/products/operator/[instance]/settings/advanced/index.astro
+++ b/src/pages/portal/products/operator/[instance]/settings/advanced/index.astro
@@ -180,8 +180,19 @@ const STATUS_BANNERS: Record<string, BannerStatus> = {
   // Output-shape statuses. Only `spec_saved` follows a write that was made and
   // read back byte-identical.
   spec_saved: { text: 'Output shape saved to your Operator.', tone: 'success' },
+  // One refusal, one sentence. The endpoint maps each build failure to its own
+  // status precisely so that a person who wrote too much is told to shorten it
+  // rather than being handed a catch-all and left to resubmit the same text.
+  spec_too_long: {
+    text: 'The output shape was not saved. One of your descriptions is longer than your Operator accepts. Shorten it and resubmit.',
+    tone: 'error',
+  },
+  spec_empty: {
+    text: 'The output shape was not saved, because every description was empty. Removing the last one is not something this page can do. Contact SMD.',
+    tone: 'error',
+  },
   spec_invalid: {
-    text: 'The output shape was not saved. Check the lengths of what you wrote and resubmit.',
+    text: 'The output shape was not saved and nothing changed on your Operator. Contact SMD.',
     tone: 'error',
   },
   spec_no_classes: {

--- a/tests/output-class-specs.test.ts
+++ b/tests/output-class-specs.test.ts
@@ -14,6 +14,10 @@
  *     to be written.
  *  3. NO SUCCESS FOR A WRITE THAT DID NOT HAPPEN. `writeSpecDocument` reports
  *     ok only after reading the object back byte-identical.
+ *  4. THE STORED BYTES ARE LF-ONLY. A browser textarea submits CRLF. Nothing
+ *     would fail loudly if it survived — the digest matches its own CRLF body,
+ *     so the applier verifies and installs it — and the seat would hold a file
+ *     whose every line carries a trailing `\r`.
  *
  * No live R2. `FakeBucket` implements the two methods the module uses and can
  * be told to drop or corrupt a write, so the read-back proof is exercised
@@ -31,6 +35,7 @@ import {
   buildSpecDocument,
   collectAuthoredBodies,
   countBodies,
+  normalizeLineEndings,
   parseSpecDocument,
   readSpecDocument,
   serializeSpecDocument,
@@ -43,6 +48,30 @@ import {
 
 const MODULE_SOURCE = readFileSync(
   fileURLToPath(new URL('../src/lib/operator/output-class-specs.ts', import.meta.url)),
+  'utf8'
+)
+
+const FORM_SOURCE = readFileSync(
+  fileURLToPath(
+    new URL('../src/components/portal/operator/OutputClassSpecs.astro', import.meta.url)
+  ),
+  'utf8'
+)
+
+const ENDPOINT_SOURCE = readFileSync(
+  fileURLToPath(
+    new URL('../src/pages/api/portal/operator/settings/output-class-specs.ts', import.meta.url)
+  ),
+  'utf8'
+)
+
+const ADVANCED_PAGE_SOURCE = readFileSync(
+  fileURLToPath(
+    new URL(
+      '../src/pages/portal/products/operator/[instance]/settings/advanced/index.astro',
+      import.meta.url
+    )
+  ),
   'utf8'
 )
 
@@ -201,6 +230,116 @@ describe('output-class specs: what the builder refuses', () => {
     for (const slug of ['../escape', 'a/b', 'Upper']) {
       const built = await buildSpecDocument([{ outputClass: slug, property: 'voice', body: 'x' }])
       expect(built.ok, slug).toBe(false)
+    }
+  })
+})
+
+describe('output-class specs: the stored bytes are LF-only', () => {
+  // A browser textarea submits CRLF. Nothing downstream converts it and nothing
+  // fails loudly if it survives, because the digest matches its own CRLF body:
+  // the applier verifies it and installs a file whose every line carries a
+  // trailing `\r`. That is different bytes from the LF file every existing
+  // proof was taken against, and a trailing character any line-oriented format
+  // check would silently inherit.
+  const CRLF = 'Open with the case name.\r\nClose with a single line beginning Next:.\r\n'
+  const LF = 'Open with the case name.\nClose with a single line beginning Next:.\n'
+
+  it('collapses CRLF and lone CR to LF', () => {
+    expect(normalizeLineEndings(CRLF)).toBe(LF)
+    expect(normalizeLineEndings('a\rb')).toBe('a\nb')
+    expect(normalizeLineEndings('a\r\r\nb')).toBe('a\n\nb')
+    expect(normalizeLineEndings(LF)).toBe(LF)
+  })
+
+  it('writes a document with no carriage return anywhere in it', async () => {
+    const built = await buildSpecDocument([
+      { outputClass: 'staff', property: 'format', body: CRLF },
+    ])
+    expect(built.ok).toBe(true)
+    if (!built.ok) return
+    expect(serializeSpecDocument(built.doc)).not.toContain('\r')
+    expect(built.doc.classes['staff']?.format?.body).not.toContain('\r')
+  })
+
+  it('hashes the LF body it is about to write, not the CRLF body that arrived', async () => {
+    const built = await buildSpecDocument([
+      { outputClass: 'staff', property: 'format', body: CRLF },
+    ])
+    expect(built.ok).toBe(true)
+    if (!built.ok) return
+    const written = built.doc.classes['staff']?.format
+    expect(written?.sha256).toBe(await sha256Hex(LF.trim()))
+    // And the digest still describes the bytes beside it, which is the property
+    // the applier checks before installing.
+    expect(written?.sha256).toBe(await sha256Hex(written?.body ?? ''))
+  })
+
+  it('produces byte-identical documents from a CRLF body and its LF equivalent', async () => {
+    const fromCrlf = await buildSpecDocument([
+      { outputClass: 'staff', property: 'format', body: CRLF },
+    ])
+    const fromLf = await buildSpecDocument([{ outputClass: 'staff', property: 'format', body: LF }])
+    expect(fromCrlf.ok && fromLf.ok).toBe(true)
+    if (!fromCrlf.ok || !fromLf.ok) return
+    expect(serializeSpecDocument(fromCrlf.doc)).toBe(serializeSpecDocument(fromLf.doc))
+  })
+
+  it('measures the ceiling against the normalised bytes, not the submitted ones', async () => {
+    // LF: 262,144 bytes, one under the ceiling after trim. CRLF: 393,216, well
+    // over it. Checking before normalising would refuse a body that fits.
+    const lines = MAX_SPEC_BODY_BYTES / 2
+    const built = await buildSpecDocument([
+      { outputClass: 'staff', property: 'format', body: 'a\r\n'.repeat(lines) },
+    ])
+    expect(built.ok).toBe(true)
+  })
+})
+
+describe('output-class specs: the server holds the ceiling, and every refusal is named', () => {
+  it('derives the maxlength attribute from the server constant rather than picking one', () => {
+    // The attribute counts UTF-16 code units and the ceiling counts UTF-8
+    // bytes, and a string is never fewer bytes than code units — so deriving it
+    // this way can only refuse text the server would also refuse. A picked
+    // number below the ceiling (it was 20,000) makes a longer body authored
+    // elsewhere render into a field the browser treats as over-limit, and
+    // constraint validation can then make the whole form unsubmittable with
+    // nothing on screen saying why.
+    expect(FORM_SOURCE).toContain('maxlength={MAX_SPEC_BODY_BYTES}')
+    expect(FORM_SOURCE).not.toMatch(/maxlength=\{\d/)
+  })
+
+  it('reports why a build was refused as a value, not a string to match on', async () => {
+    const tooLong = await buildSpecDocument([
+      { outputClass: 'staff', property: 'voice', body: 'x'.repeat(MAX_SPEC_BODY_BYTES + 1) },
+    ])
+    expect(tooLong.ok).toBe(false)
+    if (tooLong.ok) return
+    expect(tooLong.reason).toBe('body_too_long')
+
+    const empty = await buildSpecDocument([
+      { outputClass: 'staff', property: 'voice', body: '   ' },
+    ])
+    expect(empty.ok).toBe(false)
+    if (empty.ok) return
+    expect(empty.reason).toBe('no_bodies')
+
+    const bad = await buildSpecDocument([{ outputClass: 'Upper', property: 'voice', body: 'x' }])
+    expect(bad.ok).toBe(false)
+    if (bad.ok) return
+    expect(bad.reason).toBe('invalid_class')
+  })
+
+  it('gives every refusal status a banner on the page it redirects to', () => {
+    // A status with no banner renders as no message at all: the person is
+    // returned to the form, nothing saved, nothing said.
+    const block = ENDPOINT_SOURCE.match(
+      /const BUILD_FAILURE_STATUS: Record<SpecBuildFailure, string> = \{([\s\S]*?)\n\}/
+    )
+    expect(block).not.toBeNull()
+    const statuses = [...(block?.[1] ?? '').matchAll(/'([a-z_]+)'/g)].map((m) => m[1])
+    expect(statuses).toEqual(['spec_too_long', 'spec_empty', 'spec_invalid'])
+    for (const status of statuses) {
+      expect(ADVANCED_PAGE_SOURCE, status).toMatch(new RegExp(`^\\s*${status}: \\{`, 'm'))
     }
   })
 })


### PR DESCRIPTION
Plan steps 0.5 and 0.6. Both are small, and both would have corrupted a later result.

## 0.5 — Line endings

A browser `<textarea>` submits its value with **CRLF**. Nothing in the writer converted it: `collectAuthoredBodies` took `form.get(...)` raw, `buildSpecDocument` only trimmed, and `sha256Hex` hashed whatever arrived.

**Nothing failed loudly, which is the problem.** The digest matched its own CRLF body, so the applier verified it and installed it. The seat ended up holding a markdown file whose every line carried a trailing `\r` — different bytes from the LF file the one existing proof was taken against.

Benign for prose today. **Not benign for the next phase**, where every line-oriented shape check inherits that trailing character and a "required closing line" comparison silently never matches. The bug would have surfaced as *the shape checker doesn't work* rather than *the bytes are wrong*, which is a much worse place to start looking.

`buildSpecDocument` now normalises CRLF and lone CR to LF **before** trimming and hashing, so the stored bytes, the digest, and the installed file all agree and are LF-only.

**Kill-tested** — removing the normalisation fails four tests:
```
× hashes the LF body it is about to write, not the CRLF body that arrived
× produces byte-identical documents from a CRLF body and its LF equivalent
× measures the ceiling against the normalised bytes, not the submitted ones
4 failed | 28 passed
```
Restoring: 32 passed.

## 0.6 — The character cap

The textarea capped typing at 20,000 while the server accepts 256,000, and the two counted different things — the browser counts LF-normalised characters, the wire carries CRLF.

Worse than a mismatch: a body authored elsewhere and longer than the cap renders into a field the browser then treats as over-limit, and constraint validation can make the whole form unsubmittable with no explanation.

The client-side limit now agrees with the server invariant, and **the real limit is enforced server-side with a message**. A browser attribute is a convenience, never the thing that holds a server rule.

## Note on the diff

`origin/main` moved while this branch was in flight (another session's staging-environment work). Merged forward: no conflicts, `tests/staging-isolation.test.ts` and the full `wrangler.toml` intact and verified present after the merge.

## Status

| AC | Layer | Met |
|---|---|---|
| CRLF and lone CR normalised before trim and hash | repo | yes |
| A CRLF body and its LF equivalent produce identical documents | repo | yes |
| Client cap agrees with the server invariant | repo | yes |
| The real ceiling is enforced server-side with a message | repo | yes |
| A client types a spec through the form and it installs correctly | runtime | **no** |

No runtime row is closed by either fix.

## Test plan

- [x] `npm run verify` — 3933 passed, 0 type errors, 0 lint errors, exit 0
- [x] Normalisation kill-tested in both directions

🤖 Generated with [Claude Code](https://claude.com/claude-code)