### PR TITLE
fix(portal): the audit record is reachable by clicking — Activity joins the one-pager (#2176)

### DIFF
--- a/src/pages/portal/products/operator/[instance]/index.astro
+++ b/src/pages/portal/products/operator/[instance]/index.astro
@@ -308,9 +308,24 @@ const empty = surfaceState !== 'active' ? EMPTY[surfaceState] : null
   {
     surfaceState === 'active' && (
       <>
-        {/* Header row: status label left, the single Settings entry right —
-            Settings is the act surface and never appears in the reading flow. */}
-        <div class="mt-8 flex items-center justify-end gap-4">
+        {/* Header row: status label left, the two standing entries right —
+            Activity (the read surface: every action the operator took, the
+            audit record §4.5 promises is viewable here) and Settings (the act
+            surface). Neither appears in the reading flow below. Activity was
+            orphaned from all navigation until #2176 — the 2026-08-02 dress
+            rehearsal found the principal role could not reach the audit
+            record by clicking; tests/portal-operator-nav.test.ts now guards
+            both links. */}
+        <div class="mt-8 flex items-center justify-end gap-6">
+          <a
+            href={`${operatorBase}/activity`}
+            class="inline-flex min-h-11 items-center gap-2 px-1 font-mono text-label font-semibold uppercase tracking-[0.18em] text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2"
+          >
+            Activity & Audit
+            <span aria-hidden="true" class="font-body font-black text-[color:var(--color-primary)]">
+              →
+            </span>
+          </a>
           <a
             href={`${operatorBase}/settings`}
             class="inline-flex min-h-11 items-center gap-2 px-1 font-mono text-label font-semibold uppercase tracking-[0.18em] text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2"

--- a/tests/portal-operator-nav.test.ts
+++ b/tests/portal-operator-nav.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Nav-reachability guard for the operator instance surfaces (#2176).
+ *
+ * The failure class: a page can exist, be fed by a healthy seam, pass its own
+ * tests — and be reachable by no click. The 2026-08-02 dress rehearsal found
+ * exactly that: the Activity & Audit page (the surface backing the service
+ * agreement's "viewable by the Firm in the portal at any time") was orphaned —
+ * the one-pager linked only Settings, so the principal role could not find
+ * the audit record at all (vfy_01KZ1Z5SQKC0XFZZDFBRWVW4X7).
+ *
+ * This guard pins the two standing entries on the operator one-pager and, in
+ * the other direction, that each linked target's page file actually exists —
+ * a link to a deleted page fails here too, not in a client's browser.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync, existsSync } from 'fs'
+import { resolve } from 'path'
+
+const ONE_PAGER = resolve('src/pages/portal/products/operator/[instance]/index.astro')
+const INSTANCE_DIR = resolve('src/pages/portal/products/operator/[instance]')
+
+const source = readFileSync(ONE_PAGER, 'utf8')
+
+/** The standing outbound entries the one-pager must always carry. */
+const STANDING_LINKS: Array<{ path: string; label: string }> = [
+  { path: 'activity', label: 'Activity & Audit' },
+  { path: 'settings', label: 'Settings' },
+]
+
+describe('operator one-pager standing navigation (#2176)', () => {
+  for (const { path, label } of STANDING_LINKS) {
+    it(`links to ${path} ("${label}")`, () => {
+      // The template-literal href shape the page uses for instance-scoped
+      // links. A refactor to a different shape must update this guard in the
+      // same PR — that is the conscious act the guard exists to force.
+      expect(source).toContain(`href={\`\${operatorBase}/${path}\`}`)
+      expect(source).toContain(label)
+    })
+
+    it(`the ${path} target page exists`, () => {
+      const asDir = resolve(INSTANCE_DIR, path, 'index.astro')
+      const asFile = resolve(INSTANCE_DIR, `${path}.astro`)
+      expect(
+        existsSync(asDir) || existsSync(asFile),
+        `linked target ${path} has no page file — the link would 404`
+      ).toBe(true)
+    })
+  }
+
+  it('guard can fail: a link the page does not carry is not reported present', () => {
+    // FALSE CONTROL (Law 12): the same assertion shape against a path the
+    // one-pager genuinely does not link must fail — otherwise the greens
+    // above measure nothing.
+    expect(source).not.toContain('href={`${operatorBase}/definitely-not-a-page`}')
+  })
+})


### PR DESCRIPTION
Closes #2176.

## What

One nav entry: **Activity & Audit** now stands beside **Settings** in the operator one-pager's header row (`[instance]/index.astro`) — the read surface next to the act surface. Visual treatment is byte-identical to the existing Settings entry (same classes, same arrow affordance): no new hierarchy, no new primary CTA (`docs/style/UI-PATTERNS.md` button-hierarchy pattern respected by adding nothing louder than what exists).

## Why one link is the whole fix

The page existed, the ADR 0043 seam behind it was live-proven healthy this session, its tests were green — and no navigation anywhere reached it. The 2026-08-02 dress rehearsal (Captain, principal role, pilot-smokeball) failed on the first click: "I don't see any audit log in the portal" (`vfy_01KZ1Z5SQKC0XFZZDFBRWVW4X7`). This was the last blocker named in the #2122 client-readiness verdict.

## The guard

`tests/portal-operator-nav.test.ts` pins the standing links in both directions: the one-pager must carry each link, and each linked target's page file must exist (a link to a deleted page fails in CI, not in a client's browser). **Proven able to fail**: run against the pre-fix page it reports exactly the missing Activity link; a false control pins the assertion shape.

## Rehearsal re-run

After merge + deploy: same walk as today — principal role, pilot instance, land on the one-pager, click Activity & Audit, see the feed. That re-run closing clean is what flips the audit log's client-ready verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WuMUbsiED3zA96MTzikqGi