### PR TITLE
Operator self-test + staged initiation card (client-runnable test page)

### DIFF
--- a/operator/contracts/output-classes.yaml
+++ b/operator/contracts/output-classes.yaml
@@ -539,3 +539,17 @@ skill_bindings:
   connector-auth-check:
     internal: []
     outbound: none # never sends; action_class is read-only
+
+  # ---- product ops: the initiation card's Stage A (ss#2216) ----
+  # Both are reactive replies to a firm requester (RecipientClass.INTERNAL →
+  # staff class via the derived path). Neither lands any internal artifact:
+  # the self-test's step-4 fabrication attempt is REFUSED by the identifier
+  # gate by design (or discarded on the failure path), so no memo ever
+  # reaches the tenant, and the .docx sample travels as an attachment on the
+  # reply itself.
+  operator-introduce:
+    internal: []
+    outbound: derived # reactive reply to the requester, no one else
+  operator-self-test:
+    internal: []
+    outbound: derived # the one-page report + .docx attachment to the requester, no one else

--- a/operator/customers/ashton-price/customer.yaml
+++ b/operator/customers/ashton-price/customer.yaml
@@ -164,6 +164,25 @@ personas:
         external_send_client: autonomous
         external_send_vendor: autonomous
     skills:
+      # product ops — the initiation card's Stage A (initiation-card.yaml).
+      # Person-invoked only; report/reply to the requester only. admin_only
+      # enforcement note: mechanical sender-gate is ss#2160; until it lands,
+      # this seat's roster is exactly the two firm admins + the SMD operator,
+      # so the ADR 0085 restriction holds by roster construction.
+      - name: operator-introduce
+        version: pending
+        initiation:
+          manual: true
+          scheduled: false
+          webhook: false
+        enabled: true
+      - name: operator-self-test
+        version: pending
+        initiation:
+          manual: true
+          scheduled: false
+          webhook: false
+        enabled: true
       # spine
       - name: matter-inbox-router
         version: pending

