### PR TITLE
fix(operator): voice boot-sync scoped to cohort/ + set-e-safe FAILED branch + converge-on-boot (ss#2223)

### DIFF
--- a/operator/templates/bootstrap.sh
+++ b/operator/templates/bootstrap.sh
@@ -154,39 +154,61 @@ log "Using root-owned customer.yaml: ${CUSTOMER_YAML}"
 # the hermes user (entrypoint already dropped privilege), so synced files are
 # hermes-owned — no extra chown, no race with entrypoint's blanket chown.
 export SMD_VOICE_VAULT_DIR="${HERMES_HOME:-/opt/data}/voice"
-R2_VOICE_PREFIX="s3://${R2_BUCKET_CONFIG}/vaults/${CUSTOMER_SLUG}/voice/"
+# CONTENT-FREE CONTRACT (ss#2223 AC5): the seat mirrors ONLY cohort/ — the
+# content-free structural fingerprints (cohort/<cohort>/<id>.json) that
+# LocalVaultSampleReader consumes. Nothing else under vaults/<slug>/voice/
+# (e.g. a raw samples/ corpus staged during ingest) may ever land on a seat:
+# this fetch is SCOPED so it cannot write raw text, regardless of what sits
+# in R2.
+R2_VOICE_COHORT_PREFIX="s3://${R2_BUCKET_CONFIG}/vaults/${CUSTOMER_SLUG}/voice/cohort/"
 # Empty/absent vault is the COMMON case (no corpus ingested yet) and MUST NOT
 # fail the boot under `set -e`. Three states must stay DISTINCT (ss#2223): a
-# genuinely empty vault, a successful sync, and a FAILED probe. The old code
-# used `aws s3 ls ... 2>/dev/null | grep -q .` as the existence gate, which
-# collapsed "errored/propagation-lagged listing" into "no corpus ingested" and
-# silently left voice inactive while the samples sat in R2 at the right keys.
+# genuinely empty vault, a successful sync, and a FAILED probe. The pre-fix
+# code used `aws s3 ls ... 2>/dev/null | grep -q .` as the existence gate,
+# which collapsed "errored/propagation-lagged listing" into "no corpus
+# ingested" and silently left voice inactive while the samples sat in R2 at
+# the right keys. So: no separate LIST gate — `cp --recursive` IS the probe
+# (no-op success on an empty prefix), state is decided from the JSON that
+# actually landed, and cp's stderr is surfaced instead of discarded.
 #
-# Fix: drop the separate LIST gate (the source of both the silent-swallow and
-# the first-write propagation flakiness) and let `cp --recursive` BE the probe.
-# cp against a truly empty prefix is a no-op success; against a populated one it
-# recurses cohort/**. We then decide state from what actually landed on the
-# volume, and surface cp's stderr instead of discarding it.
-mkdir -p "${SMD_VOICE_VAULT_DIR}"
+# Refresh-on-boot via stage + swap: the volume survives reprovision BY DESIGN,
+# so each boot must CONVERGE the mirror on authored R2 state (gone means gone)
+# — a sample deleted from R2 disappears from the seat on the next boot, and
+# any pre-scoping raw samples/ dir is swapped away. Staging keeps a FAILED
+# probe non-destructive: the previous mirror is retained for that boot.
+_voice_stage="${SMD_VOICE_VAULT_DIR}.stage"
+rm -rf "${_voice_stage}"
+mkdir -p "${_voice_stage}/cohort"
+_voice_cp_rc=0
+# `|| _voice_cp_rc=$?` keeps a failing probe from killing the boot: under
+# `set -e` a bare `var="$(failing cmd)"` assignment exits the script, which
+# would turn a transient R2 error into a seat crash-loop and makes the FAILED
+# branch below unreachable.
 _voice_cp_err="$(
   AWS_ACCESS_KEY_ID="${R2_ACCESS_KEY_ID}" \
   AWS_SECRET_ACCESS_KEY="${R2_SECRET_ACCESS_KEY}" \
     aws s3 cp --recursive --only-show-errors \
       --endpoint-url "${R2_ENDPOINT_URL}" \
-      "${R2_VOICE_PREFIX}" "${SMD_VOICE_VAULT_DIR}/" 2>&1
-)"
-_voice_cp_rc=$?
+      "${R2_VOICE_COHORT_PREFIX}" "${_voice_stage}/cohort/" 2>&1
+)" || _voice_cp_rc=$?
 # The reader consumes cohort/<cohort>/*.json; count those as the ground truth,
 # independent of the LIST view that made the old probe flaky.
