### PR TITLE
feat(doctrine): Law 12, a check that cannot fail has measured nothing

### DIFF
--- a/.claude/hooks/reflex-primer.sh
+++ b/.claude/hooks/reflex-primer.sh
@@ -51,6 +51,7 @@ cat <<'PRIMER'
 9. The deliverable is the client's act, not your artifact: name the terminal seam, enumerate every gate between the client and the effect, and escalate an unclosable gate before building the closable ones.
 10. Your snapshot is not the system. Tree state, branch lists, merged PRs, and installed dependencies decay within minutes of the briefing that reported them. Re-probe before acting on any of them.
 11. The Captain's attention is the scarcest resource on the venture: default to three lines (shipped / next / blocked), put detail in the PR or issue and link it, and escalate only what costs money, touches a client, or changes a promise. An escalation is one sentence of stakes, two options, your pick, and you proceed on your pick unless told otherwise.
+12. A check that cannot fail has measured nothing. Before reporting an observation, name what would have made it false and confirm your instrument would have shown it.
 PRIMER
 
 # Law 2 escape-hatch visibility.

--- a/docs/doctrine/agent-operating-doctrine.md
+++ b/docs/doctrine/agent-operating-doctrine.md
@@ -280,6 +280,33 @@ The cost that keeps this honest is under-reporting. An agent that hides a real g
 
 ---
 
+### Law 12: A check that cannot fail has measured nothing
+
+```yaml
+id: check-must-be-able-to-fail
+primer_line: 'A check that cannot fail has measured nothing. Before reporting an observation, name what would have made it false and confirm your instrument would have shown it.'
+cost: low
+tier: primer
+enforcement:
+  - .claude/hooks/reflex-primer.sh
+incidents:
+  - date: 2026-08-01
+    ref: "evidence-packet tamper test (#2122: the check ran `sed 's/Acme/Acmf/'` against a manifest whose slug is lowercase `acme`, so it altered nothing; openssl then verified the unmodified bytes and the session reported a passing tamper test. The signature was in fact sound, which is worse -- a real regression would have been reported green by the same command)"
+  - date: 2026-08-01
+    ref: 'memory-corpus audit (asked for a wrongness rate, the session built six checks and three failed on the instrument rather than the claim: guessed ADR filenames produced five false FAILs against memories that were correct, an issue number was checked as a PR, and an absence assertion was written inverted so the correct result was labelled a failure. Measured memory error rate 2/147; measured first-attempt instrument error rate 3/6)'
+escalation: none pending
+```
+
+Law 5 asks whether an observation exists. Law 10 asks whether it is still current. This one asks the question underneath both: whether the instrument that produced it was capable of returning the other answer. A reading from a check that could only ever come back green is not weak evidence, it is no evidence, and it is more dangerous than an admitted gap because it is reported with the confidence of a measurement.
+
+The failure does not look like carelessness from inside. Each of the incidents above was a deliberate verification step, run on purpose, by a session that believed it was being rigorous. What was skipped in every case was the cheapest part: stating, before reading the output, what a failure would have looked like. When that step is taken the broken instrument announces itself immediately -- in the memory audit the deliberately-false control failed on the first run and exposed three bad checks in minutes.
+
+This venture already enforces exactly this discipline on its code and not on its reasoning. `operator/contracts/runtime-controls.yaml` exists because a control can be registered yet inert, and refuses the status `enforced` without a named negative-fire probe. The Dockerfile's own note on a mode assertion records that it "measured the environment, not the code" and passed for months under a permissive umask. The gap this law closes is that the same standard was never applied to the checks an agent runs on its own work.
+
+It is `primer` rather than `gate` because the failure is a missing thought, not a detectable state: no hook can see that a passing command was incapable of failing. The cost is `low` -- naming the falsifier takes one sentence and usually one extra command, and unlike a radar line it produces no false positives to teach agents to skim.
+
+---
+
 ## Mechanisms under review
 
 ```yaml


### PR DESCRIPTION
Law 5 asks whether an observation exists. Law 10 asks whether it is still current. Neither asks the question underneath both: **whether the instrument that produced the reading was capable of returning the other answer.**

A reading from a check that could only ever come back green is not weak evidence. It is no evidence, and it is more dangerous than an admitted gap because it arrives with the confidence of a measurement.

## The two incidents behind it

Both on 2026-08-01, both *inside deliberate verification steps*, run by a session that believed it was being rigorous.

**The evidence-packet tamper test (#2122).** The check ran `sed 's/Acme/Acmf/'` against a manifest whose slug is lowercase `acme`. It altered nothing. `openssl` then verified the unmodified bytes and the session reported a passing tamper test. The signature happened to be sound — which is the worse outcome, because a real regression would have been reported green by the identical command.

**The memory-corpus audit.** Asked for a wrongness rate, the same session built six checks and three failed on the *instrument* rather than the claim: guessed ADR filenames produced five false FAILs against memories that were correct, an issue number was checked as a PR, and an absence assertion was written inverted so the correct result was labelled a failure.

> Measured memory error rate: **2 of 147**. Measured first-attempt instrument error rate: **3 of 6**.

The data was not the problem. The measuring was.

## Why this is not a diligence ask

None of those felt careless from inside. What was skipped every time was the cheapest step: stating, *before reading the output*, what a failure would have looked like. When that step is taken the broken instrument announces itself immediately — in the memory audit the deliberately-false control failed on its first run and exposed three bad checks within minutes.

## Precedent already in this repo

The venture enforces exactly this standard on its code and not on its reasoning:

- `operator/contracts/runtime-controls.yaml` refuses the status `enforced` without a named negative-fire probe, because a control can be registered yet inert.
- The Dockerfile's own note on a mode assertion records that it *"measured the environment, not the code"* and passed for months under a permissive umask.

Law 11 applies that standard to the checks an agent runs on its own work.

## Tier

`primer`, not `gate`: no hook can detect that a passing command was incapable of failing. Cost `low` — naming the falsifier is one sentence and usually one extra command, and unlike a radar line it produces no false positives to teach agents to skim past the laws above it.

## Verified by its own standard

- **Negative control on the parity gate:** breaking the primer line makes `doctrine-integrity` fail with `check-must-be-able-to-fail: primer_line not found verbatim`; restoring it passes 13/13. The gate is not vacuously green.
- **Runtime, not file contents:** the hook emits line 11 on a real payload, and correctly emits nothing on an empty prompt. My first attempt to check this printed nothing and looked like a broken hook — it was a malformed test payload, caught precisely because the check was run against the runtime rather than the file.
- `npm run verify` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3ck3zHJVYLDxZWa73fZi6
