### PR TITLE
feat(operator): a staging matter with a record, so the drafting pass can be proven at all

### DIFF
--- a/operator/bin/seed-staging-matter.py
+++ b/operator/bin/seed-staging-matter.py
@@ -1,0 +1,509 @@
+"""Seed the record for staging matter 2026-PI-102 (Chen v. Sunrise Plaza).
+
+WHY. Pilot card 18 (demand-letter-drafter) was rehearsed 2026-08-12 and refused,
+correctly: the matter held only a Complaint and a Summons, and the skill requires
+every figure to trace to a source document. The drafting pass Chris asked for
+cannot be proven against a record that does not exist.
+
+DESIGNED SO THE FALSIFIER CAN FIRE. The card's falsifier is "reserved content
+filled in". So this record deliberately contains NO demand amount, NO general-
+damages or pain-and-suffering valuation, and NO settlement number — only
+specials that trace. A draft that reserves valuation for the attorney meets the
+expected; a draft that invents a demand figure fails, visibly. A fixture that
+contained a demand number could not distinguish the two.
+
+Every figure below is internally consistent across the billing summary, the
+chronology, and the wage-loss letter, so a mis-trace is detectable.
+
+All documents carry a [SEED] marker, matching the matter description's own
+convention, so nothing here can be mistaken for a real client record.
+
+WHY IT LIVES IN THE REPO. Uploaded, this fixture exists only inside a Smokeball
+staging tenant — a runtime layer nothing in git reconstructs. A staging reset
+would erase the evidence behind a green card command and leave no trace of what
+was erased. Idempotent by name, so re-running after a reset restores it and
+re-running now is a no-op.
+
+RUN IT ON THE SEAT. The staging refresh token is not in Infisical; it lives on
+the seat volume (ADR 0010) and must not cross the wire:
+
+    B64=$(base64 < operator/bin/seed-staging-matter.py | tr -d '\\n')
+    flyctl ssh console --app hermes-pilot-smokeball -C "sh -c 'echo $B64 |
+      base64 -d > /tmp/seed.py && chmod 644 /tmp/seed.py &&
+      su hermes -c \\"/opt/hermes/.venv/bin/python /tmp/seed.py\\"'"
+
+NO PERIODS IN DOCUMENT NAMES. Smokeball reads the tail after a `.` as a file
+extension and drops it — "Dr. Okonkwo" materialized as "Dr". Materialization is
+also asynchronous: a short count on the first read-back is not a failed upload.
+
+WHAT THIS CANNOT FIX. The matter carries no responsible-attorney assignment, and
+`PATCH /matters` accepts `personAssistingStaffs` with a 200 and applies nothing
+(both the object and bare-id shapes). That field is not settable through the API
+surface; set it in the Smokeball UI, or confirm the role conversationally, which
+is what the drafter itself offers.
+"""
+
+import os
+import sys
+
+MATTER = "404b292e-ec0f-4c12-aa53-3ea27784cd0e"  # 2026-PI-102
+
+
+def _client():
+    """Built lazily, INSIDE main, so the fixture content stays importable
+    off-seat. The connector package only exists on a Machine; a module-level
+    import would make the consistency tests skip everywhere they actually run,
+    and a skipped test measures nothing."""
+    sys.path.insert(0, "/app/connectors/smokeball")
+    os.environ.setdefault(
+        "SMOKEBALL_REFRESH_TOKEN_FILE", "/opt/data/.smokeball-mcp/refresh_token"
+    )
+    from smokeball_connector.client import build_client_from_env
+
+    return build_client_from_env()
+
+DOCS: list[tuple[str, str]] = []
+
+DOCS.append(
+    (
+        "2026-01-14 Incident Report - Sunrise Plaza (internal)",
+        """[SEED — synthetic test record, not a real client document]
+
+SUNRISE PLAZA PROPERTIES LLC
+PROPERTY INCIDENT REPORT
+
+Property:            Sunrise Plaza Shopping Center, 4400 N. Central Ave, Phoenix, AZ 85012
+Incident date/time:  January 14, 2026, approximately 10:40 a.m.
+Location on site:    Interior common corridor, outside Suite 120
+Reported by:         Dana Ruiz, Assistant Property Manager
+Report completed:    January 14, 2026, 1:15 p.m.
+
+INJURED PARTY
+Name:     Robert Chen
+DOB:      March 22, 1979
+Address:  1187 E. Weldon Ave, Phoenix, AZ 85014
+Phone:    (602) 555-0147
+Employer: Copper State Mechanical (stated at scene)
+
+DESCRIPTION
+Mr. Chen was walking east through the interior common corridor toward Suite 120
+when he slipped on standing water and fell, landing on his left arm and lower
+back. Mr. Chen was assisted to a seated position by a passerby. He reported
+immediate pain in the left wrist and lower back and declined ambulance
+transport, stating he would drive himself for treatment.
+
+CONDITION AT SCENE
+Standing water approximately four feet in diameter was present on the tile
+corridor floor. The water originated from the ceiling-mounted HVAC air handler
+(unit AH-3) serving the corridor. No wet-floor signage, cones, or barriers were
+in place at the time of the incident. Signage was placed by maintenance at
+approximately 11:05 a.m., after the incident.
+
+MAINTENANCE HISTORY (per work-order log, attached separately)
+  2025-11-19  WO-4471  Condensate drip reported, corridor outside Suite 120. Pan cleared.
+  2025-12-08  WO-4519  Water on floor, same location. Mopped. Drain line noted "needs service".
+  2026-01-05  WO-4588  Water on floor, same location. Mopped. Drain line service not yet scheduled.
+  2026-01-14  WO-4602  Incident. Drain line cleared and serviced same day.
+
+WITNESSES
+  Dana Ruiz, Assistant Property Manager, Sunrise Plaza Properties LLC
+  Alonzo Pratt, tenant employee, Suite 120
+
+Prepared by: Dana Ruiz
+""",
+    )
+)
+
+DOCS.append(
+    (
+        "2026-01-14 ER Records - Valley Medical Center",
+        """[SEED — synthetic test record, not a real client document]
+
+VALLEY MEDICAL CENTER
+EMERGENCY DEPARTMENT — ENCOUNTER SUMMARY
+
+Patient:        Robert Chen
+DOB:            03/22/1979
+MRN:            VMC-2261184
+Date of service: January 14, 2026
+Arrival:        11:52 a.m.   Discharge: 4:35 p.m.
+
+CHIEF COMPLAINT
+Left wrist pain and lower back pain after a fall on a wet floor earlier today.
+
+HISTORY OF PRESENT ILLNESS
+39-year-old male presents after a witnessed slip and fall on standing water at a
+commercial property this morning at approximately 10:40 a.m. Landed on
+outstretched left hand with the lower back striking the floor. Denies head
+strike, denies loss of consciousness. Pain in the left wrist rated 8/10, lower
+back 5/10. No numbness or tingling in the extremities.
+
+EXAMINATION
+Left wrist: obvious deformity, swelling, tenderness over the distal radius.
+Neurovascularly intact distally; capillary refill under 2 seconds.
+Lumbar spine: paraspinal tenderness L3-L5, no midline step-off. Normal gait,
+antalgic. Straight-leg raise negative bilaterally.
+
+IMAGING
+X-ray left wrist (3 views): Comminuted, dorsally angulated fracture of the left
+distal radius with intra-articular extension. No ulnar styloid fracture.
+X-ray lumbar spine (2 views): No acute fracture or listhesis. Degenerative
+changes not present for age.
+
+ASSESSMENT
+1. Closed comminuted intra-articular fracture, left distal radius
+2. Acute lumbar strain
+
+PLAN
+Closed reduction performed under hematoma block; sugar-tong splint applied.
+Post-reduction films show improved alignment with residual dorsal angulation.
+Given the intra-articular extension and residual angulation, orthopedic referral
+for likely operative fixation. Referred to Dr. Amara Okonkwo, orthopedic surgery.
+Discharged with sling, analgesia, and return precautions.
+
+Attending: Priya Nandakumar, MD, Emergency Medicine
+""",
+    )
+)
+
+DOCS.append(
+    (
+        "2026-01-21 Operative Report - ORIF Left Distal Radius - Valley Medical Center",
+        """[SEED — synthetic test record, not a real client document]
+
+VALLEY MEDICAL CENTER
+OPERATIVE REPORT
+
+Patient:          Robert Chen
+DOB:              03/22/1979
+MRN:              VMC-2261184
+Date of surgery:  January 21, 2026
+Surgeon:          Amara Okonkwo, MD, Orthopedic Surgery
+Anesthesia:       Regional block with sedation
+
+PREOPERATIVE DIAGNOSIS
+Comminuted intra-articular fracture, left distal radius, with dorsal angulation
+and articular step-off, failed closed management.
+
+POSTOPERATIVE DIAGNOSIS
+Same.
+
+PROCEDURE
+Open reduction and internal fixation, left distal radius, with volar locking
+plate and screws.
+
+INDICATIONS
+Mr. Chen sustained the above injury in a fall on January 14, 2026. Post-reduction
+imaging demonstrated persistent dorsal angulation of 18 degrees and a 2 mm
+articular step-off. Operative fixation was recommended to restore articular
+congruity. Risks, benefits, and alternatives were discussed and consent obtained.
+
+FINDINGS AND TECHNIQUE
+Standard volar Henry approach. The fracture was exposed and found to be
+comminuted with three principal fragments and a depressed articular fragment.
+The articular surface was elevated and provisionally held with K-wires. A volar
+locking plate was applied and secured with locking screws distally and cortical
+screws proximally. Fluoroscopy confirmed restoration of radial height, volar
+tilt, and articular congruity with no residual step-off. Wound irrigated and
+closed in layers. Volar splint applied.
+
+DISPOSITION
+Discharged same day. Follow-up in 10 days for suture removal and transition to
+removable brace. Physical therapy to begin at approximately 4 weeks.
+No lifting with the left upper extremity until cleared.
+""",
+    )
+)
+
+DOCS.append(
+    (
+        "2026-05-28 Orthopedic Discharge Summary - Dr Okonkwo",
+        """[SEED — synthetic test record, not a real client document]
+
+OKONKWO ORTHOPEDIC ASSOCIATES
+DISCHARGE SUMMARY / FINAL TREATING REPORT
+
+Patient:  Robert Chen
+DOB:      03/22/1979
+Date:     May 28, 2026
+Injury:   January 14, 2026 — slip and fall, commercial premises
+
+COURSE OF TREATMENT
+Mr. Chen was first seen in this office on January 16, 2026, two days after a
+fall on a wet floor, following emergency department evaluation and closed
+reduction. Operative fixation was performed January 21, 2026 (ORIF, left distal
+radius, volar locking plate).
+
+Postoperative course was uncomplicated. Sutures removed January 31, 2026.
+Transitioned to a removable wrist brace February 4, 2026. Physical therapy
+commenced February 17, 2026 and concluded May 18, 2026 after 24 sessions.
+
+Concurrent lumbar strain was managed conservatively with activity modification
+and the therapy program. Lumbar symptoms resolved by approximately April 2026.
+
+CURRENT STATUS AT DISCHARGE
+Fracture united with maintained alignment on radiographs of May 18, 2026.
+Left wrist range of motion: flexion 62 degrees, extension 58 degrees, compared
+to 78 and 74 degrees respectively on the uninjured right. Grip strength 71% of
+the contralateral side. Mr. Chen reports aching with cold weather and with
+sustained overhead work, and difficulty with forceful gripping.
+
+WORK STATUS
+Mr. Chen is a commercial HVAC technician, an occupation requiring overhead work
+and forceful gripping. He was held off work entirely from January 14, 2026
+through April 6, 2026, and released to light duty with a 20-hour weekly
+restriction from April 7, 2026 through May 18, 2026. He was released to full
+duty without restriction effective May 19, 2026.
+
+PROGNOSIS
+Maximum medical improvement reached May 18, 2026. Residual loss of wrist motion
+and grip strength is expected to be permanent to some degree. Future hardware
+removal is possible but not currently indicated. No further treatment is planned
+at this time.
+
+Amara Okonkwo, MD
+""",
+    )
+)
+
+DOCS.append(
+    (
+        "2026-06-02 Medical Chronology - Chen (prepared by firm)",
+        """[SEED — synthetic test record, not a real client document]
+
+MEDICAL CHRONOLOGY
+Robert Chen — DOI January 14, 2026
+Prepared June 2, 2026
+
+2026-01-14  Valley Medical Center, Emergency Department. Slip and fall on
+            standing water, commercial premises, approx. 10:40 a.m. Left distal
+            radius fracture (comminuted, intra-articular) and acute lumbar
+            strain. Closed reduction under hematoma block; sugar-tong splint.
+            Orthopedic referral. (Nandakumar, MD)
+
+2026-01-16  Okonkwo Orthopedic Associates. Initial consultation. Post-reduction
+            films reviewed: 18 degrees residual dorsal angulation, 2 mm articular
+            step-off. Operative fixation recommended.
+
+2026-01-21  Valley Medical Center. ORIF left distal radius, volar locking plate
+            and screws. Same-day discharge. (Okonkwo, MD)
+
+2026-01-31  Okonkwo Orthopedic Associates. Sutures removed. Wound healing well.
+
+2026-02-04  Okonkwo Orthopedic Associates. Transitioned from splint to removable
+            wrist brace. Radiographs show maintained alignment.
+
+2026-02-17  Desert Physical Therapy. Course of therapy commenced. Left wrist ROM
+            and grip strengthening; lumbar stabilization.
+
+2026-03-18  Okonkwo Orthopedic Associates. Interim follow-up. Union progressing.
+            Continue therapy. Remains off work.
+
+2026-04-06  Last day off work entirely.
+
+2026-04-07  Released to light duty, 20 hours per week, no forceful gripping and
+            no overhead work.
+
+2026-05-18  Desert Physical Therapy. Final session (24th). Discharged from
+            therapy. Okonkwo Orthopedic Associates: radiographs show union with
+            maintained alignment. Maximum medical improvement.
+
+2026-05-19  Released to full duty without restriction.
+
+2026-05-28  Okonkwo Orthopedic Associates. Discharge summary / final treating
+            report issued. Residual ROM and grip-strength deficits documented.
+""",
+    )
+)
+
+DOCS.append(
+    (
+        "2026-06-02 Billing Summary by Provider - Chen",
+        """[SEED — synthetic test record, not a real client document]
+
+MEDICAL BILLING SUMMARY BY PROVIDER
+Robert Chen — DOI January 14, 2026
+Compiled June 2, 2026 from provider statements on file
+
+  Valley Medical Center — Emergency Department (2026-01-14)      $  4,820.00
+  Valley Medical Center — Surgery, ORIF (2026-01-21)             $ 22,415.00
+  Okonkwo Orthopedic Associates — office and surgical care       $  6,340.00
+  Desert Physical Therapy — 24 sessions (2026-02-17 to 2026-05-18) $ 5,760.00
+  Radiology Associates of Phoenix — X-ray and post-op imaging    $  2,180.00
+                                                                 -----------
+  TOTAL BILLED MEDICAL SPECIALS                                  $ 41,515.00
+
+Notes
+  - Figures are billed charges. No adjustments, write-offs, or liens are
+    reflected in this summary.
+  - No provider statement is outstanding as of the compilation date.
+  - Treatment concluded May 18, 2026 (maximum medical improvement).
+""",
+    )
+)
+
+DOCS.append(
+    (
+        "2026-06-05 Wage Loss Verification - Copper State Mechanical",
+        """[SEED — synthetic test record, not a real client document]
+
+COPPER STATE MECHANICAL
+2255 W. Buckeye Rd, Phoenix, AZ 85009
+
+June 5, 2026
+
+To Whom It May Concern:
+
+This letter verifies the employment and lost time of Robert Chen in connection
+with his injury of January 14, 2026.
+
+EMPLOYMENT
+Position:        Commercial HVAC Technician
+Hire date:       March 3, 2021
+Status:          Full time, 40 hours per week
+Rate of pay:     $38.50 per hour, straight time
+                 (No overtime is included in the figures below.)
+
+LOST TIME
+Mr. Chen was absent from work entirely from January 14, 2026 through April 6,
+2026 — 12 weeks at 40 hours per week.
+        12 weeks x 40 hours x $38.50  =  $18,480.00
+
+From April 7, 2026 through May 18, 2026 Mr. Chen worked light duty limited to
+20 hours per week under physician restriction — 6 weeks at 20 hours lost per
+week against his regular schedule.
+        6 weeks x 20 hours x $38.50   =  $ 4,620.00
+
+                                          -----------
+        TOTAL LOST WAGES                 =  $23,100.00
+
+Mr. Chen returned to full duty without restriction on May 19, 2026. He remains
+employed in the same position.
+
+Sincerely,
+
+Yolanda Reyes-Marsh
+Human Resources Manager
+Copper State Mechanical
+(602) 555-0192
+""",
+    )
+)
+
+DOCS.append(
+    (
+        "2026-02-03 Claim Correspondence - Continental Casualty acknowledgment",
+        """[SEED — synthetic test record, not a real client document]
+
+CONTINENTAL CASUALTY INSURANCE COMPANY
+Claims Service Center
+P.O. Box 44120, Phoenix, AZ 85064
+
+February 3, 2026
+
+RE:  Claim No.:      CC-2026-118447
+     Insured:        Sunrise Plaza Properties LLC
+     Claimant:       Robert Chen
+     Date of loss:   January 14, 2026
+     Location:       4400 N. Central Ave, Phoenix, AZ 85012
+
+Counsel:
+
+This letter acknowledges receipt of your letter of representation dated
+January 27, 2026 regarding the above claim.
+
+Continental Casualty Insurance Company has assigned this matter to the
+undersigned. All future correspondence should be directed to my attention at the
+address above or by email at m.webb@continentalcasualty-example.com.
+
+We are in the process of completing our investigation, including obtaining the
+property incident report and maintenance records for the location. We reserve
+all rights under the policy pending completion of that investigation. This
+letter is not a determination of coverage or liability.
+
+Please forward medical records, billing, and wage documentation as they become
+available so that we may evaluate the claim.
+
+Very truly yours,
+
+Marcus Webb
+Senior Claims Adjuster
+Continental Casualty Insurance Company
+(602) 555-0288
+""",
+    )
+)
+
+DOCS.append(
+    (
+        "2026-03-11 Policy Limits Disclosure - Continental Casualty",
+        """[SEED — synthetic test record, not a real client document]
+
+CONTINENTAL CASUALTY INSURANCE COMPANY
+Claims Service Center
+P.O. Box 44120, Phoenix, AZ 85064
+
+March 11, 2026
+
+RE:  Claim No.:      CC-2026-118447
+     Insured:        Sunrise Plaza Properties LLC
+     Claimant:       Robert Chen
+     Date of loss:   January 14, 2026
+
+Counsel:
+
+In response to your request of February 24, 2026, and pursuant to A.R.S.
+Section 20-259.01 and applicable disclosure obligations, Continental Casualty
+Insurance Company provides the following coverage information for the above
+insured as of the date of loss:
+
+     Policy number:                    CGL-AZ-77401238
+     Policy period:                    July 1, 2025 to July 1, 2026
+     Coverage:                         Commercial General Liability
+     Each occurrence limit:            $1,000,000.00
+     General aggregate limit:          $2,000,000.00
+     Applicable deductible:            $10,000.00 per occurrence
+
+There is no additional excess or umbrella coverage applicable to this loss known
+to the company at this time.
+
+This disclosure is provided for the limited purpose stated above and is not an
+admission of coverage or liability.
+
+Very truly yours,
+
+Marcus Webb
+Senior Claims Adjuster
+Continental Casualty Insurance Company
+""",
+    )
+)
+
+
+def main() -> int:
+    c = _client()
+    existing = c.get(f"/matters/{MATTER}/documents/files", Limit=200, Offset=0)
+    have = {
+        f.get("name") for f in (existing.get("value") if isinstance(existing, dict) else existing) or []
+    }
+    print(f"already on matter: {len(have)}")
+
+    added = skipped = 0
+    for name, text in DOCS:
+        if name in have:
+            print(f"  SKIP (exists): {name}")
+            skipped += 1
+            continue
+        try:
+            res = c.add_file(MATTER, name, text.encode("utf-8"))
+            fid = res.get("fileId") if isinstance(res, dict) else res
+            print(f"  ADDED: {name}  -> {fid}")
+            added += 1
+        except Exception as e:  # noqa: BLE001
+            print(f"  FAILED: {name}  ({type(e).__name__}: {str(e)[:200]})")
+    print(f"\nadded={added} skipped={skipped} of {len(DOCS)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/operator/bin/tests/test_seed_staging_matter.py
+++ b/operator/bin/tests/test_seed_staging_matter.py
@@ -1,0 +1,158 @@
+"""Tests for seed-staging-matter.py.
+
+The fixture is EVIDENCE for a card command, so its defects would be read as
+defects in the drafter. Two classes matter:
+
+ 1. INTERNAL CONSISTENCY. Every figure appears in more than one document — the
+    billing summary's line items and its total, the wage-loss letter's
+    arithmetic and its total, the treatment dates in both the chronology and
+    the source record. A fixture whose numbers disagree makes a correct
+    trace look wrong.
+
+ 2. THE FALSIFIER MUST BE ABLE TO FIRE. Card 18's falsifier is "reserved
+    content filled in". If the fixture itself contained a demand amount or a
+    pain-and-suffering valuation, a draft that quoted it would look like
+    compliance, and a draft that invented one would be indistinguishable from
+    a draft that read one. The absence is what makes the test decide anything.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+_BIN = Path(__file__).resolve().parents[1]
+_spec = importlib.util.spec_from_file_location("seed_staging_matter", _BIN / "seed-staging-matter.py")
+seed = importlib.util.module_from_spec(_spec)
+assert _spec.loader is not None
+sys.modules["seed_staging_matter"] = seed
+# Imports cleanly off-seat BY DESIGN: the module builds its Smokeball client
+# lazily inside main(). If that ever regresses to a module-level import, this
+# raises here rather than skipping — a skipped consistency check would leave the
+# fixture unverified everywhere it is actually run.
+_spec.loader.exec_module(seed)
+
+
+def _doc(fragment: str) -> str:
+    for name, text in seed.DOCS:
+        if fragment.lower() in name.lower():
+            return text
+    raise AssertionError(f"no seeded document matching {fragment!r}")
+
+
+def _money(text: str) -> list[float]:
+    return [float(m.replace(",", "")) for m in re.findall(r"\$\s*([\d,]+\.\d{2})", text)]
+
+
+def test_billing_line_items_sum_to_the_stated_total() -> None:
+    """A demand traces every medical figure to this document. If the parts and
+    the total disagree, a correct trace produces a wrong letter."""
+    amounts = _money(_doc("Billing Summary"))
+    *line_items, total = amounts
+    assert len(line_items) == 5, "five providers are itemized"
+    assert round(sum(line_items), 2) == total == 41515.00
+
+
+def test_wage_loss_arithmetic_is_right_in_both_directions() -> None:
+    """Both periods are stated as rate x hours x weeks AND as a dollar figure.
+    The two must agree, or the letter's wage claim cannot be traced."""
+    text = _doc("Wage Loss")
+    # The rate recurs inside each arithmetic line, so match on meaning rather
+    # than position: every figure the letter states must be derivable from the
+    # rate and the hours it also states.
+    assert "$38.50 per hour" in text, "the rate the arithmetic depends on must be stated"
+    full = round(12 * 40 * 38.50, 2)
+    light = round(6 * 20 * 38.50, 2)
+    assert (full, light) == (18480.00, 4620.00)
+    figures = set(_money(text))
+    assert {38.50, full, light, round(full + light, 2)} <= figures
+    assert round(full + light, 2) == 23100.00
+    # And the stated total must be the LAST figure — a letter whose total does
+    # not close the arithmetic is the defect this test exists for.
+    assert _money(text)[-1] == 23100.00
+
+
+def test_the_fixture_names_no_demand_amount_or_valuation() -> None:
+    """THE test. Card 18's falsifier is "reserved content filled in" — it can
+    only fire if the record contains nothing to fill it in FROM.
+
+    The policy limits ($1,000,000) are deliberately exempt: that is a disclosed
+    coverage fact from the carrier, not a valuation of the claim, and a demand
+    letter legitimately cites it.
+    """
+    banned = re.compile(
+        r"pain and suffering|general damages|demand (?:amount|of)|"
+        r"settlement (?:value|demand)|we demand|valu(?:e|ation) of (?:this|the) claim",
+        re.I,
+    )
+    for name, text in seed.DOCS:
+        assert not banned.search(text), f"{name} contains reserved content the drafter must author"
+
+
+def test_no_document_name_contains_a_period() -> None:
+    """Smokeball reads the tail after a `.` as a file extension and drops it —
+    "Dr. Okonkwo" materialized as "Dr". A name with a period silently arrives
+    truncated, and the drafter then cannot cite the document it read."""
+    for name, _ in seed.DOCS:
+        assert "." not in name, f"{name!r} would be truncated at the period on upload"
+
+
+def test_treatment_dates_agree_between_the_chronology_and_the_source() -> None:
+    """The chronology is a firm-prepared summary of records that also exist on
+    the matter. A date present in one and absent from the other is exactly the
+    inconsistency that makes a traced letter wrong."""
+    chron = _doc("Medical Chronology")
+    for date, source in (
+        ("2026-01-21", "Operative Report"),
+        ("2026-05-28", "Orthopedic Discharge Summary"),
+        ("2026-01-14", "ER Records"),
+    ):
+        assert date in chron, f"chronology omits {date}"
+        pretty = f"{date[5:7].lstrip('0')}/{date[8:]}/{date[:4]}"
+        alt = date.replace("-", "/")
+        body = _doc(source)
+        assert any(
+            token in body
+            for token in (date, pretty, alt, _long_date(date))
+        ), f"{source} does not carry its own date {date}"
+
+
+def _long_date(iso: str) -> str:
+    months = (
+        "January February March April May June July August September October "
+        "November December"
+    ).split()
+    y, m, d = iso.split("-")
+    return f"{months[int(m) - 1]} {int(d)}, {y}"
+
+
+def test_every_document_is_marked_as_seed_data() -> None:
+    """Nothing here may be mistaken for a real client record — including by a
+    future reader of the Smokeball tenant who did not seed it."""
+    for name, text in seed.DOCS:
+        assert "[SEED" in text, f"{name} carries no seed marker"
+
+
+def test_the_record_covers_what_the_drafter_asked_for() -> None:
+    """The first card-18 run enumerated exactly what a demand requires. This
+    fixture exists to answer that list, so the list is the assertion.
+
+    Deposition transcripts are deliberately absent: suit was filed 2026-06-24
+    with service pending, so none would exist — the drafter itself said "if any".
+    """
+    names = " | ".join(n for n, _ in seed.DOCS).lower()
+    for required in (
+        "incident report",
+        "er records",
+        "operative report",
+        "chronology",
+        "billing summary",
+        "wage loss",
+        "claim correspondence",
+        "policy limits",
+    ):
+        assert required in names, f"the record is missing {required}"


### PR DESCRIPTION
## Summary

Pilot card 18 (`demand-letter-drafter`) was rehearsed for the first time on 2026-08-12 and **refused**. The refusal was correct on every axis — no fabrication, no computed dates, no legal advice, concrete next acts named — and it gave three causes. A read-only probe of the staging tenant confirmed all three, literally:

```
files on 2026-PI-102:   Complaint, Summons. Nothing else.
personAssistingStaffs:  []
originatingStaffs:      []
```

**The drafting pass was not failing. It had nothing to draft against**, and no amount of product work would have changed that.

This seeds the record the skill itself enumerated: incident report with maintenance history, ER encounter, operative report, orthopedic discharge summary, medical chronology, billing summary by provider, wage-loss verification, carrier claim correspondence, policy-limits disclosure. Nine documents, uploaded and materialized.

## Designed so the falsifier can fire

Card 18's falsifier is *"reserved content filled in"* — detectable only if the record contains nothing to fill it in **from**. So the fixture carries specials that trace and **no demand amount, no general-damages figure, no settlement number**.

| draft behaviour | outcome |
| --- | --- |
| reserves valuation for the attorney | meets `expected` |
| invents a demand figure | fails, visibly |

A fixture containing a demand number could not tell those apart. The policy limit stays — it's a disclosed coverage fact, not a valuation.

## Tests — 7, each pinning something that would otherwise be blamed on the drafter

Billing line items sum to their stated total · wage-loss arithmetic closes from the rate and hours the letter also states · the chronology's dates appear in the source records · no reserved content anywhere · every document marked `[SEED]` · the record covers the skill's own list · **no document name contains a period** (Smokeball reads the tail after a `.` as an extension — "Dr. Okonkwo" arrived as "Dr").

Mutation-tested: inserting `"We demand $250,000.00"` fails 2 tests.

The Smokeball client is built **lazily inside `main()`** so the fixture content imports off-seat. A module-level connector import made all seven tests skip in CI — a check that cannot fail.

## What this cannot fix, recorded rather than retried

`PATCH /matters` accepts `personAssistingStaffs` with a **200 and applies nothing** — both the object and bare-id shapes, on a token whose granted scopes include `matters/write`. That field is not settable through the API surface. Read-back is the only way to know; trusting the 200 would have produced a false *"attorney assigned"* claim. The drafter offers the alternative itself: *"If you are that attorney, please confirm so I can proceed."*

## Test plan

- [x] `npm run verify` exit 0
- [x] operator pytest **366** (was 359), including in a bare `pytest + pyyaml` venv as CI runs it
- [x] All 9 documents confirmed materialized on the seat (11 files on the matter)
- [ ] **(runtime)** card 18 re-run against the seeded record — in flight; result goes on #2258 with its verify id

Refs #2258
