### PR TITLE
feat(audit): the console vocabulary names every type the ledgers contain (#2122)

### DIFF
--- a/operator/adapter/audit_log.py
+++ b/operator/adapter/audit_log.py
@@ -207,6 +207,39 @@ ACCEPTED_ACTION_TYPES = frozenset(
         "REPLY_SENT",
         "REPLY_HELD",
         "REPLY_FAILED",
+        # ------------------------------------------------------------------
+        # 2026-08-02 vocabulary reconciliation (#2122). Every type below has a
+        # LIVE producer and live rows on both seats' ledgers, yet was absent
+        # from this vocabulary — so ?action= filters silently no-opped and the
+        # compliance roll-up could not name the bulk of the ledger (TOOL_CALL_
+        # COMPLETED alone is ~69% of pilot rows). Producers named per type;
+        # the TS mirror (src/lib/portal/operator/audit.ts) and the producers
+        # manifest extend in lockstep — the parity test enforces it.
+        #
+        # Per-tool + per-turn audit (overlay hermes-smd-audit, ss#842/#981):
+        "TOOL_CALL_COMPLETED",
+        "LLM_TURN_COMPLETED",
+        # Webhook routing + suppression (overlay hermes-smd-webhook-router /
+        # webhook_gate.py, ADR 0021 Stream E):
+        "WEBHOOK_ROUTED",
+        "WEBHOOK_SUPPRESSED",
+        # Mediated connector broker rows (overlay shared/broker_audit.py):
+        "BROKER_DECISION_ALLOWED",
+        "BROKER_EXECUTED",
+        # Live config apply (overlay config_applier, ADR 0044 WS3):
+        "CONFIG_WRITE",
+        # Confirm-send seam (overlay hermes-smd-trust):
+        "CONFIRM_SEND_DISPATCHED",
+        "CONFIRM_SEND_FAILED",
+        # Authored-format spec gate (overlay shared/spec_gate.py, overlay#207):
+        "SPEC_GATE_TRIGGERED",
+        # Report-only voice gate (overlay hermes-smd-trust/voice_gate.py) —
+        # distinct from the VOICE_GATE_PASSED/NEAR_PASS/FAILED triple above,
+        # which nothing currently emits:
+        "VOICE_GATE_TRIGGERED",
+        # Client-correction capture appended broker-side (ss#2091,
+        # operator/workspace_broker/corrections.py):
+        "CORRECTION_PROPOSED",
     }
 )
 

--- a/operator/contracts/audit-action-type-producers.json
+++ b/operator/contracts/audit-action-type-producers.json
@@ -8,7 +8,7 @@
     "evidence packet CONSUME these values (audit viewer filters, compliance.ts roll-ups,",
     "evidence/packet.py _count(...) buckets). But nothing asserted that each consumed",
     "value has a RUNTIME PRODUCER. An action_type can sit in the enum, be mirrored to TS,",
-    "be counted by the compliance packet, and be emitted by NOBODY — a dashboard column or",
+    "be counted by the compliance packet, and be emitted by NOBODY \u2014 a dashboard column or",
     "compliance metric that is structurally always-zero. That is the inert-control class:",
     "a consumer with no producer reads as 'feature present, value 0' indistinguishable from",
     "'genuinely zero events'.",
@@ -19,17 +19,17 @@
     "                 named producerFile exists and contains the token in code).",
     "  'overlay'    = it is emitted by the venturecrane/hermes-smd-overlay runtime that ships",
     "                 on customer Machines (a separate, pinned repo not checked out in this",
-    "                 CI; we record overlayProducer + reason — the same cross-repo",
+    "                 CI; we record overlayProducer + reason \u2014 the same cross-repo",
     "                 human-decision shape operator/contracts/overlay-pairs.json uses).",
     "  'deferred'   = in the closed vocabulary and CONSUMED (viewer filter / compliance),",
-    "                 but NO producer writes the literal row yet — persistence is gated on a",
+    "                 but NO producer writes the literal row yet \u2014 persistence is gated on a",
     "                 tracked issue. This is the live inert-control instance the guard found;",
     "                 it carries producerIntent + reason naming the gap and the unblocking",
     "                 work, so the always-zero metric is documented loudly, not hidden.",
     "",
     "ENFORCEMENT (tests/operator-audit-producers.test.ts):",
     "  1. COVERAGE: manifest keys == ACCEPTED_ACTION_TYPES exactly. A new action_type with",
