### PR TITLE
fix(auth): only Clerk's verified primary email can auto-link or JIT-create a portal user

### DIFF
--- a/src/lib/auth/clerk-bridge.ts
+++ b/src/lib/auth/clerk-bridge.ts
@@ -44,7 +44,13 @@ export interface PortalUserRow {
 }
 
 export interface ClerkUserProfile {
-  email: string
+  /**
+   * Clerk's VERIFIED PRIMARY email, or null when Clerk holds no verified
+   * primary address (see src/lib/auth/clerk-profile.ts). Null disables
+   * email-based auto-linking and JIT creation in ensureLocalUser — an
+   * unverified address must never bind a Clerk identity to a local row.
+   */
+  email: string | null
   name: string
 }
 
@@ -66,12 +72,17 @@ export interface PortalContext {
  * role='admin'. That path never JIT-creates a row, so admin cannot be
  * self-provisioned through this bridge. Magic-link auth survives only as
  * a legacy portal fallback for in-flight client invitations.
+ *
+ * Returns null when the Clerk user has no existing binding AND no trusted
+ * (verified primary) email: with nothing to key on, auto-linking would
+ * trust an unverified address and JIT creation would fabricate an
+ * identity. Callers treat null as "no portal access".
  */
 export async function ensureLocalUser(
   db: D1Database,
   clerkUserId: string,
   profile: ClerkUserProfile
-): Promise<PortalUserRow> {
+): Promise<PortalUserRow | null> {
   const existing = await db
     .prepare('SELECT * FROM users WHERE clerk_user_id = ?')
     .bind(clerkUserId)
@@ -79,13 +90,20 @@ export async function ensureLocalUser(
 
   if (existing) return existing
 
+  // No trusted email → no email-based linking, no JIT creation. An
+  // already-bound user resolved above regardless; a new-to-SS Clerk user
+  // without a verified primary address gets the explicit "no access"
+  // state, never a fabricated or mis-linked row.
+  if (!profile.email) return null
+
   // Auto-link path: a users row may already exist for this email from
   // before the Clerk migration (or from an admin-created client invite
   // that hasn't been redeemed via Clerk yet). UNIQUE(org_id, email) means
   // we cannot INSERT a duplicate row; we must bind the existing row to
   // this Clerk identity instead. Only links when clerk_user_id IS NULL
   // so we never overwrite an existing binding. Email comes from Clerk's
-  // verified primary email, which is the trust anchor.
+  // verified primary email, which is the trust anchor — ENFORCED by the
+  // null-guard above + clerk-profile.ts (unverified addresses never get here).
   //
   // Matched through the shared identity normalization (src/lib/identity/email.ts):
   // trimmed and lowercased on the input side, `lower()` on the column side.
@@ -192,6 +210,11 @@ async function resolveEntityByUserBinding(
  * The two paths coexist because Operator features still need Clerk
  * Organizations for multi-user matter access; direct binding via
  * entity_id is the simpler path for single-user portal access.
+ *
+ * Also returns null when ensureLocalUser cannot establish a local row
+ * (unbound Clerk user with no verified primary email) — the caller's
+ * sign-in redirect converges on the no_subscription state via
+ * /auth/after-sign-in.
  */
 export async function resolveClerkPortalContext(
   db: D1Database,
@@ -202,6 +225,7 @@ export async function resolveClerkPortalContext(
   if (!auth.userId) return null
 
   const user = await ensureLocalUser(db, auth.userId, profile)
+  if (!user) return null
 
   let client: Entity | null = null
   if (user.entity_id) {

--- a/src/lib/auth/clerk-profile.ts
+++ b/src/lib/auth/clerk-profile.ts
@@ -1,0 +1,54 @@
+/**
+ * Trusted profile extraction from a Clerk user.
+ *
+ * The email returned here feeds ensureLocalUser (clerk-bridge.ts), whose
+ * auto-link path binds a Clerk identity to a pre-existing local users row
+ * purely by email match. That makes the email a trust anchor: an address
+ * that Clerk has NOT verified must never reach the auto-link path, or an
+ * attacker-added secondary address could bind their Clerk identity to
+ * another person's client seat (invoices, SOWs, documents).
+ *
+ * Policy: only Clerk's verified PRIMARY email is trusted. Anything else —
+ * missing primary, unverified primary — yields email: null, and the bridge
+ * refuses to auto-link or JIT-create (2026-08-14 code-review finding; the
+ * previous fallback to emailAddresses[0] contradicted the bridge's own
+ * "verified primary is the trust anchor" contract).
+ *
+ * Typed structurally (not against @clerk/astro's User) so the bridge and
+ * tests stay decoupled from Clerk's SDK types; the real Clerk user object
+ * satisfies this shape.
+ */
+
+export interface ClerkEmailLike {
+  emailAddress: string
+  verification?: { status?: string | null } | null
+}
+
+export interface ClerkUserLike {
+  primaryEmailAddress?: ClerkEmailLike | null
+  firstName?: string | null
+  lastName?: string | null
+  username?: string | null
+}
+
+/** The verified primary email address, or null when there is no trusted email. */
+export function verifiedPrimaryEmail(clerkUser: ClerkUserLike): string | null {
+  const primary = clerkUser.primaryEmailAddress
+  if (!primary?.emailAddress) return null
+  return primary.verification?.status === 'verified' ? primary.emailAddress : null
+}
+
+/**
+ * Extract the email + display name we persist locally from a Clerk user.
+ * email is null when Clerk holds no verified primary address — callers
+ * pass it through to ensureLocalUser, which then refuses email-based
+ * linking and JIT creation.
+ */
+export function clerkProfile(clerkUser: ClerkUserLike): { email: string | null; name: string } {
+  const email = verifiedPrimaryEmail(clerkUser)
+  const name =
+    [clerkUser.firstName, clerkUser.lastName].filter(Boolean).join(' ').trim() ||
+    clerkUser.username ||
+    (email ?? '')
+  return { email, name }
+}

--- a/src/lib/portal/session.ts
+++ b/src/lib/portal/session.ts
@@ -18,6 +18,7 @@
  */
 
 import { resolveClerkPortalContext, type PortalContext } from '../auth/clerk-bridge'
+import { clerkProfile } from '../auth/clerk-profile'
 
 export type { PortalContext } from '../auth/clerk-bridge'
 
@@ -40,17 +41,13 @@ export async function getPortalClient(
   const clerkUser = await locals.currentUser()
   if (!clerkUser) return null
 
-  const email =
-    clerkUser.primaryEmailAddress?.emailAddress ?? clerkUser.emailAddresses[0]?.emailAddress ?? ''
-  const name =
-    [clerkUser.firstName, clerkUser.lastName].filter(Boolean).join(' ').trim() ||
-    clerkUser.username ||
-    email
-
   return resolveClerkPortalContext(
     db,
     { userId: auth.userId, orgId: auth.orgId, sessionId: auth.sessionId },
-    { email, name },
+    // Verified-primary-only email extraction (clerk-profile.ts): an
+    // unverified address yields email:null and the bridge refuses to
+    // auto-link or JIT-create.
+    clerkProfile(clerkUser),
     // Fire-and-forget on the Workers request path; awaited when no
     // ExecutionContext is available (local dev, tests).
     { waitUntil: locals.cfContext ? (p) => locals.cfContext!.waitUntil(p) : undefined }

--- a/src/pages/auth/after-sign-in.ts
+++ b/src/pages/auth/after-sign-in.ts
@@ -10,6 +10,7 @@ import {
   getPortalBaseUrl,
 } from '../../lib/config/app-url'
 import { chooseSignedInSurface, hostnameOf } from '../../lib/auth/after-sign-in-target'
+import { clerkProfile } from '../../lib/auth/clerk-profile'
 
 /**
  * Post-sign-in dispatcher.
@@ -42,19 +43,6 @@ import { chooseSignedInSurface, hostnameOf } from '../../lib/auth/after-sign-in-
  * subdomain rewrite in src/middleware.ts handles routing on a single host.
  */
 
-type ClerkUser = NonNullable<Awaited<ReturnType<App.Locals['currentUser']>>>
-
-/** Extract the email + display name we persist locally from a Clerk user. */
-function clerkProfile(clerkUser: ClerkUser): { email: string; name: string } {
-  const email =
-    clerkUser.primaryEmailAddress?.emailAddress ?? clerkUser.emailAddresses[0]?.emailAddress ?? ''
-  const name =
-    [clerkUser.firstName, clerkUser.lastName].filter(Boolean).join(' ').trim() ||
-    clerkUser.username ||
-    email
-  return { email, name }
-}
-
 export const GET: APIRoute = async ({ locals, redirect, url }) => {
   const auth = locals.auth()
   if (!auth.userId) {
@@ -70,15 +58,21 @@ export const GET: APIRoute = async ({ locals, redirect, url }) => {
   }
 
   // Link/JIT the local row first; the admin shim then sees the linked row.
+  // Null when the Clerk user has no local binding AND no verified primary
+  // email (clerk-profile.ts) — nothing to key on, so no row is linked or
+  // created and both eligibility checks below fail closed to the
+  // no_subscription state.
   const userRow = await ensureLocalUser(env.DB, auth.userId, clerkProfile(clerkUser))
 
-  // Login accountability: record the sign-in at the true sign-in moment.
-  // Covers admin-only and dual-eligible users who may never hit a portal
-  // route (entity_id is NULL for admin-only). Never throws.
-  const loginEntityId =
-    userRow.entity_id ??
-    (auth.orgId ? ((await resolveClerkEntity(env.DB, auth.orgId))?.id ?? null) : null)
-  await stampLoginIfNewSession(env.DB, userRow, auth.sessionId, loginEntityId)
+  if (userRow) {
+    // Login accountability: record the sign-in at the true sign-in moment.
+    // Covers admin-only and dual-eligible users who may never hit a portal
+    // route (entity_id is NULL for admin-only). Never throws.
+    const loginEntityId =
+      userRow.entity_id ??
+      (auth.orgId ? ((await resolveClerkEntity(env.DB, auth.orgId))?.id ?? null) : null)
+    await stampLoginIfNewSession(env.DB, userRow, auth.sessionId, loginEntityId)
+  }
 
   const adminSession = await resolveAdminSessionFromClerk(auth.userId, env.DB, env.SESSIONS)
 
@@ -87,7 +81,9 @@ export const GET: APIRoute = async ({ locals, redirect, url }) => {
   // bound to a customer entity is a legitimate portal (Operator) user. Per
   // operator-access.ts, in-product authorization keys off product_roles, not
   // users.role — so we must not exclude an admin from the portal seat here.
-  const portalEligible = Boolean(userRow.entity_id || auth.orgId)
+  // Requires a local row: without one, an active Clerk org alone must not
+  // grant a portal surface (getPortalClient would bounce it anyway).
+  const portalEligible = Boolean(userRow && (userRow.entity_id || auth.orgId))
 
   // Host-aware selection. Fail-safe: any throw falls back to chooseSignedInSurface
   // with unknown hosts, which yields the admin-first default — so a dispatcher

--- a/tests/clerk-bridge.test.ts
+++ b/tests/clerk-bridge.test.ts
@@ -7,8 +7,19 @@ import {
 import { resolve } from 'path'
 import type { D1Database } from '@cloudflare/workers-types'
 
-import { ensureLocalUser, resolveClerkPortalContext } from '../src/lib/auth/clerk-bridge'
+import {
+  ensureLocalUser,
+  resolveClerkPortalContext,
+  type PortalUserRow,
+} from '../src/lib/auth/clerk-bridge'
+import { clerkProfile, verifiedPrimaryEmail } from '../src/lib/auth/clerk-profile'
 import { ORG_ID } from '../src/lib/constants'
+
+/** Narrow ensureLocalUser's nullable return for the cases that expect a row. */
+function expectRow(row: PortalUserRow | null): PortalUserRow {
+  expect(row).not.toBeNull()
+  return row!
+}
 
 const migrationsDir = resolve(process.cwd(), 'migrations')
 
@@ -58,10 +69,12 @@ describe('ensureLocalUser', () => {
       .bind(boundClerkId, PRE_CLERK_USER_ID)
       .run()
 
-    const result = await ensureLocalUser(db, boundClerkId, {
-      email: PRE_CLERK_EMAIL,
-      name: 'Pre Clerk Client',
-    })
+    const result = expectRow(
+      await ensureLocalUser(db, boundClerkId, {
+        email: PRE_CLERK_EMAIL,
+        name: 'Pre Clerk Client',
+      })
+    )
 
     expect(result.id).toBe(PRE_CLERK_USER_ID)
     expect(result.clerk_user_id).toBe(boundClerkId)
@@ -80,7 +93,9 @@ describe('ensureLocalUser', () => {
     const upper = PRE_CLERK_EMAIL.toUpperCase()
     expect(upper).not.toBe(PRE_CLERK_EMAIL)
 
-    const result = await ensureLocalUser(db, newClerkId, { email: upper, name: 'Pre Clerk Client' })
+    const result = expectRow(
+      await ensureLocalUser(db, newClerkId, { email: upper, name: 'Pre Clerk Client' })
+    )
 
     // Linked the SEEDED row (with its entity binding) — not a new orphan.
     expect(result.id).toBe(PRE_CLERK_USER_ID)
@@ -99,10 +114,12 @@ describe('ensureLocalUser', () => {
     // that INSERT crash and left the pre-Clerk row orphaned.
     const newClerkId = 'user_first_sign_in'
 
-    const result = await ensureLocalUser(db, newClerkId, {
-      email: PRE_CLERK_EMAIL,
-      name: 'Pre Clerk Client',
-    })
+    const result = expectRow(
+      await ensureLocalUser(db, newClerkId, {
+        email: PRE_CLERK_EMAIL,
+        name: 'Pre Clerk Client',
+      })
+    )
 
     expect(result.id).toBe(PRE_CLERK_USER_ID)
     expect(result.clerk_user_id).toBe(newClerkId)
@@ -141,10 +158,12 @@ describe('ensureLocalUser', () => {
     // of the bound row. The impostor sign-in carries a verified Clerk
     // email; this asserts that even on email collision against a bound
     // row, the existing binding is preserved.
-    const result = await ensureLocalUser(db, impostorClerkId, {
-      email: 'impostor@example.com',
-      name: 'Impostor',
-    })
+    const result = expectRow(
+      await ensureLocalUser(db, impostorClerkId, {
+        email: 'impostor@example.com',
+        name: 'Impostor',
+      })
+    )
 
     expect(result.clerk_user_id).toBe(impostorClerkId)
     expect(result.id).not.toBe(PRE_CLERK_USER_ID)
@@ -158,16 +177,119 @@ describe('ensureLocalUser', () => {
 
   it('JIT-creates a fresh client row when no email or clerk_user_id matches', async () => {
     const newClerkId = 'user_brand_new'
-    const result = await ensureLocalUser(db, newClerkId, {
-      email: 'brand-new@example.com',
-      name: 'Brand New',
-    })
+    const result = expectRow(
+      await ensureLocalUser(db, newClerkId, {
+        email: 'brand-new@example.com',
+        name: 'Brand New',
+      })
+    )
 
     expect(result.clerk_user_id).toBe(newClerkId)
     expect(result.email).toBe('brand-new@example.com')
     expect(result.role).toBe('client')
     expect(result.entity_id).toBeNull()
     expect(result.id).not.toBe(PRE_CLERK_USER_ID)
+  })
+
+  // ── No trusted email (2026-08-14 review finding) ─────────────────────────
+  // clerk-profile.ts yields email:null when Clerk has no VERIFIED PRIMARY
+  // address. The bridge must then refuse email-based linking and JIT
+  // creation: an unverified address auto-linking to a seeded row would hand
+  // one person another person's client seat.
+
+  it('does NOT auto-link a pre-Clerk row when the profile carries no trusted email', async () => {
+    const result = await ensureLocalUser(db, 'user_no_trusted_email', {
+      email: null,
+      name: 'Untrusted',
+    })
+
+    expect(result).toBeNull()
+
+    // The seeded row stayed unlinked — the seat is still waiting for its
+    // real owner.
+    const seeded = await db
+      .prepare('SELECT clerk_user_id FROM users WHERE id = ?')
+      .bind(PRE_CLERK_USER_ID)
+      .first<{ clerk_user_id: string | null }>()
+    expect(seeded?.clerk_user_id).toBeNull()
+  })
+
+  it('does NOT JIT-create a row when the profile carries no trusted email', async () => {
+    const before = await db.prepare('SELECT COUNT(*) AS n FROM users').first<{ n: number }>()
+
+    const result = await ensureLocalUser(db, 'user_no_trusted_email_2', {
+      email: null,
+      name: '',
+    })
+    expect(result).toBeNull()
+
+    const after = await db.prepare('SELECT COUNT(*) AS n FROM users').first<{ n: number }>()
+    expect(after?.n).toBe(before?.n)
+  })
+
+  it('still resolves an already-bound row when the profile carries no trusted email', async () => {
+    // A user whose row is already keyed by clerk_user_id needs no email at
+    // all — losing primary-email verification later must not lock them out.
+    const boundClerkId = 'user_bound_then_unverified'
+    await db
+      .prepare('UPDATE users SET clerk_user_id = ? WHERE id = ?')
+      .bind(boundClerkId, PRE_CLERK_USER_ID)
+      .run()
+
+    const result = expectRow(
+      await ensureLocalUser(db, boundClerkId, { email: null, name: 'Whoever' })
+    )
+    expect(result.id).toBe(PRE_CLERK_USER_ID)
+    expect(result.entity_id).toBe(PRE_CLERK_ENTITY_ID)
+  })
+})
+
+describe('clerkProfile / verifiedPrimaryEmail', () => {
+  it('trusts a verified primary address', () => {
+    const user = {
+      primaryEmailAddress: {
+        emailAddress: 'owner@example.com',
+        verification: { status: 'verified' },
+      },
+      firstName: 'Pat',
+      lastName: 'Owner',
+    }
+    expect(verifiedPrimaryEmail(user)).toBe('owner@example.com')
+    expect(clerkProfile(user)).toEqual({ email: 'owner@example.com', name: 'Pat Owner' })
+  })
+
+  it('rejects an UNVERIFIED primary address', () => {
+    const user = {
+      primaryEmailAddress: {
+        emailAddress: 'attacker-added@example.com',
+        verification: { status: 'unverified' },
+      },
+    }
+    expect(verifiedPrimaryEmail(user)).toBeNull()
+    expect(clerkProfile(user).email).toBeNull()
+  })
+
+  it('rejects a primary address with no verification record', () => {
+    const user = { primaryEmailAddress: { emailAddress: 'x@example.com' } }
+    expect(verifiedPrimaryEmail(user)).toBeNull()
+  })
+
+  it('yields null when there is no primary address at all — never falls back to another address', () => {
+    // The pre-fix behavior fell back to emailAddresses[0]; the profile shape
+    // deliberately no longer even accepts that list.
+    expect(verifiedPrimaryEmail({ primaryEmailAddress: null })).toBeNull()
+    expect(clerkProfile({ primaryEmailAddress: null }).email).toBeNull()
+  })
+
+  it('derives name from username, never from an untrusted email', () => {
+    const user = {
+      primaryEmailAddress: {
+        emailAddress: 'x@example.com',
+        verification: { status: 'unverified' },
+      },
+      username: 'pat-o',
+    }
+    expect(clerkProfile(user)).toEqual({ email: null, name: 'pat-o' })
   })
 })
 
@@ -299,6 +421,16 @@ describe('resolveClerkPortalContext', () => {
       { userId: BOUND_CLERK_ID, orgId: null },
       { email: PRE_CLERK_EMAIL, name: 'Pre Clerk Client' }
     )
+    expect(await loginEvents()).toHaveLength(0)
+  })
+
+  it('returns null (no access, no rows, no login stamp) for an unbound user with no trusted email', async () => {
+    const ctx = await resolveClerkPortalContext(
+      db,
+      { userId: 'user_untrusted_new', orgId: null, sessionId: 'sess_untrusted' },
+      { email: null, name: 'Untrusted' }
+    )
+    expect(ctx).toBeNull()
     expect(await loginEvents()).toHaveLength(0)
   })
 })

--- a/tests/email-identity.test.ts
+++ b/tests/email-identity.test.ts
@@ -125,8 +125,8 @@ describe('ensureLocalUser — auto-link tolerates surrounding whitespace', () =>
       name: 'Seeded Client',
     })
 
-    expect(result.id).toBe(PRE_CLERK_USER_ID)
-    expect(result.entity_id).toBe(PRE_CLERK_ENTITY_ID)
+    expect(result?.id).toBe(PRE_CLERK_USER_ID)
+    expect(result?.entity_id).toBe(PRE_CLERK_ENTITY_ID)
 
     // No second, entity-less row was minted alongside the seeded one. Scoped
     // to the address: migrations/0005_seed_admin_user.sql seeds an unrelated


### PR DESCRIPTION
2026-08-14 code-review Security finding #1 (docs/reviews/code-review-2026-08-14.md, lands via #2374).

The bridge auto-links a Clerk identity to a pre-existing local `users` row purely by email match, with a comment declaring verified-primary the trust anchor — but both call sites fell back to `emailAddresses[0]`, so an unverified (attacker-addable) secondary address could theoretically bind to another person's client seat (invoices, SOWs, documents).

- New `src/lib/auth/clerk-profile.ts`: shared `clerkProfile()` (deduplicates `session.ts` + `after-sign-in.ts`), verified-primary-only; anything else yields `email: null`
- `ensureLocalUser` returns `null` when there is no existing binding and no trusted email — no auto-link, no JIT insert (previously `''` could be inserted as an email)
- `after-sign-in`: null row → both eligibilities fail closed to the existing `no_subscription` state. Already-bound rows resolve by `clerk_user_id` regardless of email, so nobody currently linked can be locked out.

Tests: 8 new cases (bridge refusal ×3, profile policy ×5); 135 pass across the four auth suites. Typecheck, lint, knip clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLzzpTuYY8j3EaWbXfxz4x