### PR TITLE
feat(voice): the delivery gate is enforced, and a spec's rules are checked against the firm's own writing

### DIFF
--- a/operator/bin/spec_selftest.py
+++ b/operator/bin/spec_selftest.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""Run a voice spec's own rules against the firm's own writing.
+
+THE MECHANISM THIS IMPLEMENTS
+------------------------------
+A distilled spec asserts rules about how a firm writes. Some of those rules are
+wrong, and the wrong ones are not obviously wrong — they are plausible
+generalizations from a corpus that mostly supports them. The 2026-08-01 bake-off
+found a candidate card whose own load-bearing threshold was violated by three of
+the firm's letters, stated as a hard gate, with nothing anywhere that would have
+noticed.
+
+The check is almost embarrassingly direct: **run the rules against the documents
+they were derived from.** A rule that blocks output the firm itself produces is
+not a description of the firm's voice. It is a description of most of the firm's
+voice, promoted past its evidence.
+
+WHY 100% AND NOT 90%
+---------------------
+A `block` rule must hold on EVERY exemplary document, not most. At corpus sizes
+that are realistic here — a dozen letters, sometimes fewer — a 90% threshold
+tolerates exactly one falsifying document, and the falsifying document is the
+one carrying the information. Tolerance calibrated as a percentage silently
+converts "the firm does this differently sometimes" into "the firm does this",
+which is the error the whole exercise exists to avoid.
+
+DEMOTION IS NOT FAILURE
+------------------------
+A `block` rule that fails auto-demotes to `warn` and carries its counterexamples
+forward into the card. That is deliberately not an error: an inconsistency in a
+firm's own writing is INFORMATION, and the person who can resolve it is the
+firm. Refusing the whole spec would throw that away; silently dropping the rule
+would hide it. Demoting it and naming the documents puts the disagreement in
+front of the only party who can settle whether it is house style, drift, or two
+authors who genuinely differ.
+
+WHAT `exemplary` MEANS, AND WHY THE CUSTOMER LABELS IT
+-------------------------------------------------------
+Only documents the customer marked `exemplary` gate a rule. Nothing in a
+filename says whether a letter is house style or an associate's off-day, and an
+agent that averages the two produces a spec describing neither. The label is
+human-supplied for the same reason the fixed strings are: it is a judgment about
+the firm's own intent, and there is no evidence in the corpus that settles it.
+An unlabeled document is checked and REPORTED but does not gate, so a corpus
+nobody has labeled yet still yields useful signal without silently promoting
+drift into a rule.
+
+Usage::
+
+    python3 operator/bin/spec_selftest.py --rules rules.json \\
+        --corpus <dir> [--labels labels.json] [--out gate.json]
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import re
+import sys
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Sequence
+
+_BIN = Path(__file__).resolve().parent
+
+
+def _load_profile_module():
+    """Import voice_profile by path, so the measurement code is shared not copied.
+
+    Registered in ``sys.modules`` BEFORE ``exec_module`` because ``@dataclass``
+    resolves its own module out of ``sys.modules`` during class creation, and a
+    module that is not there yet raises on the first decorated class. Cheap
+    mistake, obscure traceback.
+    """
+    spec = importlib.util.spec_from_file_location("_vp_selftest", _BIN / "voice_profile.py")
+    if spec is None or spec.loader is None:  # pragma: no cover
+        raise RuntimeError("cannot load voice_profile.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_VP = _load_profile_module()
+
+BLOCK = "block"
+WARN = "warn"
+
+
+@dataclass
+class RuleResult:
+    """One rule, checked against every document it claims to describe."""
+
+    rule_id: str
+    kind: str
+    tier_declared: str
+    tier_effective: str
+    passed_docs: list[str] = field(default_factory=list)
+    failed_docs: list[str] = field(default_factory=list)
+    failed_exemplary_docs: list[str] = field(default_factory=list)
+    detail: str = ""
+
+    @property
+    def demoted(self) -> bool:
+        return self.tier_declared == BLOCK and self.tier_effective == WARN
+
+
+def _absence_hits(prose: str, pattern: str, flags: int) -> int:
+    return len(re.compile(pattern, flags).findall(prose))
+
+
+def check_rule(rule: dict, prose_by_doc: dict[str, str], exemplary: set[str]) -> RuleResult:
+    """Evaluate one rule against every document, then decide its effective tier.
+
+    Rule kinds are deliberately few. Each maps to something the profiler already
+    computes, because a rule the profiler cannot recompute is a rule whose
+    threshold nobody can check later — and a gate whose threshold cannot be
+    recomputed is not a gate.
+    """
+    rule_id = str(rule.get("id") or "?")
+    kind = str(rule.get("kind") or "")
+    declared = str(rule.get("tier") or WARN).lower()
+    result = RuleResult(rule_id=rule_id, kind=kind, tier_declared=declared, tier_effective=declared)
+
+    for doc, prose in sorted(prose_by_doc.items()):
+        ok = True
+        if kind == "absence":
+            hits = _absence_hits(prose, str(rule.get("pattern") or "(?!)"), re.IGNORECASE if rule.get("ignore_case") else 0)
+            ok = hits == 0
+        elif kind in {"min_pct_short_sentences", "max_mean_sentence_words", "max_sentence_words"}:
+            lengths = [len(_VP.words(s)) for s in _VP.sentences(prose)]
+            lengths = [n for n in lengths if n]
+            if not lengths:
+                continue
+            if kind == "min_pct_short_sentences":
+                pct = 100 * sum(1 for n in lengths if n <= int(rule.get("at_most_words", 5))) / len(lengths)
+                ok = pct >= float(rule.get("threshold", 0))
+                result.detail = f"threshold >= {rule.get('threshold')}%"
+            elif kind == "max_mean_sentence_words":
+                ok = (sum(lengths) / len(lengths)) <= float(rule.get("threshold", 1e9))
+                result.detail = f"threshold <= {rule.get('threshold')} mean words"
+            else:
+                ok = max(lengths) <= float(rule.get("threshold", 1e9))
+                result.detail = f"threshold <= {rule.get('threshold')} words"
+        else:
+            # An unknown kind is REPORTED, never silently passed. A rule this
+            # module cannot evaluate must not read as one it evaluated and
+            # approved — that is the shape of every false-confidence defect in
+            # this subsystem.
+            result.tier_effective = WARN
+            result.detail = f"unknown rule kind {kind!r} — not evaluated, demoted"
+            return result
+
+        (result.passed_docs if ok else result.failed_docs).append(doc)
+        if not ok and doc in exemplary:
+            result.failed_exemplary_docs.append(doc)
+
+    if declared == BLOCK and result.failed_exemplary_docs:
+        result.tier_effective = WARN
+    return result
+
+
+def selftest(
+    rules: Sequence[dict],
+    corpus: dict[str, str],
+    exemplary: set[str] | None = None,
+) -> dict:
+    """Check every rule against the corpus and return the effective gate."""
+    prose_by_doc = {doc: _VP.segment(text, doc)[0] for doc, text in corpus.items()}
+    # No labels supplied ⇒ every document gates. That is the stricter reading
+    # and the safer default: it can only demote a rule that would otherwise have
+    # blocked the firm's own writing.
+    marks = exemplary if exemplary is not None else set(prose_by_doc)
+
+    results = [check_rule(r, prose_by_doc, marks) for r in rules]
+    demoted = [r for r in results if r.demoted]
+    return {
+        "schema_version": 1,
+        "corpus_docs": len(prose_by_doc),
+        "exemplary_docs": sorted(marks),
+        "rules_checked": len(results),
+        "rules_demoted": len(demoted),
+        "results": [asdict(r) | {"demoted": r.demoted} for r in results],
+    }
+
+
+def render_demotions(report: dict) -> str:
+    """The lines that belong in the card, in front of the customer.
+
+    ADR 0083 already requires the customer to approve a spec. What it does not
+    require, and what this supplies, is that they are shown where their OWN
+    letters break the rule they are approving.
+    """
+    lines: list[str] = []
+    for r in report["results"]:
+        if not r["demoted"]:
+            continue
+        docs = ", ".join(r["failed_exemplary_docs"])
+        lines.append(
+            f"- `{r['rule_id']}` demoted from block to warn: your own writing does not "
+            f"follow it in {docs}. {r['detail']}".rstrip()
+        )
+    return "\n".join(lines)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--rules", required=True, type=Path)
+    ap.add_argument("--corpus", required=True, nargs="+", type=Path)
+    ap.add_argument("--labels", type=Path, help='JSON: {"exemplary": ["01-...md", ...]}')
+    ap.add_argument("--out", type=Path)
+    args = ap.parse_args(argv)
+
+    corpus = _VP.load_corpus(args.corpus)
+    if not corpus:
+        print("REFUSED: empty corpus", file=sys.stderr)
+        return 1
+
+    rules = json.loads(args.rules.read_text())
+    if isinstance(rules, dict):
+        rules = rules.get("rules", [])
+
+    exemplary = None
+    if args.labels and args.labels.exists():
+        exemplary = set(json.loads(args.labels.read_text()).get("exemplary") or [])
+
+    report = selftest(rules, corpus, exemplary)
+    if args.out:
+        args.out.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
+
+    print(f"checked {report['rules_checked']} rule(s) against {report['corpus_docs']} document(s)")
+    if report["rules_demoted"]:
+        print(f"\n{report['rules_demoted']} rule(s) DEMOTED — the firm's own writing breaks them:\n")
+        print(render_demotions(report))
+        print("\nDemotion is not an error. Show these to the firm; they are the only")
+        print("party who can say whether this is house style, drift, or two authors.")
+    else:
+        print("no demotions: every block-tier rule holds on all exemplary documents")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/operator/bin/tests/test_runtime_control_conformance.py
+++ b/operator/bin/tests/test_runtime_control_conformance.py
@@ -76,6 +76,31 @@ def _hook_of(wired_via: str) -> str:
     return (wired_via or "").split("/", 1)[0].strip()
 
 
+#: `wired_via` prefix for a control the agent reaches by CALLING A TOOL rather
+#: than by a hook firing around one.
+#:
+#: The schema assumed every control was hook-wired, which was true until a
+#: control existed that the agent invokes directly. A tool IS a wiring — it is
+#: registered, classified in TOOL_ACTION_CLASS_MAP, and refusable — it is simply
+#: not in the hook surface, and forcing it to name a hook would invent one.
+#:
+#: This is NOT an escape hatch from the hook cross-check. A hook-form value is
+#: still validated against overlay-hook-surface.json, and a tool-form value gets
+#: its own cross-check below: the named tool must actually be instructed
+#: somewhere a shipped skill will read it. A control nothing tells the agent to
+#: call is inert in exactly the way this registry exists to expose, and writing
+#: `tool / anything` must not buy an exemption from proving otherwise.
+_TOOL_PREFIX = "tool"
+
+
+def _tool_of(wired_via: str) -> str:
+    """`"tool / <tool_name>"` -> `<tool_name>`, else `""`."""
+    parts = (wired_via or "").split("/", 1)
+    if len(parts) != 2 or parts[0].strip() != _TOOL_PREFIX:
+        return ""
+    return parts[1].strip()
+
+
 # --------------------------------------------------------------------------- #
 # structure                                                                    #
 # --------------------------------------------------------------------------- #
@@ -160,11 +185,37 @@ def test_wired_via_hooks_exist_in_surface() -> None:
     required = set(_hook_surface().get("requiredHooks") or {})
     for key, spec in _controls().items():
         wired = spec.get("wired_via")
-        if not wired:
+        if not wired or _tool_of(wired):
             continue
         hook = _hook_of(wired)
         assert hook in required, (
             f"{key}: wired_via names hook {hook!r} which is not in overlay-hook-surface.json"
+        )
+
+
+def test_tool_wired_controls_are_actually_instructed() -> None:
+    """A tool-wired control must be something a shipped skill tells the agent to call.
+
+    The counterpart of the hook cross-check, and the reason `tool /` is not an
+    exemption. A hook fires whether or not anyone asked; a tool runs only if
+    something in the agent's context says to run it. So a tool-wired control
+    whose name appears in no shipped skill or discipline is inert by
+    construction — exactly the state this registry exists to expose — and it
+    would otherwise be indistinguishable from a wired one.
+    """
+    searched = [
+        *(_OP / "skills").rglob("*.md"),
+        *(_OP / "templates" / "drafting").rglob("*.md"),
+    ]
+    for key, spec in _controls().items():
+        tool = _tool_of(spec.get("wired_via") or "")
+        if not tool:
+            continue
+        instructed = any(tool in path.read_text() for path in searched)
+        assert instructed, (
+            f"{key}: wired_via names tool {tool!r}, but no shipped skill or drafting "
+            "discipline instructs the agent to call it. A control nothing invokes is "
+            "inert; either wire it or mark the entry inert."
         )
 
 

--- a/operator/bin/tests/test_spec_selftest.py
+++ b/operator/bin/tests/test_spec_selftest.py
@@ -1,0 +1,174 @@
+"""Running a spec's rules against the writing they were derived from.
+
+The failure this prevents is specific and was observed: a candidate card stated
+a threshold as a hard gate, called it "the load-bearing number", and three of
+the firm's own letters violated it. Nothing anywhere would have noticed, because
+nothing ran the rules against the corpus.
+
+Ordered by which failure ships a bad gate rather than a broken build:
+
+1. An unknown rule kind must DEMOTE, never silently pass. A rule this module
+   cannot evaluate that reads as evaluated-and-approved is the exact shape of
+   every false-confidence defect in this subsystem.
+2. A block rule the corpus violates must demote AND name the documents, because
+   the documents are the information the firm needs to resolve it.
+3. Unlabeled corpora gate on everything. The permissive reading — only labeled
+   documents gate, so an unlabeled corpus gates on nothing — would turn the
+   whole check off by omission.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_BIN = Path(__file__).resolve().parents[1]
+_SEED = _BIN.parents[1] / "operator" / "customers" / "pilot-smokeball" / "seed" / "voice"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("_sst", _BIN / "spec_selftest.py")
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["_sst"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+st = _load()
+
+CORPUS = {
+    "a": "Plain prose. No punctuation tricks here.",
+    "b": "This one has a semicolon; right here in the body.",
+}
+
+
+def _rule(**over):
+    base = {"id": "S2", "kind": "absence", "tier": "block", "pattern": ";"}
+    base.update(over)
+    return base
+
+
+# --------------------------------------------------- silent-pass is the enemy
+
+
+def test_an_unknown_rule_kind_demotes_rather_than_passing():
+    """A rule nobody evaluated must not read as one that held."""
+    report = st.selftest([_rule(kind="vibes", tier="block")], CORPUS)
+    r = report["results"][0]
+    assert r["tier_effective"] == st.WARN
+    assert "not evaluated" in r["detail"]
+
+
+# ------------------------------------------------------------ the mechanism
+
+
+def test_a_rule_the_corpus_violates_demotes_and_names_the_document():
+    report = st.selftest([_rule()], CORPUS)
+    r = report["results"][0]
+    assert r["demoted"]
+    assert r["tier_effective"] == st.WARN
+    assert r["failed_exemplary_docs"] == ["b"]
+
+
+def test_a_rule_the_corpus_honors_stays_block():
+    report = st.selftest([_rule(id="S1", pattern="—")], CORPUS)
+    assert report["results"][0]["tier_effective"] == st.BLOCK
+    assert report["rules_demoted"] == 0
+
+
+def test_one_violating_document_is_enough():
+    """100%, not 90%. At a dozen documents a percentage tolerates exactly the
+    falsifying one, and the falsifying one carries the information."""
+    corpus = {f"d{i}": "Plain prose." for i in range(20)}
+    corpus["d20"] = "One semicolon; here."
+    assert st.selftest([_rule()], corpus)["rules_demoted"] == 1
+
+
+def test_a_warn_rule_is_not_demoted_further():
+    report = st.selftest([_rule(tier="warn")], CORPUS)
+    assert report["results"][0]["tier_effective"] == st.WARN
+    assert not report["results"][0]["demoted"]
+
+
+# ----------------------------------------------------------------- labelling
+
+
+def test_an_unlabelled_corpus_gates_on_every_document():
+    """The stricter reading, and the safe default.
+
+    The permissive one — only labelled documents gate — turns the check off for
+    any corpus nobody has labelled yet, which is every corpus at the start.
+    """
+    assert st.selftest([_rule()], CORPUS, exemplary=None)["rules_demoted"] == 1
+
+
+def test_labels_restrict_which_documents_gate():
+    """A document the firm did not call exemplary is reported, not gating."""
+    report = st.selftest([_rule()], CORPUS, exemplary={"a"})
+    r = report["results"][0]
+    assert not r["demoted"]
+    assert r["failed_docs"] == ["b"]  # still reported
+    assert r["failed_exemplary_docs"] == []
+
+
+# --------------------------------------------------------- customer-facing
+
+
+def test_demotions_render_for_the_customer():
+    """ADR 0083 requires approval; this is what makes approval informed."""
+    text = st.render_demotions(st.selftest([_rule()], CORPUS))
+    assert "S2" in text and "b" in text
+    assert "your own writing" in text
+
+
+# ------------------------------------------------------------ real corpus
+
+
+@pytest.mark.skipif(not _SEED.exists(), reason="rehearsal corpus not present")
+def test_the_hyphen_rule_demotes_on_the_two_late_documents():
+    """Reproduces the documented finding, from the rules side.
+
+    Documents 12 and 13 were added after the original eleven and are the only
+    two that break the open-numeral habit. Whether that is newer house style or
+    associate drift is not knowable from the corpus, which is exactly why the
+    rule demotes to warn and the documents get named rather than the rule being
+    dropped or kept.
+    """
+    corpus = {p.name: p.read_text() for p in sorted(_SEED.glob("*.md")) if p.name[0].isdigit()}
+    rule = _rule(
+        id="S6",
+        ignore_case=True,
+        pattern=r"\b(?:twenty|thirty|forty|fifty|sixty|seventy|eighty|ninety)-(?:one|two|three|four|five|six|seven|eight|nine)\b",
+    )
+    r = st.selftest([rule], corpus)["results"][0]
+    assert r["demoted"]
+    assert r["failed_exemplary_docs"] == [
+        "12-client-status-duarte.md",
+        "13-client-status-tolliver.md",
+    ]
+
+
+@pytest.mark.skipif(not _SEED.exists(), reason="rehearsal corpus not present")
+def test_a_threshold_rules_verdict_depends_on_the_tokenizer():
+    """WHY THE TOKENIZER SHIPS WITH THE CARD, demonstrated rather than argued.
+
+    The bake-off's splitter put three documents under a 15% short-sentence
+    threshold, at 12.8 / 12.1 / 10.3. This module's splitter puts every document
+    over it, the lowest at 15.9. Neither is wrong; they segment sentences
+    differently, and roughly a factor of two separates them on the same files.
+
+    So the SAME rule blocks under one tokenizer and passes under another. A
+    threshold without the code that computed it is not a gate, it is a number
+    someone remembers. This test pins the local verdict so a change to the
+    splitter shows up here as a rule silently flipping, which is the only way
+    anyone would notice.
+    """
+    corpus = {p.name: p.read_text() for p in sorted(_SEED.glob("*.md")) if p.name[0].isdigit()}
+    rule = {"id": "R3", "kind": "min_pct_short_sentences", "tier": "block", "at_most_words": 5, "threshold": 15}
+    r = st.selftest([rule], corpus)["results"][0]
+    assert not r["demoted"], "the splitter changed; re-derive every threshold rule"
+    assert len(r["passed_docs"]) == 13

--- a/operator/contracts/runtime-controls.yaml
+++ b/operator/contracts/runtime-controls.yaml
@@ -42,8 +42,14 @@
 #
 # STATUS VOCABULARY:
 #   enforced  — wired into the live dispatch path AND has a named live_probe that
-#               proves it fires. (Today: only the two checks already proven by the
-#               overlay gateway:startup activation handler.)
+#               proves it fires. Two flavours today, and the difference matters
+#               when reading an entry: AUTOMATED (the overlay gateway:startup
+#               activation handler, which os._exit(1)s at boot if the control does
+#               not fire) and MANUAL-OBSERVED (a named seat probe someone ran, with
+#               a crane_verify id in the note). Manual-observed is a weaker claim —
+#               it proves the control fired ONCE, not that a regression would be
+#               caught — and an entry carrying it must say so rather than let a
+#               reader assume the boot gate is watching.
 #   unprobed  — wired into dispatch, but no negative-fire probe proves it fires on
 #               a live turn. The #1285 risk surface (a hook can be registered yet
 #               inert on live turns). Requires owner + tracking + note.
@@ -58,8 +64,19 @@
 #                      (path is in venturecrane/hermes-smd-overlay, not checked
 #                      out here — the same cross-repo limit overlay-pairs.json and
 #                      overlay-hook-surface.json document).
-#   wired_via        — "<hook> / <overlay-plugin>" that invokes the control.
-#                      Must reference a hook in overlay-hook-surface.json.
+#   wired_via        — how the control is REACHED, in one of two forms:
+#                        "<hook> / <overlay-plugin>"  — cross-checked against
+#                          overlay-hook-surface.json.
+#                        "tool / <tool_name>"  — for a control the agent reaches by
+#                          CALLING a tool rather than by a hook firing around one.
+#                          Cross-checked differently and not more weakly: a shipped
+#                          skill or the drafting discipline must instruct the agent
+#                          to call it. A hook fires whether or not anyone asked; a
+#                          tool runs only if something in the agent's context says
+#                          to, so a tool nobody instructs is inert in exactly the
+#                          way this registry exists to expose.
+#                      Empty ONLY for a root-side process outside dispatch entirely
+#                      (see spec_applier), which has neither.
 #   live_probe       — name of the negative-fire probe that proves it fires.
 #                      Recorded for the B3 review; the probe itself is not built
 #                      here. Empty for unprobed/inert.
@@ -223,18 +240,17 @@ controls:
     control: draft_delivery_gate
     class: dispatch-guard
     substrate_module: overlay:plugins/hermes-smd-drafting/__init__.py
-    # EMPTY BY NECESSITY, not by omission — the same shape as spec_applier above.
-    # `wired_via` names a hook in overlay-hook-surface.json, and this control has
-    # none: it is a TOOL the agent calls (registered through
-    # shared/tool_registration.py), not a hook fired around one. Naming a hook
-    # here would invent one and break the surface cross-check. What makes it
-    # reachable is the drafting discipline instructing delivery through it, and
-    # what makes it enforceable is that the gate it runs is the same
-    # shared.spec_gate the hook-wired sibling uses.
-    wired_via: ''
-    live_probe: ''
-    probe_surface: ''
-    status: unprobed
+    # A TOOL the agent calls, not a hook fired around one — so `wired_via` takes
+    # the `tool /` form rather than naming a hook that does not exist. That form
+    # is not an exemption from the surface cross-check: it swaps one check for
+    # another, because a hook fires whether or not anyone asked while a tool runs
+    # only if something in the agent's context says to. test_tool_wired_controls_
+    # are_actually_instructed asserts a shipped skill or the drafting discipline
+    # names it; a control nothing invokes is inert however good its code is.
+    wired_via: 'tool / smd_deliver_draft'
+    live_probe: seat_probe_refuses_unread_work_product
+    probe_surface: staging
+    status: enforced
     owner: SMDurgan
     tracking: '#2094'
     note: >-
@@ -257,9 +273,24 @@ controls:
       the failure this catches is a model that forgot to read its spec, not an
       adversary routing around a control, and the adversary case (an
       agent-writable spec as a persistent injection channel) is closed by root
-      ownership in #2084. UNPROBED: the tool exists on the pinned overlay
-      (1594f687) but no seat has been rebuilt onto that pin, so no live refusal
-      or authorization has been observed.
+      ownership in #2084. ENFORCED, manual-observed 2026-08-01 on
+      hermes-pilot-smokeball at SMD_OVERLAY_REF=1594f687
+      (vfy_01KYZNTJAEST5HEVJATYFY9ED3): with work_product declared
+      voice_spec: expected and SMD_SPEC_DIR root-owned and EMPTY, a work_product
+      delivery on a turn with no read was REFUSED, carrying the
+      internal-artifact wording rather than the send wording; the same call for
+      an undeclared class was ALLOWED, which is the trust property observed live
+      — an explicit output_class selects which declaration is consulted and
+      cannot manufacture one. READ THE PROBE'S LIMITS BEFORE TRUSTING THE
+      STATUS. It is MANUAL: someone ran seat-probe against the gateway's env, so
+      it proves the control fired once, NOT that a regression would be caught.
+      There is no boot gate on this one. It also ran outside a full agent turn,
+      so the audit row did not emit — the broker refused the append because the
+      caller was not the gateway process, and the gate logged exactly that while
+      stating the downgrade still stands, which is the fail-closed-on-audit-
+      failure path behaving correctly. A real turn emits the row. The other half
+      of the feature, a draft delivered IN the declared voice, is still
+      unobserved: it needs a spec in the vault, authored through the portal.
 
   taint_gate:
     control: taint_gate


### PR DESCRIPTION
Two commits, both from the same finding: a control or a rule that nobody ran against reality reads exactly like one that holds.

---

# 1. The draft-delivery gate is enforced, and the registry can say so

**The gate refuses on a live seat.** Observed on `hermes-pilot-smokeball` at `SMD_OVERLAY_REF=1594f687` — which the peer session's own rebuild had already put there, so no redeploy was needed (`vfy_01KYZNTJAEST5HEVJATYFY9ED3`):

| condition | result |
|---|---|
| `work_product` declared `expected`, `SMD_SPEC_DIR` root-owned and **empty**, turn did not read | **REFUSED** — internal-artifact wording, not send wording |
| same call, class the seat never declared | **ALLOWED** |

**The second row is the one to keep.** It is the trust property observed live: an explicit `output_class` selects *which* authored declaration is consulted and cannot manufacture one.

## Recording it required fixing the schema, not working around it

`enforced` demanded a `wired_via`, and `wired_via` had to name a hook. **A tool-wired control can never satisfy that** — it is reached by the agent *calling* it. The schema encoded "every control is hook-wired," true until it wasn't.

So `wired_via` gains a `tool / <name>` form, and **it swaps one cross-check for another rather than dropping one**: a hook fires whether or not anyone asked, a tool runs only if something in the agent's context says to, so `test_tool_wired_controls_are_actually_instructed` asserts a shipped skill names it. `tool / anything` must not buy an exemption.

## Two kinds of `enforced`

**automated** (the boot handler, which `os._exit(1)`s if the control does not fire) and **manual-observed** (a named seat probe someone ran). Manual-observed proves the control fired **once**, not that a regression would be caught, and the vocabulary now says so.

Two limits are written into the entry: the probe ran outside a full agent turn so the audit row did not emit (the broker refused a non-gateway caller and the gate logged exactly that while stating the downgrade stands — fail-closed-on-audit-failure working), and **a draft delivered *in* the declared voice is still unobserved**, pending a spec in the vault.

---

# 2. A spec's rules, run against the writing they were derived from

The synthesis calls this **the single highest-value mechanism in the build**. A rule that blocks output the firm *itself produces* is not a description of the firm's voice — it is a description of **most** of it, promoted past its evidence.

**The observed failure:** a candidate card stated a short-sentence threshold as a hard gate, called it *"the load-bearing number"*, and three of the firm's own letters violated it.

**100%, not 90%.** At a dozen letters, a percentage tolerates exactly one falsifying document — and the falsifying document is the one carrying the information.

**Demotion is the design.** A failing `block` rule drops to `warn` and carries its counterexamples into the card. Refusing the spec throws the information away; dropping the rule hides it. Naming the documents puts the disagreement in front of the only party who can settle it. ADR 0083 requires the customer to approve a spec; `render_demotions` is what makes that approval *informed*.

Against the real corpus it reproduces the documented finding from the rules side: the open-numeral rule demotes, naming 12 and 13 — the two documents added after the original eleven, and the only two that break the habit.

## It surfaced something sharper than the argument for it

The bake-off's splitter put three documents **under** a 15% short-sentence threshold, at 12.8 / 12.1 / 10.3. This module's splitter puts **every** document over it, lowest 15.9. Neither is wrong — they segment differently, by roughly a factor of two on the same files.

**So the same rule blocks under one tokenizer and passes under another.** A threshold without the code that computed it is not a gate, it is a number someone remembers. A test now pins the local verdict so a splitter change surfaces as a rule silently flipping.

## Two defaults chosen against the permissive reading

- **An unknown rule kind demotes** rather than passing — a rule nobody evaluated must not read as one that held.
- **An unlabelled corpus gates on everything.** The permissive reading turns the check off for any corpus nobody has labelled, which is every corpus at the start.

---

## Verified

3766 TS tests passed. `operator/bin` 240 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdHKmUPQWuYFPpYm128Wjm
