### PR TITLE
A&P bring-up alert routing: central to Christa + Scott (pre-token gate)

### DIFF
--- a/operator/customers/ashton-price/customer.yaml
+++ b/operator/customers/ashton-price/customer.yaml
@@ -681,26 +681,34 @@ business_hours:
   end: '18:00'
 
 escalation:
-  # red_flag_recipients is the CENTRAL case-alert list — under matter_staff
-  # routing (below) it is no longer the delivery target for case-level alerts;
-  # it remains the pre-connect placeholder and the central-mode target.
+  # red_flag_recipients is the CENTRAL case-alert list — the delivery target
+  # while case_alert_routing.mode is central (below).
+  # Bring-up composition (Captain, 2026-08-09): everything goes to Christa AND
+  # Scott — Christa so the firm sees and judges real output from day one, Scott
+  # so SMD sees exactly what she's seeing. Routing to SMD only was explicitly
+  # rejected ("how would we know if it is correct?").
   red_flag_recipients:
+    - christa@ashtonandprice.com
     - scott@smd.services
   # System/technical failures stay with SMD (correspondence 10: "System and
   # technical monitoring stays with us").
   failure_recipients:
     - scott@smd.services
-  # Christa's routing requirement (correspondence 09, 2026-07-23; committed in
-  # 10): case-level alerts (verification stalls, deadline flags, drafts
-  # awaiting review) route per matter to the attorney/paralegal assigned in
-  # Smokeball — never a central inbox on the firm's side. Resolution + fallback
-  # algorithm: operator/skills/deadline-miss-escalator/references/case-alert-routing.md.
+  # BRING-UP POSTURE (Captain, 2026-08-09): central routing during stand-up so
+  # no alert reaches any firm staff beyond Christa until the firm says widen.
+  # Christa's per-matter routing requirement (correspondence 09, 2026-07-23;
+  # committed in 10 — case-level alerts route per matter to the assigned
+  # attorney/paralegal, never a central firm inbox) is the GRADUATION target:
+  # flip mode back to matter_staff on the firm's "turn it up", per the
+  # 2026-07-29 call agreement that alerts start with Chris + Christa only.
+  # Resolution + fallback algorithm (matter_staff mode):
+  # operator/skills/deadline-miss-escalator/references/case-alert-routing.md.
   # fallback_recipients is DELIBERATELY unauthored: who receives an alert when
   # a matter has no usable assignment is the firm's call (working-session
   # input, firm-input register); until authored, resolution failure HOLDS the
   # alert fail-closed and flags the matter in place. Never invented.
   case_alert_routing:
-    mode: matter_staff
+    mode: central
 
 # ---- VOICE LIBRARY ----
 # Empty until the firm's voice is read in place from documents they point at

--- a/tests/customer-commitments.test.ts
+++ b/tests/customer-commitments.test.ts
@@ -338,14 +338,25 @@ describe('pilot-smokeball commitments contract (ADR 0075)', () => {
     expect({ ...authoredCeiling }).toEqual(derived)
   })
 
-  // (g) Per-matter alert routing (#2004, correspondence 09): case-level alerts
-  // route to the matter's assigned attorney/paralegal — never a central inbox
-  // on the firm's side. The seat must author matter_staff routing, must NOT
-  // author a fallback (who receives an unassigned matter's alert is the firm's
-  // working-session call; until then resolution failure holds fail-closed),
-  // and must author external_send_internal so the routed delivery is not
-  // refused at the gate.
-  it('(g) ashton-price authors matter_staff routing, no invented fallback, and internal-send delivery', () => {
+  // (g) Case-alert routing. Two authored postures, both commitment-backed:
+  //
+  // BRING-UP (current, Captain 2026-08-09): central routing to exactly
+  // Christa + Scott — the firm sees and judges real output from day one
+  // (Christa), SMD sees exactly what she's seeing (Scott), and nothing reaches
+  // any other firm staff until the firm says widen. This narrows, and is
+  // consistent with, the 2026-07-29 call agreement that alerts start with
+  // Chris + Christa only ("least disruptive").
+  //
+  // GRADUATION TARGET (#2004, correspondence 09, committed in 10): case-level
+  // alerts route per matter to the assigned attorney/paralegal — never a
+  // central firm inbox. When the firm says turn it up, mode flips back to
+  // matter_staff and this test's pins move with it in the same PR.
+  //
+  // Constant across both: no invented fallback (who receives an unassigned
+  // matter's alert is the firm's call; until authored, resolution failure
+  // holds fail-closed), and external_send_internal authored autonomous so the
+  // routed delivery is not refused at the gate.
+  it('(g) ashton-price authors bring-up central routing (Christa + Scott), no invented fallback, and internal-send delivery', () => {
     const raw = parseYaml(readFileSync(join(AP_DIR, 'customer.yaml'), 'utf-8')) as Record<
       string,
       unknown
@@ -357,9 +368,19 @@ describe('pilot-smokeball commitments contract (ADR 0075)', () => {
       )
     }
     const routing = result.value.escalation.case_alert_routing
-    expect(routing?.mode, 'case_alert_routing.mode must be matter_staff (correspondence 09)').toBe(
-      'matter_staff'
-    )
+    expect(
+      routing?.mode,
+      'case_alert_routing.mode must be central during bring-up (Captain 2026-08-09); matter_staff is the graduation target'
+    ).toBe('central')
+    // The client address is derived from the seat's own authored roster (the
+    // staff-role user), never hardcoded here — the client-identity gate bans
+    // the literal domain outside customer.yaml.
+    const staffUser = result.value.users.find((u) => u.role === 'staff')
+    expect(staffUser, 'the seat must author a staff-role user (Christa)').toBeTruthy()
+    expect(
+      result.value.escalation.red_flag_recipients,
+      "bring-up central list is exactly the staff-role user + Scott (Captain 2026-08-09) — widening is the firm's call"
+    ).toEqual([staffUser!.email, 'scott@smd.services'])
     expect(
       routing?.fallback_recipients,
       'fallback_recipients must stay unauthored until the firm names one (working-session input)'


### PR DESCRIPTION
Captain direction 2026-08-09 (stand-up planning session): during bring-up, all case-alert output goes to Christa AND Scott — never SMD-only ("how would we know if it is correct?"), never scattered to firm staff before the firm says widen.

## What changes

- `operator/customers/ashton-price/customer.yaml`: `case_alert_routing.mode` matter_staff → **central**; `red_flag_recipients` = Christa + scott@smd.services. Config comments record the direction and keep matter_staff (correspondence 09/10 commitment) as the graduation target.
- `tests/customer-commitments.test.ts` gate (g): re-pinned to the bring-up posture (mode central, exact two-recipient list, derived from the seat roster — the client-identity gate bans the literal domain in tests). Fallback-unauthored and external_send_internal pins unchanged.

## Why now

Without this, the moment the firm's Smokeball consent lands, 12 armed cron routines route per-matter alerts to whatever attorney/paralegal Smokeball names — before any tuning. This must merge BEFORE the ashton-price rebuild so one rebuild carries both.

`npm run verify` exit 0 (4079 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLzzpTuYY8j3EaWbXfxz4x