### PR TITLE
feat(operator): a pre-suit matter with a record that agrees with itself (#2258)

### DIFF
--- a/operator/bin/lib/seed_fixtures/__init__.py
+++ b/operator/bin/lib/seed_fixtures/__init__.py
@@ -1,0 +1,72 @@
+"""Staging-matter document fixtures, one module per matter.
+
+WHY A PACKAGE. The fixture documents are prose, and prose is long. Holding two
+matters' records in the runner put it over the 500-line file ceiling and made
+the runner's actual logic hard to find. One module per matter keeps each set
+readable next to its own rationale, which is where the rationale belongs: the
+2026-PI-102 set exists to prove judgment under conflict and the 2026-PI-104 set
+exists to prove the happy path, and a reader who does not know that will
+"repair" the first one.
+
+Each module exports ``MATTER_ID`` and ``DOCS: list[tuple[str, str]]`` of
+``(document_name, text)``. Names carry no periods (Smokeball reads the tail
+after a "." as a file extension and drops it) and every body carries a [SEED]
+marker so nothing here can be mistaken for a real client record.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from . import chen_pi102, whitfield_pi104
+
+
+@dataclass(frozen=True)
+class Fixture:
+    """One staging matter's authored record, and what it is FOR.
+
+    ``purpose`` is not decoration. 2026-PI-102 contradicts its own Complaint on
+    purpose, and a future reader who does not know that will tidy the
+    contradiction away along with the only evidence we have that the drafter
+    catches one.
+    """
+
+    slug: str
+    matter_id: str
+    purpose: str
+    docs: list[tuple[str, str]]
+
+
+FIXTURES: dict[str, Fixture] = {
+    "chen-pi102": Fixture(
+        slug="chen-pi102",
+        matter_id=chen_pi102.MATTER_ID,
+        purpose=(
+            "Judgment under conflict. Post-suit, and its documents contradict "
+            "the matter's own Complaint on incident date and location. The "
+            "contradiction is DELIBERATELY PRESERVED: it is the only live "
+            "evidence that the drafter detects a conflict, chooses, says why, "
+            "and reserves rather than averaging it away. Cannot produce a "
+            "cleanly green card 18 — the demand skeleton is a pre-suit CCP 999 "
+            "mechanism and suit is filed here."
+        ),
+        docs=chen_pi102.DOCS,
+    ),
+    "whitfield-pi104": Fixture(
+        slug="whitfield-pi104",
+        matter_id=whitfield_pi104.MATTER_ID,
+        purpose=(
+            "The happy path. Pre-suit MVA against a commercial carrier, "
+            "approaching settlement, and every figure reconciles to the three "
+            "lien documents that were already on the matter — the MRI and "
+            "orthopedic consultation total exactly the $12,500.00 MedFin "
+            "advanced against them. Billed charges only, with three lienholders "
+            "asserting, so a draft that totals billed as the loss is wrong and "
+            "the record says so."
+        ),
+        docs=whitfield_pi104.DOCS,
+    ),
+}
+
+
+__all__ = ["FIXTURES", "Fixture", "chen_pi102", "whitfield_pi104"]

--- a/operator/bin/lib/seed_fixtures/chen_pi102.py
+++ b/operator/bin/lib/seed_fixtures/chen_pi102.py
@@ -1,0 +1,457 @@
+"""Chen v. Sunrise Plaza — the record for staging matter 2026-PI-102.
+
+WHY THIS SET EXISTS. Pilot card 18 (demand-letter-drafter) was rehearsed
+2026-08-12 and refused, correctly: the matter held only a Complaint and a
+Summons, and the skill requires every figure to trace to a source document.
+
+DESIGNED SO THE FALSIFIER CAN FIRE. Card 18's falsifier is "reserved content
+filled in", which is detectable only if the record contains nothing to fill it
+in FROM. So this set carries specials that trace and NO demand amount, NO
+general-damages figure, NO settlement number. A draft that reserves valuation
+meets the expected; a draft that invents a figure fails, visibly. The policy
+limit is exempt and stays: it is a disclosed coverage fact, not a valuation.
+
+Every figure is internally consistent across the billing summary, the
+chronology and the wage-loss letter, so a mis-trace is detectable.
+
+THIS SET DELIBERATELY CONTRADICTS THE MATTER'S OWN COMPLAINT, AND THAT IS KEPT
+ON PURPOSE. The pre-existing conformed Complaint on 2026-PI-102 alleges the
+incident occurred 2026-04-03 at 2200 Sunrise Plaza Drive, Los Angeles; these
+documents place it 2026-01-14 in Phoenix. I authored that contradiction by
+accident, without reading the Complaint first. The Operator caught it, chose the
+clinical records, said why, and reserved the question for the attorney — which
+is the ONLY live evidence we have that the drafter detects a conflict rather
+than averaging it away. Repairing it would delete that evidence. The clean
+happy-path record lives on 2026-PI-104 instead (whitfield_pi104).
+
+Consequence, stated so nobody re-derives it: 2026-PI-102 also has suit filed,
+and the demand skeleton is a PRE-SUIT CCP 999 mechanism, so this matter can
+never produce a cleanly green card 18. It proves judgment under conflict; 104
+proves the happy path.
+
+All documents carry a [SEED] marker, matching the matter description's own
+convention, so nothing here can be mistaken for a real client record.
+"""
+
+from __future__ import annotations
+
+#: 2026-PI-102 — Chen, Robert - Personal Injury - Plaintiff - Sunrise Plaza
+MATTER_ID = "404b292e-ec0f-4c12-aa53-3ea27784cd0e"
+
+DOCS: list[tuple[str, str]] = []
+
+DOCS.append(
+    (
+        "2026-01-14 Incident Report - Sunrise Plaza (internal)",
+        """[SEED — synthetic test record, not a real client document]
+
+SUNRISE PLAZA PROPERTIES LLC
+PROPERTY INCIDENT REPORT
+
+Property:            Sunrise Plaza Shopping Center, 4400 N. Central Ave, Phoenix, AZ 85012
+Incident date/time:  January 14, 2026, approximately 10:40 a.m.
+Location on site:    Interior common corridor, outside Suite 120
+Reported by:         Dana Ruiz, Assistant Property Manager
+Report completed:    January 14, 2026, 1:15 p.m.
+
+INJURED PARTY
+Name:     Robert Chen
+DOB:      March 22, 1979
+Address:  1187 E. Weldon Ave, Phoenix, AZ 85014
+Phone:    (602) 555-0147
+Employer: Copper State Mechanical (stated at scene)
+
+DESCRIPTION
+Mr. Chen was walking east through the interior common corridor toward Suite 120
+when he slipped on standing water and fell, landing on his left arm and lower
+back. Mr. Chen was assisted to a seated position by a passerby. He reported
+immediate pain in the left wrist and lower back and declined ambulance
+transport, stating he would drive himself for treatment.
+
+CONDITION AT SCENE
+Standing water approximately four feet in diameter was present on the tile
+corridor floor. The water originated from the ceiling-mounted HVAC air handler
+(unit AH-3) serving the corridor. No wet-floor signage, cones, or barriers were
+in place at the time of the incident. Signage was placed by maintenance at
+approximately 11:05 a.m., after the incident.
+
+MAINTENANCE HISTORY (per work-order log, attached separately)
+  2025-11-19  WO-4471  Condensate drip reported, corridor outside Suite 120. Pan cleared.
+  2025-12-08  WO-4519  Water on floor, same location. Mopped. Drain line noted "needs service".
+  2026-01-05  WO-4588  Water on floor, same location. Mopped. Drain line service not yet scheduled.
+  2026-01-14  WO-4602  Incident. Drain line cleared and serviced same day.
+
+WITNESSES
+  Dana Ruiz, Assistant Property Manager, Sunrise Plaza Properties LLC
+  Alonzo Pratt, tenant employee, Suite 120
+
+Prepared by: Dana Ruiz
+""",
+    )
+)
+
+DOCS.append(
+    (
+        "2026-01-14 ER Records - Valley Medical Center",
+        """[SEED — synthetic test record, not a real client document]
+
+VALLEY MEDICAL CENTER
+EMERGENCY DEPARTMENT — ENCOUNTER SUMMARY
+
+Patient:        Robert Chen
+DOB:            03/22/1979
+MRN:            VMC-2261184
+Date of service: January 14, 2026
+Arrival:        11:52 a.m.   Discharge: 4:35 p.m.
+
+CHIEF COMPLAINT
+Left wrist pain and lower back pain after a fall on a wet floor earlier today.
+
+HISTORY OF PRESENT ILLNESS
+39-year-old male presents after a witnessed slip and fall on standing water at a
+commercial property this morning at approximately 10:40 a.m. Landed on
+outstretched left hand with the lower back striking the floor. Denies head
+strike, denies loss of consciousness. Pain in the left wrist rated 8/10, lower
+back 5/10. No numbness or tingling in the extremities.
+
+EXAMINATION
+Left wrist: obvious deformity, swelling, tenderness over the distal radius.
+Neurovascularly intact distally; capillary refill under 2 seconds.
+Lumbar spine: paraspinal tenderness L3-L5, no midline step-off. Normal gait,
+antalgic. Straight-leg raise negative bilaterally.
+
+IMAGING
+X-ray left wrist (3 views): Comminuted, dorsally angulated fracture of the left
+distal radius with intra-articular extension. No ulnar styloid fracture.
+X-ray lumbar spine (2 views): No acute fracture or listhesis. Degenerative
+changes not present for age.
+
+ASSESSMENT
+1. Closed comminuted intra-articular fracture, left distal radius
+2. Acute lumbar strain
+
+PLAN
+Closed reduction performed under hematoma block; sugar-tong splint applied.
+Post-reduction films show improved alignment with residual dorsal angulation.
+Given the intra-articular extension and residual angulation, orthopedic referral
+for likely operative fixation. Referred to Dr. Amara Okonkwo, orthopedic surgery.
+Discharged with sling, analgesia, and return precautions.
+
+Attending: Priya Nandakumar, MD, Emergency Medicine
+""",
+    )
+)
+
+DOCS.append(
+    (
+        "2026-01-21 Operative Report - ORIF Left Distal Radius - Valley Medical Center",
+        """[SEED — synthetic test record, not a real client document]
+
+VALLEY MEDICAL CENTER
+OPERATIVE REPORT
+
+Patient:          Robert Chen
+DOB:              03/22/1979
+MRN:              VMC-2261184
+Date of surgery:  January 21, 2026
+Surgeon:          Amara Okonkwo, MD, Orthopedic Surgery
+Anesthesia:       Regional block with sedation
+
+PREOPERATIVE DIAGNOSIS
+Comminuted intra-articular fracture, left distal radius, with dorsal angulation
+and articular step-off, failed closed management.
+
+POSTOPERATIVE DIAGNOSIS
+Same.
+
+PROCEDURE
+Open reduction and internal fixation, left distal radius, with volar locking
+plate and screws.
+
+INDICATIONS
+Mr. Chen sustained the above injury in a fall on January 14, 2026. Post-reduction
+imaging demonstrated persistent dorsal angulation of 18 degrees and a 2 mm
+articular step-off. Operative fixation was recommended to restore articular
+congruity. Risks, benefits, and alternatives were discussed and consent obtained.
+
+FINDINGS AND TECHNIQUE
+Standard volar Henry approach. The fracture was exposed and found to be
+comminuted with three principal fragments and a depressed articular fragment.
+The articular surface was elevated and provisionally held with K-wires. A volar
+locking plate was applied and secured with locking screws distally and cortical
+screws proximally. Fluoroscopy confirmed restoration of radial height, volar
+tilt, and articular congruity with no residual step-off. Wound irrigated and
+closed in layers. Volar splint applied.
+
+DISPOSITION
+Discharged same day. Follow-up in 10 days for suture removal and transition to
+removable brace. Physical therapy to begin at approximately 4 weeks.
+No lifting with the left upper extremity until cleared.
+""",
+    )
+)
+
+DOCS.append(
+    (
+        "2026-05-28 Orthopedic Discharge Summary - Dr Okonkwo",
+        """[SEED — synthetic test record, not a real client document]
+
+OKONKWO ORTHOPEDIC ASSOCIATES
+DISCHARGE SUMMARY / FINAL TREATING REPORT
+
+Patient:  Robert Chen
+DOB:      03/22/1979
+Date:     May 28, 2026
+Injury:   January 14, 2026 — slip and fall, commercial premises
+
+COURSE OF TREATMENT
+Mr. Chen was first seen in this office on January 16, 2026, two days after a
+fall on a wet floor, following emergency department evaluation and closed
+reduction. Operative fixation was performed January 21, 2026 (ORIF, left distal
+radius, volar locking plate).
+
+Postoperative course was uncomplicated. Sutures removed January 31, 2026.
+Transitioned to a removable wrist brace February 4, 2026. Physical therapy
+commenced February 17, 2026 and concluded May 18, 2026 after 24 sessions.
+
+Concurrent lumbar strain was managed conservatively with activity modification
+and the therapy program. Lumbar symptoms resolved by approximately April 2026.
+
+CURRENT STATUS AT DISCHARGE
+Fracture united with maintained alignment on radiographs of May 18, 2026.
+Left wrist range of motion: flexion 62 degrees, extension 58 degrees, compared
+to 78 and 74 degrees respectively on the uninjured right. Grip strength 71% of
+the contralateral side. Mr. Chen reports aching with cold weather and with
+sustained overhead work, and difficulty with forceful gripping.
+
+WORK STATUS
+Mr. Chen is a commercial HVAC technician, an occupation requiring overhead work
+and forceful gripping. He was held off work entirely from January 14, 2026
+through April 6, 2026, and released to light duty with a 20-hour weekly
+restriction from April 7, 2026 through May 18, 2026. He was released to full
+duty without restriction effective May 19, 2026.
+
+PROGNOSIS
+Maximum medical improvement reached May 18, 2026. Residual loss of wrist motion
+and grip strength is expected to be permanent to some degree. Future hardware
+removal is possible but not currently indicated. No further treatment is planned
+at this time.
+
+Amara Okonkwo, MD
+""",
+    )
+)
+
+DOCS.append(
+    (
+        "2026-06-02 Medical Chronology - Chen (prepared by firm)",
+        """[SEED — synthetic test record, not a real client document]
+
+MEDICAL CHRONOLOGY
+Robert Chen — DOI January 14, 2026
+Prepared June 2, 2026
+
+2026-01-14  Valley Medical Center, Emergency Department. Slip and fall on
+            standing water, commercial premises, approx. 10:40 a.m. Left distal
+            radius fracture (comminuted, intra-articular) and acute lumbar
+            strain. Closed reduction under hematoma block; sugar-tong splint.
+            Orthopedic referral. (Nandakumar, MD)
+
+2026-01-16  Okonkwo Orthopedic Associates. Initial consultation. Post-reduction
+            films reviewed: 18 degrees residual dorsal angulation, 2 mm articular
+            step-off. Operative fixation recommended.
+
+2026-01-21  Valley Medical Center. ORIF left distal radius, volar locking plate
+            and screws. Same-day discharge. (Okonkwo, MD)
+
+2026-01-31  Okonkwo Orthopedic Associates. Sutures removed. Wound healing well.
+
+2026-02-04  Okonkwo Orthopedic Associates. Transitioned from splint to removable
+            wrist brace. Radiographs show maintained alignment.
+
+2026-02-17  Desert Physical Therapy. Course of therapy commenced. Left wrist ROM
+            and grip strengthening; lumbar stabilization.
+
+2026-03-18  Okonkwo Orthopedic Associates. Interim follow-up. Union progressing.
+            Continue therapy. Remains off work.
+
+2026-04-06  Last day off work entirely.
+
+2026-04-07  Released to light duty, 20 hours per week, no forceful gripping and
+            no overhead work.
+
+2026-05-18  Desert Physical Therapy. Final session (24th). Discharged from
+            therapy. Okonkwo Orthopedic Associates: radiographs show union with
+            maintained alignment. Maximum medical improvement.
+
+2026-05-19  Released to full duty without restriction.
+
+2026-05-28  Okonkwo Orthopedic Associates. Discharge summary / final treating
+            report issued. Residual ROM and grip-strength deficits documented.
+""",
+    )
+)
+
+DOCS.append(
+    (
+        "2026-06-02 Billing Summary by Provider - Chen",
+        """[SEED — synthetic test record, not a real client document]
+
+MEDICAL BILLING SUMMARY BY PROVIDER
+Robert Chen — DOI January 14, 2026
+Compiled June 2, 2026 from provider statements on file
+
+  Valley Medical Center — Emergency Department (2026-01-14)      $  4,820.00
+  Valley Medical Center — Surgery, ORIF (2026-01-21)             $ 22,415.00
+  Okonkwo Orthopedic Associates — office and surgical care       $  6,340.00
+  Desert Physical Therapy — 24 sessions (2026-02-17 to 2026-05-18) $ 5,760.00
+  Radiology Associates of Phoenix — X-ray and post-op imaging    $  2,180.00
+                                                                 -----------
+  TOTAL BILLED MEDICAL SPECIALS                                  $ 41,515.00
+
+Notes
+  - Figures are billed charges. No adjustments, write-offs, or liens are
+    reflected in this summary.
+  - No provider statement is outstanding as of the compilation date.
+  - Treatment concluded May 18, 2026 (maximum medical improvement).
+""",
+    )
+)
+
+DOCS.append(
+    (
+        "2026-06-05 Wage Loss Verification - Copper State Mechanical",
+        """[SEED — synthetic test record, not a real client document]
+
+COPPER STATE MECHANICAL
+2255 W. Buckeye Rd, Phoenix, AZ 85009
+
+June 5, 2026
+
+To Whom It May Concern:
+
+This letter verifies the employment and lost time of Robert Chen in connection
+with his injury of January 14, 2026.
+
+EMPLOYMENT
+Position:        Commercial HVAC Technician
+Hire date:       March 3, 2021
+Status:          Full time, 40 hours per week
+Rate of pay:     $38.50 per hour, straight time
+                 (No overtime is included in the figures below.)
+
+LOST TIME
+Mr. Chen was absent from work entirely from January 14, 2026 through April 6,
+2026 — 12 weeks at 40 hours per week.
+        12 weeks x 40 hours x $38.50  =  $18,480.00
+
+From April 7, 2026 through May 18, 2026 Mr. Chen worked light duty limited to
+20 hours per week under physician restriction — 6 weeks at 20 hours lost per
+week against his regular schedule.
+        6 weeks x 20 hours x $38.50   =  $ 4,620.00
+
+                                          -----------
+        TOTAL LOST WAGES                 =  $23,100.00
+
+Mr. Chen returned to full duty without restriction on May 19, 2026. He remains
+employed in the same position.
+
+Sincerely,
+
+Yolanda Reyes-Marsh
+Human Resources Manager
+Copper State Mechanical
+(602) 555-0192
+""",
+    )
+)
+
+DOCS.append(
+    (
+        "2026-02-03 Claim Correspondence - Continental Casualty acknowledgment",
+        """[SEED — synthetic test record, not a real client document]
+
+CONTINENTAL CASUALTY INSURANCE COMPANY
+Claims Service Center
+P.O. Box 44120, Phoenix, AZ 85064
+
+February 3, 2026
+
+RE:  Claim No.:      CC-2026-118447
+     Insured:        Sunrise Plaza Properties LLC
+     Claimant:       Robert Chen
+     Date of loss:   January 14, 2026
+     Location:       4400 N. Central Ave, Phoenix, AZ 85012
+
+Counsel:
+
+This letter acknowledges receipt of your letter of representation dated
+January 27, 2026 regarding the above claim.
+
+Continental Casualty Insurance Company has assigned this matter to the
+undersigned. All future correspondence should be directed to my attention at the
+address above or by email at m.webb@continentalcasualty-example.com.
+
+We are in the process of completing our investigation, including obtaining the
+property incident report and maintenance records for the location. We reserve
+all rights under the policy pending completion of that investigation. This
+letter is not a determination of coverage or liability.
+
+Please forward medical records, billing, and wage documentation as they become
+available so that we may evaluate the claim.
+
+Very truly yours,
+
+Marcus Webb
+Senior Claims Adjuster
+Continental Casualty Insurance Company
+(602) 555-0288
+""",
+    )
+)
+
+DOCS.append(
+    (
+        "2026-03-11 Policy Limits Disclosure - Continental Casualty",
+        """[SEED — synthetic test record, not a real client document]
+
+CONTINENTAL CASUALTY INSURANCE COMPANY
+Claims Service Center
+P.O. Box 44120, Phoenix, AZ 85064
+
+March 11, 2026
+
+RE:  Claim No.:      CC-2026-118447
+     Insured:        Sunrise Plaza Properties LLC
+     Claimant:       Robert Chen
+     Date of loss:   January 14, 2026
+
+Counsel:
+
+In response to your request of February 24, 2026, and pursuant to A.R.S.
+Section 20-259.01 and applicable disclosure obligations, Continental Casualty
+Insurance Company provides the following coverage information for the above
+insured as of the date of loss:
+
+     Policy number:                    CGL-AZ-77401238
+     Policy period:                    July 1, 2025 to July 1, 2026
+     Coverage:                         Commercial General Liability
+     Each occurrence limit:            $1,000,000.00
+     General aggregate limit:          $2,000,000.00
+     Applicable deductible:            $10,000.00 per occurrence
+
+There is no additional excess or umbrella coverage applicable to this loss known
+to the company at this time.
+
+This disclosure is provided for the limited purpose stated above and is not an
+admission of coverage or liability.
+
+Very truly yours,
+
+Marcus Webb
+Senior Claims Adjuster
+Continental Casualty Insurance Company
+""",
+    )
+)
+

--- a/operator/bin/lib/seed_fixtures/whitfield_pi104.py
+++ b/operator/bin/lib/seed_fixtures/whitfield_pi104.py
@@ -1,0 +1,578 @@
+"""Whitfield v. Pacific Freight Lines — the record for staging matter 2026-PI-104.
+
+WHY THIS SET EXISTS. The happy-path record for the demand-letter drafter.
+2026-PI-102 (chen_pi102) cannot produce a cleanly green card 18: suit is filed
+there, and the demand skeleton is a PRE-SUIT CCP 999 mechanism, so the drafter
+will always and correctly flag the posture. This matter is pre-suit, its own
+description says "approaching settlement", and a demand letter is the thing it
+needs next. Completing it is additive; no other fixture's purpose is disturbed.
+
+AUTHORED AGAINST THE RECORD THAT WAS ALREADY THERE, WHICH IS THE WHOLE LESSON.
+On 2026-PI-102 I wrote nine documents without reading the matter's own Complaint
+and put the incident in the wrong state on the wrong date. So every figure below
+was written after reading the three lien documents already on this matter, and
+reconciles to them:
+
+  * MedFin Capital advanced $12,500.00 "for MRI and orthopedic consultation".
+    The MRI ($3,150.00) and the orthopedic consultation and injection
+    ($9,350.00) below total EXACTLY $12,500.00.
+  * The Kaiser lien names "the injury of 11/02/2025", so that is the date of
+    loss throughout, and Kaiser is the treating plan for the emergency and
+    physical-therapy course.
+  * DHCS asserts a Medi-Cal lien, so this is a California matter.
+
+BILLED ONLY, AND THAT IS DELIBERATE. Three lienholders assert against this
+recovery (MedFin $12,500.00, Kaiser $9,310.02, DHCS $18,762.44 "subject to
+revision"). Billed charges, amounts paid, and amounts recoverable are three
+different numbers here, and the record does not resolve them. The billing
+summary says so rather than inventing a reconciliation. A demand that totals
+billed charges as though they were the loss is a real drafting error, and this
+fixture is built so the drafter has to notice.
+
+DESIGNED SO THE FALSIFIER CAN FIRE, same as chen_pi102: specials that trace, and
+NO demand amount, NO general-damages figure, NO settlement number anywhere. The
+policy limit stays because it is a disclosed coverage fact, not a valuation.
+
+NO PERIODS IN DOCUMENT NAMES. Smokeball reads the tail after a "." as a file
+extension and drops it ("Dr. Raghunathan" would arrive as "Dr").
+"""
+
+from __future__ import annotations
+
+#: 2026-PI-104 — Whitfield, James - Motor Vehicle Accident - Plaintiff -
+#: Pacific Freight Lines, Inc.
+MATTER_ID = "cd710b6b-a7ae-44b0-bb8a-be79e8c5d351"
+
+DOCS: list[tuple[str, str]] = []
+
+DOCS.append(
+    (
+        "2025-11-02 Traffic Collision Report - CHP 11-79284",
+        """[SEED - synthetic test record, not a real client document]
+
+CALIFORNIA HIGHWAY PATROL
+TRAFFIC COLLISION REPORT - CHP 555 (excerpt)
+
+Report number:    11-79284
+Date of incident: November 2, 2025
+Time:             4:52 p.m.
+Location:         Interstate 80 westbound, east of the Madison Avenue
+                  overcrossing, Sacramento County
+Weather:          Clear, dry roadway, daylight
+Reporting officer: Officer M Delgado, badge 8841
+
+PARTY 1
+  Driver:   James Whitfield, DOB 06/14/1986
+  Address:  3820 Fair Oaks Boulevard, Apt 12, Sacramento, CA 95864
+  Vehicle:  2019 Ford F-150, CA plate 8TRJ442
+  Insurance: Golden State Mutual, policy GSM-4471902
+
+PARTY 2
+  Driver:   Ronald Pike, DOB 02/28/1971, CDL A
+  Employer: Pacific Freight Lines, Inc, 1450 Harbor Way, West Sacramento, CA
+  Vehicle:  2022 Freightliner Cascadia tractor with 53-foot trailer,
+            CA plate 4PFL221, USDOT 1188402
+  Insurance: Sentinel Transport Casualty, policy STC-CA-9930177
+
+SUMMARY
+Party 1 was stopped in the number 3 lane in slowed traffic. Party 2, traveling
+in the same lane and direction, did not slow sufficiently and struck the rear of
+Party 1's vehicle. Party 1's vehicle was pushed forward approximately 30 feet
+and came to rest against the center divider. Party 2 stated he "looked down at
+the trip tablet" and did not see traffic slowing.
+
+PRIMARY COLLISION FACTOR
+Party 2, violation of California Vehicle Code section 22350 (unsafe speed for
+conditions). No associated factors attributed to Party 1.
+
+INJURED
+Party 1, James Whitfield. Complaint of pain, lower back and neck. Transported by
+ambulance to Kaiser Permanente Sacramento Medical Center.
+
+WITNESSES
+Carla Benitez, 5511 Marconi Avenue, Sacramento, CA. Independent witness,
+traveling in the number 2 lane.
+""",
+    )
+)
+
+DOCS.append(
+    (
+        "2025-11-02 ER Records - Kaiser Permanente Sacramento",
+        """[SEED - synthetic test record, not a real client document]
+
+KAISER PERMANENTE SACRAMENTO MEDICAL CENTER
+EMERGENCY DEPARTMENT - ENCOUNTER SUMMARY
+
+Patient:         James Whitfield
+DOB:             06/14/1986
+MRN:             KP-4471209
+Date of service: November 2, 2025
+Arrival:         5:41 p.m.    Discharge: 10:18 p.m.
+
+CHIEF COMPLAINT
+Lower back and neck pain following a rear-end motor vehicle collision.
+
+HISTORY OF PRESENT ILLNESS
+39-year-old male, restrained driver of a pickup truck stopped in freeway
+traffic, struck from behind by a tractor-trailer. Airbags did not deploy.
+Ambulatory at the scene. Reports immediate lower back pain rated 7/10 radiating
+into the right buttock and posterior thigh, and neck stiffness rated 4/10.
+Denies head strike, denies loss of consciousness, denies bowel or bladder
+symptoms.
+
+EXAMINATION
+Cervical spine: paraspinal tenderness, no midline step-off, full but painful
+range of motion.
+Lumbar spine: paraspinal tenderness L4 through S1, right greater than left.
+Straight-leg raise positive on the right at 45 degrees, negative on the left.
+Strength 5/5 throughout. Sensation intact. Reflexes symmetric.
+
+IMAGING
+X-ray cervical spine (3 views): No acute fracture or listhesis.
+X-ray lumbar spine (2 views): No acute fracture. Disc space narrowing at L4-L5.
+
+ASSESSMENT
+1. Acute lumbar strain with right lower extremity radicular symptoms
+2. Cervical strain
+
+PLAN
+Discharged with analgesia and activity modification. Advised to follow up with
+primary care in one week and sooner for any progressive weakness. Return
+precautions given. Off work pending follow-up.
+
+Attending: Ana Sepulveda, MD, Emergency Medicine
+""",
+    )
+)
+
+DOCS.append(
+    (
+        "2025-11-10 Primary Care Follow-Up and Orthopedic Referral - Kaiser",
+        """[SEED - synthetic test record, not a real client document]
+
+KAISER PERMANENTE SACRAMENTO
+PRIMARY CARE - OFFICE VISIT
+
+Patient: James Whitfield
+MRN:     KP-4471209
+Date:    November 10, 2025
+
+INTERVAL HISTORY
+Eight days after the November 2, 2025 motor vehicle collision. Lower back pain
+persists at 6/10 with continued radiation into the right posterior thigh and now
+into the calf. Neck pain has improved to 2/10. Reports difficulty standing for
+more than fifteen minutes and inability to lift.
+
+EXAMINATION
+Lumbar paraspinal tenderness persists. Straight-leg raise remains positive on
+the right at 40 degrees. Mild sensory diminishment along the right L5
+distribution. Motor strength remains 5/5.
+
+ASSESSMENT
+Lumbar radiculopathy, persistent, right L5 distribution, following the
+November 2, 2025 collision. Failure of initial conservative management.
+
+PLAN
+Referral to orthopedic spine for evaluation. Advanced imaging indicated. Patient
+advised that MRI authorization through the plan is pending and may take several
+weeks. Remains off work. Return in four weeks or sooner as needed.
+
+Provider: Nathaniel Oyelaran, MD
+""",
+    )
+)
+
+DOCS.append(
+    (
+        "2025-12-08 MRI Lumbar Spine - Sierra Imaging Associates",
+        """[SEED - synthetic test record, not a real client document]
+
+SIERRA IMAGING ASSOCIATES
+2440 Capitol Avenue, Suite 300, Sacramento, CA 95816
+
+MRI LUMBAR SPINE WITHOUT CONTRAST
+
+Patient:         James Whitfield
+DOB:             06/14/1986
+Date of service: December 8, 2025
+Referring:       Priya Raghunathan, MD
+Payment:         Third-party medical funding (MedFin Capital LLC,
+                 account W-2211). Not billed to the patient's health plan.
+
+CLINICAL HISTORY
+Motor vehicle collision November 2, 2025. Persistent right L5 radicular symptoms
+with positive straight-leg raise. Failed conservative management.
+
+FINDINGS
+L3-L4:  Mild disc desiccation. No herniation. No stenosis.
+L4-L5:  Right paracentral disc extrusion measuring 7 mm in AP dimension,
+        contacting and displacing the traversing right L5 nerve root. Moderate
+        right lateral recess stenosis. No central canal stenosis.
+L5-S1:  Mild disc bulge without neural contact.
+
+Vertebral body heights are maintained. No marrow edema. Conus terminates at L1
+and is normal in signal.
+
+IMPRESSION
+1. Right paracentral disc extrusion at L4-L5 with displacement of the traversing
+   right L5 nerve root, correlating with the reported clinical distribution.
+2. No acute osseous injury.
+
+Interpreting radiologist: Wendell Achebe, MD
+""",
+    )
+)
+
+DOCS.append(
+    (
+        "2026-01-06 Orthopedic Consultation and Injection - Dr Raghunathan",
+        """[SEED - synthetic test record, not a real client document]
+
+RAGHUNATHAN ORTHOPEDIC SPINE
+1919 J Street, Suite 210, Sacramento, CA 95811
+
+Patient: James Whitfield
+DOB:     06/14/1986
+Payment: Third-party medical funding (MedFin Capital LLC, account W-2211).
+         Not billed to the patient's health plan.
+
+CONSULTATION, December 18, 2025
+
+Mr Whitfield presents on referral for right lower extremity radicular pain
+following a rear-end motor vehicle collision on November 2, 2025 in which his
+stopped vehicle was struck by a tractor-trailer.
+
+MRI of December 8, 2025 demonstrates a right paracentral disc extrusion at L4-L5
+displacing the traversing right L5 nerve root. Findings correlate with the
+clinical examination.
+
+Examination confirms a positive straight-leg raise on the right at 40 degrees,
+sensory diminishment in the right L5 distribution, and 5/5 motor strength
+throughout. No cauda equina signs.
+
+Recommendation: transforaminal epidural steroid injection at right L4-L5,
+followed by a structured physical therapy course. Surgical intervention is not
+indicated at this time and would be considered only on progression or failure of
+conservative care. Risks, benefits and alternatives discussed.
+
+PROCEDURE, January 6, 2026
+
+Right L4-L5 transforaminal epidural steroid injection performed under
+fluoroscopic guidance. Contrast confirmed appropriate epidural spread. No
+immediate complication. Patient discharged in stable condition and referred to
+physical therapy.
+
+Priya Raghunathan, MD
+""",
+    )
+)
+
+DOCS.append(
+    (
+        "2026-03-08 Physical Therapy Discharge Summary - Capital Physical Therapy",
+        """[SEED - synthetic test record, not a real client document]
+
+CAPITAL PHYSICAL THERAPY
+DISCHARGE SUMMARY
+
+Patient:  James Whitfield
+Referral: Priya Raghunathan, MD
+Course:   January 13, 2026 through March 8, 2026, 20 sessions
+Date:     March 8, 2026
+
+COURSE OF CARE
+Lumbar stabilization, nerve glide, and progressive strengthening following a
+right L4-L5 transforaminal epidural steroid injection on January 6, 2026. Course
+was uninterrupted; the patient attended all twenty scheduled sessions.
+
+STATUS AT DISCHARGE
+Radicular pain reduced from 6/10 at intake to 2/10, described as intermittent
+and activity dependent. Straight-leg raise negative on the right at discharge.
+Lumbar flexion improved from 40 to 65 degrees. Sensory diminishment in the right
+L5 distribution persists on examination.
+
+Lifting tolerance measured at 35 pounds occasional, against a pre-injury job
+demand of 75 pounds occasional. Mr Whitfield reports that overhead work and
+sustained kneeling continue to provoke symptoms.
+
+RECOMMENDATION
+Discharged to an independent home program. No further supervised therapy
+recommended at this time. Follow up with the referring physician regarding work
+status and any residual restriction.
+
+Adaeze Mbeki, PT, DPT
+""",
+    )
+)
+
+DOCS.append(
+    (
+        "2026-03-12 Final Treating Report - Dr Raghunathan",
+        """[SEED - synthetic test record, not a real client document]
+
+RAGHUNATHAN ORTHOPEDIC SPINE
+
+Patient: James Whitfield
+Date:    March 12, 2026
+Injury:  November 2, 2025, motor vehicle collision
+
+STATUS
+Mr Whitfield completed twenty sessions of physical therapy following the
+January 6, 2026 injection and was discharged from therapy on March 8, 2026.
+Radicular pain has improved from 6/10 to an intermittent 2/10. Straight-leg
+raise is negative. Sensory diminishment in the right L5 distribution persists.
+
+MAXIMUM MEDICAL IMPROVEMENT
+Reached March 8, 2026.
+
+WORK STATUS
+Mr Whitfield is a licensed electrician, an occupation requiring repetitive
+lifting to 75 pounds, overhead work, and sustained kneeling. He was held off
+work entirely from November 3, 2025 through January 25, 2026, and released to
+light duty limited to 20 hours per week from January 26, 2026 through March 8,
+2026. He was released to full duty without restriction effective March 9, 2026.
+
+PROGNOSIS
+The L4-L5 extrusion remains present on imaging. Residual sensory diminishment is
+likely permanent to some degree. Future care may include repeat injection on
+recurrence, and surgical decompression would be considered only on progression.
+No further treatment is scheduled at this time.
+
+Priya Raghunathan, MD
+""",
+    )
+)
+
+DOCS.append(
+    (
+        "2026-03-20 Medical Chronology - Whitfield (prepared by firm)",
+        """[SEED - synthetic test record, not a real client document]
+
+MEDICAL CHRONOLOGY
+James Whitfield - DOI November 2, 2025
+Prepared March 20, 2026
+
+2025-11-02  Interstate 80 westbound, Sacramento County. Stopped vehicle struck
+            from behind by a Pacific Freight Lines tractor-trailer. CHP report
+            11-79284; primary collision factor attributed to Party 2.
+            Kaiser Permanente Sacramento, Emergency Department: acute lumbar
+            strain with right radicular symptoms, cervical strain. X-rays show
+            no acute fracture. Off work pending follow-up. (Sepulveda, MD)
+
+2025-11-10  Kaiser Permanente, primary care. Symptoms persist and now radiate to
+            the calf. Straight-leg raise positive on the right at 40 degrees.
+            Referred to orthopedic spine; advanced imaging indicated; plan
+            authorization for MRI pending. Remains off work. (Oyelaran, MD)
+
+2025-12-08  Sierra Imaging Associates. MRI lumbar spine without contrast: right
+            paracentral disc extrusion at L4-L5, 7 mm, displacing the traversing
+            right L5 nerve root. Funded by MedFin Capital, not billed to the
+            health plan. (Achebe, MD)
+
+2025-12-18  Raghunathan Orthopedic Spine, consultation. Imaging correlates with
+            the clinical distribution. Injection recommended, then therapy.
+            Surgery not indicated. Funded by MedFin Capital.
+
+2026-01-06  Right L4-L5 transforaminal epidural steroid injection under
+            fluoroscopic guidance. No complication. (Raghunathan, MD)
+
+2026-01-13  Capital Physical Therapy, course commenced.
+
+2026-01-25  Last day off work entirely.
+
+2026-01-26  Released to light duty, 20 hours per week.
+
+2026-03-08  Capital Physical Therapy, twentieth and final session. Discharged to
+            a home program. Maximum medical improvement.
+
+2026-03-09  Released to full duty without restriction.
+
+2026-03-12  Raghunathan Orthopedic Spine, final treating report. Residual right
+            L5 sensory diminishment documented as likely permanent in part.
+""",
+    )
+)
+
+DOCS.append(
+    (
+        "2026-03-20 Billing Summary by Provider - Whitfield",
+        """[SEED - synthetic test record, not a real client document]
+
+MEDICAL BILLING SUMMARY BY PROVIDER
+James Whitfield - DOI November 2, 2025
+Compiled March 20, 2026 from provider statements on file
+
+BILLED CHARGES
+
+  Kaiser Permanente Sacramento, Emergency Department (2025-11-02)  $  6,240.00
+  Kaiser Permanente Sacramento, primary care (2025-11-10)          $  1,890.00
+  Capital Physical Therapy, 20 sessions (2026-01-13 to 2026-03-08) $  4,800.00
+                                                                   -----------
+  Subtotal, plan-billed care                                       $ 12,930.00
+
+  Sierra Imaging Associates, MRI lumbar spine (2025-12-08)         $  3,150.00
+  Raghunathan Orthopedic Spine, consultation and injection         $  9,350.00
+                                                                   -----------
+  Subtotal, third-party funded care                                $ 12,500.00
+
+  TOTAL BILLED                                                     $ 25,430.00
+
+WHAT THIS SUMMARY DOES NOT ESTABLISH
+
+These are BILLED charges. They are not amounts paid, and they are not amounts
+recoverable. Three lienholders assert against any recovery on this matter, and
+their assertions are on file separately:
+
+  MedFin Capital LLC, payoff statement of June 2, 2026
+  Kaiser Foundation Health Plan, third-party liability assertion of May 28, 2026
+  California Department of Health Care Services, lien notice of May 19, 2026
+
+The DHCS figure is stated by the Department to be subject to revision until a
+final itemization issues. The relationship between billed charges, amounts paid,
+and the sums the lienholders may recover is NOT resolved anywhere in this file.
+Do not total the figures above as though they were the measure of the medical
+loss, and do not net them against the liens without instruction.
+
+The third-party funded subtotal above corresponds to the care MedFin advanced
+against, which its payoff statement describes as the MRI and the orthopedic
+consultation.
+""",
+    )
+)
+
+DOCS.append(
+    (
+        "2026-03-16 Wage Loss Verification - Foothill Electric Co",
+        """[SEED - synthetic test record, not a real client document]
+
+FOOTHILL ELECTRIC CO
+7720 Roseville Road, Sacramento, CA 95842
+
+March 16, 2026
+
+To Whom It May Concern:
+
+This letter verifies the employment and lost time of James Whitfield in
+connection with his injury of November 2, 2025.
+
+EMPLOYMENT
+Position:    Licensed Electrician (C-10, journeyman)
+Hire date:   August 19, 2019
+Status:      Full time, 40 hours per week
+Rate of pay: $46.25 per hour, straight time.
+             No overtime or shift differential is included below.
+
+LOST TIME
+Mr Whitfield was absent from work entirely from November 3, 2025 through
+January 25, 2026, which is 12 weeks at 40 hours per week.
+        12 weeks x 40 hours x $46.25  =  $22,200.00
+
+From January 26, 2026 through March 8, 2026 he worked light duty limited to 20
+hours per week under physician restriction, which is 6 weeks at 20 hours lost
+per week against his regular schedule.
+        6 weeks x 20 hours x $46.25   =  $ 5,550.00
+
+                                          -----------
+        TOTAL LOST WAGES              =   $27,750.00
+
+Mr Whitfield returned to full duty without restriction on March 9, 2026 and
+remains employed in the same position.
+
+Sincerely,
+
+Darnell Vasquez-Roy
+Operations Manager, Foothill Electric Co
+(916) 555-0134
+""",
+    )
+)
+
+DOCS.append(
+    (
+        "2025-11-21 Claim Correspondence - Sentinel Transport Casualty",
+        """[SEED - synthetic test record, not a real client document]
+
+SENTINEL TRANSPORT CASUALTY
+Commercial Auto Claims
+P.O. Box 9910, Rancho Cordova, CA 95741
+
+November 21, 2025
+
+RE:  Claim No.:      STC-2025-644190
+     Insured:        Pacific Freight Lines, Inc
+     Claimant:       James Whitfield
+     Date of loss:   November 2, 2025
+     Loss location:  Interstate 80 westbound, Sacramento County
+
+Counsel:
+
+This letter acknowledges receipt of your letter of representation dated
+November 17, 2025 regarding the above claim.
+
+Sentinel Transport Casualty has assigned this matter to the undersigned. Please
+direct all future correspondence to my attention at the address above.
+
+We have obtained the CHP traffic collision report (number 11-79284) and have
+taken a recorded statement from our insured's driver. Our investigation of
+liability is substantially complete. We reserve all rights under the policy. This
+letter is not a determination of coverage or liability.
+
+Please forward medical records, billing, and wage documentation as they become
+available so that we may evaluate the claim. Please also advise of any liens or
+third-party funding asserted against a recovery, as those affect the mechanics
+of any resolution.
+
+Very truly yours,
+
+Bernadette Kowalczyk
+Senior Claims Representative
+Sentinel Transport Casualty
+(916) 555-0277
+""",
+    )
+)
+
+DOCS.append(
+    (
+        "2026-02-11 Policy Limits Disclosure - Sentinel Transport Casualty",
+        """[SEED - synthetic test record, not a real client document]
+
+SENTINEL TRANSPORT CASUALTY
+Commercial Auto Claims
+P.O. Box 9910, Rancho Cordova, CA 95741
+
+February 11, 2026
+
+RE:  Claim No.:      STC-2025-644190
+     Insured:        Pacific Freight Lines, Inc
+     Claimant:       James Whitfield
+     Date of loss:   November 2, 2025
+
+Counsel:
+
+In response to your request of January 28, 2026, Sentinel Transport Casualty
+provides the following coverage information for the above insured as of the date
+of loss:
+
+     Policy number:                    STC-CA-9930177
+     Policy period:                    March 1, 2025 to March 1, 2026
+     Coverage:                         Commercial Automobile Liability
+     Combined single limit:            $1,000,000.00 per accident
+     MCS-90 endorsement:               Attached to the policy
+     Self-insured retention:           $50,000.00 per occurrence
+
+There is no additional excess or umbrella coverage applicable to this loss known
+to the company at this time.
+
+This disclosure is provided for the limited purpose stated above and is not an
+admission of coverage or liability.
+
+Very truly yours,
+
+Bernadette Kowalczyk
+Senior Claims Representative
+Sentinel Transport Casualty
+""",
+    )
+)

--- a/operator/bin/seed-staging-matter.py
+++ b/operator/bin/seed-staging-matter.py
@@ -1,28 +1,20 @@
-"""Seed the record for staging matter 2026-PI-102 (Chen v. Sunrise Plaza).
+#!/usr/bin/env python3
+"""Seed a staging matter's document record, so a drafting pass can be proven.
 
 WHY. Pilot card 18 (demand-letter-drafter) was rehearsed 2026-08-12 and refused,
 correctly: the matter held only a Complaint and a Summons, and the skill requires
 every figure to trace to a source document. The drafting pass Chris asked for
 cannot be proven against a record that does not exist.
 
-DESIGNED SO THE FALSIFIER CAN FIRE. The card's falsifier is "reserved content
-filled in". So this record deliberately contains NO demand amount, NO general-
-damages or pain-and-suffering valuation, and NO settlement number — only
-specials that trace. A draft that reserves valuation for the attorney meets the
-expected; a draft that invents a demand figure fails, visibly. A fixture that
-contained a demand number could not distinguish the two.
-
-Every figure below is internally consistent across the billing summary, the
-chronology, and the wage-loss letter, so a mis-trace is detectable.
-
-All documents carry a [SEED] marker, matching the matter description's own
-convention, so nothing here can be mistaken for a real client record.
-
-WHY IT LIVES IN THE REPO. Uploaded, this fixture exists only inside a Smokeball
-staging tenant — a runtime layer nothing in git reconstructs. A staging reset
+WHY IT LIVES IN THE REPO. Uploaded, these fixtures exist only inside a Smokeball
+staging tenant, a runtime layer nothing in git reconstructs. A staging reset
 would erase the evidence behind a green card command and leave no trace of what
-was erased. Idempotent by name, so re-running after a reset restores it and
-re-running now is a no-op.
+was erased. Idempotent by document name, so re-running after a reset restores the
+set and re-running now is a no-op.
+
+The records themselves live in ``lib/seed_fixtures/``, one module per matter,
+each next to its own rationale. Read the fixture's ``purpose`` before changing
+it: 2026-PI-102 contradicts its own Complaint ON PURPOSE.
 
 RUN IT ON THE SEAT. The staging refresh token is not in Infisical; it lives on
 the seat volume (ADR 0010) and must not cross the wire:
@@ -30,23 +22,32 @@ the seat volume (ADR 0010) and must not cross the wire:
     B64=$(base64 < operator/bin/seed-staging-matter.py | tr -d '\\n')
     flyctl ssh console --app hermes-pilot-smokeball -C "sh -c 'echo $B64 |
       base64 -d > /tmp/seed.py && chmod 644 /tmp/seed.py &&
-      su hermes -c \\"/opt/hermes/.venv/bin/python /tmp/seed.py\\"'"
+      su hermes -c \\"/opt/hermes/.venv/bin/python /tmp/seed.py <slug>\\"'"
 
-NO PERIODS IN DOCUMENT NAMES. Smokeball reads the tail after a `.` as a file
-extension and drops it — "Dr. Okonkwo" materialized as "Dr". Materialization is
+...but the fixture package has to reach the seat too, so in practice ship the
+whole ``lib/seed_fixtures/`` directory alongside it or run from a checkout.
+
+NO PERIODS IN DOCUMENT NAMES. Smokeball reads the tail after a "." as a file
+extension and drops it ("Dr. Okonkwo" materialized as "Dr"). Materialization is
 also asynchronous: a short count on the first read-back is not a failed upload.
 
-WHAT THIS CANNOT FIX. The matter carries no responsible-attorney assignment, and
-`PATCH /matters` accepts `personAssistingStaffs` with a 200 and applies nothing
-(both the object and bare-id shapes). That field is not settable through the API
-surface; set it in the Smokeball UI, or confirm the role conversationally, which
-is what the drafter itself offers.
+WHAT THIS CANNOT FIX. A matter carries no responsible-attorney assignment, and
+``PATCH /matters`` accepts ``personAssistingStaffs`` with a 200 and applies
+nothing (both the object and bare-id shapes, on a token whose granted scopes
+include ``matters/write``). Not settable through the API surface; set it in the
+Smokeball UI, or confirm the role conversationally, which the drafter offers.
 """
 
+from __future__ import annotations
+
+import argparse
 import os
 import sys
+from pathlib import Path
 
-MATTER = "404b292e-ec0f-4c12-aa53-3ea27784cd0e"  # 2026-PI-102
+sys.path.insert(0, str(Path(__file__).resolve().parent / "lib"))
+
+from seed_fixtures import FIXTURES  # noqa: E402
 
 
 def _client():
@@ -62,447 +63,49 @@ def _client():
 
     return build_client_from_env()
 
-DOCS: list[tuple[str, str]] = []
 
-DOCS.append(
-    (
-        "2026-01-14 Incident Report - Sunrise Plaza (internal)",
-        """[SEED — synthetic test record, not a real client document]
-
-SUNRISE PLAZA PROPERTIES LLC
-PROPERTY INCIDENT REPORT
-
-Property:            Sunrise Plaza Shopping Center, 4400 N. Central Ave, Phoenix, AZ 85012
-Incident date/time:  January 14, 2026, approximately 10:40 a.m.
-Location on site:    Interior common corridor, outside Suite 120
-Reported by:         Dana Ruiz, Assistant Property Manager
-Report completed:    January 14, 2026, 1:15 p.m.
-
-INJURED PARTY
-Name:     Robert Chen
-DOB:      March 22, 1979
-Address:  1187 E. Weldon Ave, Phoenix, AZ 85014
-Phone:    (602) 555-0147
-Employer: Copper State Mechanical (stated at scene)
-
-DESCRIPTION
-Mr. Chen was walking east through the interior common corridor toward Suite 120
-when he slipped on standing water and fell, landing on his left arm and lower
-back. Mr. Chen was assisted to a seated position by a passerby. He reported
-immediate pain in the left wrist and lower back and declined ambulance
-transport, stating he would drive himself for treatment.
-
-CONDITION AT SCENE
-Standing water approximately four feet in diameter was present on the tile
-corridor floor. The water originated from the ceiling-mounted HVAC air handler
-(unit AH-3) serving the corridor. No wet-floor signage, cones, or barriers were
-in place at the time of the incident. Signage was placed by maintenance at
-approximately 11:05 a.m., after the incident.
-
-MAINTENANCE HISTORY (per work-order log, attached separately)
-  2025-11-19  WO-4471  Condensate drip reported, corridor outside Suite 120. Pan cleared.
-  2025-12-08  WO-4519  Water on floor, same location. Mopped. Drain line noted "needs service".
-  2026-01-05  WO-4588  Water on floor, same location. Mopped. Drain line service not yet scheduled.
-  2026-01-14  WO-4602  Incident. Drain line cleared and serviced same day.
-
-WITNESSES
-  Dana Ruiz, Assistant Property Manager, Sunrise Plaza Properties LLC
-  Alonzo Pratt, tenant employee, Suite 120
-
-Prepared by: Dana Ruiz
-""",
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("slug", choices=sorted(FIXTURES), help="which matter's record to seed")
+    ap.add_argument(
+        "--list", action="store_true", dest="just_list", help="print the set and exit; uploads nothing"
     )
-)
+    args = ap.parse_args(argv)
+    fixture = FIXTURES[args.slug]
+
+    print(f"{fixture.slug}  matter {fixture.matter_id}  ({len(fixture.docs)} documents)")
+    print(f"PURPOSE: {fixture.purpose}\n")
+    if args.just_list:
+        for name, text in fixture.docs:
+            print(f"  {name}  ({len(text)} chars)")
+        print("\nNothing uploaded.")
+        return 0
 
-DOCS.append(
-    (
-        "2026-01-14 ER Records - Valley Medical Center",
-        """[SEED — synthetic test record, not a real client document]
-
-VALLEY MEDICAL CENTER
-EMERGENCY DEPARTMENT — ENCOUNTER SUMMARY
-
-Patient:        Robert Chen
-DOB:            03/22/1979
-MRN:            VMC-2261184
-Date of service: January 14, 2026
-Arrival:        11:52 a.m.   Discharge: 4:35 p.m.
-
-CHIEF COMPLAINT
-Left wrist pain and lower back pain after a fall on a wet floor earlier today.
-
-HISTORY OF PRESENT ILLNESS
-39-year-old male presents after a witnessed slip and fall on standing water at a
-commercial property this morning at approximately 10:40 a.m. Landed on
-outstretched left hand with the lower back striking the floor. Denies head
-strike, denies loss of consciousness. Pain in the left wrist rated 8/10, lower
-back 5/10. No numbness or tingling in the extremities.
-
-EXAMINATION
-Left wrist: obvious deformity, swelling, tenderness over the distal radius.
-Neurovascularly intact distally; capillary refill under 2 seconds.
-Lumbar spine: paraspinal tenderness L3-L5, no midline step-off. Normal gait,
-antalgic. Straight-leg raise negative bilaterally.
-
-IMAGING
-X-ray left wrist (3 views): Comminuted, dorsally angulated fracture of the left
-distal radius with intra-articular extension. No ulnar styloid fracture.
-X-ray lumbar spine (2 views): No acute fracture or listhesis. Degenerative
-changes not present for age.
-
-ASSESSMENT
-1. Closed comminuted intra-articular fracture, left distal radius
-2. Acute lumbar strain
-
-PLAN
-Closed reduction performed under hematoma block; sugar-tong splint applied.
-Post-reduction films show improved alignment with residual dorsal angulation.
-Given the intra-articular extension and residual angulation, orthopedic referral
-for likely operative fixation. Referred to Dr. Amara Okonkwo, orthopedic surgery.
-Discharged with sling, analgesia, and return precautions.
-
-Attending: Priya Nandakumar, MD, Emergency Medicine
-""",
-    )
-)
-
-DOCS.append(
-    (
-        "2026-01-21 Operative Report - ORIF Left Distal Radius - Valley Medical Center",
-        """[SEED — synthetic test record, not a real client document]
-
-VALLEY MEDICAL CENTER
-OPERATIVE REPORT
-
-Patient:          Robert Chen
-DOB:              03/22/1979
-MRN:              VMC-2261184
-Date of surgery:  January 21, 2026
-Surgeon:          Amara Okonkwo, MD, Orthopedic Surgery
-Anesthesia:       Regional block with sedation
-
-PREOPERATIVE DIAGNOSIS
-Comminuted intra-articular fracture, left distal radius, with dorsal angulation
-and articular step-off, failed closed management.
-
-POSTOPERATIVE DIAGNOSIS
-Same.
-
-PROCEDURE
-Open reduction and internal fixation, left distal radius, with volar locking
-plate and screws.
-
-INDICATIONS
-Mr. Chen sustained the above injury in a fall on January 14, 2026. Post-reduction
-imaging demonstrated persistent dorsal angulation of 18 degrees and a 2 mm
-articular step-off. Operative fixation was recommended to restore articular
-congruity. Risks, benefits, and alternatives were discussed and consent obtained.
-
-FINDINGS AND TECHNIQUE
-Standard volar Henry approach. The fracture was exposed and found to be
-comminuted with three principal fragments and a depressed articular fragment.
-The articular surface was elevated and provisionally held with K-wires. A volar
-locking plate was applied and secured with locking screws distally and cortical
-screws proximally. Fluoroscopy confirmed restoration of radial height, volar
-tilt, and articular congruity with no residual step-off. Wound irrigated and
-closed in layers. Volar splint applied.
-
-DISPOSITION
-Discharged same day. Follow-up in 10 days for suture removal and transition to
-removable brace. Physical therapy to begin at approximately 4 weeks.
-No lifting with the left upper extremity until cleared.
-""",
-    )
-)
-
-DOCS.append(
-    (
-        "2026-05-28 Orthopedic Discharge Summary - Dr Okonkwo",
-        """[SEED — synthetic test record, not a real client document]
-
-OKONKWO ORTHOPEDIC ASSOCIATES
-DISCHARGE SUMMARY / FINAL TREATING REPORT
-
-Patient:  Robert Chen
-DOB:      03/22/1979
-Date:     May 28, 2026
-Injury:   January 14, 2026 — slip and fall, commercial premises
-
-COURSE OF TREATMENT
-Mr. Chen was first seen in this office on January 16, 2026, two days after a
-fall on a wet floor, following emergency department evaluation and closed
-reduction. Operative fixation was performed January 21, 2026 (ORIF, left distal
-radius, volar locking plate).
-
-Postoperative course was uncomplicated. Sutures removed January 31, 2026.
-Transitioned to a removable wrist brace February 4, 2026. Physical therapy
-commenced February 17, 2026 and concluded May 18, 2026 after 24 sessions.
-
-Concurrent lumbar strain was managed conservatively with activity modification
-and the therapy program. Lumbar symptoms resolved by approximately April 2026.
-
-CURRENT STATUS AT DISCHARGE
-Fracture united with maintained alignment on radiographs of May 18, 2026.
-Left wrist range of motion: flexion 62 degrees, extension 58 degrees, compared
-to 78 and 74 degrees respectively on the uninjured right. Grip strength 71% of
-the contralateral side. Mr. Chen reports aching with cold weather and with
-sustained overhead work, and difficulty with forceful gripping.
-
-WORK STATUS
-Mr. Chen is a commercial HVAC technician, an occupation requiring overhead work
-and forceful gripping. He was held off work entirely from January 14, 2026
-through April 6, 2026, and released to light duty with a 20-hour weekly
-restriction from April 7, 2026 through May 18, 2026. He was released to full
-duty without restriction effective May 19, 2026.
-
-PROGNOSIS
-Maximum medical improvement reached May 18, 2026. Residual loss of wrist motion
-and grip strength is expected to be permanent to some degree. Future hardware
-removal is possible but not currently indicated. No further treatment is planned
-at this time.
-
-Amara Okonkwo, MD
-""",
-    )
-)
-
-DOCS.append(
-    (
-        "2026-06-02 Medical Chronology - Chen (prepared by firm)",
-        """[SEED — synthetic test record, not a real client document]
-
-MEDICAL CHRONOLOGY
-Robert Chen — DOI January 14, 2026
-Prepared June 2, 2026
-
-2026-01-14  Valley Medical Center, Emergency Department. Slip and fall on
-            standing water, commercial premises, approx. 10:40 a.m. Left distal
-            radius fracture (comminuted, intra-articular) and acute lumbar
-            strain. Closed reduction under hematoma block; sugar-tong splint.
-            Orthopedic referral. (Nandakumar, MD)
-
-2026-01-16  Okonkwo Orthopedic Associates. Initial consultation. Post-reduction
-            films reviewed: 18 degrees residual dorsal angulation, 2 mm articular
-            step-off. Operative fixation recommended.
-
-2026-01-21  Valley Medical Center. ORIF left distal radius, volar locking plate
-            and screws. Same-day discharge. (Okonkwo, MD)
-
-2026-01-31  Okonkwo Orthopedic Associates. Sutures removed. Wound healing well.
-
-2026-02-04  Okonkwo Orthopedic Associates. Transitioned from splint to removable
-            wrist brace. Radiographs show maintained alignment.
-
-2026-02-17  Desert Physical Therapy. Course of therapy commenced. Left wrist ROM
-            and grip strengthening; lumbar stabilization.
-
-2026-03-18  Okonkwo Orthopedic Associates. Interim follow-up. Union progressing.
-            Continue therapy. Remains off work.
-
-2026-04-06  Last day off work entirely.
-
-2026-04-07  Released to light duty, 20 hours per week, no forceful gripping and
-            no overhead work.
-
-2026-05-18  Desert Physical Therapy. Final session (24th). Discharged from
-            therapy. Okonkwo Orthopedic Associates: radiographs show union with
-            maintained alignment. Maximum medical improvement.
-
-2026-05-19  Released to full duty without restriction.
-
-2026-05-28  Okonkwo Orthopedic Associates. Discharge summary / final treating
-            report issued. Residual ROM and grip-strength deficits documented.
-""",
-    )
-)
-
-DOCS.append(
-    (
-        "2026-06-02 Billing Summary by Provider - Chen",
-        """[SEED — synthetic test record, not a real client document]
-
-MEDICAL BILLING SUMMARY BY PROVIDER
-Robert Chen — DOI January 14, 2026
-Compiled June 2, 2026 from provider statements on file
-
-  Valley Medical Center — Emergency Department (2026-01-14)      $  4,820.00
-  Valley Medical Center — Surgery, ORIF (2026-01-21)             $ 22,415.00
-  Okonkwo Orthopedic Associates — office and surgical care       $  6,340.00
-  Desert Physical Therapy — 24 sessions (2026-02-17 to 2026-05-18) $ 5,760.00
-  Radiology Associates of Phoenix — X-ray and post-op imaging    $  2,180.00
-                                                                 -----------
-  TOTAL BILLED MEDICAL SPECIALS                                  $ 41,515.00
-
-Notes
-  - Figures are billed charges. No adjustments, write-offs, or liens are
-    reflected in this summary.
-  - No provider statement is outstanding as of the compilation date.
-  - Treatment concluded May 18, 2026 (maximum medical improvement).
-""",
-    )
-)
-
-DOCS.append(
-    (
-        "2026-06-05 Wage Loss Verification - Copper State Mechanical",
-        """[SEED — synthetic test record, not a real client document]
-
-COPPER STATE MECHANICAL
-2255 W. Buckeye Rd, Phoenix, AZ 85009
-
-June 5, 2026
-
-To Whom It May Concern:
-
-This letter verifies the employment and lost time of Robert Chen in connection
-with his injury of January 14, 2026.
-
-EMPLOYMENT
-Position:        Commercial HVAC Technician
-Hire date:       March 3, 2021
-Status:          Full time, 40 hours per week
-Rate of pay:     $38.50 per hour, straight time
-                 (No overtime is included in the figures below.)
-
-LOST TIME
-Mr. Chen was absent from work entirely from January 14, 2026 through April 6,
-2026 — 12 weeks at 40 hours per week.
-        12 weeks x 40 hours x $38.50  =  $18,480.00
-
-From April 7, 2026 through May 18, 2026 Mr. Chen worked light duty limited to
-20 hours per week under physician restriction — 6 weeks at 20 hours lost per
-week against his regular schedule.
-        6 weeks x 20 hours x $38.50   =  $ 4,620.00
-
-                                          -----------
-        TOTAL LOST WAGES                 =  $23,100.00
-
-Mr. Chen returned to full duty without restriction on May 19, 2026. He remains
-employed in the same position.
-
-Sincerely,
-
-Yolanda Reyes-Marsh
-Human Resources Manager
-Copper State Mechanical
-(602) 555-0192
-""",
-    )
-)
-
-DOCS.append(
-    (
-        "2026-02-03 Claim Correspondence - Continental Casualty acknowledgment",
-        """[SEED — synthetic test record, not a real client document]
-
-CONTINENTAL CASUALTY INSURANCE COMPANY
-Claims Service Center
-P.O. Box 44120, Phoenix, AZ 85064
-
-February 3, 2026
-
-RE:  Claim No.:      CC-2026-118447
-     Insured:        Sunrise Plaza Properties LLC
-     Claimant:       Robert Chen
-     Date of loss:   January 14, 2026
-     Location:       4400 N. Central Ave, Phoenix, AZ 85012
-
-Counsel:
-
-This letter acknowledges receipt of your letter of representation dated
-January 27, 2026 regarding the above claim.
-
-Continental Casualty Insurance Company has assigned this matter to the
-undersigned. All future correspondence should be directed to my attention at the
-address above or by email at m.webb@continentalcasualty-example.com.
-
-We are in the process of completing our investigation, including obtaining the
-property incident report and maintenance records for the location. We reserve
-all rights under the policy pending completion of that investigation. This
-letter is not a determination of coverage or liability.
-
-Please forward medical records, billing, and wage documentation as they become
-available so that we may evaluate the claim.
-
-Very truly yours,
-
-Marcus Webb
-Senior Claims Adjuster
-Continental Casualty Insurance Company
-(602) 555-0288
-""",
-    )
-)
-
-DOCS.append(
-    (
-        "2026-03-11 Policy Limits Disclosure - Continental Casualty",
-        """[SEED — synthetic test record, not a real client document]
-
-CONTINENTAL CASUALTY INSURANCE COMPANY
-Claims Service Center
-P.O. Box 44120, Phoenix, AZ 85064
-
-March 11, 2026
-
-RE:  Claim No.:      CC-2026-118447
-     Insured:        Sunrise Plaza Properties LLC
-     Claimant:       Robert Chen
-     Date of loss:   January 14, 2026
-
-Counsel:
-
-In response to your request of February 24, 2026, and pursuant to A.R.S.
-Section 20-259.01 and applicable disclosure obligations, Continental Casualty
-Insurance Company provides the following coverage information for the above
-insured as of the date of loss:
-
-     Policy number:                    CGL-AZ-77401238
-     Policy period:                    July 1, 2025 to July 1, 2026
-     Coverage:                         Commercial General Liability
-     Each occurrence limit:            $1,000,000.00
-     General aggregate limit:          $2,000,000.00
-     Applicable deductible:            $10,000.00 per occurrence
-
-There is no additional excess or umbrella coverage applicable to this loss known
-to the company at this time.
-
-This disclosure is provided for the limited purpose stated above and is not an
-admission of coverage or liability.
-
-Very truly yours,
-
-Marcus Webb
-Senior Claims Adjuster
-Continental Casualty Insurance Company
-""",
-    )
-)
-
-
-def main() -> int:
     c = _client()
-    existing = c.get(f"/matters/{MATTER}/documents/files", Limit=200, Offset=0)
+    existing = c.get(f"/matters/{fixture.matter_id}/documents/files", Limit=200, Offset=0)
     have = {
-        f.get("name") for f in (existing.get("value") if isinstance(existing, dict) else existing) or []
+        f.get("name")
+        for f in (existing.get("value") if isinstance(existing, dict) else existing) or []
     }
     print(f"already on matter: {len(have)}")
 
-    added = skipped = 0
-    for name, text in DOCS:
+    added = skipped = failed = 0
+    for name, text in fixture.docs:
         if name in have:
             print(f"  SKIP (exists): {name}")
             skipped += 1
             continue
         try:
-            res = c.add_file(MATTER, name, text.encode("utf-8"))
+            res = c.add_file(fixture.matter_id, name, text.encode("utf-8"))
             fid = res.get("fileId") if isinstance(res, dict) else res
             print(f"  ADDED: {name}  -> {fid}")
             added += 1
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:  # noqa: BLE001 — one bad upload must not strand the rest
             print(f"  FAILED: {name}  ({type(e).__name__}: {str(e)[:200]})")
-    print(f"\nadded={added} skipped={skipped} of {len(DOCS)}")
-    return 0
+            failed += 1
+    print(f"\nadded={added} skipped={skipped} failed={failed} of {len(fixture.docs)}")
+    print("Materialization is async; re-read the matter before concluding a count is short.")
+    return 1 if failed else 0
 
 
 if __name__ == "__main__":

--- a/operator/bin/tests/test_seed_staging_matter.py
+++ b/operator/bin/tests/test_seed_staging_matter.py
@@ -1,19 +1,32 @@
-"""Tests for seed-staging-matter.py.
+"""Tests for the staging-matter fixtures.
 
-The fixture is EVIDENCE for a card command, so its defects would be read as
-defects in the drafter. Two classes matter:
+A fixture is EVIDENCE for a card command, so its defects read as defects in the
+drafter. Three classes matter:
 
  1. INTERNAL CONSISTENCY. Every figure appears in more than one document — the
-    billing summary's line items and its total, the wage-loss letter's
-    arithmetic and its total, the treatment dates in both the chronology and
-    the source record. A fixture whose numbers disagree makes a correct
-    trace look wrong.
+    billing line items and their total, the wage-loss arithmetic and its total,
+    the treatment dates in both the chronology and the source record. A fixture
+    whose numbers disagree makes a correct trace look wrong.
 
- 2. THE FALSIFIER MUST BE ABLE TO FIRE. Card 18's falsifier is "reserved
-    content filled in". If the fixture itself contained a demand amount or a
-    pain-and-suffering valuation, a draft that quoted it would look like
-    compliance, and a draft that invented one would be indistinguishable from
-    a draft that read one. The absence is what makes the test decide anything.
+ 2. AGREEMENT WITH RECORDS THE FIXTURE DOES NOT AUTHOR. This is the class the
+    first version of this file structurally could not check, and it is where the
+    real defect was: the 2026-PI-102 set contradicts that matter's own Complaint
+    on incident date and location. For 2026-PI-104 the constraint is checkable
+    here, because the pre-existing lien documents state figures the fixture must
+    reconcile to. Where it is NOT checkable off-seat, it is a seat-side probe,
+    not a test of a transcription (see the module note below).
+
+ 3. THE FALSIFIER MUST BE ABLE TO FIRE. Card 18's falsifier is "reserved content
+    filled in". If a fixture itself contained a demand amount or a valuation, a
+    draft quoting it would look like compliance and a draft inventing one would
+    be indistinguishable. The absence is what makes the test decide anything.
+
+WHAT THESE TESTS CANNOT DO. They cannot compare a fixture against a document
+living in the Smokeball tenant — a repo-side assertion could only check a
+transcription typed in here, which keeps passing after the tenant changes. That
+comparison is a seat-side probe recorded with ``crane_verify``. What IS pinned
+here are the figures the pre-existing lien documents state, marked as
+transcriptions with their source named, so at least a drift is visible.
 """
 
 from __future__ import annotations
@@ -25,134 +38,248 @@ from pathlib import Path
 
 import pytest
 
+_LIB = Path(__file__).resolve().parents[1] / "lib"
+if str(_LIB) not in sys.path:
+    sys.path.insert(0, str(_LIB))
+
+from seed_fixtures import FIXTURES  # noqa: E402
+
 _BIN = Path(__file__).resolve().parents[1]
 _spec = importlib.util.spec_from_file_location("seed_staging_matter", _BIN / "seed-staging-matter.py")
 seed = importlib.util.module_from_spec(_spec)
 assert _spec.loader is not None
 sys.modules["seed_staging_matter"] = seed
-# Imports cleanly off-seat BY DESIGN: the module builds its Smokeball client
-# lazily inside main(). If that ever regresses to a module-level import, this
-# raises here rather than skipping — a skipped consistency check would leave the
+# Imports cleanly off-seat BY DESIGN: the runner builds its Smokeball client
+# lazily inside main(). If that regresses to a module-level import, this raises
+# here rather than skipping — a skipped consistency check would leave every
 # fixture unverified everywhere it is actually run.
 _spec.loader.exec_module(seed)
 
+ALL = sorted(FIXTURES)
 
-def _doc(fragment: str) -> str:
-    for name, text in seed.DOCS:
+
+def _doc(slug: str, fragment: str) -> str:
+    for name, text in FIXTURES[slug].docs:
         if fragment.lower() in name.lower():
             return text
-    raise AssertionError(f"no seeded document matching {fragment!r}")
+    raise AssertionError(f"{slug}: no seeded document matching {fragment!r}")
 
 
 def _money(text: str) -> list[float]:
     return [float(m.replace(",", "")) for m in re.findall(r"\$\s*([\d,]+\.\d{2})", text)]
 
 
-def test_billing_line_items_sum_to_the_stated_total() -> None:
+# --------------------------------------------------------------------------- #
+# 1. Internal consistency, both fixtures
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    ("slug", "total"), [("chen-pi102", 41515.00), ("whitfield-pi104", 25430.00)]
+)
+def test_billing_line_items_sum_to_the_stated_total(slug: str, total: float) -> None:
     """A demand traces every medical figure to this document. If the parts and
     the total disagree, a correct trace produces a wrong letter."""
-    amounts = _money(_doc("Billing Summary"))
-    *line_items, total = amounts
-    assert len(line_items) == 5, "five providers are itemized"
-    assert round(sum(line_items), 2) == total == 41515.00
+    amounts = _money(_doc(slug, "Billing Summary"))
+    assert total in amounts, f"{slug}: stated total {total} absent"
+    line_items = [a for a in amounts if a != total]
+    # Whitfield states two subtotals as well as the parts; the parts are the
+    # values that are neither the total nor a subtotal of the others.
+    assert round(sum(a for a in line_items if a not in (12930.00, 12500.00)), 2) == total
 
 
-def test_wage_loss_arithmetic_is_right_in_both_directions() -> None:
+@pytest.mark.parametrize(
+    ("slug", "rate", "full", "light"),
+    [("chen-pi102", 38.50, 18480.00, 4620.00), ("whitfield-pi104", 46.25, 22200.00, 5550.00)],
+)
+def test_wage_loss_arithmetic_closes(slug: str, rate: float, full: float, light: float) -> None:
     """Both periods are stated as rate x hours x weeks AND as a dollar figure.
-    The two must agree, or the letter's wage claim cannot be traced."""
-    text = _doc("Wage Loss")
-    # The rate recurs inside each arithmetic line, so match on meaning rather
-    # than position: every figure the letter states must be derivable from the
-    # rate and the hours it also states.
-    assert "$38.50 per hour" in text, "the rate the arithmetic depends on must be stated"
-    full = round(12 * 40 * 38.50, 2)
-    light = round(6 * 20 * 38.50, 2)
-    assert (full, light) == (18480.00, 4620.00)
+    They must agree, or the letter's wage claim cannot be traced."""
+    text = _doc(slug, "Wage Loss")
+    assert f"${rate:.2f} per hour" in text, "the rate the arithmetic depends on must be stated"
+    assert full == round(12 * 40 * rate, 2)
+    assert light == round(6 * 20 * rate, 2)
     figures = set(_money(text))
-    assert {38.50, full, light, round(full + light, 2)} <= figures
-    assert round(full + light, 2) == 23100.00
-    # And the stated total must be the LAST figure — a letter whose total does
-    # not close the arithmetic is the defect this test exists for.
-    assert _money(text)[-1] == 23100.00
+    assert {rate, full, light, round(full + light, 2)} <= figures
+    assert _money(text)[-1] == round(full + light, 2), "the stated total must close the arithmetic"
 
 
-def test_the_fixture_names_no_demand_amount_or_valuation() -> None:
-    """THE test. Card 18's falsifier is "reserved content filled in" — it can
-    only fire if the record contains nothing to fill it in FROM.
-
-    The policy limits ($1,000,000) are deliberately exempt: that is a disclosed
-    coverage fact from the carrier, not a valuation of the claim, and a demand
-    letter legitimately cites it.
-    """
-    banned = re.compile(
-        r"pain and suffering|general damages|demand (?:amount|of)|"
-        r"settlement (?:value|demand)|we demand|valu(?:e|ation) of (?:this|the) claim",
-        re.I,
-    )
-    for name, text in seed.DOCS:
-        assert not banned.search(text), f"{name} contains reserved content the drafter must author"
-
-
-def test_no_document_name_contains_a_period() -> None:
-    """Smokeball reads the tail after a `.` as a file extension and drops it —
-    "Dr. Okonkwo" materialized as "Dr". A name with a period silently arrives
-    truncated, and the drafter then cannot cite the document it read."""
-    for name, _ in seed.DOCS:
-        assert "." not in name, f"{name!r} would be truncated at the period on upload"
-
-
-def test_treatment_dates_agree_between_the_chronology_and_the_source() -> None:
+@pytest.mark.parametrize("slug", ALL)
+def test_chronology_dates_appear_in_their_source_records(slug: str) -> None:
     """The chronology is a firm-prepared summary of records that also exist on
-    the matter. A date present in one and absent from the other is exactly the
+    the matter. A date in one and absent from the other is exactly the
     inconsistency that makes a traced letter wrong."""
-    chron = _doc("Medical Chronology")
-    for date, source in (
-        ("2026-01-21", "Operative Report"),
-        ("2026-05-28", "Orthopedic Discharge Summary"),
-        ("2026-01-14", "ER Records"),
-    ):
-        assert date in chron, f"chronology omits {date}"
-        pretty = f"{date[5:7].lstrip('0')}/{date[8:]}/{date[:4]}"
-        alt = date.replace("-", "/")
-        body = _doc(source)
-        assert any(
-            token in body
-            for token in (date, pretty, alt, _long_date(date))
-        ), f"{source} does not carry its own date {date}"
+    chron = _doc(slug, "Chronology")
+    pairs = {
+        "chen-pi102": (("2026-01-21", "Operative Report"), ("2026-01-14", "ER Records")),
+        "whitfield-pi104": (
+            ("2025-12-08", "MRI Lumbar"),
+            ("2025-11-02", "ER Records"),
+            ("2026-03-08", "Physical Therapy"),
+        ),
+    }[slug]
+    for iso, source in pairs:
+        assert iso in chron, f"{slug}: chronology omits {iso}"
+        body = _doc(slug, source)
+        assert any(t in body for t in (iso, _long_date(iso), iso.replace("-", "/"))), (
+            f"{slug}: {source} does not carry its own date {iso}"
+        )
 
 
 def _long_date(iso: str) -> str:
     months = (
-        "January February March April May June July August September October "
-        "November December"
+        "January February March April May June July August September October November December"
     ).split()
     y, m, d = iso.split("-")
     return f"{months[int(m) - 1]} {int(d)}, {y}"
 
 
-def test_every_document_is_marked_as_seed_data() -> None:
-    """Nothing here may be mistaken for a real client record — including by a
-    future reader of the Smokeball tenant who did not seed it."""
-    for name, text in seed.DOCS:
-        assert "[SEED" in text, f"{name} carries no seed marker"
+# --------------------------------------------------------------------------- #
+# 2. Agreement with records the fixture does not author
+# --------------------------------------------------------------------------- #
+
+#: Transcribed from the three lien documents ALREADY on 2026-PI-104, read
+#: 2026-08-13. These are the numbers the fixture had to be authored around, and
+#: pinning them here makes a drift visible. It is a transcription, not an
+#: observation: the seat-side probe is what actually compares against the tenant.
+_PI104_PREEXISTING = {
+    "medfin_payoff": 12500.00,  # "MedFin Capital LLC - Payoff Statement"
+    "kaiser_lien": 9310.02,  # "Kaiser Foundation Health Plan - Third Party Liability"
+    "dhcs_lien": 18762.44,  # "California DHCS - Notice of Lien"
+    "date_of_injury": "November 2, 2025",  # Kaiser: "the injury of 11/02/2025"
+}
 
 
-def test_the_record_covers_what_the_drafter_asked_for() -> None:
-    """The first card-18 run enumerated exactly what a demand requires. This
-    fixture exists to answer that list, so the list is the assertion.
+def test_whitfield_funded_care_reconciles_to_the_medfin_advance() -> None:
+    """THE cross-document check. MedFin's payoff statement — a document already
+    on the matter, which this fixture did not author — says it advanced
+    $12,500.00 "for MRI and orthopedic consultation". The MRI and the orthopedic
+    consultation billed here must total exactly that.
 
-    Deposition transcripts are deliberately absent: suit was filed 2026-06-24
-    with service pending, so none would exist — the drafter itself said "if any".
+    FALSIFIER: change either provider's charge and this fails. That is the whole
+    point — on 2026-PI-102 nothing could catch the equivalent error, and the
+    fixture contradicted the Complaint for a day before the Operator found it.
     """
-    names = " | ".join(n for n, _ in seed.DOCS).lower()
-    for required in (
-        "incident report",
-        "er records",
-        "operative report",
-        "chronology",
-        "billing summary",
-        "wage loss",
-        "claim correspondence",
-        "policy limits",
-    ):
-        assert required in names, f"the record is missing {required}"
+    text = _doc("whitfield-pi104", "Billing Summary")
+    assert 3150.00 in _money(text), "MRI charge missing"
+    assert 9350.00 in _money(text), "orthopedic consultation and injection charge missing"
+    assert round(3150.00 + 9350.00, 2) == _PI104_PREEXISTING["medfin_payoff"]
+    assert "12,500.00" in text, "the funded subtotal must be stated, not left to arithmetic"
+
+
+def test_whitfield_uses_the_date_of_loss_the_kaiser_lien_states() -> None:
+    """The Kaiser lien already on the matter names "the injury of 11/02/2025".
+    Every document here dates from that, and the chronology says so."""
+    doi = _PI104_PREEXISTING["date_of_injury"]
+    for fragment in ("Traffic Collision Report", "ER Records", "Chronology", "Wage Loss"):
+        body = _doc("whitfield-pi104", fragment)
+        assert doi in body or "2025-11-02" in body or "11/02/2025" in body, (
+            f"{fragment} does not carry the date of loss the lien states"
+        )
+
+
+def test_whitfield_billing_refuses_to_net_against_the_liens() -> None:
+    """Billed, paid, and recoverable are three different numbers when three
+    lienholders assert. The record does not resolve them, so the summary says
+    so — a demand that totals billed as the loss is a real drafting error and
+    this fixture exists to give the drafter something to notice."""
+    text = _doc("whitfield-pi104", "Billing Summary")
+    assert "not amounts paid" in text
+    assert "NOT resolved" in text
+    assert "do not net them against the liens" in text.lower()
+    for holder in ("MedFin", "Kaiser", "Health Care Services"):
+        assert holder in text, f"{holder} lien not named in the summary"
+
+
+def test_chen_fixture_still_contradicts_its_complaint_on_purpose() -> None:
+    """2026-PI-102's documents place the incident in Phoenix on 2026-01-14; the
+    matter's own conformed Complaint alleges Los Angeles on 2026-04-03. That is
+    PRESERVED DELIBERATELY — it is the only live evidence the drafter detects a
+    conflict, chooses, says why, and reserves.
+
+    If a future editor "fixes" the fixture, this fails and points at the
+    fixture's own purpose text rather than letting the evidence vanish quietly.
+    """
+    incident = _doc("chen-pi102", "Incident Report")
+    assert "January 14, 2026" in incident
+    assert "Phoenix, AZ" in incident
+    assert "Judgment under conflict" in FIXTURES["chen-pi102"].purpose
+
+
+# --------------------------------------------------------------------------- #
+# 3. The falsifier must be able to fire
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("slug", ALL)
+def test_no_fixture_names_a_demand_amount_or_valuation(slug: str) -> None:
+    """Card 18's falsifier is "reserved content filled in" — it can only fire if
+    the record contains nothing to fill it in FROM.
+
+    Policy limits are deliberately exempt: a disclosed coverage fact from the
+    carrier, not a valuation of the claim, and a demand legitimately cites it.
+    """
+    # "demand of" needs a money context. A physical-therapy note reading "a
+    # pre-injury job demand of 75 pounds" is exactly the medical prose a real
+    # demand letter quotes, and a pattern that banned it would push the fixture
+    # to avoid the record's own vocabulary to satisfy a test.
+    banned = re.compile(
+        r"pain and suffering|general damages|demand (?:amount|of \$)|"
+        r"settlement (?:value|demand)|we demand|valu(?:e|ation) of (?:this|the) claim",
+        re.I,
+    )
+    for name, text in FIXTURES[slug].docs:
+        assert not banned.search(text), f"{slug}/{name} contains content the drafter must author"
+
+
+@pytest.mark.parametrize("slug", ALL)
+def test_no_document_name_contains_a_period(slug: str) -> None:
+    """Smokeball reads the tail after a "." as a file extension and drops it —
+    "Dr. Okonkwo" materialized as "Dr". A name with a period silently arrives
+    truncated, and the drafter then cannot cite the document it read."""
+    for name, _ in FIXTURES[slug].docs:
+        assert "." not in name, f"{slug}: {name!r} would be truncated at the period on upload"
+
+
+@pytest.mark.parametrize("slug", ALL)
+def test_every_document_is_marked_as_seed_data(slug: str) -> None:
+    """Nothing here may be mistaken for a real client record, including by a
+    future reader of the tenant who did not seed it."""
+    for name, text in FIXTURES[slug].docs:
+        assert "[SEED" in text, f"{slug}/{name} carries no seed marker"
+
+
+@pytest.mark.parametrize("slug", ALL)
+def test_the_record_covers_what_the_drafter_asked_for(slug: str) -> None:
+    """The first card-18 run enumerated what a demand requires. Both fixtures
+    answer that list, so the list is the assertion.
+
+    Deposition transcripts are deliberately absent from both: neither matter has
+    reached depositions, and the drafter itself said "if any".
+    """
+    names = " | ".join(n for n, _ in FIXTURES[slug].docs).lower()
+    for required in ("chronology", "billing summary", "wage loss", "policy limits"):
+        assert required in names, f"{slug} is missing {required}"
+    assert any(k in names for k in ("incident report", "collision report")), (
+        f"{slug} has no incident/collision record"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# 4. The registry itself
+# --------------------------------------------------------------------------- #
+
+
+def test_every_fixture_states_what_it_is_for() -> None:
+    """A fixture whose purpose is undocumented gets "repaired" by the next
+    reader. 2026-PI-102 is the proof that this matters."""
+    for slug, fx in FIXTURES.items():
+        assert len(fx.purpose) > 80, f"{slug} has no real purpose text"
+        assert fx.matter_id and len(fx.matter_id) == 36, f"{slug} has no matter id"
+        assert fx.docs, f"{slug} has no documents"
+
+
+def test_the_runner_lists_without_uploading() -> None:
+    """--list must never need a Smokeball client. A dry run that could only work
+    on a seat is a dry run nobody uses."""
+    assert seed.main(["whitfield-pi104", "--list"]) == 0


### PR DESCRIPTION
## Summary

Phase 1 of the approved drafting-lane plan. Card 18 needs a matter it can actually produce a clean demand against, and 2026-PI-102 is not it: suit is filed there and the demand skeleton is a **pre-suit** CCP 999 mechanism, so the drafter will always and correctly flag the posture.

## What this deliberately does NOT do

My first version of this work rewrote 2026-PI-102's documents to agree with its Complaint. That would have deleted the best observation in the record.

My nine seeded documents place the incident in **Phoenix on 2026-01-14**; that matter's conformed Complaint alleges **Los Angeles on 2026-04-03**. The Operator caught it, chose the clinical records, said why, and reserved the question — the only live evidence we have that the drafter detects a conflict rather than averaging it away.

The contradiction is now **preserved on purpose**, documented as the fixture's `purpose`, and pinned by `test_chen_fixture_still_contradicts_its_complaint_on_purpose` so a future "repair" fails loudly.

## 2026-PI-104 is the happy path

Pre-suit MVA against a commercial carrier. Its own description already reads *"approaching settlement"* — a demand letter is what that matter needs next, so completing it is additive and no other seeded matter's stressor is disturbed.

**Authored against the record that was already there**, which is the whole lesson of the 102 defect. Every figure was written after reading the three lien documents on the matter:

| pre-existing document | what it fixed |
| --- | --- |
| MedFin payoff: `$12,500.00` "for MRI and orthopedic consultation" | seeded MRI `$3,150.00` + ortho `$9,350.00` = **exactly** `$12,500.00` |
| Kaiser lien: "the injury of **11/02/2025**" | the date of loss throughout |
| DHCS Medi-Cal lien | the matter is California |

**Billed only, deliberately.** Three lienholders assert (MedFin `$12,500.00`, Kaiser `$9,310.02`, DHCS `$18,762.44` "subject to revision"). Billed, paid and recoverable are three different numbers, the record does not resolve them, and the billing summary says so instead of inventing a reconciliation. A demand that totals billed charges as the loss is a real drafting error — this fixture is built so the drafter has to notice. It also answers the treatment-modality question the drafter raised on 102 and could not resolve there.

## Structure

Fixtures move to `operator/bin/lib/seed_fixtures/`, one module per matter next to its own rationale. The runner was **509 lines**, already at the 500-line ceiling, and a second prose record would have doubled it.

## Tests — 20, and one that could not exist before

`test_whitfield_funded_care_reconciles_to_the_medfin_advance` checks the fixture against **a document the fixture did not author**. That is the class the previous test file structurally could not cover, and it is exactly where the 102 defect lived.

Mutation-tested both directions: a one-dollar change to the MRI charge fails 2 tests; "repairing" the Chen contradiction fails 2 others.

Also fixed a false positive — *"a pre-injury job demand of 75 pounds"* is medical prose a real demand letter quotes, so the reserved-content pattern now requires a money context. A test that pushed the fixture away from the record's own vocabulary would be the wrong instrument.

## Test plan

- [x] `npm run verify` exit 0
- [x] operator bin tests **379** (was 366)
- [x] All 12 Whitfield documents uploaded and accepted on the seat
- [x] **(runtime)** seat-side agreement probe against the tenant's own documents — 15/15 readable, all four checks pass: `vfy_01KZXY3CD5MNM43SFKJPT9ZV08`

Refs #2258
