### PR TITLE
feat(doctrine): the primer tells you when your snapshot has expired (#2110)

### DIFF
--- a/.claude/hooks/reflex-primer.sh
+++ b/.claude/hooks/reflex-primer.sh
@@ -18,7 +18,7 @@
 # review: 2026-09-30 per the doctrine's mechanisms-under-review block.
 #
 # Wire protocol:
-#   stdin:  JSON with .prompt (Claude Code hook contract)
+#   stdin:  JSON with .prompt, .cwd, .session_id (Claude Code hook contract)
 #   stdout: lines below become additional context for the next turn
 #   exit 0 always; never block the Captain on hook plumbing.
 
@@ -28,7 +28,14 @@ if ! command -v jq >/dev/null 2>&1; then
   exit 0
 fi
 
-PROMPT=$(jq -r '.prompt // empty' 2>/dev/null) || exit 0
+# Capture stdin ONCE. The payload is needed three times (.prompt, .cwd,
+# .session_id) and stdin cannot be re-read, so a bare `jq` here would consume
+# it and starve the staleness block below.
+PAYLOAD=$(cat 2>/dev/null) || exit 0
+# `.prompt` is what this harness sends and is load-bearing; `.prompt_text`
+# appears in the published hook reference. Accept either so a field rename
+# cannot silently reduce the primer to a no-op.
+PROMPT=$(printf '%s' "$PAYLOAD" | jq -r '.prompt // .prompt_text // empty' 2>/dev/null) || exit 0
 [ -z "$PROMPT" ] && exit 0
 
 cat <<'PRIMER'
@@ -61,5 +68,138 @@ if [ -f "$HATCH_LOG" ]; then
     fi
   fi
 fi
+
+# Law 10 surface: your snapshot is not the system.
+#
+# The gitStatus block, branch list, and dependency state seeded into a
+# session's context are captured ONCE at session start. With concurrent
+# sessions merging into main every ~25 minutes, they are wrong within
+# minutes, and an agent reasoning carefully from them is still wrong.
+# Session-start detection cannot close this: session start is exactly when
+# the answer is still right. So the check runs every turn.
+#
+# Incident 2026-07-31: sync-primary.sh fast-forwarded the primary across a
+# major-version lockfile change on behalf of a NEWLY starting session,
+# invalidating node_modules for sessions already running in that tree three
+# hours after their briefing rendered "Deps | current". Six of seven
+# checkouts ended the day running a stale toolchain against new source.
+#
+# Three invariants this block must never violate:
+#   1. It must never kill the primer. The script runs `set -e`, and a failing
+#      `git rev-parse` or `stat` -- the NORMAL case here -- would propagate.
+#      Verified 2026-07-31 with both guards removed: exit 128, and on
+#      UserPromptSubmit a non-zero exit forfeits the stdout injection, so the
+#      laws are computed and then discarded. Two independent containments are
+#      kept, and EITHER ALONE IS SUFFICIENT (invoking as `staleness_block ||
+#      true` puts the body in an `||` list, which already suspends `set -e`
+#      for it). That redundancy is deliberate, not an oversight to tidy: a
+#      later edit that drops one must not silently arm the failure. The block
+#      also sits AFTER the heredoc, so even total containment failure leaves
+#      the laws already printed. tests/staleness-detection.test.ts asserts
+#      exit 0 and all primer lines on stdout across every failure path.
+#   2. It must measure the tree the session is actually in. CLAUDE_PROJECT_DIR
+#      is pinned at launch and does not follow EnterWorktree, so preferring it
+#      would report on the primary from inside a worktree: this law's own
+#      failure, reintroduced by its enforcement, wearing doctrine's authority.
+#      Payload .cwd first, matching worktree-guard.mjs:53.
+#   3. It must not cry wolf. A line that is sometimes wrong and always loud
+#      teaches agents to skim past laws 1 through 10. mtime alone fires on
+#      `git stash`, `git restore`, and rebases that rewrite the lockfile
+#      without changing it, so mtime only GATES a content comparison.
+staleness_block() {
+  set +e
+
+  local tree root
+  tree=$(printf '%s' "$PAYLOAD" | jq -r '.cwd // empty' 2>/dev/null)
+  [ -n "$tree" ] && [ -d "$tree" ] || tree="$PWD"
+  [ -d "$tree" ] || tree="${CLAUDE_PROJECT_DIR:-}"
+  [ -n "$tree" ] && [ -d "$tree" ] || return 0
+
+  root=$(git -C "$tree" rev-parse --show-toplevel 2>/dev/null)
+  [ -n "$root" ] && [ -d "$root" ] || return 0
+  local name
+  name=$(basename "$root")
+
+  # --- Signal 1: main moved under you --------------------------------------
+  # Reads the local origin/main ref; deliberately does NOT fetch, because a
+  # network round trip on every turn is not affordable. Concurrent sessions
+  # fetch at every start, so the ref stays close to current in practice.
+  local behind
+  behind=$(git -C "$root" rev-list --count HEAD..origin/main 2>/dev/null)
+  if [ -n "$behind" ] && [ "$behind" -gt 0 ] 2>/dev/null; then
+    echo "[doctrine] Law 10: origin/main is ${behind} commit(s) ahead of your HEAD (as of the last fetch). Anything you were briefed about main predates them."
+  fi
+
+  # --- Signal 2: the working tree moved since you were briefed --------------
+  # Baselined per session so this speaks only on CHANGE, not merely on dirt.
+  # Without a session id there is no baseline to diff against, so it stays
+  # silent rather than guess.
+  local sid dirty base_file prev
+  sid=$(printf '%s' "$PAYLOAD" | jq -r '.session_id // empty' 2>/dev/null)
+  if [ -n "$sid" ]; then
+    dirty=$(git -C "$root" status --porcelain 2>/dev/null | wc -l | tr -d ' ')
+    base_file="${TMPDIR:-/tmp}/ss-staleness-$(printf '%s' "${sid}:${root}" | cksum | cut -d' ' -f1)"
+    if [ -f "$base_file" ]; then
+      prev=$(cat "$base_file" 2>/dev/null)
+      if [ -n "$prev" ] && [ -n "$dirty" ] && [ "$prev" != "$dirty" ]; then
+        echo "[doctrine] Law 10: working tree changed since session start (${prev} path(s) then, ${dirty} now). The gitStatus in your system prompt is out of date; re-read it before reasoning about the tree."
+      fi
+    else
+      printf '%s' "${dirty:-0}" >"$base_file" 2>/dev/null
+    fi
+  fi
+
+  # --- Signal 3: dependencies no longer match the lockfile ------------------
+  local lock rec
+  lock="$root/package-lock.json"
+  rec="$root/node_modules/.package-lock.json"
+  [ -f "$lock" ] || return 0
+
+  if [ ! -d "$root/node_modules" ]; then
+    echo "[doctrine] Law 10: ${name} has no node_modules. Run npm ci before trusting build, typecheck, or test results."
+    return 0
+  fi
+  if [ ! -f "$rec" ]; then
+    echo "[doctrine] Law 10: ${name} has node_modules but no install record; an install may be in flight. Do not start a second one."
+    return 0
+  fi
+
+  local lm rm_
+  lm=$(stat -f %m "$lock" 2>/dev/null || stat -c %Y "$lock" 2>/dev/null)
+  rm_=$(stat -f %m "$rec" 2>/dev/null || stat -c %Y "$rec" 2>/dev/null)
+  [ -n "$lm" ] && [ -n "$rm_" ] || return 0
+  [ "$((lm - rm_))" -gt 2 ] 2>/dev/null || return 0
+
+  # mtime says stale. Confirm against content before speaking: compare only
+  # packages present in BOTH files, and only flag version mismatches. Entries
+  # absent from the install record are optional platform-specific binaries
+  # (141 of them in this repo on darwin) and are NOT drift -- counting them
+  # would make this line fire in every checkout, forever.
+  command -v node >/dev/null 2>&1 || return 0
+  local verdict count example
+  verdict=$(node -e '
+    const fs = require("fs")
+    try {
+      const lock = JSON.parse(fs.readFileSync(process.argv[1], "utf8"))
+      const rec = JSON.parse(fs.readFileSync(process.argv[2], "utf8"))
+      let n = 0, ex = ""
+      for (const [k, v] of Object.entries(lock.packages || {})) {
+        if (!k.startsWith("node_modules/")) continue
+        const i = rec.packages && rec.packages[k]
+        if (!i) continue
+        if (i.version !== v.version) {
+          n++
+          if (!ex) ex = k.slice("node_modules/".length) + " " + i.version + " vs " + v.version
+        }
+      }
+      process.stdout.write(n ? n + "|" + ex : "0")
+    } catch (e) { process.stdout.write("0") }
+  ' "$lock" "$rec" 2>/dev/null)
+  count=${verdict%%|*}
+  example=${verdict#*|}
+  [ -n "$count" ] && [ "$count" != "0" ] 2>/dev/null || return 0
+  echo "[doctrine] Law 10: ${name} dependencies are stale; ${count} package version(s) differ from package-lock.json (e.g. ${example}). Run npm ci before trusting build, typecheck, or test results."
+}
+staleness_block || true
 
 exit 0

--- a/.claude/hooks/reflex-primer.sh
+++ b/.claude/hooks/reflex-primer.sh
@@ -164,11 +164,20 @@ staleness_block() {
     return 0
   fi
 
-  local lm rm_
-  lm=$(stat -f %m "$lock" 2>/dev/null || stat -c %Y "$lock" 2>/dev/null)
-  rm_=$(stat -f %m "$rec" 2>/dev/null || stat -c %Y "$rec" 2>/dev/null)
-  [ -n "$lm" ] && [ -n "$rm_" ] || return 0
-  [ "$((lm - rm_))" -gt 2 ] 2>/dev/null || return 0
+  # Cheap gate: is the lockfile newer than npm's install record?
+  #
+  # `find -newer` rather than `stat`, because stat's mtime flag is not
+  # portable and fails UNSAFELY. BSD spells it `stat -f %m`; GNU spells it
+  # `stat -c %Y`. Writing `stat -f %m ... || stat -c %Y ...` looks like a
+  # correct fallback and is not: on GNU, `-f` means "display filesystem
+  # status", so it SUCCEEDS with filesystem information instead of failing,
+  # the `||` branch never runs, and the arithmetic silently gives up. Caught
+  # by CI on 2026-07-31 after passing on macOS, which is the same
+  # works-on-my-machine failure this law is about.
+  #
+  # Over-triggering here is harmless: this only gates the content comparison
+  # below, which is what actually decides whether to speak.
+  [ -n "$(find "$lock" -newer "$rec" 2>/dev/null)" ] || return 0
 
   # mtime says stale. Confirm against content before speaking: compare only
   # packages present in BOTH files, and only flag version mismatches. Entries

--- a/tests/staleness-detection.test.ts
+++ b/tests/staleness-detection.test.ts
@@ -1,0 +1,367 @@
+/**
+ * The primer keeps speaking, and it speaks about the right tree (Law 10).
+ *
+ * `reflex-primer.sh` is the always-on doctrine surface: its stdout is injected
+ * into context on every user prompt. Two facts make it unusually dangerous to
+ * extend, and both are the reason this file exists.
+ *
+ * FIRST: it runs `set -e`. The staleness block added for Law 10 stats files
+ * that are routinely absent (`node_modules/.package-lock.json` is missing on
+ * any fresh clone, which is precisely the case it exists to report). An
+ * unguarded failure there does not degrade the primer, it DELETES it, and
+ * `tests/doctrine-integrity.test.ts` cannot see that: it reads the script as
+ * text and never executes it, so every law would still "appear in the primer"
+ * while no law reached a single turn.
+ *
+ * SECOND: on `UserPromptSubmit`, exit code 2 erases the user's prompt outright.
+ * A crash in a diagnostic block must never cost the Captain their message.
+ *
+ * So the load-bearing assertion here is not that the new signals work. It is
+ * that every doctrine `primer_line` still reaches STDOUT, and the exit code is
+ * still 0, under every malformed input and missing file we could construct.
+ * The signals are tested too, but they are the smaller half.
+ *
+ * GIT_* IS STRIPPED FROM EVERY CHILD. `cwd` does not isolate a git subprocess:
+ * `GIT_DIR`, `GIT_WORK_TREE`, and `GIT_INDEX_FILE` win over it, and git hooks
+ * export them. The hook runs `git rev-parse`, `git rev-list`, and `git status`;
+ * a fixture that omits the strip measures the real repository instead of the
+ * fixture, which is the same class of bug Law 10 is about.
+ */
+import { execFileSync } from 'node:child_process'
+import { mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { parse as parseYaml } from 'yaml'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { readFileSync } from 'node:fs'
+
+const REPO_ROOT = fileURLToPath(new URL('..', import.meta.url))
+const HOOK = join(REPO_ROOT, '.claude', 'hooks', 'reflex-primer.sh')
+const DOCTRINE = join(REPO_ROOT, 'docs', 'doctrine', 'agent-operating-doctrine.md')
+
+/** Every canonical primer_line, parsed from the doctrine the same way
+ *  doctrine-integrity.test.ts parses it. */
+const PRIMER_LINES: string[] = [
+  ...readFileSync(DOCTRINE, 'utf8').matchAll(/```yaml\n([\s\S]*?)```/g),
+]
+  .map((m) => parseYaml(m[1]) as Record<string, unknown>)
+  .filter((d): d is { primer_line: string } => typeof d?.primer_line === 'string')
+  .map((d) => d.primer_line)
+
+const scratch: string[] = []
+afterEach(() => {
+  while (scratch.length) rmSync(scratch.pop() as string, { recursive: true, force: true })
+})
+
+function cleanEnv(extra: Record<string, string> = {}): Record<string, string> {
+  return {
+    ...Object.fromEntries(
+      Object.entries({ ...process.env, HUSKY: '0' }).filter(([k]) => !k.startsWith('GIT_'))
+    ),
+    ...extra,
+  }
+}
+
+function git(dir: string, ...args: string[]): void {
+  execFileSync('git', ['-C', dir, ...args], { env: cleanEnv(), stdio: 'pipe' })
+}
+
+interface TreeOpts {
+  /** Versions written into package-lock.json */
+  lock?: Record<string, string>
+  /** Versions written into node_modules/.package-lock.json. Omit for no record. */
+  installed?: Record<string, string> | null
+  /** Create node_modules at all. */
+  nodeModules?: boolean
+  /** Write a package-lock.json at all. */
+  lockfile?: boolean
+  /** Make package-lock.json appear newer than the install record. */
+  lockNewer?: boolean
+  /** Extra commits on origin/main beyond HEAD. */
+  aheadBy?: number
+}
+
+function makeTree(opts: TreeOpts = {}): string {
+  const {
+    lock = { astro: '7.1.3' },
+    installed = { astro: '7.1.3' },
+    nodeModules = true,
+    lockfile = true,
+    lockNewer = false,
+    aheadBy = 0,
+  } = opts
+
+  const root = mkdtempSync(join(tmpdir(), 'staleness-'))
+  scratch.push(root)
+
+  const pkgs = (v: Record<string, string>) =>
+    Object.fromEntries(Object.entries(v).map(([n, ver]) => [`node_modules/${n}`, { version: ver }]))
+
+  writeFileSync(join(root, 'package.json'), JSON.stringify({ name: 'fixture' }, null, 2))
+  if (lockfile) {
+    writeFileSync(
+      join(root, 'package-lock.json'),
+      JSON.stringify({ lockfileVersion: 3, packages: pkgs(lock) }, null, 2)
+    )
+  }
+  if (nodeModules) {
+    mkdirSync(join(root, 'node_modules'), { recursive: true })
+    if (installed) {
+      writeFileSync(
+        join(root, 'node_modules', '.package-lock.json'),
+        JSON.stringify({ lockfileVersion: 3, packages: pkgs(installed) }, null, 2)
+      )
+    }
+  }
+
+  git(root, 'init', '--quiet', '--initial-branch=main')
+  git(root, 'config', 'user.email', 'probe@example.invalid')
+  git(root, 'config', 'user.name', 'probe')
+  git(root, 'add', '-A')
+  git(root, 'commit', '--quiet', '-m', 'baseline')
+  git(root, 'update-ref', 'refs/remotes/origin/main', 'HEAD')
+
+  for (let i = 0; i < aheadBy; i++) {
+    writeFileSync(join(root, `extra-${i}.txt`), 'x')
+    git(root, 'add', '-A')
+    git(root, 'commit', '--quiet', '-m', `ahead ${i}`)
+  }
+  if (aheadBy > 0) {
+    // origin/main carries the extra commits; HEAD is moved back behind them.
+    git(root, 'update-ref', 'refs/remotes/origin/main', 'HEAD')
+    git(root, 'reset', '--hard', '--quiet', `HEAD~${aheadBy}`)
+  }
+
+  if (lockNewer && lockfile) {
+    const future = new Date(Date.now() + 60_000)
+    utimesSync(join(root, 'package-lock.json'), future, future)
+  }
+  return root
+}
+
+interface Payload {
+  prompt?: string
+  cwd?: string
+  session_id?: string
+}
+
+function runHook(
+  payload: Payload | string,
+  opts: { cwd?: string; env?: Record<string, string> } = {}
+): { out: string; code: number } {
+  const body = typeof payload === 'string' ? payload : JSON.stringify(payload)
+  try {
+    const out = execFileSync('bash', [HOOK], {
+      input: body,
+      cwd: opts.cwd ?? REPO_ROOT,
+      env: cleanEnv({ TMPDIR: mkdtempSync(join(tmpdir(), 'staleness-tmp-')), ...(opts.env ?? {}) }),
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    })
+    return { out, code: 0 }
+  } catch (err) {
+    const e = err as { stdout?: string; stderr?: string; status?: number }
+    return { out: `${e.stdout ?? ''}${e.stderr ?? ''}`, code: e.status ?? -1 }
+  }
+}
+
+/** The invariant that matters more than any signal. */
+function expectLawsIntact(res: { out: string; code: number }): void {
+  expect(res.code).toBe(0)
+  const missing = PRIMER_LINES.filter((l) => !res.out.includes(l))
+  expect(missing).toEqual([])
+}
+
+describe('the primer survives everything the staleness block can hit', () => {
+  it('sanity: the doctrine actually yielded primer lines to check', () => {
+    expect(PRIMER_LINES.length).toBeGreaterThanOrEqual(9)
+  })
+
+  it('emits every law when the tree is entirely healthy', () => {
+    expectLawsIntact(runHook({ prompt: 'hi', cwd: makeTree(), session_id: 's1' }))
+  })
+
+  it('survives a tree with no node_modules', () => {
+    expectLawsIntact(
+      runHook({ prompt: 'hi', cwd: makeTree({ nodeModules: false }), session_id: 's2' })
+    )
+  })
+
+  it('survives node_modules with no install record (the set -e trap)', () => {
+    expectLawsIntact(
+      runHook({ prompt: 'hi', cwd: makeTree({ installed: null }), session_id: 's3' })
+    )
+  })
+
+  it('survives a tree with no package-lock.json', () => {
+    expectLawsIntact(
+      runHook({ prompt: 'hi', cwd: makeTree({ lockfile: false }), session_id: 's4' })
+    )
+  })
+
+  it('survives a cwd that does not exist', () => {
+    expectLawsIntact(runHook({ prompt: 'hi', cwd: '/nonexistent/path/xyz', session_id: 's5' }))
+  })
+
+  it('survives a cwd that is not a git repository', () => {
+    const d = mkdtempSync(join(tmpdir(), 'staleness-nogit-'))
+    scratch.push(d)
+    expectLawsIntact(runHook({ prompt: 'hi', cwd: d, session_id: 's6' }))
+  })
+
+  it('survives a payload with no .cwd', () => {
+    expectLawsIntact(runHook({ prompt: 'hi', session_id: 's7' }))
+  })
+
+  it('survives a payload with no .session_id', () => {
+    expectLawsIntact(runHook({ prompt: 'hi', cwd: makeTree() }))
+  })
+
+  it('survives malformed JSON without erasing the prompt (exit must not be 2)', () => {
+    const res = runHook('{not json at all')
+    expect(res.code).not.toBe(2)
+  })
+
+  it('still exits 0 on an empty payload', () => {
+    expect(runHook('{}').code).toBe(0)
+  })
+})
+
+describe('signal: main moved under you', () => {
+  it('reports when origin/main is ahead', () => {
+    const res = runHook({ prompt: 'hi', cwd: makeTree({ aheadBy: 3 }), session_id: 'm1' })
+    expectLawsIntact(res)
+    expect(res.out).toContain('origin/main is 3 commit(s) ahead')
+  })
+
+  it('stays silent when HEAD is level with origin/main', () => {
+    const res = runHook({ prompt: 'hi', cwd: makeTree(), session_id: 'm2' })
+    expect(res.out).not.toContain('ahead of your HEAD')
+  })
+})
+
+describe('signal: dependencies drifted from the lockfile', () => {
+  it('reports real version drift', () => {
+    const root = makeTree({
+      lock: { astro: '7.1.3' },
+      installed: { astro: '6.4.8' },
+      lockNewer: true,
+    })
+    const res = runHook({ prompt: 'hi', cwd: root, session_id: 'd1' })
+    expectLawsIntact(res)
+    expect(res.out).toContain('dependencies are stale')
+    expect(res.out).toContain('astro 6.4.8 vs 7.1.3')
+  })
+
+  /**
+   * The false-positive guard, and the reason mtime alone is not enough.
+   *
+   * `git stash`, `git restore`, a rebase, and a branch switch all rewrite
+   * package-lock.json without changing its content. Observed live on
+   * 2026-07-31: a worktree read 156 hours stale by mtime with zero version
+   * mismatches. Speaking there demands a 90-second reinstall for nothing, and
+   * a line that is sometimes wrong and always loud teaches agents to skim past
+   * every law above it.
+   */
+  it('stays silent when mtime is stale but content matches', () => {
+    const root = makeTree({
+      lock: { astro: '7.1.3' },
+      installed: { astro: '7.1.3' },
+      lockNewer: true,
+    })
+    const res = runHook({ prompt: 'hi', cwd: root, session_id: 'd2' })
+    expectLawsIntact(res)
+    expect(res.out).not.toContain('dependencies are stale')
+  })
+
+  /** Absences are optional platform-specific binaries, not drift. Counting
+   *  them would make this fire in every checkout on earth, forever. */
+  it('does not count packages absent from the install record as drift', () => {
+    const root = makeTree({
+      lock: { astro: '7.1.3', 'satteri-linux-x64': '0.9.5' },
+      installed: { astro: '7.1.3' },
+      lockNewer: true,
+    })
+    const res = runHook({ prompt: 'hi', cwd: root, session_id: 'd3' })
+    expect(res.out).not.toContain('dependencies are stale')
+  })
+
+  it('names a missing node_modules rather than guessing', () => {
+    const res = runHook({ prompt: 'hi', cwd: makeTree({ nodeModules: false }), session_id: 'd4' })
+    expect(res.out).toContain('no node_modules')
+  })
+
+  it('reports a possible in-flight install rather than "never installed"', () => {
+    const res = runHook({ prompt: 'hi', cwd: makeTree({ installed: null }), session_id: 'd5' })
+    expect(res.out).toContain('install may be in flight')
+    expect(res.out).not.toContain('no node_modules')
+  })
+})
+
+describe('it measures the tree the session is in, not the launch directory', () => {
+  /**
+   * Invariant 2. CLAUDE_PROJECT_DIR is pinned at launch and does not follow
+   * EnterWorktree. Preferring it would give a worktree session a verdict about
+   * the primary: this law's own failure mode, reintroduced by its enforcement,
+   * wearing doctrine's authority.
+   */
+  it('prefers payload .cwd over CLAUDE_PROJECT_DIR and over process cwd', () => {
+    const drifted = makeTree({
+      lock: { astro: '7.1.3' },
+      installed: { astro: '6.4.8' },
+      lockNewer: true,
+    })
+    const healthy = makeTree()
+
+    const res = runHook(
+      { prompt: 'hi', cwd: drifted, session_id: 'r1' },
+      { cwd: healthy, env: { CLAUDE_PROJECT_DIR: healthy } }
+    )
+    expect(res.out).toContain('dependencies are stale')
+  })
+
+  it('falls back to the process cwd when .cwd is absent', () => {
+    const drifted = makeTree({
+      lock: { astro: '7.1.3' },
+      installed: { astro: '6.4.8' },
+      lockNewer: true,
+    })
+    const res = runHook({ prompt: 'hi', session_id: 'r2' }, { cwd: drifted })
+    expect(res.out).toContain('dependencies are stale')
+  })
+})
+
+describe('signal: the working tree moved since you were briefed', () => {
+  it('is silent on the first turn (it is establishing the baseline)', () => {
+    const root = makeTree()
+    const tmp = mkdtempSync(join(tmpdir(), 'staleness-base-'))
+    scratch.push(tmp)
+    const res = runHook({ prompt: 'hi', cwd: root, session_id: 'w1' }, { env: { TMPDIR: tmp } })
+    expect(res.out).not.toContain('working tree changed')
+  })
+
+  it('reports on a later turn once the dirty count has changed', () => {
+    const root = makeTree()
+    const tmp = mkdtempSync(join(tmpdir(), 'staleness-base-'))
+    scratch.push(tmp)
+
+    runHook({ prompt: 'hi', cwd: root, session_id: 'w2' }, { env: { TMPDIR: tmp } })
+    writeFileSync(join(root, 'appeared.txt'), 'new')
+    const res = runHook({ prompt: 'hi', cwd: root, session_id: 'w2' }, { env: { TMPDIR: tmp } })
+
+    expectLawsIntact(res)
+    expect(res.out).toContain('working tree changed since session start')
+  })
+
+  it('stays silent when the tree has not moved', () => {
+    const root = makeTree()
+    const tmp = mkdtempSync(join(tmpdir(), 'staleness-base-'))
+    scratch.push(tmp)
+    runHook({ prompt: 'hi', cwd: root, session_id: 'w3' }, { env: { TMPDIR: tmp } })
+    const res = runHook({ prompt: 'hi', cwd: root, session_id: 'w3' }, { env: { TMPDIR: tmp } })
+    expect(res.out).not.toContain('working tree changed')
+  })
+})


### PR DESCRIPTION
Closes part of #2110.

## The problem

Every observation a session is briefed with is captured **once, at session start**, and consumed later as if current. With merges landing every ~25 minutes, an agent that reads its briefing, reasons carefully, and acts is still wrong. Then it reports that it was mistaken. That is not sloppiness; it is the correct behaviour of a careful agent in an environment that is lying to it.

Session-start detection cannot close this, because session start is exactly when the answer is still right. crane-mcp's `getNodeModulesDrift` is correct and fires there. So the check moves to **every turn**, in the hook that already runs on every turn.

## What this adds

Three signals in `reflex-primer.sh`, each silent unless it has something to say:

| Signal | Fires when |
|---|---|
| Main moved | `origin/main` is ahead of your HEAD |
| Tree moved | dirty-path count differs from a per-session baseline |
| Dependencies | installed versions content-differ from `package-lock.json` |

## Why the dependency signal gates on mtime but speaks only on content

Observed live on 2026-07-31: a worktree read **156 hours stale by mtime with zero version mismatches**, because a checkout rewrote `package-lock.json` without changing it. `git stash`, `git restore`, and rebases all do this. Absences are not drift either: 141 entries in this repo are optional platform-specific binaries absent on darwin by design.

Counting either as drift would make this line fire in every checkout, forever. A line that is sometimes wrong and always loud teaches agents to skim past every law above it.

## Why two containments, and how I know they work

The primer runs `set -e`, and its stdout is the doctrine surface for all nine laws. A failing `git rev-parse` or `stat` inside the new block does not degrade the primer, it deletes it, and `doctrine-integrity.test.ts` cannot see that: it reads the script as text and never executes it, so every law would still "appear in the primer" while no law reached a single turn. On `UserPromptSubmit`, exit 2 also erases the user's prompt outright.

Kill-tested. Removing **either** guard alone changes nothing, because `staleness_block || true` already suspends `set -e` for the body. Removing **both**:

```
exit=128  laws printed=9
× survives a cwd that is not a git repository
```

A non-zero exit forfeits the stdout injection, so the laws are computed and then discarded. Both containments are kept deliberately so a later edit dropping one as redundant cannot silently arm the failure. The block also sits **after** the heredoc, which is why the laws still printed even in total failure.

## Tree resolution

Prefers payload `.cwd` over `CLAUDE_PROJECT_DIR`, which is pinned at launch and does not follow `EnterWorktree`. Preferring the variable would give a worktree session a verdict about the primary: this law's own failure mode, reintroduced by its enforcement, wearing the authority of the doctrine block. Matches `worktree-guard.mjs:53`.

## Tests

`tests/staleness-detection.test.ts`, 23 cases. This is the **first execution coverage any bash hook in `.claude/hooks/` has had**. The load-bearing assertions are not that the signals work; they are that every doctrine `primer_line` still reaches **stdout** and the exit code is still 0, across: no `node_modules`, no install record, no lockfile, nonexistent cwd, non-git cwd, absent `.cwd`, absent `session_id`, malformed JSON, empty payload.

`GIT_*` is stripped from every child. `cwd` does not isolate a git subprocess, and this hook runs `git rev-parse`, `git rev-list`, and `git status`; a fixture that omits the strip measures the real repository instead of the fixture, which is the same class of bug this law is about.

## Acceptance criteria

- [x] Per-turn detection of tree, main, and dependency staleness
- [x] Content confirmation so mtime-only churn stays silent
- [x] Primer survives every failure path with exit 0 (kill-tested)
- [x] Measures the tree the session is in, not the launch directory
- [x] `npm run verify` green
- [ ] **(runtime)** Observed firing and falling silent on a real session in a real stale tree

The runtime AC is deliberately unticked. It cannot be met until this is merged and the hook is the one Claude Code actually executes; a scratch-fixture run is a test, not an observation.

## Not in this PR

Law 10 itself, `sync-primary.sh`'s fast-forward warning, `session-peers.sh`, and the crane-console fixes. The primer is a single point of failure for all nine laws, so it ships and is proven alone. Landing a doctrine change alongside it would mean `doctrine-integrity.test.ts` passes while the script no longer runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
