### PR TITLE
feat(operator): a client can author the shape rules their Operator is held to

### DIFF
--- a/src/components/portal/operator/OutputClassRules.astro
+++ b/src/components/portal/operator/OutputClassRules.astro
@@ -1,0 +1,149 @@
+---
+import Field from '../form/Field.astro'
+import TextArea from '../form/TextArea.astro'
+import TextInput from '../form/TextInput.astro'
+import CheckboxOption from '../form/CheckboxOption.astro'
+import {
+  assertionFieldName,
+  describeAssertions,
+  MAX_FORBIDDEN_ENTRIES,
+  MAX_PREFIX_CHARS,
+  RULE_LABEL,
+  type Assertions,
+} from '../../../lib/operator/format-assertions'
+
+/**
+ * The checked half of one output class's shape (ADR 0083 §3).
+ *
+ * THE DIVISION THIS RENDERS. Its sibling `OutputClassSpecs` collects prose — the
+ * guidance the model writes with, graded and never enforced. This collects
+ * RULES, which the seat's checker decides against and refuses on. Format is
+ * binary where voice is probabilistic, and the form has to make that legible or
+ * a client reasonably assumes their typed paragraph is enforced.
+ *
+ * WHAT IS ENFORCED IS SHOWN BACK IN PLAIN ENGLISH. `describeAssertions` renders
+ * the stored rules as sentences above the controls. Rules → sentence is
+ * inspectable; the reverse direction, deriving rules from a typed sentence,
+ * would turn a misreading into a hard block on something nobody wrote.
+ *
+ * WITHHELD WHERE IT WOULD NOT BIND. Under any declaration but
+ * `format_spec: expected` the gate never reads shape rules, so authoring one
+ * would leave a client believing something is enforced while nothing checks it.
+ * The controls are withheld and the reason is stated.
+ */
+
+interface Props {
+  outputClass: string
+  /** True when the seat declares `format_spec: expected` for this class. */
+  binds: boolean
+  /** What is stored in the vault today, or null. */
+  rules: Assertions | null
+}
+
+const { outputClass, binds, rules } = Astro.props
+
+const eyebrowClass =
+  'font-mono text-label uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)]'
+const mutedNoteClass =
+  'font-mono text-label uppercase tracking-[0.14em] text-[color:var(--ss-color-text-muted)]'
+
+const enforced = describeAssertions(rules)
+
+const field = {
+  opening: assertionFieldName(outputClass, 'opening_line_prefix'),
+  closing: assertionFieldName(outputClass, 'closing_line_prefix'),
+  single: assertionFieldName(outputClass, 'single_closing_line'),
+  bullets: assertionFieldName(outputClass, 'forbid_bullets'),
+  forbidden: assertionFieldName(outputClass, 'forbid_substrings'),
+  ceiling: assertionFieldName(outputClass, 'max_chars'),
+}
+---
+
+<div class="mt-6 border-t-[3px] border-[color:var(--ss-color-text-primary)] pt-5">
+  <h4 class={eyebrowClass}>Shape rules</h4>
+
+  {
+    binds ? (
+      <Fragment>
+        <p class="mt-2 mb-0 font-body text-caption text-[color:var(--ss-color-text-secondary)]">
+          The description above is guidance your Operator writes with. These rules are checked. An
+          output that breaks one does not go out.
+        </p>
+
+        {enforced.length > 0 ? (
+          <ul class="mt-4 mb-0 list-none border-[3px] border-[color:var(--ss-color-text-primary)] p-4">
+            {enforced.map((sentence) => (
+              <li class="font-body text-caption text-[color:var(--ss-color-text-primary)]">
+                {sentence}
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p class={`mt-4 mb-0 ${mutedNoteClass}`}>
+            No rules set. Nothing is checked for this kind of work.
+          </p>
+        )}
+
+        <div class="mt-5 grid gap-5 md:grid-cols-2">
+          <Field label={RULE_LABEL.opening_line_prefix}>
+            <TextInput
+              name={field.opening}
+              maxlength={MAX_PREFIX_CHARS}
+              value={rules?.opening_line_prefix ?? ''}
+              placeholder="e.g. Summary:"
+              mono
+            />
+          </Field>
+          <Field label={RULE_LABEL.closing_line_prefix}>
+            <TextInput
+              name={field.closing}
+              maxlength={MAX_PREFIX_CHARS}
+              value={rules?.closing_line_prefix ?? ''}
+              placeholder="e.g. Next:"
+              mono
+            />
+          </Field>
+          <Field label={RULE_LABEL.forbid_substrings}>
+            <TextArea
+              name={field.forbidden}
+              rows={3}
+              value={(rules?.forbid_substrings ?? []).join('\n')}
+              placeholder="One per line"
+              mono
+            />
+          </Field>
+          <Field label={RULE_LABEL.max_chars}>
+            <TextInput
+              name={field.ceiling}
+              value={rules?.max_chars ? String(rules.max_chars) : ''}
+              placeholder="Characters"
+              mono
+            />
+          </Field>
+        </div>
+
+        <div class="mt-5 flex flex-col gap-2">
+          <CheckboxOption
+            name={field.single}
+            value="true"
+            label={`${RULE_LABEL.single_closing_line} (needs a required closing line)`}
+            checked={rules?.single_closing_line === true}
+          />
+          <CheckboxOption
+            name={field.bullets}
+            value="true"
+            label={RULE_LABEL.forbid_bullets}
+            checked={rules?.forbid_bullets === true}
+          />
+        </div>
+
+        <p class={`mt-4 mb-0 ${mutedNoteClass}`}>At most {MAX_FORBIDDEN_ENTRIES} words to avoid</p>
+      </Fragment>
+    ) : (
+      <p class="mt-2 mb-0 font-body text-caption text-[color:var(--ss-color-text-secondary)]">
+        Checked rules are not switched on for this kind of work, so none can be set here. The
+        description above still guides how your Operator shapes it. Contact SMD to switch them on.
+      </p>
+    )
+  }
+</div>

--- a/src/components/portal/operator/OutputClassSpecs.astro
+++ b/src/components/portal/operator/OutputClassSpecs.astro
@@ -2,12 +2,14 @@
 import Field from '../form/Field.astro'
 import TextArea from '../form/TextArea.astro'
 import SubmitButton from '../form/SubmitButton.astro'
+import OutputClassRules from './OutputClassRules.astro'
 import {
   MAX_SPEC_BODY_BYTES,
   SPEC_PROPERTIES,
   specFieldName,
   type SpecDocument,
 } from '../../../lib/operator/output-class-specs'
+import type { Assertions } from '../../../lib/operator/format-assertions'
 import type { OutputClasses } from '../../../lib/operator/customer-yaml/types'
 
 /**
@@ -71,19 +73,38 @@ const PROPERTY_LABEL: Record<(typeof SPEC_PROPERTIES)[number], string> = {
   format: 'How it should be shaped',
 }
 
+/**
+ * The rules currently stored for a class's format property, if any.
+ *
+ * SHOWN ONLY WHERE THEY BIND. The seat's gate reads shape rules only for a
+ * class declaring `format_spec: expected`; under any other declaration an
+ * authored rule would sit in the vault unchecked. Offering the controls there
+ * would let a client author something they believe is enforced while nothing
+ * checks it — the failure this whole surface exists to remove — so the controls
+ * are withheld and the reason is said out loud instead.
+ */
+function storedRules(slug: string): Assertions | null {
+  return current?.classes?.[slug]?.format?.assertions ?? null
+}
+
 const rows = Object.entries(declared)
   .sort(([a], [b]) => a.localeCompare(b))
-  .map(([slug, entry]) => ({
-    slug,
-    label: classLabel(slug),
-    properties: SPEC_PROPERTIES.map((property) => ({
-      property,
-      field: specFieldName(slug, property),
-      label: PROPERTY_LABEL[property],
-      expected: entry[`${property}_spec`] === 'expected',
-      body: current?.classes?.[slug]?.[property]?.body ?? '',
-    })),
-  }))
+  .map(([slug, entry]) => {
+    const rules = storedRules(slug)
+    return {
+      slug,
+      label: classLabel(slug),
+      rulesBind: entry.format_spec === 'expected',
+      rules,
+      properties: SPEC_PROPERTIES.map((property) => ({
+        property,
+        field: specFieldName(slug, property),
+        label: PROPERTY_LABEL[property],
+        expected: entry[`${property}_spec`] === 'expected',
+        body: current?.classes?.[slug]?.[property]?.body ?? '',
+      })),
+    }
+  })
 ---
 
 <section class="mt-10" aria-labelledby="output-shape-heading">
@@ -136,6 +157,8 @@ const rows = Object.entries(declared)
                   </p>
                 </div>
               ))}
