### PR TITLE
fix(substrate): the identifier gate can see matter numbers and ISO datetimes

### DIFF
--- a/operator/safety-substrate/identifier_filter.py
+++ b/operator/safety-substrate/identifier_filter.py
@@ -118,9 +118,26 @@ _A_NUMBER_RE = re.compile(r"\bA#?[-\s]?(?:\d[-\s]?){8,9}\b")
 _RECEIPT_RE = re.compile(r"\b[A-Z]{3}\d{10}\b")
 # SSN.
 _SSN_RE = re.compile(r"\b\d{3}-\d{2}-\d{4}\b")
-# Case / docket numbers: federal-style "1:24-cv-01234", or "No. 24-12345".
+# Case / docket numbers: federal-style "1:24-cv-01234", or "No. 24-12345", or a
+# practice-management MATTER number ("2026-PI-101", "PI-2026-0001").
+#
+# The matter-number alternation was added 2026-07-31. Before it, this pattern
+# could not see a matter number at all: probed live, "2026-PI-107" -> no hit,
+# "PI-2026-0001" -> no hit. Every IDENTIFIER_UNVERIFIED row on the pilot seat
+# showed only date shapes, which read as "no identifier problems found" when the
+# truth was "this filter is blind to the identifiers this firm uses." A gate that
+# cannot see a class of value is not reporting on it, and silence from it meant
+# nothing.
+#
+# Still REPORT-ONLY, deliberately. See the posture note in the overlay's
+# plugins/hermes-smd-trust/outbound.py: enforcement flips only after the
+# false-positive rate is measured on real traffic, and that discipline is not
+# overridden here. What changes is that the signal now exists to measure.
 _CASE_RE = re.compile(
-    r"\b(?:\d{1,2}:\d{2}-[a-z]{2}-\d{3,6}|No\.?\s?\d{2,4}-\d{2,6})\b",
+    r"\b(?:\d{1,2}:\d{2}-[a-z]{2}-\d{3,6}"
+    r"|No\.?\s?\d{2,4}-\d{2,6}"
+    r"|\d{4}-[A-Z]{2}-\d{3,4}"
+    r"|[A-Z]{2}-\d{4}-\d{4})\b",
     re.IGNORECASE,
 )
 
@@ -128,7 +145,15 @@ _CASE_RE = re.compile(
 _DATE_RES: tuple[re.Pattern[str], ...] = (
     re.compile(r"\b\d{1,2}/\d{1,2}/\d{2,4}\b"),
     re.compile(r"\b\d{1,2}-\d{1,2}-\d{2,4}\b"),
-    re.compile(r"\b\d{4}-\d{2}-\d{2}\b"),
+    # ISO date, and the date half of an ISO *datetime*. The trailing \b this
+    # replaced could not match "2026-08-12T09:00:00Z": between the final "2" and
+    # the "T" there is no word boundary, both being word chars. Smokeball events
+    # carry ISO datetimes (create_event start_time/end_time), so a digest that
+    # correctly read a hearing and wrote its date was flagged unverified — a
+    # false positive at daily volume, and one that would have been measured as
+    # the model's fabrication rate. The negative lookahead also declines
+    # "2026-08-12-99", which the old \b form wrongly matched as a date.
+    re.compile(r"\b\d{4}-\d{2}-\d{2}(?![\d-])"),
     re.compile(
         r"\b(?:January|February|March|April|May|June|July|August|September|"
         r"October|November|December|Jan|Feb|Mar|Apr|Jun|Jul|Aug|Sep|Sept|Oct|"

--- a/operator/safety-substrate/tests/test_identifier_filter.py
+++ b/operator/safety-substrate/tests/test_identifier_filter.py
@@ -18,9 +18,12 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+import pytest
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from identifier_filter import (  # noqa: E402
+    _CASE_RE,
     IdKind,
     Mode,
     ProvenanceRegister,
@@ -200,6 +203,83 @@ def test_annotations_include_value_for_human_reviewer() -> None:
     notes = " ".join(result.annotations())
     assert "A999999999" in notes
     assert "A999999999" in refusal_message(result)
+
+
+# ---------------------------------------------------------------------------
+# Matter numbers (added 2026-07-31)
+#
+# Before this, _CASE_RE could not see a practice-management matter number at
+# all. Every IDENTIFIER_UNVERIFIED row on the pilot seat carried only date
+# shapes, which reads as "no identifier problems" when the truth was "this
+# filter is blind to the identifiers this firm uses." Silence from a gate that
+# cannot see a class of value means nothing.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("value", ["2026-PI-101", "2026-PI-107", "PI-2026-0001"])
+def test_case_re_sees_matter_numbers(value: str) -> None:
+    assert _CASE_RE.search(value), f"{value} must be visible to the identifier gate"
+
+
+@pytest.mark.parametrize("value", ["1:24-cv-01234", "No. 24-12345"])
+def test_case_re_still_sees_federal_dockets(value: str) -> None:
+    """The matter alternation is additive; the original shapes must not regress."""
+    assert _CASE_RE.search(value)
+
+
+@pytest.mark.parametrize("value", ["2026-08-12", "2026-08-12T09:00:00Z"])
+def test_case_re_does_not_claim_dates_are_case_numbers(value: str) -> None:
+    assert not _CASE_RE.search(value)
+
+
+# ---------------------------------------------------------------------------
+# ISO datetimes (added 2026-08-01)
+#
+# `\b\d{4}-\d{2}-\d{2}\b` could not match the date inside an ISO *datetime*:
+# between the final "2" and the "T" there is no word boundary. Smokeball events
+# carry ISO datetimes, so a digest that correctly read a hearing and wrote its
+# date was flagged unverified — a false positive at daily volume, and one that
+# would have been measured as the model's fabrication rate.
+# ---------------------------------------------------------------------------
+
+
+def test_iso_datetime_read_verifies_a_correctly_written_date() -> None:
+    """The regression this fix exists for: the agent reads an event whose start
+    time is an ISO datetime and writes the date in prose. That is correct
+    behaviour and must not be flagged."""
+    reg = ProvenanceRegister()
+    reg.add_read_text('{"subject": "Deposition", "start_time": "2026-08-06T10:00:00Z"}')
+    result = check("The deposition is set for August 6, 2026.", reg)
+    assert not result.has_unverified, result.annotations()
+
+
+def test_iso_datetime_with_offset_also_verifies() -> None:
+    reg = ProvenanceRegister()
+    reg.add_read_text('{"start_time": "2026-07-25T14:00:00-07:00"}')
+    assert not check("Response was due 2026-07-25.", reg).has_unverified
+
+
+def test_unread_date_is_still_flagged_after_the_iso_fix() -> None:
+    """Widening extraction must not widen *verification* — a date the agent
+    never read stays flagged."""
+    reg = ProvenanceRegister()
+    reg.add_read_text('{"start_time": "2026-08-06T10:00:00Z"}')
+    result = check("The hearing is October 13, 2026.", reg)
+    assert result.has_unverified
+    assert result.unverified[0].kind is IdKind.DATE
+
+
+def test_iso_pattern_declines_a_longer_digit_run() -> None:
+    """The ISO branch must not read "2026-08-12" out of "2026-08-12-99".
+
+    Narrowly about the ISO branch: a separate `\\d{1,2}-\\d{1,2}-\\d{2,4}` pattern
+    still reads "08-12-99" here as 1999-08-12, which is its own business. What
+    this pins is that the ISO branch stops claiming a date the run does not
+    carry — the old trailing \\b matched it.
+    """
+    reg = ProvenanceRegister()
+    canonicals = {h.canonical for h in check("ref 2026-08-12-99 attached.", reg).unverified}
+    assert "2026-08-12" not in canonicals
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Two blind spots in `operator/safety-substrate/identifier_filter.py`, both of which made this gate's **silence meaningless rather than reassuring**.

## Matter numbers

`_CASE_RE` matched federal docket style only. Probed live: `2026-PI-107` → no hit, `PI-2026-0001` → no hit. Every `IDENTIFIER_UNVERIFIED` row on the pilot seat carried only date shapes, which reads as "no identifier problems" when the truth was "this filter cannot see the identifiers this firm uses."

This back-ports the alternation from overlay #208 — and it back-ports it because **this file is the source of truth**. The module header says so, and the overlay's copy is vendored from it. But #208 landed the change in the vendored copy only, and the test that calls itself a contract test imports `shared.identifier_filter`, the overlay's *own* copy, so it cannot detect the divergence it exists to prevent. The two files were out of parity in exactly the direction the docstring forbids.

## ISO datetimes

`\b\d{4}-\d{2}-\d{2}\b` extracts nothing from `2026-08-12T09:00:00Z` — between the final `2` and the `T` there is no word boundary, both being word characters. Smokeball events carry ISO datetimes (`create_event` start_time/end_time), so an agent that **correctly** read a hearing and wrote its date in prose was flagged `UNVERIFIED`.

That is a false positive at daily volume, on the most consequential value class this product handles, and it would have been measured as the model's own fabrication rate the moment anyone tried to tune this gate off report-only.

## Why now

Merged #2115 today and observed the result on pilot-smokeball: 5 of 7 matter references correct, 2 still wrong — including a deposition the model labelled `2026-PI-105` while the event object in front of it carried `matterNumber: 2026-PI-101` (`vfy_01KYZBTMFRM72S7VF2W4ADJMVP`). In-code supply is necessary and not sufficient. This gate is the mechanism that would catch the residue, and it was blind to both of the shapes involved.

## Evidence

Kill-tested rather than assumed — with the old pattern restored in memory, a correctly-written `August 6, 2026` against a read ISO `start_time` **flags**; with the new one it verifies.

One test I wrote was wrong and the suite caught it: I asserted the whole filter declines `2026-08-12-99`, but a separate `\d{1,2}-\d{1,2}-\d{2,4}` branch still reads `08-12-99` as `1999-08-12`. The assertion is narrowed to the ISO branch, which is what actually changed.

Widening extraction must not widen *verification*, so a date the agent never read stays flagged — pinned by test. **187 substrate tests pass.**

## Not in this PR

- **The cross-repo drift detector.** It needs a change in the overlay, whose checkout currently holds 307 lines of uncommitted work from a concurrent session on #208's own branch. Not mine to disturb.
- **Any change of posture.** Still `Mode.REPORT`. The tune-on-traffic discipline is not overridden here; what changes is that the signal now exists to measure.

Refs #2115.