### PR TITLE
feat(operator): matter parties carry addresses, so membership is answerable (ss#2167)

### DIFF
--- a/operator/connectors/smokeball/smokeball_connector/server.py
+++ b/operator/connectors/smokeball/smokeball_connector/server.py
@@ -134,31 +134,89 @@ def _orient_parties(matter: dict[str, Any]) -> tuple[str, list[str]] | None:
     return clients[0], others  # plaintiff-side (default): client is the plaintiff
 
 
-def _resolve_surname(
-    client: Any, contact_id: str, cache: dict[str, str | None], budget: list[int] | None
-) -> str | None:
-    """get_contact -> surname, memoized in ``cache``; ``budget`` (a 1-elem list)
-    caps live lookups on the list path. Best-effort: a failed fetch yields None."""
+def _contact_email(contact: Any) -> str | None:
+    """The party's routable address, from the nested (``person``/``company``) shape
+    confirmed live 2026-07-08 with a flat fallback. Structured fields only, lowered
+    for comparison against a send's recipients."""
+    if not isinstance(contact, dict):
+        return None
+    for holder in (contact.get("person"), contact.get("company"), contact):
+        if not isinstance(holder, dict):
+            continue
+        raw = holder.get("email")
+        if isinstance(raw, str) and raw.strip():
+            return raw.strip().lower()
+    return None
+
+
+def _contact_roles(contact: Any) -> list[str]:
+    """Role-tag names on a contact (``[{"name": "Plaintiff", "type": "Role"}]``,
+    live-confirmed 2026-08-10). Non-Role tags are ignored; shape drift yields an
+    empty list, never a raise."""
+    if not isinstance(contact, dict):
+        return []
+    out: list[str] = []
+    for tag in contact.get("tags") or []:
+        if not isinstance(tag, dict):
+            continue
+        if (tag.get("type") or "") != "Role":
+            continue
+        name = (tag.get("name") or "").strip()
+        if name:
+            out.append(name[:40])
+    return out
+
+
+def _resolve_party(
+    client: Any, contact_id: str, cache: dict[str, dict | None], budget: list[int] | None
+) -> dict | None:
+    """get_contact -> one party record (label + email + roles), memoized in
+    ``cache``; ``budget`` (a 1-elem list) caps live lookups on the list path.
+
+    Best-effort: a failed fetch OR an exhausted budget yields None, and the caller
+    MUST treat None as *membership unresolved*, never as evidence of non-membership
+    (ss#2167 — a budget artifact that read as "not a party" would withhold a
+    correct send and name its recipient an outsider; confident wrong output is
+    worse than none).
+
+    One fetch now serves both the caption label and the party address, so matter
+    identity costs no additional API calls on the caption path."""
     if contact_id in cache:
         return cache[contact_id]
     if budget is not None:
         if budget[0] <= 0:
+            # Deliberately NOT cached: absence here is the budget, not a fact.
             return None
         budget[0] -= 1
-    label: str | None = None
+    record: dict | None = None
     try:
-        label = _party_surname(client.get(f"/contacts/{contact_id}"))
+        contact = client.get(f"/contacts/{contact_id}")
+        record = {
+            "contact_id": contact_id,
+            "label": _party_surname(contact),
+            "email": _contact_email(contact),
+            "roles": _contact_roles(contact),
+        }
     except Exception:  # noqa: BLE001 — enrichment must never break the read path
-        label = None
-    cache[contact_id] = label
-    return label
+        record = None
+    cache[contact_id] = record
+    return record
+
+
+def _resolve_surname(
+    client: Any, contact_id: str, cache: dict[str, dict | None], budget: list[int] | None
+) -> str | None:
+    """Caption label for one party. Behavior is unchanged; it now reads the shared
+    party record so the caption and membership paths share a single fetch."""
+    record = _resolve_party(client, contact_id, cache, budget)
+    return record.get("label") if record else None
 
 
 def _attach_caption(
     client: Any,
     matter: Any,
     *,
-    cache: dict[str, str | None] | None = None,
+    cache: dict[str, dict | None] | None = None,
     budget: list[int] | None = None,
 ) -> None:
     """Mutate ``matter`` in place, adding a ``caption`` ("Plaintiff v. Defendant"
@@ -196,10 +254,74 @@ def _attach_captions_to_list(client: Any, resp: Any) -> None:
     items = resp.get("value")
     if not isinstance(items, list):
         return
-    cache: dict[str, str | None] = {}
+    cache: dict[str, dict | None] = {}
     budget = [_CAPTION_MAX_LOOKUPS]
     for item in items:
         _attach_caption(client, item, cache=cache, budget=budget)
+
+
+def _attach_parties(client: Any, matter: Any) -> None:
+    """Mutate ``matter`` in place, adding ``parties`` (one record per client /
+    other-side contact: id, side, email, roles) and ``parties_complete``.
+
+    ss#2167 — the outbound matter-identity gate answers "is this recipient a party
+    to this matter?", which needs the parties' ADDRESSES. The caption path already
+    fetches those contacts and discards everything but the surname.
+
+    Deliberately NOT attached on the list path. ``_attach_captions_to_list`` is
+    bounded by ``_CAPTION_MAX_LOOKUPS``, and a budget-truncated party list is
+    byte-identical to a complete one — a real party whose fetch fell off the end
+    would classify as "not a party", withholding a CORRECT send and naming its
+    recipient an outsider. So the unbounded single-matter read is the only producer.
+
+    ``parties_complete`` is the gate's contract: true only when every listed party
+    resolved AND carries an address. Anything else — a failed fetch, a party with
+    no email, a party-less matter (no keys attached at all) — must read to the gate
+    as *membership unresolved*, never as *not a party*. The two verdicts are
+    different sentences to a reviewer and must never collapse into one."""
+    if not isinstance(matter, dict):
+        return
+    try:
+        ids = [
+            (cid, side)
+            for side, key in (("client", "clientIds"), ("other_side", "otherSideIds"))
+            for cid in (matter.get(key) or [])
+            if cid
+        ]
+        if not ids:
+            return  # party-less matter attaches nothing, as with the caption
+        cache: dict[str, dict | None] = {}
+        parties: list[dict] = []
+        complete = True
+        for cid, side in ids:
+            record = _resolve_party(client, cid, cache, None)  # unbounded: one matter
+            if record is None:
+                complete = False
+                continue
+            email = record.get("email")
+            if not email:
+                complete = False  # a party we cannot address cannot be matched
+            parties.append(
+                {
+                    "contact_id": cid,
+                    "side": side,
+                    "email": email,
+                    "roles": record.get("roles") or [],
+                }
+            )
+        if not parties:
+            # Nothing resolved at all (every lookup failed). Attach NOTHING rather
+            # than an empty list: absent is the same signal a party-less matter
+            # gives, whereas ``parties: []`` invites a caller that forgets the flag
+            # to read "nobody is a party" — the precise collapse of *unresolved*
+            # into *not a party* this function exists to prevent.
+            return
+        # Assigned only after the set is built, so a mid-loop raise leaves no
+        # partial parties key behind.
+        matter["parties"] = parties
+        matter["parties_complete"] = complete
+    except Exception:  # noqa: BLE001 — enrichment must never break the read path
+        return
 
 
 # ---- Matter-ref enrichment (tasks, events) --------------------------------
@@ -409,6 +531,17 @@ def list_matters(
         Offset=offset,
     )
     _attach_captions_to_list(client, resp)
+    # ss#2167 — the reply lane's membership binding. Measured 2026-08-10
+    # (vfy_01KZQ200CB8XE84E1M38PQ5WGB): get_matter does NOT fire on reply turns
+    # (4/77 replies vs a 3/77 control), so party data from the single-matter read
+    # never reaches 74% of sends. The router DOES resolve a sender by contact, and
+    # a contact-filtered listing is exactly "the matters this person is party to" —
+    # the same membership relation from the other direction. Echoing the filter is
+    # what lets the read-tap bind contact -> matters without changing any skill.
+    # Only ever set when the CALLER filtered by contact: an unfiltered listing says
+    # nothing about membership and must not be read as if it did.
+    if contact_id and isinstance(resp, dict):
+        resp["matters_for_contact"] = contact_id
     return resp
 
 
@@ -419,10 +552,13 @@ def get_matter(matter_id: str) -> Any:
     per-matter case-alert routing — plus status, isLead).
 
     Enriched with a composed ``caption`` ("Plaintiff v. Defendant") from the
-    matter's own party contacts (best-effort; absent for party-less matters)."""
+    matter's own party contacts (best-effort; absent for party-less matters), and
+    with ``parties`` + ``parties_complete`` — the membership facts the outbound
+    matter-identity gate joins against a send's recipients (ss#2167)."""
     client = _get_client()
     matter = client.get(f"/matters/{matter_id}")
     _attach_caption(client, matter)
+    _attach_parties(client, matter)
     return matter
 
 

--- a/operator/connectors/smokeball/tests/test_matter_parties.py
+++ b/operator/connectors/smokeball/tests/test_matter_parties.py
@@ -1,0 +1,188 @@
+"""Unit coverage for ``parties`` / ``parties_complete`` (ss#2167).
+
+The outbound matter-identity gate answers one question — "is this recipient a
+party to the matter this letter is about?" — and it needs the parties' ADDRESSES
+to do it. This module locks the contract the gate depends on.
+
+The load-bearing rule under test is the one the design review flagged as the way
+this control could produce confident wrong output: **an unresolved party must
+never be indistinguishable from a genuine non-party.** A budget-truncated or
+failed lookup that read as "not a party" would withhold a CORRECT send and tell a
+reviewer the recipient was an outsider. So every partial resolution sets
+``parties_complete: False``, and the gate treats anything short of an explicit
+True as *membership unresolved*.
+
+No live Smokeball calls: an ``httpx.MockTransport`` is injected so the real
+resolution logic runs against scripted responses.
+"""
+
+from __future__ import annotations
+
+import httpx
+
+from smokeball_connector import server as srv
+from smokeball_connector.client import SmokeballClient
+
+
+def _mock_client(handler) -> SmokeballClient:
+    client = SmokeballClient(
+        region="us", environment="staging", client_id="cid", client_secret="sec", api_key="apikey"
+    )
+    client._http = httpx.Client(transport=httpx.MockTransport(handler))
+    return client
+
+
+def _contacts_handler(contacts: dict[str, dict], captured: list[httpx.Request] | None = None):
+    def handler(request: httpx.Request) -> httpx.Response:
+        if captured is not None:
+            captured.append(request)
+        path = request.url.path
+        if path.endswith("/oauth2/token"):
+            return httpx.Response(
+                200, json={"access_token": "tok", "expires_in": 3600, "token_type": "Bearer"}
+            )
+        if "/contacts/" in path:
+            cid = path.rsplit("/", 1)[-1]
+            if cid in contacts:
+                return httpx.Response(200, json=contacts[cid])
+            return httpx.Response(404, json={"error": "not found"})
+        return httpx.Response(200, json={"ok": True})
+
+    return handler
+
+
+def _person(last: str, email: str | None = None, roles: list[str] | None = None) -> dict:
+    person: dict = {"firstName": "Given", "lastName": last}
+    if email is not None:
+        person["email"] = email
+    out: dict = {"person": person}
+    if roles is not None:
+        out["tags"] = [{"name": r, "type": "Role"} for r in roles]
+    return out
+
+
+def _matter() -> dict:
+    return {
+        "clientIds": ["c1"],
+        "otherSideIds": ["d1"],
+        "matterType": {"name": "Personal Injury - Plaintiff"},
+    }
+
+
+# ---- the happy path -------------------------------------------------------
+
+
+def test_parties_carry_address_side_and_roles() -> None:
+    client = _mock_client(
+        _contacts_handler(
+            {
+                "c1": _person("Bell", "t.bell@example.com", ["Plaintiff", "Client"]),
+                "d1": _person("Draper", "d.draper@example.com", ["Defendant"]),
+            }
+        )
+    )
+    matter = _matter()
+    srv._attach_parties(client, matter)
+
+    assert matter["parties_complete"] is True
+    by_id = {p["contact_id"]: p for p in matter["parties"]}
+    assert by_id["c1"]["email"] == "t.bell@example.com"
+    assert by_id["c1"]["side"] == "client"
+    assert by_id["c1"]["roles"] == ["Plaintiff", "Client"]
+    assert by_id["d1"]["side"] == "other_side"
+
+
+def test_addresses_are_lowercased_for_recipient_comparison() -> None:
+    # Recipients arrive normalized/lower-cased; membership must compare equal.
+    client = _mock_client(
+        _contacts_handler({"c1": _person("Bell", "T.Bell@Example.COM"), "d1": _person("D", "d@x.io")})
+    )
+    matter = _matter()
+    srv._attach_parties(client, matter)
+    assert {p["email"] for p in matter["parties"]} == {"t.bell@example.com", "d@x.io"}
+
+
+# ---- unresolved must never read as non-membership -------------------------
+
+
+def test_failed_lookup_marks_incomplete_rather_than_dropping_silently() -> None:
+    # d1 404s. The gate must not conclude "d1's address is not a party".
+    client = _mock_client(_contacts_handler({"c1": _person("Bell", "b@x.io")}))
+    matter = _matter()
+    srv._attach_parties(client, matter)
+    assert matter["parties_complete"] is False
+
+
+def test_party_without_an_address_marks_incomplete() -> None:
+    # A party we cannot address cannot be matched against a recipient, so the set
+    # is not a sound basis for a non-membership verdict.
+    client = _mock_client(
+        _contacts_handler({"c1": _person("Bell", "b@x.io"), "d1": _person("Draper")})
+    )
+    matter = _matter()
+    srv._attach_parties(client, matter)
+    assert matter["parties_complete"] is False
+
+
+def test_party_less_matter_attaches_nothing_at_all() -> None:
+    # Absent reads as unresolved. An empty parties list with complete=True would
+    # mean "nobody is a party", which would withhold every send on this matter
+    # while claiming the recipient is an outsider.
+    client = _mock_client(_contacts_handler({}))
+    matter = {"matterType": {"name": "Personal Injury - Plaintiff"}}
+    srv._attach_parties(client, matter)
+    assert "parties" not in matter
+    assert "parties_complete" not in matter
+
+
+def test_enrichment_never_breaks_the_read() -> None:
+    class Boom:
+        def get(self, *a, **k):
+            raise RuntimeError("vendor down")
+
+    matter = _matter()
+    srv._attach_parties(Boom(), matter)  # must not raise
+    assert "parties" not in matter  # absent, never partial
+
+
+# ---- the list path must not produce membership ----------------------------
+
+
+def test_list_path_attaches_no_parties() -> None:
+    # _CAPTION_MAX_LOOKUPS bounds the list path, and a truncated party set is
+    # byte-identical to a complete one. Only the unbounded single-matter read
+    # may produce membership.
+    client = _mock_client(
+        _contacts_handler({"c1": _person("Bell", "b@x.io"), "d1": _person("Draper", "d@x.io")})
+    )
+    resp = {"value": [_matter()]}
+    srv._attach_captions_to_list(client, resp)
+    assert "parties" not in resp["value"][0]
+    assert "parties_complete" not in resp["value"][0]
+
+
+def test_budget_exhaustion_is_not_cached_as_a_resolved_fact() -> None:
+    # A budget miss must stay unresolved so a later unbounded read can resolve it;
+    # caching None would freeze "unknown" into the session as though it were known.
+    client = _mock_client(_contacts_handler({"c1": _person("Bell", "b@x.io")}))
+    cache: dict[str, dict | None] = {}
+    assert srv._resolve_party(client, "c1", cache, [0]) is None
+    assert "c1" not in cache
+    assert srv._resolve_party(client, "c1", cache, None) is not None
+
+
+# ---- the caption path is unchanged ----------------------------------------
+
+
+def test_caption_still_composes_from_the_shared_fetch() -> None:
+    captured: list[httpx.Request] = []
+    client = _mock_client(
+        _contacts_handler(
+            {"c1": _person("Alvarez", "a@x.io"), "d1": _person("Draper", "d@x.io")}, captured
+        )
+    )
+    matter = _matter()
+    srv._attach_caption(client, matter)
+    assert matter["caption"] == "Alvarez v. Draper"
+    # One fetch per party — membership rides the caption's existing calls.
+    assert len([r for r in captured if "/contacts/" in r.url.path]) == 2


### PR DESCRIPTION
Connector half of the outbound matter-identity control. Overlay half: venturecrane/hermes-smd-overlay#235.

Refs #2167.

## What

The gate has to answer one question — *is this recipient a party to the matter this letter is about?* — and the address it needs was already being fetched and thrown away: `_resolve_surname` pulled the full contact record for the caption and kept only the surname.

`_resolve_party` now caches the whole record (label + email + role tags) and `_resolve_surname` reads the label off it, so the caption path is behaviourally unchanged and **membership costs no additional API calls**.

`_attach_parties` (on `get_matter` **only**) attaches `parties` + `parties_complete`.

## The two rules that keep this from producing confident wrong output

Both were flagged in design review as the way a control like this goes wrong:

1. **Unresolved must never read as non-membership.** A budget-exhausted or failed lookup that classified as "not a party" would withhold a *correct* send and tell the reviewer its recipient was an outsider. So a failed fetch, a party with no address, or a total failure all fall short of `parties_complete: true` — and a total failure attaches **nothing at all** rather than an empty list a caller could misread as "nobody is a party". A test asserted this and caught the empty-list case in the first implementation.

2. **The list path may not produce membership.** `_attach_captions_to_list` is bounded by `_CAPTION_MAX_LOOKUPS`, and a truncated party set is byte-identical to a complete one. Only the unbounded single-matter read may produce it.

## The reply lane

`list_matters` also echoes `matters_for_contact` when the caller filtered by contact. Measured on the pilot (`vfy_01KZQ200CB8XE84E1M38PQ5WGB`): `get_matter` does **not** fire on reply turns — 4 of 77 replies against a 3 of 77 control — so party data from the single-matter read never reaches ~74% of sends. The router does resolve senders by contact, and a contact-filtered listing is the same membership relation from the other direction, which reaches the reply lane **without changing any skill**.

## Status

`193 passed, 1 skipped` across the connector suite. **Not yet runtime-proven** — the live kill-test is open and the `(runtime)` ACs on #2167 stay unticked until it runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HCGWNBMsux9idQukKPmCNj