### PR TITLE
docs(adr): decision #52 says ss-console is PUBLIC (#2116)

### DIFF
--- a/docs/adr/decision-stack.md
+++ b/docs/adr/decision-stack.md
@@ -908,46 +908,46 @@ All 11 artifacts are scaffolded as GitHub issues in smdservices/ss-console. Ever
 
 # Appendix - Decision Index
 
-| Issue | Decision                                                                                                                             |
-| ----- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| #2    | Revenue-based qualification - SUPERSEDED (ADR 0003); revenue is no longer a gate                                                     |
-| #3    | Launch verticals - home services + professional services + contractor/trades, problem-qualified                                      |
-| #4    | Disqualification criteria - 4 hard stops, 5 soft flags                                                                               |
-| #5    | Ideal client profile - synthesis                                                                                                     |
-| #6    | Financial visibility - in core with 30-day prerequisite gate                                                                         |
-| #9    | Tool evaluation framework - rubric-based, bias toward keep                                                                           |
-| #10   | Scope boundary language - positive definition + 4 exclusions                                                                         |
-| #11   | Scope creep protocol - parking lot, pre-handoff review                                                                               |
-| #12   | Retainer model - SUPERSEDED 2026-05-13 by #44 (see ADR 0004)                                                                         |
-| #13   | Paid assessment - free for first 3, then $250                                                                                        |
-| #14   | Payment terms - 50% deposit at signing, 50% at completion                                                                            |
-| #15   | ROI anchor math - owner does the math, we ask the questions                                                                          |
-| #16   | Pricing model - scope-based, $175/hr → $200 → $250 → $300 rate progression                                                           |
-| #17   | Assessment capture - MacWhisper Pro + Claude extraction                                                                              |
-| #18   | Assessment to proposal - solution design phase, SOW within 48 hours                                                                  |
-| #19   | Follow-up cadence - 3-touch over 7 days, then mark dead                                                                              |
-| #20   | Positioning standard - we voice, team framing (venture-wide)                                                                         |
-| #21   | Networking strategy - BNI + chambers + vertical associations                                                                         |
-| #22   | Accountant partnership - co-value, no fee, warm handoff                                                                              |
-| #23   | Client referral incentive - no formal incentive, ask at handoff                                                                      |
-| #24   | Outreach messaging - vertical-specific message and channel                                                                           |
-| #25   | Pipeline math - 15-20 touches/week, 2-3 engagements/month, 25-30% close                                                              |
-| #26   | Review request - verbal at handoff, automated email 2 days later                                                                     |
-| #27   | Safety net - 2-week async from handoff                                                                                               |
-| #28   | Internal champion - identify at assessment, orient Day 1                                                                             |
-| #29   | Feedback collection - verbal at handoff, survey 30 days later                                                                        |
-| #30   | Case study workflow - agent-drafted, client-approved, one page                                                                       |
-| #42   | Taxonomy two-layer model - 5-cat observation, 6-cat delivery (see ADR 0001)                                                          |
-| #43   | Outside View unified diagnostic - one product, three depths, portal-resident artifact (see ADR 0002)                                 |
-| #44   | Productized Operator offering - flat-rate retainer SKU, second front door, Hermes-leaning stack (see ADR 0004)                       |
-| #45   | Entitlement is configurable; draft-for-review external send is one authored option, not a default or invariant (see ADRs 0025, 0035) |
-| #46   | Capability-adapter pattern - skills bind to capability interfaces; adapters implement; customer.yaml wires (see ADR 0006)            |
-| #47   | Per-customer Machine isolation - one Fly.io Machine per customer; deployment isolation, not runtime tenancy (see ADR 0007)           |
-| #48   | Customer-owned memory artifact - per-customer namespaces; portable export; verifiable deletion (see ADR 0008)                        |
-| #49   | Cross-Machine query prohibition - boot-time binding check + shared-catalog merge gate (see ADR 0009)                                 |
-| #50   | Operator launch pricing - flat monthly retainer + stand-up fee, internal, never published (see ADR 0063)                             |
-| #51   | Hosted Agent self-serve SKU - $79/mo BYO-key personal Hermes agent, 25 founding seats at $49/mo (see ADR 0067)                       |
-| #52   | Repository visibility - venture consoles PRIVATE, hermes-smd-overlay PUBLIC (provisioning depends on it) (see ADR 0081)              |
+| Issue | Decision                                                                                                                                                                                                                                                    |
+| ----- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| #2    | Revenue-based qualification - SUPERSEDED (ADR 0003); revenue is no longer a gate                                                                                                                                                                            |
+| #3    | Launch verticals - home services + professional services + contractor/trades, problem-qualified                                                                                                                                                             |
+| #4    | Disqualification criteria - 4 hard stops, 5 soft flags                                                                                                                                                                                                      |
+| #5    | Ideal client profile - synthesis                                                                                                                                                                                                                            |
+| #6    | Financial visibility - in core with 30-day prerequisite gate                                                                                                                                                                                                |
+| #9    | Tool evaluation framework - rubric-based, bias toward keep                                                                                                                                                                                                  |
+| #10   | Scope boundary language - positive definition + 4 exclusions                                                                                                                                                                                                |
+| #11   | Scope creep protocol - parking lot, pre-handoff review                                                                                                                                                                                                      |
+| #12   | Retainer model - SUPERSEDED 2026-05-13 by #44 (see ADR 0004)                                                                                                                                                                                                |
+| #13   | Paid assessment - free for first 3, then $250                                                                                                                                                                                                               |
+| #14   | Payment terms - 50% deposit at signing, 50% at completion                                                                                                                                                                                                   |
+| #15   | ROI anchor math - owner does the math, we ask the questions                                                                                                                                                                                                 |
+| #16   | Pricing model - scope-based, $175/hr → $200 → $250 → $300 rate progression                                                                                                                                                                                  |
+| #17   | Assessment capture - MacWhisper Pro + Claude extraction                                                                                                                                                                                                     |
+| #18   | Assessment to proposal - solution design phase, SOW within 48 hours                                                                                                                                                                                         |
+| #19   | Follow-up cadence - 3-touch over 7 days, then mark dead                                                                                                                                                                                                     |
+| #20   | Positioning standard - we voice, team framing (venture-wide)                                                                                                                                                                                                |
+| #21   | Networking strategy - BNI + chambers + vertical associations                                                                                                                                                                                                |
+| #22   | Accountant partnership - co-value, no fee, warm handoff                                                                                                                                                                                                     |
+| #23   | Client referral incentive - no formal incentive, ask at handoff                                                                                                                                                                                             |
+| #24   | Outreach messaging - vertical-specific message and channel                                                                                                                                                                                                  |
+| #25   | Pipeline math - 15-20 touches/week, 2-3 engagements/month, 25-30% close                                                                                                                                                                                     |
+| #26   | Review request - verbal at handoff, automated email 2 days later                                                                                                                                                                                            |
+| #27   | Safety net - 2-week async from handoff                                                                                                                                                                                                                      |
+| #28   | Internal champion - identify at assessment, orient Day 1                                                                                                                                                                                                    |
+| #29   | Feedback collection - verbal at handoff, survey 30 days later                                                                                                                                                                                               |
+| #30   | Case study workflow - agent-drafted, client-approved, one page                                                                                                                                                                                              |
+| #42   | Taxonomy two-layer model - 5-cat observation, 6-cat delivery (see ADR 0001)                                                                                                                                                                                 |
+| #43   | Outside View unified diagnostic - one product, three depths, portal-resident artifact (see ADR 0002)                                                                                                                                                        |
+| #44   | Productized Operator offering - flat-rate retainer SKU, second front door, Hermes-leaning stack (see ADR 0004)                                                                                                                                              |
+| #45   | Entitlement is configurable; draft-for-review external send is one authored option, not a default or invariant (see ADRs 0025, 0035)                                                                                                                        |
+| #46   | Capability-adapter pattern - skills bind to capability interfaces; adapters implement; customer.yaml wires (see ADR 0006)                                                                                                                                   |
+| #47   | Per-customer Machine isolation - one Fly.io Machine per customer; deployment isolation, not runtime tenancy (see ADR 0007)                                                                                                                                  |
+| #48   | Customer-owned memory artifact - per-customer namespaces; portable export; verifiable deletion (see ADR 0008)                                                                                                                                               |
+| #49   | Cross-Machine query prohibition - boot-time binding check + shared-catalog merge gate (see ADR 0009)                                                                                                                                                        |
+| #50   | Operator launch pricing - flat monthly retainer + stand-up fee, internal, never published (see ADR 0063)                                                                                                                                                    |
+| #51   | Hosted Agent self-serve SKU - $79/mo BYO-key personal Hermes agent, 25 founding seats at $49/mo (see ADR 0067)                                                                                                                                              |
+| #52   | Repository visibility - ss-console PUBLIC (2026-08-01; going private 07-27 was containment, not policy), hermes-smd-overlay PUBLIC (provisioning depends on it); client material lives in the private venturecrane/engagements repo (see ADR 0081 revision) |
 
 ---
 


### PR DESCRIPTION
Follow-up to #2118. `docs/adr/decision-stack.md:950` was a second doctrine surface still reading `venture consoles PRIVATE`, which is the exact text an agent consults before acting on repo visibility.

Now reads: `ss-console` PUBLIC as of 2026-08-01, containment framing named, overlay unchanged, and client material located in the private `venturecrane/engagements` repo.

Docs-only. `tests/doctrine-integrity.test.ts` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3ck3zHJVYLDxZWa73fZi6