### PR TITLE
fix(operator): the broker boot check now opens the socket (0.2)

### DIFF
--- a/operator/bin/boot-smoke-test.sh
+++ b/operator/bin/boot-smoke-test.sh
@@ -48,6 +48,32 @@ ssh_exec() {
   fi
 }
 
+ssh_exec_script() {
+  # As ssh_exec, but for a check that CONTAINS SINGLE QUOTES.
+  #
+  # ssh_exec wraps its command in `sh -c '...'`, so a check carrying a single
+  # quote closes the wrapper early and the remainder is mangled — silently, and
+  # presenting as a failed check rather than a broken one. The note above has
+  # kept every existing check quote-free, which works right up until a check
+  # genuinely needs a quoted string (an inline python program, say), at which
+  # point the constraint costs more than it saves.
+  #
+  # Base64 carries the program through both shell layers untouched: the encoded
+  # text contains no quotes at all, so nothing can collide. Decoded and run ON
+  # THE MACHINE, exactly as written here.
+  local step="$1"
+  shift
+  local cmd="$*"
+  local encoded
+  encoded="$(printf '%s' "${cmd}" | base64 | tr -d '\n')"
+  if fly ssh console -a "${APP_NAME}" \
+    --command "sh -c 'echo ${encoded} | base64 -d | sh'" >/dev/null 2>&1; then
+    pass "${step}"
+  else
+    fail "${step} — command failed: ${cmd}"
+  fi
+}
+
 # ---------- Step 1: wait for Machine state=started ----------
 log "Waiting for Machine state=started (up to 60s)..."
 ATTEMPT=0
@@ -156,6 +182,35 @@ ssh_exec "agent-state-owner-is-hermes" "[ \"\$(stat -c %U /opt/data/agent-state.
 # wraps this whole string in `sh -c '...'`, so a single-quoted `awk '{print $4}'`
 # would collide with the outer quote and mangle the command.
 ssh_exec "broker-respawn-supervised" "pid=\$(pgrep -f workspace_broker.server | head -1); [ -n \"\$pid\" ] && ppid=\$(grep -m1 PPid /proc/\$pid/status | tr -dc 0-9) && [ \"\$(stat -c %U /proc/\$ppid)\" = root ]"
+
+# The check above proves the broker can be RESTARTED. It never opens the socket,
+# so it cannot tell a working broker from one whose socket is gone, whose parent
+# directory lost its setgid bit, or which is refusing every connection. A seat in
+# that state has no document surface at all and reports healthy on every signal
+# we watch — the same shape as the 2026-07-16 scheduler outage, which ran eight
+# days green because the check confirmed a process EXISTED rather than that it
+# WORKED.
+#
+# `health` is the right call to make: it sits ABOVE the broker's gateway-PID gate
+# (workspace_broker/server.py:282 vs :291), so any process may issue it, and it
+# reports whether the credential, customer, jobs and audit stores actually
+# loaded. Run as the AGENT uid, because "hermes can reach this socket" is the
+# property that matters — root reaching it proves nothing about the caller that
+# needs it.
+#
+# SCOPE IT HONESTLY: this proves the socket answers and the stores loaded. It
+# CANNOT prove the gateway can authorize a privileged verb, because only the
+# gateway process may make that call and this is not it. Claiming otherwise
+# would rebuild the blind spot one layer up.
+# The socket path is taken from the canonical default rather than the env, and
+# that is not laziness: a fresh `fly ssh console` session inherits NONE of the
+# app's environment (verified — SMD_WORKSPACE_BROKER_SOCKET is unset there),
+# while the entrypoint sets both the env var and this path from the same
+# constant. Reading the env here would make the check fail on every seat for a
+# reason that has nothing to do with the broker, which is worse than a path that
+# can drift. Same idiom as every other absolute path in this file. If the
+# entrypoint's SOCKET_PATH ever moves, this line moves with it.
+ssh_exec_script "broker-socket-answers-health" "setpriv --reuid=hermes --regid=hermes --init-groups /opt/hermes/.venv/bin/python3 -c \"import socket,os,json,sys; p=os.environ.get('SMD_WORKSPACE_BROKER_SOCKET') or '/run/smd-workspace-broker/broker.sock'; s=socket.socket(socket.AF_UNIX,socket.SOCK_STREAM); s.settimeout(5); s.connect(p); s.sendall(b'{\\\"action\\\":\\\"health\\\"}'+bytes([10])); r=json.loads(s.recv(65536).decode()); sys.exit(0 if r.get('ok') and r.get('credential_ready') and r.get('customer_ready') else 1)\""
 
 # ---------- Step 12: /app governance artifacts are root-owned, not agent-writable (SEC-31) ----------
 # The activation-gate source the gateway:startup hook force-loads


