### PR TITLE
feat(operator): seat-readiness — a readiness check that can fail, driven by what the code declares

### DIFF
--- a/operator/bin/seat-readiness.py
+++ b/operator/bin/seat-readiness.py
@@ -1,0 +1,606 @@
+#!/usr/bin/env python3
+"""seat-readiness.py — is this seat actually ready, checked against what the code
+requires rather than what someone remembered.
+
+WHY THIS EXISTS (2026-08-12). A&P was reported READY to connect Smokeball. It was
+not: the connector reads three secrets and the seat carried two. The readiness
+note that cleared it said "`SMOKEBALL_PROD_CLIENT_ID/SECRET` in Infisical /ss (key
+names verified this session)" — it enumerated two of three, found both, and
+declared ready. **It could not fail on the third, because the third was never in
+the list.** Every check here is derived from a machine source for exactly that
+reason: a hand-maintained readiness list rots into false coverage the moment the
+thing it forgot is the thing that breaks.
+
+The credential check reads each connector's own `manifest.toml`
+(`[[connector.required_secrets]]`) and asks whether the SEAT carries every
+`runtime_env` the connector declares. That is deliberately the seat and not the
+vault: the SDK's SecretSpec docstring is explicit that the vault->runtime remap
+belongs to the overlay registry and must never be duplicated into the manifest
+("so the manifest never becomes a second, contradictory wiring spec"), so a
+vault-side check here would have to re-encode the mapping and could drift from
+`provision-customer.sh`. The Machine's own env is the layer that matters anyway
+(Law 9) and it needs no mapping to read.
+
+UNKNOWN IS NEVER PASS. A stopped Machine cannot answer the currency question, so
+that row reports UNKNOWN and the run is not green. A readiness tool whose unknown
+rows read as ready is the same defect this file exists to kill.
+
+NO SECRET VALUE IS EVER READ OR PRINTED. `flyctl secrets list` returns names and
+digests only; nothing here dereferences a value.
+
+USAGE
+    operator/bin/seat-readiness.py <slug> [--json] [--no-seat]
+
+    --no-seat  skip every check that needs Fly (for CI / offline); those rows
+               report UNKNOWN rather than passing.
+
+Exit codes: 0 = every blocker row passed; 1 = a blocker row FAILED or is UNKNOWN;
+2 = the seat/config could not be read at all.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import tomllib
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CUSTOMERS = REPO_ROOT / "operator" / "customers"
+CONNECTORS = REPO_ROOT / "operator" / "connectors"
+
+PASS = "PASS"
+FAIL = "FAIL"
+UNKNOWN = "UNKNOWN"
+INFO = "INFO"
+
+
+@dataclass
+class Row:
+    """One readiness fact.
+
+    `falsifier` is not decoration: a row that cannot state what would have made it
+    FAIL is a row that proves nothing, and writing it forces the question.
+    """
+
+    section: str
+    check: str
+    status: str
+    detail: str
+    falsifier: str
+    blocker: bool = True
+
+
+@dataclass
+class Report:
+    slug: str
+    rows: list[Row] = field(default_factory=list)
+
+    def add(self, *a, **kw) -> None:
+        self.rows.append(Row(*a, **kw))
+
+    @property
+    def blocking(self) -> list[Row]:
+        return [r for r in self.rows if r.blocker and r.status in (FAIL, UNKNOWN)]
+
+
+def _run(cmd: list[str], timeout: int = 60) -> tuple[int, str]:
+    try:
+        p = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+        return p.returncode, (p.stdout or "") + (p.stderr or "")
+    except Exception as exc:  # noqa: BLE001 — a probe failure is UNKNOWN, never PASS
+        return 127, str(exc)
+
+
+def load_customer(slug: str) -> dict:
+    path = CUSTOMERS / slug / "customer.yaml"
+    if not path.is_file():
+        print(f"FATAL: no customer.yaml at {path}", file=sys.stderr)
+        raise SystemExit(2)
+    return yaml.safe_load(path.read_text()) or {}
+
+
+def seat_secret_names(app: str) -> set[str] | None:
+    """Fly secret NAMES for the app. None means we could not ask — never an
+    empty set, because 'no secrets' and 'could not look' must not be the same
+    answer to a readiness question."""
+    code, out = _run(["flyctl", "secrets", "list", "--app", app, "--json"])
+    if code != 0:
+        return None
+    try:
+        return {row["name"] for row in json.loads(out) if isinstance(row, dict) and "name" in row}
+    except Exception:  # noqa: BLE001
+        return None
+
+
+# ---------------------------------------------------------------- credentials
+def check_connector_credentials(rep: Report, cfg: dict, staged: set[str] | None) -> None:
+    """Every `runtime_env` a connector's manifest declares must exist on the seat.
+
+    This is the check that would have caught SMOKEBALL_API_KEY on 2026-07-29.
+    """
+    connectors = cfg.get("connectors") or {}
+    if not connectors:
+        rep.add(
+            "credentials",
+            "connectors authored",
+            INFO,
+            "no connectors authored on this seat",
+            "a connector present in customer.yaml but not seen here",
+            blocker=False,
+        )
+        return
+
+    for capability, conn in connectors.items():
+        if not isinstance(conn, dict) or not conn.get("enabled"):
+            continue
+        backend = str(conn.get("backend", ""))
+        if not backend.startswith("mcp:"):
+            continue
+        name = backend.split(":", 1)[1]
+        manifest_path = CONNECTORS / name / "manifest.toml"
+        if not manifest_path.is_file():
+            # A vendor MCP with no in-repo manifest declares nothing we can check.
+            rep.add(
+                "credentials",
+                f"{capability} ({backend})",
+                INFO,
+                "no in-repo manifest — nothing declared to verify",
+                "a manifest appearing later that declares secrets nobody checked",
+                blocker=False,
+            )
+            continue
+
+        data = tomllib.loads(manifest_path.read_text())
+        conn_tbl = data.get("connector", data)
+        required = [
+            s["runtime_env"]
+            for s in (conn_tbl.get("required_secrets") or [])
+            if isinstance(s, dict) and s.get("runtime_env")
+        ]
+        if not required:
+            rep.add(
+                "credentials",
+                f"{capability} ({backend})",
+                INFO,
+                "manifest declares no required_secrets",
+                "the connector reading an env var it never declared",
+                blocker=False,
+            )
+            continue
+
+        if staged is None:
+            rep.add(
+                "credentials",
+                f"{capability}: {len(required)} declared secret(s)",
+                UNKNOWN,
+                "could not read the seat's secret names",
+                "a seat probe that succeeds and shows one missing",
+            )
+            continue
+
+        missing = [e for e in required if e not in staged]
+        env = str(conn.get("environment", "")) or "(unset)"
+        if missing:
+            rep.add(
+                "credentials",
+                f"{capability}: declared secrets present on seat",
+                FAIL,
+                f"environment={env}; MISSING {', '.join(sorted(missing))} "
+                f"(declared in operator/connectors/{name}/manifest.toml; staged by "
+                f"provision-customer.sh from its per-environment vault names)",
+                "all declared runtime_env names present on the seat",
+            )
+        else:
+            rep.add(
+                "credentials",
+                f"{capability}: declared secrets present on seat",
+                PASS,
+                f"environment={env}; all {len(required)} present: {', '.join(sorted(required))}",
+                "a declared runtime_env absent from the seat's Fly secrets",
+            )
+
+
+# ------------------------------------------------------------------- currency
+def check_currency(rep: Report, app: str, no_seat: bool) -> None:
+    """The running overlay ref must equal origin/main's pin.
+
+    Same property `bin/connect-smokeball.sh` gates on (#2149) — a token must not
+    land on a stale seat. Reported here so it is visible BEFORE connect day
+    rather than as a bare non-zero exit from the connect script.
+    """
+    code, out = _run(
+        ["git", "-C", str(REPO_ROOT), "show", "origin/main:operator/contracts/overlay-pairs.json"]
+    )
+    expected = ""
+    if code == 0:
+        m = re.search(r'"overlayRef"\s*:\s*"([0-9a-f]{40})"', out)
+        expected = m.group(1) if m else ""
+    if not expected:
+        rep.add(
+            "currency",
+            "seat runs origin/main's pinned overlay",
+            UNKNOWN,
+            "could not read overlayRef from origin/main",
+            "a readable pin that differs from the seat's",
+        )
+        return
+
+    if no_seat:
+        rep.add(
+            "currency",
+            "seat runs origin/main's pinned overlay",
+            UNKNOWN,
+            f"--no-seat; pin is {expected[:12]}",
+            "a seat probe showing a different ref",
+        )
+        return
+
+    code, out = _run(
+        [
+            "flyctl",
+            "ssh",
+            "console",
+            "-a",
+            app,
+            "-C",
+            "sh -c 'GPID=$(pgrep -f \"hermes.*gateway run\" | head -1); [ -n \"$GPID\" ] || exit 1; "
+            'tr "\\0" "\\n" < /proc/$GPID/environ | grep ^SMD_OVERLAY_REF= | cut -d= -f2\'',
+        ],
+        timeout=120,
+    )
+    running = "".join(re.findall(r"[0-9a-f]{40}", out))[:40]
+    if len(running) != 40:
+        rep.add(
+            "currency",
+            "seat runs origin/main's pinned overlay",
+            UNKNOWN,
+            f"no gateway to read SMD_OVERLAY_REF from (machine stopped or gateway down); "
+            f"pin is {expected[:12]}",
+            "a running gateway whose ref differs from the pin",
+        )
+        return
+    if running != expected:
+        rep.add(
+            "currency",
+            "seat runs origin/main's pinned overlay",
+            FAIL,
+            f"seat runs {running[:12]}, origin/main pins {expected[:12]} — "
+            f"connect-smokeball.sh will refuse (#2149). Fix: "
+            f"yes s | operator/bin/reprovision.sh <slug>",
+            "the two refs matching",
+        )
+    else:
+        rep.add(
+            "currency",
+            "seat runs origin/main's pinned overlay",
+            PASS,
+            f"both {expected[:12]}",
+            "a seat ref differing from the pin",
+        )
+
+
+def check_machine(rep: Report, app: str, no_seat: bool) -> None:
+    if no_seat:
+        rep.add("machine", "machine state", UNKNOWN, "--no-seat", "a stopped machine", blocker=False)
+        return
+    code, out = _run(["flyctl", "machines", "list", "--app", app, "--json"])
+    if code != 0:
+        rep.add("machine", "machine state", UNKNOWN, "could not list machines", "a readable state")
+        return
+    try:
+        machines = json.loads(out)
+        states = [m.get("state", "?") for m in machines] or ["(none)"]
+    except Exception:  # noqa: BLE001
+        rep.add("machine", "machine state", UNKNOWN, "unparseable machine list", "a parseable list")
+        return
+    started = any(s == "started" for s in states)
+    rep.add(
+        "machine",
+        "machine started",
+        PASS if started else FAIL,
+        f"state(s): {', '.join(states)}",
+        "a machine reporting started when it is not (or vice versa)",
+        blocker=False,
+    )
+
+
+# ------------------------------------------------------------------- routines
+def check_routines(rep: Report, cfg: dict, raw: str) -> None:
+    """Scheduled AND webhook initiation, because 'routines are off' is only true
+    when both are. Crons are the visible half; a live webhook trigger fires on the
+    firm's own activity and is the half that surprises people."""
+    active_schedules = re.findall(r"^\s+schedule:\s*'", raw, re.M)
+    rep.add(
+        "routines",
+        "scheduled routines off",
+        PASS if not active_schedules else FAIL,
+        f"{len(active_schedules)} active schedule line(s)",
+        "an uncommented schedule: line counted as off",
+        blocker=False,
+    )
+
+    enabled_skills: dict[str, dict] = {}
+    for persona in cfg.get("personas") or []:
+        for s in (persona.get("skills") or []) if isinstance(persona, dict) else []:
+            if isinstance(s, dict) and s.get("name"):
+                enabled_skills[s["name"]] = s
+
+    triggers = cfg.get("webhook_triggers") or []
+    if not triggers:
+        rep.add(
+            "routines",
+            "webhook-initiated routines off",
+            PASS,
+            "no webhook_triggers authored",
+            "an authored trigger not counted here",
+            blocker=False,
+        )
+        return
+    live = []
+    for t in triggers:
+        if not isinstance(t, dict):
+            continue
+        skill = t.get("skill", "?")
+        spec = enabled_skills.get(skill)
+        if spec and spec.get("enabled") and (spec.get("initiation") or {}).get("webhook"):
+            live.append(f"{t.get('source', '?')}/{t.get('event_type', '?')} -> {skill}")
+    rep.add(
+        "routines",
+        "webhook-initiated routines off",
+        PASS if not live else FAIL,
+        "; ".join(live) if live else "no trigger reaches an enabled webhook-initiable skill",
+        "a trigger whose skill is enabled+webhook-initiable counted as off",
+        blocker=False,
+    )
+
+
+# -------------------------------------------------------------------- channel
+def check_channel(rep: Report, cfg: dict) -> None:
+    """Can a person say anything to this Operator?
+
+    Every initiation-card command is something a human SAYS. If no inbound
+    conversational channel is authored, the card is unusable and case alerts
+    addressed to humans cannot be delivered — regardless of what else is green.
+    """
+    conns = cfg.get("connectors") or {}
+    email = conns.get("Email") if isinstance(conns, dict) else None
+    adapter = (email or {}).get("adapter") if isinstance(email, dict) else None
+    enabled = bool((email or {}).get("enabled")) if isinstance(email, dict) else False
+    if adapter and enabled:
+        rep.add(
+            "channel",
+            "inbound conversational channel authored",
+            PASS,
+            f"Email adapter={adapter}",
+            "an Email connector authored but disabled, or absent",
+        )
+    else:
+        rep.add(
+            "channel",
+            "inbound conversational channel authored",
+            FAIL,
+            "no enabled Email connector — nobody at the firm can address this "
+            "Operator, so no initiation-card command can be spoken and "
+            "human-addressed alerts cannot be delivered",
+            "an enabled Email connector with an adapter",
+        )
+
+    esc = cfg.get("escalation") or {}
+    recips = list(esc.get("red_flag_recipients") or [])
+    if recips:
+        rep.add(
+            "channel",
+            "case alerts deliverable",
+            PASS if (adapter and enabled) else FAIL,
+            f"{len(recips)} recipient(s) authored; "
+            + ("a channel exists" if (adapter and enabled) else "NO channel to deliver on"),
+            "recipients authored with no channel, reported as deliverable",
+        )
+
+
+# ---------------------------------------------------------------------- card
+def check_initiation_card(rep: Report, slug: str, cfg: dict) -> None:
+    path = CUSTOMERS / slug / "initiation-card.yaml"
+    if not path.is_file():
+        rep.add(
+            "card", "initiation card present", INFO, "no initiation-card.yaml", "a card appearing later", blocker=False
+        )
+        return
+    card = yaml.safe_load(path.read_text()) or {}
+    enabled_skills = {
+        s["name"]
+        for persona in (cfg.get("personas") or [])
+        for s in (persona.get("skills") or [])
+        if isinstance(s, dict) and s.get("name") and s.get("enabled")
+    }
+    total = green = 0
+    unbound: list[str] = []
+    for stage in card.get("stages") or []:
+        locked = bool(stage.get("locked"))
+        for cmd in stage.get("commands") or []:
+            total += 1
+            if str(cmd.get("rehearsal", "")).strip() == "green":
+                green += 1
+            backed = str(cmd.get("backed_by", ""))
+            if not locked and backed and backed != "core-dialogue" and backed not in enabled_skills:
+                unbound.append(backed)
+    rep.add(
+        "card",
+        "initiation-card commands rehearsed",
+        PASS if green == total and total else FAIL,
+        f"{green}/{total} green — the card's own rule is that a pending command is "
+        f"not spoken at the firm",
+        "a command marked green without a rehearsal record",
+    )
+    if unbound:
+        rep.add(
+            "card",
+            "unlocked card commands are backed by bound skills",
+            FAIL,
+            f"unbound: {', '.join(sorted(set(unbound)))}",
+            "every unlocked command's backed_by present and enabled",
+        )
+
+
+# ------------------------------------------------------------------ coverage
+def coverage_rows(slug: str, cfg: dict) -> list[dict]:
+    """One row per routine the FIRM was promised, generated from routine-grid.yaml.
+
+    IMPLEMENTATION-PLAN §6 wants a coverage checklist whose unproven-row count is
+    the honest answer to "are we done?", and warns that a hand-maintained one
+    "rots into false coverage". So the ROWS are generated: routine-grid.yaml is
+    the compiled letter-07 grid (ADR 0075, every tier traced verbatim to the
+    letter), which makes completeness structural — a capability the firm was
+    promised cannot be missing from this table, because the table is derived from
+    the promise.
+
+    The `proving` column is deliberately NOT invented. Nothing on this machine
+    knows whether a routine was demonstrated to the firm, so it reports
+    "(none recorded)" and a human pastes the crane_verify id. A blank that looks
+    like a pass is the failure this file exists to prevent.
+    """
+    grid_path = CUSTOMERS / slug / "routine-grid.yaml"
+    if not grid_path.is_file():
+        return []
+    grid = yaml.safe_load(grid_path.read_text()) or {}
+
+    skills: dict[str, dict] = {}
+    for persona in cfg.get("personas") or []:
+        for s in (persona.get("skills") or []) if isinstance(persona, dict) else []:
+            if isinstance(s, dict) and s.get("name"):
+                skills[s["name"]] = s
+
+    conns = cfg.get("connectors") or {}
+    email = conns.get("Email") if isinstance(conns, dict) else None
+    has_channel = bool(isinstance(email, dict) and email.get("adapter") and email.get("enabled"))
+
+    out: list[dict] = []
+    for row in grid.get("rows") or []:
+        named = list(row.get("skills") or [])
+        bound = [n for n in named if n in skills and skills[n].get("enabled")]
+        unbound = [n for n in named if n not in bound]
+        init = {
+            k
+            for n in bound
+            for k, v in (skills[n].get("initiation") or {}).items()
+            if v
+        }
+        # Can a real person or event actually make this routine run today?
+        # `runnable` is an explicit boolean, not something a caller infers from
+        # the prose: counting on a string prefix silently missed the
+        # "person-invoked only — but NO channel" case, which is exactly the kind
+        # of soft undercount that makes a checker read greener than the world.
+        if not bound:
+            can_run, runnable = "NO — skill not bound/enabled on this seat", False
+        elif any((skills[n].get("initiation") or {}).get("scheduled") for n in bound):
+            can_run, runnable = "scheduled (off means it will not fire — see the crons row)", True
+        elif "webhook" in init:
+            can_run, runnable = (
+                ("webhook", True)
+                if has_channel
+                else ("NO — webhook-initiable but this seat has no inbound channel", False)
+            )
+        elif "manual" in init:
+            can_run, runnable = (
+                ("person-invoked", True)
+                if has_channel
+                else ("NO — person-invoked, and no channel exists to invoke it on", False)
+            )
+        else:
+            can_run, runnable = "NO — no initiation authored", False
+        out.append(
+            {
+                "routine": row.get("routine", "?"),
+                "letter_section": row.get("letter_section", ""),
+                "start_verbatim": row.get("start_verbatim", ""),
+                "skills": named,
+                "unbound": unbound,
+                "can_run_today": can_run,
+                "runnable": runnable,
+                "proving": "(none recorded)",
+            }
+        )
+    return out
+
+
+def print_coverage(slug: str, rows: list[dict]) -> None:
+    print(f"\nCOVERAGE — {slug} — {len(rows)} routine(s) the firm was promised (letter 07 grid)")
+    print("=" * 78)
+    for i, r in enumerate(rows, 1):
+        print(f"\n{i:>2}. {r['routine']}  [{r['letter_section']}]  start: {r['start_verbatim']}")
+        print(f"    skills: {', '.join(r['skills']) or '(none named)'}")
+        if r["unbound"]:
+            print(f"    UNBOUND on this seat: {', '.join(r['unbound'])}")
+        print(f"    can run today: {r['can_run_today']}")
+        print(f"    proving event: {r['proving']}")
+    unproven = sum(1 for r in rows if r["proving"] == "(none recorded)")
+    blocked = sum(1 for r in rows if not r["runnable"])
+    print("\n" + "=" * 78)
+    print(f"unproven rows: {unproven}/{len(rows)}   cannot-run-today rows: {blocked}/{len(rows)}")
+    print("The unproven count is the honest answer to 'are we done?' (plan §6).")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("slug")
+    ap.add_argument("--json", action="store_true", dest="as_json")
+    ap.add_argument("--no-seat", action="store_true", help="skip Fly probes; they report UNKNOWN")
+    ap.add_argument("--coverage", action="store_true", help="emit the letter-07 coverage table too")
+    args = ap.parse_args()
+
+    if not re.fullmatch(r"[a-z0-9][a-z0-9-]{0,31}", args.slug):
+        print(f"FATAL: invalid slug {args.slug!r}", file=sys.stderr)
+        return 2
+
+    cfg = load_customer(args.slug)
+    raw = (CUSTOMERS / args.slug / "customer.yaml").read_text()
+    app = f"hermes-{args.slug}"
+    rep = Report(args.slug)
+
+    staged = None if args.no_seat else seat_secret_names(app)
+    check_connector_credentials(rep, cfg, staged)
+    check_currency(rep, app, args.no_seat)
+    check_machine(rep, app, args.no_seat)
+    check_routines(rep, cfg, raw)
+    check_channel(rep, cfg)
+    check_initiation_card(rep, args.slug, cfg)
+
+    cov = coverage_rows(args.slug, cfg) if args.coverage else []
+
+    if args.as_json:
+        payload = {"slug": args.slug, "rows": [r.__dict__ for r in rep.rows]}
+        if args.coverage:
+            payload["coverage"] = cov
+        print(json.dumps(payload, indent=2))
+    else:
+        print(f"\nSEAT READINESS — {args.slug}\n" + "=" * 72)
+        section = None
+        for r in rep.rows:
+            if r.section != section:
+                section = r.section
+                print(f"\n[{section}]")
+            print(f"  {r.status:<8} {r.check}")
+            print(f"           {r.detail}")
+        blocking = rep.blocking
+        print("\n" + "=" * 72)
+        if blocking:
+            print(f"NOT READY — {len(blocking)} blocking row(s):")
+            for r in blocking:
+                print(f"  {r.status}  {r.check}")
+        else:
+            print("All blocking rows pass.")
+        print("(UNKNOWN is never PASS — an unanswerable check is not a ready one.)")
+        if args.coverage:
+            print_coverage(args.slug, cov)
+    return 1 if rep.blocking else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/operator/bin/tests/test_seat_readiness.py
+++ b/operator/bin/tests/test_seat_readiness.py
@@ -1,0 +1,248 @@
+"""Tests for seat-readiness.py.
+
+The point of this file is narrow and it is NOT "the readiness tool runs". The
+tool exists because a readiness check that enumerated two of three required
+secrets reported READY and could not have said anything else. So the tests that
+matter here are the ones that prove each check CAN FAIL, and that an
+unanswerable check never reads as ready.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+_BIN = Path(__file__).resolve().parents[1]
+_spec = importlib.util.spec_from_file_location("seat_readiness", _BIN / "seat-readiness.py")
+sr = importlib.util.module_from_spec(_spec)
+assert _spec.loader is not None
+# Registered BEFORE exec: @dataclass resolves annotations via
+# sys.modules[cls.__module__], which is None for a module that only exists as a
+# local variable.
+sys.modules["seat_readiness"] = sr
+_spec.loader.exec_module(sr)
+
+
+def _report() -> "sr.Report":
+    return sr.Report("fixture")
+
+
+SMOKEBALL_CFG = {
+    "connectors": {
+        "PracticeManagement": {
+            "backend": "mcp:smokeball",
+            "enabled": True,
+            "environment": "production",
+        }
+    }
+}
+
+# The real declared set, read from the shipped manifest rather than retyped —
+# retyping it here would rebuild the exact defect this tool exists to catch.
+DECLARED = {
+    s["runtime_env"]
+    for s in __import__("tomllib")
+    .loads((_BIN.parents[1] / "operator/connectors/smokeball/manifest.toml").read_text())["connector"][
+        "required_secrets"
+    ]
+}
+
+
+def test_manifest_declares_more_than_the_two_that_were_checked() -> None:
+    """The 2026-07-29 readiness note verified CLIENT_ID + CLIENT_SECRET only.
+
+    If the manifest ever declared just those two, the credential check below
+    could not fail on the third and this whole file would be theatre.
+    """
+    assert "SMOKEBALL_API_KEY" in DECLARED
+    assert len(DECLARED) >= 3
+
+
+def test_credentials_fail_when_a_declared_secret_is_missing() -> None:
+    """The A&P case, reproduced: client id + secret staged, API key absent."""
+    rep = _report()
+    sr.check_connector_credentials(
+        rep, SMOKEBALL_CFG, {"SMOKEBALL_CLIENT_ID", "SMOKEBALL_CLIENT_SECRET"}
+    )
+    row = next(r for r in rep.rows if r.section == "credentials")
+    assert row.status == sr.FAIL
+    assert "SMOKEBALL_API_KEY" in row.detail
+    assert rep.blocking
+
+
+def test_credentials_pass_when_every_declared_secret_is_present() -> None:
+    """The control. Without this, a check that always FAILs would look correct."""
+    rep = _report()
+    sr.check_connector_credentials(rep, SMOKEBALL_CFG, set(DECLARED))
+    row = next(r for r in rep.rows if r.section == "credentials")
+    assert row.status == sr.PASS
+    assert not rep.blocking
+
+
+def test_credentials_unknown_when_the_seat_cannot_be_probed() -> None:
+    """An unreadable seat must not pass. `None` (could not ask) and `set()` (asked,
+    nothing there) are deliberately different inputs."""
+    rep = _report()
+    sr.check_connector_credentials(rep, SMOKEBALL_CFG, None)
+    row = next(r for r in rep.rows if r.section == "credentials")
+    assert row.status == sr.UNKNOWN
+    assert rep.blocking, "UNKNOWN must block; an unanswerable check is not a ready one"
+
+
+def test_empty_seat_is_a_failure_not_an_unknown() -> None:
+    rep = _report()
+    sr.check_connector_credentials(rep, SMOKEBALL_CFG, set())
+    assert next(r for r in rep.rows if r.section == "credentials").status == sr.FAIL
+
+
+def test_disabled_connector_is_not_checked() -> None:
+    cfg = {"connectors": {"PracticeManagement": {**SMOKEBALL_CFG["connectors"]["PracticeManagement"], "enabled": False}}}
+    rep = _report()
+    sr.check_connector_credentials(rep, cfg, set())
+    assert not [r for r in rep.rows if r.status == sr.FAIL]
+
+
+def test_channel_fails_with_no_email_connector() -> None:
+    """A&P today: every initiation-card command is something a person says, and
+    there is nobody to say it to."""
+    rep = _report()
+    sr.check_channel(rep, {"escalation": {"red_flag_recipients": ["a@b.com"]}})
+    statuses = {r.check: r.status for r in rep.rows}
+    assert statuses["inbound conversational channel authored"] == sr.FAIL
+    assert statuses["case alerts deliverable"] == sr.FAIL
+
+
+def test_channel_passes_with_an_enabled_email_connector() -> None:
+    rep = _report()
+    sr.check_channel(
+        rep,
+        {
+            "connectors": {"Email": {"adapter": "msgraph", "enabled": True}},
+            "escalation": {"red_flag_recipients": ["a@b.com"]},
+        },
+    )
+    assert all(r.status == sr.PASS for r in rep.rows)
+
+
+def test_channel_fails_when_the_connector_is_authored_but_disabled() -> None:
+    """Authored-but-off is the shape that reads as configured and is not."""
+    rep = _report()
+    sr.check_channel(rep, {"connectors": {"Email": {"adapter": "msgraph", "enabled": False}}})
+    assert rep.rows[0].status == sr.FAIL
+
+
+def test_routines_off_requires_both_schedules_and_webhooks_quiet() -> None:
+    """'Routines are off' is only true when BOTH halves are off. The webhook half
+    is the one that fires on the firm's own activity."""
+    cfg = {
+        "personas": [
+            {
+                "skills": [
+                    {"name": "memo", "enabled": True, "initiation": {"webhook": True}},
+                ]
+            }
+        ],
+        "webhook_triggers": [{"source": "smokeball", "event_type": "matter.updated", "skill": "memo"}],
+    }
+    rep = _report()
+    sr.check_routines(rep, cfg, "# schedule: '0 7 * * *'\n")
+    by = {r.check: r for r in rep.rows}
+    assert by["scheduled routines off"].status == sr.PASS, "a commented schedule is off"
+    assert by["webhook-initiated routines off"].status == sr.FAIL
+    assert "memo" in by["webhook-initiated routines off"].detail
+
+
+def test_active_schedule_line_is_detected() -> None:
+    rep = _report()
+    sr.check_routines(rep, {}, "      schedule: '0 7 * * *'\n")
+    assert next(r for r in rep.rows if r.check == "scheduled routines off").status == sr.FAIL
+
+
+def test_webhook_trigger_to_a_disabled_skill_is_off() -> None:
+    cfg = {
+        "personas": [{"skills": [{"name": "memo", "enabled": False, "initiation": {"webhook": True}}]}],
+        "webhook_triggers": [{"source": "smokeball", "event_type": "x", "skill": "memo"}],
+    }
+    rep = _report()
+    sr.check_routines(rep, cfg, "")
+    assert next(r for r in rep.rows if r.check == "webhook-initiated routines off").status == sr.PASS
+
+
+def test_every_row_states_a_falsifier() -> None:
+    """Law 12, enforced on the tool itself: a row that cannot say what would have
+    made it false is a row that proves nothing."""
+    rep = _report()
+    sr.check_connector_credentials(rep, SMOKEBALL_CFG, set())
+    sr.check_channel(rep, {"connectors": {"Email": {"adapter": "x", "enabled": True}}})
+    sr.check_routines(rep, {}, "")
+    assert rep.rows
+    for r in rep.rows:
+        assert r.falsifier.strip(), f"row {r.check!r} carries no falsifier"
+
+
+def _grid_cfg(initiation: dict, *, channel: bool) -> dict:
+    cfg: dict = {
+        "personas": [{"skills": [{"name": "discovery-served-watch", "enabled": True, "initiation": initiation}]}]
+    }
+    if channel:
+        cfg["connectors"] = {"Email": {"adapter": "msgraph", "enabled": True}}
+    return cfg
+
+
+def test_person_invoked_with_no_channel_is_not_runnable() -> None:
+    """Regression: the first cut derived 'blocked' from `can_run_today.startswith("NO")`,
+    so 'person-invoked only — but NO channel to invoke it on' was counted as
+    RUNNABLE. It undercounted A&P's blocked routines 2 vs 8. A checker that reads
+    greener than the world is the defect, not a cosmetic bug."""
+    rows = sr.coverage_rows("ashton-price", _grid_cfg({"manual": True}, channel=False))
+    assert rows, "ashton-price must have grid rows for this test to mean anything"
+    served = next(r for r in rows if r["skills"] == ["discovery-served-watch"])
+    assert served["runnable"] is False
+    assert "NO" in served["can_run_today"]
+
+
+def test_person_invoked_with_a_channel_is_runnable() -> None:
+    rows = sr.coverage_rows("ashton-price", _grid_cfg({"manual": True}, channel=True))
+    served = next(r for r in rows if r["skills"] == ["discovery-served-watch"])
+    assert served["runnable"] is True
+
+
+def test_unbound_skill_is_not_runnable() -> None:
+    rows = sr.coverage_rows("ashton-price", {"personas": []})
+    assert rows
+    assert all(r["runnable"] is False for r in rows)
+    assert all(r["unbound"] for r in rows if r["skills"])
+
+
+def test_coverage_has_one_row_per_promised_routine() -> None:
+    """Completeness is structural: the rows come from the compiled letter-07 grid,
+    so a promised capability cannot be missing from the table."""
+    grid = yaml.safe_load((sr.CUSTOMERS / "ashton-price" / "routine-grid.yaml").read_text())
+    rows = sr.coverage_rows("ashton-price", sr.load_customer("ashton-price"))
+    assert len(rows) == len(grid["rows"]) == 19
+
+
+def test_proving_is_never_invented() -> None:
+    """Nothing on this machine knows whether a routine was demonstrated to the
+    firm, so every generated row must say so rather than leave a blank that reads
+    as a pass."""
+    rows = sr.coverage_rows("ashton-price", sr.load_customer("ashton-price"))
+    assert rows and all(r["proving"] == "(none recorded)" for r in rows)
+
+
+@pytest.mark.parametrize("slug", ["ashton-price", "pilot-smokeball"])
+def test_real_seats_parse(slug: str) -> None:
+    """The shipped configs load and produce rows — catches a schema change that
+    would silently drop a section."""
+    cfg = sr.load_customer(slug)
+    raw = (sr.CUSTOMERS / slug / "customer.yaml").read_text()
+    rep = sr.Report(slug)
+    sr.check_connector_credentials(rep, cfg, set())
+    sr.check_routines(rep, cfg, raw)
+    sr.check_channel(rep, cfg)
+    sr.check_initiation_card(rep, slug, cfg)
+    assert {r.section for r in rep.rows} >= {"credentials", "routines", "channel", "card"}

--- a/operator/customers/ashton-price/customer.yaml
+++ b/operator/customers/ashton-price/customer.yaml
@@ -616,7 +616,9 @@ personas:
     #   schedule: '19 9 * * 1' # weekly Mon 0919 seat-local — trial-prep deadline sweep
     #   pre_run: pre_run.py
     #   wake_policy: pre_run_decides
-    # Native Google/Himalaya mail skills disabled — the Operator's inbox is AgentMail.
+    # Native Google/Himalaya mail skills disabled — this firm runs M365 (F-002),
+    # and the Operator's own mailbox is the one the firm is creating in its own
+    # tenant (letter 18), reached over Microsoft Graph once Track E wires it.
     skills_disabled:
       - google-workspace
       - himalaya
@@ -658,17 +660,38 @@ connectors:
     token_ref: 'infisical:/operator/ashton-price/practice-management/smokeball-oauth'
     webhook_url: 'https://hermes-ashton-price.fly.dev/webhooks/smokeball'
 
-  # The Operator's OWN inbox (default-on). AGENTMAIL_API_KEY is a Fly secret.
-  Email:
-    adapter: agentmail
-    backend: mcp:agentmail
-    enabled: true
-    webhook_url: 'https://hermes-ashton-price.fly.dev/webhooks/agentmail'
-
-  # NOTE: A&P's mail/calendar platform is M365 / Office 365 (confirmed). Mail +
-  # calendar ride Microsoft Graph (Smokeball has no calendar API). The M365
-  # backend is not yet runtime-wired (Track E), so the Calendar connector is added
-  # at a later provision — authoring it here would be dropped by translate.py.
+  # NO Email connector is authored, deliberately (Captain, 2026-08-12).
+  #
+  # This block used to author `adapter: agentmail` while the note directly below
+  # it said the firm runs M365 — a contradiction that made the file assert a
+  # channel this firm will never use. The authored field is what the system ACTS
+  # on, so provisioning staged an AgentMail credential onto the seat for a
+  # mailbox that does not exist: `mint-agentmail-keys.py ashton-price` exits 1,
+  # `inbox 'ashton-price@agentmail.to' does not exist`, and the account's 8
+  # inboxes contain no A&P seat (the two `ap-*-standin` boxes are rehearsal
+  # stand-ins, not this firm's mailbox).
+  #
+  # The cost of leaving it was concrete, not cosmetic. `provision-customer.sh`
+  # stages the AgentMail keys only when this file names agentmail, and it falls
+  # back to the GLOBAL org-wide key when no per-seat key is vaulted. A&P has no
+  # per-seat key, so the seat was handed the org-wide credential — the one that
+  # can send as ANY inbox on the account, which is the exact credential shape
+  # behind the ss#2258 incident. Removing the authoring removes the credential at
+  # its source rather than scoping a key for a channel nobody will use.
+  #
+  # A&P's mail and calendar ride Microsoft Graph (F-002: the firm runs Outlook;
+  # Smokeball has no calendar API), and the firm is creating the Operator's own
+  # mailbox inside its own M365 tenant (letter 18, 2026-07-29 — name to follow
+  # from Christa). That backend is not yet runtime-wired (Track E), so the Email
+  # and Calendar connectors are authored at a later provision; authoring msgraph
+  # here now would be dropped by translate.py.
+  #
+  # CONSEQUENCE, stated so it is not discovered later: until Track E lands, this
+  # seat has NO inbound-mail lane. `matter-inbox-router` stays in the skill list
+  # but has no webhook source, so the PI skills described as "webhook-initiable
+  # via the matter-inbox-router spine" are person-invoked only. Nothing is lost
+  # that worked — without an inbox that lane was already inert.
+  #
   # Documents ride the Smokeball Documents API (get_files_on_matter), not a
   # separate store.
 
@@ -690,11 +713,13 @@ webhook_triggers:
     # coalesced.
     throttle:
       cooldown_minutes: 30
-  # An inbound email to the Operator routes through the spine to the right skill.
-  - source: agentmail
-    event_type: message.received
-    skill: matter-inbox-router
-    persona: operator
+  # NO inbound-mail trigger, deliberately (Captain, 2026-08-12) — paired with the
+  # removed Email connector above. This authored `source: agentmail`, a channel
+  # this firm does not use and has no inbox on, so the trigger could never fire.
+  # It is re-authored against msgraph when Track E wires the firm's own M365
+  # Operator mailbox (letter 18), at which point `matter-inbox-router` regains a
+  # webhook source and the spine-initiable PI skills become webhook-initiable
+  # again.
 
 # ---- SCOPE ----
 scope:


### PR DESCRIPTION
A&P was reported READY to connect Smokeball. It was not — the connector reads three secrets and the seat carried two.

The readiness note that cleared it (`STANDUP-READINESS-2026-07-29.md:31-33`) said: *"Our app + prod credentials: READY. `SMOKEBALL_PROD_CLIENT_ID/SECRET` in Infisical /ss (key names verified this session)."* It enumerated two of three, found both, and declared ready. **It could not have said anything else, because the third was never in the list.**

That is what this PR addresses. Not the missing key — the checker that could not fail.

## Why the pilot didn't catch it

`pilot-smokeball/customer.yaml:692` is `environment: staging # our own STAGING tenant`. A&P is `environment: production`. Different app, different credential set. Weeks of pilot work proved the *mechanism*; nothing has ever exercised the *production credentials*.

## What it checks, and where each answer comes from

| Section | Source of truth |
| --- | --- |
| credentials | each connector's `manifest.toml` `[[connector.required_secrets]]` vs the seat's Fly secret **names** |
| currency | running `SMD_OVERLAY_REF` vs `origin/main`'s pin — the property `connect-smokeball.sh` gates on (#2149) |
| routines | active `schedule:` lines **and** webhook triggers reaching an enabled webhook-initiable skill |
| channel | is any inbound conversational channel authored at all |
| card | `initiation-card.yaml` rehearsal state; unlocked commands whose `backed_by` is unbound |

**The credential check reads the seat, not the vault, on purpose.** The SDK's `SecretSpec` docstring (`manifest.py:60-62`) forbids putting the vault→runtime remap in the manifest, "so the manifest never becomes a second, contradictory wiring spec." A vault-side check would have to re-encode that mapping and could drift from `provision-customer.sh`. The Machine's own env is the layer that matters (Law 9) and needs no mapping to read.

## UNKNOWN is never PASS

A stopped Machine cannot answer the currency question, so that row is `UNKNOWN` and the run is not green. `seat_secret_names()` returns `None` for "could not ask" and never an empty set — "no secrets" and "could not look" must not be the same answer to a readiness question.

## --coverage: the plan's §6 checklist, generated

`IMPLEMENTATION-PLAN-2026-08-10.md` §6 specifies a coverage checklist whose unproven-row count is the honest answer to "are we done?", and warns that a hand-maintained one "rots into false coverage."

So the rows are **generated** from `routine-grid.yaml` — the compiled letter-07 grid (ADR 0075, every tier traced verbatim to the letter). Completeness is structural: a capability the firm was promised cannot be missing from the table, because the table is derived from the promise.

The `proving` column is never invented. Nothing on this machine knows whether a routine was demonstrated to the firm, so it reads `(none recorded)` until a human pastes a `crane_verify` id. A blank that looks like a pass is the failure this file exists to prevent.

## Current output

**ashton-price** — 5 blocking rows; `SMOKEBALL_API_KEY` missing; currency UNKNOWN (machine stopped); no inbound channel; case alerts undeliverable; 0/18 card commands green. Coverage: **19/19 unproven, 8/19 cannot run today**.

**pilot-smokeball** (the control) — credentials, currency, machine, channel and alert-deliverability all PASS. Coverage: 0/19 cannot run today. Without a seat that passes, a tool that fails everything would look correct.

## A bug this caught in itself

`blocked` first counted rows whose `can_run_today` started with `"NO"`, which silently skipped `"person-invoked only — but NO channel to invoke it on"` and undercounted A&P **2 vs 8**. Now an explicit `runnable` boolean, with a regression test naming the incident.

## Verification

- 20 tests, including both directions on every check (can-fail *and* can-pass), UNKNOWN-blocks, and "every row states a falsifier"
- Mutation-tested: forcing the credential check to find nothing missing is caught by 2 tests
- `npm run verify` exit 0; operator pytest 348 passed (was 328)

Refs #2258
