### PR TITLE
chore(deps): nanoid 3.3.16 -> 3.3.18 via override; empty the audit allowlist (#2196)

### DIFF
--- a/.github/audit-allowlist.json
+++ b/.github/audit-allowlist.json
@@ -1,9 +1,6 @@
 {
-  "$comment": "Time-boxed npm-audit exceptions. Each entry is a GHSA the CI audit gate will tolerate at high/critical severity UNTIL `expires`. After that date the allowlist is ignored and the gate fails again, forcing resolution. Consumed by scripts/audit-allowlist.mjs (Security workflow). This is NOT a place to silence real exposure: every entry must be triaged non-reachable in this app and tracked to a fix.",
-  "expires": "2026-08-14",
-  "tracking": "https://github.com/venturecrane/ss-console/issues/2196",
-  "reason": "Full reset 2026-08-09. Every Astro-6-era entry from the previous (expired 2026-08-04) allowlist was cleared for real by the shipped Astro 7 migration plus the 2026-08-09 dependency-bump pass: overrides raised to fast-uri 3.1.5, undici ^7.29.0, brace-expansion ^5.0.9, js-yaml ^4.3.1, postcss 8.5.23, nanoid@^5 ^5.1.16 (root), and wrangler 4.118.0 + matching overrides in workers/fleet-alerts, workers/cost-anomaly, workers/cost-telemetry (each now audits to 0 vulnerabilities). The single remaining advisory is nanoid <3.3.17: the fix (3.3.17, published 2026-08-03) is blocked by the .npmrc min-release-age=7 supply-chain cooldown until 2026-08-10. This is exactly the scenario this allowlist exists for; expiry gives 4 days of margin past the cooldown, and #2196 tracks the bump.",
-  "allow": {
-    "GHSA-2v37-7h3g-55p8": "nanoid <3.3.17: custom generators can loop indefinitely when size is zero. Not reachable: root-tree consumers are postcss (nanoid/non-secure with fixed size 6, build-time source-map input ids) and ics (default nanoid(), fixed size 21, booking calendar UIDs). Neither uses customRandom/customAlphabet nor passes caller-controlled size, both of which the advisory requires. Fix lands via #2196 once the 7-day cooldown clears on 2026-08-10."
-  }
+  "$comment": "Time-boxed npm-audit exceptions. Each entry is a GHSA the CI audit gate will tolerate at high/critical severity UNTIL `expires`. After that date the allowlist is ignored and the gate fails again, forcing resolution. Consumed by scripts/audit-allowlist.mjs (Security workflow). This is NOT a place to silence real exposure: every entry must be triaged non-reachable in this app and tracked to a fix. Currently EMPTY: the last entry (GHSA-2v37-7h3g-55p8, nanoid <3.3.18) was cleared on 2026-08-14 by the nanoid@^3 -> ^3.3.18 override (#2196); root and all workers/* trees audit to 0.",
+  "expires": null,
+  "tracking": null,
+  "allow": {}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2362,9 +2362,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2382,9 +2379,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2402,9 +2396,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2422,9 +2413,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2442,9 +2430,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2462,9 +2447,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2482,9 +2464,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2502,9 +2481,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2739,9 +2715,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2756,9 +2729,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2773,9 +2743,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2790,9 +2757,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2807,9 +2771,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2824,9 +2785,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2841,9 +2799,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2858,9 +2813,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7664,9 +7616,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "brace-expansion": "^5.0.9",
     "js-yaml": "^4.3.1",
     "postcss": "8.5.23",
+    "nanoid@^3": "^3.3.18",
     "nanoid@^5": "^5.1.16"
   }
 }


### PR DESCRIPTION
The allowlist expires **today** (2026-08-14); this lands the tracked fix so the daily Security run stays green.

- GHSA-2v37-7h3g-55p8 range is `<3.3.18` (advisory widened past the allowlist's '3.3.17' note)
- Adds `nanoid@^3: ^3.3.18` override — the existing `^5` override only covered the Clerk chain, not the `ics`/`postcss` 3.x line
- `npm audit`: **0 vulnerabilities**; the exact CI gate invocation (`node scripts/audit-allowlist.mjs . workers/*`) run locally: **passed** with the emptied allowlist
- Evidence: vfy_01M01REMFS54236QKNCV4XVCCC

Closes #2196

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLzzpTuYY8j3EaWbXfxz4x