### PR TITLE
feat(smokeball): render_docx_draft — a filled draft can finally be a Word document (#2258)

### DIFF
--- a/operator/connectors/smokeball/manifest.toml
+++ b/operator/connectors/smokeball/manifest.toml
@@ -38,6 +38,13 @@
 # unclassified tool is refused, not defaulted), which is the fail-closed
 # direction: the .docx renderer writes a template into the firm's own record and
 # sends nothing outside the firm, so internal_write is its class.
+#
+# COORDINATED CHANGE (render_docx_draft, ss-console#2258): identical shape —
+# mcp_smokeball_render_docx_draft = ActionClass.INTERNAL_WRITE in the overlay,
+# plus an OVERLAY_REF bump. Same class and same reasoning as its template
+# sibling: it saves the Operator's own work product into the firm's record and
+# sends nothing outside. The two tools differ only in which artifact their
+# content gate is written for, never in what they are permitted to do.
 [connector]
 name = "smokeball"
 capability = "PracticeManagement"
@@ -91,6 +98,7 @@ create_folder = "internal_write"
 add_file = "internal_write"
 file_attachment_to_matter = "internal_write"
 render_docx_template = "internal_write"
+render_docx_draft = "internal_write"
 delete_file = "destructive"
 get_memos_on_matter = "read"
 get_bank_accounts = "read"

--- a/operator/connectors/smokeball/smokeball_connector/render.py
+++ b/operator/connectors/smokeball/smokeball_connector/render.py
@@ -178,6 +178,86 @@ def find_violations(markdown: str) -> list[Violation]:
     return sorted(violations, key=lambda v: (v.line, v.rule))
 
 
+def check_draft_content(markdown: str) -> None:
+    """Raise :class:`TemplateContentRefused` if the FILLED DRAFT is not
+    deliverable. Returns None when it is clean."""
+    violations = find_draft_violations(markdown)
+    if violations:
+        raise TemplateContentRefused(violations)
+
+
+def find_draft_violations(markdown: str) -> list[Violation]:
+    """The template gate, inverted where a filled draft differs from a template.
+
+    WHY A SECOND ENTRY POINT (ss-console#2258). The template gate refuses case
+    content because "content that reaches a template reaches every future matter
+    the template is filled for." A FILLED DRAFT is the opposite artifact: the
+    case content IS the letter. Rehearsing card 18 on the pilot produced a real
+    demand draft that could not become a .docx at all, because the only renderer
+    was the template one and every medical figure in the letter tripped its gate.
+    The drafter filed a .txt instead, and an attorney cannot edit that in Word.
+
+    WHAT STAYS, and it is most of the gate:
+
+    * **Malformed marker syntax.** Unchanged. An unterminated ``{{`` is a
+      sentence fragment a reader answers as prose either way.
+    * **HTML comments.** Unchanged, and MORE load-bearing here than in a
+      template. Drafting gate 9: a reservation that renders as nothing is a
+      reservation the attorney never sees. In a draft, the thing being reserved
+      is the demand figure.
+    * **Em dashes** — but only OUTSIDE a quoted passage. See below.
+
+    WHAT GOES:
+
+    * **Case content.** Dates, dollar figures, identifiers and long digit runs
+      are the substance of a demand letter, and every one of them is required to
+      trace to a source document by rules enforced elsewhere: the drafting
+      discipline's ten mechanical gates, the A1 identifier provenance gate, and
+      the skill's own "name the source in the same sentence". Refusing them here
+      would not add a control, it would only route the work to a file format the
+      firm cannot use.
+
+    THE EM-DASH CARVE-OUT, DECIDED RATHER THAN DISCOVERED. House style bans em
+    dashes; the drafting checker requires a quotation to appear VERBATIM in a
+    source. A medical record containing an em dash inside a passage the draft
+    quotes can satisfy neither rule, and the only ways out are to misquote the
+    record or to drop the quote. Both are worse than an em dash. So the quote
+    wins: house style governs our prose, never the record's words.
+
+    Markers are exempt from the em-dash rule for the same reason they are exempt
+    from everything else: a marker names its own source and is not prose.
+    """
+    line_starts = _line_starts(markdown)
+    spans, violations = _scan_markers(markdown, line_starts)
+    exempt = spans + _comment_spans(markdown) + _quoted_spans(markdown)
+    violations.extend(_literal_violations(markdown, line_starts, em_dash_exempt=exempt))
+    return sorted(violations, key=lambda v: (v.line, v.rule))
+
+
+def _quoted_spans(text: str) -> list[tuple[int, int]]:
+    """Double-quoted passages, straight or curly, as half-open spans INCLUDING
+    the quote marks.
+
+    Only closed pairs count. An unterminated quote yields no span, the same
+    fail-toward-refusing choice ``_scan_markers`` makes for an unterminated
+    marker: treating the rest of the document as quoted would exempt everything
+    after a stray quote mark from the em-dash rule.
+    """
+    out: list[tuple[int, int]] = []
+    for opener, closer in (('"', '"'), ("“", "”")):
+        pos = 0
+        while True:
+            start = text.find(opener, pos)
+            if start == -1:
+                break
+            end = text.find(closer, start + 1)
+            if end == -1:
+                break
+            out.append((start, end + 1))
+            pos = end + 1
+    return out
+
+
 def _line_starts(text: str) -> list[int]:
     starts = [0]
     for i, ch in enumerate(text):
@@ -319,13 +399,29 @@ def _case_content_violations(
     return sorted(out, key=lambda v: v.line)
 
 
-def _literal_violations(text: str, line_starts: list[int]) -> list[Violation]:
+def _literal_violations(
+    text: str,
+    line_starts: list[int],
+    em_dash_exempt: list[tuple[int, int]] | None = None,
+) -> list[Violation]:
     """Em dashes (house style + drafting rule 7) and HTML comments (drafting gate
-    9: a reservation that vanishes on render was never reserved)."""
+    9: a reservation that vanishes on render was never reserved).
+
+    ``em_dash_exempt`` is empty for a TEMPLATE — a skeleton has no quotations of
+    its own, and exempting spans there would only create a way to smuggle house
+    style violations past the gate. A filled draft passes its quoted passages,
+    because the record's words are not ours to restyle (see
+    :func:`find_draft_violations`). HTML comments are never exempt on either
+    path: a comment inside a quotation still renders as nothing.
+    """
+    exempt = em_dash_exempt or []
     out: list[Violation] = []
     seen_em: set[int] = set()
     start = text.find(_EM_DASH)
     while start != -1:
+        if _in_spans(start, exempt):
+            start = text.find(_EM_DASH, start + 1)
+            continue
         line = _line_of(line_starts, start)
         if line not in seen_em:
             seen_em.add(line)

--- a/operator/connectors/smokeball/smokeball_connector/server.py
+++ b/operator/connectors/smokeball/smokeball_connector/server.py
@@ -1199,6 +1199,96 @@ def render_docx_template(
     return out
 
 
+@server.tool()
+def render_docx_draft(
+    matter_id: str,
+    file_name: str,
+    draft_markdown: str,
+    folder_id: str | None = None,
+) -> Any:
+    """Render a FILLED DRAFT (markdown) to a real Word .docx and file it on a
+    matter, for attorney review. The sibling of ``render_docx_template``, and the
+    difference between them is which artifact you have.
+
+    **Use this one for a draft: a demand letter, discovery responses, a brief.**
+    Use ``render_docx_template`` for a reusable skeleton. A draft filed through
+    the template tool will be refused on every case fact it contains, because a
+    template is refused for exactly what a draft is made of.
+
+    WHY IT EXISTS. Until this, the only .docx path was the template renderer, so
+    a filled demand letter could not become a Word document at all and was filed
+    as .txt. An attorney cannot edit that in Word, and "here is your demand
+    letter, as a text file" is not the deliverable.
+
+    **The content gate refuses; it never repairs.** Nothing is rendered or
+    uploaded until the markdown passes, and the whole violation list comes back
+    in ``refusals`` with ``fileId: null``. Three rules, each mechanical:
+
+    - malformed marker syntax (unbalanced ``{{``/``}}``, or an empty marker),
+    - an em dash OUTSIDE a quoted passage. House style bans them; the drafting
+      checker requires quotations to appear verbatim in a source. A record whose
+      quoted words contain an em dash can satisfy only one of those, so the quote
+      wins. Restyling the record's words to satisfy our house style would be a
+      misquotation, which is a far worse defect than a dash,
+    - an HTML comment. Drafting gate 9: ``<!-- ... -->`` renders as nothing, so a
+      reservation written that way is one the attorney never sees. In a draft the
+      reserved thing is usually the demand figure.
+
+    Case content is NOT refused here. Dates, figures, identifiers and case
+    numbers are the substance of the letter. What binds them is enforced
+    elsewhere and is stricter: every figure must trace to a source document.
+
+    **``{{FILL:}}``, ``{{NOT IN RECORD:}}`` and ``{{ATTORNEY:}}`` markers are
+    preserved and rendered visibly**, as literal unstyled runs. Do not resolve a
+    marker you cannot source and do not delete one to make the draft look
+    finished: an unresolved marker in front of the attorney is the point of the
+    draft, and a letter that looks complete when it is not is the failure this
+    whole lane exists to prevent.
+
+    ``file_name`` gains a ``.docx`` suffix if it lacks one. ``folder_id`` is
+    optional (matter root if omitted).
+
+    Returns ``fileId``, ``sha256`` and ``sizeBytes`` of the rendered bytes, and
+    an empty ``refusals``. Smokeball materialization is ASYNCHRONOUS and this
+    tool does not poll: confirm with ``get_file``, and confirm it is the document
+    with ``read_document``, before reporting it delivered.
+
+    Classified INTERNAL_WRITE at the overlay: the Operator saving its own work
+    product into the firm's record. Nothing leaves the firm; delivery to anyone
+    outside is a separate, separately-gated act."""
+    from .render import (
+        TemplateContentRefused,
+        check_draft_content,
+        render_markdown_to_docx,
+    )
+
+    if not file_name.lower().endswith(".docx"):
+        file_name = f"{file_name}.docx"
+    try:
+        check_draft_content(draft_markdown)
+    except TemplateContentRefused as exc:
+        return {
+            "matterId": matter_id,
+            "fileName": file_name,
+            "fileId": None,
+            "sha256": None,
+            "sizeBytes": None,
+            "refusals": [str(v) for v in exc.violations],
+        }
+    data = render_markdown_to_docx(draft_markdown)
+    result = add_file(
+        matter_id,
+        file_name,
+        content_base64=base64.b64encode(data).decode("ascii"),
+        folder_id=folder_id,
+    )
+    out = dict(result) if isinstance(result, dict) else {"result": result}
+    out["sha256"] = hashlib.sha256(data).hexdigest()
+    out["sizeBytes"] = len(data)
+    out["refusals"] = []
+    return out
+
+
 # ---- Memos ----------------------------------------------------------------
 #
 # Lean lossless representation (context-cost fix): Smokeball returns BOTH an RTF

--- a/operator/connectors/smokeball/tests/test_conformance.py
+++ b/operator/connectors/smokeball/tests/test_conformance.py
@@ -61,6 +61,7 @@ EXPECTED_TOOLS = {
     "create_webhook_subscription",
     "create_memo",
     "render_docx_template",
+    "render_docx_draft",
 }
 
 _SCRIPT = shutil.which("smokeball-mcp")
@@ -140,6 +141,11 @@ def test_write_surface_is_memo_document_and_deadline_engine() -> None:
         # gated markdown skeleton server-side and files it into the matter via
         # the same two-stage upload as add_file. Bytes never transit the model.
         "render_docx_template": "internal_write",
+        # The FILLED-DRAFT producer (ss-console#2258). Same class and same
+        # reasoning as its template sibling: the Operator saving its own work
+        # product into the firm's record, bytes never transiting the model. The
+        # two differ only in which artifact their content gate is written for.
+        "render_docx_draft": "internal_write",
     }
 
 

--- a/operator/connectors/smokeball/tests/test_render_docx_draft.py
+++ b/operator/connectors/smokeball/tests/test_render_docx_draft.py
@@ -1,0 +1,277 @@
+"""Unit coverage for ``render_docx_draft`` — the .docx FILLED-DRAFT producer.
+
+The template renderer and this one are the same machine pointed at opposite
+artifacts, so almost every test here is a pair: the same input, refused by one
+gate and accepted by the other. That pairing is the contract. If both gates ever
+agree about case content, one of them is wrong.
+
+Three things this file is really protecting:
+
+1. **Case content passes.** A demand letter is dates and dollar figures. The
+   template gate refuses those for a good reason that does not apply here, and
+   the consequence of getting it wrong is the one already observed on the pilot:
+   the draft could not be a .docx at all and was filed as a .txt an attorney
+   cannot edit in Word.
+2. **Markers survive, visibly.** A draft whose ``{{ATTORNEY:}}`` marker was
+   silently resolved or dropped looks finished. That is worse than a refusal,
+   because it is invisible.
+3. **The em-dash carve-out is bounded to quotations.** The record's words are
+   not ours to restyle; our own prose is.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+
+import httpx
+import pytest
+
+from smokeball_connector import server
+from smokeball_connector.extract import _docx_text
+from smokeball_connector.render import (
+    TemplateContentRefused,
+    check_draft_content,
+    check_template_content,
+    find_draft_violations,
+    find_violations,
+    render_markdown_to_docx,
+)
+
+_UPLOAD_URL = "https://s3.example.com/apiuploads/draft-1?X-Amz-Signature=deadbeef"
+
+_FILLED_DRAFT = """# DEMAND LETTER DRAFT - ATTORNEY REVIEW REQUIRED
+
+Matter 2026-PI-104. Date of loss November 2, 2025.
+
+## Medical specials
+
+- Kaiser Permanente Sacramento, emergency department: $6,240.00
+- Sierra Imaging Associates, MRI lumbar spine: $3,150.00
+- Total billed: $25,430.00
+
+## Wage loss
+
+Mr Whitfield lost $27,750.00 in wages between 2025-11-03 and 2026-03-08.
+
+## Reserved
+
+{{ATTORNEY: decision reserved - the demand figure, and whether damages exceed
+the disclosed each-occurrence limit}}
+
+{{NOT IN RECORD: final DHCS itemization, searched the lien correspondence}}
+"""
+
+
+def _draft_rules(markdown: str) -> list[str]:
+    return [v.rule for v in find_draft_violations(markdown)]
+
+
+# ---- The inversion: case content ------------------------------------------
+
+
+def test_a_filled_draft_passes_the_draft_gate() -> None:
+    assert find_draft_violations(_FILLED_DRAFT) == []
+    check_draft_content(_FILLED_DRAFT)  # does not raise
+
+
+def test_the_same_draft_is_refused_by_the_TEMPLATE_gate() -> None:
+    """The pairing that makes the first test mean something. If this ever stops
+    failing, the two gates have collapsed into one and the template rule that
+    keeps one matter's facts out of every future matter is gone."""
+    rules = [v.rule for v in find_violations(_FILLED_DRAFT)]
+    assert "case-content" in rules
+    with pytest.raises(TemplateContentRefused):
+        check_template_content(_FILLED_DRAFT)
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        "2024-03-01",
+        "3/1/2024",
+        "March 1, 2024",
+        "$4,500.00",
+        "$250",
+        "ZZ-9999-0001",
+        "2026-PI-102",
+        "000123-000456",
+        "1234567",
+    ],
+)
+def test_every_case_content_shape_the_template_refuses_is_allowed_in_a_draft(content: str) -> None:
+    """Each of these is refused by the template gate BY DESIGN and is required
+    in a draft. Parametrized against the same list the template tests use, so
+    the two files disagree explicitly rather than by omission."""
+    body = f"The record establishes {content} on this matter.\n"
+    assert "case-content" in [v.rule for v in find_violations(body)]
+    assert find_draft_violations(body) == []
+
+
+# ---- What the draft gate KEEPS ---------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "broken",
+    [
+        "A sentence with {{FILL: unterminated marker\n",
+        "A sentence with a stray }} close\n",
+        "An {{}} empty marker\n",
+    ],
+)
+def test_malformed_markers_are_still_refused(broken: str) -> None:
+    """An unterminated marker is a sentence fragment a reader answers as prose.
+    That is true of a draft exactly as it is of a template."""
+    assert _draft_rules(broken), f"{broken!r} produced no violation"
+
+
+def test_html_comments_are_still_refused() -> None:
+    """Drafting gate 9, and MORE load-bearing in a draft than in a template: the
+    thing usually written in a comment is the reservation, and a reservation
+    that renders as nothing is one the attorney never sees."""
+    assert "html-comment" in _draft_rules("Body text.\n\n<!-- reserved: the demand figure -->\n")
+
+
+def test_an_em_dash_in_our_own_prose_is_still_refused() -> None:
+    assert "em-dash" in _draft_rules("We reviewed the record — carefully.\n")
+
+
+# ---- The em-dash carve-out, and its bounds ---------------------------------
+
+
+def test_an_em_dash_inside_a_quotation_is_allowed() -> None:
+    """House style bans em dashes; the drafting checker requires quotations to
+    appear VERBATIM in a source. A record whose quoted words contain an em dash
+    can satisfy only one of those. The quote wins, because restyling the
+    record's words is a misquotation and that is the worse defect."""
+    body = 'The report reads "the lane looked clear — nothing ahead" at 24:7.\n'
+    assert find_draft_violations(body) == []
+
+
+def test_the_carve_out_does_not_leak_past_the_closing_quote() -> None:
+    """The exemption is the quoted span, not the rest of the document."""
+    body = 'He said "the lane looked clear" and then we — the firm — followed up.\n'
+    assert "em-dash" in _draft_rules(body)
+
+
+def test_an_unterminated_quote_exempts_nothing() -> None:
+    """Same fail-toward-refusing choice the marker scanner makes: treating the
+    rest of the document as quoted would let one stray quote mark disable the
+    rule for everything after it."""
+    body = 'He said "the lane looked clear and then we — the firm — followed up.\n'
+    assert "em-dash" in _draft_rules(body)
+
+
+def test_curly_quotes_are_honored_too() -> None:
+    """A record pasted from Word carries curly quotes. Honoring only straight
+    ones would refuse exactly the quotations most likely to be real."""
+    body = "The report reads “the lane looked clear — nothing ahead” at 24:7.\n"
+    assert find_draft_violations(body) == []
+
+
+def test_a_template_gets_no_quote_carve_out() -> None:
+    """A skeleton has no quotations of its own, so exempting spans there would
+    only create a way past house style."""
+    body = 'A skeleton line with "a quoted — passage" in it.\n'
+    assert "em-dash" in [v.rule for v in find_violations(body)]
+
+
+# ---- Markers survive the render, visibly -----------------------------------
+
+
+def test_markers_render_verbatim_and_visible() -> None:
+    """Read back through the same extractor ``read_document`` uses, so this
+    asserts what the attorney would actually see in the filed document."""
+    text = _docx_text(render_markdown_to_docx(_FILLED_DRAFT))
+    assert "{{ATTORNEY: decision reserved" in text
+    assert "{{NOT IN RECORD: final DHCS itemization" in text
+    assert "$25,430.00" in text
+    assert "Date of loss November 2, 2025." in text
+
+
+def test_a_marker_containing_emphasis_characters_survives_intact() -> None:
+    markdown = "Body {{FILL: the *styled* caption | matter record}} tail.\n"
+    text = _docx_text(render_markdown_to_docx(markdown))
+    assert "{{FILL: the *styled* caption | matter record}}" in text
+
+
+# ---- The tool ---------------------------------------------------------------
+
+
+def _mock_client(handler) -> object:
+    from smokeball_connector.client import SmokeballClient
+
+    client = SmokeballClient(
+        region="us",
+        environment="staging",
+        client_id="cid",
+        client_secret="sec",
+        api_key="apikey",
+    )
+    client._http = httpx.Client(transport=httpx.MockTransport(handler))
+    return client
+
+
+def _handler(captured: list[httpx.Request]):
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        path = request.url.path
+        if path.endswith("/oauth2/token"):
+            return httpx.Response(
+                200, json={"access_token": "tok", "expires_in": 3600, "token_type": "Bearer"}
+            )
+        if request.method == "POST" and path.endswith("/documents/files"):
+            return httpx.Response(202, json={"fileId": "file-77", "uploadUrl": _UPLOAD_URL})
+        if str(request.url) == _UPLOAD_URL:
+            return httpx.Response(200)
+        return httpx.Response(200, json={"ok": True})
+
+    return handler
+
+
+def test_tool_files_the_rendered_draft(monkeypatch) -> None:
+    captured: list[httpx.Request] = []
+    monkeypatch.setattr(server, "_get_client", lambda: _mock_client(_handler(captured)))
+
+    out = server.render_docx_draft("m-104", "Demand Letter Draft", _FILLED_DRAFT)
+
+    assert out["fileId"] == "file-77"
+    assert out["fileName"] == "Demand Letter Draft.docx"
+    assert out["refusals"] == []
+    put = next(r for r in captured if r.method == "PUT")
+    assert hashlib.sha256(put.content).hexdigest() == out["sha256"]
+    assert len(put.content) == out["sizeBytes"]
+    assert "{{ATTORNEY: decision reserved" in _docx_text(put.content)
+
+
+def test_tool_refuses_without_uploading_anything(monkeypatch) -> None:
+    """A refusal must not leave a partial artifact on the matter. The attorney
+    would have no way to tell it apart from a finished one."""
+    captured: list[httpx.Request] = []
+    monkeypatch.setattr(server, "_get_client", lambda: _mock_client(_handler(captured)))
+
+    out = server.render_docx_draft("m-104", "Bad Draft", "Body — dash.\n\n<!-- hidden -->\n")
+
+    assert out["fileId"] is None
+    assert out["sha256"] is None
+    assert len(out["refusals"]) == 2
+    assert not [r for r in captured if r.method == "PUT"]
+    assert not [r for r in captured if r.method == "POST" and r.url.path.endswith("/documents/files")]
+
+
+def test_tool_adds_the_docx_suffix(monkeypatch) -> None:
+    captured: list[httpx.Request] = []
+    monkeypatch.setattr(server, "_get_client", lambda: _mock_client(_handler(captured)))
+    out = server.render_docx_draft("m-104", "No Suffix", _FILLED_DRAFT)
+    assert out["fileName"] == "No Suffix.docx"
+
+
+def test_tool_sends_base64_it_computed_itself(monkeypatch) -> None:
+    """``add_file`` bans model-composed base64 (#2055) and names the renderer as
+    the carve-out. The bytes on the wire must be the ones this tool encoded."""
+    captured: list[httpx.Request] = []
+    monkeypatch.setattr(server, "_get_client", lambda: _mock_client(_handler(captured)))
+    server.render_docx_draft("m-104", "Draft", _FILLED_DRAFT)
+    put = next(r for r in captured if r.method == "PUT")
+    assert base64.b64encode(put.content)  # round-trips; bytes are real docx bytes
+    assert put.content[:2] == b"PK", "a .docx is a zip container"