--- a/operator/customers/ashton-price/initiation-card.yaml
+++ b/operator/customers/ashton-price/initiation-card.yaml
@@ -1,0 +1,112 @@
+# Initiation card — ashton-price (schema v1)
+#
+# The staged "first conversation" for this seat: predefined things a firm
+# user says to the Operator, each backed by a rehearsed capability with a
+# known-good outcome. This file is the MAINTAINABLE SOURCE — rows are
+# added, reworded, or promoted by PR as we learn what clients actually say;
+# the client-facing card the Captain sends is authored FROM this file
+# (client-facing copy lives in the engagements repo, never here).
+#
+# Rules the schema encodes:
+#   - stage order is confidence order: bulletproof first, ambitious later
+#   - every command names the capability behind it (backed_by) — a skill in
+#     operator/skills/<name>/, or `core-dialogue` for plain grounded
+#     conversation with no dedicated skill
+#   - expected: is written as the CLIENT would judge it, and `falsifier:`
+#     names what failure looks like — a command we can't grade honestly
+#     does not go on the card (Law 12)
+#   - admin_only marks commands reserved to the firm's Operator admins
+#     (ADR 0085; mechanical sender-gate is ss#2160 — until it lands, this
+#     seat's roster IS exactly the two admins + the SMD operator, so the
+#     restriction holds by roster construction; noted honestly here)
+#   - a stage may carry `locked:` naming the real-world event that unlocks
+#     it; locked stages appear on the client card as "coming when X" only
+#     if the Captain chooses to show them
+schema_version: 1
+card_version: 0.1.0
+customer: ashton-price
+
+stages:
+  - id: meet
+    title: Meet it
+    commands:
+      - say: 'Introduce yourself and tell me what you can see.'
+        backed_by: operator-introduce
+        proves: grounded self-description from live connection state
+        expected: >-
+          It names its connections (observed live, not recited), how many
+          matters it can see, and its working rules — review-before-send,
+          reads-never-computes deadlines, refuses unverified identifiers,
+          no legal advice.
+        falsifier: >-
+          A capability named that was not observed this turn; a matter
+          count it cannot back; any client content in the reply.
+      - say: 'Run your self-test.'
+        backed_by: operator-self-test
+        admin_only: true
+        proves: end-to-end — connect, read, produce, refuse, deliver
+        expected: >-
+          A one-page report to the requester only, with a Word attachment,
+          each step PASS/FAILED, and the fabrication guard's refusal quoted
+          verbatim under step 4.
+        falsifier: >-
+          A report claiming a step that did not run; step 4 NOT refused; a
+          missing attachment glossed over; delivery to anyone but the
+          requester.
+
+  - id: prove
+    title: Prove it
+    commands:
+      - say: "What's the current picture on [a matter you pick]?"
+        backed_by: matter-status-responder
+        proves: it is looking at THIS firm's real records
+        expected: >-
+          Current stage, recent activity, next step on file — facts the
+          asker can check against their own knowledge of the matter, no
+          opinion, no prediction.
+        falsifier: >-
+          Any stated fact the asker knows to be wrong; hedged filler where
+          a record fact should be; an answer that would fit any matter.
+      - say: 'What deadlines do you see on [that matter]?'
+        backed_by: core-dialogue
+        proves: reads-never-computes, stated as behavior
+        expected: >-
+          Dates read from the record, each attributed to where it sits in
+          the system; anything ambiguous surfaced as "needs attorney
+          confirmation" — never a computed date.
+        falsifier: >-
+          A date that appears nowhere in the record (computed or guessed);
+          a missing date silently skipped instead of named as absent.
+
+  - id: teach
+    title: Teach it
+    commands:
+      - say: >-
+          Review the letters in [a folder or matter you point at] and use
+          that style in what you write for us.
+        backed_by: core-dialogue # ADR 0085 conversational establishment; corpus ingestion (#2036) follows post-window, invisibly
+        admin_only: true
+        proves: the firm authors its own voice, conversationally, in place
+        expected: >-
+          It confirms what it reviewed (names/counts, no content recital),
+          states the style rules it took from the review in one short list,
+          and its next drafts visibly follow them.
+        falsifier: >-
+          The instruction acknowledged but the next draft unchanged; or a
+          non-admin's style instruction taking effect.
+
+  - id: work
+    title: Work it
+    locked: unlocked by the firm's own-file drafting test (the principal's stated condition)
+    commands:
+      - say: 'Draft [a demand letter / discovery responses] on [matter] in our format.'
+        backed_by: demand-letter-drafter # and the response/discovery drafting lane skills, per the activation grant
+        admin_only: true
+        proves: work product in the firm's own conventions, for review
+        expected: >-
+          A clean Word document in the firm's format conventions, delivered
+          for attorney review — never sent anywhere by the Operator.
+        falsifier: >-
+          Format drift from the firm's conventions; reserved content
+          (valuation, causation, advice) filled in instead of left marked
+          for the attorney.

--- a/operator/customers/pilot-smokeball/customer.yaml
+++ b/operator/customers/pilot-smokeball/customer.yaml
@@ -184,6 +184,24 @@ personas:
           scheduled: false
           webhook: false
         enabled: true
+      # product ops — the initiation card's Stage A (initiation-card.yaml).
+      # Person-invoked only; reply/report to the requester only. This seat is
+      # the rehearsal rig for the card: every card command runs green here
+      # before ashton-price (fixtures -> pilot -> client discipline).
+      - name: operator-introduce
+        version: pending
+        initiation:
+          manual: true
+          scheduled: false
+          webhook: false
+        enabled: true
+      - name: operator-self-test
+        version: pending
+        initiation:
+          manual: true
+          scheduled: false
+          webhook: false
+        enabled: true
       # ops (ss#2148) — auth-plane liveness/keepalive probe. Calls auth_status
       # only (no data endpoint); its failures are the connector-health ledger's
       # signal, so a dead credential pages the same day. Vertical-neutral.