-    "     no manifest entry fails CI, forcing a conscious producer classification — the gate",
+    "     no manifest entry fails CI, forcing a conscious producer classification \u2014 the gate",
     "     that would have caught a consumed-but-never-produced type.",
     "  2. ss-console PRODUCERS ARE REAL: each 'ss-console' entry's producerFile exists and",
     "     contains the token in code. Deleting the only producer of a still-consumed type",
@@ -159,7 +159,7 @@
     "RBAC_EVENT": {
       "side": "deferred",
       "producerIntent": "src/lib/portal/operator/rbac-audit.ts",
-      "reason": "rbac-audit.ts builds structured audit:rbac_event events for user-management actions, but the audit_log PERSISTENCE path (the writer that stamps action='RBAC_EVENT' onto a row) is gated on #821/#891 and not yet wired. The value is in the closed vocabulary and the viewer can filter on it, so it is currently consumed-but-never-produced — surfaced here deliberately rather than hidden. Flip to side=ss-console with producerFile once #821 lands the persistence path that writes the literal RBAC_EVENT row."
+      "reason": "rbac-audit.ts builds structured audit:rbac_event events for user-management actions, but the audit_log PERSISTENCE path (the writer that stamps action='RBAC_EVENT' onto a row) is gated on #821/#891 and not yet wired. The value is in the closed vocabulary and the viewer can filter on it, so it is currently consumed-but-never-produced \u2014 surfaced here deliberately rather than hidden. Flip to side=ss-console with producerFile once #821 lands the persistence path that writes the literal RBAC_EVENT row."
     },
     "COMPLIANCE_PACKET_EXPORTED": {
       "side": "ss-console",
@@ -285,6 +285,66 @@
       "side": "overlay",
       "overlayProducer": "plugins/hermes-smd-reply (post_tool_call, ADR 0055)",
       "reason": "emitted on the customer Machine when the AgentMail reply send is attempted but errors (HTTP / unreachable / timeout)."
+    },
+    "TOOL_CALL_COMPLETED": {
+      "side": "overlay",
+      "overlayProducer": "plugins/hermes-smd-audit (post_tool_call hook, emit_tool_event)",
+      "reason": "one row per tool invocation on the customer Machine; the highest-volume type on both seats (~69% of pilot rows, live-probed 2026-08-02)."
+    },
+    "LLM_TURN_COMPLETED": {
+      "side": "overlay",
+      "overlayProducer": "plugins/hermes-smd-audit (post_llm_call hook, emit_llm_event)",
+      "reason": "one row per completed agent turn; does not fire on interrupted turns (documented in the overlay's docs/hook-surface.md)."
+    },
+    "WEBHOOK_ROUTED": {
+      "side": "overlay",
+      "overlayProducer": "plugins/hermes-smd-webhook-router (ADR 0021 Stream E)",
+      "reason": "one row per inbound webhook successfully routed to a skill; payload source + event_type in metadata."
+    },
+    "WEBHOOK_SUPPRESSED": {
+      "side": "overlay",
+      "overlayProducer": "webhook_gate.py (suppression audit)",
+      "reason": "one row per suppressed inbound; the suppression stands whether or not the audit write succeeds (gate comment webhook_gate.py:440-443)."
+    },
+    "BROKER_DECISION_ALLOWED": {
+      "side": "overlay",
+      "overlayProducer": "plugins/hermes-smd-trust (workspace broker decision seam)",
+      "reason": "decision row written before mediated-connector grant redemption."
+    },
+    "BROKER_EXECUTED": {
+      "side": "overlay",
+      "overlayProducer": "plugins/hermes-smd-workspace (broker execution seam)",
+      "reason": "execution row paired with broker-signed receipt evidence."
+    },
+    "CONFIG_WRITE": {
+      "side": "overlay",
+      "overlayProducer": "config_applier/applier.py (ADR 0044 WS3)",
+      "reason": "one row per live customer.yaml apply; digests carry old/new config provenance, never content."
+    },
+    "CONFIRM_SEND_DISPATCHED": {
+      "side": "overlay",
+      "overlayProducer": "plugins/hermes-smd-trust (confirm-send seam)",
+      "reason": "emitted when a confirmed external send dispatches."
+    },
+    "CONFIRM_SEND_FAILED": {
+      "side": "overlay",
+      "overlayProducer": "plugins/hermes-smd-trust (confirm-send seam)",
+      "reason": "emitted when a confirmed external send errors."
+    },
+    "SPEC_GATE_TRIGGERED": {
+      "side": "overlay",
+      "overlayProducer": "shared/spec_gate.py (authored-format gate, overlay#207)",
+      "reason": "emitted when output fails the client-authored format spec."
+    },
+    "VOICE_GATE_TRIGGERED": {
+      "side": "overlay",
+      "overlayProducer": "plugins/hermes-smd-trust/voice_gate.py",
+      "reason": "report-only voice-gate signal; distinct from VOICE_GATE_PASSED/NEAR_PASS/FAILED which have no emitter."
+    },
+    "CORRECTION_PROPOSED": {
+      "side": "ss-console",
+      "producerFile": "operator/workspace_broker/corrections.py",
+      "reason": "the workspace broker appends the client-correction capture row directly to the Machine ledger (ss#2091); declared in both vocabularies 2026-08-02 (#2122) so ledger contents are never outside the closed set."
     }
   }
 }

