### PR TITLE
feat(operator): a broken authored-spec control alerts a person, and the pin that stops it silencing the seat (ss#2234)

### DIFF
--- a/docs/adr/0083-authorship-model-output-classes.md
+++ b/docs/adr/0083-authorship-model-output-classes.md
@@ -115,3 +115,60 @@ The read-in-place bridge (#2071) is **kept and repointed**: name-resolution, con
 - [ ] (runtime) A seat carries an authored firm voice spec and an authored persona voice, and a delivered draft is observed in the declared voice for its class
 - [ ] (runtime) A delivered digest is observed honoring a customer-authored format, and honoring it identically on a second run
 - [ ] (runtime) The gate blocks or down-ranks an output that does not conform to its class's declared voice, observed on the live path
+
+## Amendment — 2026-08-10: what a declared-but-uninstalled spec costs (ss#2228, ss#2234)
+
+The Decision above says each property is "authored by the customer **or fails closed to
+the persona's own authored judgment**." The runtime implemented only the first half of
+that sentence for one state, and the second half never arrived.
+
+`shared/spec_gate.py` treated a class that declares `voice_spec: expected` with **no spec
+installed** as a hard refusal, on the stated reasoning that "refusing is the entire point
+of the declaration." On `pilot-smokeball` the `staff` class was declared during a proving
+window (#2094) and the spec never followed. From 2026-08-04 to 08-09 every autonomous
+staff send refused with `spec_not_read` — an instruction the model could not follow,
+because there was no spec to read. The firm's escalations and digests fell back to
+Smokeball matter memos, the Captain's mail stopped, and nothing alerted. Six days.
+
+**A control that can only fail silently and permanently is not a control.** The
+declaration was working; what it did was wrong.
+
+**Ruling (Captain, 2026-08-10).** A declared-but-never-installed spec remains a broken
+control and is still recorded as one. What it _costs_ now depends on who is waiting:
+
+| Class                                                       | Who is waiting                        | Disposition                                                   |
+| ----------------------------------------------------------- | ------------------------------------- | ------------------------------------------------------------- |
+| `staff`                                                     | a person inside the firm, on ops mail | **proceed** in the persona's own authored register, and alert |
+| `outbound_client` / `outbound_vendor` / `outbound_external` | someone outside the firm              | draft for human review, and alert                             |
+| `work_product` / `record`                                   | nobody — it is an artifact            | **still refuse**                                              |
+
+The asymmetry is the point. Persona voice needs no customer corpus and exists from day
+one (§1), so falling back to it imposes nothing — it is the ADR's own "fails closed to the
+persona's own authored judgment", finally implemented. The firm's voice to the outside
+world has no such fallback: the persona's register is the _wrong_ voice there, not a
+neutral one. And an artifact blocks no one, so refusing costs nothing.
+
+**Two states are not this, and refuse everywhere:** a spec whose bytes no longer match the
+root-recorded digest (tamper must never become an escape hatch by deleting a file), and a
+manifest the seat cannot read at all. The second required a new distinction —
+`spec_manifest.manifest_state()` — because `load_entries()` returned the same empty result
+for "nothing installed" and "cannot look", and treating the latter as the former would let
+a lost `SMD_SPEC_DIR` unlock autonomous sending while every health signal read green.
+
+**Consequence worth stating plainly:** for `staff`, `expected` and `none` now produce
+identical _send_ behaviour. What the declaration still buys is the alarm — a declared
+class with no installed spec raises `spec_control_broken:<class>.<property>` through the
+heartbeat, independent of whether the seat happens to send anything.
+
+**The same ruling closes the mirror-image defect.** A declared-but-uninstalled _format_
+spec used to yield no violations and silently PASS — the opposite failure direction from
+voice, in the same function — and a body the gate could not inspect (`None`, which the
+content floor treats as fail-toward-draft) was coerced to `""` and skipped the format
+check entirely.
+
+Amended acceptance criteria:
+
+- [ ] (repo) A declared-but-uninstalled spec is distinguishable from an unreadable manifest, and only the former can waive a refusal
+- [ ] (repo) `work_product` and `record` still refuse on a broken control; `staff` proceeds; outbound drafts
+- [ ] (runtime) A staff-class send reaches its recipient on a seat whose declared staff spec is not installed, observed as the recipient
+- [ ] (runtime) The broken control raises an alert that reaches a person, once, and resolves when a spec is installed

--- a/migrations/0104_spec_control_observability.sql
+++ b/migrations/0104_spec_control_observability.sql
@@ -1,0 +1,63 @@
+-- 0104: authored-spec control alerting (ss#2234, amends ADR 0083)
+--
+-- The incident this closes (ss#2228): pilot-smokeball declared
+-- output_classes.staff.voice_spec: expected and the staff spec was never
+-- installed. Every autonomous staff send refused for six days with a remedy the
+-- model could not perform, the firm's escalations fell into matter memos nobody
+-- watches, and NOTHING ALERTED. The gate noticed every time and wrote an audit
+-- row; an audit row is a record, not an alarm.
+--
+-- Two changes:
+--
+-- 1. fleet_status gains spec_control_json + spec_control_ok — the seat-reported
+--    comparison of what customer.yaml DECLARES against what the root-owned spec
+--    manifest has INSTALLED (heartbeat fields spec_control / spec_control_ok,
+--    overlay shared/spec_control_check.py). Reported on the heartbeat rather
+--    than at the send site on purpose: a control's health must not depend on
+--    the seat happening to send something.
+--
+--    spec_control_ok is a SEPARATE column from the map, and the distinction is
+--    the whole point: ok=0 means the seat could not read its own config or
+--    manifest — "we cannot look" — which is OUR fault and must never be
+--    reported as the firm's missing spec. An unreadable manifest and an empty
+--    one produce identical emptiness and want opposite responses.
+--
+-- 2. fleet_alert_state's condition CHECK widens to accept
+--    spec_control_broken:<class>.<property> and spec_control_unprovable.
+--    Keyed per PROPERTY, not per class: a seat can have staff.voice installed
+--    and staff.format missing, and resolving one must not clear the other.
+--    SQLite cannot ALTER a CHECK, so this is the full-table rebuild copied from
+--    0103 (itself copied from 0094). Composite PK preserved: one alert row per
+--    (seat, condition).
+--
+-- Ordering is safe by construction: migrations apply before the worker deploy,
+-- and every pre-existing condition value stays valid throughout.
+
+ALTER TABLE fleet_status ADD COLUMN spec_control_json TEXT;
+ALTER TABLE fleet_status ADD COLUMN spec_control_ok INTEGER;
+
+CREATE TABLE fleet_alert_state_new (
+  customer_slug   TEXT NOT NULL,
+  condition       TEXT NOT NULL
+    CHECK (
+      condition IN ('heartbeat_red','hard_stop','scheduler_error','work_overdue','connector_check_error','spec_control_unprovable')
+      OR condition LIKE 'connector_down:%'
+      OR condition LIKE 'connector_token_expiring:%'
+      OR condition LIKE 'spec_control_broken:%'
+    ),
+  status          TEXT NOT NULL CHECK (status IN ('open', 'resolved')),
+  opened_at       TEXT NOT NULL,
+  resolved_at     TEXT,
+  last_alert_id   TEXT,
+  updated_at      TEXT NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (customer_slug, condition)
+);
+
+INSERT INTO fleet_alert_state_new (
+  customer_slug, condition, status, opened_at, resolved_at, last_alert_id, updated_at)
+SELECT
+  customer_slug, condition, status, opened_at, resolved_at, last_alert_id, updated_at
+FROM fleet_alert_state;
+
+DROP TABLE fleet_alert_state;
+ALTER TABLE fleet_alert_state_new RENAME TO fleet_alert_state;

--- a/migrations/rollbacks/0104_spec_control_observability_down.sql
+++ b/migrations/rollbacks/0104_spec_control_observability_down.sql
@@ -1,0 +1,34 @@
+-- Rollback for 0104: drop the spec-control columns and narrow the
+-- fleet_alert_state CHECK back to the 0103 vocabulary. Open
+-- spec_control_broken / spec_control_unprovable rows are dropped by the copy
+-- filter — they cannot satisfy the narrowed CHECK.
+
+ALTER TABLE fleet_status DROP COLUMN spec_control_json;
+ALTER TABLE fleet_status DROP COLUMN spec_control_ok;
+
+CREATE TABLE fleet_alert_state_new (
+  customer_slug   TEXT NOT NULL,
+  condition       TEXT NOT NULL
+    CHECK (
+      condition IN ('heartbeat_red','hard_stop','scheduler_error','work_overdue','connector_check_error')
+      OR condition LIKE 'connector_down:%'
+      OR condition LIKE 'connector_token_expiring:%'
+    ),
+  status          TEXT NOT NULL CHECK (status IN ('open', 'resolved')),
+  opened_at       TEXT NOT NULL,
+  resolved_at     TEXT,
+  last_alert_id   TEXT,
+  updated_at      TEXT NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (customer_slug, condition)
+);
+
+INSERT INTO fleet_alert_state_new (
+  customer_slug, condition, status, opened_at, resolved_at, last_alert_id, updated_at)
+SELECT
+  customer_slug, condition, status, opened_at, resolved_at, last_alert_id, updated_at
+FROM fleet_alert_state
+WHERE condition NOT LIKE 'spec_control_broken:%'
+  AND condition != 'spec_control_unprovable';
+
+DROP TABLE fleet_alert_state;
+ALTER TABLE fleet_alert_state_new RENAME TO fleet_alert_state;

--- a/operator/contracts/output-classes.yaml
+++ b/operator/contracts/output-classes.yaml
@@ -29,8 +29,33 @@
 # A THIRD STATE, and the reason customer.yaml carries a declaration while the
 # spec itself lives in the customer's own vault object: a class may DECLARE that
 # a spec is expected and the spec may then be missing or hash-mismatched. That
-# is not "unauthored" — it is a broken control wearing an unauthored costume,
-# and it fails closed. See customer.yaml `output_classes:` and ADR 0083.
+# is not "unauthored" — it is a broken control wearing an unauthored costume.
+# See customer.yaml `output_classes:` and ADR 0083.
+#
+# WHAT THE THIRD STATE COSTS — amended 2026-08-10 (Captain ruling, ss#2228/#2234).
+# It used to fail closed everywhere, full stop. That was wrong in one direction:
+# on pilot-smokeball the `staff` class declared a voice spec nobody installed,
+# and for six days every autonomous internal send refused with a remedy the
+# model could not perform — there is no spec to read — while the firm's
+# escalations landed in matter memos nobody watches and nothing alerted. A
+# control that can only fail silently and permanently is not a control.
+#
+# So the cost now falls on whoever can bear it, and the question is WHO IS
+# WAITING:
+#   staff                       a person is waiting on ops mail → PROCEED in the
+#                               persona's own authored register, and alert.
+#   outbound_client/_vendor/    the FIRM's voice to someone outside it, where the
+#   _external                   persona register is the wrong voice rather than a
+#                               neutral one → draft for a human, and alert.
+#   work_product, record        artifacts with no reader blocked → still refuse.
+#
+# Two states are NOT this third state and still fail closed everywhere: a spec
+# whose bytes no longer match the root-recorded digest (tamper must never become
+# an escape hatch), and a manifest the seat cannot read at all (absence of
+# evidence is not evidence of absence). The alert is
+# `spec_control_broken:<class>.<property>` on the fleet-alerts worker; the
+# unreadable case pages separately as `spec_control_unprovable`, because the
+# firm's authoring gap and our own blindness have different owners.
 #
 # DERIVED VS DECLARED. Four of the six classes are resolved at the send site
 # from `shared/recipient_classifier.RecipientClass`, which the trust decision

--- a/operator/contracts/runtime-controls.yaml
+++ b/operator/contracts/runtime-controls.yaml
@@ -210,11 +210,16 @@ controls:
   spec_read_mark:
     control: spec_read_mark
     class: dispatch-guard
-    substrate_module: overlay:plugins/hermes-smd-trust/spec_gate.py
+    # Path corrected 2026-08-10: this said plugins/hermes-smd-trust/spec_gate.py,
+    # but overlay#212 relocated the gate to shared/ (hyphenated plugin dirs are
+    # not dotted module paths, so two plugins cannot import each other). The
+    # conformance test only existence-checks `ss-console:`-prefixed modules, so
+    # an `overlay:` path can rot unnoticed — it did, for nine days.
+    substrate_module: overlay:shared/spec_gate.py
     wired_via: 'pre_tool_call / hermes-smd-trust'
-    live_probe: ''
-    probe_surface: ''
-    status: unprobed
+    live_probe: seat_audit_spec_gate_triggered_rows
+    probe_surface: staging
+    status: enforced
     owner: SMDurgan
     tracking: '#2084'
     note: >-
@@ -232,9 +237,20 @@ controls:
       the stamp would be self-certifying. NOW BOUND, and the "bound nowhere"
       note this entry carried until 2026-08-01 is retired: pilot-smokeball
       declares staff AND work_product at voice_spec: expected, live in the
-      projection at vfy_01KYZK1WCKAT6RV57VJB8W29QF. Still `unprobed` because a
-      declaration is not an observation — the seat has not yet been rebuilt onto
-      the pin that carries the delivery tool, so no turn has exercised the gate.
+      projection at vfy_01KYZK1WCKAT6RV57VJB8W29QF. ENFORCED as of 2026-08-10,
+      and the `unprobed` this entry carried is retired by an observation nobody
+      wanted: the gate fired on EVERY autonomous staff send on pilot-smokeball
+      from 08-04 to 08-09 — SPEC_GATE_TRIGGERED rows, reason spec_not_read,
+      output_class staff — because the seat declared a staff voice spec that was
+      never installed (ss#2228, vfy_01KZP6JY5481272X5GZZDW5XT7). The control was
+      real; what it did was wrong. AMENDED BEHAVIOUR (ss#2234, Captain ruling):
+      a declared-but-never-installed spec is a broken control whose cost now
+      depends on who is waiting — staff proceeds in the persona's own authored
+      register, outbound routes to a human, work_product and record still
+      refuse. Tamper and an unreadable manifest refuse everywhere. The alarm is
+      no longer this gate's audit row (nobody reads those, which is how six days
+      passed): shared/spec_control_check.py reports declared-vs-installed on the
+      heartbeat and the fleet-alerts worker opens spec_control_broken.
 
   draft_delivery_gate:
     control: draft_delivery_gate

--- a/src/pages/api/internal/heartbeat.ts
+++ b/src/pages/api/internal/heartbeat.ts
@@ -59,6 +59,8 @@ interface HeartbeatBody {
   connector_check_ok?: unknown
   connectors?: unknown
   connector_token_age?: unknown
+  spec_control_ok?: unknown
+  spec_control?: unknown
 }
 
 // The breaker ladder vocabulary (overlay shared/cost_breaker.read_level).
@@ -153,6 +155,64 @@ function parseConnectorTokenAgeJson(value: unknown): string | null {
   return JSON.stringify(parsed)
 }
 
+// Authored-spec control map (ss#2234): "<output_class>.<property>" →
+// { declared, installed }. Keyed per PROPERTY because a seat can have
+// staff.voice installed and staff.format missing, and resolving one must not
+// clear the alert on the other.
+const SPEC_CONTROL_MAX_KEYS = 64
+const SPEC_CONTROL_KEY_RE = /^[a-z_]{1,40}\.(voice|format)$/
+
+// Same three-tier rule as the connector map. Both flags are REQUIRED in a kept
+// entry and neither is defaulted: `installed` is what opens and closes the
+// alert, so inferring it from a missing field would be manufacturing the
+// verdict. An entry that cannot supply both is dropped (that key holds);
+// a structurally-invalid MAP → NULL (nothing this beat is trusted, every open
+// alert holds).
+function parseSpecControlJson(value: unknown): string | null {
+  if (value === undefined) return null
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return null
+  const entries = Object.entries(value as Record<string, unknown>)
+  if (entries.length > SPEC_CONTROL_MAX_KEYS) return null
+  const parsed: Record<string, { declared: boolean; installed: boolean }> = {}
+  for (const [key, raw] of entries) {
+    if (!SPEC_CONTROL_KEY_RE.test(key)) continue
+    if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) continue
+    const entry = raw as Record<string, unknown>
+    if (typeof entry.declared !== 'boolean' || typeof entry.installed !== 'boolean') continue
+    parsed[key] = { declared: entry.declared, installed: entry.installed }
+  }
+  return JSON.stringify(parsed)
+}
+
+/**
+ * Every alert-driving field, parsed-not-cast.
+ *
+ * All of these share ONE contract that the surrounding upsert depends on: they
+ * overwrite every beat INCLUDING back to NULL. A stale pinned verdict must not
+ * outlive the signal that produced it — `COALESCE` here would keep a
+ * `scheduler_ok=0` (or a broken-control map) forever after an overlay rollback
+ * dropped the field. Grouped into one function so that contract is stated once
+ * and a new field cannot quietly acquire different semantics.
+ *
+ * The three `*_ok` booleans share `parseSchedulerOk`'s 1/0/NULL coercion, and 0
+ * always means the SEAT's own check is broken — the alerter pages that
+ * separately (`connector_check_error`, `spec_control_unprovable`) rather than
+ * letting the whole class go dark or, worse, reporting our blindness as the
+ * customer's missing config.
+ */
+function parseObservability(body: HeartbeatBody) {
+  return {
+    schedulerOk: parseSchedulerOk(body.scheduler_ok),
+    schedulerJobCount: parseNonNegInt(body.scheduler_job_count),
+    schedulerMaxOverdueSeconds: parseNonNegInt(body.scheduler_max_overdue_seconds),
+    connectorCheckOk: parseSchedulerOk(body.connector_check_ok),
+    connectorsJson: parseConnectorsJson(body.connectors),
+    connectorTokenAgeJson: parseConnectorTokenAgeJson(body.connector_token_age),
+    specControlOk: parseSchedulerOk(body.spec_control_ok),
+    specControlJson: parseSpecControlJson(body.spec_control),
+  }
+}
+
 export const POST: APIRoute = async ({ request }) => {
   const auth = await verifyMachineRequest(request, env.MACHINE_HEARTBEAT_KEY, env.DB)
   if (!auth.ok) {
@@ -184,27 +244,61 @@ export const POST: APIRoute = async ({ request }) => {
       ? body.sticky_stop_level
       : null
 
-  // Scheduler-liveness signals (WP-2). Like sticky_stop_level, these overwrite
-  // every beat INCLUDING back to NULL when the emitter stops reporting them — a
-  // stale pinned scheduler_ok=0 must not outlive the signal (e.g. after an
-  // overlay rollback that drops the field). COALESCE here would pin a broken
-  // verdict forever, so these deliberately do NOT use it.
-  const schedulerOk = parseSchedulerOk(body.scheduler_ok)
-  const schedulerJobCount = parseNonNegInt(body.scheduler_job_count)
-  const schedulerMaxOverdueSeconds = parseNonNegInt(body.scheduler_max_overdue_seconds)
+  const {
+    schedulerOk,
+    schedulerJobCount,
+    schedulerMaxOverdueSeconds,
+    connectorCheckOk,
+    connectorsJson,
+    connectorTokenAgeJson,
+    specControlOk,
+    specControlJson,
+  } = parseObservability(body)
 
-  // Connector-health signals (ADR 0080). Same overwrite-including-NULL
-  // contract as the scheduler fields; connector_check_ok shares
-  // scheduler_ok's 1/0/NULL coercion (0 = the seat's own check is broken —
-  // the alerter pages connector_check_error rather than the class going
-  // silently dark).
-  const connectorCheckOk = parseSchedulerOk(body.connector_check_ok)
-  const connectorsJson = parseConnectorsJson(body.connectors)
-  // Token-file ages (ss#2148) — same overwrite-including-NULL contract: a seat
-  // that stops reporting ages must not leave a stale age pinned (the expiry
-  // condition holds on NULL rather than evaluating a frozen value).
-  const connectorTokenAgeJson = parseConnectorTokenAgeJson(body.connector_token_age)
+  await upsertFleetStatus({
+    entityId: auth.entityId,
+    slug: auth.slug,
+    body,
+    heartbeatStatus,
+    stickyStopLevel,
+    schedulerOk,
+    schedulerJobCount,
+    schedulerMaxOverdueSeconds,
+    connectorsJson,
+    connectorCheckOk,
+    connectorTokenAgeJson,
+    specControlJson,
+    specControlOk,
+  })
 
+  return jsonResponse(200, { ok: true, heartbeat_status: heartbeatStatus })
+}
+
+interface FleetStatusUpsert {
+  entityId: string
+  slug: string
+  body: HeartbeatBody
+  heartbeatStatus: string
+  stickyStopLevel: string | null
+  schedulerOk: 0 | 1 | null
+  schedulerJobCount: number | null
+  schedulerMaxOverdueSeconds: number | null
+  connectorsJson: string | null
+  connectorCheckOk: 0 | 1 | null
+  connectorTokenAgeJson: string | null
+  specControlJson: string | null
+  specControlOk: 0 | 1 | null
+}
+
+/**
+ * The upsert, and the two update disciplines it deliberately mixes.
+ *
+ * `COALESCE` for the four fields where a beat that omits one has nothing to say
+ * (timestamps, uptime, version). Plain overwrite — INCLUDING back to NULL — for
+ * everything an alert reads, because a stale pinned verdict must never outlive
+ * the signal that produced it.
+ */
+async function upsertFleetStatus(u: FleetStatusUpsert): Promise<void> {
   // Re-keyed on customer_slug (migration 0093): several seats share one entity,
   // so ON CONFLICT(entity_id) would collide them into one row. entity_id is now
   // a plain column and is refreshed from the request on every upsert.
@@ -213,8 +307,9 @@ export const POST: APIRoute = async ({ request }) => {
        entity_id, customer_slug, last_heartbeat_ts, last_audit_ts, last_skill_ts,
        process_uptime_seconds, version, heartbeat_status, sticky_stop_level,
        scheduler_ok, scheduler_job_count, scheduler_max_overdue_seconds,
-       connectors_json, connector_check_ok, connector_token_age_json, updated_at
-     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
+       connectors_json, connector_check_ok, connector_token_age_json,
+       spec_control_json, spec_control_ok, updated_at
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
      ON CONFLICT(customer_slug) DO UPDATE SET
        entity_id               = excluded.entity_id,
        last_heartbeat_ts       = excluded.last_heartbeat_ts,
@@ -230,28 +325,30 @@ export const POST: APIRoute = async ({ request }) => {
        connectors_json         = excluded.connectors_json,
        connector_check_ok      = excluded.connector_check_ok,
        connector_token_age_json = excluded.connector_token_age_json,
+       spec_control_json       = excluded.spec_control_json,
+       spec_control_ok         = excluded.spec_control_ok,
        updated_at              = datetime('now')`
   )
     .bind(
-      auth.entityId,
-      auth.slug,
-      body.heartbeat_ts,
-      body.last_audit_ts ?? null,
-      body.last_skill_ts ?? null,
-      typeof body.process_uptime_seconds === 'number' ? body.process_uptime_seconds : null,
-      typeof body.version === 'string' ? body.version : null,
-      heartbeatStatus,
-      stickyStopLevel,
-      schedulerOk,
-      schedulerJobCount,
-      schedulerMaxOverdueSeconds,
-      connectorsJson,
-      connectorCheckOk,
-      connectorTokenAgeJson
+      u.entityId,
+      u.slug,
+      u.body.heartbeat_ts,
+      u.body.last_audit_ts ?? null,
+      u.body.last_skill_ts ?? null,
+      typeof u.body.process_uptime_seconds === 'number' ? u.body.process_uptime_seconds : null,
+      typeof u.body.version === 'string' ? u.body.version : null,
+      u.heartbeatStatus,
+      u.stickyStopLevel,
+      u.schedulerOk,
+      u.schedulerJobCount,
+      u.schedulerMaxOverdueSeconds,
+      u.connectorsJson,
+      u.connectorCheckOk,
+      u.connectorTokenAgeJson,
+      u.specControlJson,
+      u.specControlOk
     )
     .run()
-
-  return jsonResponse(200, { ok: true, heartbeat_status: heartbeatStatus })
 }
 
 function deriveStatus(

--- a/tests/operator-spec-loader.test.ts
+++ b/tests/operator-spec-loader.test.ts
@@ -130,13 +130,28 @@ describe('Operator contracts — the spec controls are registered', () => {
     expect(registry.controls['spec_read_mark']).toBeTruthy()
   })
 
-  it('declares both UNPROBED with an owner and a tracking item', () => {
-    // Honest status is the registry's whole purpose. Neither control has a live
-    // negative-fire probe yet, and claiming `enforced` would make this file
-    // another instance of the class it exists to expose.
-    for (const name of ['spec_applier', 'spec_read_mark']) {
+  it('declares an honest status with an owner and a tracking item', () => {
+    // Honest status is the registry's whole purpose, and honesty cuts both
+    // ways: claiming `enforced` without a probe would make this file another
+    // instance of the class it exists to expose, and holding `unprobed` after
+    // a control has demonstrably fired is the same lie in the other direction.
+    //
+    // spec_applier is still unprobed — nothing yet demonstrates on a live seat
+    // that a published spec arrives, that a rejected one is refused, or that
+    // the tree survives a restart.
+    //
+    // spec_read_mark is ENFORCED as of 2026-08-10, on an observation nobody
+    // wanted: it fired on every autonomous staff send on pilot-smokeball from
+    // 08-04 to 08-09 (SPEC_GATE_TRIGGERED, reason spec_not_read, output_class
+    // staff — ss#2228, vfy_01KZP6JY5481272X5GZZDW5XT7). Six days of a control
+    // working exactly as written, doing the wrong thing.
+    const expected: Record<string, string> = {
+      spec_applier: 'unprobed',
+      spec_read_mark: 'enforced',
+    }
+    for (const [name, status] of Object.entries(expected)) {
       const entry = registry.controls[name]
-      expect(entry.status).toBe('unprobed')
+      expect(entry.status).toBe(status)
       expect(entry.owner).toBeTruthy()
       expect(entry.tracking).toBe('#2084')
       expect(entry.note).toBeTruthy()

--- a/tests/spec-control-observability.test.ts
+++ b/tests/spec-control-observability.test.ts
@@ -1,0 +1,368 @@
+/**
+ * Integration coverage for authored-spec control alerting (ss#2234).
+ *
+ * The incident this closes (ss#2228): `pilot-smokeball` declared
+ * `output_classes.staff.voice_spec: expected`, the staff spec was never
+ * installed, and every autonomous staff send refused for six days. The gate
+ * wrote an audit row each time. Nobody reads audit rows, so the firm's mail
+ * stopped and nothing said so.
+ *
+ * Real-D1 concerns the pure worker unit tests cannot reach:
+ *   1. Migration 0104 — the fleet_alert_state CHECK rebuild accepts the new
+ *      literal and the spec_control_broken:<class>.<prop> prefix, rejects junk,
+ *      and preserves pre-existing open rows byte-identically (a mangled copy
+ *      would manufacture a false RECOVERED on deploy).
+ *   2. Ingest — the spec_control map parse (store / drop-entry / whole-map
+ *      NULL) and the absent-overwrites-to-NULL contract.
+ *   3. Worker runOnce against the rebuilt schema — an alert opens, resolves
+ *      when a spec lands, resolves differently when the DECLARATION is
+ *      withdrawn, and holds when the seat says it cannot look.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import {
+  createTestD1,
+  discoverNumericMigrations,
+  runMigrations,
+  installWorkerdPolyfills,
+} from '@venturecrane/crane-test-harness'
+import path from 'node:path'
+import { POST } from '../src/pages/api/internal/heartbeat'
+import { runOnce, type Env as WorkerEnv } from '../workers/fleet-alerts/src/index'
+import { env as testEnv } from 'cloudflare:workers'
+
+installWorkerdPolyfills()
+
+const migrationsDir = path.resolve(__dirname, '../migrations')
+const MACHINE_KEY = 'test-machine-heartbeat-key-32-chars'
+
+const ORG_ID = 'org-spec'
+const ENTITY_A = 'ent-spec-a'
+const FRESH = new Date().toISOString()
+
+function allMigrations(): string[] {
+  return discoverNumericMigrations(migrationsDir)
+}
+function before0104(): string[] {
+  return allMigrations().filter((f) => !f.includes('0104_spec_control_observability'))
+}
+function migration0104(): string[] {
+  return allMigrations().filter((f) => f.includes('0104_spec_control_observability'))
+}
+
+async function seedOrgEntityConfig(db: D1Database, slug: string): Promise<void> {
+  await db
+    .prepare(
+      `INSERT OR IGNORE INTO organizations (id, name, slug, created_at, updated_at)
+       VALUES (?, 'Spec Org', 'spec-org', datetime('now'), datetime('now'))`
+    )
+    .bind(ORG_ID)
+    .run()
+  await db
+    .prepare(
+      `INSERT OR IGNORE INTO entities (id, org_id, name, slug, stage, stage_changed_at, created_at, updated_at)
+       VALUES (?, ?, 'spec-entity', 'spec-entity', 'ongoing', datetime('now'), datetime('now'), datetime('now'))`
+    )
+    .bind(ENTITY_A, ORG_ID)
+    .run()
+  await db
+    .prepare(
+      `INSERT INTO customer_configs
+         (entity_id, org_id, customer_slug, schema_version, personas_json, git_sha, synced_at)
+       VALUES (?, ?, ?, '1.0.0', '[]', 'sha', '2026-08-10T00:00:00Z')`
+    )
+    .bind(ENTITY_A, ORG_ID, slug)
+    .run()
+}
+
+// ===========================================================================
+// 1. Migration 0104
+// ===========================================================================
+
+describe('migration 0104 — spec-control columns + CHECK widening', () => {
+  it('preserves a pre-existing open alert row byte-identically across the rebuild', async () => {
+    const db = createTestD1()
+    await runMigrations(db, { files: before0104() })
+    await db
+      .prepare(
+        `INSERT INTO fleet_alert_state
+           (customer_slug, condition, status, opened_at, resolved_at, last_alert_id, updated_at)
+         VALUES ('pilot-smokeball', 'connector_down:smokeball', 'open',
+                 '2026-08-09T01:37:00Z', NULL, 'resend-abc', '2026-08-09T01:37:00Z')`
+      )
+      .run()
+    await runMigrations(db, { files: migration0104() })
+    const row = await db
+      .prepare(`SELECT * FROM fleet_alert_state WHERE customer_slug = 'pilot-smokeball'`)
+      .first<Record<string, unknown>>()
+    expect(row).toEqual({
+      customer_slug: 'pilot-smokeball',
+      condition: 'connector_down:smokeball',
+      status: 'open',
+      opened_at: '2026-08-09T01:37:00Z',
+      resolved_at: null,
+      last_alert_id: 'resend-abc',
+      updated_at: '2026-08-09T01:37:00Z',
+    })
+  })
+
+  it('CHECK accepts the new literal + the spec_control_broken prefix, rejects junk', async () => {
+    const db = createTestD1()
+    await runMigrations(db, { files: allMigrations() })
+    const insert = (condition: string) =>
+      db
+        .prepare(
+          `INSERT INTO fleet_alert_state (customer_slug, condition, status, opened_at)
+           VALUES ('seat', ?, 'open', datetime('now'))`
+        )
+        .bind(condition)
+        .run()
+    await expect(insert('spec_control_unprovable')).resolves.toBeTruthy()
+    await expect(insert('spec_control_broken:staff.voice')).resolves.toBeTruthy()
+    await expect(insert('spec_control_broken:outbound_client.format')).resolves.toBeTruthy()
+    await expect(insert('junk_condition')).rejects.toThrow()
+    // The prefix requires a colon — a bare 'spec_control_broken' is not one.
+    await expect(insert('spec_control_broken')).rejects.toThrow()
+    // Older vocabularies must still be accepted after the rebuild.
+    await expect(insert('connector_token_expiring:smokeball')).resolves.toBeTruthy()
+    await expect(insert('heartbeat_red')).resolves.toBeTruthy()
+  })
+
+  it('fleet_status gains the two nullable spec-control columns', async () => {
+    const db = createTestD1()
+    await runMigrations(db, { files: allMigrations() })
+    await seedOrgEntityConfig(db, 'colcheck')
+    await db
+      .prepare(
+        `INSERT INTO fleet_status (entity_id, customer_slug, heartbeat_status, spec_control_json, spec_control_ok)
+         VALUES (?, 'colcheck', 'green', '{}', 1)`
+      )
+      .bind(ENTITY_A)
+      .run()
+    const row = await db
+      .prepare(
+        `SELECT spec_control_json, spec_control_ok FROM fleet_status WHERE customer_slug = 'colcheck'`
+      )
+      .first<Record<string, unknown>>()
+    expect(row).toEqual({ spec_control_json: '{}', spec_control_ok: 1 })
+  })
+})
+
+// ===========================================================================
+// 2. Ingest
+// ===========================================================================
+
+function heartbeatRequest(slug: string, body: Record<string, unknown>): Parameters<typeof POST>[0] {
+  const request = new Request('http://test.local/api/internal/heartbeat', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${MACHINE_KEY}`,
+      'X-Tenant-Slug': slug,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  })
+  return { request, params: {}, locals: {} } as unknown as Parameters<typeof POST>[0]
+}
+
+async function readFleet(db: D1Database, slug: string): Promise<Record<string, unknown> | null> {
+  return db
+    .prepare('SELECT spec_control_json, spec_control_ok FROM fleet_status WHERE customer_slug = ?')
+    .bind(slug)
+    .first<Record<string, unknown>>()
+}
+
+describe('POST /api/internal/heartbeat — spec-control fields (ss#2234)', () => {
+  let db: D1Database
+
+  beforeEach(async () => {
+    db = createTestD1()
+    await runMigrations(db, { files: allMigrations() })
+    await seedOrgEntityConfig(db, 'alpha')
+    ;(testEnv as unknown as Record<string, unknown>).DB = db
+    ;(testEnv as unknown as Record<string, unknown>).MACHINE_HEARTBEAT_KEY = MACHINE_KEY
+  })
+
+  it('stores a valid spec_control map and spec_control_ok', async () => {
+    const res = await POST(
+      heartbeatRequest('alpha', {
+        heartbeat_ts: new Date().toISOString(),
+        spec_control_ok: true,
+        spec_control: {
+          'staff.voice': { declared: true, installed: false },
+          'work_product.voice': { declared: true, installed: true },
+        },
+      })
+    )
+    expect(res.status).toBe(200)
+    const row = await readFleet(db, 'alpha')
+    expect(row?.spec_control_ok).toBe(1)
+    const map = JSON.parse(String(row?.spec_control_json))
+    expect(map['staff.voice']).toEqual({ declared: true, installed: false })
+    expect(map['work_product.voice']).toEqual({ declared: true, installed: true })
+  })
+
+  it('drops an invalid entry but keeps valid siblings', async () => {
+    await POST(
+      heartbeatRequest('alpha', {
+        heartbeat_ts: new Date().toISOString(),
+        spec_control: {
+          'staff.voice': { declared: true, installed: false },
+          // `installed` is what opens and closes the alert — never defaulted.
+          'staff.format': { declared: true },
+          'staff.voice.extra': { declared: true, installed: true },
+          'bad key!': { declared: true, installed: true },
+          'staff.tone': { declared: true, installed: true },
+        },
+      })
+    )
+    const map = JSON.parse(String((await readFleet(db, 'alpha'))?.spec_control_json))
+    expect(Object.keys(map)).toEqual(['staff.voice'])
+  })
+
+  it('structurally-invalid map stores NULL (trust nothing, hold everything)', async () => {
+    for (const junk of [['array'], 'string', 42]) {
+      await POST(
+        heartbeatRequest('alpha', { heartbeat_ts: new Date().toISOString(), spec_control: junk })
+      )
+      expect((await readFleet(db, 'alpha'))?.spec_control_json).toBeNull()
+    }
+  })
+
+  it('absent fields overwrite back to NULL (never COALESCE-pinned)', async () => {
+    await POST(
+      heartbeatRequest('alpha', {
+        heartbeat_ts: new Date().toISOString(),
+        spec_control_ok: true,
+        spec_control: { 'staff.voice': { declared: true, installed: false } },
+      })
+    )
+    expect((await readFleet(db, 'alpha'))?.spec_control_json).not.toBeNull()
+    // A seat that stops reporting must not leave a stale verdict pinned.
+    await POST(heartbeatRequest('alpha', { heartbeat_ts: new Date().toISOString() }))
+    const row = await readFleet(db, 'alpha')
+    expect(row?.spec_control_json).toBeNull()
+    expect(row?.spec_control_ok).toBeNull()
+  })
+
+  it('spec_control_ok=false reaches the wire as 0, not as absence', async () => {
+    await POST(
+      heartbeatRequest('alpha', {
+        heartbeat_ts: new Date().toISOString(),
+        spec_control_ok: false,
+      })
+    )
+    expect((await readFleet(db, 'alpha'))?.spec_control_ok).toBe(0)
+  })
+})
+
+// ===========================================================================
+// 3. Worker lifecycle against the rebuilt schema
+// ===========================================================================
+
+describe('fleet-alerts — spec_control conditions end to end', () => {
+  let db: D1Database
+
+  beforeEach(async () => {
+    db = createTestD1()
+    await runMigrations(db, { files: allMigrations() })
+    await seedOrgEntityConfig(db, 'seat')
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(JSON.stringify({ id: 'resend-1' }), { status: 200 }))
+    )
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  function workerEnv(): WorkerEnv {
+    return { DB: db, RESEND_API_KEY: 'rk_test' }
+  }
+
+  async function setSpecControl(json: string | null, ok: number | null = 1): Promise<void> {
+    await db
+      .prepare(
+        `INSERT INTO fleet_status (entity_id, customer_slug, last_heartbeat_ts, heartbeat_status, spec_control_json, spec_control_ok)
+         VALUES (?, 'seat', ?, 'green', ?, ?)
+         ON CONFLICT(customer_slug) DO UPDATE SET
+           spec_control_json = excluded.spec_control_json,
+           spec_control_ok   = excluded.spec_control_ok`
+      )
+      .bind(ENTITY_A, FRESH, json, ok)
+      .run()
+  }
+
+  async function alertStatus(condition: string): Promise<string | null> {
+    const row = await db
+      .prepare(
+        `SELECT status FROM fleet_alert_state WHERE customer_slug = 'seat' AND condition = ?`
+      )
+      .bind(condition)
+      .first<{ status: string }>()
+    return row?.status ?? null
+  }
+
+  it('opens on a declared-but-uninstalled spec and resolves when the spec lands', async () => {
+    await setSpecControl(JSON.stringify({ 'staff.voice': { declared: true, installed: false } }))
+    await runOnce(workerEnv(), Date.now())
+    expect(await alertStatus('spec_control_broken:staff.voice')).toBe('open')
+
+    await setSpecControl(JSON.stringify({ 'staff.voice': { declared: true, installed: true } }))
+    await runOnce(workerEnv(), Date.now())
+    expect(await alertStatus('spec_control_broken:staff.voice')).toBe('resolved')
+  })
+
+  it('resolves when the DECLARATION is withdrawn, not only when a spec lands', async () => {
+    // The regression this guards: flipping voice_spec expected -> none removes
+    // the key from the seat's map entirely. Nothing would evaluate it again, so
+    // without the open-keys feedback the alert would sit open forever — a
+    // control whose all-clear never arrives is the defect being fixed here.
+    await setSpecControl(JSON.stringify({ 'staff.voice': { declared: true, installed: false } }))
+    await runOnce(workerEnv(), Date.now())
+    expect(await alertStatus('spec_control_broken:staff.voice')).toBe('open')
+
+    await setSpecControl('{}')
+    await runOnce(workerEnv(), Date.now())
+    expect(await alertStatus('spec_control_broken:staff.voice')).toBe('resolved')
+  })
+
+  it('holds an open key when the seat reports it cannot look, and pages separately', async () => {
+    await setSpecControl(JSON.stringify({ 'staff.voice': { declared: true, installed: false } }))
+    await runOnce(workerEnv(), Date.now())
+    expect(await alertStatus('spec_control_broken:staff.voice')).toBe('open')
+
+    // ok=0 means the seat cannot read its own manifest. The per-key alert must
+    // HOLD (not resolve on data the seat just disowned) and a distinct
+    // condition must page: "we cannot look" is our fault, not the firm's.
+    await setSpecControl('{}', 0)
+    await runOnce(workerEnv(), Date.now())
+    expect(await alertStatus('spec_control_broken:staff.voice')).toBe('open')
+    expect(await alertStatus('spec_control_unprovable')).toBe('open')
+  })
+
+  it('surfaces a stale hold when the whole map goes NULL', async () => {
+    await setSpecControl(JSON.stringify({ 'staff.voice': { declared: true, installed: false } }))
+    await runOnce(workerEnv(), Date.now())
+    await setSpecControl(null, null)
+    const summary = await runOnce(workerEnv(), Date.now())
+    expect(await alertStatus('spec_control_broken:staff.voice')).toBe('open')
+    expect(summary.stale_holds).toContainEqual({
+      customer_slug: 'seat',
+      condition: 'spec_control_broken:staff.voice',
+    })
+  })
+
+  it('does not open anything for a seat with no declarations', async () => {
+    await setSpecControl('{}')
+    await runOnce(workerEnv(), Date.now())
+    const rows = await db
+      .prepare(
+        `SELECT condition FROM fleet_alert_state
+          WHERE customer_slug = 'seat' AND status = 'open' AND condition LIKE 'spec_control%'`
+      )
+      .all<{ condition: string }>()
+    expect(rows.results ?? []).toEqual([])
+  })
+})

--- a/workers/fleet-alerts/src/index.test.ts
+++ b/workers/fleet-alerts/src/index.test.ts
@@ -33,6 +33,8 @@ function row(overrides: Partial<FleetStatusRow>): FleetStatusRow {
     connectors_json: null,
     connector_check_ok: null,
     connector_token_age_json: null,
+    spec_control_json: null,
+    spec_control_ok: null,
     ...overrides,
   }
 }
@@ -174,14 +176,21 @@ function computeStaleHolds(state: FakeState): StaleHold[] {
   const out: StaleHold[] = []
   for (const [key, status] of state.alertState) {
     if (status !== 'open') continue
-    const [slug, condition] = key.split(':')
+    // Prefix conditions carry their own ':', so rejoin everything after the slug.
+    const [slug, ...conditionParts] = key.split(':')
+    const condition = conditionParts.join(':')
     const f = fleetBySlug.get(slug)
     const held =
       !f ||
       (condition === 'scheduler_error' && f.scheduler_ok === null) ||
       (condition === 'work_overdue' && f.scheduler_max_overdue_seconds === null) ||
       (condition === 'heartbeat_red' && f.last_heartbeat_ts === null) ||
-      (condition === 'hard_stop' && f.sticky_stop_level === null)
+      (condition === 'hard_stop' && f.sticky_stop_level === null) ||
+      (condition === 'spec_control_unprovable' && f.spec_control_ok === null) ||
+      // ss#2234: only a whole-map NULL strands a spec_control_broken key. A key
+      // that merely vanishes is a WITHDRAWN declaration, which auto-resolves
+      // through openSpecControlKeys — mirroring getStaleHolds' own comment.
+      (condition.startsWith('spec_control_broken:') && f.spec_control_json === null)
     if (held) out.push({ customer_slug: slug, condition: condition as StaleHold['condition'] })
   }
   return out.sort(
@@ -197,6 +206,19 @@ function makeEnv(state: FakeState, withResend = true, extra: Partial<Env> = {}):
         all() {
           if (sql.includes('LEFT JOIN fleet_status')) {
             return Promise.resolve({ results: computeStaleHolds(state) })
+          }
+          // getOpenSpecControlKeys (ss#2234) — the open spec_control_broken
+          // rows fed back so a WITHDRAWN declaration can resolve. Checked
+          // before the fleet_alert_state catch-alls because it is an unbound
+          // all() on that table.
+          if (sql.includes("condition LIKE 'spec_control_broken:%'")) {
+            const results = [...state.alertState.entries()]
+              .filter(([key, status]) => status === 'open' && key.includes(':spec_control_broken:'))
+              .map(([key]) => {
+                const [customer_slug, ...rest] = key.split(':')
+                return { customer_slug, condition: rest.join(':') }
+              })
+            return Promise.resolve({ results })
           }
           if (sql.includes('FROM fleet_status')) {
             return Promise.resolve({ results: state.fleet })
@@ -871,5 +893,163 @@ describe('connector_token_expiring (ss#2148)', () => {
     expect(conditionLabel('connector_token_expiring:smokeball')).toBe(
       'Connector credential expiring: smokeball'
     )
+  })
+})
+
+describe('spec_control (ss#2234)', () => {
+  const specJson = (entries: Record<string, { declared: boolean; installed: boolean }>) =>
+    JSON.stringify(entries)
+  const specStates = (r: FleetStatusRow, openKeys: string[] = []) =>
+    evaluateConditions([r], NOW, RED, {
+      overdueThresholdSeconds: OVERDUE,
+      openSpecControlKeys: openKeys.length ? { [r.customer_slug]: openKeys } : {},
+    }).filter((c) => c.condition.startsWith('spec_control_'))
+
+  it('NULL spec-control fields push nothing (hold)', () => {
+    expect(specStates(row({}))).toHaveLength(0)
+  })
+
+  it('corrupt spec-control json pushes no per-key condition (hold, never a page from junk)', () => {
+    const out = specStates(row({ spec_control_ok: 1, spec_control_json: '{nope' }))
+    expect(out.filter((c) => c.condition.startsWith('spec_control_broken:'))).toHaveLength(0)
+  })
+
+  it('declared and installed pushes inactive (a landed spec resolves)', () => {
+    const out = specStates(
+      row({
+        spec_control_ok: 1,
+        spec_control_json: specJson({ 'staff.voice': { declared: true, installed: true } }),
+      })
+    )
+    const broken = out.filter((c) => c.condition === 'spec_control_broken:staff.voice')
+    expect(broken).toHaveLength(1)
+    expect(broken[0].active).toBe(false)
+    expect(broken[0].detail).toContain('spec installed')
+  })
+
+  it('declared and NOT installed opens the condition', () => {
+    const out = specStates(
+      row({
+        spec_control_ok: 1,
+        spec_control_json: specJson({ 'staff.voice': { declared: true, installed: false } }),
+      })
+    )
+    const broken = out.filter((c) => c.condition === 'spec_control_broken:staff.voice')
+    expect(broken[0].active).toBe(true)
+    expect(broken[0].detail).toContain('none is installed')
+  })
+
+  it('keys are independent — one broken, one healthy on the same seat', () => {
+    const out = specStates(
+      row({
+        spec_control_ok: 1,
+        spec_control_json: specJson({
+          'staff.voice': { declared: true, installed: true },
+          'staff.format': { declared: true, installed: false },
+        }),
+      })
+    )
+    const byCondition = Object.fromEntries(out.map((c) => [c.condition, c.active]))
+    expect(byCondition['spec_control_broken:staff.voice']).toBe(false)
+    expect(byCondition['spec_control_broken:staff.format']).toBe(true)
+  })
+
+  it('an entry missing either flag is dropped, never defaulted', () => {
+    // `installed` is what opens and closes the alert; inferring it would be
+    // manufacturing the verdict.
+    const out = specStates(
+      row({
+        spec_control_ok: 1,
+        spec_control_json: JSON.stringify({ 'staff.voice': { declared: true } }),
+      })
+    )
+    expect(out.filter((c) => c.condition.startsWith('spec_control_broken:'))).toHaveLength(0)
+  })
+
+  it('a WITHDRAWN declaration resolves its open alert and says which repair it was', () => {
+    // The key vanishes from the map entirely when voice_spec flips to `none`,
+    // so without openSpecControlKeys nothing would ever evaluate it again and
+    // the alert would sit open forever.
+    const out = specStates(row({ spec_control_ok: 1, spec_control_json: '{}' }), ['staff.voice'])
+    const broken = out.filter((c) => c.condition === 'spec_control_broken:staff.voice')
+    expect(broken).toHaveLength(1)
+    expect(broken[0].active).toBe(false)
+    expect(broken[0].detail).toContain('no longer declared')
+  })
+
+  it('ok=0 opens spec_control_unprovable and HOLDS every per-key condition', () => {
+    // "We cannot look" must never be reported as the firm's missing spec, and
+    // must not resolve keys from data the seat just said it cannot trust.
+    const out = specStates(
+      row({
+        spec_control_ok: 0,
+        spec_control_json: specJson({ 'staff.voice': { declared: true, installed: true } }),
+      }),
+      ['staff.voice']
+    )
+    expect(out).toHaveLength(1)
+    expect(out[0].condition).toBe('spec_control_unprovable')
+    expect(out[0].active).toBe(true)
+  })
+
+  it('ok=1 resolves spec_control_unprovable', () => {
+    const out = specStates(row({ spec_control_ok: 1, spec_control_json: '{}' }))
+    const unprovable = out.filter((c) => c.condition === 'spec_control_unprovable')
+    expect(unprovable).toHaveLength(1)
+    expect(unprovable[0].active).toBe(false)
+  })
+
+  it('ok NULL pushes no unprovable condition (a quiet seat has not recovered)', () => {
+    const out = specStates(row({ spec_control_json: '{}' }))
+    expect(out.filter((c) => c.condition === 'spec_control_unprovable')).toHaveLength(0)
+  })
+
+  it('labels both condition forms', () => {
+    expect(conditionLabel('spec_control_broken:staff.voice')).toBe(
+      'Authored spec declared but not installed: staff.voice'
+    )
+    expect(conditionLabel('spec_control_unprovable')).toBe(
+      'Authored-spec manifest unreadable (spec health unknown)'
+    )
+  })
+
+  it('runOnce opens once, stays silent while open, then resolves once when the spec lands', async () => {
+    const state: FakeState = {
+      fleet: [
+        row({
+          customer_slug: 'pilot-smokeball',
+          spec_control_ok: 1,
+          spec_control_json: specJson({ 'staff.voice': { declared: true, installed: false } }),
+        }),
+      ],
+      alertState: new Map(),
+      writes: [],
+    }
+    const env = makeEnv(state)
+    const fetchMock = stubResend()
+
+    await runOnce(env, NOW)
+    const bodies = () => fetchMock.mock.calls.map((c) => String((c[1] as { body: string }).body))
+    expect(bodies().some((b) => b.includes('ALERT') && b.includes('staff.voice'))).toBe(true)
+    expect(state.writes).toContain('open:pilot-smokeball:spec_control_broken:staff.voice')
+
+    // Still broken on the next tick: no second email.
+    fetchMock.mockClear()
+    await runOnce(env, NOW)
+    expect(bodies().filter((b) => b.includes('staff.voice'))).toHaveLength(0)
+
+    // The spec lands.
+    fetchMock.mockClear()
+    state.fleet = [
+      row({
+        customer_slug: 'pilot-smokeball',
+        spec_control_ok: 1,
+        spec_control_json: specJson({ 'staff.voice': { declared: true, installed: true } }),
+      }),
+    ]
+    await runOnce(env, NOW)
+    const recovered = bodies().filter((b) => b.includes('RECOVERED') && b.includes('staff.voice'))
+    expect(recovered).toHaveLength(1)
+    expect(recovered[0]).toContain('spec installed')
   })
 })

--- a/workers/fleet-alerts/src/index.ts
+++ b/workers/fleet-alerts/src/index.ts
@@ -62,6 +62,8 @@
 
 import { escapeHtml } from './html'
 import { notifySinkAlerts, type SinkNotification } from './sink-notify'
+import { getOpenSpecControlKeys, specControlConditions } from './spec-control'
+import { getStaleHolds } from './stale-holds'
 import { tokenExpiryConditions } from './token-expiry'
 
 export type { SinkNotification }
@@ -114,8 +116,10 @@ export type FleetCondition =
   | 'scheduler_error'
   | 'work_overdue'
   | 'connector_check_error'
+  | 'spec_control_unprovable'
   | `connector_down:${string}`
   | `connector_token_expiring:${string}`
+  | `spec_control_broken:${string}`
 
 export interface FleetStatusRow {
   customer_slug: string
@@ -126,6 +130,8 @@ export interface FleetStatusRow {
   connectors_json: string | null
   connector_check_ok: number | null
   connector_token_age_json: string | null
+  spec_control_json: string | null
+  spec_control_ok: number | null
 }
 
 /** One per-server entry from the seat's connectors map (writer-side ages). */
@@ -290,6 +296,15 @@ export interface EvaluateOptions {
   connectorRunAgeThresholdSeconds?: number
   tokenLifetimesDays?: Record<string, number>
   tokenWarnDays?: number
+  /**
+   * customer_slug → the `<class>.<prop>` keys that currently have an OPEN
+   * spec_control_broken alert (ss#2234). Needed because a declaration can be
+   * WITHDRAWN: the key then vanishes from the seat's map entirely, and without
+   * this the alert would strand open forever with no signal to close it. Every
+   * other condition's source field goes NULL rather than disappearing, which is
+   * why this is the first condition that needs it.
+   */
+  openSpecControlKeys?: Record<string, string[]>
 }
 
 export function evaluateConditions(
@@ -303,6 +318,7 @@ export function evaluateConditions(
     connectorRunAgeThresholdSeconds = DEFAULT_CONNECTOR_RUN_AGE_SECONDS,
     tokenLifetimesDays = {},
     tokenWarnDays = DEFAULT_TOKEN_EXPIRY_WARN_DAYS,
+    openSpecControlKeys = {},
   } = options
   const out: ConditionState[] = []
   for (const row of rows) {
@@ -355,6 +371,7 @@ export function evaluateConditions(
     }
     out.push(...connectorConditions(row, connectorRunAgeThresholdSeconds))
     out.push(...tokenExpiryConditions(row, tokenLifetimesDays, tokenWarnDays))
+    out.push(...specControlConditions(row, openSpecControlKeys[row.customer_slug] ?? []))
   }
   return out
 }
@@ -427,7 +444,8 @@ async function listFleetStatus(db: D1Database): Promise<FleetStatusRow[]> {
     .prepare(
       `SELECT customer_slug, last_heartbeat_ts, sticky_stop_level,
               scheduler_ok, scheduler_max_overdue_seconds,
-              connectors_json, connector_check_ok, connector_token_age_json
+              connectors_json, connector_check_ok, connector_token_age_json,
+              spec_control_json, spec_control_ok
          FROM fleet_status`
     )
     .all<FleetStatusRow>()
@@ -469,52 +487,13 @@ async function markResolved(db: D1Database, s: ConditionState): Promise<void> {
     .run()
 }
 
-/**
- * Open alerts stranded by the per-field NULL-hold: the alert is open but the
- * seat now reports NULL for its source field (or has no row). One LEFT JOIN;
- * no UI (4 seats). The runbook documents the manual-resolve UPDATE.
- */
-async function getStaleHolds(db: D1Database): Promise<StaleHold[]> {
-  const result = await db
-    .prepare(
-      `SELECT s.customer_slug AS customer_slug, s.condition AS condition
-         FROM fleet_alert_state s
-         LEFT JOIN fleet_status f ON f.customer_slug = s.customer_slug
-        WHERE s.status = 'open'
-          AND (
-            f.customer_slug IS NULL
-            OR (s.condition = 'scheduler_error' AND f.scheduler_ok IS NULL)
-            OR (s.condition = 'work_overdue' AND f.scheduler_max_overdue_seconds IS NULL)
-            OR (s.condition = 'heartbeat_red' AND f.last_heartbeat_ts IS NULL)
-            OR (s.condition = 'hard_stop' AND f.sticky_stop_level IS NULL)
-            OR (s.condition = 'connector_check_error' AND f.connector_check_ok IS NULL)
-            OR (
-              s.condition LIKE 'connector_down:%'
-              AND (
-                f.connectors_json IS NULL
-                OR json_extract(f.connectors_json, '$."' || substr(s.condition, 16) || '"') IS NULL
-              )
-            )
-            OR (
-              s.condition LIKE 'connector_token_expiring:%'
-              AND (
-                f.connector_token_age_json IS NULL
-                OR json_extract(f.connector_token_age_json, '$."' || substr(s.condition, 26) || '"') IS NULL
-              )
-            )
-          )
-        ORDER BY s.customer_slug ASC, s.condition ASC`
-    )
-    .all<StaleHold>()
-  return result.results ?? []
-}
-
 const CONDITION_LABEL: Record<string, string> = {
   heartbeat_red: 'Machine not heartbeating',
   hard_stop: 'Cost breaker HARD_STOP',
   scheduler_error: 'Cron scheduler broken/unreadable',
   work_overdue: 'Scheduled work not firing',
   connector_check_error: 'Connector health check broken (outages not counted)',
+  spec_control_unprovable: 'Authored-spec manifest unreadable (spec health unknown)',
 }
 
 /** Label lookup with the per-connector prefix form (ADR 0080). */
@@ -524,6 +503,9 @@ export function conditionLabel(condition: FleetCondition): string {
   }
   if (condition.startsWith('connector_token_expiring:')) {
     return `Connector credential expiring: ${condition.slice('connector_token_expiring:'.length)}`
+  }
+  if (condition.startsWith('spec_control_broken:')) {
+    return `Authored spec declared but not installed: ${condition.slice('spec_control_broken:'.length)}`
   }
   return CONDITION_LABEL[condition] ?? condition
 }
@@ -638,6 +620,7 @@ export async function runOnce(env: Env, nowMs: number = Date.now()): Promise<Run
     connectorRunAgeThresholdSeconds: connectorRunAgeSeconds(env),
     tokenLifetimesDays: tokenLifetimesDays(env),
     tokenWarnDays: tokenWarnDays(env),
+    openSpecControlKeys: await getOpenSpecControlKeys(env.DB),
   })
   const transitions: Transition[] = []
 

--- a/workers/fleet-alerts/src/spec-control.ts
+++ b/workers/fleet-alerts/src/spec-control.ts
@@ -1,0 +1,167 @@
+/**
+ * spec_control_broken:<class>.<property> and spec_control_unprovable —
+ * authored-spec control health (ss#2234, amends ADR 0083).
+ *
+ * The incident (ss#2228): pilot-smokeball declared
+ * `output_classes.staff.voice_spec: expected`, the staff spec was never
+ * installed, and every autonomous staff send refused for six days with a remedy
+ * the model could not perform. The gate noticed each time and wrote an audit
+ * row. Nobody reads audit rows. This is the half that reaches a person.
+ *
+ * The seat ships `spec_control` — a map of "<class>.<property>" →
+ * `{declared, installed}` computed by comparing customer.yaml against the
+ * root-owned spec manifest (overlay `shared/spec_control_check.py`) — on the
+ * HEARTBEAT rather than at the send site, so a broken control is reported
+ * whether or not the seat happens to be sending.
+ *
+ * Two conditions, because two faults with different owners:
+ *
+ *   spec_control_broken:<class>.<prop>  the firm declared a spec and none is
+ *                                       installed. Theirs to author.
+ *   spec_control_unprovable             the seat could not read its own config
+ *                                       or manifest. Ours to fix, and it must
+ *                                       never be reported as the firm's gap.
+ *
+ * Keyed per PROPERTY: a seat can have staff.voice installed and staff.format
+ * missing, and installing one must not clear the alert on the other.
+ */
+
+import type { ConditionState, FleetStatusRow } from './index'
+
+/**
+ * customer_slug → `<class>.<prop>` keys with an OPEN spec_control_broken alert.
+ *
+ * Every other condition's source field goes NULL when it stops applying, which
+ * the NULL-hold handles. A spec_control key is different: withdrawing the
+ * declaration (`voice_spec: expected` → `none`) removes the key from the seat's
+ * map entirely, so nothing would ever evaluate it again and the alert would sit
+ * open forever. Feeding the open keys back in lets a withdrawal resolve, with a
+ * detail line saying which repair it was.
+ */
+export async function getOpenSpecControlKeys(db: D1Database): Promise<Record<string, string[]>> {
+  const result = await db
+    .prepare(
+      `SELECT customer_slug, condition
+         FROM fleet_alert_state
+        WHERE status = 'open' AND condition LIKE 'spec_control_broken:%'`
+    )
+    .all<{ customer_slug: string; condition: string }>()
+  const out: Record<string, string[]> = {}
+  for (const row of result.results ?? []) {
+    const key = row.condition.slice('spec_control_broken:'.length)
+    if (!key) continue
+    ;(out[row.customer_slug] ??= []).push(key)
+  }
+  return out
+}
+
+export interface SpecControlEntry {
+  declared: boolean
+  installed: boolean
+}
+
+/** "<class>.<prop>" → {declared, installed}. Corrupt/malformed → null (hold). */
+export function parseSpecControlMap(json: string | null): Record<string, SpecControlEntry> | null {
+  if (json === null) return null
+  let raw: unknown
+  try {
+    raw = JSON.parse(json)
+  } catch {
+    return null
+  }
+  if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) return null
+  const out: Record<string, SpecControlEntry> = {}
+  for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+    if (typeof value !== 'object' || value === null || Array.isArray(value)) continue
+    const entry = value as Record<string, unknown>
+    // Both flags required, neither defaulted: `installed` is what opens and
+    // closes the alert, so inferring it would be manufacturing the verdict.
+    if (typeof entry.declared !== 'boolean' || typeof entry.installed !== 'boolean') continue
+    out[key] = { declared: entry.declared, installed: entry.installed }
+  }
+  return out
+}
+
+/**
+ * Conditions for one seat.
+ *
+ * `spec_control_unprovable` is tri-state on the seat's own check:
+ *   ok === 0  → active (the seat says it cannot read config or manifest)
+ *   ok === 1  → inactive (resolves)
+ *   ok null   → push NOTHING (hold) — a seat that stopped reporting has not
+ *               recovered, it has gone quiet.
+ *
+ * `spec_control_broken:<key>` is tri-state per key:
+ *   declared && !installed → active
+ *   installed              → inactive (resolves — a spec landed)
+ *   key absent from a reported map → inactive (resolves — the DECLARATION was
+ *     withdrawn, which is also a real repair: nothing is expected any more)
+ *   map absent/corrupt, or the check itself is broken → push NOTHING (hold)
+ *
+ * The detail line states WHICH repair happened, because "spec installed" and
+ * "declaration withdrawn" both clear the gap and an operator needs to know
+ * which one they got. Resolving on a withdrawn declaration is deliberate: with
+ * nothing declared there is no control to be broken. The alert tracks the gap,
+ * not the ambition.
+ */
+export function specControlConditions(
+  row: FleetStatusRow,
+  knownKeys: readonly string[] = []
+): ConditionState[] {
+  const out: ConditionState[] = []
+
+  if (row.spec_control_ok === 0) {
+    out.push({
+      customer_slug: row.customer_slug,
+      condition: 'spec_control_unprovable',
+      active: true,
+      detail:
+        'The seat cannot read its authored-spec manifest or its customer config, ' +
+        'so it cannot report whether declared specs are installed. This is a seat ' +
+        'fault, not a missing spec: check SMD_SPEC_DIR and the spec applier.',
+    })
+    // The map cannot be trusted while the check is broken — hold every
+    // per-key condition rather than resolving them on absent data.
+    return out
+  }
+  if (row.spec_control_ok === 1) {
+    out.push({
+      customer_slug: row.customer_slug,
+      condition: 'spec_control_unprovable',
+      active: false,
+      detail: 'The seat can read its authored-spec manifest again.',
+    })
+  }
+
+  const map = parseSpecControlMap(row.spec_control_json)
+  if (map === null) return out
+
+  // Evaluate every key the seat reports, plus any key we have an open alert
+  // for — otherwise a withdrawn declaration would strand its alert open
+  // forever, since the key simply stops appearing in the map.
+  const keys = new Set<string>([...Object.keys(map), ...knownKeys])
+  for (const key of keys) {
+    const entry = map[key]
+    if (entry === undefined) {
+      out.push({
+        customer_slug: row.customer_slug,
+        condition: `spec_control_broken:${key}`,
+        active: false,
+        detail: `${key}: no longer declared — the seat expects no spec for it.`,
+      })
+      continue
+    }
+    const broken = entry.declared && !entry.installed
+    out.push({
+      customer_slug: row.customer_slug,
+      condition: `spec_control_broken:${key}`,
+      active: broken,
+      detail: broken
+        ? `${key}: the seat declares this spec and none is installed. Autonomous ` +
+          'internal mail proceeds in the persona register; outbound routes to a ' +
+          'draft. Author and install the spec, or set the declaration to none.'
+        : `${key}: spec installed.`,
+    })
+  }
+  return out
+}

--- a/workers/fleet-alerts/src/stale-holds.ts
+++ b/workers/fleet-alerts/src/stale-holds.ts
@@ -1,0 +1,57 @@
+/**
+ * Open alerts stranded by the per-field NULL-hold.
+ *
+ * Every condition holds rather than resolving when its source field goes NULL —
+ * a seat that stopped reporting has gone quiet, not recovered. The cost of that
+ * correctness is that an alert can sit open with nothing left to evaluate it.
+ * This query finds those, one LEFT JOIN, per-condition clauses hand-written
+ * because each condition knows its own source column. No UI (four seats); the
+ * runbook documents the manual-resolve UPDATE.
+ *
+ * Extracted from index.ts (ss#2234) to keep that file under its line ceiling,
+ * the same move `token-expiry.ts` and `spec-control.ts` made. The `substr`
+ * offsets are 1-indexed and point at the character after the prefix's colon.
+ */
+
+import type { StaleHold } from './index'
+
+export async function getStaleHolds(db: D1Database): Promise<StaleHold[]> {
+  const result = await db
+    .prepare(
+      `SELECT s.customer_slug AS customer_slug, s.condition AS condition
+         FROM fleet_alert_state s
+         LEFT JOIN fleet_status f ON f.customer_slug = s.customer_slug
+        WHERE s.status = 'open'
+          AND (
+            f.customer_slug IS NULL
+            OR (s.condition = 'scheduler_error' AND f.scheduler_ok IS NULL)
+            OR (s.condition = 'work_overdue' AND f.scheduler_max_overdue_seconds IS NULL)
+            OR (s.condition = 'heartbeat_red' AND f.last_heartbeat_ts IS NULL)
+            OR (s.condition = 'hard_stop' AND f.sticky_stop_level IS NULL)
+            OR (s.condition = 'connector_check_error' AND f.connector_check_ok IS NULL)
+            OR (
+              s.condition LIKE 'connector_down:%'
+              AND (
+                f.connectors_json IS NULL
+                OR json_extract(f.connectors_json, '$."' || substr(s.condition, 16) || '"') IS NULL
+              )
+            )
+            OR (
+              s.condition LIKE 'connector_token_expiring:%'
+              AND (
+                f.connector_token_age_json IS NULL
+                OR json_extract(f.connector_token_age_json, '$."' || substr(s.condition, 26) || '"') IS NULL
+              )
+            )
+            OR (s.condition = 'spec_control_unprovable' AND f.spec_control_ok IS NULL)
+            -- A spec_control_broken key that VANISHES from the map is not
+            -- stranded: a withdrawn declaration auto-resolves through
+            -- openSpecControlKeys. Only a whole-map NULL strands it, so this
+            -- clause deliberately does not test the individual key.
+            OR (s.condition LIKE 'spec_control_broken:%' AND f.spec_control_json IS NULL)
+          )
+        ORDER BY s.customer_slug ASC, s.condition ASC`
+    )
+    .all<StaleHold>()
+  return result.results ?? []
+}


### PR DESCRIPTION
Console half of the #2228 fix. **Merge after** the paired overlay PR venturecrane/hermes-smd-overlay#231 — this PR pins it. Contract: #2234.

## What happened

`pilot-smokeball` declared `output_classes.staff.voice_spec: expected` during a proving window (#2094). The staff spec never followed. From 2026-08-04 to 08-09 every autonomous staff send refused with `spec_not_read` — an instruction the model could not follow, because there was no spec to read. Escalations and digests fell back to Smokeball matter memos. The Captain's mail stopped on 08-03 and **nothing alerted** until he noticed and asked.

The gate saw it every single time and wrote an audit row. Nobody reads audit rows. That is the gap this PR closes.

## The alert

New `spec_control_broken:<class>.<property>` and `spec_control_unprovable`, following the `connector_token_expiring:<server>` precedent (ss#2148) end to end: seat check → heartbeat field → ingest → `fleet_alert_state` edge transitions → email.

**Two conditions, because two faults with different owners.** `spec_control_broken` is the firm's authoring gap. `spec_control_unprovable` is the seat unable to read its own manifest — which must *never* be reported as the firm's missing spec, since one is theirs to fix and one is ours.

**Reported on the heartbeat, not at the send site.** A control's health cannot depend on the seat happening to send something; that dependency is exactly why six days passed quietly.

**Both flags ship, and neither is defaulted.** Entries carry `declared` AND `installed`, so a RECOVERED email says *which* repair happened — a spec landed, or the declaration was withdrawn. A control whose all-clear also fires when the control is deleted is the same defect class being fixed here, and this sequence withdraws a declaration twice (#2229, then the follow-on re-declare).

**Keyed per property.** A seat can have `staff.voice` installed and `staff.format` missing; installing one must not clear the other's alert.

## Also here

- **Migration 0104** — two nullable `fleet_status` columns + the `fleet_alert_state` CHECK rebuild (SQLite cannot `ALTER` a CHECK), copied from 0103's template, with the rollback down-file.
- **`OVERLAY_REF` 8833b3fe → 4c44442f.** `verify-overlay-pairs.py` PASS at the new ref, all 9 pairs; the range has zero intersection with tracked pair paths.
- **ADR 0083 amended** with the ruling, and its consequence stated plainly: *for `staff`, `expected` and `none` now produce identical send behaviour and differ only in whether an alert fires.* `output-classes.yaml`'s third-state prose amended to match — otherwise the next reader re-derives the old rule from an un-amended registry.
- **`runtime-controls.yaml`: `spec_read_mark` `unprobed` → `enforced`.** Six days of `SPEC_GATE_TRIGGERED` rows is an observation. Holding `unprobed` after a control has demonstrably fired is the same dishonesty as claiming `enforced` without a probe — in the other direction. Its `substrate_module` path was also **wrong**: overlay#212 moved the gate to `shared/` nine days ago, and the conformance test only existence-checks `ss-console:`-prefixed paths, so an `overlay:` path rots unseen.

## Structure

`getStaleHolds` → `stale-holds.ts`, and the upsert + observability parse out of the heartbeat `POST`. Both were forced by the repo's line ceilings and both follow the `token-expiry.ts` precedent.

## Tests

`npm run verify` green (exit 0). New **13 real-D1 integration tests** (`tests/spec-control-observability.test.ts`) — the migration rebuild preserving open rows byte-identically, CHECK vocabulary incl. older forms still accepted, ingest three-tier parse, and the worker lifecycle including the withdrawn-declaration resolve and the ok=0 hold. Plus **12 new worker unit tests** covering the required matrix (NULL holds, corrupt holds, per-key independence, labels, open-once/resolve-once).

## AC (runtime — carried on #2234)

- [ ] (runtime) Pilot seat runs the new pin; a staff-class send with no staff spec installed reaches `scott@smd.services`
- [ ] (runtime) `spec_control_broken:staff.voice` opens, emails once, and does not repeat on the next 2-minute tick
- [ ] (runtime) An outbound send in the same state produces a draft, not a refusal

Evidence IDs land in #2234's Proof column. One probe precedes them: `wrangler secret list --name ss-fleet-alerts` must show `RESEND_API_KEY` — without it `sendTransitionEmail` returns early, `processTransition` never marks state, and the alert retries every 2 minutes forever with no mail and no row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YMQcxGtkEyrCvYxEAi8Y5e
