### PR TITLE
chore(auth): delete dead invalidateAdminSessionCache (test-only usage defeated knip)

### DIFF
--- a/src/lib/auth/admin-session-shim.ts
+++ b/src/lib/auth/admin-session-shim.ts
@@ -117,15 +117,10 @@ export async function resolveAdminSessionFromClerk(
   return sessionData
 }
 
-/**
- * Invalidate the cached admin session for a Clerk user_id. Call after any
- * mutation that changes the user's role or email (admin tools, future
- * settings flows). Optional — natural TTL expiry resolves stale state
- * within 120s either way.
- */
-export async function invalidateAdminSessionCache(
-  clerkUserId: string,
-  kv: KVNamespace
-): Promise<void> {
-  await kv.delete(`admin-session:${clerkUserId}`)
-}
+// An explicit invalidateAdminSessionCache(clerkUserId, kv) helper existed
+// here but had zero production call sites — no admin route mutates a user's
+// role or email today (resend-invitation only touches role='client' rows,
+// which never enter this cache). Deleted 2026-08-14 (code review); the 120s
+// TTL above IS the invalidation story. If a role/email mutation surface is
+// ever built, reintroduce the helper (a kv.delete of the admin-session:<id>
+// key) and call it from that mutation path.

--- a/tests/admin-session-shim.test.ts
+++ b/tests/admin-session-shim.test.ts
@@ -22,10 +22,7 @@ import type { D1Database } from '@cloudflare/workers-types'
 // @cloudflare/workers-types in tsconfig) so it is the SAME nominal type the
 // shim's signature uses — importing the non-versioned index causes a ts(2345)
 // identity mismatch when passing the fake KV straight into the function.
-import {
-  resolveAdminSessionFromClerk,
-  invalidateAdminSessionCache,
-} from '../src/lib/auth/admin-session-shim'
+import { resolveAdminSessionFromClerk } from '../src/lib/auth/admin-session-shim'
 
 installWorkerdPolyfills()
 
@@ -141,13 +138,5 @@ describe('resolveAdminSessionFromClerk', () => {
     )
     const session = await resolveAdminSessionFromClerk(ADMIN_CLERK, db, kv)
     expect(session).toMatchObject({ userId: 'u-admin', role: 'admin' })
-  })
-
-  it('invalidateAdminSessionCache deletes the cached entry', async () => {
-    const { kv, store } = createMemoryKv()
-    await resolveAdminSessionFromClerk(ADMIN_CLERK, db, kv)
-    expect(store.has(cacheKey(ADMIN_CLERK))).toBe(true)
-    await invalidateAdminSessionCache(ADMIN_CLERK, kv)
-    expect(store.has(cacheKey(ADMIN_CLERK))).toBe(false)
   })
 })


### PR DESCRIPTION
2026-08-14 code-review Code Quality finding #1 (report lands via #2374).

Exported, documented, unit-tested — zero production call sites. knip missed it because the test import satisfies its usage graph. No admin route mutates a user's role or email today (`resend-invitation` only touches `role='client'` rows, which never enter the admin-session cache), so there is nothing correct to wire it into; the shim's 120s TTL is the actual invalidation mechanism, per its own contract.

Deleted the function + its test; left a breadcrumb comment for reintroduction if a role/email mutation surface is ever built.

Shim suite 6/6, typecheck, knip clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLzzpTuYY8j3EaWbXfxz4x