### PR TITLE
feat(operator): cron_containment heartbeat field — a contained seat is visibly contained (ss#2276)

### DIFF
--- a/migrations/0105_cron_containment_observability.sql
+++ b/migrations/0105_cron_containment_observability.sql
@@ -1,0 +1,12 @@
+-- ss#2276: cron containment visibility.
+--
+-- The overlay's CRON_CONTAINMENT volume sentinel durably disables all managed
+-- cron jobs across boots (the #2258-incident lever). The heartbeat reports the
+-- sentinel state every tick as cron_containment 1/0; this column stores it so
+-- a contained seat is visibly contained on the admin roster — never mistaken
+-- for a quietly broken one (Law 12).
+--
+-- 1 = sentinel present (crons deliberately off), 0 = normal, NULL = the seat
+-- has not reported (pre-upgrade overlay, or the check itself failed).
+-- Overwrite-including-NULL discipline, same as the other alert-driving fields.
+ALTER TABLE fleet_status ADD COLUMN cron_containment INTEGER;

--- a/migrations/rollbacks/0105_cron_containment_observability_down.sql
+++ b/migrations/rollbacks/0105_cron_containment_observability_down.sql
@@ -1,0 +1,2 @@
+-- Rollback for 0105: drop the cron_containment column.
+ALTER TABLE fleet_status DROP COLUMN cron_containment;

--- a/src/lib/admin/fleet-roster.ts
+++ b/src/lib/admin/fleet-roster.ts
@@ -240,6 +240,8 @@ export interface SchedulerSignal {
   connectorCheckOk?: number | null
   /** fleet_status.connectors_json verbatim; parsed defensively here. */
   connectorsJson?: string | null
+  /** ss#2276: 1 = crons deliberately contained, 0 normal, NULL unreported. */
+  cronContainment?: number | null
 }
 
 /**
@@ -274,6 +276,7 @@ export function seatSignals(
     scheduler_max_overdue_seconds: number | null
     connector_check_ok: number | null
     connectors_json: string | null
+    cron_containment?: number | null
   } | null
 ): SchedulerSignal {
   return {
@@ -281,6 +284,7 @@ export function seatSignals(
     maxOverdueSeconds: fleet?.scheduler_max_overdue_seconds ?? null,
     connectorCheckOk: fleet?.connector_check_ok ?? null,
     connectorsJson: fleet?.connectors_json ?? null,
+    cronContainment: fleet?.cron_containment ?? null,
   }
 }
 
@@ -306,6 +310,7 @@ interface RosterNoteInputs {
   summaryStatus: SummaryStatus | null
   connectorCheckOk: number | null
   failingConnectors: string[]
+  cronContainment: number | null
 }
 
 // Note precedence, most-actionable first: a hard breaker stop and a broken
@@ -322,6 +327,10 @@ function rosterHealthNote(inputs: RosterNoteInputs): string | null {
   }
   if (inputs.connectorCheckOk === 0) return 'connector health check broken'
   if (inputs.stickyStopLevel === 'SOFT_STOP') return 'cost breaker soft stop'
+  // ss#2276: a deliberate state, not a fault - but it must be SAID, because it
+  // also explains a zero job count and suppressed routines. Sits above
+  // 'overdue' so containment is named instead of read as lateness.
+  if (inputs.cronContainment === 1) return 'crons contained (deliberate)'
   if (inputs.overdue) return 'scheduled work overdue'
   if (inputs.summaryStatus === 'red') return 'operator reports a problem'
   if (inputs.summaryStatus === 'yellow') return 'operator reports a warning'
@@ -337,6 +346,8 @@ function signalEscalations(inputs: RosterNoteInputs): (RosterHealthColor | null)
     inputs.overdue ? 'yellow' : null,
     inputs.failingConnectors.length > 0 ? 'red' : null,
     inputs.connectorCheckOk === 0 ? 'red' : null,
+    // Containment paints attention-yellow: deliberate, but never invisible.
+    inputs.cronContainment === 1 ? 'yellow' : null,
   ]
 }
 
@@ -381,6 +392,7 @@ export function rosterHealth(
     summaryStatus,
     connectorCheckOk: scheduler?.connectorCheckOk ?? null,
     failingConnectors: failingConnectorNames(scheduler?.connectorsJson),
+    cronContainment: scheduler?.cronContainment ?? null,
   }
   const color = escalatedColor(heartbeatColor, signalEscalations(inputs))
   return { color, label: heartbeatLabel, note: rosterHealthNote(inputs) }

--- a/src/lib/admin/fleet-status.ts
+++ b/src/lib/admin/fleet-status.ts
@@ -60,6 +60,8 @@ export interface FleetStatusRow {
   connectors_json: string | null
   /** Connector self-check verdict: 1 healthy / 0 broken / NULL unreported. */
   connector_check_ok: number | null
+  /** ss#2276: 1 = crons deliberately contained (volume sentinel), 0 normal, NULL unreported. */
+  cron_containment: number | null
   sentry_errors_last_24h: number | null
   sentry_errors_synced_at: string | null
   updated_at: string
@@ -71,7 +73,7 @@ export async function listFleetStatus(db: D1Database): Promise<FleetStatusRow[]>
       `SELECT entity_id, customer_slug, last_heartbeat_ts, last_audit_ts, last_skill_ts,
               process_uptime_seconds, version, heartbeat_status, sticky_stop_level,
               scheduler_ok, scheduler_job_count, scheduler_max_overdue_seconds,
-              connectors_json, connector_check_ok,
+              connectors_json, connector_check_ok, cron_containment,
               sentry_errors_last_24h, sentry_errors_synced_at, updated_at
          FROM fleet_status
         ORDER BY customer_slug ASC`

--- a/src/pages/api/internal/heartbeat.ts
+++ b/src/pages/api/internal/heartbeat.ts
@@ -24,6 +24,7 @@
  *     "scheduler_max_overdue_seconds": <integer>,  // optional
  *     "connector_check_ok":      <boolean | 0/1>,  // optional (ADR 0080)
  *     "connectors":              <map server → entry> // optional (ADR 0080)
+ *     "cron_containment":        <boolean | 0/1>,  // optional (ss#2276 sentinel)
  *   }
  *
  * The handler doesn't trust the Machine's `heartbeat_status` — it derives
@@ -61,6 +62,7 @@ interface HeartbeatBody {
   connector_token_age?: unknown
   spec_control_ok?: unknown
   spec_control?: unknown
+  cron_containment?: unknown
 }
 
 // The breaker ladder vocabulary (overlay shared/cost_breaker.read_level).
@@ -210,6 +212,9 @@ function parseObservability(body: HeartbeatBody) {
     connectorTokenAgeJson: parseConnectorTokenAgeJson(body.connector_token_age),
     specControlOk: parseSchedulerOk(body.spec_control_ok),
     specControlJson: parseSpecControlJson(body.spec_control),
+    // ss#2276: 1 = the CRON_CONTAINMENT volume sentinel is present (all managed
+    // crons deliberately off, surviving boots), 0 = normal, NULL = unreported.
+    cronContainment: parseSchedulerOk(body.cron_containment),
   }
 }
 
