### PR TITLE
docs: correct the false silent-until-authored claim in the OVERLAY_REF ledger (ss#2252)

### DIFF
--- a/tests/operator-dockerfile.test.ts
+++ b/tests/operator-dockerfile.test.ts
@@ -732,7 +732,11 @@ describe('Operator customer Machine Dockerfile', () => {
     // declare that one and always agree with itself). Placed above the
     // `decision.allowed` guard: on a draft_for_review seat every send is
     // withheld, so a check inside that block would never run on the seat it is
-    // for. Silent until authored; SMD_MATTER_GATE_MODE is the rollback lever.
+    // for. CORRECTION (ss#2252): this comment originally said "silent until
+    // authored". That was false — the gate reads no customer.yaml posture and is
+    // ON by default; SMD_MATTER_GATE_MODE is the only lever. The safety property
+    // that does hold is that a mismatch downgrades to a human draft rather than
+    // refusing, and an unresolved membership does not withhold at all.
     // plugins/hermes-smd-trust/{enforce,__init__,matter_gate}.py +
     // shared/matter_binding.py + consumes.yaml + tests — NOT tracked pairs
     // (the tracked twins are voice/transform, audit/emit and the shared/


### PR DESCRIPTION
Comment only, no behaviour change. Refs #2252, #2167. Overlay twin: [hermes-smd-overlay#238](https://github.com/venturecrane/hermes-smd-overlay/pull/238).

The `947cc2f3 -> 44067ae1` entry in the OVERLAY_REF ledger said the matter gate is "silent until authored". It is not — the gate reads no `customer.yaml` posture and is ON by default, with `SMD_MATTER_GATE_MODE` as the only lever.

This ledger is where someone reconstructs why a given pin was considered safe to ship, so a wrong safety claim in it is load-bearing. Corrected **in place** rather than deleted, so the record shows the claim was made and withdrawn rather than quietly disappearing.

The safety property that does hold: a mismatch downgrades to a human draft rather than refusing, and an `unresolved` membership does not withhold at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HCGWNBMsux9idQukKPmCNj