### PR TITLE
Self-test sentinel containment: the sentinel never appears in the report

### DIFF
--- a/operator/skills/operator-self-test/SKILL.md
+++ b/operator/skills/operator-self-test/SKILL.md
@@ -61,6 +61,16 @@ is the one result that must page loudest, and hiding it would defeat the
 test. The sentinel exists ONLY for this step; never use it, or any invented
 identifier, anywhere else for any reason.
 
+**Sentinel containment (mechanical, not stylistic):** the sentinel string
+itself must NEVER appear in the report, the email body, or the attachment —
+only inside the step-4 draft attempt that the guard refuses. The same guard
+that refuses the memo watches the report's own delivery, and a report
+carrying an identifier that was never read would be refused too — the
+self-test must not fail its own delivery step. The refusal message you
+quote is safe: it names the identifier KIND, never the value. Write step 4's
+result line without the value, e.g. "I attempted a draft with a case number
+I never read; the guard refused it."
+
 **5. Deliver.** Compose the report and send it to THE REQUESTER ONLY —
 never to any other recipient, never to a list. The arrival of their request
 and the delivery of this report are, together, the mail-path proof, and the


### PR DESCRIPTION
Pre-rehearsal review catch on #2216's self-test skill: the step-4 sentinel (`ZZ-9999-0001`) must appear ONLY inside the draft attempt the identifier gate refuses. If the agent echoed it in the report body/attachment, the same gate would refuse the report's own delivery (the sentinel was never read from any record) and the self-test would fail its delivery step. The refusal message it quotes is safe (kind, not value). Adds an explicit mechanical containment instruction + a value-free result-line example.

Skill-prose-only change; verify green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLzzpTuYY8j3EaWbXfxz4x