### PR TITLE
fix(operator): disabled-skills reconciler converges instead of racing a 30s window (ss#2230)

### DIFF
--- a/operator/bin/tests/test_deploy_ordering.py
+++ b/operator/bin/tests/test_deploy_ordering.py
@@ -170,10 +170,12 @@ def test_disabled_skills_reconciler_subshell_scrubs_r2() -> None:
     """SEC-23: the disabled-skills reconciler subshell is forked ~300 lines before
     the parent's R2 strip, so it must scrub the account-wide R2 key from its OWN
     environ — else its /proc/<pid>/environ leaks the key to a same-uid code-executing
-    agent for the ~30s it lives. This guard fails if the `unset` inside the subshell
+    agent while it lives. This guard fails if the `unset` inside the subshell
     is removed."""
     lines = _code_lines(_BOOTSTRAP)
-    loop_idx = _first_index(lines, r"for _ in 1 2 3 4 5 6")
+    # ss#2230 replaced the fixed 6x5s window with a convergent while-loop; the
+    # anchor follows the loop, the SEC-23 assertion is unchanged.
+    loop_idx = _first_index(lines, r'while \[ "\$\{_ticks\}" -lt 60 \]')
     assert loop_idx != -1, "could not find the disabled-skills reconciler loop"
     window = "\n".join(lines[max(0, loop_idx - 6) : loop_idx])
     assert re.search(r"\bunset\b.*\bR2_ACCESS_KEY_ID\b", window), (

--- a/operator/templates/bootstrap.sh
+++ b/operator/templates/bootstrap.sh
@@ -506,20 +506,40 @@ log "Removing customer-disabled bundled skills from profile catalogs..."
 log "Disabled skill guard passed"
 
 # Hermes' gateway startup sync can rehydrate bundled skill directories after
-# this preflight guard runs. Keep a short-lived reconciler alive during gateway
-# startup so disabled bundled skills are removed again after that sync without
-# mutating the overlay's profile `skills` list shape.
+# this preflight guard runs. Keep a reconciler alive during gateway startup so
+# disabled bundled skills are removed again after that sync without mutating
+# the overlay's profile `skills` list shape.
+#
+# ss#2230: the original fixed 6×5s window was a losing race by construction —
+# on 2026-08-10 a clean reprovision failed boot smoke because the rehydration
+# landed after the 30s window and nothing re-pruned. Converge instead: re-prune
+# every 5s until the --check pass comes back clean on three consecutive probes,
+# but never exit before 120s of coverage (a clean streak in the first seconds
+# only proves the sync has not STARTED yet — exiting on it would re-create the
+# race), under a 300s ceiling. A rehydration later than 300s would still win;
+# boot smoke's own --check step remains the arbiter either way (Law 12 — the
+# gate can still fail, and did, which is how this defect was found).
 (
   # SEC-23: strip the account-wide R2 key from THIS subshell's environ. The
   # subshell is forked here, ~300 lines before the parent's `unset` (below), so
   # without this its /proc/<pid>/environ would expose the account-wide key to a
-  # same-uid code-executing agent for the ~30s it lives. ensure-disabled-skills.py
+  # same-uid code-executing agent while it lives. ensure-disabled-skills.py
   # operates on local HERMES_HOME skill dirs and never needs R2.
   unset R2_ACCESS_KEY_ID R2_SECRET_ACCESS_KEY
-  for _ in 1 2 3 4 5 6; do
+  _clean_streak=0
+  _ticks=0
+  while [ "${_ticks}" -lt 60 ]; do
+    _ticks=$((_ticks + 1))
     sleep 5
     /opt/hermes/.venv/bin/python3 /app/ensure-disabled-skills.py "${CUSTOMER_YAML}" "${HERMES_HOME}" \
       || true
+    if /opt/hermes/.venv/bin/python3 /app/ensure-disabled-skills.py --check "${CUSTOMER_YAML}" "${HERMES_HOME}" \
+      > /dev/null 2>&1; then
+      _clean_streak=$((_clean_streak + 1))
+      [ "${_clean_streak}" -ge 3 ] && [ "${_ticks}" -ge 24 ] && break
+    else
+      _clean_streak=0
+    fi
   done
 ) &
 

--- a/tests/operator-dockerfile.test.ts
+++ b/tests/operator-dockerfile.test.ts
@@ -1015,6 +1015,22 @@ describe('Operator Machine profile guards', () => {
     ).toBe(true)
   })
 
+  it('runs a convergent (not fixed-window) disabled-skills reconciler (ss#2230)', () => {
+    expect(
+      BOOTSTRAP.includes('ensure-disabled-skills.py --check'),
+      'the reconciler must probe with --check until the prune has converged'
+    ).toBe(true)
+    expect(
+      BOOTSTRAP.includes('[ "${_ticks}" -ge 24 ]'),
+      'the reconciler must not exit on an early clean streak — a clean check before ' +
+        'the gateway sync starts proves nothing (the 2026-08-10 race)'
+    ).toBe(true)
+    expect(
+      BOOTSTRAP.includes('for _ in 1 2 3 4 5 6'),
+      'the fixed 30s reconcile window is the ss#2230 defect; it must not return'
+    ).toBe(false)
+  })
+
   it('packages and runs the operator identity guard before the gateway starts', () => {
     expect(
       DOCKERFILE.includes(


### PR DESCRIPTION
## The defect

`bootstrap.sh` step 7b.1 prunes customer-disabled bundled skills, then keeps a reconciler alive for exactly 6×5s to catch Hermes' gateway startup sync rehydrating them. On the 2026-08-10 clean reprovision the rehydration landed **after** the 30s window: nothing re-pruned, `.bundled_manifest` re-exposed the two `skills_disabled` entries, and `boot-smoke-test.sh` failed `disabled-skills-pruned` durably (#2230's live diagnosis). A fixed window is a losing race by construction.

## The fix

The reconciler now converges: re-prune every 5s until the pruner's own `--check` comes back clean on **three consecutive probes AND at least 120s have elapsed**, under a 300s ceiling. The minimum span matters: a clean streak in the first seconds only proves the gateway sync has not *started* — exiting on it would re-create the exact race. Honest residual: a rehydration later than 300s would still win; `boot-smoke-test.sh`'s `--check` step remains the arbiter either way (Law 12 — that gate can fail, and did, which is how this defect was found).

SEC-23 R2-key strip in the subshell is preserved unchanged.

## Tests

- `bash -n` clean.
- New pins in `tests/operator-dockerfile.test.ts`: the `--check` probe exists in bootstrap, the minimum-coverage guard exists, and the fixed `for _ in 1 2 3 4 5 6` window must never return.
- `npm run verify` exit 0.

## Runtime proof

Rides the next reprovision (the A&P seat rebuild after the #2258 fixes land — the same event #2230 was found on). The boot-smoke `disabled-skills-pruned` step passing on that clean reprovision is the closing evidence; will be recorded via crane_verify on #2230.

Fixes the structural half of #2230; the issue stays open until the reprovision proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JCLvsu88hfAAFDkKqV2eLC