+
+              <OutputClassRules outputClass={row.slug} binds={row.rulesBind} rules={row.rules} />
             </div>
           ))}
 

--- a/src/lib/operator/format-assertions.ts
+++ b/src/lib/operator/format-assertions.ts
@@ -1,0 +1,333 @@
+/**
+ * The closed vocabulary of machine-checkable shape rules a client can author
+ * (ADR 0083 §3), and the producing half of a contract whose consuming half has
+ * been live since overlay#207.
+ *
+ * THE GAP THIS CLOSES. The seat's checker (`shared/format_check.py`) reads
+ * `assertions` out of the root-owned manifest, the applier carries them
+ * verbatim from the customer's vault object, and the gate refuses a
+ * non-conforming send. Every one of those existed. Nothing wrote assertions
+ * into the vault object: the console emitted `{body, sha256}` and no more. So
+ * the enforceable half of "how it should be shaped" was authorable by hand-
+ * editing JSON and by no other means — which is to say, by us and not by a
+ * client. This module is what a Named Administrator uses instead.
+ *
+ * RULES → SENTENCE, NEVER SENTENCE → RULES. The client picks from the closed
+ * set below and `describeAssertions` renders the picks back as plain English.
+ * The reverse direction — deriving rules from their typed prose — is refused by
+ * design: a model doing that conversion turns a misreading into a hard block on
+ * a rule the client never wrote and cannot see, which is strictly worse than
+ * advisory prose. Rules → sentence is inspectable; sentence → rules is not.
+ * The seat's own checker docstring draws this line first.
+ *
+ * FORMAT ONLY, NEVER VOICE. ADR 0083 §3: format is binary, voice is
+ * probabilistic. Assertions decide; prose is graded. Offering a checkable rule
+ * for voice would promise enforcement of how something SOUNDS — a promise the
+ * substrate cannot keep. `assertionsApplyTo` is the single place that says so.
+ *
+ * AN INERT RULE IS A DEFECT, NOT A NO-OP. `single_closing_line` means nothing
+ * without a closing prefix to count, so authoring it alone is refused rather
+ * than stored. The applier holds the same line about malformed assertions:
+ * silently discarding a shape rule "would leave the customer believing a rule
+ * is enforced while nothing checks it — worse than refusing the write."
+ *
+ * GROWING THIS SET IS A TWO-REPO ACT. A rule offered here that the seat's
+ * `KNOWN_ASSERTIONS` does not carry is ignored on the seat — degrading safely,
+ * but leaving the client believing something is enforced that is not. The seat
+ * must understand a rule before this file offers it.
+ * `tests/format-assertions.test.ts` pins the set so adding one is deliberate
+ * and reviewed rather than incidental.
+ */
+
+import type { SpecProperty } from './output-class-specs'
+
+/**
+ * Every rule name, mirroring the seat's `shared/format_check.py`
+ * `KNOWN_ASSERTIONS`. Order is the order the form renders them.
+ */
+export const ASSERTION_RULES = [
+  'opening_line_prefix',
+  'closing_line_prefix',
+  'single_closing_line',
+  'forbid_bullets',
+  'forbid_substrings',
+  'max_chars',
+] as const
+
+export type AssertionRule = (typeof ASSERTION_RULES)[number]
+
+/** The stored shape: what rides in the vault object beside a format body. */
+export type Assertions = Partial<{
+  opening_line_prefix: string
+  closing_line_prefix: string
+  single_closing_line: true
+  forbid_bullets: true
+  forbid_substrings: string[]
+  max_chars: number
+}>
+
+/**
+ * Which spec property may carry assertions. See the FORMAT ONLY note above —
+ * this is deliberately a function rather than a bare constant, so a caller that
+ * wants to author a rule for voice has to read the reason it cannot.
+ */
+export function assertionsApplyTo(property: SpecProperty): boolean {
+  return property === 'format'
+}
+
+// ---------------------------------------------------------------------------
+// Bounds
+//
+// Each one exists to keep a rule readable when rendered back. A forbidden-word
+// list nobody can read in a sentence is a rule the client cannot verify, and an
+// unverifiable rule is the thing this whole surface exists to replace.
+// ---------------------------------------------------------------------------
+
+/** A line prefix. Long enough for a real required opener, short of a paragraph. */
+export const MAX_PREFIX_CHARS = 120
+/** Forbidden substrings: how many, and how long each may be. */
+export const MAX_FORBIDDEN_ENTRIES = 25
+export const MAX_FORBIDDEN_CHARS = 100
+/** Upper bound on an authored length ceiling. */
+export const MAX_LENGTH_CEILING = 200_000
+
+/** Form field name for one rule on one class. Mirrors `specFieldName`. */
+export function assertionFieldName(outputClass: string, rule: AssertionRule): string {
+  return `assertions[${outputClass}].${rule}`
+}
+
+// ---------------------------------------------------------------------------
+// Build (form → stored shape)
+// ---------------------------------------------------------------------------
+
+export type AssertionBuildResult =
+  { ok: true; assertions: Assertions } | { ok: false; errors: readonly string[] }
+
+/**
+ * Read one class's rules out of a submitted form.
+ *
+ * The iteration is over `ASSERTION_RULES`, never over the form's own keys —
+ * the same security property `collectAuthoredBodies` holds. A hand-crafted POST
+ * naming a rule outside the vocabulary contributes nothing, because nothing here
+ * ever looks for it. That is stronger than refusing an unknown rule: an unknown
+ * rule cannot be expressed on this surface at all.
+ */
+export function buildAssertions(form: FormData, outputClass: string): AssertionBuildResult {
+  const errors: string[] = []
+  const out: Assertions = {}
+
+  readPrefix(form, outputClass, 'opening_line_prefix', out, errors)
+  readPrefix(form, outputClass, 'closing_line_prefix', out, errors)
+  readFlag(form, outputClass, 'single_closing_line', out)
+  readFlag(form, outputClass, 'forbid_bullets', out)
+  readForbidden(form, outputClass, out, errors)
+  readCeiling(form, outputClass, out, errors)
+
+  // An inert rule is refused, not stored. See the header.
+  if (out.single_closing_line === true && out.closing_line_prefix === undefined) {
+    errors.push(
+      '"only one closing line" needs a closing line to count. Set the required closing line, ' +
+        'or clear this rule.'
+    )
+  }
+
+  if (errors.length > 0) return { ok: false, errors }
+  return { ok: true, assertions: out }
+}
+
+/**
+ * A required line prefix.
+ *
+ * TRIMMED, DELIBERATELY. The seat compares against lines it has already
+ * stripped, so a trailing space authored here would be invisible on screen and
+ * could only ever make the rule harder to satisfy. Trimming makes every stored
+ * prefix one the client can see in full.
+ */
+function readPrefix(
+  form: FormData,
+  outputClass: string,
+  rule: 'opening_line_prefix' | 'closing_line_prefix',
+  out: Assertions,
+  errors: string[]
+): void {
+  const raw = form.get(assertionFieldName(outputClass, rule))
+  if (typeof raw !== 'string') return
+  const value = raw.trim()
+  if (value.length === 0) return
+  if (value.length > MAX_PREFIX_CHARS) {
+    errors.push(`${RULE_LABEL[rule]}: keep it under ${MAX_PREFIX_CHARS} characters.`)
+    return
+  }
+  out[rule] = value
+}
+
+/** A checkbox. Present means true; the stored value is only ever `true`. */
+function readFlag(
+  form: FormData,
+  outputClass: string,
+  rule: 'single_closing_line' | 'forbid_bullets',
+  out: Assertions
+): void {
+  if (form.get(assertionFieldName(outputClass, rule)) !== null) out[rule] = true
+}
+
+/** One forbidden substring per line. Blank lines are not rules. */
+function readForbidden(
+  form: FormData,
+  outputClass: string,
+  out: Assertions,
+  errors: string[]
+): void {
+  const raw = form.get(assertionFieldName(outputClass, 'forbid_substrings'))
+  if (typeof raw !== 'string') return
+  const entries = raw
+    .split(/\r\n?|\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+  if (entries.length === 0) return
+  if (entries.length > MAX_FORBIDDEN_ENTRIES) {
+    errors.push(`${RULE_LABEL.forbid_substrings}: at most ${MAX_FORBIDDEN_ENTRIES} entries.`)
+    return
+  }
+  const overlong = entries.find((entry) => entry.length > MAX_FORBIDDEN_CHARS)
+  if (overlong !== undefined) {
+    errors.push(
+      `${RULE_LABEL.forbid_substrings}: each entry must be under ${MAX_FORBIDDEN_CHARS} characters.`
+    )
+    return
+  }
+  out.forbid_substrings = entries
+}
+
+/** A positive whole-number character ceiling. */
+function readCeiling(form: FormData, outputClass: string, out: Assertions, errors: string[]): void {
+  const raw = form.get(assertionFieldName(outputClass, 'max_chars'))
+  if (typeof raw !== 'string') return
+  const value = raw.trim()
+  if (value.length === 0) return
+  if (!/^\d+$/.test(value)) {
+    errors.push(`${RULE_LABEL.max_chars}: must be a whole number.`)
+    return
+  }
+  const parsed = Number(value)
+  if (parsed <= 0 || parsed > MAX_LENGTH_CEILING) {
+    errors.push(`${RULE_LABEL.max_chars}: must be between 1 and ${MAX_LENGTH_CEILING}.`)
+    return
+  }
+  out.max_chars = parsed
+}
+
+// ---------------------------------------------------------------------------
+// Parse (vault object → stored shape)
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse assertions read back from the vault.
+ *
+ * STRICT, AND THE STRICTNESS IS THE POINT. An unrecognised rule name or a
+ * malformed value fails the parse, which surfaces the whole document as
+ * unreadable and refuses the write rather than round-tripping a rule this
+ * surface cannot show. Carrying an unshowable rule forward would leave a client
+ * looking at a form that does not describe what their Operator enforces.
+ */
+export function parseAssertions(raw: unknown, path: string, errors: string[]): Assertions | null {
+  if (raw === undefined || raw === null) return null
+  if (typeof raw !== 'object' || Array.isArray(raw)) {
+    errors.push(`${path}: must be an object when present`)
+    return null
+  }
+  const out: Assertions = {}
+  for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+    if (!(ASSERTION_RULES as readonly string[]).includes(key)) {
+      errors.push(`${path}.${key}: not a rule this surface can show`)
+      continue
+    }
+    parseOneRule(key as AssertionRule, value, `${path}.${key}`, out, errors)
+  }
+  return Object.keys(out).length > 0 ? out : null
+}
+
+function parseOneRule(
+  rule: AssertionRule,
+  value: unknown,
+  path: string,
+  out: Assertions,
+  errors: string[]
+): void {
+  if (rule === 'opening_line_prefix' || rule === 'closing_line_prefix') {
+    if (typeof value !== 'string' || value.length === 0) {
+      errors.push(`${path}: must be a non-empty string`)
+      return
+    }
+    out[rule] = value
+    return
+  }
+  if (rule === 'single_closing_line' || rule === 'forbid_bullets') {
+    if (value !== true) {
+      errors.push(`${path}: must be true when present`)
+      return
+    }
+    out[rule] = true
+    return
+  }
+  if (rule === 'forbid_substrings') {
+    if (!Array.isArray(value) || value.some((v) => typeof v !== 'string' || v.length === 0)) {
+      errors.push(`${path}: must be an array of non-empty strings`)
+      return
+    }
+    out.forbid_substrings = value as string[]
+    return
+  }
+  if (!Number.isInteger(value) || typeof value !== 'number' || value <= 0) {
+    errors.push(`${path}: must be a positive whole number`)
+    return
+  }
+  out.max_chars = value
+}
+
+// ---------------------------------------------------------------------------
+// Describe (stored shape → plain English)
+// ---------------------------------------------------------------------------
+
+/** Human label per rule, shared by the form and every error message. */
+export const RULE_LABEL: Record<AssertionRule, string> = {
+  opening_line_prefix: 'Required opening line',
+  closing_line_prefix: 'Required closing line',
+  single_closing_line: 'Only one closing line',
+  forbid_bullets: 'No bullets or numbered lists',
+  forbid_substrings: 'Words to avoid',
+  max_chars: 'Length limit',
+}
+
+/**
+ * What is enforced, as sentences a client can check against their intent.
+ *
+ * This is the readable half of the contract. The client picked rules; this
+ * shows them back in the words they would have used, so the rule and the
+ * understanding of the rule cannot drift apart. Empty means nothing is
+ * mechanically enforced for this class — which the caller must say plainly
+ * rather than leave as an absence.
+ */
+export function describeAssertions(assertions: Assertions | null | undefined): string[] {
+  if (!assertions) return []
+  const out: string[] = []
+  if (assertions.opening_line_prefix !== undefined) {
+    out.push(`The first line must begin "${assertions.opening_line_prefix}".`)
+  }
+  if (assertions.closing_line_prefix !== undefined) {
+    out.push(`The last line must begin "${assertions.closing_line_prefix}".`)
+  }
+  if (assertions.single_closing_line === true && assertions.closing_line_prefix !== undefined) {
+    out.push(`Exactly one line may begin "${assertions.closing_line_prefix}".`)
+  }
+  if (assertions.forbid_bullets === true) {
+    out.push('No line may be a bullet or a numbered item.')
+  }
+  if (assertions.forbid_substrings !== undefined) {
+    out.push(`These may not appear: ${assertions.forbid_substrings.join(', ')}.`)
+  }
+  if (assertions.max_chars !== undefined) {
+    out.push(`The whole output must be under ${assertions.max_chars} characters.`)
+  }
+  return out
+}

