### PR TITLE
feat(substrate): the gate can see a mispairing, not just a fabrication

### DIFF
--- a/operator/safety-substrate/identifier_filter.py
+++ b/operator/safety-substrate/identifier_filter.py
@@ -70,6 +70,7 @@ from __future__ import annotations
 import datetime
 import enum
 import re
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 
 
@@ -105,6 +106,7 @@ class IdKind(str, enum.Enum):
     CASE_NUMBER = "case_number"  # docket / case number
     DATE = "date"
     NAME = "name"  # recipient name in a greeting slot
+    PAIR = "pair"  # a (case number, date) asserted together on one line
 
 
 # ---------------------------------------------------------------------------
@@ -177,6 +179,17 @@ _DATE_RES: tuple[re.Pattern[str], ...] = (
 _GREETING_RE = re.compile(
     r"(?:^|\n)\s*(?:Dear|Hi|Hello|Greetings)\s+([A-Z][A-Za-z'.\-]+(?:\s+[A-Z][A-Za-z'.\-]+){0,2})\s*[,:]",
 )
+
+# Bound the (case x date) cross-product on a pathological line. A real digest
+# row carries one matter and one or two dates; anything past this is noise, and
+# an unbounded product on a paragraph-length "line" would be a cheap DoS on the
+# gate itself.
+_MAX_PAIRS_PER_LINE = 8
+
+# Bound the pair register the same way the session registers are bounded
+# elsewhere. A seeded record contributes a handful of pairs; a runaway seeder
+# must not grow this without limit on a long-lived Machine.
+_MAX_REGISTERED_PAIRS = 4096
 
 _DATE_STRPTIME_FORMATS: tuple[str, ...] = (
     "%m/%d/%Y",
@@ -310,6 +323,61 @@ def _extract(text: str, include_names: bool = True) -> list[IdentifierHit]:
     return hits
 
 
+def pair_key(case_canonical: str, date_canonical: str) -> str:
+    """The register key for one (case number, date) assertion."""
+    return f"{case_canonical}|{date_canonical}"
+
+
+def _extract_pairs(text: str) -> list[IdentifierHit]:
+    """Return the (case number, date) co-occurrences asserted **per line**.
+
+    Why this exists: atom-level provenance cannot see a *mispairing*. On
+    2026-08-01 the Operator wrote "matter 2026-PI-105, deposition of plaintiff
+    Alvarez, August 6, 2026" when the deposition event carried
+    ``matterNumber=2026-PI-101``. Both "2026-PI-105" and "2026-08-06" had been
+    legitimately read that session — one from the Okafor trial tasks, the other
+    from the Alvarez event — so every atom verified and the line passed clean.
+    What was never read is the two of them *together*.
+
+    Line-scoped because a line is the unit of assertion in the artifacts this
+    guards: one digest row, one ledger row, one escalation item. Two identifiers
+    on the same line are being claimed about each other; two identifiers three
+    paragraphs apart are not.
+    """
+    hits: list[IdentifierHit] = []
+    if not isinstance(text, str) or not text:
+        return hits
+
+    offset = 0
+    for line in text.splitlines(keepends=True):
+        cases = [(m, _canon_digits(m.group(0))) for m in _CASE_RE.finditer(line)]
+        if cases:
+            dates: list[tuple[re.Match[str], str]] = []
+            for pat in _DATE_RES:
+                for m in pat.finditer(line):
+                    canon = _canon_date(m.group(0))
+                    if canon:
+                        dates.append((m, canon))
+            emitted = 0
+            for cm, ccanon in cases:
+                for dm, dcanon in dates:
+                    if emitted >= _MAX_PAIRS_PER_LINE:
+                        break
+                    start = offset + min(cm.start(), dm.start())
+                    end = offset + max(cm.end(), dm.end())
+                    hits.append(
+                        IdentifierHit(
+                            IdKind.PAIR,
+                            f"{cm.group(0)} ↔ {dm.group(0)}",
+                            pair_key(ccanon, dcanon),
+                            (start, end),
+                        )
+                    )
+                    emitted += 1
+        offset += len(line)
+    return hits
+
+
 # ---------------------------------------------------------------------------
 # Provenance register
 # ---------------------------------------------------------------------------
@@ -327,14 +395,68 @@ class ProvenanceRegister:
     def __init__(self) -> None:
         self._canon: set[str] = set()
         self._names: set[str] = set()
+        self._pairs: set[str] = set()
 
     def add_read_text(self, text: str) -> None:
         """Register the structured-shape identifiers found in a blob the agent
         read (dates, A-numbers, receipts, SSNs, case numbers). Names are NOT
         scanned from read text — register them via :meth:`add_name` from
-        structured matter/contact metadata."""
+        structured matter/contact metadata.
+
+        **Deliberately registers no pairs.** A tool result is a *collection* of
+        records: pairing every case number in the blob with every date in the
+        blob would register the cross-product and verify exactly the mispairings
+        this is meant to catch. Pairs come from :meth:`add_record`, one record
+        at a time, where the association is a fact rather than an inference.
+        """
         for hit in _extract(text, include_names=False):
             self.add(hit.kind, hit.canonical)
+
+    def add_record(self, case_number: str | None, dates: Iterable[str]) -> None:
+        """Register one record's identifiers **and the associations within it**.
+
+        This is the structured seam: the caller holds a single record (a task, an
+        event) whose matter binding was resolved in code, so "this date belongs
+        to this matter" is known rather than guessed. Callers pass raw values;
+        canonicalization happens here so a seeder cannot register a key shaped
+        differently from the one :func:`check` will look up.
+        """
+        case_canon = _canon_digits(case_number) if case_number else ""
+        if case_canon:
+            self._canon.add(case_canon)
+        for raw in dates:
+            if not raw:
+                continue
+            # Route through _extract rather than _canon_date so the seeder and
+            # check() canonicalize identically BY CONSTRUCTION. _canon_date alone
+            # parses only date-shaped strings, and a record's date field is
+            # routinely an ISO *datetime* ("2026-08-06T10:00:00Z") — seeding that
+            # directly registered nothing, so every pair on that record silently
+            # failed to verify. A key the checker will never look up is worse
+            # than no key: it reads as a mispairing.
+            for hit in _extract(str(raw), include_names=False):
+                if hit.kind is not IdKind.DATE:
+                    continue
+                self._canon.add(hit.canonical)
+                if case_canon and len(self._pairs) < _MAX_REGISTERED_PAIRS:
+                    self._pairs.add(pair_key(case_canon, hit.canonical))
+
+    def add_pair(self, case_canonical: str, date_canonical: str) -> None:
+        """Register one already-canonical association directly."""
+        if case_canonical and date_canonical and len(self._pairs) < _MAX_REGISTERED_PAIRS:
+            self._pairs.add(pair_key(case_canonical, date_canonical))
+
+    @property
+    def has_pairs(self) -> bool:
+        """True once anything has seeded an association.
+
+        :func:`check` consults this before reporting any pair: a register with no
+        associations cannot judge one, and a gate that cannot see must not claim
+        to have seen. Reporting pairs from an unseeded register would flag every
+        line carrying a matter and a date — which is every line of a deadline
+        digest, and marking everything is how a reader learns to ignore the mark.
+        """
+        return bool(self._pairs)
 
     def add(self, kind: IdKind, canonical: str) -> None:
         """Register one canonical identifier directly (e.g. from structured
@@ -355,10 +477,12 @@ class ProvenanceRegister:
     def verifies(self, hit: IdentifierHit) -> bool:
         if hit.kind is IdKind.NAME:
             return hit.canonical in self._names
+        if hit.kind is IdKind.PAIR:
+            return hit.canonical in self._pairs
         return hit.canonical in self._canon
 
     def __bool__(self) -> bool:
-        return bool(self._canon or self._names)
+        return bool(self._canon or self._names or self._pairs)
 
 
 # ---------------------------------------------------------------------------
@@ -385,10 +509,18 @@ class IdentifierResult:
         """Human-facing review notes (FLAG mode). Includes the raw value so the
         reviewer can judge it — this is surfaced to the firm's reviewer, not an
         audit log."""
-        return [
-            f"unverified {h.kind.value}: {h.raw!r} — not found in anything read this session"
-            for h in self.unverified
-        ]
+        notes: list[str] = []
+        for h in self.unverified:
+            if h.kind is IdKind.PAIR:
+                notes.append(
+                    f"unverified pair: {h.raw} — both values were read this session, "
+                    "but never together on one record"
+                )
+            else:
+                notes.append(
+                    f"unverified {h.kind.value}: {h.raw!r} — not found in anything read this session"
+                )
+        return notes
 
     def audit_metadata(self) -> dict:
         """Audit-row metadata: KINDS and REDACTED shapes only, never the raw
@@ -429,6 +561,11 @@ def check(body: str, register: ProvenanceRegister, mode: Mode = Mode.REPORT) -> 
     posture.
     """
     hits = _extract(body)
+    # Pairs only when the register carries associations to judge them against.
+    # An unseeded register cannot distinguish a mispairing from a correct one, so
+    # it reports neither — see ProvenanceRegister.has_pairs.
+    if register.has_pairs:
+        hits.extend(_extract_pairs(body))
     unverified = tuple(h for h in hits if not register.verifies(h))
     return IdentifierResult(
         mode=mode,

--- a/operator/safety-substrate/tests/test_identifier_filter.py
+++ b/operator/safety-substrate/tests/test_identifier_filter.py
@@ -283,6 +283,118 @@ def test_iso_pattern_declines_a_longer_digit_run() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Pair-keyed provenance (added 2026-08-01)
+#
+# These cases are a transcript, not a hypothetical. On 2026-08-01, after the
+# matter-number join shipped (#2115), the Operator's delivered escalation mail
+# still carried two wrong references out of seven. Atom-level provenance would
+# have caught one of them and missed the other, because both of its values had
+# been legitimately read — just never together.
+# ---------------------------------------------------------------------------
+
+
+def _seeded_from_the_2026_08_01_tenant() -> ProvenanceRegister:
+    """The records the Operator actually read on the run that produced the
+    mispairing: the Alvarez deposition event and the Okafor trial-binder tasks."""
+    reg = ProvenanceRegister()
+    reg.add_record("2026-PI-101", ["2026-08-06T10:00:00Z"])  # Alvarez deposition
+    reg.add_record("2026-PI-105", ["2026-07-15"])  # Okafor exhibit list
+    reg.add_record("PI-2026-0001", ["2026-06-30"])  # Johnson / Sutter records
+    return reg
+
+
+def test_the_live_mispairing_is_caught() -> None:
+    """THE regression. Delivered 2026-08-01T19:08:57Z:
+
+        "matter 2026-PI-105, deposition of plaintiff Alvarez, August 6, 2026"
+
+    The deposition event carried matterNumber=2026-PI-101. Both 2026-PI-105 and
+    2026-08-06 were read that session, so every atom verifies and the line passed
+    clean. The pair never existed on any record.
+    """
+    reg = _seeded_from_the_2026_08_01_tenant()
+    body = "- matter 2026-PI-105, deposition of plaintiff Alvarez, August 6, 2026 (due in 5 days)"
+
+    atoms = [h for h in check(body, reg).unverified if h.kind is not IdKind.PAIR]
+    assert not atoms, f"atom-level check should pass — that is the whole problem: {atoms}"
+
+    pairs = [h for h in check(body, reg).unverified if h.kind is IdKind.PAIR]
+    assert pairs, "the mispairing must be caught"
+    assert pairs[0].canonical == "2026PI105|2026-08-06"
+
+
+def test_the_correctly_paired_line_is_not_flagged() -> None:
+    """From the same delivered mail, and the control for the test above: this row
+    WAS right, and must stay quiet."""
+    reg = _seeded_from_the_2026_08_01_tenant()
+    body = "- matter 2026-PI-105, trial binder exhibit list missing (authored due 2026-07-15)"
+    assert not check(body, reg).has_unverified
+
+
+def test_the_mangled_matter_number_is_caught_as_an_atom() -> None:
+    """The other live error: the record says PI-2026-0001, the mail said
+    2026-PI-001 — a number belonging to no matter in the tenant. This one atom
+    provenance does catch."""
+    reg = _seeded_from_the_2026_08_01_tenant()
+    result = check("- matter 2026-PI-001, Sutter Roseville records overdue", reg)
+    assert any(h.kind is IdKind.CASE_NUMBER for h in result.unverified)
+
+
+def test_pairs_are_line_scoped_not_document_scoped() -> None:
+    """Two correct rows must not cross-verify each other's values."""
+    reg = _seeded_from_the_2026_08_01_tenant()
+    good = "- matter 2026-PI-101, deposition 2026-08-06\n- matter 2026-PI-105, exhibit list 2026-07-15"
+    assert not check(good, reg).has_unverified
+
+    swapped = "- matter 2026-PI-101, exhibit list 2026-07-15\n- matter 2026-PI-105, deposition 2026-08-06"
+    assert [h for h in check(swapped, reg).unverified if h.kind is IdKind.PAIR]
+
+
+def test_unseeded_register_reports_no_pairs_at_all() -> None:
+    """A register with no associations cannot judge one. Reporting pairs here
+    would flag every line of every deadline digest — marking everything is how a
+    reader learns to ignore the mark."""
+    reg = ProvenanceRegister()
+    reg.add_read_text("matter 2026-PI-105 and a date 2026-08-06 appear in this read")
+    assert not reg.has_pairs
+    result = check("- matter 2026-PI-105, something on 2026-08-06", reg)
+    assert not [h for h in result.unverified if h.kind is IdKind.PAIR]
+
+
+def test_add_read_text_never_registers_the_cross_product() -> None:
+    """A tool result is a collection of records. Pairing everything in the blob
+    would verify precisely the mispairings this exists to catch."""
+    reg = ProvenanceRegister()
+    reg.add_read_text('[{"m":"2026-PI-101","d":"2026-08-06"},{"m":"2026-PI-105","d":"2026-07-15"}]')
+    assert not reg.has_pairs
+
+
+def test_add_record_canonicalizes_so_seeder_and_checker_agree() -> None:
+    """The seeder passes raw values; a key shaped differently from the one check()
+    looks up would silently verify nothing."""
+    reg = ProvenanceRegister()
+    reg.add_record("2026-PI-101", ["2026-08-06T10:00:00Z"])
+    assert not check("- matter 2026-PI-101, deposition August 6, 2026", reg).has_unverified
+
+
+def test_pair_audit_metadata_redacts_the_values() -> None:
+    reg = _seeded_from_the_2026_08_01_tenant()
+    body = "- matter 2026-PI-105, deposition of plaintiff Alvarez, August 6, 2026"
+    blob = repr(check(body, reg).audit_metadata())
+    assert "2026-PI-105" not in blob
+    assert "August 6, 2026" not in blob
+
+
+def test_pair_annotation_explains_the_distinction() -> None:
+    """A reviewer must not read "unverified" as "fabricated" here — both values
+    are real, the association is not."""
+    reg = _seeded_from_the_2026_08_01_tenant()
+    body = "- matter 2026-PI-105, deposition of plaintiff Alvarez, August 6, 2026"
+    notes = " ".join(check(body, reg, mode=Mode.FLAG).annotations())
+    assert "never together" in notes
+
+
+# ---------------------------------------------------------------------------
 # Boot self-check
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Atom-level provenance asks *"was this value read?"*. That question cannot catch the defect the Operator actually shipped.

## The line this exists for

Delivered to the firm at **2026-08-01T19:08:57Z**, after the matter-number join (#2115) was merged and live on the seat:

> `matter 2026-PI-105, deposition of plaintiff Alvarez, August 6, 2026`

The deposition event carried `matterNumber=2026-PI-101`. Both `2026-PI-105` and `2026-08-06` had been legitimately read that session — the first from the Okafor trial-binder tasks, the second from the Alvarez event — so **every atom verified and the line passed clean**. What was never read is the two of them together.

Kill-tested rather than asserted: with pair extraction neutered, that exact line reports nothing; with it, `pair 2026PI105|2026-08-06`.

Evidence for the delivered mail: `vfy_01KYZBTMFRM72S7VF2W4ADJMVP`.

## What changed

The register now holds **associations** as well as values.

- **`add_record(case, dates)`** is the structured seam. The caller holds *one* record whose matter binding was resolved in code, so "this date belongs to this matter" is a fact rather than an inference.
- **`check` extracts (case × date) co-occurrences per line.** A line is the unit of assertion in the artifacts this guards — one digest row, one ledger row. Two identifiers on one line are being claimed about each other; two identifiers three paragraphs apart are not.
- **`add_read_text` deliberately registers no pairs.** A tool result is a *collection* of records; pairing every case in the blob with every date in the blob would register the cross-product and verify precisely the mispairings this exists to catch. Pinned by test.

## Pairs are inert until something seeds them

`check` consults `has_pairs` first. A register with no associations cannot judge one, and reporting pairs from an unseeded register would flag every line carrying a matter and a date — which is every line of a deadline digest.

Marking everything is how a reader learns to ignore the mark. A gate that cannot see must not claim to have seen.

## A bug found by a test written to find it

`add_record` passed a raw ISO datetime to `_canon_date`, which parses only date-shaped strings. Seeding a record therefore registered nothing, and every pair on it silently failed to verify — **a key the checker never looks up reads as a mispairing**, which is the worst possible failure direction for this gate. Seeding now routes through `_extract`, so seeder and checker canonicalize identically by construction.

## Bounds and posture

8 pairs per line (an unbounded cross-product on a paragraph-length "line" is a cheap DoS on the gate itself), 4096 registered pairs.

**Still `Mode.REPORT`.** Nothing here changes posture. What changes is that the signal can now distinguish *"you invented this"* from *"these are both real and you put them together"* — and the annotation says so explicitly, because a reviewer must not read the second as the first.

## Not in this PR

Structured seeding on the read path (`shared/provenance.py::record_read`) lives in the overlay, whose checkout currently holds ~307 lines of uncommitted work from a concurrent session. Until that lands, `has_pairs` is false on a live seat and this code is correctly dormant.

196 substrate tests pass; full `npm run verify` green.

Refs #2115, #2124, #2125.