### PR TITLE
fix(portal): the activity feed walks the window, not one slice of it (#2179)

### DIFF
--- a/src/lib/portal/operator/activity-read.ts
+++ b/src/lib/portal/operator/activity-read.ts
@@ -80,20 +80,110 @@ export async function loadActivityPage(
   if (!isRuntimeReadConfigured(deps.env)) {
     return buildAuditListPage(consoleRows, params)
   }
-  const result = await readMachineRuntime(
+  // Walk the Machine ledger across the requested window rather than taking one
+  // slice of it (#2179). The single unpaginated fetch starved the client feed:
+  // the newest page of a working seat is dominated by suppressed telemetry
+  // (tool calls, turns), so the slice could contain zero client-visible events
+  // while dozens sat just behind it — live-proven 2026-08-02 (56 mapped events
+  // in-window, page rendered none, seam ok; vfy_01KZ204YY88HD2VJ2ZXNW85JDV).
+  const machine = await collectMachineWindow(deps, customerSlug, actor, params.from ?? null)
+  // Curated client language only (Captain decision 7): entries without
+  // authored client copy never reach the page, regardless of filters.
+  const clientRows = machine.rows.filter((r) => isClientVisibleAction(r.action))
+  const page = buildAuditListPage([...clientRows, ...consoleRows], params)
+  return { ...page, machineCoverageFloor: machine.coverageFloor }
+}
+
+/** Overlay `shared/runtime_read.py` clamps `limit` to this (MAX_LIMIT). */
+const MACHINE_PAGE_LIMIT = 200
+/** Pages walked per view before declaring a coverage floor: 15 × 200 = 3,000
+ * ledger rows, ~2.5 weeks of the pilot's current volume for a 7-day window.
+ * A budget (not a loop-until-done) bounds page latency against a runaway
+ * seat; exhausting it is surfaced honestly, never silently. */
+const MACHINE_PAGE_BUDGET = 15
+
+/**
+ * Collect Machine-ledger entries newest-first until the window's `from` bound
+ * is passed, the ledger is exhausted, or the page budget runs out.
+ *
+ * The seam (overlay `_read_audit_log`) keyset-paginates `ORDER BY id DESC`
+ * with `WHERE id < cursor`, advertising a next cursor only on a full page —
+ * ULIDs sort by time, so once a page's oldest `ts` precedes `from`, every
+ * later page is older still and the walk stops.
+ *
+ * One LOGICAL read, one read-audit row: the first segment is audited per
+ * ADR 0043 (attempt + outcome); continuation segments of the same walk reuse
+ * a no-op sink rather than writing N rows per page view. A first-segment
+ * failure is already recorded before the fail-closed empty return.
+ *
+ * `coverageFloor` is the oldest ts actually scanned when the budget ran out
+ * with in-window ledger still unread — the page states the floor rather than
+ * letting a truncated walk read as "nothing happened before this".
+ */
+async function collectMachineWindow(
+  deps: ActivityReadDeps,
+  customerSlug: string,
+  actor: RuntimeReadActor,
+  from: string | null
+): Promise<MachineWindow> {
+  return walkMachineWindow(
     {
       transport: createMachineRuntimeTransport(deps.env),
       audit: createRuntimeReadAudit(deps.db, { actorUserId: deps.actorUserId }),
     },
     customerSlug,
-    { kind: 'audit_log' },
-    actor
+    actor,
+    from
   )
-  const rows = result.ok ? parseAuditEntries(result.data) : []
-  // Curated client language only (Captain decision 7): entries without
-  // authored client copy never reach the page, regardless of filters.
-  const clientRows = rows.filter((r) => isClientVisibleAction(r.action))
-  return buildAuditListPage([...clientRows, ...consoleRows], params)
+}
+
+export interface MachineWindow {
+  rows: AuditEntry[]
+  coverageFloor: string | null
+}
+
+/** The injectable core of the windowed walk. Exported for unit testing at the
+ * same transport boundary the runtime-read tests use. */
+export async function walkMachineWindow(
+  deps: Parameters<typeof readMachineRuntime>[0],
+  customerSlug: string,
+  actor: RuntimeReadActor,
+  from: string | null
+): Promise<MachineWindow> {
+  const noopAudit = { record: async () => {} }
+
+  const rows: AuditEntry[] = []
+  let cursor: string | null = null
+  for (let segment = 0; segment < MACHINE_PAGE_BUDGET; segment++) {
+    const result = await readMachineRuntime(
+      { transport: deps.transport, audit: segment === 0 ? deps.audit : noopAudit },
+      customerSlug,
+      { kind: 'audit_log', limit: MACHINE_PAGE_LIMIT, ...(cursor !== null ? { cursor } : {}) },
+      actor
+    )
+    if (!result.ok) return { rows, coverageFloor: null }
+    const parsed = parseAuditEntries(result.data)
+    if (parsed.length === 0) return { rows, coverageFloor: null }
+    rows.push(...parsed)
+
+    const oldest = parsed[parsed.length - 1].ts
+    // ISO timestamps compare lexicographically; a date-only `from` sorts
+    // before any same-day timestamp, so entries ON the from-date survive.
+    if (from !== null && oldest < from) return { rows, coverageFloor: null }
+
+    cursor = nextCursorOf(result.data)
+    if (cursor === null) return { rows, coverageFloor: null }
+  }
+  // Budget exhausted with ledger (and possibly window) still unread.
+  return { rows, coverageFloor: rows.length > 0 ? rows[rows.length - 1].ts : null }
+}
+
+/** The seam envelope's next-page cursor, defensively. Absent/malformed → null
+ * (treated as exhausted — fail toward a shorter honest feed, never a loop). */
+function nextCursorOf(data: unknown): string | null {
+  if (!isRecord(data)) return null
+  const cursor = data['cursor']
+  return typeof cursor === 'string' && cursor.length > 0 ? cursor : null
 }
 
 /**

--- a/src/lib/portal/operator/audit.ts
+++ b/src/lib/portal/operator/audit.ts
@@ -496,7 +496,13 @@ export function applyAuditSort(rows: readonly AuditEntry[], sort: AuditSort): Au
 }
 
 /** Pagination return value. See {@link Page} (pagination.ts). */
-export type AuditListPage = Page<AuditEntry>
+export type AuditListPage = Page<AuditEntry> & {
+  /** Oldest Machine-ledger ts actually scanned when the windowed walk hit its
+   * page budget with in-window ledger still unread (#2179). Absent/null when
+   * the window was fully covered. The page renders a coverage note from it —
+   * a truncated walk must never read as "nothing happened before this". */
+  machineCoverageFloor?: string | null
+}
 
 /**
  * Apply offset-based pagination to a sorted+filtered list. Thin wrapper over

--- a/src/pages/portal/products/operator/[instance]/activity/index.astro
+++ b/src/pages/portal/products/operator/[instance]/activity/index.astro
@@ -4,6 +4,7 @@ import { resolveOperatorAccess } from '../../../../../../lib/portal/operator-acc
 import {
   defaultAuditDateRange,
   distinctAuditSkills,
+  formatAuditTimestamp,
   parseAuditListParams,
 } from '../../../../../../lib/portal/operator/audit'
 import { loadActivityPage } from '../../../../../../lib/portal/operator/activity-read'
@@ -148,6 +149,21 @@ const complianceView =
       sort={resolvedParams.sort}
       availableSkills={availableSkills}
     />
+
+    {
+      /* Coverage floor (#2179): the windowed ledger walk hit its page budget
+         before reaching the window start. State the floor — a truncated walk
+         must never read as "nothing happened before this". */
+      activityPage.machineCoverageFloor && (
+        <p
+          aria-label="Coverage note"
+          class="font-mono text-label uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)]"
+        >
+          Operator events shown back to {formatAuditTimestamp(activityPage.machineCoverageFloor)}.
+          For earlier events in this range, narrow the date filter or request an evidence packet.
+        </p>
+      )
+    }
 
     {
       activityPage.totalCount === 0 ? (

--- a/tests/operator-activity-read.test.ts
+++ b/tests/operator-activity-read.test.ts
@@ -214,3 +214,151 @@ describe('console-plane unions: logins + portal actions', () => {
     expect(page.rows[0].reason).toBeNull()
   })
 })
+
+// ---------------------------------------------------------------------------
+// #2179 — the windowed walk. The starvation reproduction is the centerpiece:
+// a seam whose first page is ALL suppressed telemetry with the client-visible
+// events behind it. The pre-fix single-fetch code fails this by construction
+// (live-proven 2026-08-02: 56 mapped events in-window, page rendered zero,
+// seam ok — vfy_01KZ204YY88HD2VJ2ZXNW85JDV).
+// ---------------------------------------------------------------------------
+
+import { walkMachineWindow } from '../src/lib/portal/operator/activity-read'
+
+/** Build a 200-row full page of suppressed telemetry (TOOL_CALL_COMPLETED). */
+function telemetryPage(idPrefix: string, day: string, cursor: string | null) {
+  const entries = Array.from({ length: 200 }, (_, i) => ({
+    id: `${idPrefix}-${String(i).padStart(3, '0')}`,
+    ts: `${day}T12:00:${String(i % 60).padStart(2, '0')}.000Z`,
+    actor: 'agent',
+    action: 'TOOL_CALL_COMPLETED',
+  }))
+  return { entries, cursor }
+}
+
+/** A transport serving a scripted sequence of audit_log pages. */
+function scriptedTransport(pages: Array<{ entries: unknown[]; cursor: string | null }>) {
+  const calls: Array<{ cursor?: string | null; limit?: number | null }> = []
+  const transport: import('../src/lib/operator/runtime-read').MachineRuntimeTransport = {
+    read: async (_slug, query) => {
+      calls.push({ cursor: query.cursor, limit: query.limit })
+      const page = pages[calls.length - 1]
+      if (!page) return { data: { entries: [], cursor: null } }
+      return { data: page }
+    },
+  }
+  return { calls, transport }
+}
+
+function recordingAudit() {
+  const records: unknown[] = []
+  return { records, audit: { record: async (row: unknown) => void records.push(row) } }
+}
+
+describe('walkMachineWindow (#2179): starvation reproduction', () => {
+  it('reaches client-visible events buried behind a full page of suppressed telemetry', async () => {
+    const buried = {
+      entries: [
+        { id: 'r-1', ts: '2026-07-29T09:00:00.000Z', actor: 'agent', action: 'REPLY_SENT' },
+        { id: 'r-0', ts: '2026-07-29T08:00:00.000Z', actor: 'agent', action: 'REPLY_HELD' },
+      ],
+      cursor: null,
+    }
+    const { transport, calls } = scriptedTransport([
+      telemetryPage('t', '2026-07-30', 't-199'),
+      buried,
+    ])
+    const { audit } = recordingAudit()
+
+    const win = await walkMachineWindow(
+      { transport, audit },
+      'smith-pi',
+      { actor: 'partner@firm.com', actorRole: 'principal' },
+      '2026-07-26'
+    )
+
+    // The buried replies were reached — the single-fetch code never made call 2.
+    expect(calls.length).toBe(2)
+    expect(calls[1].cursor).toBe('t-199')
+    const actions = win.rows.map((r) => r.action)
+    expect(actions).toContain('REPLY_SENT')
+    expect(actions).toContain('REPLY_HELD')
+    expect(win.coverageFloor).toBeNull()
+  })
+
+  it('stops walking once a page passes the window start (no full-history scan)', async () => {
+    const oldPage = {
+      entries: [
+        { id: 'o-1', ts: '2026-07-01T09:00:00.000Z', actor: 'agent', action: 'REPLY_SENT' },
+      ],
+      cursor: 'o-1',
+    }
+    const { transport, calls } = scriptedTransport([
+      telemetryPage('t', '2026-07-30', 't-199'),
+      oldPage,
+      telemetryPage('never', '2026-06-01', null),
+    ])
+    const { audit } = recordingAudit()
+
+    await walkMachineWindow(
+      { transport, audit },
+      'smith-pi',
+      { actor: 'a', actorRole: 'principal' },
+      '2026-07-26'
+    )
+    // Page 2's oldest ts (Jul 1) precedes from (Jul 26) → page 3 never fetched.
+    expect(calls.length).toBe(2)
+  })
+
+  it('declares an honest coverage floor when the page budget exhausts in-window', async () => {
+    // 15-page budget, every page full, all newer than `from`, cursor always present.
+    const pages = Array.from({ length: 16 }, (_, i) =>
+      telemetryPage(
+        `p${String(i).padStart(2, '0')}`,
+        '2026-07-30',
+        `p${String(i).padStart(2, '0')}-199`
+      )
+    )
+    const { transport, calls } = scriptedTransport(pages)
+    const { audit } = recordingAudit()
+
+    const win = await walkMachineWindow(
+      { transport, audit },
+      'smith-pi',
+      { actor: 'a', actorRole: 'principal' },
+      '2026-07-01'
+    )
+    expect(calls.length).toBe(15) // budget, not the 16th page
+    expect(win.coverageFloor).not.toBeNull()
+  })
+
+  it('one logical read = one read-audit row, regardless of segments walked', async () => {
+    const { transport } = scriptedTransport([
+      telemetryPage('t', '2026-07-30', 't-199'),
+      telemetryPage('u', '2026-07-29', 'u-199'),
+      { entries: [], cursor: null },
+    ])
+    const { audit, records } = recordingAudit()
+
+    await walkMachineWindow(
+      { transport, audit },
+      'smith-pi',
+      { actor: 'a', actorRole: 'principal' },
+      '2026-07-01'
+    )
+    expect(records.length).toBe(1)
+  })
+
+  it('FALSE CONTROL: a window whose ledger truly has no visible events stays empty without a floor', async () => {
+    const { transport } = scriptedTransport([telemetryPage('t', '2026-07-30', null)])
+    const { audit } = recordingAudit()
+    const win = await walkMachineWindow(
+      { transport, audit },
+      'smith-pi',
+      { actor: 'a', actorRole: 'principal' },
+      '2026-07-26'
+    )
+    expect(win.rows.every((r) => r.action === 'TOOL_CALL_COMPLETED')).toBe(true)
+    expect(win.coverageFloor).toBeNull()
+  })
+})


### PR DESCRIPTION
Closes #2179.

## The defect, live-proven

One unpaginated Machine fetch, filtered after (`activity-read.ts:89`). A working seat's newest page is dominated by suppressed telemetry, so the pilot rehearsal rendered **7 console rows and zero Machine events** while **56 client-visible events** (43 `REPLY_SENT`, 13 `REPLY_HELD`) sat in the exact window behind 1,113 suppressed rows — with the seam answering `ok` (`vfy_01KZ204YY88HD2VJ2ZXNW85JDV`). A false 'operator did nothing', worse than the #2176 orphaned page because it looks like an answer.

## The fix

`walkMachineWindow`: newest-first cursor walk of the seam (its documented keyset contract) until the window's `from` is passed, the ledger exhausts, or a **15-page budget** (3,000 rows) runs out. ULID ordering makes the stop condition one string compare. **One logical read = one read-audit row** (ADR 0043 posture kept; continuation segments use a no-op sink). Budget exhaustion declares an honest **coverage floor** the page renders ('Operator events shown back to …') — truncation never reads as absence in either direction.

## Tests

Five new, at the injectable transport boundary: the **starvation reproduction** (visible events behind a full suppressed page — fails by construction against the pre-fix code), window-stop (no full-history scan), budget + floor, single-audit-row-per-walk, and a false control (genuinely event-free window → empty, no floor). `npm run verify` exit 0.

## Rehearsal re-run after deploy

Same walk as today: Activity page on pilot-smokeball should now show the reply events from the last 7 days alongside the console rows, and the skill filter should begin populating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WuMUbsiED3zA96MTzikqGi