--- a/src/lib/operator/output-class-specs.ts
+++ b/src/lib/operator/output-class-specs.ts
@@ -50,6 +50,8 @@
  * document no longer declares).
  */
 
+import { assertionsApplyTo, parseAssertions, type Assertions } from './format-assertions'
+
 /** Schema version of the vault document. Must match the applier's constant. */
 export const SPEC_SCHEMA_VERSION = 1
 
@@ -89,10 +91,20 @@ export function specFieldName(outputClass: string, property: SpecProperty): stri
   return `specs[${outputClass}].${property}`
 }
 
-/** One authored body, with the digest this module computed over it. */
+/**
+ * One authored body, with the digest this module computed over it, and — for
+ * the `format` property only — the machine-checkable rules that ride beside it.
+ *
+ * TWO HALVES OF ONE SUBMISSION, NEITHER DERIVED FROM THE OTHER. `body` is the
+ * prose that goes in front of the model; `assertions` is what goes in front of
+ * the seat's checker. The seat's `shared/format_check.py` says it first:
+ * nothing parses English into rules, and nothing infers prose from rules. They
+ * are authored together and stored together. See `./format-assertions`.
+ */
 export interface SpecBody {
   body: string
   sha256: string
+  assertions?: Assertions
 }
 
 /** The vault document: per class, per property, an authored body. */
