### PR TITLE
feat(ci): closed bugs carry an escape analysis (ss#2280)

### DIFF
--- a/.github/workflows/escape-analysis-on-close.yml
+++ b/.github/workflows/escape-analysis-on-close.yml
@@ -1,0 +1,99 @@
+name: Escape analysis on bug close
+
+# ss#2280. Ask the four questions at the moment the knowledge is cheapest.
+#
+# The 2026-08-12 latent-defect audit found ELEVEN instruments that could not
+# fail — a D1 fake ignoring SQL, an HMAC parity test pinning a transcription of
+# the script instead of the script, a workflow step whose findings path `bash -e`
+# killed before it could print, a mock acknowledging nothing the caller sent.
+# Each had been green for as long as it existed. They were found by one
+# heavyweight audit that only ran because the Captain asked why bugs keep
+# escaping.
+#
+# This is the everyday version. When a bug closes, its author still knows why the
+# defect hid — a week later nobody does. Four questions, a sentence each; the
+# fourth is the one that matters, because it turns one fix into a closed class.
+#
+# DELIBERATELY NARROW. Fires only on `type:bug`, only on a completed close, and
+# any bug that does not warrant the analysis takes `escape-analysis-exempt` — a
+# visible, greppable decision rather than a silent skip. A gate that fires on
+# everything gets routed around, and then it protects nothing (the lesson already
+# written into scope-deferred-todo.yml).
+#
+# The DECISION logic lives in scripts/escape-analysis.mjs and is unit-tested in
+# tests/escape-analysis.test.ts, including a falsifier per accept case. That split
+# exists because this workflow guards against checks that cannot fail and must not
+# become the twelfth: github-script bodies cannot be executed by any test, so the
+# part that decides is not written in one.
+
+on:
+  issues:
+    types: [closed]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check:
+    name: Closed bugs carry an escape analysis
+    runs-on: ubuntu-latest
+    # Cheap pre-filter so the job does not even start on features and chores.
+    # The module re-checks the label itself; this only saves a runner.
+    if: contains(join(github.event.issue.labels.*.name, ','), 'type:bug')
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Only the checker module is needed; history is irrelevant here.
+          fetch-depth: 1
+
+      - name: Evaluate the close
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const { checkEscapeAnalysis, rejectionComment } =
+              await import(`${process.env.GITHUB_WORKSPACE}/scripts/escape-analysis.mjs`);
+
+            const issue = context.payload.issue;
+
+            // Comments are read at close time rather than trusting the payload:
+            // the analysis is usually the comment posted moments before closing.
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              per_page: 100,
+            });
+
+            const verdict = checkEscapeAnalysis({
+              body: issue.body || '',
+              comments: comments.map((c) => c.body || ''),
+              labels: (issue.labels || []).map((l) => l.name),
+              stateReason: issue.state_reason,
+            });
+
+            if (verdict.ok) {
+              core.info(`escape analysis: ${verdict.reason}`);
+              return;
+            }
+
+            // Reopen rather than merely comment. A comment on a closed issue is
+            // read by nobody, which would make this a gate that cannot fail in a
+            // second sense — it would fire and change nothing.
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              body: rejectionComment({ missing: verdict.missing }),
+            });
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              state: 'open',
+            });
+
+            core.setFailed(
+              `#${issue.number} closed without an escape analysis (missing: ${verdict.missing.join(', ')}). Reopened.`
+            );

