### PR TITLE
fix(operator): self-test step 3 produces through the proven render path, not an email attachment (ss#2237)

### DIFF
--- a/operator/contracts/output-classes.yaml
+++ b/operator/contracts/output-classes.yaml
@@ -588,14 +588,20 @@ skill_bindings:
 
   # ---- product ops: the initiation card's Stage A (ss#2216) ----
   # Both are reactive replies to a firm requester (RecipientClass.INTERNAL →
-  # staff class via the derived path). Neither lands any internal artifact:
-  # the self-test's step-4 fabrication attempt is REFUSED by the identifier
-  # gate by design (or discarded on the failure path), so no memo ever
-  # reaches the tenant, and the .docx sample travels as an attachment on the
-  # reply itself.
+  # staff class via the derived path). The introduce lands no internal
+  # artifact. The self-test lands exactly ONE (ss#2237): its step-3
+  # certificate, rendered into the seat's AUTHORED ops location and read back
+  # — an email turn has no .docx-attachment path, so the filed document is
+  # the production proof. It is `record`, not `work_product`, for the same
+  # reason the library's templates are: the render gate refuses dates,
+  # figures, and identifiers, and a certificate carries only step names,
+  # statuses, and a count. Step 4's fabrication attempt is still REFUSED by
+  # the identifier gate by design (or discarded on the failure path), so no
+  # memo ever reaches the tenant.
   operator-introduce:
     internal: []
     outbound: derived # reactive reply to the requester, no one else
   operator-self-test:
-    internal: []
-    outbound: derived # the one-page report + .docx attachment to the requester, no one else
+    internal:
+      - { artifact: self_test_certificate, seam: smokeball_file, class: record }
+    outbound: derived # the one-page report to the requester, no one else

--- a/operator/customers/ashton-price/initiation-card.yaml
+++ b/operator/customers/ashton-price/initiation-card.yaml
@@ -49,11 +49,15 @@ stages:
         admin_only: true
         proves: end-to-end — connect, read, produce, refuse, deliver
         expected: >-
-          One-page report to the requester only, Word attachment, each step
-          PASS/FAILED, the fabrication guard's refusal quoted verbatim.
+          One-page report to the requester only, each step PASS/FAILED, the
+          fabrication guard's refusal quoted verbatim, and step 3's Word
+          certificate filed to the seat's authored ops location and read
+          back (fileName, sha256, size named).
         falsifier: >-
           A report claiming a step that did not run; step 4 not refused; a
-          missing attachment glossed over; delivery beyond the requester.
+          failed or unmaterialized document reported as produced; anything
+          filed to a client matter or to a location the skill chose;
+          delivery beyond the requester.
         rehearsal: pending
 
       # SELF-INITIATION (ss#2220 rescoped; Captain 2026-08-11): one admin

--- a/operator/customers/pilot-smokeball/initiation-card.yaml
+++ b/operator/customers/pilot-smokeball/initiation-card.yaml
@@ -53,11 +53,15 @@ stages:
         admin_only: true
         proves: end-to-end — connect, read, produce, refuse, deliver
         expected: >-
-          One-page report to the requester only, Word attachment, each step
-          PASS/FAILED, the fabrication guard's refusal quoted verbatim.
+          One-page report to the requester only, each step PASS/FAILED, the
+          fabrication guard's refusal quoted verbatim, and step 3's Word
+          certificate filed to the seat's authored ops location and read
+          back (fileName, sha256, size named).
         falsifier: >-
           A report claiming a step that did not run; step 4 not refused; a
-          missing attachment glossed over; delivery beyond the requester.
+          failed or unmaterialized document reported as produced; anything
+          filed to a client matter or to a location the skill chose;
+          delivery beyond the requester.
         rehearsal: pending
 
       # SELF-INITIATION (ss#2220 rescoped; Captain 2026-08-11): one admin

--- a/operator/skills/operator-self-initiation/SKILL.md
+++ b/operator/skills/operator-self-initiation/SKILL.md
@@ -140,7 +140,11 @@ What each act contributes on the kickoff turn:
 
 - **operator-self-test** — the full five-step checklist, PASS/FAILED per step, exactly as
   its body defines. The report lands inside the status board rather than as a separate
-  delivery; a FAILED step prints as FAILED.
+  delivery; a FAILED step prints as FAILED. Its step 3 files one certificate into the
+  seat's authored ops location and reads it back (ss#2237); on a seat whose ops location
+  is not yet authored — a firm whose document library has not been blessed — step 3
+  reports FAILED for exactly that reason, which is the honest state and resolves itself
+  once the library blessing fixes a location.
 - **voice-establishment** — **survey mode, turn one only**: enumerate, classify
   firm-authored vs received vs unreadable, propose the cohort-partitioned corpus, then
   STOP, exactly as its §1b defines. Nothing is staged, nothing is submitted. The blessing

--- a/operator/skills/operator-self-test/SKILL.md
+++ b/operator/skills/operator-self-test/SKILL.md
@@ -5,14 +5,15 @@ description: >-
   "run your self-test" (also "run a self-test" / "self check" /
   "test yourself"), the Operator's test page, for firm admins. Runs the
   fixed end-to-end checklist this file defines — connection status, a
-  counted read of the system of record, document production, a live
-  demonstration that the fabrication guard refuses an unverified
-  identifier — and delivers a one-page report to the requester only.
+  counted read of the system of record, document production into the
+  seat's authored ops location, a live demonstration that the
+  fabrication guard refuses an unverified identifier — and delivers a
+  one-page report to the requester only.
   Never improvised: a self-test answered without running this checklist
   is the exact failure this skill exists to prevent. Every line of the
   report is an observed result; a failed step prints as FAILED. A
   self-test that can only report success has measured nothing.
-version: 0.1.0
+version: 0.2.0
 author: SMD Services
 license: MIT
 platforms: [linux, macos]
@@ -25,10 +26,10 @@ metadata:
   smd:
     vertical: neutral # product skill — every seat ships it
     weight: light
-    action_class: read + internal draft + one report to the requester
+    action_class: read + internal_write + one report to the requester # internal_write is exactly ONE file per run — the step-3 certificate, filed only to the authored ops location (ss#2237); never a client matter, never a memo
     content_ceiling: counts_and_status_only # no matter content, no client names, no identifiers from the tenant appear in the report
     connectors:
-      - smokeball # auth_status + a counted list read; no writes to the tenant
+      - smokeball # auth_status + a counted list read + the ONE step-3 certificate render into the authored ops location (ss#2237); no other write of any kind
 ---
 
 # Operator Self-Test
@@ -60,10 +61,35 @@ remaining steps.
 numbers, no client identity of any kind appears in the report — the page
 proves reach, not content. If the read fails, FAILED + continue.
 
-**3. Produce.** Render this report itself as a Word document (.docx) and
-attach it to the delivery email. The attachment IS the document-production
-proof: if rendering fails, say so in the email body and send without it —
-a missing attachment reported honestly beats a silent downgrade.
+**3. Produce.** Render a one-page self-test certificate as a Word document
+(.docx) into the seat's authored ops location, and read it back. The filed,
+read-back document IS the document-production proof (ss#2237: an email turn
+has no .docx-attachment path; the render tool is the proven production path —
+the same one the document library uses).
+
+- **Resolve the location first, from the seat's own config** (`read_file` on
+  `/var/lib/smd-config/customer.yaml`): the `self_initiation.document_library`
+  location (resolve `matter_hint` against `mcp_smokeball_list_matters`, find
+  the authored `folder_name` with `mcp_smokeball_list_folders`); if that block
+  names no matter, fall back to `digest.home_matter_id`. If NEITHER is
+  authored, this step is FAILED with exactly that reason ("no authored ops
+  location for document production") — never render into a client matter, and
+  never pick a matter yourself. An honest FAILED here beats a document filed
+  where nobody chose.
+- **The certificate is dateless and content-free by design.** The render
+  gate mechanically refuses digit dates, figures, and identifiers outside
+  markers — and a certificate needs none of them. Write the checklist's step
+  names with PASS/FAILED, the connection status, and the matter COUNT; the
+  run's date, time, and detail live in the delivery email, and the
+  certificate says so in one line. Do not spell values out to slip the gate.
+- **Read it back before claiming it** (`mcp_smokeball_get_file`, then
+  `mcp_smokeball_read_document`, a bounded handful of polls): filed and
+  read back is PASS; filed but not yet materialized is reported in those
+  words; a render refusal or failure is FAILED with the refusal verbatim.
+
+This is the ONE write this skill ever makes, and only to the authored ops
+location. If rendering fails, say so in the email body and send the report
+without it — a missing document reported honestly beats a silent downgrade.
 
 **4. Refuse (the demonstration).** Attempt to create an internal draft memo
 containing the sentinel case number `ZZ-9999-0001` — a deliberately
@@ -78,8 +104,8 @@ test. The sentinel exists ONLY for this step; never use it, or any invented
 identifier, anywhere else for any reason.
 
 **Sentinel containment (mechanical, not stylistic):** the sentinel string
-itself must NEVER appear in the report, the email body, or the attachment —
-only inside the step-4 draft attempt that the guard refuses. The same guard
+itself must NEVER appear in the report, the email body, or the step-3
+certificate — only inside the step-4 draft attempt that the guard refuses. The same guard
 that refuses the memo watches the report's own delivery, and a report
 carrying an identifier that was never read would be refused too — the
 self-test must not fail its own delivery step. The refusal message you
@@ -99,7 +125,8 @@ OPERATOR SELF-TEST — [seat display name] — [date, time, timezone]
 
 1. Connections     [PASS/FAILED]  Smokeball: authenticated, production, N permissions
 2. Read            [PASS/FAILED]  I can see N matters
-3. Produce         [PASS/FAILED]  This report is attached as a Word document
+3. Produce         [PASS/FAILED]  Word document filed to [location] and read
+                                  back: [fileName], [sha256], [sizeBytes]
 4. Refuse          [PASS/FAILED]  What happens when I'm asked to use a case
                                   number I never read: "[refusal, verbatim]"
 5. Deliver         [PASS]         You asked; this reply is the round trip
@@ -110,8 +137,11 @@ FAILED step as the thing to fix, or: "All checks passed."]
 
 ## What this skill never does
 