@@ -232,7 +244,17 @@ function parseClassEntry(
       errors.push(`classes.${slug}.${prop}.sha256: must be a hex sha256 string`)
       continue
     }
-    parsed[prop] = { body, sha256: declared.trim().toLowerCase() }
+    const stored: SpecBody = { body, sha256: declared.trim().toLowerCase() }
+    // Assertions on a non-format property are refused rather than dropped: a
+    // stored rule this surface will not render is a rule the client cannot see
+    // and cannot have chosen. See `assertionsApplyTo`.
+    if (value['assertions'] !== undefined && !assertionsApplyTo(prop)) {
+      errors.push(`classes.${slug}.${prop}.assertions: only the format property carries rules`)
+      continue
+    }
+    const rules = parseAssertions(value['assertions'], `classes.${slug}.${prop}.assertions`, errors)
+    if (rules !== null) stored.assertions = rules
+    parsed[prop] = stored
   }
   return parsed
 }
@@ -303,7 +325,10 @@ export type SpecBuildResult =
  * file on the next cycle. A document that ends up with no bodies at all is
  * refused here; see the fail-closed note in the header.
  */
-export async function buildSpecDocument(bodies: readonly AuthoredBody[]): Promise<SpecBuildResult> {
+export async function buildSpecDocument(
+  bodies: readonly AuthoredBody[],
+  assertionsByClass: ReadonlyMap<string, Assertions> = new Map()
+): Promise<SpecBuildResult> {
   const errors: string[] = []
   let invalidClass = false
   let tooLong = false
@@ -328,7 +353,17 @@ export async function buildSpecDocument(bodies: readonly AuthoredBody[]): Promis
       continue
     }
     const entry = classes[slug] ?? {}
-    entry[authored.property] = { body, sha256: await sha256Hex(body) }
+    const stored: SpecBody = { body, sha256: await sha256Hex(body) }
+    // Rules attach to the format body and to nothing else. A class whose format
+    // prose is blank stores no rules either: the seat would install no format
+    // file, so the manifest would carry no entry for the checker to read them
+    // from, and a rule stored with nowhere to live is one the client believes
+    // is enforced while nothing checks it.
+    if (assertionsApplyTo(authored.property)) {
+      const rules = assertionsByClass.get(slug)
+      if (rules !== undefined && Object.keys(rules).length > 0) stored.assertions = rules
+    }
+    entry[authored.property] = stored
     classes[slug] = entry
   }
 