--- a/operator/contracts/overlay-pairs.json
+++ b/operator/contracts/overlay-pairs.json
@@ -13,8 +13,8 @@
     {
       "adapterPath": "operator/adapter/audit_log.py",
       "overlayPath": "plugins/hermes-smd-audit/emit.py",
-      "syncNote": "2026-07-04 #1686 audit hash chain: overlayRef 122ee0a2 -> 7e70b376 (overlay#131 chain schema/export + #132 lint/format; also ships overlay#128-130 interactive metering + gate-clear from the cost-plane wave). emit.py overlaySha256 recomputed (ensure_schema now applies CHAIN_COLUMN_ALTERS). NEW PAIR: workspace_broker/chain.py <-> shared/audit_chain.py, byte-identical twins (canonicalization + verify_chain must never drift between the broker writer and the Machine-side export/verifier).",
-      "sha256": "f125db1ae5ed8c3ad3d7f5e7bb5d3c4c74efba116e1b505fa560061773ca0d3d",
+      "syncNote": "2026-07-04 #1686 audit hash chain: overlayRef 122ee0a2 -> 7e70b376 (overlay#131 chain schema/export + #132 lint/format; also ships overlay#128-130 interactive metering + gate-clear from the cost-plane wave). emit.py overlaySha256 recomputed (ensure_schema now applies CHAIN_COLUMN_ALTERS). NEW PAIR: workspace_broker/chain.py <-> shared/audit_chain.py, byte-identical twins (canonicalization + verify_chain must never drift between the broker writer and the Machine-side export/verifier). 2026-08-02 (#2122 vocabulary reconciliation): 12 live-producer action types added to the adapter-side ACCEPTED_ACTION_TYPES (TOOL_CALL_COMPLETED, LLM_TURN_COMPLETED, WEBHOOK_ROUTED/SUPPRESSED, BROKER_*, CONFIG_WRITE, CONFIRM_SEND_*, SPEC_GATE_TRIGGERED, VOICE_GATE_TRIGGERED, CORRECTION_PROPOSED). Overlay twin (plugins/hermes-smd-audit/schemas.py vocabulary) gains its own additions in overlay#217; overlaySha256 re-records when the pin bumps to include it. The two vocabularies converge on the live-producer set; declared-but-dead overlay-only types (HONCHO_OBSERVATION/PROMOTION/DISMISSAL, CURATOR_*) are intentionally not imported console-side.",
+      "sha256": "6a0f236fe24b7e128c8950c084b54a6c36026710223f1cfdb5b107ff67c8d535",
       "overlaySha256": "b34e74403207f3b61e695f5c9ef25adda5c2a1d5db3e5f903b640efebfbb49f8"
     },
     {

--- a/src/lib/portal/operator/activity-language.ts
+++ b/src/lib/portal/operator/activity-language.ts
@@ -128,6 +128,25 @@ export const SUPPRESSED_ACTIONS: ReadonlySet<string> = new Set([
   'DECOMMISSION_STEP_COMPLETE',
   'DECOMMISSION_STEP_FAILED',
   'DECOMMISSION_FINAL',
+  // 2026-08-02 vocabulary reconciliation (#2122). All twelve start
+  // suppressed: they were invisible before (unknown types render nothing),
+  // and promoting any to a client-visible category requires authored client
+  // copy + a Captain call — a product decision, not a vocabulary side
+  // effect. Candidates for promotion when that call is made:
+  // CONFIRM_SEND_DISPATCHED (a send, sibling of mapped REPLY_SENT) and
+  // CORRECTION_PROPOSED (the client's own correction being recorded).
+  'TOOL_CALL_COMPLETED',
+  'LLM_TURN_COMPLETED',
+  'WEBHOOK_ROUTED',
+  'WEBHOOK_SUPPRESSED',
+  'BROKER_DECISION_ALLOWED',
+  'BROKER_EXECUTED',
+  'CONFIG_WRITE',
+  'CONFIRM_SEND_DISPATCHED',
+  'CONFIRM_SEND_FAILED',
+  'SPEC_GATE_TRIGGERED',
+  'VOICE_GATE_TRIGGERED',
+  'CORRECTION_PROPOSED',
 ])
 
 type SummaryBuilder = (entry: AuditEntry) => string

--- a/src/lib/portal/operator/audit.ts
+++ b/src/lib/portal/operator/audit.ts
@@ -126,6 +126,25 @@ export const AUDIT_ACTION_TYPES = [
   'DECOMMISSION_STEP_COMPLETE',
   'DECOMMISSION_STEP_FAILED',
   'DECOMMISSION_FINAL',
+  // 2026-08-02 vocabulary reconciliation (#2122): live-producer types that
+  // were being written to both seats' ledgers while absent here, so the
+  // ?action= filter silently no-opped on them and the roll-ups could not
+  // name the bulk of the ledger. All start SUPPRESSED in activity-language
+  // (they were already invisible; surfacing any to clients is a product
+  // call with authored copy, not a vocabulary side effect). Mirrors
+  // operator/adapter/audit_log.py — extend both together (parity test).
+  'TOOL_CALL_COMPLETED',
+  'LLM_TURN_COMPLETED',
+  'WEBHOOK_ROUTED',
+  'WEBHOOK_SUPPRESSED',
+  'BROKER_DECISION_ALLOWED',
+  'BROKER_EXECUTED',
+  'CONFIG_WRITE',
+  'CONFIRM_SEND_DISPATCHED',
+  'CONFIRM_SEND_FAILED',
+  'SPEC_GATE_TRIGGERED',
+  'VOICE_GATE_TRIGGERED',
+  'CORRECTION_PROPOSED',
 ] as const
 
 export type AuditActionType = (typeof AUDIT_ACTION_TYPES)[number]
@@ -148,6 +167,11 @@ export const CONSOLE_ACTION_TYPES = [
   'CONNECTOR_RECONSENT_REQUESTED',
   'OUTPUT_SPEC_AUTHORED',
   'OUTPUT_SPEC_REJECTED',
+  // Synthesized by activity-read from operator_entitlement_changes (0097).
+  // Was rendered and categorized but absent from BOTH validation lists, so
+  // ?action=ENTITLEMENT_CHANGED silently no-opped to "show everything"
+  // (#2122 read-side survey, defect 1). Console-plane: no Machine producer.
+  'ENTITLEMENT_CHANGED',
 ] as const
 
 const AUDIT_ACTION_TYPE_SET: ReadonlySet<string> = new Set([


### PR DESCRIPTION
## What

Console half of the #2122 vocabulary reconciliation (overlay half: venturecrane/hermes-smd-overlay#217).

Twelve action types with **live producers and live rows on both seats** were absent from the console vocabulary — including the ledger's dominant types (`TOOL_CALL_COMPLETED` alone is ~69% of pilot rows, live-probed 2026-08-02, `vfy_01KZ1K8DW324M0W84G2WC0G3VC`). Effects fixed:

- `?action=` filters on the missing types silently no-opped to "show everything" (validator drops unknown values, `audit.ts:346`)
- compliance roll-ups keyed on the vocabulary could not name the bulk of the ledger
- `ENTITLEMENT_CHANGED` was rendered + categorized but in NO validation list (read-side survey defect 1) — now in `CONSOLE_ACTION_TYPES` where its synthetic siblings live

## Deliberately no client-visible change

All twelve enter `SUPPRESSED_ACTIONS`: unknown types already rendered nothing, so classification makes the invisibility a **declared decision** instead of a vocabulary accident. The exhaustiveness test now covers them. Promotion candidates needing a Captain call + authored copy (noted in the code): `CONFIRM_SEND_DISPATCHED` (sibling of mapped `REPLY_SENT`) and `CORRECTION_PROPOSED` (the client's own correction being recorded).

## Gates updated consciously

- Producers manifest: +12 entries with named producers (11 overlay, `CORRECTION_PROPOSED` = ss-console broker `workspace_broker/corrections.py`)
- `overlay-pairs.json`: `audit_log.py` hash re-recorded with syncNote pairing to overlay#217; overlaySha256 re-records when the pin bumps

Deliberately NOT imported: overlay-only declared-but-dead types (`HONCHO_OBSERVATION/PROMOTION/DISMISSAL`, `CURATOR_*`) — adding consumed-but-never-produced types is the inert-control class the producers guard exists to prevent.

`npm run verify`: exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WuMUbsiED3zA96MTzikqGi