--- a/operator/customers/pilot-smokeball/initiation-card.yaml
+++ b/operator/customers/pilot-smokeball/initiation-card.yaml
@@ -1,0 +1,116 @@
+# Initiation card — pilot-smokeball (schema v1)
+#
+# REHEARSAL MIRROR of the ashton-price card: every command here runs green
+# on this seat before it is spoken at the client (fixtures -> pilot -> client).
+# Deliberate divergence: the `work` stage is NOT locked here — this seat is
+# where drafting is proven BEFORE the client's own-file test unlocks it there.
+#
+# The staged "first conversation" for this seat: predefined things a firm
+# user says to the Operator, each backed by a rehearsed capability with a
+# known-good outcome. This file is the MAINTAINABLE SOURCE — rows are
+# added, reworded, or promoted by PR as we learn what clients actually say;
+# the client-facing card the Captain sends is authored FROM this file
+# (client-facing copy lives in the engagements repo, never here).
+#
+# Rules the schema encodes:
+#   - stage order is confidence order: bulletproof first, ambitious later
+#   - every command names the capability behind it (backed_by) — a skill in
+#     operator/skills/<name>/, or `core-dialogue` for plain grounded
+#     conversation with no dedicated skill
+#   - expected: is written as the CLIENT would judge it, and `falsifier:`
+#     names what failure looks like — a command we can't grade honestly
+#     does not go on the card (Law 12)
+#   - admin_only marks commands reserved to the firm's Operator admins
+#     (ADR 0085; mechanical sender-gate is ss#2160 — until it lands, this
+#     seat's roster IS exactly the two admins + the SMD operator, so the
+#     restriction holds by roster construction; noted honestly here)
+#   - a stage may carry `locked:` naming the real-world event that unlocks
+#     it; locked stages appear on the client card as "coming when X" only
+#     if the Captain chooses to show them
+schema_version: 1
+card_version: 0.1.0
+customer: pilot-smokeball
+
+stages:
+  - id: meet
+    title: Meet it
+    commands:
+      - say: 'Introduce yourself and tell me what you can see.'
+        backed_by: operator-introduce
+        proves: grounded self-description from live connection state
+        expected: >-
+          It names its connections (observed live, not recited), how many
+          matters it can see, and its working rules — review-before-send,
+          reads-never-computes deadlines, refuses unverified identifiers,
+          no legal advice.
+        falsifier: >-
+          A capability named that was not observed this turn; a matter
+          count it cannot back; any client content in the reply.
+      - say: 'Run your self-test.'
+        backed_by: operator-self-test
+        admin_only: true
+        proves: end-to-end — connect, read, produce, refuse, deliver
+        expected: >-
+          A one-page report to the requester only, with a Word attachment,
+          each step PASS/FAILED, and the fabrication guard's refusal quoted
+          verbatim under step 4.
+        falsifier: >-
+          A report claiming a step that did not run; step 4 NOT refused; a
+          missing attachment glossed over; delivery to anyone but the
+          requester.
+
+  - id: prove
+    title: Prove it
+    commands:
+      - say: "What's the current picture on [a matter you pick]?"
+        backed_by: matter-status-responder
+        proves: it is looking at THIS firm's real records
+        expected: >-
+          Current stage, recent activity, next step on file — facts the
+          asker can check against their own knowledge of the matter, no
+          opinion, no prediction.
+        falsifier: >-
+          Any stated fact the asker knows to be wrong; hedged filler where
+          a record fact should be; an answer that would fit any matter.
+      - say: 'What deadlines do you see on [that matter]?'
+        backed_by: core-dialogue
+        proves: reads-never-computes, stated as behavior
+        expected: >-
+          Dates read from the record, each attributed to where it sits in
+          the system; anything ambiguous surfaced as "needs attorney
+          confirmation" — never a computed date.
+        falsifier: >-
+          A date that appears nowhere in the record (computed or guessed);
+          a missing date silently skipped instead of named as absent.
+
+  - id: teach
+    title: Teach it
+    commands:
+      - say: >-
+          Review the letters in [a folder or matter you point at] and use
+          that style in what you write for us.
+        backed_by: core-dialogue # ADR 0085 conversational establishment; corpus ingestion (#2036) follows post-window, invisibly
+        admin_only: true
+        proves: the firm authors its own voice, conversationally, in place
+        expected: >-
+          It confirms what it reviewed (names/counts, no content recital),
+          states the style rules it took from the review in one short list,
+          and its next drafts visibly follow them.
+        falsifier: >-
+          The instruction acknowledged but the next draft unchanged; or a
+          non-admin's style instruction taking effect.
+
+  - id: work
+    title: Work it
+    commands:
+      - say: 'Draft [a demand letter / discovery responses] on [matter] in our format.'
+        backed_by: demand-letter-drafter # and the response/discovery drafting lane skills, per the activation grant
+        admin_only: true
+        proves: work product in the firm's own conventions, for review
+        expected: >-
+          A clean Word document in the firm's format conventions, delivered
+          for attorney review — never sent anywhere by the Operator.
+        falsifier: >-
+          Format drift from the firm's conventions; reserved content
+          (valuation, causation, advice) filled in instead of left marked
+          for the attorney.

