### PR TITLE
feat(operator): identifier_gate registered ENFORCED + first connect-smokeball.sh tests (#2171 PR C)

### DIFF
--- a/operator/bin/tests/test_connect_smokeball.py
+++ b/operator/bin/tests/test_connect_smokeball.py
@@ -1,0 +1,119 @@
+"""Regression pins for bin/connect-smokeball.sh (ss#2149 / ss#2171 PR C).
+
+The script's two refusal branches were live-proven at merge (#2184:
+vfy_01KZ20HF7AMCCZTT0N49WJVNAR currency-refusal, #2192 rescoped) but carried
+ZERO test coverage — a regression in the seat-currency gate would have gone
+uncaught until the next live connect attempt. These tests pin the gate
+hermetically by stubbing `fly` on PATH; `git show origin/main:...` runs
+against the real repo (CI checkouts carry origin).
+
+What is pinned:
+  * arg validation (usage, slug shape, missing customer.yaml)
+  * currency REFUSAL: seat ref != origin/main pin -> exit 3, "REFUSED"
+  * fail-closed: unreadable seat ref -> exit 3 (a seat whose gateway is down
+    must not receive a token)
+  * currency PASS falls through to the next gate (missing env -> exit 2),
+    proving the gate passes on a matching ref rather than refusing everything
+    (Law 12: the check must be able to pass, or the refusal tests measure
+    nothing).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = REPO_ROOT / "bin" / "connect-smokeball.sh"
+
+# A syntactically-valid 40-hex ref that will never equal a real pin.
+_STALE_REF = "deadbeef" * 5
+
+
+def _origin_main_overlay_ref() -> str:
+    """Read the pin exactly the way the script does."""
+    out = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "show", "origin/main:operator/contracts/overlay-pairs.json"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    return str(json.loads(out)["overlayRef"])
+
+
+def _write_fly_stub(bin_dir: Path, ref_output: str | None) -> None:
+    """A fake `fly` that prints ``ref_output`` for the ssh env probe (or
+    nothing at all when ``ref_output`` is None — the unreadable-seat case)."""
+    stub = bin_dir / "fly"
+    body = "#!/usr/bin/env bash\n"
+    if ref_output is not None:
+        body += f"echo '{ref_output}'\n"
+    body += "exit 0\n"
+    stub.write_text(body)
+    stub.chmod(stub.stat().st_mode | stat.S_IEXEC)
+
+
+def _run(args: list[str], bin_dir: Path | None = None, env_extra: dict | None = None):
+    env = dict(os.environ)
+    # The env gate must see ABSENCE, not inherited operator creds.
+    env.pop("OPERATOR_OAUTH_STATE_MASTER", None)
+    env.pop("SMOKEBALL_STAGING_CLIENT_ID", None)
+    env.pop("SMOKEBALL_PROD_CLIENT_ID", None)
+    if bin_dir is not None:
+        env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    if env_extra:
+        env.update(env_extra)
+    return subprocess.run(
+        ["bash", str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=120,
+    )
+
+
+def test_no_args_is_usage_error() -> None:
+    result = _run([])
+    assert result.returncode == 1
+    assert "Usage" in result.stderr or "usage" in result.stderr.lower()
+
+
+def test_invalid_slug_refused() -> None:
+    result = _run(["Bad_Slug!"])
+    assert result.returncode == 1
+    assert "invalid slug" in result.stderr
+
+
+def test_missing_customer_yaml_refused() -> None:
+    result = _run(["no-such-customer"])
+    assert result.returncode == 1
+    assert "no customer.yaml" in result.stderr
+
+
+def test_stale_seat_is_refused_exit_3(tmp_path: Path) -> None:
+    _write_fly_stub(tmp_path, _STALE_REF)
+    result = _run(["pilot-smokeball"], bin_dir=tmp_path)
+    assert result.returncode == 3, result.stderr
+    assert "REFUSED" in result.stderr
+    assert "reprovision.sh pilot-smokeball" in result.stderr  # remediation printed
+
+
+def test_unreadable_seat_ref_fails_closed_exit_3(tmp_path: Path) -> None:
+    _write_fly_stub(tmp_path, None)  # gateway down / env unreadable
+    result = _run(["pilot-smokeball"], bin_dir=tmp_path)
+    assert result.returncode == 3, result.stderr
+    assert "cannot verify" in result.stderr
+
+
+def test_current_seat_passes_gate_and_stops_at_env_check(tmp_path: Path) -> None:
+    """The pass direction (Law 12): a seat on the pinned ref clears the gate —
+    the run proceeds to the yaml/env stage and fails there on MISSING env
+    (exit 2), never on the currency gate (exit 3)."""
+    _write_fly_stub(tmp_path, _origin_main_overlay_ref())
+    result = _run(["pilot-smokeball"], bin_dir=tmp_path)
+    assert "proceeding" in result.stderr  # the gate's success line
+    assert result.returncode == 2, result.stderr
+    assert "missing required env" in result.stderr

--- a/operator/contracts/runtime-controls.yaml
+++ b/operator/contracts/runtime-controls.yaml
@@ -292,6 +292,49 @@ controls:
       of the feature, a draft delivered IN the declared voice, is still
       unobserved: it needs a spec in the vault, authored through the portal.
 
+  identifier_gate:
+    control: identifier_gate
+    class: dispatch-guard
+    substrate_module: overlay:plugins/hermes-smd-trust/outbound.py
+    wired_via: 'pre_tool_call / hermes-smd-trust'
+    live_probe: seat_probe_refuses_unread_identifier
+    probe_surface: staging
+    status: enforced
+    owner: SMDurgan
+    tracking: '#2171'
+    note: >-
+      The A1 identifier-integrity gate, REFUSING as of overlay#226 (report-only
+      before that — Captain directive 2026-08-02: every seat blocking,
+      pre-live). Block set is every IdKind except NAME, by exclusion; ambient
+      dates (utc today/yesterday) verify against the system clock; the
+      empty-register carve applies to the DRAFT gate only — the SEND gate
+      blocks with an empty register, because an autonomous send composed with
+      nothing read is exactly "cannot verify". Rollback lever:
+      SMD_IDENTIFIER_GATE_MODE=report (operator-only env, consumes.yaml-
+      declared, never client-authorable; unset or garbage = block; rows keep
+      emitting in either mode — telemetry continuity). Rollback runbook:
+      `fly secrets set SMD_IDENTIFIER_GATE_MODE=report -a hermes-<slug>` +
+      restart (minutes) vs pin revert + reprovision (slow path). ENFORCED,
+      manual-observed 2026-08-09 on BOTH product seats at
+      SMD_OVERLAY_REF=ba6d116a: pilot-smokeball
+      (vfy_01KZMK0Q0EHQ0M6AJQ8VBA795G) — fabricated A-number draft BLOCKED
+      with the re-read refusal message, read-then-draft same identifier
+      ALLOWED, env=report downgrade ALLOWED, send-gate-with-empty-register
+      BLOCKED, and audit-failure-never-rescinds observed live (the broker
+      refused the probe's non-gateway append; the block stood);
+      smd-staging (vfy_01KZMR2MFRD51AV5MPA90A4YSR) — fabricate BLOCKED /
+      pass-direction ALLOWED on the same pin. READ THE PROBE'S LIMITS: MANUAL
+      probes drove the deployed plugin in the gateway env via seat-probe, so
+      they prove the deployed code's decision at the seam, not that a
+      regression would be caught (no boot gate), and the probe rows did not
+      land in audit_log (broker provenance control — correct); organic
+      gateway turns emit rows normally, with the new mode/blocked/
+      block_bypass/date_distance metadata. Pre-flip blast radius
+      (vfy_01KZKXFSC72HNT48EJD6MJAYDX): 40/40 post-extraction-fix rows were
+      DATE-kind cron memo composition — the audited fabrication class, not an
+      FP class. FP watch: date_distance buckets + block_bypass make the
+      carve and the DATE class measurable post-flip.
+
   taint_gate:
     control: taint_gate
     class: dispatch-guard


### PR DESCRIPTION
The bookkeeping that closes #2171's product half, now that the flip is live-proven on both product seats at ba6d116a.

## What ships

1. **`runtime-controls.yaml` gains `identifier_gate: enforced`** (MANUAL-OBSERVED) citing the live proofs:
   - pilot-smokeball `vfy_01KZMK0Q0EHQ0M6AJQ8VBA795G` — fabricated A-number → BLOCK with the re-read refusal; read-then-draft → allowed; `SMD_IDENTIFIER_GATE_MODE=report` → allowed; send-gate with empty register → BLOCK; audit-failure-never-rescinds observed live (broker refused the probe's non-gateway append, the block stood — the provenance control and the never-rescind path proving each other).
   - smd-staging `vfy_01KZMR2MFRD51AV5MPA90A4YSR` — fabricate BLOCK / pass ALLOW on the same pin.
   - Entry states the probe's limits per the registry's honesty convention (manual = fired once, no boot gate) and carries the rollback runbook line.
2. **First-ever regression tests for `bin/connect-smokeball.sh`** (`operator/bin/tests/test_connect_smokeball.py`, 6 pass): usage/slug/missing-yaml, stale-seat REFUSED exit 3, unreadable-ref fail-closed exit 3, and the Law-12 pass direction (matching ref clears the gate, run stops at the env check exit 2). The gate's refusal branches previously had zero coverage.

## Evidence

`npm run verify` exit 0; operator `bin/tests` 265 pass. Blast radius pre-flip: `vfy_01KZKXFSC72HNT48EJD6MJAYDX`.

Closes the product-side gate chain of #2171 (A&P-specific rows are the client-implementation effort per the 2026-08-09 scope split).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jh5riRHbD7PbW4cyybVzyn