--- a/src/pages/api/portal/operator/settings/output-class-specs.ts
+++ b/src/pages/api/portal/operator/settings/output-class-specs.ts
@@ -54,6 +54,7 @@ import {
   promoteCorrection,
   type CorrectionCitation,
 } from '../../../../../lib/portal/operator/voice-corrections'
+import { buildAssertions, type Assertions } from '../../../../../lib/operator/format-assertions'
 
 const OPERATOR_ROOT = '/portal/products/operator'
 
@@ -116,6 +117,32 @@ function mergeUnaddressed(
     classes[slug] = entry
   }
   return { schema_version: built.schema_version, classes }
+}
+
+/**
+ * Every declared class's machine-checkable rules, or the first refusal.
+ *
+ * ALL CLASSES ARE VALIDATED BEFORE ANY IS ACCEPTED. Errors accumulate across
+ * classes so one save reports everything wrong with it. A form that refused one
+ * rule at a time would read as the surface moving the goalposts — the same
+ * reasoning the seat's checker gives for returning all violations at once.
+ */
+function collectAssertions(
+  form: FormData,
+  classes: readonly string[]
+): { ok: true; byClass: Map<string, Assertions> } | { ok: false; errors: readonly string[] } {
+  const byClass = new Map<string, Assertions>()
+  const errors: string[] = []
+  for (const outputClass of classes) {
+    const built = buildAssertions(form, outputClass)
+    if (!built.ok) {
+      errors.push(...built.errors.map((e) => `${outputClass}: ${e}`))
+      continue
+    }
+    if (Object.keys(built.assertions).length > 0) byClass.set(outputClass, built.assertions)
+  }
+  if (errors.length > 0) return { ok: false, errors }
+  return { ok: true, byClass }
 }
 
 async function recordAttempt(
@@ -228,7 +255,16 @@ export const POST: APIRoute = async ({ request, locals }) => {
   const classes = declaredClasses(row.output_classes)
   if (classes.length === 0) return redirectWithStatus(auth.customerSlug, 'spec_no_classes')
 
-  const built = await buildSpecDocument(collectAuthoredBodies(form, classes))
+  // Rules before prose. A refused rule must not be reported as a saved spec,
+  // and the two halves come from one submission, so neither is written unless
+  // both are acceptable.
+  const rules = collectAssertions(form, classes)
+  if (!rules.ok) {
+    await recordAttempt(auth, 'rejected', { reason: 'invalid_rule', errors: rules.errors })
+    return redirectWithStatus(auth.customerSlug, 'spec_invalid_rule')
+  }
+
+  const built = await buildSpecDocument(collectAuthoredBodies(form, classes), rules.byClass)
   if (!built.ok) {
     await recordAttempt(auth, 'rejected', { reason: built.reason, errors: built.errors })
     return redirectWithStatus(auth.customerSlug, BUILD_FAILURE_STATUS[built.reason])

--- a/src/pages/portal/products/operator/[instance]/settings/advanced/index.astro
+++ b/src/pages/portal/products/operator/[instance]/settings/advanced/index.astro
@@ -195,6 +195,12 @@ const STATUS_BANNERS: Record<string, BannerStatus> = {
     text: 'The output shape was not saved and nothing changed on your Operator. Contact SMD.',
     tone: 'error',
   },
+  // A rule the client CAN fix, so it gets its own sentence rather than the
+  // catch-all: the specific problem is listed under the rule on the form.
+  spec_invalid_rule: {
+    text: 'The output shape was not saved. One of your shape rules cannot be applied as written. Check the rules below and resubmit.',
+    tone: 'error',
+  },
   spec_no_classes: {
     text: 'No output classes are set up for this Operator, so there is nothing to save.',
     tone: 'error',

--- a/tests/format-assertions.test.ts
+++ b/tests/format-assertions.test.ts
@@ -1,0 +1,303 @@
+/**
+ * Client-authored shape rules (ADR 0083 §3, the producing half of overlay#207).
+ *
+ * Four properties here are load-bearing enough that a regression would be
+ * silent and would reach a running Operator:
+ *
+ *  1. THE VOCABULARY IS PINNED. A rule this surface offers that the seat's
+ *     `shared/format_check.py::KNOWN_ASSERTIONS` does not carry is IGNORED on
+ *     the seat — safe degradation, but it leaves the client believing something
+ *     is enforced that is not. Growing the set must be a deliberate, reviewed,
+ *     two-repo act, so the set is asserted literally.
+ *  2. FORMAT ONLY. Voice is probabilistic and graded; format is binary and
+ *     decided. A checkable rule on the voice property would promise enforcement
+ *     of how something sounds.
+ *  3. NO INERT RULE. A stored rule nothing can check is worse than no rule.
+ *     `single_closing_line` without a closing prefix is refused, not stored.
+ *  4. RULES → SENTENCE. Every rule renders back in plain English, so the rule
+ *     and the client's understanding of it cannot drift apart. A rule with no
+ *     sentence is invisible.
+ */
+
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+import {
+  ASSERTION_RULES,
+  MAX_FORBIDDEN_CHARS,
+  MAX_FORBIDDEN_ENTRIES,
+  MAX_LENGTH_CEILING,
+  MAX_PREFIX_CHARS,
+  RULE_LABEL,
+  assertionFieldName,
+  assertionsApplyTo,
+  buildAssertions,
+  describeAssertions,
+  parseAssertions,
+  type Assertions,
+} from '../src/lib/operator/format-assertions'
+import {
+  buildSpecDocument,
+  collectAuthoredBodies,
+  parseSpecDocument,
+  serializeSpecDocument,
+} from '../src/lib/operator/output-class-specs'
+
+const ADVANCED_PAGE_SOURCE = readFileSync(
+  fileURLToPath(
+    new URL(
+      '../src/pages/portal/products/operator/[instance]/settings/advanced/index.astro',
+      import.meta.url
+    )
+  ),
+  'utf8'
+)
+
+const ENDPOINT_SOURCE = readFileSync(
+  fileURLToPath(
+    new URL('../src/pages/api/portal/operator/settings/output-class-specs.ts', import.meta.url)
+  ),
+  'utf8'
+)
+
+/** A form carrying one class's rules. */
+function ruleForm(outputClass: string, values: Record<string, string>): FormData {
+  const form = new FormData()
+  for (const [rule, value] of Object.entries(values)) {
+    form.set(assertionFieldName(outputClass, rule as (typeof ASSERTION_RULES)[number]), value)
+  }
+  return form
+}
+
+describe('the rule vocabulary is a closed set the seat also understands', () => {
+  it('pins the exact rules, so growing the set is deliberate', () => {
+    // Mirrors shared/format_check.py::KNOWN_ASSERTIONS. If this fails because a
+    // rule was ADDED, the seat must understand it first — an unknown rule is
+    // ignored there, which silently under-enforces.
+    expect([...ASSERTION_RULES]).toEqual([
+      'opening_line_prefix',
+      'closing_line_prefix',
+      'single_closing_line',
+      'forbid_bullets',
+      'forbid_substrings',
+      'max_chars',
+    ])
+  })
+
+  it('gives every rule a label and a sentence', () => {
+    for (const rule of ASSERTION_RULES) {
+      expect(RULE_LABEL[rule], rule).toBeTruthy()
+    }
+    const everything: Assertions = {
+      opening_line_prefix: 'Summary:',
+      closing_line_prefix: 'Next:',
+      single_closing_line: true,
+      forbid_bullets: true,
+      forbid_substrings: ['ASAP'],
+      max_chars: 900,
+    }
+    // One sentence per authored rule — nothing enforced without being stated.
+    expect(describeAssertions(everything)).toHaveLength(ASSERTION_RULES.length)
+  })
+
+  it('says nothing when nothing is authored', () => {
+    expect(describeAssertions(null)).toEqual([])
+    expect(describeAssertions({})).toEqual([])
+  })
+})
+
+describe('rules attach to format and never to voice', () => {
+  it('answers for each property', () => {
+    expect(assertionsApplyTo('format')).toBe(true)
+    expect(assertionsApplyTo('voice')).toBe(false)
+  })
+
+  it('stores rules on the format body only', async () => {
+    const rules = new Map<string, Assertions>([['staff', { forbid_bullets: true }]])
+    const built = await buildSpecDocument(
+      [
+        { outputClass: 'staff', property: 'voice', body: 'Warm and brief.' },
+        { outputClass: 'staff', property: 'format', body: 'Lead with the ask.' },
+      ],
+      rules
+    )
+    expect(built.ok).toBe(true)
+    if (!built.ok) return
+    expect(built.doc.classes.staff?.voice?.assertions).toBeUndefined()
+    expect(built.doc.classes.staff?.format?.assertions).toEqual({ forbid_bullets: true })
+  })
+
+  it('refuses a vault document that put rules on voice', () => {
+    const parsed = parseSpecDocument(
+      JSON.stringify({
+        schema_version: 1,
+        classes: {
+          staff: { voice: { body: 'x', sha256: 'a', assertions: { forbid_bullets: true } } },
+        },
+      })
+    )
+    expect(parsed.ok).toBe(false)
+    if (parsed.ok) return
+    expect(parsed.errors.join(' ')).toMatch(/only the format property carries rules/)
+  })
+})
+
+describe('an inert rule is refused rather than stored', () => {
+  it('refuses "only one closing line" with no closing line to count', () => {
+    const built = buildAssertions(ruleForm('staff', { single_closing_line: 'true' }), 'staff')
+    expect(built.ok).toBe(false)
+    if (built.ok) return
+    expect(built.errors.join(' ')).toMatch(/needs a closing line to count/)
+  })
+
+  it('accepts it once a closing line exists', () => {
+    const built = buildAssertions(
+      ruleForm('staff', { single_closing_line: 'true', closing_line_prefix: 'Next:' }),
+      'staff'
+    )
+    expect(built.ok).toBe(true)
+    if (!built.ok) return
+    expect(built.assertions).toEqual({ single_closing_line: true, closing_line_prefix: 'Next:' })
+  })
+
+  it('drops a rule left blank rather than storing an empty one', () => {
+    const built = buildAssertions(
+      ruleForm('staff', { opening_line_prefix: '   ', forbid_substrings: '\n  \n', max_chars: '' }),
+      'staff'
+    )
+    expect(built.ok).toBe(true)
+    if (!built.ok) return
+    expect(built.assertions).toEqual({})
+  })
+})
+
+describe('a rule outside the vocabulary cannot be expressed', () => {
+  it('ignores a hand-crafted field naming an unknown rule', () => {
+    // The iteration is over ASSERTION_RULES, never over the form's own keys —
+    // the same security property collectAuthoredBodies holds. This is stronger
+    // than refusing an unknown rule: it cannot be submitted at all.
+    const form = new FormData()
+    form.set('assertions[staff].run_arbitrary_regex', '.*')
+    form.set('assertions[staff].forbid_bullets', 'true')
+    const built = buildAssertions(form, 'staff')
+    expect(built.ok).toBe(true)
+    if (!built.ok) return
+    expect(built.assertions).toEqual({ forbid_bullets: true })
+  })
+
+  it('refuses a vault document carrying an unknown rule', () => {
+    // Strictness here is the point: a rule this surface cannot render is a rule
+    // the client cannot see, and round-tripping it would leave the form
+    // describing something other than what the Operator enforces.
+    const errors: string[] = []
+    const parsed = parseAssertions(
+      { conjure_a_tone: true },
+      'classes.staff.format.assertions',
+      errors
+    )
+    expect(parsed).toBeNull()
+    expect(errors.join(' ')).toMatch(/not a rule this surface can show/)
+  })
+
+  it('refuses a malformed value for a known rule', () => {
+    const errors: string[] = []
+    parseAssertions({ max_chars: 0 }, 'p', errors)
+    parseAssertions({ forbid_bullets: 'yes' }, 'p', errors)
+    parseAssertions({ forbid_substrings: ['ok', ''] }, 'p', errors)
+    expect(errors).toHaveLength(3)
+  })
+})
+
+describe('the server holds every bound', () => {
+  it('refuses an over-long prefix', () => {
+    const built = buildAssertions(
+      ruleForm('staff', { opening_line_prefix: 'x'.repeat(MAX_PREFIX_CHARS + 1) }),
+      'staff'
+    )
+    expect(built.ok).toBe(false)
+  })
+
+  it('refuses too many forbidden entries, and an over-long one', () => {
+    const many = Array.from({ length: MAX_FORBIDDEN_ENTRIES + 1 }, (_, i) => `w${i}`).join('\n')
+    expect(buildAssertions(ruleForm('staff', { forbid_substrings: many }), 'staff').ok).toBe(false)
+    const long = 'x'.repeat(MAX_FORBIDDEN_CHARS + 1)
+    expect(buildAssertions(ruleForm('staff', { forbid_substrings: long }), 'staff').ok).toBe(false)
+  })
+
+  it('refuses a ceiling that is not a positive whole number', () => {
+    for (const value of ['0', '-5', '12.5', 'lots', String(MAX_LENGTH_CEILING + 1)]) {
+      expect(buildAssertions(ruleForm('staff', { max_chars: value }), 'staff').ok, value).toBe(
+        false
+      )
+    }
+  })
+
+  it('trims a prefix so no invisible character can make a rule unsatisfiable', () => {
+    const built = buildAssertions(ruleForm('staff', { closing_line_prefix: '  Next: ' }), 'staff')
+    expect(built.ok).toBe(true)
+    if (!built.ok) return
+    expect(built.assertions.closing_line_prefix).toBe('Next:')
+  })
+})
+
+describe('rules survive the round trip to the vault and back', () => {
+  it('serializes and re-parses every rule unchanged', async () => {
+    const authored: Assertions = {
+      opening_line_prefix: 'Summary:',
+      closing_line_prefix: 'Next:',
+      single_closing_line: true,
+      forbid_bullets: true,
+      forbid_substrings: ['ASAP', 'circle back'],
+      max_chars: 1200,
+    }
+    const built = await buildSpecDocument(
+      collectAuthoredBodies(formWithBody(), ['staff']),
+      new Map([['staff', authored]])
+    )
+    expect(built.ok).toBe(true)
+    if (!built.ok) return
+
+    const reparsed = parseSpecDocument(serializeSpecDocument(built.doc))
+    expect(reparsed.ok).toBe(true)
+    if (!reparsed.ok) return
+    expect(reparsed.doc.classes.staff?.format?.assertions).toEqual(authored)
+  })
+})
+
+function formWithBody(): FormData {
+  const form = new FormData()
+  form.set('specs[staff].format', 'Lead with what changed.')
+  return form
+}
+
+describe('the refusal reaches the person who can fix it', () => {
+  it('gives the invalid-rule status a banner on the page it redirects to', () => {
+    // A status with no banner renders as no message at all: the person is
+    // returned to the form, nothing saved, nothing said.
+    expect(ENDPOINT_SOURCE).toMatch(/'spec_invalid_rule'/)
+    expect(ADVANCED_PAGE_SOURCE).toMatch(/^\s*spec_invalid_rule: \{/m)
+  })
+
+  it('withholds the rule controls where the seat would not check them', () => {
+    // Offering rules under a class the gate does not bind would let a client
+    // author something they believe is enforced while nothing checks it. The
+    // binding is computed from the declaration in one component and consumed as
+    // the only branch in the other.
+    const specs = readFileSync(
+      fileURLToPath(
+        new URL('../src/components/portal/operator/OutputClassSpecs.astro', import.meta.url)
+      ),
+      'utf8'
+    )
+    const rules = readFileSync(
+      fileURLToPath(
+        new URL('../src/components/portal/operator/OutputClassRules.astro', import.meta.url)
+      ),
+      'utf8'
+    )
+    expect(specs).toMatch(/rulesBind: entry\.format_spec === 'expected'/)
+    expect(specs).toMatch(/binds=\{row\.rulesBind\}/)
+    expect(rules).toMatch(/binds \? \(/)
+  })
+})


### PR DESCRIPTION
## What this closes

ADR 0083 §3 makes format the binary half of the authorship model. The seat has enforced it since overlay#207: `shared/format_check.py` decides against `assertions` read out of the ROOT-OWNED manifest, `spec_applier` carries them verbatim from the customer's vault object, and `spec_gate` refuses a non-conforming send naming the rule broken.

Every piece of that existed except the one that lets a client use it. The console wrote `{body, sha256}` and nothing else, so `assertions` reached the vault only by hand-editing JSON. A client could describe how their work should be shaped and could not state one rule their Operator would actually be held to.

Traced this session: `vfy_01KYZ6NMJN0XYV3MXWBMVX2KAA`.

## What is here

- **`src/lib/operator/format-assertions.ts`** — the closed vocabulary (the six rules mirroring the seat's `KNOWN_ASSERTIONS`), a validator, and `describeAssertions`, which renders every stored rule back as a plain sentence.
- **`OutputClassRules.astro`** — the controls, with what is enforced today shown above them in the client's own terms.
- Endpoint validates rules before prose and writes neither unless both are acceptable; new `spec_invalid_rule` status with its own banner.

## The design lines held

**Rules → sentence, never sentence → rules.** Deriving a rule from typed prose needs a converter; if that is a model, a misreading becomes a hard block on a rule the client never wrote and cannot see. That is worse than advisory prose, because a wrong block is invisible until a message goes missing.

**Format only, never voice.** Voice is probabilistic and keeps the read-gate. "We enforce how it sounds" is a promise the substrate cannot keep.

**An inert rule is refused, not stored.** `single_closing_line` with no closing line to count is an error. Same line the applier holds: silently discarding a shape rule "would leave the customer believing a rule is enforced while nothing checks it — worse than refusing the write."

**Withheld where it would not bind.** Under any declaration but `format_spec: expected` the gate never reads shape rules, so the controls are withheld and the reason is stated on screen rather than left as an absence.

**An unknown rule cannot be expressed.** The collector iterates the vocabulary, never the form's keys — the same property `collectAuthoredBodies` holds. A vault document carrying one is refused rather than round-tripped into a form that would not show it.

**Growing the vocabulary is a two-repo act.** An unknown rule is IGNORED on the seat (correct degradation, silent under-enforcement), so the seat must understand a rule before this surface offers it. `tests/format-assertions.test.ts` pins the set literally so adding one is deliberate and reviewed.

## Acceptance criteria

- [x] (repo) A client can author machine-checkable shape rules from the portal, not only prose
- [x] (repo) Rules attach to the format property and are refused on voice
- [x] (repo) Every stored rule renders back as a sentence the client can check against their intent
- [x] (repo) An inert or malformed rule is refused at write time, with a banner
- [x] (repo) The vocabulary is pinned so it cannot outrun the seat's checker
- [ ] (runtime) A client-authored rule installs on a seat and the gate refuses an output that breaks it — blocked on driving a real turn through the gateway, tracked separately

`npm run verify` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012P3akVjzMqD4T7znk1KGQZ