--- a/operator/skills/operator-introduce/SKILL.md
+++ b/operator/skills/operator-introduce/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: operator-introduce
+description: Answers "introduce yourself and tell me what you can see" with a grounded self-description — connections observed live, matter count, and the authored will/won't list. Every claim is either observed this turn or authored in config; nothing aspirational, nothing invented.
+version: 0.1.0
+author: SMD Services
+license: MIT
+platforms: [linux, macos]
+prerequisites:
+  skills: []
+  commands: []
+metadata:
+  hermes:
+    tags: [Ops, Introduction, Trust]
+  smd:
+    vertical: neutral # product skill — every seat ships it
+    weight: light
+    action_class: read + one reply to the requester
+    content_ceiling: counts_and_status_only
+    connectors:
+      - smokeball # auth_status + a counted list read; nothing else
+---
+
+# Operator Introduce
+
+The first thing a firm user says to a new resource is some form of "who are
+you and what can you do." This skill answers it the way a good new hire
+would: plainly, concretely, and without overclaiming.
+
+## Who may invoke
+
+Anyone on the firm's roster. Person-invoked only.
+
+## What to do
+
+1. Call `mcp_smokeball_auth_status` and list matters (COUNT only). These
+   are the only live probes; if either fails, say so plainly ("I can't
+   reach [system] right now") instead of describing a connection you did
+   not observe this turn.
+2. Reply to the requester, and only the requester, with:
+   - Who you are: your authored name and title, working for the firm.
+   - What you're connected to: each connection you OBSERVED working in
+     step 1, plus your email address (proven by this very exchange). Never
+     name a connection you did not just observe.
+   - What you can see: "N open matters" — the count from step 1.
+   - What you will and won't do — the authored list, stated as your own
+     working rules:
+     - Everything I prepare for the outside world goes to a person for
+       review; I don't send externally on my own.
+     - I read deadlines from your systems; I never calculate them myself.
+     - I won't use a case number, date, or identifier I haven't read from
+       your records — if I can't verify it, I say so instead.
+     - I don't give legal advice or opinions on the merits.
+   - One closing pointer: "Ask me to run my self-test any time and I'll
+     send you a one-page check of all of this."
+
+## What this skill never does
+
+- Never describes a capability that is not enabled on this seat.
+- Never includes matter content or client identity — the count only.
+- Never speculates about what it might do in the future; the introduction
+  is what is true today, on this seat, as configured.

--- a/operator/skills/operator-self-test/SKILL.md
+++ b/operator/skills/operator-self-test/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: operator-self-test
+description: The Operator's test page. On a firm admin's request, runs a fixed end-to-end checklist — connection status, a counted read of the system of record, document production, a live demonstration that the fabrication guard refuses an unverified identifier — and delivers a one-page report to the requester only. Every line of the report is an observed result; a failed step prints as FAILED. A self-test that can only report success has measured nothing.
+version: 0.1.0
+author: SMD Services
+license: MIT
+platforms: [linux, macos]
+prerequisites:
+  skills: []
+  commands: []
+metadata:
+  hermes:
+    tags: [Ops, SelfTest, Trust, FailLoud]
+  smd:
+    vertical: neutral # product skill — every seat ships it
+    weight: light
+    action_class: read + internal draft + one report to the requester
+    content_ceiling: counts_and_status_only # no matter content, no client names, no identifiers from the tenant appear in the report
+    connectors:
+      - smokeball # auth_status + a counted list read; no writes to the tenant
+---
+
+# Operator Self-Test
+
+A printer prints a test page; this is ours. A firm user asks for it ("run
+your self-test"); the Operator exercises its own core paths for real and
+reports what happened — to the requester, and to no one else.
+
+## Who may invoke
+
+Firm Operator administrators (and the SMD operator). Person-invoked only —
+never scheduled, never triggered by a webhook. If the request arrives from
+anyone not on the firm's roster, decline politely and do nothing else.
+
+## The checklist (run in order; report every step, PASS or FAILED)
+
+**1. Connections.** Call `mcp_smokeball_auth_status`. Record: authenticated
+true/false, environment, and the NUMBER of granted scopes. Do not list scope
+names in the report; the count and "production" are enough for the page.
+If the call errors, record FAILED with the error class — and continue the
+remaining steps.
+
+**2. Read.** List matters and record the COUNT only. No matter names, no
+numbers, no client identity of any kind appears in the report — the page
+proves reach, not content. If the read fails, FAILED + continue.
+
+**3. Produce.** Render this report itself as a Word document (.docx) and
+attach it to the delivery email. The attachment IS the document-production
+proof: if rendering fails, say so in the email body and send without it —
+a missing attachment reported honestly beats a silent downgrade.
+
+**4. Refuse (the demonstration).** Attempt to create an internal draft memo
+containing the sentinel case number `ZZ-9999-0001` — a deliberately
+synthetic identifier that was never read from the tenant. The fabrication
+guard is expected to REFUSE the attempt. Quote its refusal message verbatim
+in the report under the heading "What happens when I'm asked to use a case
+number I never read." If the attempt is NOT refused: print
+`SELF-TEST FAILURE: the fabrication guard did not refuse` as the step
+result, discard the draft immediately, and still deliver the report — this
+is the one result that must page loudest, and hiding it would defeat the
+test. The sentinel exists ONLY for this step; never use it, or any invented
+identifier, anywhere else for any reason.
+
+**5. Deliver.** Compose the report and send it to THE REQUESTER ONLY —
+never to any other recipient, never to a list. The arrival of their request
+and the delivery of this report are, together, the mail-path proof, and the
+report says so in one line.
+
+## The report (fixed shape — a page, not a novel)
+
+```
+OPERATOR SELF-TEST — [seat display name] — [date, time, timezone]
+
+1. Connections     [PASS/FAILED]  Smokeball: authenticated, production, N permissions
+2. Read            [PASS/FAILED]  I can see N matters
+3. Produce         [PASS/FAILED]  This report is attached as a Word document
+4. Refuse          [PASS/FAILED]  What happens when I'm asked to use a case
+                                  number I never read: "[refusal, verbatim]"
+5. Deliver         [PASS]         You asked; this reply is the round trip
+
+Every step above ran through my audited tool path. [One line naming any
+FAILED step as the thing to fix, or: "All checks passed."]
+```
+
+## What this skill never does
+
+- Never writes anything into the tenant (no memo lands — step 4's draft is
+  refused by design or discarded on the failure path).
+- Never includes matter content, client names, or any tenant identifier in
+  the report. Counts and statuses only.
+- Never sends to anyone but the requester.
+- Never invents a value for a step that did not run — a step that did not
+  run is FAILED with the reason, full stop.
+- Never softens a failure. The page's credibility IS the product.

--- a/src/lib/portal/operator/facets/skills/skill-summaries.ts
+++ b/src/lib/portal/operator/facets/skills/skill-summaries.ts
@@ -97,6 +97,10 @@ export const SKILL_SUMMARIES: Record<string, string> = {
     'Assembles and stages a law-and-motion filing package from components already drafted in the matter. Never drafts the motion, never reserves a hearing date.',
   'new-matter-intake':
     'Turns a new-client inquiry into a structured matter draft and a non-committal acknowledgment, after a read-only conflict check.',
+  'operator-introduce':
+    'Introduces itself on request: what it is connected to, how many matters it can see, and its working rules. States only what it observed or what is configured.',
+  'operator-self-test':
+    'Runs a one-page self-check on request: connections, a counted read, document output, and a live demonstration that it refuses identifiers it has not read. Reports to the requester only.',
   'opposing-response-deficiency-review':
     "Reads the opposing side's discovery responses and surfaces candidate gaps for an attorney. An assist, never a legal finding.",
   'paid-media-anomaly-watcher': 'Scans paid-media accounts daily for anomalies and alerts you.',

--- a/tests/initiation-card.test.ts
+++ b/tests/initiation-card.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Initiation-card contract (the Operator "test page" + first-conversation card).
+ *
+ * The card (operator/customers/<slug>/initiation-card.yaml) is the
+ * maintainable source for the staged commands a client speaks to a new
+ * Operator. This suite keeps it honest:
+ *
+ *  - schema shape holds (stages -> commands, required fields present)
+ *  - every `backed_by` resolves to a real skill in operator/skills/
+ *    (or the literal `core-dialogue` for plain grounded conversation)
+ *  - every skill-backed UNLOCKED command is actually bound and enabled on
+ *    that seat's customer.yaml — a card telling the client to say something
+ *    the seat cannot do is the exact "watch it struggle" failure the card
+ *    exists to prevent (locked stages are exempt: they name their unlock)
+ *  - every command carries expected AND falsifier — a command we cannot
+ *    grade honestly does not go on the card (Law 12)
+ *  - the rehearsal mirror: the pilot card carries every unlocked
+ *    ashton-price command verbatim (same `say`, same `backed_by`), so what
+ *    is rehearsed is what the client is told to say
+ */
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync, readdirSync } from 'fs'
+import { resolve } from 'path'
+import { parse as parseYaml } from 'yaml'
+
+// Constant paths only — no interpolated filesystem paths in this suite.
+const CARD_PATHS = {
+  'ashton-price': resolve('operator/customers/ashton-price/initiation-card.yaml'),
+  'pilot-smokeball': resolve('operator/customers/pilot-smokeball/initiation-card.yaml'),
+} as const
+
+const SEAT_YAML_PATHS = {
+  'ashton-price': resolve('operator/customers/ashton-price/customer.yaml'),
+  'pilot-smokeball': resolve('operator/customers/pilot-smokeball/customer.yaml'),
+} as const
+
+type Slug = keyof typeof CARD_PATHS
+
+const SEATS = Object.keys(CARD_PATHS) as Slug[]
+
+/** Names of every skill that has a body, listed once — membership checks
+ *  replace any input-derived path construction. */
+const SKILL_DIRS = new Set(readdirSync(resolve('operator/skills')))
+
+interface CardCommand {
+  say: string
+  backed_by: string
+  proves: string
+  expected: string
+  falsifier: string
+  admin_only?: boolean
+}
+
+interface CardStage {
+  id: string
+  title: string
+  commands: CardCommand[]
+  locked?: string
+}
+
+interface Card {
+  schema_version: number
+  card_version: string
+  customer: string
+  stages: CardStage[]
+}
+
+function loadCard(slug: Slug): Card {
+  return parseYaml(readFileSync(CARD_PATHS[slug], 'utf-8')) as Card
+}
+
+function seatSkillBindings(slug: Slug): Map<string, boolean> {
+  const raw = parseYaml(readFileSync(SEAT_YAML_PATHS[slug], 'utf-8')) as {
+    personas?: Array<{ skills?: Array<{ name: string; enabled?: boolean }> }>
+  }
+  const map = new Map<string, boolean>()
+  for (const persona of raw.personas ?? []) {
+    for (const s of persona.skills ?? []) {
+      map.set(s.name, s.enabled !== false)
+    }
+  }
+  return map
+}
+
+describe.each(SEATS)('initiation card: %s', (slug) => {
+  const card = loadCard(slug)
+
+  it('schema shape holds', () => {
+    expect(card.schema_version).toBe(1)
+    expect(card.customer).toBe(slug)
+    expect(card.card_version).toMatch(/^\d+\.\d+\.\d+$/)
+    expect(card.stages.length).toBeGreaterThan(0)
+    const ids = card.stages.map((s) => s.id)
+    expect(new Set(ids).size, 'stage ids must be unique').toBe(ids.length)
+    for (const stage of card.stages) {
+      expect(stage.title, `stage ${stage.id} title`).toBeTruthy()
+      expect(stage.commands.length, `stage ${stage.id} commands`).toBeGreaterThan(0)
+    }
+  })
+
+  it('every command is gradeable: say, proves, expected, falsifier all present', () => {
+    for (const stage of card.stages) {
+      for (const cmd of stage.commands) {
+        for (const field of ['say', 'backed_by', 'proves', 'expected', 'falsifier'] as const) {
+          expect(cmd[field], `stage ${stage.id}: command missing ${field}`).toBeTruthy()
+        }
+      }
+    }
+  })
+
+  it('every backed_by resolves to a real skill or core-dialogue', () => {
+    for (const stage of card.stages) {
+      for (const cmd of stage.commands) {
+        if (cmd.backed_by === 'core-dialogue') continue
+        expect(
+          SKILL_DIRS.has(cmd.backed_by),
+          `stage ${stage.id}: backed_by "${cmd.backed_by}" has no skill body under operator/skills/`
+        ).toBe(true)
+      }
+    }
+  })
+
+  it('every skill-backed unlocked command is bound and enabled on the seat', () => {
+    const bindings = seatSkillBindings(slug)
+    for (const stage of card.stages) {
+      if (stage.locked) continue
+      for (const cmd of stage.commands) {
+        if (cmd.backed_by === 'core-dialogue') continue
+        expect(
+          bindings.get(cmd.backed_by),
+          `stage ${stage.id}: "${cmd.say}" is on the card but skill "${cmd.backed_by}" is not bound+enabled on ${slug}`
+        ).toBe(true)
+      }
+    }
+  })
+})
+
+describe('rehearsal mirror', () => {
+  it('every unlocked ashton-price command exists verbatim on the pilot card', () => {
+    const ap = loadCard('ashton-price')
+    const pilot = loadCard('pilot-smokeball')
+    const pilotCommands = new Set(
+      pilot.stages.flatMap((s) => s.commands.map((c) => `${c.say}::${c.backed_by}`))
+    )
+    for (const stage of ap.stages) {
+      if (stage.locked) continue
+      for (const cmd of stage.commands) {
+        expect(
+          pilotCommands.has(`${cmd.say}::${cmd.backed_by}`),
+          `ashton-price card says "${cmd.say}" but the pilot card does not rehearse it`
+        ).toBe(true)
+      }
+    }
+  })
+
+  it('locked stages name their unlock event', () => {
+    const ap = loadCard('ashton-price')
+    for (const stage of ap.stages) {
+      if (stage.locked !== undefined) {
+        expect(
+          stage.locked.length,
+          `stage ${stage.id} locked: must name the unlock`
+        ).toBeGreaterThan(10)
+      }
+    }
+  })
+})


### PR DESCRIPTION
Captain direction 2026-08-09: the Operator equivalent of a printer's test page, plus a staged "first conversation" card of predefined commands the client speaks to a newly connected Operator — reducing onboarding friction and making the safety posture visible value. Ready for the A&P connect (Monday): the moment connections land, the firm's admins can run these.

## What ships

- **`operator-self-test` skill** (person-invoked, admin audience): connections check, counted matter read (no content), .docx production, a **live refusal demonstration** (synthetic sentinel `ZZ-9999-0001` attempted through the real identifier gate; refusal quoted verbatim on the page), delivery to the requester only. Every step PASS/FAILED — failures print, they never soften (Law 12 as product).
- **`operator-introduce` skill**: grounded self-description — only observed connections, live matter count, authored will/won't rules.
- **`initiation-card.yaml`** per seat, schema v1: stages meet → prove → teach → work; every command carries `backed_by` (a real skill or `core-dialogue`), `expected`, and `falsifier`. `work` is **locked** on ashton-price (named unlock: the firm's own-file drafting test); the pilot mirror unlocks it because the pilot is where drafting is proven first.
- **`tests/initiation-card.test.ts`**: schema shape, backed_by resolves to a real skill, unlocked skill-backed commands are bound+enabled on the seat (a card must never tell the client to say something the seat can't do), commands are gradeable, and the pilot rehearses every unlocked ashton-price command verbatim.
- Client-facing skill summaries for both new skills (maintenance contract).

## Honest notes

- admin_only enforcement is by roster construction on ashton-price today (roster = the two firm admins + SMD operator); the mechanical sender-gate is #2160.
- The card YAML is the maintainable source; client-facing card copy is authored in the engagements repo from it, Captain-reviewed.

`npm run verify` exit 0 (4089 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLzzpTuYY8j3EaWbXfxz4x