### PR DESCRIPTION
## Summary

Rehearsing card 18 on the pilot 2026-08-12 produced a good demand draft: specials traced, the settlement figure reserved behind `{{FILL}}` markers, a privilege wall around the firm-prepared chronology built unasked. **It was filed as a `.txt`, because there was nowhere else for it to go.**

`render_docx_template` is the only .docx path and it is a **template** renderer. Its gate refuses case content for a sound reason — *"content that reaches a template reaches every future matter the template is filled for"* — and a filled demand letter is case content top to bottom. So the one artifact the firm most needs in Word was the one artifact that could not be rendered.

## The sibling, with the gate inverted

Same docx builder, same two-stage upload.

| rule | template | draft |
| --- | --- | --- |
| case content (dates, figures, identifiers) | refused | **required — it is the letter** |
| `{{FILL:}}` / `{{NOT IN RECORD:}}` / `{{ATTORNEY:}}` | refused | **preserved, rendered visibly** |
| malformed marker syntax | refused | refused |
| em dash | refused | refused **outside quoted passages** |
| HTML comment | refused | refused |

Case content is not refused here because refusing it would not add a control. Every figure is already bound to trace to a source by rules enforced elsewhere: the drafting discipline's ten mechanical gates, the A1 identifier provenance gate, and the skill's own *"name the source in the same sentence"*.

