### PR TITLE
chore(pilot): a staging-only memo delete, run by App 1 and never by the Operator

### DIFF
--- a/operator/customers/pilot-smokeball/seed/delete_memo.py
+++ b/operator/customers/pilot-smokeball/seed/delete_memo.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Remove a memo from a staging matter, through App 1 (our seeding app).
+
+WHY THIS EXISTS (2026-08-13, ss#2360). Measuring what a Smokeball envelope
+carries caused the Operator to write a supervision memo that states the wrong
+"how": an App-1 API change was recorded as an in-app touch by a person. That is
+a false record, and the staging tenant is also the corpus the establishment work
+reads back as examples of the firm's own output — so a wrong memo left in place
+can be learned from.
+
+WHY NOT THE OPERATOR. The Smokeball connector exposes `get_memos_on_matter` and
+`create_memo` and NOTHING ELSE for memos. The Operator structurally cannot delete
+one, which is correct: an agent that can erase its own supervision record is not
+a supervision record. This is our tooling reaching into our own rehearsal tenant,
+on the same App 1 that seeded it — deliberately a different hand than the agent's.
+
+STAGING ONLY. Refuses unless the resolved host is the staging API. Never point
+this at a client tenant; a wrong entry in a real supervision log is corrected by
+a correcting entry, not by deletion.
+
+USAGE
+    cd operator/customers/pilot-smokeball/seed
+    infisical run --env=prod --path=/ss -- python3 delete_memo.py \
+        --matter <matterId> --memo <memoId> [--apply]
+
+Dry-run by default: prints what it would delete and exits. `--apply` performs it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from seed_staging import API_HOST, Api
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--matter", required=True, help="matter GUID")
+    ap.add_argument("--memo", required=True, help="memo GUID")
+    ap.add_argument("--apply", action="store_true", help="actually delete (default: dry run)")
+    args = ap.parse_args()
+
+    if "staging" not in API_HOST:
+        sys.exit(f"refusing: API_HOST is {API_HOST!r}, which is not the staging tenant")
+
+    api = Api()
+
+    # Read it back first. Deleting by an id you have not looked at is how the
+    # wrong record gets removed.
+    code, memos = api.call("GET", f"/matters/{args.matter}/memos")
+    if code != 200 or not isinstance(memos, dict):
+        sys.exit(f"could not read memos on {args.matter}: HTTP {code} {memos}")
+
+    items = memos.get("value") or memos.get("items") or []
+    target = next((m for m in items if isinstance(m, dict) and m.get("id") == args.memo), None)
+    if target is None:
+        sys.exit(f"memo {args.memo} not found on matter {args.matter} — nothing to do")
+
+    print("TARGET:")
+    print(json.dumps({k: target.get(k) for k in ("id", "plainText", "createdDate", "isDeleted")}, indent=2))
+
+    if not args.apply:
+        print("\nDRY RUN — re-run with --apply to delete.")
+        return
+
+    code, resp = api.call("DELETE", f"/matters/{args.matter}/memos/{args.memo}")
+    print(f"\nDELETE -> HTTP {code} {resp if resp else ''}")
+
+    code, after = api.call("GET", f"/matters/{args.matter}/memos")
+    remaining = (after.get("value") or after.get("items") or []) if isinstance(after, dict) else []
+    still = [m for m in remaining if isinstance(m, dict) and m.get("id") == args.memo]
+    print(f"VERIFY: memo present after delete = {bool(still)}")
+    if still:
+        print(json.dumps({k: still[0].get(k) for k in ("id", "isDeleted")}, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Support tool for #2360.

## Why the Operator cannot do this

`smokeball_connector` exposes `get_memos_on_matter` and `create_memo` — and nothing else for memos. **An agent that can erase its own supervision record is not a supervision record.** That property is worth keeping, so this sits deliberately *outside* the connector: our seeding app, the same App 1 that hydrated the tenant, a different hand than the agent's.

## Why it exists at all

Measuring what a Smokeball envelope carries caused the Operator to write two memos that state the wrong "how" — an App-1 API change recorded as an in-app touch by a person (#2360). Captain's call was to remove one. There was no tool.

## Guards

- **Staging only** — refuses unless the resolved `API_HOST` is the staging tenant. A wrong entry in a *real* supervision log is corrected by a correcting entry, never by deletion.
- **Dry run by default** — `--apply` required.
- **Reads the memo back and prints it first** — deleting by an id you have not looked at is how the wrong record gets removed.
- **Verifies after**, and reports honestly if the record is still there.

That last guard earned itself immediately. The vendor returned **HTTP 202 and an immediate re-read still showed the memo.** It was gone minutes later. 202 is *accepted*, not done — the same shape as an `outcome=sent` that has not been delivered. A tool that trusted the 202, or trusted its own fast read-back, would have reported the opposite of the truth in both directions.

## Used once

Memo `84990eb9` removed from staging matter `404b292e` — `vfy_01KZYEJKZF1Q4W8MZ1S29D7SFR`.

The `trial-okafor` memo is **deliberately left in place**: it is the live reproduction #2360's runtime AC will be verified against, and deleting the evidence of an open bug would be its own mistake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLzzpTuYY8j3EaWbXfxz4x