### PR TITLE
fix(smokeball): add_file accepts plain text, encodes server-side (#2055)

### DIFF
--- a/operator/connectors/smokeball/smokeball_connector/server.py
+++ b/operator/connectors/smokeball/smokeball_connector/server.py
@@ -896,22 +896,46 @@ def create_folder(
 def add_file(
     matter_id: str,
     file_name: str,
-    content_base64: str,
+    *,
+    content_text: str | None = None,
+    content_base64: str | None = None,
     folder_id: str | None = None,
 ) -> Any:
-    """Upload a document to a matter. ``content_base64`` is the file's raw bytes
-    base64-encoded (any file type); ``folder_id`` is optional (root if omitted).
-    Runs Smokeball's two-stage upload (metadata POST -> presigned S3 PUT);
-    materialization is asynchronous, so the file may take a moment to appear in
+    """Upload a document to a matter. Supply the content EXACTLY ONE of two ways:
+
+    - ``content_text`` — **use this for every textual document** (letters,
+      briefs, memos, discovery responses, indexes, .txt/.md/.csv). Pass the
+      document's text verbatim; the connector encodes it UTF-8 server-side.
+    - ``content_base64`` — for genuinely binary files (PDF, DOCX, images) whose
+      base64 came from a tool, never from your own composition.
+
+    **Never hand-encode text to base64.** Model-written base64 fails outright or,
+    worse, decodes to subtly corrupted text — a rehearsal filed a brief reading
+    "REVIEU" with a replacement character where "REVIEW" belonged, and no
+    validity check can catch that class (#2055). ``content_text`` removes the
+    encoding step entirely.
+
+    ``folder_id`` is optional (matter root if omitted). Runs Smokeball's
+    two-stage upload (metadata POST -> presigned S3 PUT); materialization is
+    asynchronous, so the file may take a moment to appear in
     ``get_files_on_matter``. Returns the new ``fileId``.
 
     Classified INTERNAL_WRITE at the overlay: this is the agent saving its own
     work product into the firm's record — the save-back half of the read ->
     work -> save document round-trip — never an external send."""
-    try:
-        data = base64.b64decode(content_base64, validate=True)
-    except (ValueError, TypeError) as exc:
-        raise ValueError(f"content_base64 is not valid base64: {exc}") from exc
+    if (content_text is None) == (content_base64 is None):
+        supplied = "both" if content_text is not None else "neither"
+        raise ValueError(
+            "add_file: supply exactly one of content_text (plain text, encoded "
+            f"server-side) or content_base64 (binary) — got {supplied}"
+        )
+    if content_text is not None:
+        data = content_text.encode("utf-8")
+    else:
+        try:
+            data = base64.b64decode(content_base64, validate=True)
+        except (ValueError, TypeError) as exc:
+            raise ValueError(f"content_base64 is not valid base64: {exc}") from exc
     return _get_client().add_file(matter_id, file_name, data, folder_id=folder_id)
 
 

--- a/operator/connectors/smokeball/tests/test_document_writes.py
+++ b/operator/connectors/smokeball/tests/test_document_writes.py
@@ -103,7 +103,7 @@ def test_server_add_file_rejects_bad_base64(monkeypatch) -> None:
 
     # never reaches the network: bad base64 is refused before the client is built
     with pytest.raises(ValueError, match="base64"):
-        server.add_file("m-1", "x.txt", "not!!base64!!")
+        server.add_file("m-1", "x.txt", content_base64="not!!base64!!")
 
 
 def test_add_file_surfaces_literal_api_error_body() -> None:
@@ -139,6 +139,109 @@ def test_server_add_file_decodes_base64_and_delegates(monkeypatch) -> None:
 
     monkeypatch.setattr(server, "_get_client", lambda: _FakeClient())
     payload = base64.b64encode(b"hello bytes").decode()
-    out = server.add_file("m-2", "note.txt", payload, folder_id="fld-1")
+    out = server.add_file("m-2", "note.txt", content_base64=payload, folder_id="fld-1")
     assert out == {"fileId": "f-1", "uploaded": True}
     assert seen == {"matter_id": "m-2", "file_name": "note.txt", "data": b"hello bytes", "folder_id": "fld-1"}
+
+
+# ---- content_text: the model never encodes bytes (#2055) --------------------
+#
+# The rehearsal failure this closes: model-generated base64 was rejected outright
+# in two runs and, in a third, decoded to silently corrupted text ("REVIEU<?>" for
+# "REVIEW"). A validity check cannot catch that class, so the content must never
+# be model-encoded — the connector encodes text server-side instead.
+
+
+class _RecordingClient:
+    """Captures the bytes handed to the client layer (which is unchanged)."""
+
+    def __init__(self) -> None:
+        self.seen: dict = {}
+
+    def add_file(self, matter_id, file_name, data, *, folder_id=None):
+        self.seen.update(matter_id=matter_id, file_name=file_name, data=data, folder_id=folder_id)
+        return {"fileId": "f-2", "uploaded": True}
+
+
+def test_server_add_file_encodes_content_text_utf8_and_delegates(monkeypatch) -> None:
+    from smokeball_connector import server
+
+    fake = _RecordingClient()
+    monkeypatch.setattr(server, "_get_client", lambda: fake)
+    # non-ASCII on purpose: this is exactly what hand-rolled base64 mangled
+    text = "DRAFT FOR REVIEW\n§ 4.2 — café résumé ✓\n"
+    out = server.add_file("m-3", "brief.txt", content_text=text, folder_id="fld-2")
+
+    assert out == {"fileId": "f-2", "uploaded": True}
+    assert fake.seen["data"] == text.encode("utf-8")
+    # round-trips losslessly: no mojibake survives this path
+    assert fake.seen["data"].decode("utf-8") == text
+    assert fake.seen["matter_id"] == "m-3"
+    assert fake.seen["file_name"] == "brief.txt"
+    assert fake.seen["folder_id"] == "fld-2"
+
+
+def test_server_add_file_content_text_works_without_a_folder(monkeypatch) -> None:
+    from smokeball_connector import server
+
+    fake = _RecordingClient()
+    monkeypatch.setattr(server, "_get_client", lambda: fake)
+    server.add_file("m-3", "note.md", content_text="hello")
+    assert fake.seen["data"] == b"hello"
+    assert fake.seen["folder_id"] is None
+
+
+def test_server_add_file_refuses_both_content_arguments(monkeypatch) -> None:
+    """Fail closed on ambiguity, and BEFORE the client is built — an ambiguous
+    call must never reach the network with a guessed body."""
+    from smokeball_connector import server
+
+    def _boom():
+        raise AssertionError("client must not be built when the call is ambiguous")
+
+    monkeypatch.setattr(server, "_get_client", _boom)
+    with pytest.raises(ValueError, match="exactly one"):
+        server.add_file(
+            "m-1",
+            "x.txt",
+            content_text="hi",
+            content_base64=base64.b64encode(b"hi").decode(),
+        )
+
+
+def test_server_add_file_refuses_neither_content_argument(monkeypatch) -> None:
+    from smokeball_connector import server
+
+    def _boom():
+        raise AssertionError("client must not be built when no content was supplied")
+
+    monkeypatch.setattr(server, "_get_client", _boom)
+    with pytest.raises(ValueError, match="exactly one"):
+        server.add_file("m-1", "x.txt")
+
+
+def test_server_add_file_treats_empty_text_as_supplied(monkeypatch) -> None:
+    """`is None`, not truthiness: an explicitly empty document is a content
+    argument, not a missing one (it must not report as 'neither')."""
+    from smokeball_connector import server
+
+    fake = _RecordingClient()
+    monkeypatch.setattr(server, "_get_client", lambda: fake)
+    server.add_file("m-1", "empty.txt", content_text="")
+    assert fake.seen["data"] == b""
+
+
+def test_add_file_schema_offers_content_text_and_requires_neither_content() -> None:
+    """The model only ever sees the derived inputSchema + description, so the
+    steering has to be THERE: both content params present, neither required
+    (exactly-one-of is not expressible in the derived schema), and the
+    description must name content_text as the path for text."""
+    from smokeball_connector.server import server as srv
+
+    tool = next(t for t in srv.tool_surface() if t.name == "add_file")
+    props = tool.inputSchema["properties"]
+    assert "content_text" in props
+    assert "content_base64" in props
+    assert set(tool.inputSchema.get("required", [])) == {"matter_id", "file_name"}
+    assert "content_text" in (tool.description or "")
+    assert "hand-encode" in (tool.description or "")


### PR DESCRIPTION
Refs #2055. Not closing it — the runtime AC rides the drafting-lane rehearsal.

## Root cause

The 2026-07-29 rehearsal battery lost documents in 3 of 4 drafting runs, and the common cause was that the **model was hand-encoding the document to base64**:

- **R2, R4** — `add_file` rejected the model-generated `content_base64` outright ("not valid base64"). R2 fell back to email-body delivery honestly; R4's brief was delivered **nowhere**.
- **R3** — the upload "succeeded" and filed silently corrupted text (`REVIEU<?>` where `REVIEW` belonged, `DQIAVT 46OR` for `DRAFT FOR`) from a subtly-wrong ~19KB hand-encoding.

R3 is the important one: **a validity check cannot catch that class.** `validate=True` passes on well-formed base64 that decodes to the wrong bytes. The only fix is to remove the model from the encoding path.

## The change

`add_file` now accepts the document's text directly and encodes it server-side. Both content parameters are **keyword-only**, and **exactly one** must be supplied:

| supplied | behavior |
| --- | --- |
| `content_text` | `.encode("utf-8")` server-side, bytes handed to the client |
| `content_base64` | decoded as before (`validate=True`), for genuinely binary files |
| both | `ValueError`, before the client is built |
| neither | `ValueError`, before the client is built |

Keyword-only is deliberate: with two content parameters, a positional third argument could bind a base64 blob to `content_text` and file the base64 *as* the document — the same silent-corruption class this fixes. Forcing keywords makes that impossible.

The docstring is the steering surface (it is what the model sees as the tool description), so it names `content_text` as the path for every textual document and states plainly that base64 must never be hand-written.

Deliberately unchanged:

- **`client.py`** — the presigned two-stage PUT still takes `bytes`. Untouched.
- **Tool name** — so `manifest.toml` (`add_file = "internal_write"`) and the conformance name pins in `test_conformance.py` need no edit.
- Consistent with the existing `file_attachment_to_matter` precedent: bytes never cross the model's context.

## Tests

`operator/connectors/smokeball/tests/test_document_writes.py` — **135 passed** (129 before, 6 new):

- `content_text` encodes UTF-8 and delegates — asserts exact bytes and a lossless round-trip on deliberately non-ASCII text (`§ 4.2 — café résumé ✓`), the input class that got mangled in R3
- `content_text` without a `folder_id`
- both supplied → refused, and `_get_client` is monkeypatched to raise, proving the refusal happens **before** any network path
- neither supplied → refused, same fail-closed proof
- empty `content_text` counts as supplied (`is None`, not truthiness) so an explicitly empty document never reports as "neither"
- the derived `inputSchema` carries both content params, requires only `matter_id`/`file_name`, and the description names `content_text` — this one caught a real defect during development (it failed against a stale build), so it is a check that can fail

Existing base64 coverage (reject-bad-base64, decode-and-delegate) still passes, adjusted to keyword form.

Beyond the suite, the keyword-only signature was probed through the **real MCP call path** (`FastMCP.call_tool` with a JSON argument object, which is how the model calls it) to confirm schema derivation and binding both work: text bound and encoded to correct UTF-8 bytes (`é` → `195,169`, `✓` → `226,156,147`), and both failure modes surfaced the exactly-one-of error to the caller.

`npm run verify` in the worktree: 248 test files / 4011 tests passed, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014xK2DDrPdxcTABvCz88M1j