-_voice_n="$(find "${SMD_VOICE_VAULT_DIR}/cohort" -name '*.json' 2>/dev/null | wc -l | tr -d ' ')"
-if [ "${_voice_cp_rc}" -eq 0 ] && [ "${_voice_n}" -gt 0 ]; then
-  log "voice vault synced to ${SMD_VOICE_VAULT_DIR}: ${_voice_n} cohort sample(s) (agent holds no R2 credential for voice)"
-elif [ "${_voice_cp_rc}" -eq 0 ]; then
-  log "voice vault empty at ${R2_VOICE_PREFIX} (no corpus ingested) — voice stays inactive"
+_voice_n="$(find "${_voice_stage}/cohort" -name '*.json' 2>/dev/null | wc -l | tr -d ' ')"
+if [ "${_voice_cp_rc}" -eq 0 ]; then
+  rm -rf "${SMD_VOICE_VAULT_DIR}"
+  mv "${_voice_stage}" "${SMD_VOICE_VAULT_DIR}"
+  if [ "${_voice_n}" -gt 0 ]; then
+    log "voice vault synced to ${SMD_VOICE_VAULT_DIR}: ${_voice_n} cohort sample(s) (agent holds no R2 credential for voice)"
+  else
+    log "voice vault empty at ${R2_VOICE_COHORT_PREFIX} (no corpus ingested) — voice stays inactive"
+  fi
 else
   # DISTINCT from empty: the probe itself failed. Surface it — a silent failure
-  # here reads as "no corpus" and voice never activates (ss#2223).
-  log "WARN: voice vault sync FAILED (rc=${_voice_cp_rc}) — voice INACTIVE this boot (non-fatal). aws: ${_voice_cp_err}"
+  # here reads as "no corpus" and voice never activates (ss#2223). The stale
+  # mirror (if any) stays in place rather than losing voice to a transient.
+  rm -rf "${_voice_stage}"
+  _voice_prev_n="$(find "${SMD_VOICE_VAULT_DIR}/cohort" -name '*.json' 2>/dev/null | wc -l | tr -d ' ')"
+  log "WARN: voice vault sync FAILED (rc=${_voice_cp_rc}) — previous mirror retained (${_voice_prev_n} cohort sample(s)) (non-fatal). aws: ${_voice_cp_err}"
 fi
 
 # ============================================================================


### PR DESCRIPTION
## What

Three defects in the bootstrap voice-vault sync (`operator/templates/bootstrap.sh` Step 2a), all fixed in one block:

1. **Content-free contract (ss#2223 AC5).** The sync copied the whole `vaults/<slug>/voice/` prefix, so raw `samples/*.md` (full document bodies) landed on the seat — observed live on pilot-smokeball at `/opt/data/voice/samples/` today. The fetch is now scoped to `voice/cohort/` — the only shape `LocalVaultSampleReader` consumes (`cohort/<cohort>/<id>.json`, overlay `plugins/hermes-smd-voice/samples.py:149`) — so the fetch path **cannot** write raw text regardless of what sits in R2.

2. **Latent `set -e` death.** bootstrap runs under `set -euo pipefail` (line 41); the #2224 fix's bare `_voice_cp_err="$(aws s3 cp ...)"` assignment exits the script when the probe fails — the FAILED branch was unreachable, and a transient R2 error would have crash-looped the seat instead of logging WARN. Now `|| _voice_cp_rc=$?`.

3. **No convergence (gone means gone).** The volume survives reprovision by design, so upstream-deleted samples and the pre-scoping raw `samples/` dir persisted forever. The mirror now refreshes each boot via stage + atomic swap; a FAILED probe retains the previous mirror rather than losing voice to a transient.

## Evidence

- 4-case harness (synced / empty / FAILED / converge) extracting the block verbatim and running it under `set -euo pipefail` with a mocked `aws`: all pass — FAILED logs WARN with stderr surfaced and boot survives; converge swaps away raw `samples/` and upstream-deleted JSONs.
- False control: the same FAILED case against **origin/main's** block exits 255 with no output (no WARN, boot dead) — the instrument can fail, and does on the pre-fix code.
- `npm run verify` green (exit 0; the `validation failed` line in output is the `nonexistent-skill-xyz` negative-test fixture).

## Runtime follow-through (this session, after merge)

Deploy to pilot-smokeball with a log tail to capture the `voice vault synced: 13` boot line (AC3) and a negative probe of `/opt/data/voice/samples` absence (AC5) — crane_verify records to follow on ss#2223.

Closes nothing by itself — ss#2223 stays open until the runtime ACs carry verify IDs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ZLXoqHFZSawpXRaz8LCYB