### PR TITLE
fix(smokeball): a deleted event is no longer read back as live

### DIFF
--- a/operator/connectors/smokeball/smokeball_connector/server.py
+++ b/operator/connectors/smokeball/smokeball_connector/server.py
@@ -610,13 +610,20 @@ def list_events(
     from_: str | None = None,
     to: str | None = None,
     updated_since: str | None = None,
-    exclude_deleted: bool | None = None,
+    exclude_deleted: bool = True,
     limit: int = 500,
     offset: int = 0,
 ) -> Any:
     """List calendar events. ``from_`` / ``to`` bound the window (ISO 8601);
     ``matter_id`` filters to one matter. Used to read back / dedupe the deadlines
     the Operator calendars before writing a new one.
+
+    ``exclude_deleted`` defaults to True because the VENDOR default is false:
+    Smokeball deletion is soft, and an unflagged ``GET /events`` returns
+    tombstones alongside live events (proven live 2026-08-02 — 11 deleted events
+    still listed, vfy_01KZ1PM9AZQFBJCNVVFXS80VNA). A routine reading deleted
+    deadlines as live re-feeds the laundering loop (#2155); pass
+    ``exclude_deleted=False`` only for an audit-style read that wants tombstones.
 
     Each item is enriched with ``matterNumber`` and ``matterCaption`` resolved
     from its own ``matter.id`` (best-effort, bounded) — so a dedupe read compares

--- a/operator/connectors/smokeball/tests/test_calendar_task_folder_writes.py
+++ b/operator/connectors/smokeball/tests/test_calendar_task_folder_writes.py
@@ -122,8 +122,30 @@ def test_list_events_maps_window_params(rec: _Recorder) -> None:
     assert rec.calls[0] == {
         "method": "GET",
         "path": "/events",
-        "params": {"MatterId": "m-9", "From": "2026-07-01", "To": "2026-07-31", "Limit": 500, "Offset": 0},
+        "params": {
+            "MatterId": "m-9",
+            "From": "2026-07-01",
+            "To": "2026-07-31",
+            "ExcludeDeletedEvents": True,
+            "Limit": 500,
+            "Offset": 0,
+        },
     }
+
+
+def test_list_events_excludes_deleted_by_default(rec: _Recorder) -> None:
+    # The VENDOR default is false (spec: "default: false"), which returns
+    # soft-deleted tombstones alongside live events — proven live 2026-08-02
+    # when 11 deleted PROPOSED events were still listed (#2155). The connector
+    # must invert that default so a routine never reads a deleted deadline as
+    # live; tombstones are an explicit opt-in.
+    server.list_events()
+    assert rec.calls[0]["params"]["ExcludeDeletedEvents"] is True
+
+
+def test_list_events_tombstone_read_is_explicit_opt_in(rec: _Recorder) -> None:
+    server.list_events(exclude_deleted=False)
+    assert rec.calls[0]["params"]["ExcludeDeletedEvents"] is False
 
 
 # ---- folders --------------------------------------------------------------


### PR DESCRIPTION
Closes the repo half of #2155 (found executing #2137's Captain-approved cleanup).

## The defect

Smokeball deletion is **soft**, and the vendor's listing default **includes tombstones** (`ExcludeDeletedEvents` — spec says `default: false`). Live proof (vfy_01KZ1PM9AZQFBJCNVVFXS80VNA): after deleting the 11 Operator-computed PROPOSED events, an unflagged `GET /events` still returned all 16; the flagged read returned exactly the surviving 5. Our `list_events` never passed the flag, so **every Operator read of the calendar included deleted events** — the firm deletes a bad deadline, the Operator reads it back as live, the laundering loop (audit §3.4) keeps eating.

## The fix

`list_events` defaults `exclude_deleted=True`; passing `False` is an explicit opt-in for audit-style tombstone reads. Regression tests pin the default and the opt-in.

One behavioral note considered: with tombstones invisible, a routine that 'ensures an event exists' could re-create a firm-deleted event — no such routine exists (post-#2115 the Operator writes no deadline events at all), and 'never read a deleted deadline as live' dominates.

## Tests

Connector suite: 127 passed, 2 skipped (run with the local `operator-connector-sdk`). The runtime AC on #2155 (rebuilt seat's own `list_events` returns 5, not 16) stays open until the next image rebuild — the same rebuild already queued for overlay#214/#215.

Related: #2155, #2137, #2121, docs/audits/operator-output-provenance-2026-07-31.md §3.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HtkYYGzDDBwGZ7qGnuNASB