### PR TITLE
fix(operator-introduce): the send posture is read, not recited (#2338)

### DIFF
--- a/operator/skills/operator-introduce/SKILL.md
+++ b/operator/skills/operator-introduce/SKILL.md
@@ -57,25 +57,34 @@ requester, and to nobody else.
 The reads below are the same facts either way; what changes is who performs them.
 
 **On an email or webhook turn**, the seat offers `operator_seat_facts`. That tool
-performs sources 2, 3, 4, and 5 for you and returns them as one result: identity,
-the routine roster paired against the live scheduler, voice status per output
-class, and any cohort discrepancy. Call it (`depth: "introduction"` or
-`depth: "walkthrough"`) and compose from what it returns. Its per-section `read`
+performs sources 2, 3, 4, 5, and 6 for you and returns them as one result:
+identity, the routine roster paired against the live scheduler, voice status per
+output class, any cohort discrepancy, and the working rules. Call it
+(`depth: "introduction"` or `depth: "walkthrough"`) and compose from what it
+returns. Its per-section `read`
 flag carries exactly the honesty contract written below: a section that comes back
 `read: false` gets the sentence authored for that source, verbatim, and you carry
 on with the rest. This is not an optimization. On that channel this file is not in
 front of you, so a rule that lives only here is a rule nobody reads; putting the
 reads in a tool is what makes them mechanical rather than remembered.
 
+**That sentence was proved on this skill, by this skill.** The four working
+rules were authored in the fixed shape below on 2026-08-10, both installed
+copies on the pilot carried them, and the 2026-08-12 rehearsal introduction
+stated none of them — the reply mirrored the tool envelope's sections exactly
+(ss-console#2338). The rules are now source 6 and are read like everything
+else, because two of them are seat-variable and the flat versions this file
+used to carry were false on a seat authored differently.
+
 **On an `ask_operator` or CLI turn**, you have the skills index and this body, and
-`operator_seat_facts` may not be among your tools. Perform sources 2 through 5
+`operator_seat_facts` may not be among your tools. Perform sources 2 through 6
 yourself, exactly as written below.
 
 **Source 1 is yours on every channel.** The live connection probes and the matter
 count are calls you make, never something a tool asserts on your behalf, because
 "observed this turn" is a claim only an actual call can back.
 
-Five sources. Every sentence in the reply traces to one of them. If a source
+Six sources. Every sentence in the reply traces to one of them. If a source
 will not read, say the specific thing below and carry on with the rest; a
 partial introduction that names its own gap is worth more than a complete one
 that filled the gap from memory.
@@ -111,6 +120,18 @@ for one purpose only: catching a cohort directory that the configuration's
 `voice_cohorts` vocabulary does not authorize.
 _On failure:_ say nothing at all about cohorts on disk. "I could not look" must
 never render as "there was nothing there."
+
+**6. The working rules.** Two of the four are seat state, not doctrine, so they
+are read: the send posture from `personas[].entitlements.exposure` (every
+`external_send*` class, as authored), and the identifier rule from whether the
+A1 gate is refusing or in report mode. The third — never computing a deadline —
+is a consequence of the same gate rather than a separate mechanism, and only "no
+legal advice" is authored policy with nothing to read.
+_On failure:_ "I can't read my own send posture right now, so I won't tell you
+what I will and won't send on my own." Then give the rules you could read. Never
+substitute the flat sentence: a seat authoring `external_send: autonomous` really
+does send (ADR 0073), so promising review there is a false promise about the one
+thing a firm most needs to be true.
 
 ### Constrained read discipline
 
@@ -269,11 +290,14 @@ N routines: X on a schedule, Y that start when something happens, Z when you
 ask. Ask me to walk through them and I'll list every one with the state it's in.
 
 How I work:
-- Everything I prepare for the outside world goes to a person for review. I
-  don't send externally on my own.
+- [Send posture, from `working_rules.send_posture` — one sentence per outbound
+  class, in the firm's words. Never a blanket review promise when the classes
+  disagree, and never "I send nothing outward" when the reason is that no class
+  is authored: that reads as freedom when it is a refusal.]
 - I read deadlines from your systems. I never calculate them myself.
-- I won't use a case number, date, or identifier I haven't read from your
-  records. If I can't verify it, I say so instead.
+- [The identifier sentence, verbatim from `working_rules.identifier_gate.says`
+  — it differs between a seat that refuses and a seat running the gate in
+  report mode.]
 - I don't give legal advice or opinions on the merits.
 
 Ask me to run my self-test any time and I'll send you a one-page check of all


### PR DESCRIPTION
## Summary

The ss-console half of #2338. Overlay companion: **venturecrane/hermes-smd-overlay#261** (the `working_rules` section itself).

The issue assumed the fix belonged here — *"the fix is in what `operator-introduce` says about itself."* It doesn't. The four rules were already in this file's fixed shape, added **2026-08-10** (`83cb61a0`), and both installed copies on the pilot carry them at `version: 0.3.0`. The rehearsal introduction omitted them anyway, because the reply mirrored `operator_seat_facts`' section list exactly — and this file already explains why (`:64-68`): on an email turn it is not in front of the model.

So the rules move into the tool (overlay#261) and this file stops carrying flat versions of two of them.

## What was actually wrong here

Two of the four bullets were claims this seat can falsify:

- **"Everything I prepare for the outside world goes to a person for review. I don't send externally on my own."** True only where `exposure` authors it. ADR 0073 proved an authored autonomous send really sends, and `customer.yaml:172` authors `external_send_internal: autonomous` on this very seat.
- **The identifier sentence** assumes the A1 gate is refusing. It carries an operator rollback lever (`SMD_IDENTIFIER_GATE_MODE=report`) under which the gate observes and does not refuse.

Both now render from `working_rules`. The two that are genuinely invariant (never computing a deadline, no legal advice) stay as written.

## Changes

- Source 6 added, with an on-failure sentence that **refuses to substitute the flat version** — promising review on a seat that sends is a false promise about the one thing a firm most needs to be true
- "Five sources" → six; the CLI branch reads 2 through 6
- The email-turn paragraph now records that its own claim was proved on itself, with the dates

## Test plan

- [x] `npm run verify` exit 0 (273 files / 4368 tests)
- [ ] **(runtime)** After the `OVERLAY_REF` bump and reprovision: `operator/bin/rehearse-card.py pilot-smokeball --only 1` returns connections, matter count, and the four rules, with the send posture matching this seat's authored exposure rather than a blanket promise. Card command 1 moves to `rehearsal: green` only with that verify id.

Closes #2338 on merge of both halves.