## The em-dash carve-out is decided, not discovered

House style bans em dashes; the drafting checker requires quotations to appear **verbatim** in a source. A medical record whose quoted words contain an em dash can satisfy only one of those, and the two ways out are to misquote the record or drop the quote. Both are worse than a dash. **The quote wins: house style governs our prose, never the record's words.**

Bounded to closed quotation spans, straight and curly. An unterminated quote exempts nothing — the same fail-toward-refusing choice the marker scanner already makes.

## 27 tests, and most are pairs

The same input accepted by one gate and refused by the other. That pairing is the contract: **if the two gates ever agree about case content, one of them is wrong**, and `test_the_same_draft_is_refused_by_the_TEMPLATE_gate` is what says so.

Marker preservation is verified by reading the rendered .docx back through `extract._docx_text` — the same extractor `read_document` uses — so it asserts what the attorney would actually see, not what the renderer intended.

## The conformance oracle did its job

It caught the unclassified tool immediately: *"live tools ['render_docx_draft'] are neither classified nor listed as expected-unclassified — they would fall through to the fail-closed default at runtime."* `manifest.toml` `tool_classes` and the conformance expectations now carry the entry.

## Test plan

- [x] Smokeball connector suite **221 passed** in the CI-shaped per-connector venv
- [x] `npm run verify` exit 0
- [x] Overlay half **merged**: hermes-smd-overlay#266 maps `mcp_smokeball_render_docx_draft` → `INTERNAL_WRITE`, mutation-tested
- [ ] **(runtime)** The tool is UNREACHABLE on any seat until an `OVERLAY_REF` bump + reprovision — the fail-closed direction. Card 18 on the pre-suit matter is the proof, and it goes on #2258 with its verify id.

Refs #2258