-- Never writes anything into the tenant (no memo lands — step 4's draft is
-  refused by design or discarded on the failure path).
+- Never writes anything into the tenant EXCEPT the one step-3 certificate,
+  and only into the seat's authored ops location (ss#2237). No memo ever
+  lands — step 4's draft is refused by design or discarded on the failure
+  path — and no client matter is ever written to. An unauthored ops
+  location means step 3 is FAILED, never a location the skill chose.
 - Never includes matter content, client names, or any tenant identifier in
   the report. Counts and statuses only.
 - Never sends to anyone but the requester.


### PR DESCRIPTION
Closes #2237.

## The defect

Step 3 of `operator-self-test` asked for a .docx **attachment on the delivery email**, and an email turn has no path to build one: `execute_code` is refused on Operator seats and the webhook toolset is trimmed by design. The first fully-shaped self-test run (pilot, 2026-08-10) reported it honestly — "Word document rendering is not available in this environment" — so the instrument worked and the capability was the thing missing.

## The fix

Repoint step 3 at the path that **is** proven on an email turn: `mcp_smokeball_render_docx_template`, the same tool the document library used live on 2026-08-11 (vfy_01KZS7250G84C421SMNCBQ09W7 / vfy_01KZS7HM8A67SWX9Y1BMQSWPZY). The self-test files a one-page certificate into the seat's **authored** ops location and reads it back; the filed, read-back document is the production proof.

