### PR TITLE
fix(identity,billing,storage): three #2280 hardening items — email normalization, Stripe linkage silence, R2 key collisions (ss#2315)

### DIFF
--- a/src/lib/auth/clerk-bridge.ts
+++ b/src/lib/auth/clerk-bridge.ts
@@ -20,6 +20,7 @@
  */
 
 import { ORG_ID } from '../constants'
+import { EMAIL_IDENTITY_PREDICATE, normalizeEmail } from '../identity/email'
 import type { Entity } from '../db/entities'
 import { stampLoginIfNewSession } from './login-events'
 
@@ -86,7 +87,9 @@ export async function ensureLocalUser(
   // so we never overwrite an existing binding. Email comes from Clerk's
   // verified primary email, which is the trust anchor.
   //
-  // Matched case-INSENSITIVELY. The `users.email` column carries no
+  // Matched through the shared identity normalization (src/lib/identity/email.ts):
+  // trimmed and lowercased on the input side, `lower()` on the column side.
+  // The `users.email` column carries no
   // COLLATE NOCASE, so a seeded row's casing had to match Clerk's byte for
   // byte or the link silently missed — the JIT INSERT below would then
   // succeed (UNIQUE(org_id,email) is case-sensitive too), stranding the
@@ -98,10 +101,10 @@ export async function ensureLocalUser(
   const emailMatch = await db
     .prepare(
       `SELECT * FROM users
-       WHERE org_id = ? AND lower(email) = lower(?) AND clerk_user_id IS NULL
+       WHERE org_id = ? AND ${EMAIL_IDENTITY_PREDICATE} AND clerk_user_id IS NULL
        LIMIT 1`
     )
-    .bind(ORG_ID, profile.email)
+    .bind(ORG_ID, normalizeEmail(profile.email))
     .first<PortalUserRow>()
 
   if (emailMatch) {
@@ -112,6 +115,10 @@ export async function ensureLocalUser(
     return { ...emailMatch, clerk_user_id: clerkUserId }
   }
 
+  // Stored VERBATIM, not normalized. This is Clerk's verified primary address
+  // — the trust anchor — and it is what the admin console displays. The lookup
+  // above folds case; the record keeps the IdP's spelling. See the second rule
+  // in src/lib/identity/email.ts for why those are deliberately separate.
   const id = crypto.randomUUID()
   await db
     .prepare(

--- a/src/lib/auth/magic-link.ts
+++ b/src/lib/auth/magic-link.ts
@@ -16,6 +16,8 @@
  *     in a future change.
  */
 
+import { normalizeEmail } from '../identity/email'
+
 /** Default TTL for admin and client login magic links (15 minutes). */
 export const MAGIC_LINK_EXPIRY_MS = 15 * 60 * 1000
 
@@ -74,7 +76,7 @@ export async function createMagicLink(
       `INSERT INTO magic_links (id, org_id, user_id, email, token, expires_at)
        VALUES (?, ?, ?, ?, ?, ?)`
     )
-    .bind(id, subject.orgId, subject.userId, subject.email.toLowerCase().trim(), token, expiresAt)
+    .bind(id, subject.orgId, subject.userId, normalizeEmail(subject.email), token, expiresAt)
     .run()
 
   return token

--- a/src/lib/booking/intake-core.ts
+++ b/src/lib/booking/intake-core.ts
@@ -11,6 +11,7 @@ import { createContact } from '../db/contacts'
 import { updateAssessment, getAssessment } from '../db/assessments'
 import { createMeetingWithLegacyAssessment, ensureMeetingForAssessment } from '../db/meetings'
 import { appendContext } from '../db/context'
+import { EMAIL_IDENTITY_PREDICATE, normalizeEmail } from '../identity/email'
 import { interestLabel } from './config'
 import { attributionSummary, type AdAttribution } from '../marketing/attribution'
 
@@ -161,9 +162,15 @@ async function resolveContact(
   entityId: string,
   input: IntakeInput
 ): Promise<ContactResolution> {
+  // Case-INSENSITIVE, and trimmed on the input side. `contacts.email` carries
+  // no COLLATE NOCASE (migrations/0001_create_tables.sql:164), so an exact
+  // comparison made `Owner@Example.com` and `owner@example.com` two different
+  // people: the same prospect booking twice got a second contact row on the
+  // same entity and a split correspondence history. Nobody types their own
+  // address the same way twice. See src/lib/identity/email.ts.
   const existing = await db
-    .prepare('SELECT id FROM contacts WHERE org_id = ? AND email = ? LIMIT 1')
-    .bind(orgId, input.email)
+    .prepare(`SELECT id FROM contacts WHERE org_id = ? AND ${EMAIL_IDENTITY_PREDICATE} LIMIT 1`)
+    .bind(orgId, normalizeEmail(input.email))
     .first<{ id: string }>()
   if (existing) return { contactId: existing.id, contactCreated: false }
   const contact = await createContact(db, orgId, entityId, { name: input.name, email: input.email })

--- a/src/lib/identity/email.ts
+++ b/src/lib/identity/email.ts
@@ -1,0 +1,56 @@
+/**
+ * The canonical form of an email address used as an identity key (ss#2315).
+ *
+ * Email is the join key between a person and their row in `users` or
+ * `contacts`, and before this module it was normalized six different ways —
+ * three with no trim, one case-sensitive on both sides. The consequences
+ * ranged from a duplicate contact row to a silent lockout (#2282, fixed in
+ * PR #2294) to a person stranded on a second, entity-less `users` row
+ * (documented inline at `src/lib/auth/clerk-bridge.ts`).
+ *
+ * Two rules, and they are separate on purpose:
+ *
+ * 1. **Compare normalized.** Every lookup that treats an address as identity
+ *    binds `normalizeEmail(input)` and — because neither `users.email`
+ *    (`migrations/0001_create_tables.sql:136`) nor `contacts.email` (`:164`)
+ *    carries `COLLATE NOCASE` — folds the column too: `lower(email) = ?`.
+ *    Folding only the input is the bug this module exists to prevent.
+ *
+ * 2. **Store what was given.** Normalizing on the way IN is deliberately not
+ *    this module's job. `users.email` is displayed to admins and echoed back
+ *    to the person, and for Clerk-bridged rows it is the IdP's verified
+ *    primary address — the trust anchor. Rewriting its casing to satisfy a
+ *    lookup would be the lookup's problem leaking into the record. Sites
+ *    that already stored a normalized value (`src/lib/sow/service-finalize.ts`)
+ *    keep doing so; nothing new starts.
+ *
+ * Nothing here validates. Address syntax is checked at the API boundary by
+ * the route's zod schema; this is normalization only.
+ */
+
+/**
+ * Fold an address to its identity form: surrounding whitespace removed,
+ * lowercased.
+ *
+ * Case-folding the local part is technically beyond what RFC 5321 permits a
+ * receiver to assume, but every mail provider this venture transacts with
+ * treats it case-insensitively, and an IdP echoes whatever casing its own
+ * directory holds — Microsoft and Google both return the directory's spelling,
+ * not the one the person typed. Treating the two as different people has only
+ * ever produced defects.
+ */
+export function normalizeEmail(raw: string): string {
+  return raw.trim().toLowerCase()
+}
+
+/**
+ * SQL predicate for an identity lookup on an `email` column, for use with a
+ * `normalizeEmail`-normalized bind parameter.
+ *
+ * The column is folded here rather than at write time because existing rows
+ * carry whatever casing they were created with — prod holds at least one
+ * mixed-case `users` row (#2282). Callers that inline the fragment instead of
+ * importing it are equally correct; the constant exists so the reason travels
+ * with the pattern.
+ */
+export const EMAIL_IDENTITY_PREDICATE = 'lower(email) = ?'

--- a/src/lib/operator/mcp/customer-resolution.ts
+++ b/src/lib/operator/mcp/customer-resolution.ts
@@ -2,6 +2,7 @@ import type { D1Database } from '@cloudflare/workers-types'
 import { z } from 'zod'
 import type { McpConnector } from '../customer-yaml/types'
 import { parseMcpConnector } from '../../portal/customer-config'
+import { normalizeEmail } from '../../identity/email'
 
 const CUSTOMER_SLUG = /^[a-z0-9][a-z0-9-]{0,31}$/
 const MCP_RESOURCE_PREFIX = '/api/operator'
@@ -78,9 +79,14 @@ function resolvePrincipals(
   connector: McpConnector,
   userRows: readonly z.infer<typeof userRowSchema>[]
 ): AuthorizedMcpPrincipal[] {
-  const usersByEmail = new Map(userRows.map((user) => [user.email.toLowerCase(), user]))
+  // Both sides folded through the shared identity normalization: the authored
+  // `mcp_connector.access[]` email is hand-typed into customer.yaml and the
+  // users row carries whatever casing its IdP returned. A miss here does not
+  // error — the entry is dropped from the principal set, so the person simply
+  // has no MCP access and nothing says why.
+  const usersByEmail = new Map(userRows.map((user) => [normalizeEmail(user.email), user]))
   return connector.access.flatMap((entry) => {
-    const user = usersByEmail.get(entry.email.toLowerCase())
+    const user = usersByEmail.get(normalizeEmail(entry.email))
     if (!user) return []
     const clerkUserIds = [
       ...(entry.clerk_subjects ?? []),

--- a/src/lib/portal/clerk-org-members.ts
+++ b/src/lib/portal/clerk-org-members.ts
@@ -30,6 +30,7 @@
 
 import type { APIContext } from 'astro'
 import { clerkClient } from '@clerk/astro/server'
+import { normalizeEmail } from '../identity/email'
 
 /**
  * One Clerk-side participant in an organization. Discriminated by
@@ -178,8 +179,8 @@ export function dedupePendingAgainstMembers(
   pending: readonly ClerkOrgPendingInvite[],
   members: readonly ClerkOrgMember[]
 ): ClerkOrgPendingInvite[] {
-  const joinedEmails = new Set(members.map((m) => m.email.toLowerCase()))
-  return pending.filter((inv) => !joinedEmails.has(inv.email.toLowerCase()))
+  const joinedEmails = new Set(members.map((m) => normalizeEmail(m.email)))
+  return pending.filter((inv) => !joinedEmails.has(normalizeEmail(inv.email)))
 }
 
 /**

--- a/src/lib/sow/service-finalize.ts
+++ b/src/lib/sow/service-finalize.ts
@@ -16,6 +16,7 @@ import { getSowRevisionSignedKey, uploadSignedSowRevisionPdf } from '../storage/
 import { getSignedPdf } from '../signwell/client'
 import type { SignWellWebhookPayload } from '../signwell/types'
 import { sendEmail } from '../email/resend'
+import { normalizeEmail } from '../identity/email'
 import { portalWelcomeEmailHtml, signatureConfirmationEmailHtml } from '../email/templates'
 import { createStripeInvoice, sendStripeInvoice } from '../stripe/client'
 
@@ -233,7 +234,7 @@ interface FinalizeCtx {
 function buildOutboxStmts(ctx: FinalizeCtx): D1PreparedStatement[] {
   // prettier-ignore
   const { db, orgId, requestId, entityId, quoteId, engagementId, invoiceId, depositAmount, signer, now } = ctx
-  const normalizedEmail = signer.email.toLowerCase().trim()
+  const normalizedEmail = normalizeEmail(signer.email)
   return [
     db
       .prepare(
@@ -369,7 +370,7 @@ function buildFinalizationBatch(
   const milestoneIds = lineItems.map(() => crypto.randomUUID())
   const clientUserId = crypto.randomUUID()
   const contextEntryId = crypto.randomUUID()
-  const normalizedEmail = signer.email.toLowerCase().trim()
+  const normalizedEmail = normalizeEmail(signer.email)
   const stageChangeContent = 'Stage: proposing -> engaged. SOW signed via SignWell.'
   const stageChangeMetadata = JSON.stringify({
     from: 'proposing',

--- a/src/lib/storage/r2.ts
+++ b/src/lib/storage/r2.ts
@@ -1,11 +1,68 @@
 /**
  * R2 storage helpers for file uploads.
  *
- * Transcript files are stored with a structured key pattern:
- *   {orgId}/assessments/{assessmentId}/transcript/{filename}
+ * Uploaded files are stored under a structured, tenant-scoped key:
+ *   {orgId}/assessments/{assessmentId}/transcript/{nameHash}/{filename}
+ *   {orgId}/engagements/{engagementId}/docs/{nameHash}/{filename}
  *
- * This ensures tenant isolation and logical grouping within the R2 bucket.
+ * The `{nameHash}` segment exists because `{filename}` is lossy — see
+ * `uploadKeyLeaf` — and two different uploads that sanitized to the same
+ * string used to write the same key, the second destroying the first
+ * (ss#2315).
  */
+
+/** Sanitize a client-supplied filename for use in a key: alphanumerics, dots,
+ * hyphens and underscores survive; everything else becomes an underscore.
+ * Many-to-one on purpose — the hash segment is what makes the key unique. */
+function sanitizeFileName(name: string): string {
+  return name.replace(/[^a-zA-Z0-9._-]/g, '_')
+}
+
+/**
+ * The two trailing segments of an upload key: a short digest of the ORIGINAL
+ * filename, then the sanitized filename.
+ *
+ * Three properties, each load-bearing:
+ *
+ * - **Distinct names never collide.** `Scope (final).pdf` and
+ *   `Scope [final].pdf` sanitize identically but hash differently, so neither
+ *   overwrites the other. For engagement deliverables — prefix-listed and
+ *   rendered on the client portal — a collision silently removed a document
+ *   the client could see.
+ * - **The same name still replaces.** Hashing the name rather than the bytes
+ *   keeps re-uploading a corrected file a replacement, not a second entry the
+ *   UI has no way to remove.
+ * - **Display is unchanged.** The filename stays the LAST segment, so every
+ *   reader's `key.split('/').pop()` shows what it always showed, and the key
+ *   stays under its existing prefix, so prefix listing and the portal's
+ *   path-traversal checks are unaffected.
+ *
+ * Keys written before this existed are untouched and stay reachable: readers
+ * use the key recorded in D1 or the key returned by `list()`, never a
+ * recomputed one. No migration, nothing orphaned.
+ */
+export async function uploadKeyLeaf(originalName: string): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(originalName))
+  const nameHash = Array.from(new Uint8Array(digest).slice(0, 4))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('')
+  return `${nameHash}/${sanitizeFileName(originalName)}`
+}
+
+/**
+ * Structured key for an engagement deliverable.
+ *
+ * @param orgId - Organization ID for tenant scoping
+ * @param engagementId - Engagement the document belongs to
+ * @param originalName - The uploaded file's name, unsanitized
+ */
+export async function getEngagementDocumentKey(
+  orgId: string,
+  engagementId: string,
+  originalName: string
+): Promise<string> {
+  return `${orgId}/engagements/${engagementId}/docs/${await uploadKeyLeaf(originalName)}`
+}
 
 /**
  * Upload a transcript file to R2.
@@ -22,9 +79,7 @@ export async function uploadTranscript(
   assessmentId: string,
   file: File
 ): Promise<string> {
-  // Sanitize filename — keep only alphanumeric, dots, hyphens, underscores
-  const safeName = file.name.replace(/[^a-zA-Z0-9._-]/g, '_')
-  const key = `${orgId}/assessments/${assessmentId}/transcript/${safeName}`
+  const key = `${orgId}/assessments/${assessmentId}/transcript/${await uploadKeyLeaf(file.name)}`
 
   const arrayBuffer = await file.arrayBuffer()
 

--- a/src/lib/webhooks/hosted-agent-checkout-handler.ts
+++ b/src/lib/webhooks/hosted-agent-checkout-handler.ts
@@ -21,6 +21,7 @@
 
 import type { D1Database } from '@cloudflare/workers-types'
 import { ORG_ID } from '../constants'
+import { EMAIL_IDENTITY_PREDICATE, normalizeEmail } from '../identity/email'
 import { createEntity } from '../db/entities'
 import { createHostedAgentIntake } from '../db/hosted-agent-intake'
 import { HOSTED_AGENT_PRODUCT_SLUG } from '../portal/hosted-agent-access'
@@ -80,8 +81,8 @@ async function resolveBuyer(
   const email = payload.customer_details?.email
   if (email) {
     const byEmail = await db
-      .prepare('SELECT id, email, name, entity_id FROM users WHERE lower(email) = lower(?)')
-      .bind(email)
+      .prepare(`SELECT id, email, name, entity_id FROM users WHERE ${EMAIL_IDENTITY_PREDICATE}`)
+      .bind(normalizeEmail(email))
       .first<LocalUserRow>()
     if (byEmail) return byEmail
   }

--- a/src/lib/webhooks/stripe-subscription-handler.ts
+++ b/src/lib/webhooks/stripe-subscription-handler.ts
@@ -51,28 +51,148 @@ function serverError(): Response {
 }
 
 /**
- * Pull the parent subscription id off an invoice payload. Stripe moved the
- * linkage across API versions — older versions carry a top-level
- * `subscription` string; newer versions nest it under
- * `parent.subscription_details.subscription`. This client pins no
- * Stripe-Version header, so both shapes must parse (parse, never cast).
+ * Whether an invoice belongs to a subscription, and — when it does not read
+ * cleanly — the fact that we could not tell.
+ *
+ * `unlinked` and `unrecognized` were the same value (`null`) until ss#2315,
+ * and conflating them is how a Stripe API change becomes a missing invoice
+ * instead of an error. The dispatcher routes on this, so `unlinked` sends the
+ * event to the legacy one-time flow and `unrecognized` must never do that.
  */
-export function extractStripeSubscriptionId(invoice: unknown): string | null {
-  if (typeof invoice !== 'object' || invoice === null) return null
+export type StripeSubscriptionLinkage =
+  | { kind: 'linked'; subscriptionId: string }
+  | { kind: 'unlinked' }
+  | { kind: 'unrecognized'; reason: string }
+
+/** A linkage field holds either the id or the expanded object it refers to. */
+function readSubscriptionRef(value: unknown): { id: string } | { unreadable: true } | null {
+  if (value === null || value === undefined) return null
+  if (typeof value === 'string') return value.length > 0 ? { id: value } : null
+  if (typeof value === 'object') {
+    const id = (value as Record<string, unknown>)['id']
+    if (typeof id === 'string' && id.length > 0) return { id }
+  }
+  return { unreadable: true }
+}
+
+/**
+ * Resolve an invoice payload's subscription linkage.
+ *
+ * Stripe has moved this field once already: older API versions carry a
+ * top-level `subscription`, newer ones nest it under
+ * `parent.subscription_details.subscription`. Either position may hold a bare
+ * id or — because both are expandable — the expanded Subscription object.
+ * This client pins no `Stripe-Version` header, so every one of those must
+ * parse (parse, never cast).
+ *
+ * The point of the third state is the move we have not seen yet. Detection is
+ * deliberately conservative: it fires only on a POSITIVE signal that this is a
+ * subscription invoice, so a genuine one-time console-originated invoice is
+ * never mistaken for a broken one. `billing_reason` is the signal that
+ * survives a field move — whatever Stripe does to the linkage next, a cycle
+ * invoice still says why it was billed.
+ */
+export function resolveStripeSubscriptionLinkage(invoice: unknown): StripeSubscriptionLinkage {
+  if (typeof invoice !== 'object' || invoice === null) return { kind: 'unlinked' }
   const obj = invoice as Record<string, unknown>
 
-  const direct = obj['subscription']
-  if (typeof direct === 'string' && direct.length > 0) return direct
+  const direct = readSubscriptionRef(obj['subscription'])
+  if (direct && 'id' in direct) return { kind: 'linked', subscriptionId: direct.id }
 
-  const parent = obj['parent']
-  if (typeof parent === 'object' && parent !== null) {
-    const details = (parent as Record<string, unknown>)['subscription_details']
-    if (typeof details === 'object' && details !== null) {
-      const nested = (details as Record<string, unknown>)['subscription']
-      if (typeof nested === 'string' && nested.length > 0) return nested
-    }
+  const parentObj = asRecord(obj['parent'])
+  const detailsObj = asRecord(parentObj?.['subscription_details'])
+  const nested = readSubscriptionRef(detailsObj?.['subscription'])
+  if (nested && 'id' in nested) return { kind: 'linked', subscriptionId: nested.id }
+
+  const signal = subscriptionSignal(obj, {
+    directPresent: direct !== null,
+    detailsPresent: detailsObj !== null,
+    parent: parentObj,
+  })
+  return signal === null ? { kind: 'unlinked' } : { kind: 'unrecognized', reason: signal }
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === 'object' && value !== null ? (value as Record<string, unknown>) : null
+}
+
+/**
+ * Why this invoice looks like a subscription invoice despite carrying no
+ * readable linkage, or null when it simply is not one.
+ *
+ * Ordered most-durable first. `billing_reason` is checked ahead of the linkage
+ * fields because it is the signal that survives the field moving again.
+ */
+function subscriptionSignal(
+  obj: Record<string, unknown>,
+  found: {
+    directPresent: boolean
+    detailsPresent: boolean
+    parent: Record<string, unknown> | null
+  }
+): string | null {
+  const billingReason = obj['billing_reason']
+  if (typeof billingReason === 'string' && billingReason.startsWith('subscription')) {
+    return `billing_reason=${billingReason} with no readable id`
+  }
+  if (found.directPresent) return 'subscription field present but unreadable'
+  if (found.detailsPresent) return 'parent.subscription_details present but unreadable'
+  if (found.parent?.['type'] === 'subscription_details') {
+    return 'parent.type=subscription_details with no details'
   }
   return null
+}
+
+/**
+ * The subscription id, or null when there is not a readable one.
+ *
+ * Retained for call sites that only need the id. Anything that decides how to
+ * ROUTE an event must use {@link resolveStripeSubscriptionLinkage} instead —
+ * null here still cannot distinguish "no subscription" from "cannot read it".
+ */
+export function extractStripeSubscriptionId(invoice: unknown): string | null {
+  const linkage = resolveStripeSubscriptionLinkage(invoice)
+  return linkage.kind === 'linked' ? linkage.subscriptionId : null
+}
+
+/**
+ * An invoice signalled a subscription linkage this code cannot read.
+ *
+ * Loud on three surfaces, because each catches a different reader: an error
+ * log (Sentry), an operational alert to the firm, and a non-2xx so the
+ * delivery shows as FAILED in Stripe's own dashboard. Acking would leave a
+ * retainer invoice unmirrored with nothing anywhere saying so.
+ *
+ * The 500 makes Stripe retry a request that cannot succeed. That is the
+ * intent: a repeatedly failing endpoint is a signal Stripe raises on its own,
+ * and the alternative — a quiet 200 — is the defect. Retries stop when the
+ * shape is handled and the endpoint is redeployed.
+ */
+export async function handleUnrecognizedInvoiceLinkage(
+  resendApiKey: string | undefined,
+  eventType: string,
+  invoiceId: string,
+  reason: string
+): Promise<Response> {
+  console.error(
+    `[stripe-subscription] UNRECOGNIZED subscription linkage on ${eventType} for invoice ${invoiceId}: ${reason}. Invoice NOT mirrored.`
+  )
+  try {
+    await sendEmail(resendApiKey, {
+      to: ALERT_EMAIL,
+      subject: `Stripe webhook: unreadable subscription linkage (${invoiceId})`,
+      html:
+        `<p>A Stripe invoice event carried a subscription linkage this console could not read, so the invoice was <strong>not</strong> mirrored into the local <code>invoices</code> table.</p>` +
+        `<ul><li>Event: ${eventType}</li>` +
+        `<li>Stripe invoice: ${invoiceId}</li>` +
+        `<li>Reason: ${reason}</li></ul>` +
+        `<p>Most likely cause: the Stripe API version serving this webhook endpoint moved the linkage field again. Compare the raw event in the Stripe dashboard against <code>resolveStripeSubscriptionLinkage</code> in <code>src/lib/webhooks/stripe-subscription-handler.ts</code>.</p>` +
+        `<p>The endpoint returned 500, so Stripe will retry and the delivery will show as failed until the shape is handled.</p>`,
+    })
+  } catch (err) {
+    console.error('[stripe-subscription] unrecognized-linkage alert failed:', err)
+  }
+  return serverError()
 }
 
 /** The invoice-payload fields the retainer mirror consumes. */

--- a/src/pages/api/admin/engagements/[id]/deliverables.ts
+++ b/src/pages/api/admin/engagements/[id]/deliverables.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from 'astro'
 import { getEngagement } from '../../../../../lib/db/engagements'
-import { listDocuments } from '../../../../../lib/storage/r2'
+import { getEngagementDocumentKey, listDocuments } from '../../../../../lib/storage/r2'
 import { env } from 'cloudflare:workers'
 import { requireAdminSession } from '../../../../../lib/auth/admin-session'
 import { errorResponse, jsonResponse } from '../../../../../lib/api/helpers'
@@ -23,8 +23,11 @@ export const POST: APIRoute = async ({ request, locals, params }) => {
     if (!file || !(file instanceof File)) {
       return errorResponse(400, 'File required')
     }
-    const safeName = file.name.replace(/[^a-zA-Z0-9._-]/g, '_')
-    const key = `${session.orgId}/engagements/${engagementId}/docs/${safeName}`
+    // Collision-resistant key (ss#2315): two deliverables whose names
+    // sanitized to the same string used to write the same key, and the
+    // second silently removed the first from the client's document list.
+    const key = await getEngagementDocumentKey(session.orgId, engagementId, file.name)
+    const safeName = key.split('/').pop() ?? file.name
     const arrayBuffer = await file.arrayBuffer()
     await env.STORAGE.put(key, arrayBuffer, {
       httpMetadata: { contentType: file.type || 'application/octet-stream' },

--- a/src/pages/api/admin/resend-invitation.ts
+++ b/src/pages/api/admin/resend-invitation.ts
@@ -5,6 +5,7 @@ import { sendEmail } from '../../../lib/email/resend'
 import { buildMagicLinkUrl, portalInvitationEmailHtml } from '../../../lib/email/templates'
 import { env } from 'cloudflare:workers'
 import { requireAdminSession } from '../../../lib/auth/admin-session'
+import { normalizeEmail } from '../../../lib/identity/email'
 import { errorResponse, jsonResponse } from '../../../lib/api/helpers'
 
 interface UserRow {
@@ -42,7 +43,7 @@ async function maybeUpdateEmail(
   newEmail: unknown
 ): Promise<string | Response> {
   if (!newEmail || typeof newEmail !== 'string') return currentEmail
-  const normalizedEmail = newEmail.toLowerCase().trim()
+  const normalizedEmail = normalizeEmail(newEmail)
   if (normalizedEmail === currentEmail) return currentEmail
 
   // Update is org-scoped as a defense-in-depth measure even though the

--- a/src/pages/api/auth/magic-link.ts
+++ b/src/pages/api/auth/magic-link.ts
@@ -1,6 +1,7 @@
 import type { APIRoute } from 'astro'
 import { createMagicLink, MAGIC_LINK_EXPIRY_MS } from '../../../lib/auth/magic-link'
 import { ORG_ID } from '../../../lib/constants'
+import { EMAIL_IDENTITY_PREDICATE, normalizeEmail } from '../../../lib/identity/email'
 import { requirePortalBaseUrl } from '../../../lib/config/app-url'
 import { sendEmail } from '../../../lib/email/resend'
 import { buildMagicLinkUrl, magicLinkEmailHtml } from '../../../lib/email/templates'
@@ -44,7 +45,7 @@ export const POST: APIRoute = async ({ request, redirect }) => {
       return redirect('/auth/sign-in?error=server', 302)
     }
 
-    const normalizedEmail = email.toLowerCase().trim()
+    const normalizedEmail = normalizeEmail(email)
     // Look up the portal user in the current app org. Email is not globally
     // unique across organizations.
     //
@@ -59,7 +60,7 @@ export const POST: APIRoute = async ({ request, redirect }) => {
     // to check their email and nothing was ever sent. Same fix, same reason, as
     // src/lib/auth/clerk-bridge.ts:101.
     const user = await env.DB.prepare(
-      `SELECT * FROM users WHERE org_id = ? AND lower(email) = lower(?) AND role = 'client'`
+      `SELECT * FROM users WHERE org_id = ? AND ${EMAIL_IDENTITY_PREDICATE} AND role = 'client'`
     )
       .bind(ORG_ID, normalizedEmail)
       .first<UserRow>()

--- a/src/pages/api/webhooks/stripe.ts
+++ b/src/pages/api/webhooks/stripe.ts
@@ -3,7 +3,8 @@ import { z } from 'zod'
 import type { StripeWebhookEvent } from '../../../lib/stripe/types'
 import { handleInvoicePaid, handleInvoicePaymentFailed } from '../../../lib/webhooks/stripe-handler'
 import {
-  extractStripeSubscriptionId,
+  handleUnrecognizedInvoiceLinkage,
+  resolveStripeSubscriptionLinkage,
   handleRetainerInvoiceFinalized,
   handleRetainerInvoicePaid,
   handleRetainerInvoicePaymentFailed,
@@ -123,10 +124,17 @@ const StripeCheckoutSessionWebhookEventSchema = z.looseObject({
 })
 
 /**
- * Route an invoice event. Subscription-linked payloads (both API shapes:
- * top-level `subscription` and `parent.subscription_details.subscription` —
- * looseObject retains them even though the schema does not declare them)
- * belong to the retainer mirror; unlinked ones to the legacy one-time flow.
+ * Route an invoice event. Subscription-linked payloads (every API shape
+ * `resolveStripeSubscriptionLinkage` knows — looseObject retains the fields
+ * even though the schema does not declare them) belong to the retainer
+ * mirror; unlinked ones to the legacy one-time flow.
+ *
+ * A payload that signals a subscription but whose linkage cannot be read is
+ * the third case, and it must not travel either route: sending it to the
+ * legacy flow finds no local invoice row and acks, which is how a Stripe API
+ * change turns into a silently missing retainer invoice. It fails loudly
+ * instead (ss#2315).
+ *
  * Returns null when the event type is not an invoice event this route handles.
  */
 async function dispatchInvoiceEvent(eventType: string, parsed: unknown): Promise<Response | null> {
@@ -142,7 +150,16 @@ async function dispatchInvoiceEvent(eventType: string, parsed: unknown): Promise
     return errorResponse(400, 'Malformed event payload')
   }
   const invoice = eventResult.data.data.object
-  const subId = extractStripeSubscriptionId(invoice)
+  const linkage = resolveStripeSubscriptionLinkage(invoice)
+  if (linkage.kind === 'unrecognized') {
+    return handleUnrecognizedInvoiceLinkage(
+      env.RESEND_API_KEY,
+      eventType,
+      invoice.id,
+      linkage.reason
+    )
+  }
+  const subId = linkage.kind === 'linked' ? linkage.subscriptionId : null
 
   if (eventType === 'invoice.paid') {
     if (subId !== null) return handleRetainerInvoicePaid(env.DB, env.RESEND_API_KEY, subId, invoice)

--- a/tests/email-identity.test.ts
+++ b/tests/email-identity.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Email-as-identity normalization (ss#2315, #2280 hardening item 12).
+ *
+ * `email` is the join key at several identity sites and was normalized a
+ * different way at each — three of them with no trim, one case-sensitive on
+ * BOTH sides. Neither `users.email` nor `contacts.email` carries
+ * `COLLATE NOCASE` (there is no `COLLATE` anywhere in `migrations/`), so
+ * SQLite equality is case-sensitive and the JS side is the only defence.
+ *
+ * These tests pin the canonical form at the sites a caller can reach, plus a
+ * source-level guard so the next case-sensitive `email = ?` cannot land
+ * silently. Each was run against the unfixed tree first; the failures are in
+ * the PR body.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { readdirSync, readFileSync, statSync } from 'fs'
+import { resolve, extname, relative } from 'path'
+import {
+  createTestD1,
+  runMigrations,
+  discoverNumericMigrations,
+} from '@venturecrane/crane-test-harness'
+import type { D1Database } from '@cloudflare/workers-types'
+
+import { normalizeEmail } from '../src/lib/identity/email'
+import { processIntakeSubmission } from '../src/lib/booking/intake-core'
+import { ensureLocalUser } from '../src/lib/auth/clerk-bridge'
+import {
+  dedupePendingAgainstMembers,
+  type ClerkOrgMember,
+  type ClerkOrgPendingInvite,
+} from '../src/lib/portal/clerk-org-members'
+import { ORG_ID } from '../src/lib/constants'
+
+const migrationsDir = resolve(process.cwd(), 'migrations')
+
+describe('normalizeEmail', () => {
+  it('trims and lowercases', () => {
+    expect(normalizeEmail('  Owner@Example.COM \n')).toBe('owner@example.com')
+  })
+
+  it('is idempotent', () => {
+    const once = normalizeEmail(' A@B.com ')
+    expect(normalizeEmail(once)).toBe(once)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// The live defect: intake dedupe was case-sensitive on both sides
+// ---------------------------------------------------------------------------
+
+describe('processIntakeSubmission — contact dedupe is case-insensitive', () => {
+  let db: D1Database
+  const orgId = 'org-email-identity'
+
+  beforeEach(async () => {
+    db = createTestD1()
+    await runMigrations(db, { files: discoverNumericMigrations(migrationsDir) })
+    await db
+      .prepare('INSERT INTO organizations (id, name, slug) VALUES (?, ?, ?)')
+      .bind(orgId, 'Org EI', 'org-ei')
+      .run()
+  })
+
+  it('does not create a second contact when the same person books with different casing', async () => {
+    const first = await processIntakeSubmission(db, orgId, {
+      name: 'Dana Owner',
+      email: 'Owner@Example.com',
+      businessName: 'Dana Plumbing',
+    })
+    expect(first.contactCreated).toBe(true)
+
+    const second = await processIntakeSubmission(db, orgId, {
+      name: 'Dana Owner',
+      email: '  owner@example.COM ',
+      businessName: 'Dana Plumbing',
+    })
+
+    // The observable: a second `contacts` row for one human. The returned
+    // ids alone would not catch it — a fresh row also returns an id.
+    const rows = await db
+      .prepare('SELECT id, email FROM contacts WHERE org_id = ?')
+      .bind(orgId)
+      .all<{ id: string; email: string }>()
+
+    expect(rows.results).toHaveLength(1)
+    expect(second.contactCreated).toBe(false)
+    expect(second.contactId).toBe(first.contactId)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// clerk-bridge: lower() on both sides already, but no trim
+// ---------------------------------------------------------------------------
+
+describe('ensureLocalUser — auto-link tolerates surrounding whitespace', () => {
+  let db: D1Database
+  const PRE_CLERK_USER_ID = 'user-pre-clerk-ei'
+  const PRE_CLERK_ENTITY_ID = 'entity-pre-clerk-ei'
+
+  beforeEach(async () => {
+    db = createTestD1()
+    await runMigrations(db, { files: discoverNumericMigrations(migrationsDir) })
+    await db
+      .prepare('INSERT OR IGNORE INTO organizations (id, name, slug) VALUES (?, ?, ?)')
+      .bind(ORG_ID, 'SMD Services', 'smd-services')
+      .run()
+    await db
+      .prepare('INSERT INTO entities (id, org_id, name, slug) VALUES (?, ?, ?, ?)')
+      .bind(PRE_CLERK_ENTITY_ID, ORG_ID, 'Pre Clerk EI', 'pre-clerk-ei')
+      .run()
+    await db
+      .prepare(
+        `INSERT INTO users (id, org_id, email, name, role, entity_id, clerk_user_id)
+         VALUES (?, ?, ?, ?, 'client', ?, NULL)`
+      )
+      .bind(PRE_CLERK_USER_ID, ORG_ID, 'Seeded@Example.com', 'Seeded Client', PRE_CLERK_ENTITY_ID)
+      .run()
+  })
+
+  it('links the seeded row instead of stranding the person on a new one', async () => {
+    const result = await ensureLocalUser(db, 'user_clerk_ei', {
+      email: ' seeded@example.com ',
+      name: 'Seeded Client',
+    })
+
+    expect(result.id).toBe(PRE_CLERK_USER_ID)
+    expect(result.entity_id).toBe(PRE_CLERK_ENTITY_ID)
+
+    // No second, entity-less row was minted alongside the seeded one. Scoped
+    // to the address: migrations/0005_seed_admin_user.sql seeds an unrelated
+    // admin into this org.
+    const rows = await db
+      .prepare('SELECT id FROM users WHERE org_id = ? AND lower(email) = ?')
+      .bind(ORG_ID, 'seeded@example.com')
+      .all<{ id: string }>()
+    expect(rows.results).toHaveLength(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Pure-function join sites
+// ---------------------------------------------------------------------------
+
+describe('dedupePendingAgainstMembers', () => {
+  it('drops a pending invite whose address differs only by case or whitespace', () => {
+    const pending: ClerkOrgPendingInvite[] = [
+      {
+        kind: 'pending_invite',
+        email: ' Joined@Example.com ',
+        name: '',
+        clerkUserId: null,
+        role: 'member',
+        joinedAt: null,
+        invitedAt: null,
+        expiresAt: null,
+      },
+    ]
+    const members: ClerkOrgMember[] = [
+      {
+        kind: 'member',
+        email: 'joined@example.com',
+        name: 'Joined Person',
+        clerkUserId: 'user_1',
+        role: 'member',
+        joinedAt: null,
+        invitedAt: null,
+        expiresAt: null,
+      },
+    ]
+
+    expect(dedupePendingAgainstMembers(pending, members)).toHaveLength(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Permanent falsifier: no new case-sensitive identity lookup
+// ---------------------------------------------------------------------------
+
+/**
+ * A WHERE/AND predicate comparing the `email` column with a bind parameter.
+ * Deliberately does not match `SET email = ?` (an update writes, it does not
+ * join) or `resolved_by_email = ?`.
+ */
+const CASE_SENSITIVE_EMAIL_PREDICATE = /(?:\bWHERE\b|\bAND\b)\s+email\s*=\s*\?/gi
+
+function collectSourceFiles(dir: string): string[] {
+  const files: string[] = []
+  for (const entry of readdirSync(dir)) {
+    const fullPath = `${dir}/${entry}`
+    if (statSync(fullPath).isDirectory()) {
+      files.push(...collectSourceFiles(fullPath))
+      continue
+    }
+    const ext = extname(entry)
+    if (['.astro', '.ts', '.tsx'].includes(ext) && !/\.test\.tsx?$/.test(entry)) {
+      files.push(fullPath)
+    }
+  }
+  return files
+}
+
+describe('email identity guard', () => {
+  it('no shipped source compares the email column case-sensitively', () => {
+    const offenders: string[] = []
+    for (const file of collectSourceFiles(resolve('src'))) {
+      const source = readFileSync(file, 'utf-8')
+      for (const match of source.matchAll(CASE_SENSITIVE_EMAIL_PREDICATE)) {
+        const line = source.slice(0, match.index).split('\n').length
+        offenders.push(`${relative(process.cwd(), file)}:${line} — ${match[0].trim()}`)
+      }
+    }
+    expect(offenders).toEqual([])
+  })
+})

--- a/tests/r2-key-collision.test.ts
+++ b/tests/r2-key-collision.test.ts
@@ -1,0 +1,171 @@
+/**
+ * R2 key collision resistance (ss#2315, #2280 hardening item 11).
+ *
+ * Two upload paths used a client-supplied filename as the whole key leaf,
+ * sanitized with `replace(/[^a-zA-Z0-9._-]/g, '_')`. That expression is
+ * many-to-one — `notes v1.txt`, `notes+v1.txt` and `notes(v1).txt` all become
+ * `notes_v1.txt` — so two distinct uploads wrote the same key and the second
+ * destroyed the first.
+ *
+ * Engagement deliverables are the sharp half: they are prefix-listed, not
+ * pointer-indexed, and the list renders on the CLIENT portal. Losing one is
+ * losing a document a client could see.
+ *
+ * The fix must not change what anyone reads. Two invariants are pinned here
+ * alongside the collision itself: the key stays under the same prefix (so
+ * prefix listing and the portal's path-traversal check are unaffected), and
+ * the last path segment is still the sanitized filename (so every display
+ * site's `key.split('/').pop()` keeps showing the name the client gave).
+ */
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import {
+  uploadTranscript,
+  getTranscript,
+  getEngagementDocumentKey,
+  listDocuments,
+} from '../src/lib/storage/r2'
+
+// ---------------------------------------------------------------------------
+// Minimal in-memory R2
+// ---------------------------------------------------------------------------
+
+interface StoredObject {
+  key: string
+  body: ArrayBuffer
+  customMetadata?: Record<string, string>
+}
+
+function makeBucket(): { bucket: R2Bucket; store: Map<string, StoredObject> } {
+  const store = new Map<string, StoredObject>()
+  const bucket = {
+    put(key: string, body: ArrayBuffer, opts?: { customMetadata?: Record<string, string> }) {
+      store.set(key, { key, body, customMetadata: opts?.customMetadata })
+      return Promise.resolve({ key })
+    },
+    get(key: string) {
+      const hit = store.get(key)
+      if (!hit) return Promise.resolve(null)
+      return Promise.resolve({
+        key,
+        customMetadata: hit.customMetadata,
+        text: () => Promise.resolve(new TextDecoder().decode(hit.body)),
+      })
+    },
+    list({ prefix }: { prefix: string }) {
+      return Promise.resolve({
+        objects: [...store.values()]
+          .filter((o) => o.key.startsWith(prefix))
+          .map((o) => ({ key: o.key, size: o.body.byteLength, uploaded: new Date(0) })),
+      })
+    },
+  } as unknown as R2Bucket
+  return { bucket, store }
+}
+
+function textFile(name: string, contents: string): File {
+  return new File([contents], name, { type: 'text/plain' })
+}
+
+const ORG = 'org-r2'
+const ASSESSMENT = 'asm-r2'
+
+// ---------------------------------------------------------------------------
+// Transcripts
+// ---------------------------------------------------------------------------
+
+describe('uploadTranscript', () => {
+  it('gives two filenames that sanitize identically two distinct keys', async () => {
+    const { bucket } = makeBucket()
+
+    const keyA = await uploadTranscript(
+      bucket,
+      ORG,
+      ASSESSMENT,
+      textFile('notes v1.txt', 'FIRST CALL')
+    )
+    const keyB = await uploadTranscript(
+      bucket,
+      ORG,
+      ASSESSMENT,
+      textFile('notes+v1.txt', 'SECOND CALL')
+    )
+
+    expect(keyA).not.toBe(keyB)
+
+    // Both are still readable — the first was not destroyed by the second.
+    const a = await getTranscript(bucket, keyA)
+    const b = await getTranscript(bucket, keyB)
+    expect(await a?.text()).toBe('FIRST CALL')
+    expect(await b?.text()).toBe('SECOND CALL')
+  })
+
+  it('is idempotent for a re-upload under the same original filename', async () => {
+    const { bucket, store } = makeBucket()
+    await uploadTranscript(bucket, ORG, ASSESSMENT, textFile('notes.txt', 'draft'))
+    const second = await uploadTranscript(bucket, ORG, ASSESSMENT, textFile('notes.txt', 'final'))
+
+    // Replacing a transcript by re-uploading it stays a replacement, not a
+    // second orphan row: one object, latest content.
+    expect(store.size).toBe(1)
+    expect(await (await getTranscript(bucket, second))?.text()).toBe('final')
+  })
+
+  it('keeps the prefix and the displayed filename unchanged', async () => {
+    const { bucket } = makeBucket()
+    const key = await uploadTranscript(bucket, ORG, ASSESSMENT, textFile('Call Notes.txt', 'x'))
+
+    expect(key.startsWith(`${ORG}/assessments/${ASSESSMENT}/transcript/`)).toBe(true)
+    expect(key.split('/').pop()).toBe('Call_Notes.txt')
+    // No path-traversal surface introduced by the uniquifier.
+    expect(key.includes('..')).toBe(false)
+    expect(key.includes('//')).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Engagement deliverables — prefix-listed, client-visible
+// ---------------------------------------------------------------------------
+
+describe('getEngagementDocumentKey', () => {
+  const ENGAGEMENT = 'eng-r2'
+
+  it('gives colliding filenames distinct keys while both stay listable', async () => {
+    const { bucket, store } = makeBucket()
+
+    const keyA = await getEngagementDocumentKey(ORG, ENGAGEMENT, 'Scope (final).pdf')
+    const keyB = await getEngagementDocumentKey(ORG, ENGAGEMENT, 'Scope [final].pdf')
+    expect(keyA).not.toBe(keyB)
+
+    store.set(keyA, { key: keyA, body: new ArrayBuffer(1) })
+    store.set(keyB, { key: keyB, body: new ArrayBuffer(2) })
+
+    const listed = await listDocuments(bucket, `${ORG}/engagements/${ENGAGEMENT}/docs/`)
+    expect(listed.map((o) => o.key).sort()).toEqual([keyA, keyB].sort())
+  })
+
+  it('keeps the last segment as the sanitized name every display site renders', async () => {
+    const key = await getEngagementDocumentKey(ORG, ENGAGEMENT, 'Q3 Report.pdf')
+    expect(key.startsWith(`${ORG}/engagements/${ENGAGEMENT}/docs/`)).toBe(true)
+    expect(key.split('/').pop()).toBe('Q3_Report.pdf')
+  })
+
+  it('is stable for the same original filename', async () => {
+    const first = await getEngagementDocumentKey(ORG, ENGAGEMENT, 'Q3 Report.pdf')
+    const second = await getEngagementDocumentKey(ORG, ENGAGEMENT, 'Q3 Report.pdf')
+    expect(first).toBe(second)
+  })
+})
+
+describe('deliverables upload route', () => {
+  it('builds its key through the shared helper rather than its own sanitizer', () => {
+    const source = readFileSync(
+      resolve('src/pages/api/admin/engagements/[id]/deliverables.ts'),
+      'utf-8'
+    )
+    expect(source).toContain('getEngagementDocumentKey')
+    expect(source).not.toContain("replace(/[^a-zA-Z0-9._-]/g, '_')")
+  })
+})

--- a/tests/webhooks/stripe-subscription-linkage.test.ts
+++ b/tests/webhooks/stripe-subscription-linkage.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Stripe invoice → subscription linkage (ss#2315, #2280 hardening item 10).
+ *
+ * The linkage between a cycle invoice and its subscription decides which of
+ * two handlers runs, and it has moved between Stripe API versions. Reading it
+ * as `string | null` overloads `null`: "this is a one-time console-originated
+ * invoice" and "this is a retainer invoice whose linkage this code cannot
+ * read" become the same value, and the second is answered with a 200 ack and
+ * no mirror — a money-adjacent row that quietly never appears.
+ *
+ * These tests pin the three outcomes apart, and pin the expanded-object shape
+ * (Stripe's expandable fields) as parseable rather than unknown.
+ *
+ * The route is driven end-to-end, through signature verification, because the
+ * ack is the defect: the observable is the RESPONSE, and a handler-level test
+ * would not see it.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { installWorkerdPolyfills } from '@venturecrane/crane-test-harness'
+import { env as testEnv } from 'cloudflare:workers'
+import { POST } from '../../src/pages/api/webhooks/stripe'
+import {
+  extractStripeSubscriptionId,
+  resolveStripeSubscriptionLinkage,
+} from '../../src/lib/webhooks/stripe-subscription-handler'
+
+installWorkerdPolyfills()
+
+const SECRET = 'whsec_test_stripe_webhook_secret'
+
+async function computeStripeV1(timestamp: number, body: string, secret: string): Promise<string> {
+  const enc = new TextEncoder()
+  const key = await crypto.subtle.importKey(
+    'raw',
+    enc.encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  )
+  const mac = await crypto.subtle.sign('HMAC', key, enc.encode(`${timestamp}.${body}`))
+  return Array.from(new Uint8Array(mac))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('')
+}
+
+/** A schema-valid `invoice.finalized` event; `invoiceExtra` carries the shape under test. */
+function invoiceEvent(invoiceExtra: Record<string, unknown>): string {
+  return JSON.stringify({
+    id: 'evt_linkage',
+    object: 'event',
+    type: 'invoice.finalized',
+    created: 1785000000,
+    data: {
+      object: {
+        id: 'in_linkage_1',
+        object: 'invoice',
+        status: 'open',
+        amount_due: 500000,
+        amount_paid: 0,
+        currency: 'usd',
+        customer: 'cus_1',
+        customer_email: null,
+        description: null,
+        hosted_invoice_url: null,
+        invoice_pdf: null,
+        collection_method: 'charge_automatically',
+        status_transitions: { paid_at: null, finalized_at: 1785000000, voided_at: null },
+        metadata: {},
+        created: 1785000000,
+        due_date: null,
+        ...invoiceExtra,
+      },
+    },
+  })
+}
+
+async function postEvent(body: string): Promise<Response> {
+  const ts = Math.floor(Date.now() / 1000)
+  const sig = await computeStripeV1(ts, body, SECRET)
+  const request = new Request('http://test.local/api/webhooks/stripe', {
+    method: 'POST',
+    headers: new Headers({
+      'Content-Type': 'application/json',
+      'stripe-signature': `t=${ts},v1=${sig}`,
+    }),
+    body,
+  })
+  const context = {
+    request,
+    params: {},
+    locals: {},
+    redirect: (url: string, status: number) =>
+      new Response(null, { status, headers: { Location: url } }),
+  } as unknown as Parameters<typeof POST>[0]
+  return POST(context)
+}
+
+// ---------------------------------------------------------------------------
+// Tri-state resolution
+// ---------------------------------------------------------------------------
+
+describe('resolveStripeSubscriptionLinkage', () => {
+  it('reads the legacy top-level string', () => {
+    expect(resolveStripeSubscriptionLinkage({ subscription: 'sub_a' })).toEqual({
+      kind: 'linked',
+      subscriptionId: 'sub_a',
+    })
+  })
+
+  it('reads the parent.subscription_details string', () => {
+    expect(
+      resolveStripeSubscriptionLinkage({
+        parent: { type: 'subscription_details', subscription_details: { subscription: 'sub_b' } },
+      })
+    ).toEqual({ kind: 'linked', subscriptionId: 'sub_b' })
+  })
+
+  it('reads an EXPANDED subscription object at either position', () => {
+    expect(
+      resolveStripeSubscriptionLinkage({
+        subscription: { id: 'sub_c', object: 'subscription' },
+      })
+    ).toEqual({ kind: 'linked', subscriptionId: 'sub_c' })
+
+    expect(
+      resolveStripeSubscriptionLinkage({
+        parent: { subscription_details: { subscription: { id: 'sub_d', object: 'subscription' } } },
+      })
+    ).toEqual({ kind: 'linked', subscriptionId: 'sub_d' })
+  })
+
+  it('reports a genuine one-time invoice as unlinked, not unrecognized', () => {
+    expect(resolveStripeSubscriptionLinkage({ billing_reason: 'manual' }).kind).toBe('unlinked')
+    expect(resolveStripeSubscriptionLinkage({ subscription: null }).kind).toBe('unlinked')
+    expect(
+      resolveStripeSubscriptionLinkage({ parent: { type: null, subscription_details: null } }).kind
+    ).toBe('unlinked')
+    expect(resolveStripeSubscriptionLinkage({}).kind).toBe('unlinked')
+    expect(resolveStripeSubscriptionLinkage(null).kind).toBe('unlinked')
+  })
+
+  it('reports a subscription-signalling invoice it cannot read as unrecognized', () => {
+    // billing_reason is the version-stable signal: whatever Stripe does to the
+    // linkage field next, a cycle invoice still says why it was billed.
+    expect(resolveStripeSubscriptionLinkage({ billing_reason: 'subscription_cycle' }).kind).toBe(
+      'unrecognized'
+    )
+    // A linkage field that is present but shaped in a way this code cannot read.
+    expect(resolveStripeSubscriptionLinkage({ subscription: { ref: 'sub_z' } }).kind).toBe(
+      'unrecognized'
+    )
+    expect(
+      resolveStripeSubscriptionLinkage({
+        parent: { type: 'subscription_details', subscription_details: { sub_id: 'sub_z' } },
+      }).kind
+    ).toBe('unrecognized')
+  })
+})
+
+describe('extractStripeSubscriptionId', () => {
+  it('parses the expanded-object shape (previously read as no linkage at all)', () => {
+    expect(
+      extractStripeSubscriptionId({ subscription: { id: 'sub_e', object: 'subscription' } })
+    ).toBe('sub_e')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// The ack is the defect
+// ---------------------------------------------------------------------------
+
+describe('POST /api/webhooks/stripe — unreadable subscription linkage', () => {
+  beforeEach(() => {
+    Object.assign(testEnv, { STRIPE_WEBHOOK_SECRET: SECRET })
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    for (const k of Object.keys(testEnv)) {
+      delete (testEnv as unknown as Record<string, unknown>)[k]
+    }
+    vi.restoreAllMocks()
+  })
+
+  it('fails the delivery instead of acking when the shape is unreadable', async () => {
+    const res = await postEvent(
+      invoiceEvent({ billing_reason: 'subscription_cycle', parent: { type: 'something_new' } })
+    )
+
+    expect(res.status).toBe(500)
+    expect(console.error).toHaveBeenCalled()
+  })
+
+  it('still acks a genuine one-time invoice without alerting', async () => {
+    // The falsifier for the detector itself: if this over-fires, the legacy
+    // console-originated flow starts 500ing and Stripe retry-loops it.
+    const res = await postEvent(invoiceEvent({ billing_reason: 'manual' }))
+
+    expect(res.status).toBe(200)
+    expect(console.error).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Fixes #2315. Items 10, 11 and 12 from the #2280 identity-key audit's hardening list. All three were latent on the list; one is a live defect.

## 1. Email-as-identity: six normalizations, no shared helper

`src/lib/identity/email.ts` is now the canonical form (trim + lowercase), applied at every join site. Where the comparison is SQL, the column is folded too — neither `users.email` (`migrations/0001_create_tables.sql:136`) nor `contacts.email` (`:164`) carries `COLLATE NOCASE`, and there is no `COLLATE` anywhere in `migrations/`, so folding only the input is exactly the bug.

Sites: `booking/intake-core.ts`, `auth/clerk-bridge.ts`, `auth/magic-link.ts`, `pages/api/auth/magic-link.ts`, `webhooks/hosted-agent-checkout-handler.ts`, `operator/mcp/customer-resolution.ts`, `portal/clerk-org-members.ts`, `sow/service-finalize.ts`, `pages/api/admin/resend-invitation.ts`.

**The live one** was `intake-core.ts:164-166`: `WHERE org_id = ? AND email = ?`, case-sensitive on *both* sides. One prospect booking twice as `Owner@Example.com` and `owner@example.com` got two `contacts` rows on the same entity and a split correspondence history.

**Deliberate difference, kept and now documented:** comparisons are normalized, stored values are not. `users.email` is displayed in the admin console, and on the Clerk path it is the IdP's verified primary address — the trust anchor. Rewriting its casing to satisfy a lookup is the lookup's problem leaking into the record. `service-finalize.ts` already stored a normalized value and still does; nothing new started. The rule is stated at the top of the new module so the next person does not have to re-derive it.

`tests/email-identity.test.ts` also carries a permanent falsifier: a scan for `WHERE`/`AND email = ?` across shipped source. It matched `intake-core.ts` before the fix and matches nothing now.

## 2. Stripe subscription linkage: an unreadable shape looked exactly like no linkage

`extractStripeSubscriptionId` returned `string | null`, and `null` meant two different things: "one-time console-originated invoice" and "retainer invoice whose linkage this code cannot read". `dispatchInvoiceEvent` could not tell them apart, so the second became a `200 ok` with no mirror — a money-adjacent row that quietly never appears.

`resolveStripeSubscriptionLinkage` now returns `linked | unlinked | unrecognized`. Unrecognized is loud on three surfaces, because each catches a different reader: an error log (Sentry), an operational alert to `team@smd.services`, and a **500** so the delivery shows as failed in Stripe's own dashboard. The 500 makes Stripe retry a request that cannot succeed — that is the intent; a repeatedly failing endpoint is a signal Stripe raises on its own, and the quiet 200 is the defect.

Detection is conservative, and the ordering matters: `billing_reason` is checked first because it is the signal that survives the field moving *again*. A linkage field that is present but unreadable is the secondary signal. An invoice with none of those is `unlinked` and routes to the legacy flow untouched — the test for that is the falsifier for the detector itself, since over-firing would 500 the one-time flow and retry-loop it.

Also fixed while here: **a third shape already existed.** Both linkage positions are Stripe *expandable* fields, so each can arrive as an expanded Subscription object rather than a string. That was read as no linkage at all.

**A correction to the audit item's wording.** It reads as though a null extraction produces the `No local subscription … skipping` log at `:116-118`. It cannot — when extraction yields null the retainer handler is never called; the event goes to the legacy handler or a bare 200. Those are two distinct silences. This PR closes the first. The second — a *parsed* subscription id with no local `subscriptions` row — is left acking deliberately: it is legitimately reachable (a Stripe subscription the console never attached, e.g. a manual test), and a 500 there would retry-loop forever with no shape to fix. Worth its own issue if a real customer ever lands in it; I did not want to fold a judgement call about live billing behaviour into a hardening PR.

### API version pinning — flagging, not doing

The handler's comment ("this client pins no `Stripe-Version` header") is accurate but points at the wrong lever for this defect. The header on `src/lib/stripe/client.ts` governs **outbound** calls; the payload version for **inbound webhooks** is the version configured on the endpoint in the Stripe dashboard. Pinning the client would not have prevented this and would not prevent the next one.

Pinning either is a live-billing change with its own migration cost — `src/lib/stripe/client.ts:95` documents a shape that already moved under us (`unit_amount` removed from invoiceitems create in `2025-03-31.basil`), so a pin freezes us against a version we would then have to consciously step off. **That is the Captain's call, not mine.** I have not touched it. The tri-state above is the defence that works regardless of which version is serving.

## 3. R2 keys could collide and silently overwrite

Two upload paths used a client-supplied filename as the whole key leaf, sanitized with the same many-to-one expression: `Scope (final).pdf`, `Scope [final].pdf` and `Scope+final.pdf` all became `Scope_final.pdf`.

`uploadKeyLeaf` puts a short digest of the **original** filename in a path segment ahead of the sanitized name. Three properties, each chosen on purpose:

- **Distinct names never collide.**
- **The same name still replaces.** Hashing the name rather than the *content* keeps re-uploading a corrected file a replacement. A content hash would have fixed the collision and introduced a worse one: two list entries with the same displayed name and no UI to remove either.
- **Nothing that reads changes.** The filename stays the last segment, so every reader's `key.split('/').pop()` shows what it always showed; the key stays under its existing prefix, so prefix listing and the portal's path-traversal checks (`src/pages/api/portal/documents/[...key].ts:58-90`, all `startsWith`) are unaffected. The hash is hex, so it introduces no `..` or `//`.

**No migration, nothing orphaned.** I checked the read paths before changing the write paths: transcripts are read through the key stored in `assessments.transcript_path`, deliverables through the key returned by `list()`. Neither recomputes a key, so every existing object stays exactly as reachable as it was.

**Scope note — I fixed one path the item did not name.** The audit listed only `src/lib/storage/r2.ts:26-27` (transcripts). `src/pages/api/admin/engagements/[id]/deliverables.ts:26-27` had the identical expression and is the sharper half:

- Transcripts are **pointer-indexed**. The reachable transcript is always the latest either way, so a collision destroys an object that was already being dereferenced. The real exposure is narrower than "silent loss of a client transcript": `uploadTranscript` runs before `updateAssessment` (`src/pages/api/admin/assessments/[id].ts:90,108`), so if the DB write fails after a colliding put, the still-referenced key holds different bytes than the record describes.
- Deliverables are **prefix-listed**, not pointer-indexed, and the list renders on the **client portal** (`src/pages/portal/engagement/documents/index.astro:61`). Every object under the prefix is independently reachable. A collision there silently removes a document a client could see.

Same one-line sanitizer, same fix, and leaving the client-visible half alone to file separately would have been the letter of scope discipline against its point.

## Every test was run against the unfixed tree first

### 1 — email identity (`tests/email-identity.test.ts`)

```
× does not create a second contact when the same person books with different casing
  AssertionError: expected [ { …(2) }, { …(2) } ] to have a length of 1 but got 2
    - Expected   1
    + Received   2

× links the seeded row instead of stranding the person on a new one
  AssertionError: expected '85eb3e3e-78a6-4591-b27c-02539f4c73b5' to be 'user-pre-clerk-ei'

× drops a pending invite whose address differs only by case or whitespace
  AssertionError: expected [ { id: 'inv_1', …(7) } ] to have a length of +0 but got 1

× no shipped source compares the email column case-sensitively
  AssertionError: expected [ Array(1) ] to deeply equal []
    + [ "src/lib/booking/intake-core.ts:165 — AND email = ?" ]

Tests  4 failed | 2 passed (6)
```

The first assertion is the one that had to be the row count. `second.contactId` alone would not have caught it — a freshly minted duplicate returns an id just as happily as a matched one.

One correction I made to my own test mid-run: the clerk-bridge case originally asserted one `users` row in the org and failed *after* the fix, because `migrations/0005_seed_admin_user.sql` seeds an unrelated admin. Scoped to the address; re-run against the unfixed tree to confirm the corrected assertion still fails (it does — output above is from that run).

### 2 — Stripe linkage (`tests/webhooks/stripe-subscription-linkage.test.ts`)

```
× parses the expanded-object shape (previously read as no linkage at all)
  AssertionError: expected null to be 'sub_e'
    - Expected  "sub_e"
    + Received  null

× fails the delivery instead of acking when the shape is unreadable
  AssertionError: expected 200 to be 500
    - Expected  500
    + Received  200

(+ 5 tri-state cases failing on the absent export)
Tests  7 failed | 1 passed (8)
```

The route is driven end-to-end through signature verification, because the ack **is** the defect — the observable is the response, and a handler-level test cannot see it.

### 3 — R2 keys (`tests/r2-key-collision.test.ts`)

```
× gives two filenames that sanitize identically two distinct keys
  AssertionError: expected 'org-r2/assessments/asm-r2/transcript/…'
             not to be 'org-r2/assessments/asm-r2/transcript/…'

× gives colliding filenames distinct keys while both stay listable
  TypeError: getEngagementDocumentKey is not a function

Tests  5 failed | 2 passed (7)
```

Alongside the collision, the suite pins the two invariants the fix must not break: the prefix, and the last-segment filename every display site renders.

## None of the three was dismissed

All three reproduced. The only thing I re-scoped is the transcript half of item 3, whose blast radius is narrower than the audit's phrasing (above) — and the deliverables half, which is wider.

## Verify

`npm run verify` green: 4252 passed / 2 skipped / 7 todo across 266 files, plus the three worker suites. `knip` flagged an `emailsMatch` helper I had written speculatively; removed rather than kept.

Two unrelated timeouts in `tests/operator-skill-deploy.test.ts` on an earlier run turned out to be load flake — that file spawns a validator subprocess and takes 5.05s against a 5s per-test timeout. It passes in isolation and passed on the clean run. Nothing in this PR touches it.

## Status: repo-layer only

Per Law 9 this is **built**, not wired or tested against the running system. No deploy from this branch, no runtime observation, no `crane_verify` record. Specifically not claimed:

- That the intake dedupe now behaves on prod. The probe would be a mixed-case booking against the deployed endpoint, then a `contacts` row count for that address.
- That the Stripe alert fires. The probe would be a Stripe CLI event with an unreadable linkage against the deployed webhook, then the 500 in Stripe's delivery log and the alert in the `team@` mailbox.
- Anything about objects already in prod R2. The change is write-side; existing keys are untouched by construction, not by observation.

No prod D1 or prod R2 was touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLzzpTuYY8j3EaWbXfxz4x
