### PR TITLE
fix(operator): the msgraph seat needs two Graph apps, and provisioning now refuses one (ss#2258)

### DIFF
--- a/docs/runbooks/operator/implementation-playbook.md
+++ b/docs/runbooks/operator/implementation-playbook.md
@@ -61,7 +61,13 @@ _Turn a signed engagement into a running project with the client aligned._
 4. **Send the prep list.** Tell the client the decisions they will make and the
    materials to bring: samples of their own letters and templates (for voice),
    who administers each system, and which work they want the Operator to start
-   with.
+   with. Where a system needs their administrator to create something new, that
+   ask belongs on this list, not on stand-up day — the Operator's own mailbox in
+   the client's Microsoft 365 tenant is the common one, and it needs **two** app
+   registrations, not one (give their IT
+   [ms-graph-azure-ad-setup.md](ms-graph-azure-ad-setup.md), "Client-custody
+   app-only registrations"). Provisioning refuses the seat if only one exists, so
+   discovering it late costs a day.
 
 **Gate:** scope recorded, roles identified, working session scheduled, prep list
 sent.

--- a/docs/runbooks/operator/ms-graph-azure-ad-setup.md
+++ b/docs/runbooks/operator/ms-graph-azure-ad-setup.md
@@ -1,5 +1,119 @@
 # Microsoft Graph Azure AD app registration
 
+> **Two runbooks live in this file.** The section immediately below covers the
+> **client-custody, app-only** path an Operator seat uses for the client's own
+> mailbox ([ADR 0078](../../adr/0078-client-custody-email-channel.md)) — this is
+> what a client's IT administrator does, in the client's own tenant, before
+> stand-up day. Everything after it covers the older **multi-tenant delegated**
+> app registered once in the SMD tenant for the admin console's OAuth flow. They
+> are different apps for different purposes; do not conflate them.
+
+## Client-custody app-only registrations — TWO apps, not one (ADR 0078)
+
+**What the client's IT administrator must have ready before stand-up day: two app
+registrations in the firm's own Microsoft Entra tenant, and one Exchange access
+policy for each.** Provisioning refuses a seat that has only one — this is a hard
+requirement, not a recommendation (Captain decision 2026-08-13).
+
+### Why two
+
+A Microsoft Graph **app-only** token is always issued for `/.default`: every
+application permission the registration already holds, with no per-request
+scope-down and no narrower variant. One registration is therefore one permission
+set. If the app can read the mailbox and also holds `Mail.Send`, then anything
+holding that app's credential can send — including a path inside the agent that
+was never meant to transmit.
+
+The Operator's mail credentials live in two different places on the seat. The
+agent process holds the read credential (its delta poller and its `msgraph-mail`
+tool surface both genuinely need it); the send credential is materialized to a
+file only the workspace broker can read and is stripped from the agent's
+environment before the agent starts. That split is only worth anything if the two
+credentials belong to **different registrations with different grants** — which is
+the only way this channel gets the vendor-enforced fence that a rogue in-agent
+path cannot talk its way around.
+
+Proven live on the `smdopslab` sandbox seat, 2026-08-13
+(`vfy_01KZXX523V6JNWEETG4PSZDQY3`): the read app is refused `sendMail` with
+`403 ErrorAccessDenied` while the broker's send app returns `202`, and the read
+app still reads the pinned mailbox and is refused a tenant user list.
+
+### App 1 — the READ app (the agent holds this)
+
+1. **Entra → App registrations → + New registration.** Name it for what it is,
+   e.g. `Operator Mail (read)`. **Single tenant** — this app is the firm's own,
+   not a multi-tenant SMD app.
+2. **API permissions → Microsoft Graph → Application permissions:**
+   - `Mail.ReadWrite`
+   - `MailboxSettings.Read` _(optional; only if the seat needs mailbox settings)_
+   - **Do NOT add `Mail.Send`.** Adding it defeats the entire arrangement — this
+     app's credential is the one the agent process holds.
+3. **Grant admin consent** for the firm's tenant.
+4. **Certificates & secrets → + New client secret.** Record the **Value** once.
+5. Record the **Application (client) ID**. It is authored into the seat's
+   `customer.yaml` as `connectors.Email.msgraph_auth.client_id`.
+
+### App 2 — the SEND app (only the broker ever holds this)
+
+1. A second registration, e.g. `Operator Mail (send)`. Single tenant, same tenant.
+2. **API permissions → Microsoft Graph → Application permissions:** `Mail.Send`,
+   and nothing else.
+3. **Grant admin consent.**
+4. Create a client secret and record the **Value** once.
+5. This client ID and secret never appear in `customer.yaml`. They are staged as
+   operator-env secrets (below) and reach the broker alone.
+
+### Pin BOTH apps to the one mailbox (ApplicationAccessPolicy)
+
+Without this, an application permission is tenant-wide — the app could reach every
+mailbox in the firm. Run once per app, in Exchange Online PowerShell, as a tenant
+admin:
+
+```powershell
+# Repeat for BOTH app ids. $Mailbox is the Operator's own mailbox.
+New-ApplicationAccessPolicy `
+  -AppId "<client-id>" `
+  -PolicyScopeGroupId "<operator-mailbox-or-mail-enabled-security-group>" `
+  -AccessRight RestrictAccess `
+  -Description "Operator seat — pinned to the Operator mailbox only"
+
+# Prove it, per app: Accessible = True for the Operator mailbox…
+Test-ApplicationAccessPolicy -Identity "operator@firm.com"  -AppId "<client-id>"
+# …and Accessible = False for any other mailbox in the tenant.
+Test-ApplicationAccessPolicy -Identity "someone.else@firm.com" -AppId "<client-id>"
+```
+
+Policy changes can take up to ~30 minutes to take effect across Exchange.
+
+### What SMD stages (per seat)
+
+`msgraph_auth` in the seat's `customer.yaml` carries the non-secret read-side
+fields (`tenant_id`, `client_id` — **the READ app**, `mailbox`, `secret_ref`). The
+secrets are staged in the operator env (Infisical `/ss`, prod) under per-customer
+names, where `<CID>` is the customer id upper-cased with `-` → `_`:
+
+| Variable                            | Which app | Notes                                                                                                   |
+| ----------------------------------- | --------- | ------------------------------------------------------------------------------------------------------- |
+| `MSGRAPH_CLIENT_SECRET__<CID>`      | READ      | Matches `msgraph_auth.client_id`                                                                        |
+| `MSGRAPH_SEND_CLIENT_ID__<CID>`     | SEND      | Must differ from the read client id                                                                     |
+| `MSGRAPH_SEND_CLIENT_SECRET__<CID>` | SEND      | Must differ from the read secret                                                                        |
+| `MSGRAPH_SEND_TENANT_ID__<CID>`     | SEND      | Optional — defaults to the read tenant, which is correct when both apps live in the client's one tenant |
+
+`operator/bin/provision-customer.sh` refuses to provision an msgraph seat when the
+send client id or secret is unstaged, equal to the read app's, or half-staged, and
+its refusal names the exact variable to set. The refusal arms are driven in
+`tests/msgraph-two-app-fence.test.ts`.
+
+### Verify after stand-up
+
+The two-app split is only proven by watching the read app be refused. From the
+seat, acquire an app-only token with each credential and attempt
+`POST /v1.0/users/<mailbox>/sendMail`: the read app must return
+`403 ErrorAccessDenied` and the send app `202`. A read app that returns `202` has
+`Mail.Send` on it and the seat is not fenced.
+
+---
+
 > **Status note (2026-05-25):** The in-tree Python adapter (`operator/connectors/ms_graph/`) was removed per the 2026-05-24 Hermes alignment. Mail and Calendar capabilities now bind to the hosted Microsoft 365 MCPs (`mcp:m365-mail`, `mcp:m365-calendar`) per ADR 0020 and need no in-house adapter. DocumentStorage (OneDrive/SharePoint) ships as a sub-plugin in `venturecrane/hermes-smd-overlay` (issue #1055). The Azure AD app registration described below is still required; the smoke-test invocation later in this runbook will be replaced when the overlay sub-plugin ships.
 
 How to register the SMD Services Operator app in Microsoft Entra ID (Azure AD), obtain the client credentials used by the OAuth callback, and grant the Phase-1 scopes that the MS Graph adapter requires.

--- a/docs/specs/operator/email-channel-seam.md
+++ b/docs/specs/operator/email-channel-seam.md
@@ -89,6 +89,8 @@ connectors:
     poll_seconds: 45 # delta poll cadence
 ```
 
+**TWO app registrations are required per seat** (Captain decision 2026-08-13; hard requirement, provisioning refuses without both). `msgraph_auth.client_id` above is the **read-only** app (`Mail.ReadWrite`, no `Mail.Send`) — the only Graph identity the agent process ever holds. The **send-capable** app (`Mail.Send`) never appears in `customer.yaml`: it is staged as `MSGRAPH_SEND_CLIENT_ID__<CID>` / `MSGRAPH_SEND_CLIENT_SECRET__<CID>` in the operator env, materialized to a broker-owned 0600 file, and stripped from the agent's environment before the exec-drop. Both apps are pinned to the one mailbox by an Exchange `ApplicationAccessPolicy`. One registration cannot serve both roles because a Graph app-only token is always `/.default` — every permission the registration holds, with no per-request scope-down — so an app that can read the mailbox can also send from it the moment `Mail.Send` is granted. Setup: [ms-graph-azure-ad-setup.md](../../runbooks/operator/ms-graph-azure-ad-setup.md) ("client-custody app-only registrations"). Proven live on the sandbox seat 2026-08-13 (`vfy_01KZXX523V6JNWEETG4PSZDQY3`): read app refused `sendMail` with `403 ErrorAccessDenied`, send app `202`.
+
 - Schema: `msgraph_auth` block validated when `adapter: msgraph` (tenant id GUID, mailbox address, secret ref shape). Parallel in structure to the existing `google_auth` block.
 - `PersonaSendAs.agentmail_identity` generalizes to a provider-neutral send-as identity (`send_identity: { provider, address }`) with a back-compat read of the old field.
 - Provisioning: `provision-customer.sh` gains an msgraph branch (stages the client secret per-customer; skips AgentMail secrets when unbound — already conditional).

--- a/operator/bin/boot-smoke-test.sh
+++ b/operator/bin/boot-smoke-test.sh
@@ -251,14 +251,20 @@ ssh_exec "agentmail-send-key-stripped-from-agent" \
 
 # The same proof for the Graph SEND app credential (ss#2258 msgraph wave).
 #
-# READ THE LIMIT OF THIS CHECK, because it is narrower than the AgentMail one
-# above and a reader who assumes symmetry will over-trust it. It proves the
-# BROKER'S copy never reaches the agent. It does NOT prove the agent cannot send:
+# READ WHAT THIS CHECK DOES AND DOES NOT COVER. It proves the BROKER'S copy never
+# reaches the agent. It does NOT itself prove the agent cannot send —
 # MSGRAPH_CLIENT_SECRET deliberately stays in the gateway (the delta poller and
-# the msgraph-mail MCP server need it), and while a seat is on the migration
-# fallback that read credential is the SAME app registration, so it can still
-# POST /sendMail. What ends that is a send-only app registration, at which point
-# this probe becomes the real fence and starts guarding a credential the agent
+# the msgraph-mail MCP server need it), and this probe never asks Microsoft what
+# that credential is allowed to do.
+#
+# What makes the agent unable to send is upstream, at provisioning: since
+# 2026-08-13 provision-customer.sh REFUSES a seat whose MSGRAPH_SEND_* is not a
+# distinct app registration from the gateway's MSGRAPH_* (tests/msgraph-two-app
+# -fence.test.ts drives the refusal arms). So on any seat that booted, the
+# gateway's credential belongs to a read-only registration that Microsoft refuses
+# at /sendMail with 403 ErrorAccessDenied — proven on the sandbox seat 2026-08-13,
+# vfy_01KZXX523V6JNWEETG4PSZDQY3. This probe guards the other half: the one
+# credential in the tenant that DOES hold Mail.Send is a credential the agent
 # genuinely never has.
 #
 # What makes it able to FAIL: remove or reorder the `unset MSGRAPH_SEND_*` in

--- a/operator/bin/provision-customer.sh
+++ b/operator/bin/provision-customer.sh
@@ -732,27 +732,52 @@ print(str(auth.get('secret_ref') or '').strip())
   stage_secret_from_env MSGRAPH_CLIENT_SECRET "${_MSG_SECRET_VALUE}"  "Microsoft Graph app client secret (per-customer ${_MSG_SECRET_CID_KEY}, else ${_MSG_SECRET_NAME})"
   # ss#2258: the SEND-side Graph app credential, which only the workspace broker
   # ever sees (root materializes it to a 0600 file and unsets these before the
-  # exec-drop). Separate names because they are meant to become a separate app
-  # registration — read-only for the agent, send-capable only for the broker —
-  # which is the ONLY way to give this channel the vendor-enforced fence the
-  # AgentMail channel already has (a Graph app-only token is always `/.default`,
-  # so one registration cannot be two permission sets).
+  # exec-drop). Separate names because they name a SEPARATE APP REGISTRATION —
+  # read-only for the agent, send-capable only for the broker — which is the ONLY
+  # way to give this channel the vendor-enforced fence the AgentMail channel has
+  # (a Graph app-only token is always `/.default`, so one registration cannot be
+  # two permission sets: an app that can read mail can also send it the moment
+  # Mail.Send is among its grants).
   #
-  # The fallback to the read app's values is a MIGRATION AFFORDANCE and nothing
-  # more. While it is taken, the broker's key is the agent's key, so only the
-  # governed path is fenced; a rogue in-agent path can still mint its own token.
-  # Staging real MSGRAPH_SEND_* values for a seat is what ends that, and it needs
-  # no code change — only these three variables pointing at the second app.
+  # TWO REGISTRATIONS ARE REQUIRED, NOT PREFERRED (Captain decision 2026-08-13).
+  # This branch used to fall back to the read app's values and merely WARN. That
+  # fallback is a defect, not an affordance: while it is taken the broker's key IS
+  # the agent's key, so only the governed path is fenced and a rogue in-agent path
+  # can still mint its own token and POST /sendMail — the exact shape of the
+  # ss#2258 incident. A seat that cannot be fenced does not get provisioned; the
+  # client's tenant admin creates the second registration BEFORE stand-up day.
+  # See docs/runbooks/operator/ms-graph-azure-ad-setup.md ("client-custody
+  # app-only registrations") for what the tenant admin does, and ADR 0078.
+  #
+  # Proven live on the smd-staging sandbox seat 2026-08-13
+  # (vfy_01KZXX523V6JNWEETG4PSZDQY3): the read app is refused sendMail with 403
+  # ErrorAccessDenied while the broker's send app returns 202.
+  #
+  # The sentinels below delimit the block that tests/msgraph-two-app-fence.test.ts
+  # extracts and DRIVES. Keep them; a fence nobody has watched refuse is a fence
+  # nobody knows the shape of.
+  # >>> msgraph-two-app-fence
   _MSG_SEND_CID="$(printf '%s' "${CUSTOMER_ID}" | tr '[:lower:]-' '[:upper:]_' | tr -cd 'A-Z0-9_')"
   _MSG_SEND_TENANT_KEY="MSGRAPH_SEND_TENANT_ID__${_MSG_SEND_CID}"
   _MSG_SEND_CLIENT_KEY="MSGRAPH_SEND_CLIENT_ID__${_MSG_SEND_CID}"
   _MSG_SEND_SECRET_KEY="MSGRAPH_SEND_CLIENT_SECRET__${_MSG_SEND_CID}"
+  # The tenant legitimately matches the read app's (both registrations live in the
+  # CLIENT's tenant), so that one keeps its fallback. The client id and secret do
+  # NOT fall back — an unstaged value stays empty so the refusal below can tell
+  # "never staged" apart from "staged as the read app", and name the right fix.
   _MSG_SEND_TENANT="${!_MSG_SEND_TENANT_KEY:-${MSGRAPH_SEND_TENANT_ID:-${_MSG_TENANT}}}"
-  _MSG_SEND_CLIENT="${!_MSG_SEND_CLIENT_KEY:-${MSGRAPH_SEND_CLIENT_ID:-${_MSG_CLIENT}}}"
-  _MSG_SEND_SECRET="${!_MSG_SEND_SECRET_KEY:-${MSGRAPH_SEND_CLIENT_SECRET:-${_MSG_SECRET_VALUE}}}"
-  if [ "${_MSG_SEND_CLIENT}" = "${_MSG_CLIENT}" ]; then
-    log "  msgraph SEND app == READ app on this seat (migration fallback): the broker fences the governed path, but the agent's own credential can still transmit. Stage ${_MSG_SEND_CLIENT_KEY} to close it."
+  _MSG_SEND_CLIENT="${!_MSG_SEND_CLIENT_KEY:-${MSGRAPH_SEND_CLIENT_ID:-}}"
+  _MSG_SEND_SECRET="${!_MSG_SEND_SECRET_KEY:-${MSGRAPH_SEND_CLIENT_SECRET:-}}"
+  if [ -z "${_MSG_SEND_CLIENT}" ] || [ -z "${_MSG_SEND_SECRET}" ]; then
+    die "msgraph seat ${CUSTOMER_ID} has no SEND app credential. This channel requires TWO Graph app registrations in the client's tenant — a read-only one (Mail.ReadWrite, NO Mail.Send) whose client id is authored as msgraph_auth.client_id, and a send-capable one (Mail.Send) that only the broker ever sees. Both pinned to ${_MSG_MAILBOX} by an Exchange ApplicationAccessPolicy. Stage ${_MSG_SEND_CLIENT_KEY} and ${_MSG_SEND_SECRET_KEY} in the operator env, then re-run. Setup: docs/runbooks/operator/ms-graph-azure-ad-setup.md"
   fi
+  if [ "${_MSG_SEND_CLIENT}" = "${_MSG_CLIENT}" ]; then
+    die "msgraph seat ${CUSTOMER_ID} names the SAME Graph app for read and send (client id ${_MSG_CLIENT}). A Graph app-only token is always /.default, so one registration cannot be read-only for the agent and send-capable for the broker — the agent's own credential would be able to transmit. Point ${_MSG_SEND_CLIENT_KEY} at the SECOND (send-capable) registration, or correct msgraph_auth.client_id in ${CUSTOMER_YAML} to name the READ-ONLY one. Setup: docs/runbooks/operator/ms-graph-azure-ad-setup.md"
+  fi
+  if [ "${_MSG_SEND_SECRET}" = "${_MSG_SECRET_VALUE}" ]; then
+    die "msgraph seat ${CUSTOMER_ID} stages the same client secret for read and send while naming two different app registrations. One of them is wrong — a client secret belongs to exactly one registration. Re-stage ${_MSG_SEND_SECRET_KEY} with the SEND app's secret."
+  fi
+  # <<< msgraph-two-app-fence
   stage_secret_from_env MSGRAPH_SEND_TENANT_ID     "${_MSG_SEND_TENANT}"  "Graph SEND app tenant id (broker-only; per-customer ${_MSG_SEND_TENANT_KEY})"
   stage_secret_from_env MSGRAPH_SEND_CLIENT_ID     "${_MSG_SEND_CLIENT}"  "Graph SEND app client id (broker-only; per-customer ${_MSG_SEND_CLIENT_KEY})"
   stage_secret_from_env MSGRAPH_SEND_CLIENT_SECRET "${_MSG_SEND_SECRET}"  "Graph SEND app client secret (broker-only; per-customer ${_MSG_SEND_SECRET_KEY})"

--- a/operator/customers/_template/customer.yaml
+++ b/operator/customers/_template/customer.yaml
@@ -113,9 +113,42 @@ connectors:
     backend: '[build:filevine / mcp:clio-oktopeak / synthetic:no_pm]'
     enabled: true
   Email:
-    adapter: '[m365-mail / google-gmail / synthetic]'
-    backend: '[mcp:m365-mail / mcp:google-gmail / synthetic:fixture]'
+    adapter: '[msgraph / m365-mail / google-gmail / agentmail / synthetic]'
+    backend: '[mcp:msgraph-mail / mcp:m365-mail / mcp:google-gmail / synthetic:fixture]'
     enabled: true
+    # CLIENT-CUSTODY MAIL (adapter: msgraph — ADR 0078 / email-channel-seam D5).
+    # The Operator reads and sends from a mailbox inside the CLIENT's own
+    # Microsoft 365 tenant. Uncomment and author when this seat uses it; delete
+    # otherwise (a msgraph_auth block on any other adapter is a hard validation
+    # error — no dead config).
+    #
+    # THE CLIENT'S IT ADMINISTRATOR MUST CREATE **TWO** APP REGISTRATIONS BEFORE
+    # STAND-UP DAY. This is a hard requirement (Captain decision 2026-08-13);
+    # provision-customer.sh refuses the seat without both, naming the exact
+    # variable to stage.
+    #
+    #   1. READ app  — Mail.ReadWrite, NO Mail.Send. Its client id goes in
+    #      `client_id` below. This is the only Graph identity the agent holds.
+    #   2. SEND app  — Mail.Send only. Never appears in this file; staged as
+    #      MSGRAPH_SEND_CLIENT_ID__<CID> / MSGRAPH_SEND_CLIENT_SECRET__<CID> in
+    #      the operator env and materialized to the broker alone.
+    #
+    # Both pinned to the one mailbox by an Exchange ApplicationAccessPolicy. Two
+    # apps is the ONLY way to split read from send here: a Graph app-only token
+    # is always `/.default` — every permission the registration holds, with no
+    # per-request scope-down — so one app that can read the mailbox can also send
+    # from it the moment Mail.Send is granted.
+    #
+    # Setup (give this to the client's IT):
+    #   docs/runbooks/operator/ms-graph-azure-ad-setup.md
+    #     → "Client-custody app-only registrations — TWO apps, not one"
+    #
+    # msgraph_auth:
+    #   tenant_id: '[the CLIENT tenant GUID]'
+    #   client_id: '[the READ app client id — the one WITHOUT Mail.Send]'
+    #   mailbox: '[the Operator's own mailbox in the CLIENT's tenant]'
+    #   secret_ref: 'fly-secret:MSGRAPH_CLIENT_SECRET'  # READ app secret, ADR 0010
+    # poll_seconds: 45   # delta poll cadence; inbound is polling, not webhooks
   Calendar:
     # ADR 0021 Stream F migration (PR #1080): M365 calendar shipped as
     # first-party MCP. Per ADR 0020 the MCP-first ordering applies.

--- a/operator/customers/smd-staging/customer.yaml
+++ b/operator/customers/smd-staging/customer.yaml
@@ -155,13 +155,32 @@ connectors:
   # message enters through the same fence/taint/roster spine as webhook mail.
   # AgentMail is deliberately NOT bound on this seat — one mail path, one
   # custody story (ADR 0078 §1).
+  #
+  # TWO app registrations, both pinned to this mailbox by ApplicationAccessPolicy
+  # (Captain decision 2026-08-13; provision-customer.sh refuses a seat without
+  # both). `client_id` below is the READ-ONLY one — Mail.ReadWrite, NO Mail.Send —
+  # and it is the ONLY Graph identity the agent process ever holds. The
+  # send-capable registration reaches the workspace broker alone, via
+  # MSGRAPH_SEND_CLIENT_ID__SMD_STAGING / MSGRAPH_SEND_CLIENT_SECRET__SMD_STAGING,
+  # and is stripped from the agent's env before the exec-drop.
+  #
+  # The split is proven live on this seat, 2026-08-13
+  # (vfy_01KZXX523V6JNWEETG4PSZDQY3): the read app below is refused sendMail with
+  # 403 ErrorAccessDenied, the broker's send app returns 202, and the read app
+  # still reads this mailbox (200) while being refused a tenant user list (403).
+  #
+  # CORRECTED 2026-08-13: this field previously carried 83a044a4-…, which is the
+  # SEND-capable registration. Authoring it here is what a reprovision would have
+  # staged as MSGRAPH_CLIENT_ID — handing the agent the app that can transmit and
+  # undoing the fence. The read-only app is 9301fd6f-… , which is what the live
+  # seat actually runs.
   Email:
     adapter: msgraph
     backend: mcp:msgraph-mail
     enabled: true
     msgraph_auth:
       tenant_id: 'f11d2887-b7f2-4464-a9c6-d4db2166b43c'
-      client_id: '83a044a4-0b43-4cb4-b989-370aa711af20'
+      client_id: '9301fd6f-1d97-4ed4-abc3-e99e3cf326f0'
       mailbox: operator@smdopslab.onmicrosoft.com
       secret_ref: 'fly-secret:MSGRAPH_CLIENT_SECRET'
     poll_seconds: 45

--- a/operator/templates/entrypoint.sh
+++ b/operator/templates/entrypoint.sh
@@ -298,14 +298,17 @@ fi
 # token is always `/.default` — every permission the app registration holds), so
 # stripping MSGRAPH_* here would blind the seat rather than harden it.
 #
-# The consequence, stated plainly so nobody reads this channel as equivalent to
-# the AgentMail one: an in-agent path can still mint its own Graph token and POST
-# /sendMail directly. What the broker verbs add is that the GOVERNED path is
-# recipient-fenced and always audited. Closing the rest needs a SECOND app
-# registration in the tenant — read-only for the agent, send-capable only here —
-# which is a tenant-admin action, and on a client seat that is the client's to
-# grant. The MSGRAPH_SEND_* names below are already what that split would use, so
-# it becomes a provisioning change with no code change.
+# What closes the rest is the SECOND app registration — read-only for the agent,
+# send-capable only here. As of 2026-08-13 that is REQUIRED, not aspirational:
+# provision-customer.sh refuses an msgraph seat whose MSGRAPH_SEND_* credentials
+# are not a distinct registration from the gateway's MSGRAPH_*. So on any seat
+# that provisioned successfully, the MSGRAPH_* the gateway keeps below holds
+# Mail.ReadWrite and NOT Mail.Send, and the Graph token an in-agent path could
+# mint with it is refused at /sendMail by Microsoft (403 ErrorAccessDenied —
+# proven on the sandbox seat 2026-08-13, vfy_01KZXX523V6JNWEETG4PSZDQY3). Both
+# fences are live for msgraph: the vendor makes the agent's credential incapable
+# of transmitting, and the broker verbs recipient-fence and audit the governed
+# path. Setup: docs/runbooks/operator/ms-graph-azure-ad-setup.md.
 export SMD_MSGRAPH_CREDENTIAL_PATH="${BROKER_DIR}/msgraph.json"
 if [ -n "${MSGRAPH_SEND_CLIENT_SECRET:-}" ]; then
   PYTHONPATH="/opt/workspace-broker" \
@@ -395,11 +398,11 @@ unset GOOGLE_IMPERSONATE_SUBJECT GOOGLE_OAUTH_SCOPES GOOGLE_TOKEN_PATH
 # inbox-scoped key the vendor refuses to let transmit.
 unset AGENTMAIL_SEND_API_KEY
 # The Graph SEND app credential dies here too, for the same reason and at the same
-# moment. Today it may carry the SAME app registration's values as the MSGRAPH_*
-# the gateway keeps for reads, so this strip buys little on its own — but it means
-# the day a send-only app registration exists, its secret is already unreachable
-# from the agent with no further change to this file. The gateway's read-side
-# MSGRAPH_* deliberately survives; see the materialization block above for why.
+# moment. Since 2026-08-13 it carries a DIFFERENT app registration from the
+# MSGRAPH_* the gateway keeps for reads — provisioning refuses the seat otherwise
+# — so this strip is the whole point: the only credential in the tenant that holds
+# Mail.Send becomes unreachable from the agent. The gateway's read-side MSGRAPH_*
+# deliberately survives; see the materialization block above for why.
 unset MSGRAPH_SEND_TENANT_ID MSGRAPH_SEND_CLIENT_ID MSGRAPH_SEND_CLIENT_SECRET
 
 export HOME=/opt/data

--- a/operator/workspace_broker/msgraph_auth.py
+++ b/operator/workspace_broker/msgraph_auth.py
@@ -24,23 +24,30 @@ read-side and both real: the delta poller that pulls inbound mail
 server that is the agent's own mail tool surface. Stripping ``MSGRAPH_*`` from the
 gateway today would not harden the seat; it would blind it.
 
-So the honest position, stated here rather than discovered later:
+The way out is TWO app registrations in the tenant — a read-only one
+(``Mail.ReadWrite``, no ``Mail.Send``) whose credential the agent holds, and a
+send-capable one (``Mail.Send``) whose secret only ever reaches this file, both
+pinned to the one mailbox by an Exchange ``ApplicationAccessPolicy``. That is a
+tenant action requiring admin consent, so on a client seat it is the client's to
+grant. As of 2026-08-13 it is REQUIRED rather than hoped for: the Captain made two
+registrations a precondition of the channel, and ``provision-customer.sh`` refuses
+to stand up an msgraph seat whose ``MSGRAPH_SEND_*`` values are unstaged, equal to
+the read app's, or half-staged.
+
+So the position on a seat that provisioned successfully:
 
 * **Fence 2 is live** — every governed send and reply crosses this boundary, is
   checked against the seat's authored counterparty surface, and leaves a row
   written by the credential holder.
-* **Fence 1 is NOT live for msgraph.** A rogue in-agent path can still mint its
-  own Graph token from ``MSGRAPH_CLIENT_SECRET`` and POST ``/sendMail`` directly,
-  which is the shape of the original incident. Closing it needs a SECOND app
-  registration in the tenant — a read-only one (``Mail.ReadWrite``, no
-  ``Mail.Send``) for the agent, and a send-capable one whose secret only ever
-  reaches this file. That is a tenant action requiring admin consent, which for a
-  client seat is the client's to grant, not ours to take.
+* **Fence 1 is live too.** The agent's ``MSGRAPH_CLIENT_SECRET`` belongs to a
+  registration without ``Mail.Send``, so a rogue in-agent path that mints its own
+  Graph token and POSTs ``/sendMail`` is refused by Microsoft, not by us. Proven
+  on the sandbox seat 2026-08-13 (``vfy_01KZXX523V6JNWEETG4PSZDQY3``): the read
+  app got ``403 ErrorAccessDenied``, this file's credential got ``202``.
 
-The env names below are already the ones a separate send-only app would use, so
-that migration is a provisioning change with no code change. Today they may carry
-the same app registration's values as the gateway's ``MSGRAPH_*``; the day a
-send-only app exists, only what the provisioner stages changes.
+Setup for the client's tenant admin:
+``docs/runbooks/operator/ms-graph-azure-ad-setup.md`` — "Client-custody app-only
+registrations".
 """
 
 from __future__ import annotations
@@ -55,9 +62,9 @@ import yaml
 from .recipient_policy import normalize_address
 
 #: The send-capable Graph app credential, named apart from the gateway's
-#: ``MSGRAPH_*`` on purpose. Sharing the names would make the eventual split
-#: invisible in config and let a future entrypoint edit hand the agent the send
-#: app by accident — the exact failure the AgentMail key split exists to prevent.
+#: ``MSGRAPH_*`` on purpose. Sharing the names would make the split invisible in
+#: config and let a future entrypoint edit hand the agent the send app by
+#: accident — the exact failure the AgentMail key split exists to prevent.
 #: The MAILBOX is deliberately absent: it comes from customer.yaml (below), so a
 #: caller cannot express it and a secret cannot contradict the authored config.
 SEND_ENV = (

--- a/tests/msgraph-two-app-fence.test.ts
+++ b/tests/msgraph-two-app-fence.test.ts
@@ -1,0 +1,153 @@
+/**
+ * The msgraph channel refuses to provision on ONE Graph app registration.
+ *
+ * WHY THIS IS A REFUSAL AND NOT A WARNING. A Microsoft Graph app-only token is
+ * always `/.default` — every application permission the registration already
+ * holds, with no per-request scope-down. One registration is therefore one
+ * permission set: if it can read the mailbox it can also send from it the moment
+ * `Mail.Send` is granted. So the read/send split this channel needs cannot be
+ * expressed inside a single app; it needs two, and the agent process must hold
+ * only the read-only one. Captain decision 2026-08-13 made that REQUIRED, which
+ * turned the previous "warn and continue on the read app's values" fallback into
+ * a defect: while it was taken, the broker's key WAS the agent's key, so only the
+ * governed path was fenced and a rogue in-agent path could still mint its own
+ * token and POST /sendMail — the shape of the ss#2258 incident.
+ *
+ * WHAT THIS TEST DRIVES. The real fence text, extracted from
+ * `operator/bin/provision-customer.sh` between its `msgraph-two-app-fence`
+ * sentinels and executed in a harness that stubs only `die` and the surrounding
+ * variables. Extracting rather than restating is the point: a copy of the logic
+ * would keep passing after the script stopped refusing. The block sits at step 6
+ * of a script that has already talked to R2, Fly, and git by the time it runs, so
+ * driving the whole script here is not on the table — but the fence itself is
+ * pure string comparison and needs none of that.
+ *
+ * The four arms are all driven, including the pass-through, because a refusal
+ * that refuses everything is not a fence.
+ */
+import { execFileSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+const SCRIPT = fileURLToPath(new URL('../operator/bin/provision-customer.sh', import.meta.url))
+
+function fenceSource(): string {
+  const text = readFileSync(SCRIPT, 'utf8')
+  const start = text.indexOf('# >>> msgraph-two-app-fence')
+  const end = text.indexOf('# <<< msgraph-two-app-fence')
+  expect(start, 'opening fence sentinel missing from provision-customer.sh').toBeGreaterThan(-1)
+  expect(end, 'closing fence sentinel missing from provision-customer.sh').toBeGreaterThan(start)
+  const block = text.slice(start, end)
+  // The fence must still be able to refuse. A block with no `die` measures nothing.
+  expect(block).toContain('die ')
+  return block
+}
+
+type Env = Record<string, string>
+
+interface Outcome {
+  status: number
+  output: string
+}
+
+/**
+ * Run the extracted fence with the variables the script would have in scope.
+ * `die` is stubbed to print and exit 1 — the same contract the real one has
+ * (`die() { log "FATAL: $*"; exit 1; }`).
+ */
+function runFence(env: Env): Outcome {
+  const harness = [
+    'set -euo pipefail',
+    'die() { echo "FATAL: $*"; exit 1; }',
+    'CUSTOMER_ID="${CUSTOMER_ID}"',
+    'CUSTOMER_YAML="/tmp/customer.yaml"',
+    fenceSource(),
+    'echo "FENCE-PASSED client=${_MSG_SEND_CLIENT} tenant=${_MSG_SEND_TENANT}"',
+  ].join('\n')
+  try {
+    const output = execFileSync('bash', ['-c', harness], {
+      encoding: 'utf8',
+      env: { PATH: process.env['PATH'] ?? '', ...env },
+    })
+    return { status: 0, output }
+  } catch (err) {
+    const e = err as { status?: number; stdout?: string; stderr?: string }
+    return { status: e.status ?? 1, output: `${e.stdout ?? ''}${e.stderr ?? ''}` }
+  }
+}
+
+/** A seat whose READ app is authored and whose SEND app is staged distinctly. */
+function baseEnv(): Env {
+  return {
+    CUSTOMER_ID: 'acme-law',
+    _MSG_TENANT: 'tenant-guid',
+    _MSG_CLIENT: 'read-app-guid',
+    _MSG_SECRET_VALUE: 'read-app-secret',
+    _MSG_MAILBOX: 'operator@acmelaw.com',
+  }
+}
+
+describe('msgraph two-app fence (provision-customer.sh)', () => {
+  it('provisions when the send app is a genuinely distinct registration', () => {
+    const result = runFence({
+      ...baseEnv(),
+      MSGRAPH_SEND_CLIENT_ID__ACME_LAW: 'send-app-guid',
+      MSGRAPH_SEND_CLIENT_SECRET__ACME_LAW: 'send-app-secret',
+    })
+    expect(result.output).toContain('FENCE-PASSED client=send-app-guid')
+    expect(result.status).toBe(0)
+    // The tenant is shared on purpose: both registrations live in the client's
+    // own tenant, so that one field alone still falls back to the read app's.
+    expect(result.output).toContain('tenant=tenant-guid')
+  })
+
+  it('refuses a seat with no send credential staged at all, naming both variables', () => {
+    const result = runFence(baseEnv())
+    expect(result.status).toBe(1)
+    expect(result.output).toContain('has no SEND app credential')
+    expect(result.output).toContain('MSGRAPH_SEND_CLIENT_ID__ACME_LAW')
+    expect(result.output).toContain('MSGRAPH_SEND_CLIENT_SECRET__ACME_LAW')
+  })
+
+  it('refuses a seat whose send client id equals the read app (the old fallback)', () => {
+    const result = runFence({
+      ...baseEnv(),
+      MSGRAPH_SEND_CLIENT_ID__ACME_LAW: 'read-app-guid',
+      MSGRAPH_SEND_CLIENT_SECRET__ACME_LAW: 'send-app-secret',
+    })
+    expect(result.status).toBe(1)
+    expect(result.output).toContain('SAME Graph app for read and send')
+    expect(result.output).toContain('MSGRAPH_SEND_CLIENT_ID__ACME_LAW')
+  })
+
+  it('refuses a half-staged seat: two client ids but one client secret', () => {
+    const result = runFence({
+      ...baseEnv(),
+      MSGRAPH_SEND_CLIENT_ID__ACME_LAW: 'send-app-guid',
+      MSGRAPH_SEND_CLIENT_SECRET__ACME_LAW: 'read-app-secret',
+    })
+    expect(result.status).toBe(1)
+    expect(result.output).toContain('same client secret for read and send')
+    expect(result.output).toContain('MSGRAPH_SEND_CLIENT_SECRET__ACME_LAW')
+  })
+
+  it('does not silently fall back to the read app when only the global name is set', () => {
+    // A global MSGRAPH_SEND_CLIENT_ID is still honoured (single-tenant operator
+    // envs predate the per-seat names), but it must name a DIFFERENT app.
+    const sameApp = runFence({
+      ...baseEnv(),
+      MSGRAPH_SEND_CLIENT_ID: 'read-app-guid',
+      MSGRAPH_SEND_CLIENT_SECRET: 'read-app-secret',
+    })
+    expect(sameApp.status).toBe(1)
+
+    const distinct = runFence({
+      ...baseEnv(),
+      MSGRAPH_SEND_CLIENT_ID: 'send-app-guid',
+      MSGRAPH_SEND_CLIENT_SECRET: 'send-app-secret',
+    })
+    expect(distinct.status).toBe(0)
+  })
+})


### PR DESCRIPTION
## What this changes

`provision-customer.sh` used to fall back to the read app's credentials when a seat had no `MSGRAPH_SEND_*` staged, log a warning, and continue. Captain decision 2026-08-13 makes two Graph app registrations per msgraph seat **required**, which turns that fallback from an affordance into a defect. It is now three refusals.

A Graph app-only token is always issued for `/.default` — every application permission the registration already holds, with no per-request scope-down. One registration is one permission set, so an app that can read the mailbox can also send from it the moment `Mail.Send` is granted. The read/send split cannot be expressed inside one app; the broker's key was simply the agent's key while the fallback was taken.

| Condition | Before | Now |
| --- | --- | --- |
| No `MSGRAPH_SEND_*` staged | Silently used the read app | Refuses, naming `MSGRAPH_SEND_CLIENT_ID__<CID>` and `MSGRAPH_SEND_CLIENT_SECRET__<CID>` |
| Send client id == read client id | `log` warning, continued | Refuses, names the variable **and** the `customer.yaml` field to correct |
| Two client ids, one client secret | Not detected | Refuses (half-staged config) |
| Send tenant id == read tenant id | Allowed | Still allowed — both registrations legitimately live in the client's one tenant |

## Runtime proof (AC: runtime)

Proven on the `smd-staging` sandbox seat **before** the code was written, by driving both credentials against Graph from the seat.

**Evidence: `vfy_01KZXX523V6JNWEETG4PSZDQY3`**

```
read  app client_id    : 9301fd6f-…      send  app client_id : 83a044a4-…
DISTINCT REGISTRATIONS : True            same tenant         : True

READ-app sendMail: HTTP 403 ErrorAccessDenied -> REFUSED
SEND-app sendMail: HTTP 202                    -> SEND SUCCEEDED

READ-app read pinned mailbox : HTTP 200 (1 item)          -> ALLOWED
READ-app list tenant users   : HTTP 403 Authorization_RequestDenied -> REFUSED
```

Microsoft refuses the agent's credential at `/sendMail` — the vendor-enforced fence, not ours. Both fences are live for msgraph now, which is what the `msgraph_auth.py` and `entrypoint.sh` docstrings said was still missing; those are corrected here.

## Two things the proof turned up

**1. The staging seat's authored `client_id` was the SEND app.** `operator/customers/smd-staging/customer.yaml` named `83a044a4-…`, which is the send-capable registration. `provision-customer.sh` stages `MSGRAPH_CLIENT_ID` straight from that field, so a reprovision would have handed the agent the app that can transmit and undone the fence proven above. Corrected to `9301fd6f-…`, the read-only app the live seat actually runs.

**2. Ops gate — the vault has no `MSGRAPH_SEND_*` at any name.** `crane_secret_check` on `/ss` prod: `MSGRAPH_CLIENT_SECRET` and `MSGRAPH_CLIENT_SECRET__SMD_STAGING` present; every `MSGRAPH_SEND_*` missing. The staging seat's distinct send credential was set directly on Fly and exists nowhere else. **Consequence: after this merges, `smd-staging` cannot be reprovisioned until `MSGRAPH_SEND_CLIENT_ID__SMD_STAGING` and `MSGRAPH_SEND_CLIENT_SECRET__SMD_STAGING` are vaulted.** That is the correct fail-closed outcome — the alternative is a reprovision silently regressing the fence — but it is a Captain action and no agent should stage those.

## Discoverability, for the client's IT

The requirement has to be met in the client's tenant before stand-up day, so it is stated where they will meet it:

- `docs/runbooks/operator/ms-graph-azure-ad-setup.md` now **leads** with "Client-custody app-only registrations — TWO apps, not one": exact Graph permissions per app, the `New-ApplicationAccessPolicy` call per app, a `Test-ApplicationAccessPolicy` proof step, and the per-seat variable table. The file's older multi-tenant delegated runbook is explicitly demarcated so the two are not conflated.
- `operator/customers/_template/customer.yaml` — commented `msgraph_auth` block stating the two-app rule (and the Email adapter placeholder list, which had gone stale, now includes `msgraph`).
- `docs/runbooks/operator/implementation-playbook.md` — Phase 1 prep list carries the ask, so it is not discovered on stand-up day.
- `docs/specs/operator/email-channel-seam.md` D5 — the config representation now states which app `client_id` is.

## Test

`tests/msgraph-two-app-fence.test.ts` **extracts** the fence from the script between sentinels and drives all four arms including the pass-through. Extracting rather than restating is the point: a copy of the logic would keep passing after the script stopped refusing. I confirmed the instrument can fail — neutering the fence in the script fails 4 of its 5 cases; restored, all 5 pass.

`npm run verify` green (exit 0).

## Discrepancy for another lane — A&P `customer.yaml`

**Not touched here** (that file belongs to a live A&P session), reported for its owner.

`operator/customers/ashton-price/customer.yaml:685-687` states msgraph "is not yet runtime-wired (Track E)" and that "authoring msgraph here now would be dropped by translate.py". The code contradicts both halves:

- `hermes-smd-overlay/bootstrap/translate.py:510` — `_EMAIL_REPLY_ADAPTERS = frozenset({"agentmail", "msgraph"})`
- `translate.py:652-685` — materializes the `msgraph` route with `_INBOUND_EMAIL_PROMPT_MSGRAPH` and registers `adapter_to_route["msgraph"]`
- `operator/connectors/msgraph-mail/` is complete with tests, and `provision-customer.sh:685-775` stages the full msgraph credential set

The stated **consequence** in that comment — that the seat has no inbound-mail lane and the PI skills are person-invoked only — follows from the connector being unauthored, which is still true. It is the *reason* given that is stale. Worth correcting so nobody defers A&P's mail lane on a blocker that no longer exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YMQcxGtkEyrCvYxEAi8Y5e