@@ -253,6 +258,7 @@ export const POST: APIRoute = async ({ request }) => {
     connectorTokenAgeJson,
     specControlOk,
     specControlJson,
+    cronContainment,
   } = parseObservability(body)
 
   await upsertFleetStatus({
@@ -269,6 +275,7 @@ export const POST: APIRoute = async ({ request }) => {
     connectorTokenAgeJson,
     specControlJson,
     specControlOk,
+    cronContainment,
   })
 
   return jsonResponse(200, { ok: true, heartbeat_status: heartbeatStatus })
@@ -288,6 +295,7 @@ interface FleetStatusUpsert {
   connectorTokenAgeJson: string | null
   specControlJson: string | null
   specControlOk: 0 | 1 | null
+  cronContainment: 0 | 1 | null
 }
 
 /**
@@ -308,8 +316,8 @@ async function upsertFleetStatus(u: FleetStatusUpsert): Promise<void> {
        process_uptime_seconds, version, heartbeat_status, sticky_stop_level,
        scheduler_ok, scheduler_job_count, scheduler_max_overdue_seconds,
        connectors_json, connector_check_ok, connector_token_age_json,
-       spec_control_json, spec_control_ok, updated_at
-     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
+       spec_control_json, spec_control_ok, cron_containment, updated_at
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
      ON CONFLICT(customer_slug) DO UPDATE SET
        entity_id               = excluded.entity_id,
        last_heartbeat_ts       = excluded.last_heartbeat_ts,
@@ -327,6 +335,7 @@ async function upsertFleetStatus(u: FleetStatusUpsert): Promise<void> {
        connector_token_age_json = excluded.connector_token_age_json,
        spec_control_json       = excluded.spec_control_json,
        spec_control_ok         = excluded.spec_control_ok,
+       cron_containment        = excluded.cron_containment,
        updated_at              = datetime('now')`
   )
     .bind(
@@ -346,7 +355,8 @@ async function upsertFleetStatus(u: FleetStatusUpsert): Promise<void> {
       u.connectorCheckOk,
       u.connectorTokenAgeJson,
       u.specControlJson,
-      u.specControlOk
+      u.specControlOk,
+      u.cronContainment
     )
     .run()
 }

--- a/tests/cron-containment-observability.test.ts
+++ b/tests/cron-containment-observability.test.ts
@@ -1,0 +1,155 @@
+/**
+ * ss#2276 — cron containment visibility, console side.
+ *
+ * The overlay's CRON_CONTAINMENT volume sentinel durably disables all managed
+ * cron jobs across boots (the #2258-incident lever) and reports the state on
+ * every heartbeat as `cron_containment` 1/0. This file covers the two console
+ * seams:
+ *
+ *   1. Ingest (migration 0105 + heartbeat.ts): stored 1/0, junk → NULL, and
+ *      the overwrite-including-NULL discipline (a rollback that drops the
+ *      field must not pin a stale "contained" verdict).
+ *   2. Roster (fleet-roster.ts): a contained seat paints attention-yellow with
+ *      the note naming the state as deliberate — visible, never mistaken for
+ *      quiet, and never calming a worse color (Law 12).
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  createTestD1,
+  discoverNumericMigrations,
+  runMigrations,
+  installWorkerdPolyfills,
+} from '@venturecrane/crane-test-harness'
+import path from 'node:path'
+import { POST } from '../src/pages/api/internal/heartbeat'
+import { rosterHealth } from '../src/lib/admin/fleet-roster'
+import { env as testEnv } from 'cloudflare:workers'
+
+installWorkerdPolyfills()
+
+const migrationsDir = path.resolve(__dirname, '../migrations')
+const MACHINE_KEY = 'test-machine-heartbeat-key-32-chars'
+const ORG_ID = 'org-contain'
+const ENTITY = 'ent-contain'
+const SLUG = 'contain-co'
+
+async function seed(db: D1Database): Promise<void> {
+  await db
+    .prepare(
+      `INSERT INTO organizations (id, name, slug, created_at, updated_at)
+       VALUES (?, 'Contain Org', 'contain-org', datetime('now'), datetime('now'))`
+    )
+    .bind(ORG_ID)
+    .run()
+  await db
+    .prepare(
+      `INSERT INTO entities (id, org_id, name, slug, stage, stage_changed_at, created_at, updated_at)
+       VALUES (?, ?, ?, ?, 'ongoing', datetime('now'), datetime('now'), datetime('now'))`
+    )
+    .bind(ENTITY, ORG_ID, SLUG, SLUG)
+    .run()
+  await db
+    .prepare(
+      `INSERT INTO customer_configs
+         (entity_id, org_id, customer_slug, schema_version, personas_json, git_sha, synced_at)
+       VALUES (?, ?, ?, '1.0.0', '[]', 'sha', '2026-07-24T00:00:00Z')`
+    )
+    .bind(ENTITY, ORG_ID, SLUG)
+    .run()
+}
+
+function heartbeatRequest(body: Record<string, unknown>): Parameters<typeof POST>[0] {
+  const request = new Request('http://test.local/api/internal/heartbeat', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${MACHINE_KEY}`,
+      'X-Tenant-Slug': SLUG,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  })
+  return { request, params: {}, locals: {} } as unknown as Parameters<typeof POST>[0]
+}
+
+async function readContainment(db: D1Database): Promise<unknown> {
+  const row = await db
+    .prepare('SELECT cron_containment FROM fleet_status WHERE customer_slug = ?')
+    .bind(SLUG)
+    .first<{ cron_containment: unknown }>()
+  return row?.cron_containment
+}
+
+describe('POST /api/internal/heartbeat — cron_containment (ss#2276)', () => {
+  let db: D1Database
+
+  beforeEach(async () => {
+    db = createTestD1()
+    await runMigrations(db, { files: discoverNumericMigrations(migrationsDir) })
+    await seed(db)
+    for (const k of Object.keys(testEnv)) delete (testEnv as unknown as Record<string, unknown>)[k]
+    Object.assign(testEnv, { DB: db, MACHINE_HEARTBEAT_KEY: MACHINE_KEY })
+  })
+
+  it('stores 1 and 0, coercing booleans', async () => {
+    await POST(heartbeatRequest({ heartbeat_ts: new Date().toISOString(), cron_containment: 1 }))
+    expect(await readContainment(db)).toBe(1)
+    await POST(
+      heartbeatRequest({ heartbeat_ts: new Date().toISOString(), cron_containment: false })
+    )
+    expect(await readContainment(db)).toBe(0)
+    await POST(heartbeatRequest({ heartbeat_ts: new Date().toISOString(), cron_containment: true }))
+    expect(await readContainment(db)).toBe(1)
+  })
+
+  it('stores NULL for junk — never manufactures a containment verdict', async () => {
+    await POST(
+      heartbeatRequest({ heartbeat_ts: new Date().toISOString(), cron_containment: 'yes' })
+    )
+    expect(await readContainment(db)).toBeNull()
+  })
+
+  it('a beat WITHOUT the field overwrites a stored 1 back to NULL', async () => {
+    // Overwrite-including-NULL: after an overlay rollback drops the field, a
+    // stale pinned "contained" must not outlive the signal that produced it.
+    await POST(heartbeatRequest({ heartbeat_ts: new Date().toISOString(), cron_containment: 1 }))
+    expect(await readContainment(db)).toBe(1)
+    await POST(heartbeatRequest({ heartbeat_ts: new Date().toISOString() }))
+    expect(await readContainment(db)).toBeNull()
+  })
+})
+
+describe('rosterHealth — contained seat is visible, never calming (ss#2276)', () => {
+  const scheduler = (cronContainment: number | null) => ({
+    ok: 1,
+    maxOverdueSeconds: 0,
+    connectorCheckOk: 1,
+    connectorsJson: '{}',
+    cronContainment,
+  })
+
+  it('paints attention-yellow with the deliberate-containment note', () => {
+    const health = rosterHealth('green', 'just now', null, null, scheduler(1))
+    expect(health.color).toBe('yellow')
+    expect(health.note).toBe('crons contained (deliberate)')
+  })
+
+  it('never calms a red seat', () => {
+    const health = rosterHealth('red', 'stale 47m', null, null, scheduler(1))
+    expect(health.color).toBe('red')
+  })
+
+  it('containment note outranks the overdue note it explains', () => {
+    const health = rosterHealth('green', 'just now', null, null, {
+      ...scheduler(1),
+      maxOverdueSeconds: 100000,
+    })
+    expect(health.note).toBe('crons contained (deliberate)')
+  })
+
+  it('NULL and 0 participate in nothing', () => {
+    expect(rosterHealth('green', 'just now', null, null, scheduler(null)).color).toBe('green')
+    expect(rosterHealth('green', 'just now', null, null, scheduler(0)).color).toBe('green')
+    expect(rosterHealth('green', 'just now', null, null, scheduler(0)).note).toBeNull()
+  })
+})


### PR DESCRIPTION
Companion to [hermes-smd-overlay#249](https://github.com/venturecrane/hermes-smd-overlay/pull/249) (the CRON_CONTAINMENT volume sentinel that durably disables managed crons across boots — the #2258-incident containment lever).

## What

- **Migration 0105**: `fleet_status.cron_containment INTEGER` (1 = sentinel present / crons deliberately off, 0 = normal, NULL = unreported). Rollback included.
- **Receiver** (`api/internal/heartbeat.ts`): parses the field with the shared 1/0/NULL coercion, stores with the overwrite-including-NULL discipline — an overlay rollback that stops sending the field clears the stored verdict rather than pinning it.
- **Admin roster** (`fleet-roster.ts`): a contained seat paints attention-yellow with note `crons contained (deliberate)`, positioned above the 'scheduled work overdue' note it explains. Escalate-only: never calms a worse color; NULL and 0 participate in nothing. Both roster pages inherit via `seatSignals`/`rosterHealth`.

## Why loud

A contained seat emits no scheduled work. Without this field, that silence is indistinguishable from a healthy quiet seat on the console (Law 12) — which is exactly how the pilot's fabricated-send containment could have been silently undone by a reboot re-arming 13 crons.

## Tests

`tests/cron-containment-observability.test.ts`: ingest 1/0/boolean coercion, junk → NULL, absent-field overwrite-to-NULL after a stored 1, roster yellow + note, red never calmed, containment note outranks overdue, NULL/0 no-ops. `npm run verify` exit 0 (4132 passed | 2 skipped | 7 todo; the 'validation failed' line mid-output is a fixture's intentional stderr).

## AC linkage (ss#2276)

Repo AC covered here + overlay#249. The runtime AC (zero jobs at boot with sentinel; heartbeat field observed live) rides the next pilot deploy and gets its crane_verify there — not claimed by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JCLvsu88hfAAFDkKqV2eLC