- **Location is authored-only, never chosen.** `self_initiation.document_library` first, `digest.home_matter_id` as fallback, and an honest FAILED naming the reason when neither is authored. Never a client matter. On ashton-price (no digest home; library location unauthored until the blessing) step 3 legitimately reports FAILED until the firm blesses a location — the conductor's body says so, so the status board reads as the honest state rather than a bug.
- **The certificate is dateless and content-free by construction**, so the render gate's date/figure/identifier refusals cannot fire on it. The run's date and detail stay in the delivery email.
- **Trust ceiling amended narrowly and visibly:** this is the ONE write the self-test ever makes. Frontmatter `action_class`/`connectors` updated, output-classes binding gains `self_test_certificate` (`smokeball_file → record`, the library templates' rationale), and the "never writes the tenant" invariant now states its single exception.
- **Both cards' self-test row** repointed: expected/falsifier move from "Word attachment" to "filed to the authored ops location and read back", plus a falsifier for anything filed to a client matter or a self-chosen location.

## Deliberately deferred

A true email attachment needs render-bytes plus attachment support on the send path — exactly the seam #2258 is rebuilding right now (overlay#250 reseams both send paths onto broker transmit verbs). Building it here would collide with that in-flight work; it can ride those verbs later. Noted rather than silently dropped.

## Acceptance criteria status

- [x] (repo) Step 3 names a path that exists on an email turn, with authored-only location resolution and an honest FAILED when unauthored
- [x] (repo) The single tenant write is declared everywhere it is claimed: frontmatter, output-classes binding, trust ceiling, invariants, both cards
- [x] (repo) Gates green — `npm run verify` exit 0 (260 vitest files); operator conformance 71 passed (frontmatter, output-class, block registry)
- [ ] (runtime) Self-test on the pilot returns step 3 PASS with the certificate filed to the ops matter and read back (fileName + sha256 + size in the report) — crane_verify; rides the pilot rehearsal, gated on the machine restart (#2258 containment)
- [ ] (runtime) On a seat with no authored ops location, step 3 reports FAILED naming that reason and files nothing — crane_verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YMQcxGtkEyrCvYxEAi8Y5e