--- a/scripts/escape-analysis.mjs
+++ b/scripts/escape-analysis.mjs
@@ -1,0 +1,161 @@
+/**
+ * Escape analysis: the four questions a closed bug must answer.
+ *
+ * WHY (ss#2280, 2026-08-12). The venture ran a latent-defect audit after the
+ * Captain asked why bugs keep escaping build + test + review. The answer was not
+ * diligence. Eleven instruments were found that COULD NOT FAIL — a D1 fake that
+ * ignores SQL, an HMAC parity test pinning a transcription of the script instead
+ * of the script, a workflow step whose findings path `bash -e` killed before it
+ * could print, a mock acknowledging nothing the caller sent. Each had been green
+ * for as long as it existed.
+ *
+ * Those were found by one heavyweight audit. The everyday version never runs,
+ * because nothing asks the question at the moment the knowledge is cheapest: the
+ * instant someone closes a bug and still remembers why it hid.
+ *
+ * WHAT THIS ASKS. Four questions, a sentence each. Not a form — the point is the
+ * fourth answer, which is what turns one fix into a closed class:
+ *
+ *   Class                    what KIND of defect this is
+ *   Should have been caught by   which existing gate had the job
+ *   Why it missed             usually: the gate's world differed from the runtime's
+ *   Closes the class          the mechanism, not the instance
+ *
+ * DELIBERATELY SMALL. A gate that fires on everything gets routed around, and
+ * then it protects nothing (the lesson written into scope-deferred-todo.yml).
+ * This fires only on `type:bug`, only on a completed close, and any bug that
+ * genuinely does not warrant the analysis takes the exempt label — a visible,
+ * greppable decision rather than a silent skip.
+ */
+
+/** Issues without this label are none of this gate's business. */
+export const BUG_LABEL = 'type:bug'
+
+/** Escape hatch. Deliberate and visible, like `scope-deferred` on the TODO gate. */
+export const EXEMPT_LABEL = 'escape-analysis-exempt'
+
+/**
+ * The four prompts. Matching is deliberately loose on decoration (bold markers,
+ * heading level, trailing colon) and strict on wording, so the block stays
+ * greppable across the repo while nobody has to remember exact markdown.
+ */
+export const REQUIRED_PROMPTS = [
+  { key: 'class', label: 'Class', pattern: /^[\s>*_#-]*class\b\s*[:—-]/im },
+  {
+    key: 'gate',
+    label: 'Should have been caught by',
+    pattern: /^[\s>*_#-]*should have been caught by\b\s*[:—-]/im,
+  },
+  { key: 'why', label: 'Why it missed', pattern: /^[\s>*_#-]*why it missed\b\s*[:—-]/im },
+  {
+    key: 'mechanism',
+    label: 'Closes the class',
+    pattern: /^[\s>*_#-]*closes the class\b\s*[:—-]/im,
+  },
+]
+
+/** A prompt answered with nothing is not an answer. */
+const MIN_ANSWER_CHARS = 12
+
+/**
+ * Extract the text following a prompt, stopping at a blank line OR at the next
+ * prompt. Stopping at the next prompt is load-bearing, not tidiness: four empty
+ * prompts on consecutive lines would otherwise let each one's "answer" run on
+ * into the prompts below it and count as content — a checker that accepts the
+ * shape of an author satisfying the regex rather than the question. Caught by
+ * the hollow-prompts test, which failed on the first implementation.
+ */
+function answerFor(text, pattern) {
+  const match = pattern.exec(text)
+  if (!match) return ''
+  const after = text.slice(match.index + match[0].length)
+  const blankLine = after.search(/\n\s*\n/)
+  const nextPrompt = REQUIRED_PROMPTS.map((p) => {
+    // Search from the line after this prompt so it cannot match itself.
+    const rest = after.replace(/^[^\n]*/, '')
+    const hit = p.pattern.exec(rest)
+    return hit ? hit.index + (after.length - rest.length) : -1
+  }).filter((i) => i > -1)
+  const stops = [blankLine, ...nextPrompt].filter((i) => i > -1)
+  const stop = stops.length ? Math.min(...stops) : -1
+  return (stop === -1 ? after : after.slice(0, stop)).replace(/[*_>`#-]/g, '').trim()
+}
+
+/**
+ * Every field is optional so a caller can pass only what it has — the tests
+ * exercise label-only and body-only shapes, and a required-param signature would
+ * reject them at typecheck while the runtime handled them fine.
+ *
+ * @param {object} [input]
+ * @param {string} [input.body]          issue body
+ * @param {string[]} [input.comments]    comment bodies, any order
+ * @param {string[]} [input.labels]      issue label names
+ * @param {string} [input.stateReason]   GitHub close reason ("completed" | "not_planned" | ...)
+ * @returns {{ ok: boolean, skipped: boolean, reason: string, missing: string[] }}
+ */
+export function checkEscapeAnalysis({ body = '', comments = [], labels = [], stateReason } = {}) {
+  const names = labels.map((l) => String(l).toLowerCase())
+
+  if (!names.includes(BUG_LABEL)) {
+    return { ok: true, skipped: true, reason: `not labeled ${BUG_LABEL}`, missing: [] }
+  }
+  if (names.includes(EXEMPT_LABEL)) {
+    return { ok: true, skipped: true, reason: `exempted by ${EXEMPT_LABEL}`, missing: [] }
+  }
+  // A bug closed as not-planned (duplicate, cannot reproduce, won't fix) never
+  // had a fix, so there is no escape to analyse.
+  if (stateReason && stateReason !== 'completed') {
+    return { ok: true, skipped: true, reason: `closed as ${stateReason}`, missing: [] }
+  }
+
+  // The analysis may live in the body or in ANY comment, but it must be whole in
+  // ONE of them: four answers scattered across four comments is not an analysis,
+  // and stitching them would let a passing verdict emerge from fragments nobody
+  // wrote together.
+  const candidates = [body, ...comments].filter((t) => typeof t === 'string' && t.trim())
+
+  let best = REQUIRED_PROMPTS.map((p) => p.label)
+  for (const text of candidates) {
+    const missing = REQUIRED_PROMPTS.filter(
+      (p) => answerFor(text, p.pattern).length < MIN_ANSWER_CHARS
+    ).map((p) => p.label)
+    if (missing.length === 0) {
+      return { ok: true, skipped: false, reason: 'escape analysis present', missing: [] }
+    }
+    if (missing.length < best.length) best = missing
+  }
+
+  return {
+    ok: false,
+    skipped: false,
+    reason: 'escape analysis missing or incomplete',
+    missing: best,
+  }
+}
+
+/** The comment posted when a close is rejected. Says what to write, not just what is wrong. */
+export function rejectionComment({ missing }) {
+  return [
+    'Reopened: this bug closed without an escape analysis.',
+    '',
+    'Not bureaucracy. ss#2280 found eleven checks that could not fail, each green for as',
+    'long as it existed. They were found by one heavyweight audit; this asks the same',
+    'four questions at the moment the knowledge is cheapest, while you still remember why',
+    'it hid. The fourth answer is the one that matters, because it turns one fix into a',
+    'closed class.',
+    '',
+    `Missing or unanswered: ${missing.join(', ')}.`,
+    '',
+    'Add a comment in this shape, then close again:',
+    '',
+    '```markdown',
+    '## Escape analysis',
+    '**Class:** identity mismatch — two systems keyed the same object differently',
+    '**Should have been caught by:** tests/portal-operator-aliveness.test.ts',
+    '**Why it missed:** its D1 fake ignores SQL, so a wrong WHERE clause was invisible',
+    '**Closes the class:** moved the suite onto a real migrated SQLite harness',
+    '```',
+    '',
+    `If this bug genuinely does not warrant the analysis (duplicate, external, trivial typo), label it \`${EXEMPT_LABEL}\` and close again. That is a visible decision rather than a silent skip.`,
+  ].join('\n')
+}

--- a/tests/escape-analysis.test.ts
+++ b/tests/escape-analysis.test.ts
@@ -1,0 +1,143 @@
+/**
+ * The gate's decision logic, tested where it can fail.
+ *
+ * The workflow itself is `actions/github-script`, which no test can execute —
+ * so the part that DECIDES lives in a module and is exercised here. That split
+ * is the whole point: ss#2280 found eleven checks that could not fail, and a
+ * gate against that class must not be the twelfth. Every "accepts" case below
+ * has a matching "rejects" case, because a checker that only ever says yes has
+ * measured nothing.
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import {
+  BUG_LABEL,
+  EXEMPT_LABEL,
+  checkEscapeAnalysis,
+  rejectionComment,
+} from '../scripts/escape-analysis.mjs'
+
+const COMPLETE = [
+  '## Escape analysis',
+  '**Class:** identity mismatch — two systems keyed the same object differently',
+  '**Should have been caught by:** tests/portal-operator-aliveness.test.ts',
+  '**Why it missed:** the hand-rolled D1 fake ignores SQL, so a wrong WHERE clause was invisible',
+  '**Closes the class:** moved the suite onto a real migrated SQLite harness',
+].join('\n')
+
+describe('escape analysis gate: what it lets through', () => {
+  it('accepts a complete analysis in a comment', () => {
+    const r = checkEscapeAnalysis({ body: 'the bug', comments: [COMPLETE], labels: [BUG_LABEL] })
+    expect(r.ok).toBe(true)
+    expect(r.skipped).toBe(false)
+  })
+
+  it('accepts a complete analysis written into the issue body', () => {
+    expect(checkEscapeAnalysis({ body: COMPLETE, labels: [BUG_LABEL] }).ok).toBe(true)
+  })
+
+  it('accepts plain-text prompts without bold or heading decoration', () => {
+    const plain = [
+      'Class - fail-open default',
+      'Should have been caught by - the boot smoke test',
+      'Why it missed - the callee swallowed the error the wrapper was written to catch',
+      'Closes the class - tri-state return so the omitted path is reachable',
+    ].join('\n')
+    expect(checkEscapeAnalysis({ comments: [plain], labels: [BUG_LABEL] }).ok).toBe(true)
+  })
+
+  it('ignores issues that are not bugs', () => {
+    const r = checkEscapeAnalysis({ comments: ['shipped'], labels: ['type:feature'] })
+    expect(r.ok).toBe(true)
+    expect(r.skipped).toBe(true)
+  })
+
+  it('honours the exempt label as a visible decision', () => {
+    const r = checkEscapeAnalysis({ comments: ['dupe of #1'], labels: [BUG_LABEL, EXEMPT_LABEL] })
+    expect(r.ok).toBe(true)
+    expect(r.reason).toContain(EXEMPT_LABEL)
+  })
+
+  it('skips a bug closed as not planned — there was no fix to analyse', () => {
+    const r = checkEscapeAnalysis({
+      comments: ['cannot reproduce'],
+      labels: [BUG_LABEL],
+      stateReason: 'not_planned',
+    })
+    expect(r.ok).toBe(true)
+    expect(r.skipped).toBe(true)
+  })
+})
+
+describe('escape analysis gate: what it stops (the falsifiers)', () => {
+  it('rejects a bug closed with no analysis at all', () => {
+    const r = checkEscapeAnalysis({
+      body: 'portal shows the wrong seat',
+      comments: ['fixed in #2298'],
+      labels: [BUG_LABEL],
+    })
+    expect(r.ok).toBe(false)
+    expect(r.missing).toEqual([
+      'Class',
+      'Should have been caught by',
+      'Why it missed',
+      'Closes the class',
+    ])
+  })
+
+  it('rejects an analysis missing the mechanism — the answer that closes the class', () => {
+    const partial = COMPLETE.split('\n').slice(0, 4).join('\n')
+    const r = checkEscapeAnalysis({ comments: [partial], labels: [BUG_LABEL] })
+    expect(r.ok).toBe(false)
+    expect(r.missing).toEqual(['Closes the class'])
+  })
+
+  it('rejects prompts answered with nothing', () => {
+    // The shape of an author satisfying the regex rather than the question.
+    const hollow = [
+      '**Class:**',
+      '**Should have been caught by:**',
+      '**Why it missed:**',
+      '**Closes the class:**',
+    ].join('\n')
+    const r = checkEscapeAnalysis({ comments: [hollow], labels: [BUG_LABEL] })
+    expect(r.ok).toBe(false)
+    expect(r.missing).toHaveLength(4)
+  })
+
+  it('rejects an analysis scattered across separate comments', () => {
+    // Four fragments nobody wrote together are not an analysis, and stitching
+    // them would let a passing verdict emerge from parts no one reviewed as one.
+    const scattered = COMPLETE.split('\n').slice(1)
+    const r = checkEscapeAnalysis({ comments: scattered, labels: [BUG_LABEL] })
+    expect(r.ok).toBe(false)
+  })
+
+  it('reports the CLOSEST near-miss when several comments are partial', () => {
+    // Otherwise the author is told to write four answers they already wrote.
+    const oneAnswer = '**Class:** race condition'
+    const threeAnswers = COMPLETE.split('\n').slice(0, 4).join('\n')
+    const r = checkEscapeAnalysis({ comments: [oneAnswer, threeAnswers], labels: [BUG_LABEL] })
+    expect(r.missing).toEqual(['Closes the class'])
+  })
+
+  it('is case-insensitive on the label, so Type:Bug still gates', () => {
+    const r = checkEscapeAnalysis({ comments: ['done'], labels: ['Type:Bug'] })
+    expect(r.ok).toBe(false)
+  })
+})
+
+describe('the rejection comment tells the author what to write', () => {
+  it('names the missing prompts and shows the shape', () => {
+    const text = rejectionComment({ missing: ['Closes the class'] })
+    expect(text).toContain('Closes the class')
+    expect(text).toContain('## Escape analysis')
+    expect(text).toContain(EXEMPT_LABEL)
+  })
+
+  it('states why the gate exists, not just that it fired', () => {
+    // A gate that only says "rejected" gets resented and then routed around.
+    expect(rejectionComment({ missing: ['Class'] })).toContain('could not fail')
+  })
+})


### PR DESCRIPTION
The everyday version of the audit that produced #2280. Companion to crane-console#1198, which adds the `/debug` skill whose closing condition 4 this enforces.

## Why

The 2026-08-12 latent-defect audit found **eleven instruments that could not fail** — a D1 fake ignoring SQL so a wrong `WHERE` clause was structurally invisible; an HMAC parity test pinning a transcription of a shell script rather than the script (mutate the real derivation, which changes the bearer on every Machine, and it still passed 10/10); a workflow step whose findings path `bash -e` killed before it could print; a mock acknowledging nothing the caller sent, so every "applied" assertion passed regardless. Each had been green for as long as it existed.

They were found by one heavyweight audit that only ran because the Captain asked why bugs keep escaping. Nothing asks the question routinely, at the moment the knowledge is cheapest: the instant someone closes a bug and still remembers why the defect hid. A week later nobody does.

## What it asks

Four questions, a sentence each. The fourth is the one that matters — it turns one fix into a closed class.

```markdown
## Escape analysis

**Class:** identity mismatch — two systems keyed the same object differently
**Should have been caught by:** tests/portal-operator-aliveness.test.ts
**Why it missed:** its D1 fake ignores SQL, so a wrong WHERE clause was invisible
**Closes the class:** moved the suite onto a real migrated SQLite harness
```

## Deliberately narrow

Fires only on `type:bug`, only on a completed close. Bugs closed as duplicate / cannot-reproduce / won't-fix are skipped — there was no fix, so there is no escape to analyse. A bug that genuinely does not warrant the analysis takes `escape-analysis-exempt`: a visible, greppable decision rather than a silent skip.

A gate that fires on everything gets routed around, and then it protects nothing — the lesson already written into `scope-deferred-todo.yml`.

It **reopens** rather than merely commenting, because a comment on a closed issue is read by nobody. That would make this a check that cannot fail in a second sense: it would fire and change nothing.

## The gate is not the twelfth dead instrument

The decision logic is a module (`scripts/escape-analysis.mjs`), not an inline `github-script` body, precisely because github-script bodies cannot be executed by any test. Every accept case in `tests/escape-analysis.test.ts` has a matching reject case:

| Accepts | Rejects |
| --- | --- |
| complete analysis in a comment or the body | no analysis at all |
| plain text without bold/heading decoration | missing the mechanism — the answer that closes the class |
| non-bug issues, exempt label, not-planned closes | prompts answered with nothing |
| | an analysis scattered across separate comments |

**The first implementation failed its own hollow-prompts test.** Four empty prompts on consecutive lines let each one's "answer" run on into the prompts below it and count as content — the checker would have accepted the shape of an author satisfying the regex rather than the question. That is the falsifier earning its place before the gate ever ran; the fix and the reason are commented at `answerFor`.

Rejection reports the **closest** near-miss when several comments are partial, so the author is not told to write four answers they already wrote.

`npm run verify` green (14 new tests).