### PR DESCRIPTION
Plan step 0.2.

## The blind spot

`broker-respawn-supervised` is `pgrep` plus a root-parent assertion. It proves the broker can be **restarted**. It never opens the socket.

So it cannot tell a working broker from one whose socket is gone, whose parent directory lost its setgid bit, or which refuses every connection. **A seat in that state has no document surface at all and reports healthy on every signal we watch.**

Same shape as the 2026-07-16 scheduler outage, which ran eight days green because the check confirmed a process *existed* rather than that it *worked*.

## The check

`health` is the right call to make: it sits **above** the broker's gateway-PID gate (`server.py:282` vs `:291`), so any process may issue it, and it reports whether the credential, customer, jobs and audit stores actually loaded.

Run as the **agent uid** — "hermes can reach this socket" is the property that matters. Root reaching it proves nothing about the caller that needs it.

**Scoped honestly, in the code:** this proves the socket answers and the stores loaded. It **cannot** prove the gateway can authorize a privileged verb, because only the gateway may make that call and this is not it. Claiming otherwise would rebuild the blind spot one layer up.

## Two real failures on the way, both diagnosed rather than guessed

**1. A fresh `fly ssh console` inherits none of the app env.** `SMD_WORKSPACE_BROKER_SOCKET` is unset there — verified directly. Reading the env would have failed on every seat for a reason unrelated to the broker, so the check falls back to the canonical path, as every other absolute path in this file does.

**2. `ssh_exec` wraps its command in `sh -c '...'`**, and the file documents that checks must therefore contain no single quotes. An inline python program is full of them, and the collision presents as a **failed** check rather than a broken one — the worst possible symptom, since it looks like the thing under test is broken.

Added `ssh_exec_script`, which base64-encodes the command so neither shell layer can collide with it. The no-quotes constraint held right up until a check genuinely needed a quoted string; encoding removes the trap rather than working around it once.

## Kill-tested on the live seat

`vfy_01KYX4SCAZ50GBBRHXNR35KP2H`

| | |
|---|---|
| Real socket | `PASS: broker-socket-answers-health` |
| Path swapped to a dead socket | `FAIL` — **and `broker-respawn-supervised` still PASSED** |
| Restored | `PASS`, all boot smoke checks pass |

That middle row is the whole point: the old check is green while the document surface is dead.

## Status

| AC | Layer | Met |
|---|---|---|
| Boot check opens the socket and verifies the stores loaded | repo | yes |
| Runs as the agent uid, not root | repo | yes |
| Fails against a dead socket — kill-tested on a live seat | runtime | yes (`vfy_01KYX4SCAZ50GBBRHXNR35KP2H`) |
| Every seat probed once this check exists | runtime | **no** — follow-up |

## Test plan

- [x] `npm run verify` — 243 files, 0 type errors, 0 lint errors, exit 0
- [x] Full boot smoke run against `hermes-smd-staging` — all checks pass
- [x] Kill-tested against a dead socket path

🤖 Generated with [Claude Code](https://claude.com/claude-code)