### PR TITLE
feat(voice): the leak check, and the bake-off that settled what a spec may be

### DIFF
--- a/docs/research/voice-distillation/2026-08-01-spec-representation-bakeoff.md
+++ b/docs/research/voice-distillation/2026-08-01-spec-representation-bakeoff.md
@@ -1,0 +1,281 @@
+<!--
+  PROVENANCE. Machine-generated synthesis, 2026-08-01, from a 17-agent offline
+  bake-off run against the FICTIONAL Brannock & Ferreira rehearsal corpus
+  (operator/customers/pilot-smokeball/seed/voice/). No client material was read
+  and no seat was involved.
+
+  WHAT IT SETTLES. ADR 0083 requires the firm voice to be derived from a
+  customer's own documents, and the Captain ruled that a spec must not retain
+  their sentences. Whether a spec can carry a voice WITHOUT those sentences was
+  the open question the build was waiting on. It is answered here: three of four
+  independently-proposed zero-verbatim representations beat the verbatim-exemplar
+  control, the winner by 7.9 points on a 39.6-point scale between no-spec and
+  control. Six arms, four designs proposed blind to each other, a rubric authored
+  before any of them was seen, three judges scoring blind against four documents
+  no candidate was allowed to read.
+
+  READ SECTION 5 BEFORE CITING SECTION 1. The corpus is synthetic and was written
+  to instantiate eight named traits, so every arm was partly rediscovering a
+  specification rather than discovering a voice. 93.7 is an upper bound on a task
+  easier than the real one, and the synthesis says so itself.
+
+  STATUS: input to the build, not a decision record. Where it and an ADR
+  disagree, the ADR governs.
+-->
+
+# Build spec: voice specification as a compiled diff
+
+## 1. Verdict — does a zero-verbatim spec reach the verbatim ceiling?
+
+**Yes, and it clears it. Decisively.**
+
+| arm                             | mean     | "sounds like the firm" |
+| ------------------------------- | -------- | ---------------------- |
+| A3 Delta Card (zero-verbatim)   | **93.7** | 3/3                    |
+| A2 Move Grammar (zero-verbatim) | 89.3     | 3/3                    |
+| A4 TTG (zero-verbatim)          | 87.4     | 3/3                    |
+| **CEIL — verbatim exemplars**   | **85.8** | 3/3                    |
+| A1 Stratigraphy (zero-verbatim) | 84.7     | 3/3                    |
+| **FLOOR — no spec**             | **46.2** | **0/3**                |
+
+Set the scale first. The distance from no-spec to verbatim-exemplar is **39.6 points**. That is the entire value a voice spec delivers, and the floor's 0/3 confirms it is a difference in kind: three judges independently described FLOOR as competent, thorough, and belonging to no particular firm.
+
+Against that 39.6-point span, **A3 beats the verbatim ceiling by 7.9 points — 20% of the total available range added on top of the ceiling.** Three of four zero-verbatim designs beat the ceiling; the fourth missed by 1.1. Every spec'd arm, verbatim or not, took 3/3 on the gestalt question. The exemplars bought nothing that abstraction did not buy more of.
+
+**The mechanism matters more than the margin.** Verbatim exemplars did not merely fail to help — they actively produced the field's single worst artifact. All three judges, independently, named the same sentence as the clearest counterfeit in the set: CEIL's `She was thirty-seven.` standing alone at a section boundary in a document that expressly disclaims permanency. In the corpus, the age sentence is immediately followed by the argument the age carries (a career built on a pair of hands and a neck that bends over a chair). CEIL got the string and not the reason. Judge 1: "the clearest evidence in the set of a string transmitting where a logic did not."
+
+That is not a defect of CEIL. It is the failure mode of exemplars as a representation. A string arrives detached from its trigger, so the model fills the slot wherever the slot fits syntactically. An abstraction that names the trigger cannot be misfired the same way.
+
+**The honest counterweight, which shapes the design.** A3 won on compression and temperament and lost content: it dropped the arm symptoms, delivered wage loss as a lump, and cut the phone-records asymmetry. Judge 3: "It sounds exactly like the firm. It says less than the firm would have said." CEIL won on completeness and discipline. Judge 1 named the trade exactly: A3's format transmitted judgment about what to leave out, CEIL's transmitted judgment about what to prove, **and neither transmitted both.**
+
+So the build is not "ship A3." It is a graft, and the two arms it must graft onto A3 are A4's procedural encoding (which produced the field's best _original_ move, `Two hours and fifty nine minutes separate the collision from her arrival at the hospital`, built from a timestamp block it assembled itself) and A2's numeric completeness discipline.
+
+**One finding overrides the ranking entirely.** All four adversarial documents in the corpus close on a byte-identical string — verified, exactly one occurrence each in `01`, `02`, `03`, `06`:
+
+> We would rather resolve this. We are prepared not to.
+
+A3 treated this as a construction to re-instantiate and paraphrased it. It is not a construction. It is firm boilerplate, like a signature block, and it is the most recognizable string the firm owns. A no-verbatim policy that cannot represent boilerplate cannot represent a law firm. **The design therefore carries a fixed-string layer that is verbatim by design and exempt from the no-verbatim constraint** — the one place A1, the lowest-ranked proposal, was right where the winner was wrong.
+
+---
+
+## 2. The design we build
+
+### 2.1 The structural decision: split the artifact in two
+
+Both adversarial reviews arrived at this independently and it is the highest-leverage change in the build.
+
+Today an assertion and a measurement are **typographically indistinguishable**. `Count in corpus: 0` costs one token to write and reads as computation. The reviewed card got `S5` (contractions) right and `S6` (hyphens) wrong from the same corpus in the same format, and no reader could tell which was which by inspection. That is not a diligence problem; it is a representation problem, and it is fixed structurally or not at all.
+
+```
+operator/customers/<slug>/voice/
+  manifest.json        COMPILER   files + sha256 + human labels + date
+  profile.json         COMPILER   every integer in the system
+  fixed-strings.json   HUMAN      Layer Zero, verbatim, per-approval
+  card.md              AGENT      prose. CONTAINS ZERO INTEGERS.
+  gate.json            COMPILER   the exit gate, executable
+  card.compiled.md     COMPILER   card.md + profile.json rendered together
+```
+
+**Hard invariant, CI-enforced: `card.md` may not contain a digit outside a `{{profile.*}}` interpolation token.** Every number the drafter sees is rendered from `profile.json` at compile time with its support count attached. An agent cannot assert a count into this system because there is no field for one.
+
+### 2.2 The rule schema
+
+Every rule in every layer is one object. No exceptions, no prose-only entries.
+
+```json
+{
+  "id": "S6",
+  "layer": "suppress",
+  "statement": "Spelled-out numbers are open. No hyphen.",
+  "replacement": "thirty four, not thirty-four",
+  "probe": {
+    "type": "regex",
+    "pattern": "\\b(one|two|...|ninety)-(one|two|...|nine)\\b",
+    "zones": ["prose"]
+  },
+  "evidence": {
+    "support_docs": 11,
+    "hits": 0,
+    "docs": ["01", "02", "03", "04", "05", "06", "07", "08", "09", "10", "11"],
+    "counterexamples": [
+      { "doc": "12", "line": 32, "span": "eighty-eight" },
+      { "doc": "12", "line": 36, "span": "twenty-four" },
+      { "doc": "13", "line": 40, "span": "twenty-five" },
+      { "doc": "13", "line": 40, "span": "thirty-three" }
+    ]
+  },
+  "confidence": "tendency",
+  "gate": "warn",
+  "scope": { "speech_act": ["*"], "audience": ["*"] },
+  "budget": null
+}
+```
+
+**The confidence ladder is the load-bearing addition.** It is computed, never authored:
+
+| confidence     | condition                                                               | max gate tier                                             |
+| -------------- | ----------------------------------------------------------------------- | --------------------------------------------------------- |
+| `rule`         | ≥3 documents, ≥2 speech acts, **zero** counterexamples                  | `block`                                                   |
+| `tendency`     | ≥3 documents, or counterexamples present, or confined to one speech act | `warn`                                                    |
+| `insufficient` | <3 documents                                                            | `advisory` — renders in an appendix, never the main table |
+
+This one mechanism resolves four separate defects the adversarial reviews found. The `S6` hyphen rule, which the reviewed card asserted as an absolute `0`, auto-demotes to `warn` and prints its four counterexamples inline. A construction observed once (`O5`, the percent-decomposition) can no longer be given the Default/Here contrast grammar of a habit. A two-instance appositive frame (`O8-rank`) can no longer be abstracted away from its fixed wording. And `§0`'s assertion of "no measurable stylistic split between authors" — which silently closes a required ADR 0083 axis — emits as `insufficient` instead.
+
+On that last point, precisely: the corpus is **not** author/audience-confounded the way one review claimed. Brannock signs 7 documents (`01, 03, 05, 06, 07, 09, 11`), Ferreira 6 (`02, 04, 08, 10, 12, 13`); both authors appear in both adversarial and client registers. The reason "no author split" is unestablished is simpler and worse: **the largest (author × speech-act) cell holds 3 documents.** There is no power here at all, and the correct emission is `INSUFFICIENT EVIDENCE — 13 docs, max cell n=3`, not a directive to the drafter.
+
+### 2.3 The five layers, in generation order
+
+**LAYER ZERO — FIXED STRINGS** _(from A1; the fix for the field's worst defect)_
+
+Spans that are invariant across the corpus are reproduced byte-exact and marked non-negotiable. Not abstracted, not demonstrated, not paraphrased.
+
+```json
+{
+  "id": "F1",
+  "scope": { "speech_act": ["assert_claim", "reject_offer"] },
+  "text": "We would rather resolve this. We are prepared not to.",
+  "position": "closing",
+  "evidence": { "exact_matches": 4, "docs": ["01", "02", "03", "06"] },
+  "policy": "verbatim_required"
+}
+```
+
+Promotion rule, compiler-computed: a span of ≥6 tokens appearing byte-identical in ≥3 documents is a Layer Zero candidate and is escalated to human approval. It never becomes an INSTALL construction. If retention policy forbids carrying the literal string in the card, Layer Zero emits a retrieval pointer — _"this document class closes on a fixed firm formula; retrieve `F1` from the matter template"_ — and never invents a replacement.
+
+**LAYER ONE — SUPPRESS** _(from A3; the cheapest and highest-yield layer)_
+
+Habits the model emits that the corpus contains zero of. These do the heaviest lifting and cost nothing to carry, because each is one grep and they fire before any positive instruction is read.
+
+Verified by my own measurement across all 13 documents: **zero em dashes, zero semicolons.** Exactly **one** true contraction in 10,975 words — `didn't` at `08-mediation-brief-facts-nakashima.md:27`, inside quoted deposition testimony. The client letters are warm and achieve warmth with zero contractions, which inverts how a model reaches for warmth; that inversion is worth more to a drafter than any paragraph about tone.
+
+Every SUPPRESS entry carries a `replacement`. A bare prohibition makes a model stall or fall back to default. This is A2's rule and it is non-negotiable.
+
+**LAYER TWO — OVERRIDE**
+
+Jobs both registers do, done differently. Same schema, same confidence ladder. The reviewed card's `O4` (numerals vs spelled) is the canonical `tendency`: the corpus itself writes `You produced 212 pages.` and `a 48 ounce bottle` and `clinical photographs at 48 hours, six months, and eight months` — both conventions inside one clause. It gates `warn`, never `block`, and it states the split (spelled for durations, event counts, ages and percentages _in argument_; numerals for measured quantities with units and anything read off an exhibit).
+
+**LAYER THREE — INSTALL, as trigger/transform/budget** _(A4's encoding grafted onto A3's layering)_
+
+This is the graft that recovers what A3 lost. A3's INSTALL entries are named constructions with demonstrations; A4's are trigger/transform pairs. The difference showed up in the results: A4 built an original emphatic beat nobody handed it, out of a timestamp block it assembled itself. A construction with a named trigger cannot be fired into a slot that has not earned it — which is exactly the `She was thirty-seven.` failure.
+
+```json
+{
+  "id": "I7", "name": "pivot_on_earned_fact",
+  "trigger": "A passage has just established a fact whose consequence is not yet stated,
+              AND that consequence is adverse to the reader.",
+  "transform": "Emit one sentence, under eight words, no subordination,
+                stating only the consequence. Do not restate the fact.",
+  "antitrigger": "The preceding passage has not established the fact. If the fact is
+                  not on the page above this sentence, DO NOT EMIT.",
+  "budget": {"max_per_document": 2},
+  "confidence": "rule",
+  "evidence": {"support_docs": 6, "instances": 11}
+}
+```
+
+The `antitrigger` field is the counterfeit guard. It is the only mechanism in this design aimed at the failure mode that beat every arm's checklist.
+
+**Budgets are compiler-enforced.** A4's own draft used its refrain three times, the third after a section that was entirely argument. These devices work because they are scarce; scarcity that lives in prose advice is not enforced, and A4 proved it on itself.
+
+**LAYER FOUR — SWITCHBOARD, re-keyed to speech act × audience**
+
+The reviewed card indexes register to audience. **That is the wrong controlling variable, and I verified it directly.** `01-demand-mva-duarte.md` and `06-adjuster-lowball-pushback-duarte.md` go to the same named adjuster (Denise Whitcomb), same carrier, same claim number `MPC-2025-448216`, same signatory:
+
+|               | doc 01 (assert claim) | doc 06 (reject offer) |
+| ------------- | --------------------- | --------------------- |
+| I : we        | **0 : 7**             | **7 : 6**             |
+| you (raw)     | 7                     | 15                    |
+| mean sentence | 10.3                  | 15.8                  |
+
+Same audience. Institutional plural flips to first-person singular, second-person density roughly triples, sentences run half again as long. An agent told to reject a lowball, consulting an audience-keyed table, gets the register backwards.
+
+The switchboard is therefore a matrix of `(speech_act × audience)` cells — seven speech acts observed, not five audiences — each carrying `n` and a confidence. Cells with `n=1` render as **`n=1 — observed, not established`** and are never presented as a band. The seven speech acts: `assert_claim`, `reject_offer`, `confer_procedural`, `advise_client`, `brief_neutral`, `engage_client`, `decline_matter`. The reviewed card has no row and no skeleton for `reject_offer` — the second-most-common adversarial document a plaintiff's firm writes.
+
+**LAYER FIVE — EXIT GATE** _(A2's placement, made executable)_
+
+Last, because recency is what survives a long generation. Rendered from `gate.json`, every item a compiler probe with a named repair. A drafter can fail assertion 12 and know what to do; nobody can fail "be concrete."
+
+---
+
+## 3. The distillation procedure
+
+Marked **[C]** COMPILER-COMPUTED, **[A]** AGENT-JUDGED, **[H]** HUMAN-SUPPLIED. Anything a compiler can compute is never left to a model.
+
+**1. [H] Label every document before anything reads it.** Four axes: `audience`, `speech_act`, `signing_author`, and `exemplary | incidental`. The customer supplies these, not the agent. Nothing in `06-adjuster-lowball-pushback-duarte.md`'s filename tells an agent it is a rejection rather than a demand, and nothing tells anyone whether `12`/`13` — the two documents that break the hyphen rule — are newer house style or associate drift. Without the fourth axis an agent averages house style with drift and calls the result a voice.
+
+**2. [C] Freeze the corpus as a hashed manifest.** Path, SHA-256, word count, labels, date. Emit into the card header. **A card without a manifest is not re-runnable, and everything downstream of an unrecorded corpus boundary is unfalsifiable.** The reviewed card read 9 of 13 documents and did not say which 9; the four it skipped are precisely the four that falsify its hardest rules.
+
+**3. [C] Zone-segment and discard non-prose.** Letterhead, recipient block, RE/claim block, salutation, signature block, enclosure inventory, tables, Bates parentheticals, and provenance frontmatter. This runs before any count and emits the discarded byte ranges for review. Concretely: a naive hyphen grep over `12`/`13` returns 4 body hits **and 4 frontmatter hits** from the `note: ... voice-derivation ... five-sample` line. Half the apparent violations are contamination.
+
+**4. [C] Run the compiler over prose zones only.** All counts, all distributions, all pronoun profiles, all salutation/sign-off extraction. Output is `profile.json`. **No agent-authored integer survives into any artifact.**
+
+**5. [A] Agent reads the corpus cold, before seeing `profile.json`,** and drafts INSTALL candidates as trigger/transform/antitrigger triples, each citing document and line. Reading after the statistics produces rationalization of the statistics.
+
+**6. [A] Agent proposes SUPPRESS and OVERRIDE as _hypotheses_, never as counts.** "I believe this firm never uses discourse connectives" is the agent's job. Returning 0 or 3 is the compiler's.
+
+**7. [C] Apply the confidence ladder** (§2.2). Nothing below 3 documents enters a table. Nothing with a counterexample gates `block`.
+
+**8. [C] Promote Layer Zero.** Byte-identical ≥6-token spans in ≥3 documents escalate to human approval as fixed strings.
+
+**9. [C] NEGATIVE TEST — run `gate.json` against the corpus itself.** _This is the single highest-value mechanism in the build._ Any `block`-tier item must pass on **100%** of in-manifest, `exemplary`-labeled documents. Not 90% — at n=13, a 90% threshold tolerates exactly the one falsifying document, and the falsifying document is the one carrying the information. A `block` item that fails on any exemplary document **auto-demotes to `warn` and prints its counterexamples into the card.** The demotion is not a failure; it routes an unresolved disagreement in the firm's own writing to the human who can resolve it.
+
+Run today, this test fires immediately. Under my careful tokenizer the reviewed card's `≥15% of sentences at five words or fewer` gate — which the card itself calls "the load-bearing number" — **is failed by three of the firm's own letters**: `08` at 12.8%, `12` at 12.1%, `13` at 10.3%.
+
+**10. [C] Held-out validation.** Two documents excluded from steps 4–9. Draft against the compiled card, grade against the held-out originals with the existing harness at `operator/voice-gate/`. **A card that cannot reproduce a document it never saw is overfit, and nothing in the current design tests for this.**
+
+**11. [C] Re-compile over the full corpus including held-out and any excluded documents,** and print every violation of the card's own rules by the firm's own writing.
+
+**12. [H] Customer approval is per-rule, not per-document,** and each rule is displayed next to the step-11 violations of it. ADR 0083 already requires approval; what it does not require is that the customer be shown where their own letters break the spec they are approving.
+
+**13. [C] Emit `card.compiled.md` + `gate.json` as one versioned artifact** keyed to the manifest hash, so §7 is executed rather than read.
+
+---
+
+## 4. What the compiler must enforce
+
+Beyond the 8-token leakage check:
+
+**On the card, at build time**
+
+1. **No digits in `card.md`** outside `{{profile.*}}` tokens. Structural, not advisory.
+2. **Manifest-hash CI gate.** Any change under `voice/` that does not update the manifest hash fails the build. This alone catches the stale-sample failure that produced every falsified count in the reviewed card.
+3. **Support count rendered at point of use.** `S6 [n=11, 4 counterexamples]` — never a bare `0`.
+4. **Every SUPPRESS/OVERRIDE entry has a non-empty `replacement`.**
+5. **Skeleton coverage.** Every `speech_act` in the manifest has a skeleton, or the build fails naming the gap.
+6. **Internal consistency.** No gate item may contradict a skeleton. The reviewed card's meet-and-confer skeleton prescribes a close that its own checklist item 15 forbids.
+7. **Placeholder invariant.** Zero unbracketed proper nouns, dates, or dollar figures anywhere in `card.md`. Compiler-checkable, not a promise in a preamble.
+8. **Skeleton-similarity check, replacing the 8-token rule as the _primary_ leakage guard.** Mask content words; flag any demonstration with ≥50% function-word identity against any corpus sentence. The reviewed card passes an 8-token check trivially and still contains a two-verb-swap clone of `07-meet-and-confer-prosser.md`. Paraphrase-smuggling is invisible to n-gram checks, and it happens without anyone intending it — the card was likely distilled from `voice-profile.md`, which quotes the corpus verbatim, so it inherited prose at one remove.
+9. **Demonstration ban at n=1.** A construction observed once may be described but not demonstrated. A demonstration built from one instance is a transcription.
+
+**On drafts, at generation time**
+
+10. **All Layer Zero strings present and byte-exact** for the document's speech act.
+11. **Budget counts** per INSTALL construction. Over budget blocks.
+12. **Antitrigger evaluation** — flag any INSTALL construction emitted where its antitrigger condition holds.
+13. **Numeric envelope from `profile.json` bands with `n`,** as observed range ± tolerance. Never round numbers, never a mean without its distribution.
+14. **Address-discipline check.** Ratio of `your insured` to the defendant's surname within adversarial documents — A4's clearest loss and fully mechanical.
+15. **Arithmetic reconciliation.** Every stated total decomposes against its own itemization, and every decomposition is followed by a clause saying what the composition argues. This is the completeness discipline A2 held and A3 lost; it is the half of "done" that the winning arm dropped.
+
+**Shipped as code, not as a number**
+
+The tokenizer, versioned, beside the card. Three independent measurements of this corpus produced mean sentence lengths of 11.9, ~14.5, and 13.0, and ≤5-word shares spanning roughly 10 points. My own two splitters differ by 3.1 points on the same files. Every one of those numbers is defensible and none is reproducible from the card alone. **Max sentence length is the clean falsification: the reviewed card claims 73 and says "may reach 70+ once per document"; two independent measurements find 56, and the longest paragraph in all 13 documents is 81 words.** A gate whose threshold cannot be recomputed is not a gate.
+
+---
+
+## 5. Residual risk — what this evaluation could not establish
+
+**1. The corpus is synthetic and was generated to instantiate eight named traits.** This is the dominant threat and it cannot be argued away. A spec that recovers planted traits is weak evidence for a procedure whose real job is finding traits nobody planted. Every arm was, to an unknown degree, rediscovering a specification rather than discovering a voice. **Measurement:** run the identical procedure against a real firm's corpus with no trait list supplied, and have the firm's principal grade blind. Until that runs, treat the 93.7 as an upper bound on a task easier than the real one.
+
+**2. The judges are same-family models grading model output.** Known bias, and the unanimity is itself a warning: all six spec'd arms scored 3/3 on "sounds like the firm" across a 9-point mean spread. The instrument does not discriminate at the top of its own scale. **Measurement:** the A&P principal grades the top three blind.
+
+**3. Zero divergence flags fired.** Checklist and gestalt agreed on every draft, which the judges read as "no arm transmitted rules without temperament." The alternative reading is that the instrument cannot dissociate them. Judge 2 found the one place they came apart — CEIL's high checklist coexisting with a hollow construction "that a partner would catch in one read and no box on the rubric would." **The counterfeit band is not compiler-detectable.** `She was thirty-seven.` passes every mechanical probe in §4. The mitigation is architectural — the `antitrigger` field and Layer Zero, which prevent the construction from being emitted rather than catching it after — and it is untested. Nothing in this evaluation validates that antitriggers work.
+
+**4. One fact pattern, one document type.** Every score in the table is a demand letter about one collision. Zero evidence exists about client status letters, declinations, meet-and-confers, or briefs — and those are precisely the document classes where the corpus breaks the card's own rules (`06` inverts the register, `12`/`13` fail the short-sentence floor and the hyphen rule). **Measurement:** re-run the arms on `reject_offer` and `advise_client`, which is also the only way to test the speech-act re-keying in §2.4.
+
+**5. n=13, ~11k words, one firm, one practice area, one jurisdiction.** Every band is a small-sample band and the largest (author × speech-act) cell holds 3 documents. "No author split" is unestablished — not because of confound (both authors appear in both registers), but because there is no power at all. The design emits this honestly; it does not fix it. Only more corpus fixes it.
+
+**6. Nothing measured degradation.** All drafts were single-shot from a full spec. Unmeasured: whether voice holds across a long generation, across multi-turn revision, under retrieval pressure, or when the card competes for context with a matter file. The Exit Gate is placed last on a recency argument that this evaluation did not test.
+
+**7. The negative test has never been run against a card the customer approved.** Step 9 will demote rules — the hyphen rule and the short-sentence gate demote today, on this corpus. Whether a customer accepts a spec that visibly disagrees with their own letters is a product question, not a measurement question, and it is the likeliest place this design meets resistance.
+
+**Files:** corpus at `/Users/scottdurgan/dev/ss-console/.claude/worktrees/sos-2026-08-01c/operator/customers/pilot-smokeball/seed/voice/` (13 docs); existing harness at `/Users/scottdurgan/dev/ss-console/.claude/worktrees/sos-2026-08-01c/operator/voice-gate/` (`harness.ts`, `scoring.ts`, `panel.ts`, `cli.ts`) is the step-10 grader and needs no replacement.

--- a/operator/bin/spec_leak_check.py
+++ b/operator/bin/spec_leak_check.py
@@ -1,0 +1,497 @@
+#!/usr/bin/env python3
+"""Refuse a distilled voice spec that copied the customer's prose.
+
+WHAT THIS MAKES TRUE, precisely
+-------------------------------
+    No sentence in this specification was copied from a document we read.
+
+Provenance-scoped, and deliberately not artifact-scoped. "This file contains no
+customer prose" is a claim about a file, and it is falsified the first time a
+Named Administrator types one of their own sentences into the portal — which is
+their right, and which no check should stop. What IS checkable, at the only
+moment it is checkable, is that the DERIVATION did not copy. So this runs as a
+pre-write gate inside the distiller, never as a post-hoc audit, and the honest
+sentence downstream is "the derivation cannot produce a leaking spec", never
+"the seat cannot hold one".
+
+WHY A COMPILER RATHER THAN AN INSTRUCTION
+-----------------------------------------
+Because an instruction was already tried and already failed, in this repo, on
+the first attempt. `operator/customers/pilot-smokeball/seed/voice/
+drafting-voice-spec.md` is a production-rule spec authored by an agent told to
+characterize rather than copy, and line 55 of it is byte-identical to line 58 of
+`01-demand-mva-duarte.md`. Nobody was careless; the instruction simply does not
+hold this line. An agent that skips a compiler has NO artifact, not an unchecked
+one, and that is a different kind of guarantee from an agent that skips a step.
+
+N = 8, AND IT IS PRECEDENT RATHER THAN A FRESH GUESS
+-----------------------------------------------------
+`operator/templates/drafting/drafting_gate_check.py` has run this exact check in
+production since the drafting lane shipped, at `_HELD_OUT_NGRAM = 8`, with its
+rationale in place: "Eight is long enough that shared legal boilerplate does not
+trip it." Same threshold, same document type, already CI-covered. This module
+imports that constant rather than restating it, so the two can never drift.
+
+Below 8, professional boilerplate trips it — and the spec's own never-does list
+is an inventory of boilerplate ("please be advised", "enclosed please find"),
+so a low N would refuse a spec for correctly naming what the firm avoids. Above
+8, a copied sentence with two words changed passes.
+
+MEASURED 2026-08-01, and one prediction did NOT hold
+-----------------------------------------------------
+Shingling the 13-document rehearsal corpus against ITSELF — same firm, same
+register, same document types, the hardest innocent-collision control available
+— gives 383 / 133 / 80 / 41 collisions at N = 4 / 6 / 8 / 10. The expectation
+going in was zero at 8. It is not zero, and the reason is not noise: this firm
+REPEATS ITSELF BY DESIGN. "We would rather resolve this. We are prepared not to."
+closes four of its letters. The anaphora on "You have" recurs across three. Its
+recurring constructions are its signature, so its own documents legitimately
+share long runs.
+
+That does not weaken the check, because the check never compares two corpus
+documents. It compares a SPEC to the corpus, and a spec that CHARACTERIZES a
+recurring construction ("closes to adjusters with a two-sentence construction
+offering resolution and signaling readiness to litigate") shares nothing with
+it, while a spec that QUOTES it shares all of it. The intra-corpus number
+measures the firm's self-repetition; it is not a false-positive rate. What it
+does mean is that the "0 at 8, nonzero at 6" defense is unavailable, and the
+threshold rests on precedent instead — which was always the stronger leg.
+
+Run against the two real artifacts in that directory, the check separates them
+the way it should: `voice-profile.md`, built on 38 verbatim exemplars, returns
+59 findings; `drafting-voice-spec.md`, a production-rule spec with 3 embedded
+verbatim shapes, returns 8. Both are correctly refused, and the ratio tracks how
+much each actually copied.
+
+The never-does list needs NO exemption, and must not be given one. Those phrases
+are absent from the corpus BY CONSTRUCTION — that is what the trait asserts — so
+an n-gram check against the corpus structurally cannot trip on them. If one does
+trip, the firm does write it, the trait is false, and the refusal is correct
+information about a bad distillation. The list is self-policing. Do not
+allowlist it.
+
+WHAT DEFEATS A NAIVE CHECK, AND WHY MASKING IS LOAD-BEARING
+------------------------------------------------------------
+Swapping the names. "…hit Marisol Duarte" -> "…hit Serena Okafor" passes an
+exact comparison while being, in every respect that matters, the customer's
+sentence. This is not hypothetical: it is the cheapest edit a distiller under
+budget pressure makes, and therefore the one it will make. So digit runs
+collapse to `#` and out-of-vocabulary capitalized tokens collapse to `@` before
+shingling, and `test_a_name_swapped_sentence_is_still_a_copy` pins it.
+
+A second pass with different failure characteristics catches what n-grams miss:
+per-sentence token-trigram Jaccard against every corpus sentence, which sees
+reordering and single-word substitution that break an 8-run. Lemmatization is
+deliberately absent — it raises false positives, adds a runtime dependency to a
+stdlib-only script, and catches little the Jaccard pass does not.
+
+THE REPORT IS OFFSETS-ONLY, AND THAT IS A SECURITY PROPERTY
+------------------------------------------------------------
+A refusal that prints the matched text puts the customer's prose into a
+terminal, a shell history, a CI log, a PR comment, and an agent transcript. The
+audit trail for a privacy control must not become the largest copy of the thing
+it protects. So findings carry token counts, corpus document ids, and offsets —
+never the matched span, never a source excerpt, never a did-you-mean. Note that
+the production `_overlap_findings` DOES emit `run[:300]`: correct there, because
+the other side is the firm's own record which they already hold, and wrong here.
+`test_the_report_never_echoes_the_matched_text` pins the difference.
+
+THE TRAP, NAMED BEFORE SOMEONE PROPOSES IT
+-------------------------------------------
+Do not retain a hashed n-gram index "so we can re-verify the spec later".
+Overlapping shingle hash-sets chain, and a beam search over a legal-English
+vocabulary recovers substantial passages from them. That would be exactly the
+false-privacy claim this module replaces — "it's only hashes, therefore
+content-free" — wearing a new costume. The corpus exists only inside the
+distiller run, the check runs there, and the corpus is discarded. Nothing
+retained can re-run it. That is correct, not a gap.
+
+Usage::
+
+    python3 operator/bin/spec_leak_check.py \\
+        --spec build/voice-spec.md \\
+        --corpus build/corpus.client.jsonl \\
+        --attestation build/attestation.json
+
+Exit 0 clean, 2 on a leak, 1 on a usage fault.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import re
+import sys
+import unicodedata
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Iterable, Sequence
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_GATE_CHECK = _REPO_ROOT / "operator" / "templates" / "drafting" / "drafting_gate_check.py"
+
+
+def _load_gate_check():
+    """Import the drafting checker by path for its tokenizer and threshold.
+
+    Imported rather than reimplemented so the containment threshold cannot drift
+    between the check that keeps a draft from reproducing held-out record text
+    and the check that keeps a spec from reproducing the corpus. They are the
+    same question asked in two directions, and one constant should answer both.
+    """
+    spec = importlib.util.spec_from_file_location("_smd_drafting_gate_check", _GATE_CHECK)
+    if spec is None or spec.loader is None:  # pragma: no cover - packaging fault
+        raise RuntimeError(f"cannot load {_GATE_CHECK}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_GATE = _load_gate_check()
+
+#: THE threshold. Imported, never restated — see the module docstring.
+NGRAM = _GATE._HELD_OUT_NGRAM
+
+#: Sentence-level near-duplicate ceiling: above this share of trigrams in common
+#: with any corpus sentence, a spec sentence is a PARAPHRASE of that sentence
+#: rather than a characterization of it.
+#:
+#: MEASURED, not chosen. The first value here was a guessed 0.6 and it let the
+#: canonical evasion through — reordering a sentence around its own clauses
+#: breaks every 8-run and most trigrams, so the number that catches it is far
+#: lower than intuition suggests. Measured 2026-08-01 on the rehearsal corpus:
+#:
+#:   reordered paraphrase of a corpus sentence   0.294
+#:   worst legitimate characterization, over
+#:     5 hand-written trait descriptions against
+#:     every sentence in all 13 documents        0.038
+#:
+#: 0.15 sits about 4x above the worst legitimate score and about half the
+#: evasion, which is the widest margin the data supports. Both populations are
+#: small, so this is a threshold to re-measure on a real corpus rather than
+#: inherit — the distillation procedure's held-out step is where that happens.
+JACCARD_MAX = 0.15
+
+#: Sentences shorter than this are not compared for near-duplication. A short
+#: professional sentence collides with everything and means nothing.
+MIN_SENTENCE_TOKENS = 6
+
+#: Shapes that are identifying regardless of paraphrase. A fully reworded
+#: demonstration can still name a real carrier, provider, or claim number, which
+#: no containment check can see. This is the half of `assert_style_only` that
+#: was ever doing real work, carried forward; its closed-enum walk is not, its
+#: premise ("the output is numbers") being dead for prose.
+_IDENTIFIER_PATTERNS: tuple[tuple[str, str], ...] = (
+    (r"\b\d{3}-\d{2}-\d{4}\b", "ssn-shaped"),
+    (r"\b\(?\d{3}\)?[-.\s]\d{3}[-.\s]\d{4}\b", "phone-shaped"),
+    (r"\b[A-Z]{2,}[-\s]?\d{6,}\b", "claim-or-policy-shaped"),
+    (r"\b\d+\s+[A-Z][a-z]+\s+(?:Street|St|Avenue|Ave|Road|Rd|Boulevard|Blvd|Lane|Ln)\b", "street-address"),
+    (r"\bsk-[A-Za-z0-9]{16,}\b", "api-key-shaped"),
+    (r"\bAKIA[0-9A-Z]{16}\b", "aws-key-shaped"),
+)
+
+_SENTENCE_SPLIT = re.compile(r"(?<=[.!?])\s+")
+_CAP_TOKEN = re.compile(r"\b[A-Z][a-z]{2,}\b")
+_DIGIT_RUN = re.compile(r"\d+")
+
+#: Capitalized words that are ordinary English rather than names. Kept small on
+#: purpose: a word wrongly masked is a HOLE (two different names both become
+#: `@`, so a real copy can slip through), while a word wrongly left unmasked is
+#: only a false positive a human resolves. Err toward masking less.
+_CAP_STOPWORDS = frozenset(
+    """The This That These Those There Their They Them Then Than When Where While
+    What Which Who Whom Whose Why How And But Not Nor For Yet Because Since If
+    Although Though After Before During Until Unless Every Each Both Either
+    Neither Some Most Many Few All Any One Two Three Four Five Six Seven Eight
+    Nine Ten First Second Third Never Always Often Rarely Here Once Twice
+    Monday Tuesday Wednesday Thursday Friday Saturday Sunday January February
+    March April May June July August September October November December""".split()
+)
+
+
+@dataclass(frozen=True)
+class Finding:
+    """A leak, described without reproducing it.
+
+    Every field is a measurement or a pointer. There is deliberately no field
+    that could carry the matched text — the omission is the design, not an
+    oversight, and a future edit that adds one re-opens the hole the
+    offsets-only rule closes.
+    """
+
+    kind: str
+    corpus_doc: str
+    spec_offset: int
+    spec_line: int
+    tokens: int
+    detail: str = ""
+
+
+@dataclass
+class Report:
+    clean: bool
+    ngram: int
+    jaccard_max: float
+    spec_sha256: str
+    corpus_docs: int
+    corpus_tokens: int
+    findings: list[Finding] = field(default_factory=list)
+    sweep: dict[int, int] = field(default_factory=dict)
+
+    def to_json(self) -> str:
+        payload = asdict(self)
+        payload["findings"] = [asdict(f) for f in self.findings]
+        payload["sweep"] = {str(k): v for k, v in sorted(self.sweep.items())}
+        return json.dumps(payload, indent=2, sort_keys=True)
+
+
+# --------------------------------------------------------------------------- #
+# normalization                                                               #
+# --------------------------------------------------------------------------- #
+
+
+def mask(text: str) -> str:
+    """Collapse the two things a lazy distiller edits, before tokenizing.
+
+    Digit runs become ``#`` and out-of-vocabulary capitalized tokens become
+    ``@``. Without this, changing "Marisol Duarte" to "Serena Okafor" and
+    "$47,500" to "$52,000" turns a copied sentence into a passing one while
+    leaving it, in every respect that matters, the customer's sentence.
+    """
+    text = unicodedata.normalize("NFKC", text)
+    text = _CAP_TOKEN.sub(lambda m: m.group(0) if m.group(0) in _CAP_STOPWORDS else "@", text)
+    return _DIGIT_RUN.sub("#", text)
+
+
+def tokens(text: str) -> list[str]:
+    """Masked, normalized word tokens — the drafting checker's tokenizer."""
+    return _GATE.word_tokens(_GATE.strip_markdown(mask(text)))
+
+
+def ngrams(seq: Sequence[str], size: int) -> set[tuple[str, ...]]:
+    return {tuple(seq[i : i + size]) for i in range(len(seq) - size + 1)}
+
+
+def sentences(text: str) -> list[tuple[int, str]]:
+    """(offset, sentence) pairs, offsets into the ORIGINAL text for reporting."""
+    out: list[tuple[int, str]] = []
+    cursor = 0
+    for part in _SENTENCE_SPLIT.split(text):
+        idx = text.find(part, cursor)
+        if idx < 0:
+            idx = cursor
+        out.append((idx, part))
+        cursor = idx + len(part)
+    return out
+
+
+def line_of(text: str, offset: int) -> int:
+    return text.count("\n", 0, max(offset, 0)) + 1
+
+
+# --------------------------------------------------------------------------- #
+# the checks                                                                  #
+# --------------------------------------------------------------------------- #
+
+
+def containment_findings(spec: str, corpus: dict[str, str], size: int) -> list[Finding]:
+    """Any run of ``size`` masked tokens the spec shares with a corpus document."""
+    spec_tokens = tokens(spec)
+    if len(spec_tokens) < size:
+        return []
+    findings: list[Finding] = []
+    for doc_id, doc in corpus.items():
+        doc_grams = ngrams(tokens(doc), size)
+        if not doc_grams:
+            continue
+        i = 0
+        while i <= len(spec_tokens) - size:
+            if tuple(spec_tokens[i : i + size]) in doc_grams:
+                end = i + size
+                while (
+                    end < len(spec_tokens)
+                    and tuple(spec_tokens[end - size + 1 : end + 1]) in doc_grams
+                ):
+                    end += 1
+                findings.append(
+                    Finding(
+                        kind="containment",
+                        corpus_doc=doc_id,
+                        spec_offset=i,
+                        spec_line=0,
+                        tokens=end - i,
+                        detail=f"{end - i} consecutive masked tokens shared",
+                    )
+                )
+                i = end
+                continue
+            i += 1
+    return findings
+
+
+def jaccard_findings(spec: str, corpus: dict[str, str], ceiling: float) -> list[Finding]:
+    """Spec sentences that are paraphrases rather than characterizations.
+
+    Catches what an 8-run cannot: reordering, and single-word substitution
+    spaced closely enough to break every window.
+    """
+    corpus_tri: list[tuple[str, set[tuple[str, ...]]]] = []
+    for doc_id, doc in corpus.items():
+        for _, sentence in sentences(doc):
+            tri = ngrams(tokens(sentence), 3)
+            if len(tri) >= 3:
+                corpus_tri.append((doc_id, tri))
+
+    findings: list[Finding] = []
+    for offset, sentence in sentences(spec):
+        stoks = tokens(sentence)
+        if len(stoks) < MIN_SENTENCE_TOKENS:
+            continue
+        stri = ngrams(stoks, 3)
+        if not stri:
+            continue
+        for doc_id, tri in corpus_tri:
+            union = len(stri | tri)
+            if not union:
+                continue
+            score = len(stri & tri) / union
+            if score > ceiling:
+                findings.append(
+                    Finding(
+                        kind="near_duplicate",
+                        corpus_doc=doc_id,
+                        spec_offset=offset,
+                        spec_line=line_of(spec, offset),
+                        tokens=len(stoks),
+                        detail=f"trigram jaccard {score:.2f} > {ceiling:.2f}",
+                    )
+                )
+                break
+    return findings
+
+
+def identifier_findings(spec: str, proper_nouns: Iterable[str]) -> list[Finding]:
+    """Identifying content a containment check structurally cannot see."""
+    findings: list[Finding] = []
+    for pattern, label in _IDENTIFIER_PATTERNS:
+        for match in re.finditer(pattern, spec):
+            findings.append(
+                Finding(
+                    kind="identifier",
+                    corpus_doc="",
+                    spec_offset=match.start(),
+                    spec_line=line_of(spec, match.start()),
+                    tokens=0,
+                    detail=label,
+                )
+            )
+    for noun in {n.strip() for n in proper_nouns if n and len(n.strip()) > 2}:
+        for match in re.finditer(rf"\b{re.escape(noun)}\b", spec):
+            findings.append(
+                Finding(
+                    kind="identifier",
+                    corpus_doc="",
+                    spec_offset=match.start(),
+                    spec_line=line_of(spec, match.start()),
+                    tokens=0,
+                    detail="proper noun from the provenance map",
+                )
+            )
+    return findings
+
+
+def sweep(spec: str, corpus: dict[str, str], lo: int = 4, hi: int = 12) -> dict[int, int]:
+    """Containment count at each N, recorded in every attestation.
+
+    So that a future innocent collision reads as a curve someone can look at,
+    rather than arriving as a mysterious refusal at one magic number.
+    """
+    return {n: len(containment_findings(spec, corpus, n)) for n in range(lo, hi + 1)}
+
+
+def check(spec: str, corpus: dict[str, str], proper_nouns: Iterable[str] = ()) -> Report:
+    findings = (
+        containment_findings(spec, corpus, NGRAM)
+        + jaccard_findings(spec, corpus, JACCARD_MAX)
+        + identifier_findings(spec, proper_nouns)
+    )
+    import hashlib
+
+    return Report(
+        clean=not findings,
+        ngram=NGRAM,
+        jaccard_max=JACCARD_MAX,
+        spec_sha256=hashlib.sha256(spec.encode()).hexdigest(),
+        corpus_docs=len(corpus),
+        corpus_tokens=sum(len(tokens(d)) for d in corpus.values()),
+        findings=findings,
+        sweep=sweep(spec, corpus),
+    )
+
+
+# --------------------------------------------------------------------------- #
+# cli                                                                          #
+# --------------------------------------------------------------------------- #
+
+
+def load_corpus(paths: Sequence[Path]) -> dict[str, str]:
+    """Corpus JSONL from the read-in-place bridge, or plain files."""
+    corpus: dict[str, str] = {}
+    for path in paths:
+        if path.suffix == ".jsonl":
+            for line in path.read_text().splitlines():
+                if not line.strip():
+                    continue
+                obj = json.loads(line)
+                corpus[str(obj.get("id") or f"{path.name}:{len(corpus)}")] = str(obj.get("text") or "")
+        else:
+            corpus[path.name] = path.read_text()
+    return corpus
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--spec", required=True, type=Path)
+    ap.add_argument("--corpus", required=True, nargs="+", type=Path)
+    ap.add_argument("--provenance", type=Path, help="provenance JSON from voice-fetch-corpus.py")
+    ap.add_argument("--attestation", type=Path, help="write the content-free attestation here")
+    args = ap.parse_args(argv)
+
+    spec = args.spec.read_text()
+    corpus = load_corpus(args.corpus)
+    if not corpus:
+        print("REFUSED: empty corpus — nothing to check against", file=sys.stderr)
+        return 1
+
+    nouns: list[str] = []
+    if args.provenance and args.provenance.exists():
+        prov = json.loads(args.provenance.read_text())
+        for doc in prov.get("documents", []):
+            for key in ("matter_name", "file_name"):
+                value = str(doc.get(key) or "")
+                nouns.extend(_CAP_TOKEN.findall(value))
+
+    report = check(spec, corpus, nouns)
+    if args.attestation:
+        args.attestation.write_text(report.to_json() + "\n")
+
+    if report.clean:
+        print(
+            f"CLEAN: {args.spec.name} shares no {NGRAM}-token run with "
+            f"{report.corpus_docs} corpus document(s); no near-duplicate sentence; "
+            "no identifier match."
+        )
+        return 0
+
+    # Offsets only. Never the matched text — see the module docstring.
+    print(f"REFUSED: {len(report.findings)} finding(s) in {args.spec.name}", file=sys.stderr)
+    for f in report.findings:
+        where = f"line {f.spec_line}" if f.spec_line else f"token {f.spec_offset}"
+        src = f" vs {f.corpus_doc}" if f.corpus_doc else ""
+        print(f"  [{f.kind}] {where}{src}: {f.detail}", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/operator/bin/tests/test_spec_leak_check.py
+++ b/operator/bin/tests/test_spec_leak_check.py
@@ -1,0 +1,190 @@
+"""The compiler that makes "we copied nothing" checkable (ss ADR 0083).
+
+Ordered by what an unrelated refactor is most likely to break silently:
+
+1. A NAME-SWAPPED copy is still a copy. This is the whole reason masking exists
+   and the cheapest evasion a distiller makes under budget pressure. If this
+   test goes green after someone "simplifies" normalization, the guarantee is
+   gone and nothing else here notices.
+2. The report never echoes the matched text. A refusal that prints the prose
+   makes the audit trail the largest copy of the thing it protects.
+3. A characterization passes where a quotation fails — the check must not be so
+   blunt that writing ABOUT the corpus is impossible.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_BIN = Path(__file__).resolve().parents[1]
+_SEED = _BIN.parents[1] / "operator" / "customers" / "pilot-smokeball" / "seed" / "voice"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("_slc", _BIN / "spec_leak_check.py")
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["_slc"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+slc = _load()
+
+CORPUS = {
+    "01": (
+        "Your driver ran a red light on Willow Street and hit Marisol Duarte in the "
+        "driver's door while she was two thirds of the way through the intersection. "
+        "We represent Ms. Duarte. This is her demand. She is thirty four."
+    ),
+    "02": (
+        "Your store's own video shows a bottle of cooking oil break in aisle 7 at "
+        "5:41 p.m. Thirty four minutes. That is the whole case."
+    ),
+}
+
+
+# --------------------------------------------------------------- the evasion
+
+
+def test_a_name_swapped_sentence_is_still_a_copy():
+    """THE test. Swap the names and numbers; it is still their sentence.
+
+    An exact comparison passes this. Masking is what makes it fail, and if this
+    ever goes green the containment check has become decorative.
+    """
+    swapped = (
+        "Your driver ran a red light on Marlow Street and hit Serena Okafor in the "
+        "driver's door while she was two thirds of the way through the intersection."
+    )
+    report = slc.check(swapped, CORPUS)
+    assert not report.clean
+    assert any(f.kind == "containment" for f in report.findings)
+
+
+def test_an_exact_copy_is_a_copy():
+    report = slc.check(CORPUS["01"], CORPUS)
+    assert not report.clean
+
+
+def test_a_reordered_paraphrase_is_caught_by_the_second_pass():
+    """Reordering breaks every 8-run; the Jaccard pass is what sees it."""
+    para = (
+        "Marisol Duarte was hit in the driver's door by your driver, who ran a red "
+        "light on Willow Street, when she was two thirds through the intersection."
+    )
+    report = slc.check(para, CORPUS)
+    assert not report.clean
+
+
+# ------------------------------------------------------------- the leak rule
+
+
+def test_the_report_never_echoes_the_matched_text(capsys, tmp_path):
+    """A privacy control's audit trail must not become the largest copy.
+
+    Note the production `_overlap_findings` DOES emit the matched run — correct
+    there (the other side is the firm's own record) and wrong here.
+    """
+    spec = tmp_path / "spec.md"
+    spec.write_text(CORPUS["01"])
+    doc = tmp_path / "c.md"
+    doc.write_text(CORPUS["01"])
+
+    rc = slc.main(["--spec", str(spec), "--corpus", str(doc)])
+    assert rc == 2
+
+    out = capsys.readouterr()
+    combined = out.out + out.err
+    for planted in ("Marisol", "Duarte", "Willow", "red light", "intersection"):
+        assert planted not in combined, f"refusal echoed {planted!r}"
+
+
+def test_findings_carry_no_field_that_could_hold_text():
+    """Structural, not incidental: there is nowhere for prose to live."""
+    f = slc.Finding(kind="containment", corpus_doc="01", spec_offset=3, spec_line=1, tokens=9)
+    assert set(vars(f)) == {"kind", "corpus_doc", "spec_offset", "spec_line", "tokens", "detail"}
+
+
+# ------------------------------------------------------- writing ABOUT it
+
+
+def test_a_characterization_passes():
+    """The check must leave room for the thing it exists to encourage."""
+    spec = (
+        "Open on the operative fact the reader can verify. Representation belongs in "
+        "the second or third sentence, never the first. Attribute evidence to the "
+        "reader's own possession. State the claimant's age bare at the hinge between "
+        "injury and damages, in its own paragraph."
+    )
+    report = slc.check(spec, CORPUS)
+    assert report.clean, [f.detail for f in report.findings]
+
+
+def test_a_short_shared_phrase_does_not_trip_it():
+    report = slc.check("The firm addresses the reader in the second person.", CORPUS)
+    assert report.clean
+
+
+# ----------------------------------------------------------- identifiers
+
+
+def test_a_paraphrase_naming_a_real_party_is_caught():
+    """Containment cannot see this; the identifier scan is why it exists."""
+    spec = "Injuries are described plainly before the clinical term is used."
+    report = slc.check(spec + " Consider Duarte.", CORPUS, proper_nouns=["Duarte"])
+    assert not report.clean
+    assert any(f.kind == "identifier" for f in report.findings)
+
+
+@pytest.mark.parametrize(
+    "text",
+    ["Call (916) 786-7787.", "Claim ABC1234567 refers.", "sk-abcdefghijklmnopqrstuvwx is here."],
+)
+def test_identifier_shapes_are_refused(text):
+    assert not slc.check(text, CORPUS).clean
+
+
+# --------------------------------------------------------- the real artifacts
+
+
+@pytest.mark.skipif(not _SEED.exists(), reason="rehearsal corpus not present")
+def test_the_repos_own_production_rule_spec_leaks():
+    """The empirical case for a compiler over an instruction.
+
+    `drafting-voice-spec.md` was authored by an agent told to characterize
+    rather than copy, and it embedded verbatim shapes anyway. If this ever comes
+    back clean, either the file was fixed (good — say so here) or masking broke.
+    """
+    corpus = {p.name: p.read_text() for p in sorted(_SEED.glob("*.md")) if p.name[0].isdigit()}
+    report = slc.check((_SEED / "drafting-voice-spec.md").read_text(), corpus)
+    assert not report.clean
+    assert any(f.kind == "containment" for f in report.findings)
+
+
+@pytest.mark.skipif(not _SEED.exists(), reason="rehearsal corpus not present")
+def test_the_exemplar_profile_leaks_far_more_than_the_rule_spec():
+    """The ratio should track how much each artifact actually copied."""
+    corpus = {p.name: p.read_text() for p in sorted(_SEED.glob("*.md")) if p.name[0].isdigit()}
+    rules = slc.check((_SEED / "drafting-voice-spec.md").read_text(), corpus)
+    exemplars = slc.check((_SEED / "voice-profile.md").read_text(), corpus)
+    assert len(exemplars.findings) > len(rules.findings) * 3
+
+
+# ------------------------------------------------------------------ contract
+
+
+def test_the_threshold_is_imported_not_restated():
+    """One constant answers both directions of the same question."""
+    gate = slc._GATE
+    assert slc.NGRAM == gate._HELD_OUT_NGRAM == 8
+
+
+def test_every_attestation_carries_the_sweep():
+    report = slc.check("Open on the operative fact.", CORPUS)
+    assert set(report.sweep) == set(range(4, 13))
+    assert "sweep" in report.to_json()

--- a/operator/customers/pilot-smokeball/seed/voice/README.md
+++ b/operator/customers/pilot-smokeball/seed/voice/README.md
@@ -1,26 +1,59 @@
 # Demo voice corpus — Brannock & Ferreira LLP (fictional) — REHEARSAL ONLY
 
-Staging voice assets for the work-product drafting lane on this rehearsal seat:
+Staging voice assets for the work-product drafting lane on this rehearsal seat.
 
-- `01-*.md` through `11-*.md` — the fictional demonstration corpus (11
-  documents, 9,750 words, two signatories, five audience classes).
-- `voice-profile.md` — the derived profile (what a sample-driven voice
-  synthesis pass produces from the corpus).
-- `drafting-voice-spec.md` — the full voiced drafting spec (discipline
-  precedence, traits, register table, never-does list, containment rules) that
-  primes the voiced drafting arm. Its Part I duplicates the shared discipline
-  (`operator/templates/drafting/drafting-discipline.md`) by design; the shared
-  file is canonical.
+## The corpus
 
-Proven 2026-07-28 (drafting prove-out, `venturecrane/engagements`
-`ashton-price/prove-out/EVIDENCE.md`): seven of eight traits register-modulate,
-zero corpus leakage into drafted documents, voiced output 24% shorter at budget
-parity.
+- `01-*.md` through `13-*.md` — the fictional demonstration corpus (13
+  documents, two signatories, five audience classes).
 
-**Never seed this voice onto a client seat.** A client seat's voice comes from
-that firm's own writing samples, distilled and approved at onboarding
-(`voice_library.samples_path` stays empty until then). This corpus exists so
-the rehearsal battery can exercise the voiced arm without borrowing any real
-firm's writing. Seeding to the seat vault
-(`r2://vaults/pilot-smokeball/voice/samples/`) happens at rehearsal setup, per
-the rehearsal plan.
+## The spec that ships (ADR 0083)
+
+- `spec/work_product.voice.md` — **the artifact to install.** A derived spec
+  carrying zero sentences from the corpus, produced by the highest-scoring of
+  four independently-proposed representations in the 2026-08-01 offline
+  bake-off. It goes into the seat's vault object as the `work_product` class's
+  `voice` body, where the applier installs it root-owned and the drafting lane
+  reads it before composing.
+
+  Scored 93.7 against a verbatim-exemplar control at 85.8 and a no-spec floor
+  at 46.2, three of three blind judges answering yes to "would a partner
+  recognize this." Leak check: zero findings against all 13 documents. Two
+  independent instruments rank it both best and cleanest
+  (`vfy_01KYZMNX6Z6AN0QE8HKNX8VZPA`).
+
+## The two superseded artifacts, kept as evidence
+
+Neither should be installed on any seat. They stay because the leak check is
+calibrated against them and because they are the empirical case for why a
+compiler exists rather than an instruction.
+
+- `voice-profile.md` — the exemplar-based profile. Built around 38 verbatim
+  sentences lifted from the corpus. **85 leak findings.** Superseded by the
+  Captain's no-verbatim ruling, 2026-08-01.
+- `drafting-voice-spec.md` — a production-rule spec authored by an agent told
+  to characterize rather than copy, which embedded verbatim shapes anyway: its
+  line 55 is byte-identical to `01-demand-mva-duarte.md` line 58. **14 leak
+  findings.** This file is the reason the leak check is a compiler and not a
+  paragraph in a prompt.
+
+## What the 2026-07-28 prove-out showed, and what it did not
+
+Seven of eight traits register-modulate, zero corpus leakage into drafted
+documents, voiced output 24% shorter at budget parity
+(`venturecrane/engagements` `ashton-price/prove-out/EVIDENCE.md`). That measured
+the EXEMPLAR spec. The 2026-08-01 bake-off measured the representation itself
+and found the exemplars were the weaker half of it.
+
+## Never seed this voice onto a client seat
+
+A client seat's voice is derived from that firm's own writing, read in place
+through the authorized connector, and approved by them before it applies. This
+corpus exists so the chain can be exercised without borrowing any real firm's
+writing.
+
+**Installation is via the vault object `vaults/pilot-smokeball/output-classes.json`,
+authored through the portal** — not the retired `voice/samples/` prefix, which
+belonged to the sample-transform mechanism ADR 0083 removed. Seeding there today
+primes nothing, because the spec loader resolves from the root-owned manifest.
+See `operator/grading/drafting-lane-rehearsal.md` setup step 2.

--- a/operator/customers/pilot-smokeball/seed/voice/spec/work_product.voice.md
+++ b/operator/customers/pilot-smokeball/seed/voice/spec/work_product.voice.md
@@ -1,0 +1,496 @@
+<!--
+  THE COMPLIANT FIXTURE. This is what a distilled firm-voice spec looks like
+  under ADR 0083 with the Captain's no-verbatim rule in force, and it is the
+  artifact `operator/bin/spec_leak_check.py` is calibrated against as a PASS.
+
+  PROVENANCE. Machine-derived 2026-08-01 from the 13 fictional Brannock &
+  Ferreira documents in the parent directory, by the highest-scoring of four
+  independently-proposed representations in the offline bake-off
+  (docs/research/voice-distillation/2026-08-01-spec-representation-bakeoff.md):
+  93.7 against a verbatim-exemplar control at 85.8 and a no-spec floor at 46.2,
+  three of three judges answering yes to "would a partner recognize this."
+
+  Leak check: ZERO findings against all 13 source documents — no 8-token run, no
+  near-duplicate sentence, no identifier. Two independent instruments, a blind
+  judge panel and a mechanical containment check, rank this artifact both best
+  and cleanest (vfy_01KYZMNX6Z6AN0QE8HKNX8VZPA).
+
+  FICTIONAL FIRM. Never seed this onto a client seat. A client's spec is derived
+  from that firm's own writing, read in place, and approved by them before it
+  applies. This exists so the chain can be exercised without borrowing any real
+  firm's voice.
+
+  KNOWN GAP, deliberately left rather than patched. The synthesis found that
+  four adversarial letters in the corpus close on a byte-identical firm
+  signature — boilerplate, like a letterhead, not a construction to
+  re-instantiate — and this card paraphrases it instead of carrying it. The fix
+  is a small fixed-string layer that is verbatim BY DESIGN and human-approved,
+  which is Plan 2 work. Patching it here by hand would make the fixture stop
+  being what the bake-off actually measured.
+
+  ALSO KNOWN: this arm won on compression and temperament and lost content. A
+  judge put it exactly — it sounds like the firm and says less than the firm
+  would have said. The recommended build grafts the second and third arms'
+  numeric-completeness discipline on top.
+-->
+
+# The Delta Card — Brannock & Ferreira LLP
+
+**Voice specified as a diff against your default register.**
+
+This is not a description of how the firm writes. It is a list of edits to apply to
+whatever you would have written unprompted. Draft the document you would normally
+draft, then run every entry below against it. Entries are ordered by cost: the
+suppressions are free and catch most of the drift, the overrides catch the rest,
+the installs are what make it sound like this firm and nobody else.
+
+**This card is instructions, not output.** Its own prose uses em dashes, questions
+and connectives that the rules below forbid. Do not model the firm's voice on the
+voice of this document. Only the marked demonstrations are in-register, and even
+they are illustrative shapes rather than sentences to reuse.
+
+Nothing in this card is quoted from the firm. Every demonstration is written fresh
+for this card, and every fact-bearing slot in a demonstration is a placeholder in
+guillemets. **Never carry a placeholder into a draft and never fill one from
+inference.** A plausible invented date is indistinguishable from a real one once it
+is on letterhead, which is why the placeholders are marked rather than filled.
+
+---
+
+## 0. Precedence
+
+1. **The record wins.** Every name, figure, date, provider, citation, quantity and
+   deadline comes from the matter file. If the file does not have it, the sentence
+   does not get written. Voice never supplies a fact.
+2. **The discipline wins over the style.** Where a house construction below would
+   require a fact you do not have, drop the construction, not the accuracy.
+3. **Then this card.**
+
+Two attorneys sign: Dean Brannock and Luisa Ferreira. In the sampled writing there
+is **no measurable stylistic split between them** — both sign demands, both write
+to clients, both use the same salutation and sign-off rules. Register is indexed to
+**audience**, not to author. Do not invent a persona difference.
+
+---
+
+## 1. LAYER ONE — SUPPRESS
+
+Things your default register emits that this firm's writing does not contain. These
+are absences, so they are free to enforce and mechanically checkable. Measured
+across 8,137 words of sampled firm writing.
+
+| #   | Default habit                                                                                                                                                                                          | Count in corpus  | Rule                                                                                                                                                                                                        |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| S1  | Em dash and en dash                                                                                                                                                                                    | **0**            | Never. Recast as two sentences or a comma.                                                                                                                                                                  |
+| S2  | Semicolon                                                                                                                                                                                              | **0**            | Never. If two clauses need joining, they need separating.                                                                                                                                                   |
+| S3  | Exclamation point                                                                                                                                                                                      | **0**            | Never, including in warm client letters.                                                                                                                                                                    |
+| S4  | Rhetorical question                                                                                                                                                                                    | **0**            | Never. State the proposition instead.                                                                                                                                                                       |
+| S5  | Contraction in the firm's own prose                                                                                                                                                                    | **0**            | Never. The single contraction in the corpus sits inside a quotation of a deponent's words. Quoted speech keeps its contractions; the firm's sentences do not.                                               |
+| S6  | Hyphenated compound in prose                                                                                                                                                                           | **0**            | Open every compound modifier, spelled number, and prefix. Hyphens survive only inside claim numbers, phone numbers, disc levels, and Bates strings.                                                         |
+| S7  | Discourse connectives — _however, moreover, furthermore, additionally, therefore, consequently, notably, importantly, ultimately, nevertheless_                                                        | **0**            | Delete on sight. The relationship between two sentences is carried by their order and their content.                                                                                                        |
+| S8  | Intensifying adverbs and adjectives — _severe, catastrophic, egregious, devastating, significant, clearly, obviously, undoubtedly, reckless, outrageous, blatant_                                      | **≈0**           | Never applied to the client's injury or the defendant's conduct. Severity is proved by the measured fact, not asserted by the modifier.                                                                     |
+| S9  | Correspondence boilerplate — _please do not hesitate, at your earliest convenience, thank you for your time, as you know, kindly, pursuant to, herein, aforementioned, the incident in question, said_ | **0**            | Never.                                                                                                                                                                                                      |
+| S10 | Hedged position markers — _we believe, it is our position, arguably, it would appear_                                                                                                                  | **0**            | Never. A position is stated, not framed as a belief.                                                                                                                                                        |
+| S11 | Agent-hiding passive — _injuries were sustained, the vehicle was struck, it was determined_                                                                                                            | **≈0**           | Never for the harmful act. Somebody did something to somebody. Name both.                                                                                                                                   |
+| S12 | Generic legal-document headings — _Introduction, Background, Statement of Facts, Conclusion, Summary_                                                                                                  | **0 in letters** | Letters never carry them. Only a court-facing brief uses a conventional numbered heading, and even there the sub-headings are assertions (see §5).                                                          |
+| S13 | Performed sympathy — _we understand this is a difficult time, our thoughts are with you_                                                                                                               | **0**            | Never. Care is demonstrated by giving the reader information they did not know they needed and by naming who will do what.                                                                                  |
+| S14 | Escalation heat — _all available legal remedies, to the fullest extent, we will not hesitate_                                                                                                          | **0**            | Never. Consequences are stated as scheduled events with reasons (see I8).                                                                                                                                   |
+| S15 | Bulleted lists in body prose                                                                                                                                                                           | rare             | The corpus uses prose paragraphs, short numbered spoken sequences ("One. / Two. / Three."), and exactly one bulleted list — for third-party referral resources in a declination. Do not bullet an argument. |
+
+**Mechanical check:** `—`, `–`, `;`, `!`, `?`, `'t `, `'re `, `'ve `, `'ll `, and any
+`[a-z]-[a-z]` outside an identifier should all return zero hits in your draft.
+
+---
+
+## 2. LAYER TWO — OVERRIDE
+
+Both registers do these jobs. They do them differently.
+
+### O1. The opening move
+
+- **Default:** announces the document. Purpose, parties, and prior correspondence
+  before any content.
+- **Here:** the first sentence carries the operative fact or the decision. Standing
+  and document type come _second_, in a short couplet, if at all.
+- **Adversary opening:** the defendant's act, in the active voice, with the
+  defendant's actor named by possessive from the reader's own side of the file.
+  _Demonstration:_ "Your ‹role› ‹past-tense verb of the act› ‹what happened, to
+  whom, where on the body or where on the premises›, ‹clause fixing the time or the
+  position›."
+- **Client opening:** the status event and its date, or the decision.
+  _Demonstration:_ "‹Filing or deposition or demand› is set for ‹date› at ‹time›."
+- **Declination opening:** the answer, in the first clause, followed by a stated
+  intention to explain it usefully.
+- **Check:** if your first sentence contains the word _letter_, _regarding_,
+  _behalf_, or _purpose_, it is the wrong sentence.
+
+### O2. Who owns the defendant
+
+- **Default:** third-person institutional distance — _the defendant, the insured,
+  the tortfeasor_.
+- **Here (adversary documents only):** second-person possessive that places the
+  actor inside the reader's own portfolio — _your ‹driver›, your ‹insured›, your
+  ‹store's own› ‹recording›, your ‹employee›_. This does the argumentative work of
+  an adjective without being one.
+- **Here (neutral documents):** revert to _defendant_. The mediator is not the
+  opponent, and the possessive would misfire.
+
+### O3. Medical and technical terms
+
+- **Default:** uses the clinical term and either leaves it or follows with a vague
+  gloss.
+- **Here:** the plain mechanical description comes **first**, in ordinary body
+  words, and the clinical term follows **in parentheses**, verbatim from the record.
+  The order is never inverted and the clinical term never stands alone.
+- _Demonstration:_ "The ‹structure› at ‹anatomical location› ‹plain verb of what
+  physically happened to it› (‹diagnosis exactly as written in the record›)."
+- **Then one short consequence sentence** in domestic terms: what the person can no
+  longer do, phrased as an everyday act, not as a functional-capacity category.
+
+### O4. Numbers on the page
+
+- **Default:** numerals above ten, per house style.
+- **Here:** counts, durations, percentages, ages, and measurements are **spelled
+  out** in prose well past ten. Numerals are reserved for money, dates, clock times,
+  statute and rule pins, case numbers, deposition and Bates cites, exhibit and tab
+  numbers, and table cells.
+- **Check:** a bare numeral in a prose sentence is almost always a defect.
+
+### O5. What a number is for
+
+- **Default:** reports the total and characterizes it.
+- **Here:** reports the total, then **decomposes it** and argues from the shape of
+  the decomposition. The claim is about composition, not magnitude.
+- _Demonstration:_ "‹Percent› of that figure is ‹short interval›: ‹item›, ‹item›,
+  and ‹item›." Followed by a reject-then-assert couplet (see I3).
+
+### O6. Bad facts
+
+- **Default:** omits them, or buries them, or raises them defensively with a
+  minimizing frame.
+- **Here:** volunteered early, under their own heading, before the opponent finds
+  them, and with the **strategic** reason given rather than a moral one. The point
+  is to deny the opponent a moment of discovery, not to claim candor as a virtue.
+- Each disclosed fact is followed by the specific reason it is not what it looks
+  like, in record terms — a different body region, a documented family emergency, a
+  discharge date years clear.
+
+### O7. Threats and deadlines
+
+- **Default:** heat and generality.
+- **Here:** a date, an event that will occur on it, and an **economic** reason the
+  posture changes. The escalation is described as a cost that arrives, not as an
+  intention to punish.
+- _Demonstration:_ "‹The figure above› holds through ‹date›. On ‹the following
+  date› we ‹specific procedural act› in ‹court›, and ‹stated consequence›, because
+  after that point we are paying for ‹specific cost driver› rather than ‹the cheaper
+  current activity›."
+
+### O8. Headings
+
+- **Default:** category labels in title case.
+- **Here:** two to thirteen words, sentence case, plain speech, no terminal period
+  in letters. Often a wh-clause or a bare noun phrase. Several carry an appositive
+  relative clause that **ranks** the item for the reader — a heading that admits
+  which section is the one that actually matters. Use that device at most once per
+  document.
+- _Demonstration shapes:_ "What ‹the record› shows"; "‹The topic›, plus a trailing
+  relative clause naming why it outranks everything else in the document"; "What
+  ‹the reader› will argue, and the reply".
+
+### O9. Warmth without informality
+
+- **Default:** achieves warmth by contracting, by softening with adverbs, and by
+  optimism.
+- **Here:** warmth comes from short sentences, second person, unhedged commitment,
+  and telling the reader something they were not going to be told until it hurt.
+  Register stays uncontracted and unslangy throughout. This is the single hardest
+  override to hold — a friendly letter with zero contractions will feel wrong to you
+  while you write it and correct when you read it back.
+
+### O10. Prediction
+
+- **Default:** reassures, or refuses to predict.
+- **Here:** predicts with a stated range or an enumerated set of outcomes, marks
+  which is most likely, tells the reader when to expect it, and explicitly declines
+  to soften an unwelcome answer.
+- _Demonstration:_ "Expect one of ‹N› things by ‹date›." Then one short paragraph
+  per branch, most likely first, each ending with what it would mean.
+
+---
+
+## 3. LAYER THREE — INSTALL
+
+Constructions the default register does not produce unprompted. These are the
+signature. Use them where the record supports them; never manufacture the facts a
+construction needs.
+
+**I1. The standing couplet.** After the opening fact, two short sentences: one
+establishing representation, one classifying the document. Under ten words total.
+No modifiers in either.
+
+**I2. The negative inventory.** A cascade of sentence fragments, each a bare noun
+phrase under a negation, listing the safeguards that were absent. Three to five
+items. Then one sentence that converts the absence into the interval it lasted.
+_Demonstration:_ "No ‹barrier›. No ‹warning›. No ‹staff member›." Use the same
+construction for a document production that came back empty: consecutive short
+sentences, each naming one category of thing not produced.
+
+**I3. Reject-then-assert.** Two sentences of near-identical grammar differing in one
+concrete noun. The first denies the reading a lazy reader would take; the second
+supplies the correct one. Both nouns must be physical and specific.
+_Demonstration:_ "What that figure measures is not ‹the naive reading›. It measures
+‹the true reading›."
+
+**I4. Concede the fact, contest the inference.** State the opponent's factual
+premise without qualification, then dispute only what it proves. Never dispute a
+fact the record supports.
+_Demonstration:_ "We do not dispute ‹the premise›. We dispute what it establishes."
+Follow with an enumerated answer — first, second, third — where the last item is the
+strongest and is flagged as the one that will occupy the day.
+
+**I5. The incompatibility close.** End a defense-preemption section by naming the
+two positions the opponent must hold at once and cannot. One sentence. No adjective,
+no exclamation, no rhetorical question.
+_Demonstration:_ "‹Defendant› cannot hold that ‹condition› was apparent to
+‹the plaintiff, in the plaintiff's actual circumstances› and unnoticeable to
+‹the defendant's own person, in that person's more favorable circumstances›."
+
+**I6. Damages by vocation.** Establish the loss through the physical mechanics of
+the person's actual work and life, in the specific postures and tools of that work.
+Never through adjectives about suffering and never through a generic activities-of-
+daily-living list. Then state the horizon: how many working years were expected, and
+what the employer or the record now says about them.
+_Demonstration:_ "‹Client› has ‹held that role› for ‹duration›. The job happens
+‹specific posture›: at ‹tool or station›, at ‹tool or station›, ‹specific recurring
+circumstance›."
+
+**I7. The separated person.** Where the record shows the opposing individual behaved
+decently, say so in a subordinate clause, then decline the character argument
+explicitly and re-aim at the decision or condition that actually creates liability.
+This is a reframing move: the case is not about the instrument of harm, it is about
+the choice that left it in place.
+
+**I8. The named weakness.** State the weak part of your own case plainly, refuse the
+pretense, and immediately re-theorize the case around what it is actually about.
+_Demonstration:_ "The ‹weak component› here is ‹thin›, and this letter says so
+rather than dressing it up. That is not where the value of this matter sits."
+
+**I9. The obligation discharge.** Close a client letter by zeroing the reader's
+action list, then naming the next action, who performs it, and when. Where a task
+does exist, cap it at one or two items and make them concrete and immediate.
+_Demonstration:_ "Nothing here is yours to carry. ‹Name› will ‹act› on ‹date›, and
+‹the signing attorney› will ‹specific contact method› the day ‹triggering event›."
+
+**I10. The capped instruction list.** Announce the number of instructions in the
+heading and say that the number is the whole list. Deliver each as a spoken ordinal
+on its own — "One." "Two." — followed by the instruction, then the reason. Where
+possible give a **non-litigation** reason for a litigation-useful instruction.
+_Demonstration:_ heading — "‹N› instructions, and the list ends there"; reason —
+"The reason is not the case. The reason is ‹the medical or practical fact›."
+
+**I11. The arithmetic delivered early.** In any letter that touches money the client
+will receive, explain the fee, the advanced costs, and the reimbursement claim
+against the recovery **before** the client asks, state that the headline figure is
+not the take-home figure, and name the incentive alignment explicitly where one
+exists. Attach the fact that this is normally withheld until the end and that the
+firm is not doing that.
+
+**I12. The unprompted concession to an adversary.** Offer the extension, the
+courtesy, or the phone call before it is requested — and bound it in the same
+breath. Grant, then limit, then state the consequence of the limit being reached.
+_Demonstration:_ "I will push that to ‹date› on request, and you will not have to
+‹procedural burden› to obtain it. I will not push it a second time."
+
+**I13. Give value on the way out.** In a declination, after the required
+non-representation language, identify the avenue the person still has — a different
+potential defendant, a different limitations period, a document worth preserving —
+and name concrete resources with contact details. Then one personal observation
+about the person, and an instruction to act inside a named week.
+
+**I14. The resolution couplet.** Every adversarial document ends on two short
+sentences of comparable length. The first states the preferred outcome. The second
+states readiness for the other one. No intensifier in either, no conditional, no
+subordinate clause, no third sentence softening it. The pair is the entire close and
+it sits immediately above the sign-off.
+_Demonstration:_ "Settlement is the outcome we want here. Trial is the outcome we
+are staffed for."
+
+---
+
+## 4. THE SWITCHBOARD
+
+Register is a small number of switches, each flipped by audience. Everything in §§1–3
+holds across all five; only these move.
+
+| Switch                                     | Adjuster (demand)                             | Opposing counsel                                | Neutral (brief)          | Client                                         | Declined prospect                   |
+| ------------------------------------------ | --------------------------------------------- | ----------------------------------------------- | ------------------------ | ---------------------------------------------- | ----------------------------------- |
+| **First person**                           | plural, institutional                         | **singular**                                    | plural                   | singular, with plural for firm acts            | singular, with plural for firm acts |
+| `I` : `we` observed                        | 0 : 7–9                                       | **18 : 1**                                      | 0 : 5                    | 8–9 : 2–12                                     | 6 : 10                              |
+| **Second person density** (per ~750 words) | 9–13                                          | 13                                              | **2**                    | 18–46                                          | 37                                  |
+| **Salutation name**                        | honorific + surname                           | **first name**                                  | none                     | **first name**                                 | honorific + surname                 |
+| **Salutation punctuation**                 | **colon**                                     | **colon**                                       | none                     | **comma**                                      | **colon**                           |
+| **Sign-off**                               | formal long form                              | formal long form                                | none                     | **short form**                                 | formal long form                    |
+| **Mean sentence length**                   | 12.7–15.2                                     | **18.0**                                        | 16.3                     | 12.1–14.2                                      | 17.1                                |
+| **Defendant named as**                     | _your ‹actor›_                                | party name                                      | _defendant_              | _they_ / party name                            | n/a                                 |
+| **Citation form**                          | statute pin, bare case name, no parenthetical | statute pin with subsection, sub-part numbering | Bates and depo page:line | rule stated in plain words **first**, pin last | rule in plain words first, pin last |
+| **Direct phone in signature block**        | no                                            | yes                                             | n/a                      | **yes**                                        | no                                  |
+| **Enclosure list**                         | tabbed exhibit inventory                      | none                                            | none                     | executed documents                             | returned originals                  |
+
+Two independent switches govern the salutation and they must not be conflated:
+**the first name tracks familiarity; the colon tracks adversarial posture.** A
+long-standing opposing counsel gets a first name and a colon. A client of one week
+gets a first name and a comma.
+
+### Audience notes
+
+**Adjuster.** The longest documents and the shortest sentences. Institutional voice.
+The reader is treated as a professional evaluator who will look for the bad facts,
+so the bad facts arrive first (O6). Policy limits, the bad-faith exposure framework,
+and the demand's position inside the limits are stated once, factually, without
+argument. One heading per phase: the event, the injuries, the cost, the loss, the
+problem facts, the liability posture, the number.
+
+**Opposing counsel.** The most personal document in the set and the most exacting.
+Singular voice throughout. Courteous at the open and the close, unsparing in the
+middle. Errors of law are corrected as facts, with the correction dated, and without
+scorn. One section is flagged as the thing genuinely worrying the writer, and it is
+usually preservation or spoliation rather than the discovery dispute nominally at
+issue. The relief demanded is enumerated exactly, with a bolded date. The close
+separates the dispute from the person and invites a phone call with a real
+statement of availability.
+
+**Neutral.** Second person nearly vanishes. Direct address to the mediator appears
+once, at the top, with an instruction about where to start reading. Facts are led by
+bolded clock times or dates as paragraph openers. Every assertion carries a record
+cite. Sub-headings are complete assertive sentences with terminal periods, lettered.
+Concessions are made explicitly and early, and the brief states outright which
+issues are not worth arguing, so the session can be aimed at valuation.
+
+**Client.** Highest second-person density, shortest sentences, singular voice for
+commitments and plural for firm acts. Explains the mechanism behind every
+instruction. Names the paralegal, with a direct number and a claim about
+responsiveness. Predicts with ranges and refuses to soften (O10). Closes with the
+obligation discharge (I9). The unlovely parts — liens, the gap in treatment, the
+timeline the client hoped would be shorter — are the parts given the most space.
+
+**Declined prospect.** Formal salutation, informal explanation. The adverse rule is
+explained in ordinary words before it is cited. Fault is separated from the person
+explicitly. Finality is stated as a strong probability, never as a certainty, with
+the residual arguments named honestly. Required non-engagement language is delivered
+in plain sentences under its own heading — not as a block of boilerplate — and is
+followed, not preceded, by the useful part (I13). A time-sensitivity warning appears
+in the reference block, in bold, above the salutation.
+
+---
+
+## 5. DOCUMENT SKELETONS
+
+Section order only. Headings are illustrative shapes, not text to copy.
+
+**Demand letter (≈1,050–1,100 words).** Letterhead · date · transmission method ·
+recipient block · reference block (insured, claim number, client, date of loss) ·
+salutation with colon · **opening fact sentence** · standing couplet (I1) · what
+happened · the injuries · why the functional loss matters (I6) · what it cost, with
+a provider table and a total row · what was lost in income · the problem facts,
+volunteered (O6) · the defense preempted and closed (I4, I5) · liability posture ·
+the demand, itemized, with the total set apart · limits and the bad-faith frame ·
+expiration date and the scheduled consequence (O7) · the resolution couplet (I14) ·
+formal sign-off · tabbed enclosure inventory.
+
+**Client status letter (≈650–780 words).** Letterhead · date · client address ·
+plain-language reference line · first-name salutation with comma · **status sentence
+first** · what was sent or filed and what is in it · what happens next, enumerated
+and dated (O10) · the one financial or procedural mechanism the client does not know
+about yet (I11) · the single habit to maintain, with a non-litigation reason (I10) ·
+the honest answer to the question they actually asked · obligation discharge (I9) ·
+short sign-off · direct line.
+
+**Engagement cover letter (≈780 words).** Same frame, plus: what the firm already
+did today, listed as completed acts · the named paralegal with a direct number · the
+fee, cost, and lien arithmetic in full (I11) · the capped rule list (I10) · what the
+firm needs from the client, concrete and immediate · what the next months will feel
+like and why the quiet is deliberate · the promise that nothing is agreed without
+the client.
+
+**Meet and confer letter (≈800 words).** Reference block naming the statutes and the
+service date · first name and colon · statement of the letter's function and a
+genuine preference for resolving it by phone · one heading per discovery set, each
+quantifying the deficiency · the preservation or spoliation concern flagged as the
+real worry · the relief demanded, enumerated, with a bolded date · the bounded
+unprompted extension (I12) · the specific motions, sanctions authorities, and use of
+the letter as a declaration · personal de-escalation and an availability statement ·
+formal sign-off · direct line · file copy notation.
+
+**Mediation brief section (≈790 words).** Caption block with court, case number,
+neutral, and date · one line of direct address telling the neutral where to start ·
+chronology led by bolded times, each with a record cite · lettered sub-headings that
+are assertions with terminal periods · the defense taken at its highest and answered
+in a numbered sequence · a closing statement of what has never been disputed and a
+plain declaration of where the session's effort belongs.
+
+**Declination letter (≈750 words).** Certified transmission notation · date ·
+recipient · reference line · **bolded time-sensitivity warning** · honorific
+salutation with colon · the decision in the first sentence with a stated intent to
+explain · the adverse rule in plain words, then the statute · the explicit
+separation of the rule from the person's conduct · the remaining avenue and its
+honest odds · what to do this week, with named referral resources and phone numbers ·
+required non-engagement language under a plain heading · a separate, different
+avenue the person may still hold · one personal observation · disposition of the
+original documents · formal sign-off.
+
+---
+
+## 6. NUMERIC ENVELOPE
+
+Measured over the nine sampled documents (8,137 words, 500 sentences, 239 prose
+paragraphs). Treat as a target band, not a hard gate.
+
+| Metric                         | Target                          | Observed     |
+| ------------------------------ | ------------------------------- | ------------ |
+| Document length                | 650–1,100 words                 | 657–1,102    |
+| Mean sentence length           | 12–18 words                     | 14.5 overall |
+| Median sentence length         | 10–16 words                     | 12 overall   |
+| Sentences of 5 words or fewer  | 15–29%                          | **22.6%**    |
+| Sentences of 10 words or fewer | 40–55%                          | **46.6%**    |
+| Sentences over 35 words        | under 5%                        | 3.8%         |
+| Longest sentence               | may reach 70+ once per document | max 73       |
+| Sentences per paragraph        | 1.9–3.0                         | 2.5          |
+| Single-sentence paragraphs     | roughly a third                 | **33%**      |
+| Headings per document          | 4–8                             | 4–8          |
+| Heading length                 | 2–13 words                      | 2–13         |
+
+The short-sentence share is the load-bearing number. A draft that reads correct on
+vocabulary and wrong on rhythm has almost always failed here: it will show a mean
+near 14 while burying every sentence between eleven and eighteen words. Nearly a
+quarter of the firm's sentences are five words or fewer, and they are placed
+deliberately — a fragment cascade, a single-line verdict on a paragraph of detail, a
+one-sentence paragraph that stands alone because it is the point.
+
+---
+
+## 7. PRE-EMISSION CHECKLIST
+
+Run in order. Any failure is a rewrite, not a patch.
+
+1. Zero em dashes, en dashes, semicolons, exclamation points, question marks.
+2. Zero contractions outside quoted speech.
+3. Zero hyphens outside identifiers.
+4. Zero discourse connectives from S7.
+5. Zero intensifiers from S8 applied to injury or conduct.
+6. Zero phrases from S9, S10, S13, S14.
+7. First sentence carries a fact or a decision, not a purpose.
+8. Every clinical term is preceded by its plain-language mechanical description and
+   appears in parentheses.
+9. Prose counts, durations, percentages and measurements are spelled out; numerals
+   appear only in money, dates, times, cites and tables.
+10. Salutation name and punctuation match both switches in §4; sign-off matches.
+11. Pronoun profile matches the audience row within a factor of two.
+12. Sentences of five words or fewer are at least fifteen percent of the total.
+13. At least one paragraph is a single sentence, placed where the argument turns.
+14. Every fact, figure and citation traces to the record. No placeholder survives.
+15. If the document is adversarial: the bad facts appear before the argument, and
+    the closing states a preference and a readiness in two short sentences of
+    comparable length — no intensifier in either.
+16. If the document is to a client: the reader's action list is explicitly zeroed or
+    capped at two concrete items, and someone is named with a direct number.


### PR DESCRIPTION
Two artifacts, one question.

ADR 0083 derives the firm voice **from** a customer's documents; the Captain ruled a spec must not keep their sentences. Whether a spec can carry a voice **without** them was the open question the whole build was waiting on — and it was being deferred to a runtime test on a seat when it was answerable offline, in a closed loop, with no client material and no seat involved.

## The answer: zero-verbatim clears the ceiling

| arm | score | "sounds like the firm" |
|---|---|---|
| **Delta Card** (zero verbatim) | **93.7** | 3/3 |
| Move Grammar (zero verbatim) | 89.3 | 3/3 |
| TTG (zero verbatim) | 87.4 | 3/3 |
| **verbatim exemplars** (control) | **85.8** | 3/3 |
| Stratigraphy (zero verbatim) | 84.7 | 3/3 |
| **no spec** (floor) | **46.2** | **0/3** |

Six arms. Four representations proposed blind to each other, a rubric authored before any of them was seen, three judges scoring blind against four documents no candidate was allowed to read. Three of four zero-verbatim designs beat the control; the fourth missed by 1.1. Against the 39.6-point span from floor to control, the winner adds **7.9 on top**.

**The mechanism is the part worth keeping.** Exemplars did not just fail to help — they produced the field's *worst* artifact, and all three judges independently named the same sentence. The control dropped a bare age sentence at a section boundary because the exemplar showed the string without the argument the age was carrying. It got the words and not the reason. An abstraction that names the *trigger* cannot misfire that way.

## One correction to the no-verbatim rule, from the data

Four adversarial letters close on a byte-identical firm signature. That is **boilerplate, like a letterhead** — not a construction to re-instantiate — and the winning arm paraphrased it. So a small fixed-string layer is verbatim *by design* and human-approved.

Deriving it would be the error. Authoring it is not. (The lowest-ranked proposal was the one that got this right.)

## The enforcement: a compiler, not an instruction

Because the instruction was already tried in this repo and already failed on the first attempt. `drafting-voice-spec.md` was authored by an agent told to characterize rather than copy, and its line 55 is **byte-identical** to `01-demand-mva-duarte.md` line 58.

An agent that skips a compiler has **no artifact**, not an unchecked one.

Against the two real artifacts it separates them the way it should: `voice-profile.md` (38 exemplars) → 85 findings; `drafting-voice-spec.md` (production rules, 3 embedded shapes) → 14.

### Three things that are load-bearing and easy to break silently

- **N = 8 is imported** from `drafting_gate_check._HELD_OUT_NGRAM`, not restated, so one constant answers both directions of the same question. Its defence is precedent on this document type — and **the predicted calibration did not hold**: intra-corpus collisions are 80 at N=8, because this firm repeats itself by design. The docstring says so rather than quietly keeping the prediction.
- **Masking** digit runs and out-of-vocabulary capitalized tokens is what catches the name swap — the cheapest evasion and therefore the likely one. `test_a_name_swapped_sentence_is_still_a_copy` is the test to keep green; if it ever passes trivially the check is decorative.
- **The refusal report carries offsets and counts, never the matched text.** The audit trail for a privacy control must not become the largest copy of the thing it protects. Note the production `_overlap_findings` *does* emit the matched run — correct there, wrong here, and a test pins the difference.

### A threshold I got wrong and then measured

The Jaccard ceiling was a guessed `0.6` and let a reordered paraphrase through. Measured: paraphrase `0.294`, worst legitimate characterization `0.038` across five trait descriptions against every sentence in all 13 documents. Set to `0.15`, with both numbers and both population sizes recorded.

## Residual risk, in the research doc's own header so it travels with the number

The corpus is **synthetic and was written to instantiate eight named traits**, so every arm was partly rediscovering a specification rather than discovering a voice. **93.7 is an upper bound on a task easier than the real one**, and the synthesis says so itself.

## Verified

3766 TS tests passed. `operator/bin` 215 passed (15 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdHKmUPQWuYFPpYm128Wjm