### PR TITLE
test(billing): behavioral coverage for the revenue path — quote math, billing portal, contacts, SOW props

### DIFF
--- a/tests/admin-contacts-route.test.ts
+++ b/tests/admin-contacts-route.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Behavioral coverage for POST /api/admin/contacts/[id] (2026-08-14 code
+ * review, Testing #2 — org-scoped update/delete with a _method=DELETE
+ * override and null-vs-undefined sparse-update semantics, previously
+ * untested).
+ *
+ * Real migrated D1, real route handler. The only fake is locals.session
+ * (the admin-session shim's output — the same seam every admin route
+ * trusts after middleware).
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  createTestD1,
+  runMigrations,
+  discoverNumericMigrations,
+} from '@venturecrane/crane-test-harness'
+import { resolve } from 'path'
+import type { D1Database } from '@cloudflare/workers-types'
+import { env as testEnv } from 'cloudflare:workers'
+
+import { ORG_ID } from '../src/lib/constants'
+import { POST } from '../src/pages/api/admin/contacts/[id]'
+
+const migrationsDir = resolve(process.cwd(), 'migrations')
+
+const ENTITY_ID = 'entity-contacts-route'
+const CONTACT_ID = 'contact-under-test'
+
+function adminLocals(): App.Locals {
+  return {
+    session: {
+      userId: 'u-admin-test',
+      orgId: ORG_ID,
+      role: 'admin',
+      email: 'admin@example.com',
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    },
+  } as unknown as App.Locals
+}
+
+async function callRoute(opts: {
+  contactId?: string
+  fields?: Record<string, string>
+  locals?: App.Locals
+}): Promise<Response> {
+  const form = new FormData()
+  for (const [k, v] of Object.entries(opts.fields ?? {})) form.set(k, v)
+  const request = new Request('https://admin.smd.services/api/admin/contacts/x', {
+    method: 'POST',
+    body: form,
+  })
+  return POST({
+    request,
+    locals: opts.locals ?? adminLocals(),
+    params: { id: opts.contactId },
+    redirect: (path: string, status?: number) =>
+      new Response(null, { status: status ?? 302, headers: { Location: path } }),
+  } as unknown as Parameters<typeof POST>[0])
+}
+
+async function readContact(db: D1Database, id: string) {
+  return db.prepare('SELECT * FROM contacts WHERE id = ?').bind(id).first<{
+    id: string
+    org_id: string
+    entity_id: string
+    name: string
+    email: string | null
+    phone: string | null
+    title: string | null
+    role: string | null
+  }>()
+}
+
+describe('POST /api/admin/contacts/[id]', () => {
+  let db: D1Database
+
+  beforeEach(async () => {
+    db = createTestD1()
+    await runMigrations(db, { files: discoverNumericMigrations(migrationsDir) })
+
+    for (const k of Object.keys(testEnv)) delete (testEnv as unknown as Record<string, unknown>)[k]
+    Object.assign(testEnv, { DB: db })
+
+    await db
+      .prepare('INSERT OR IGNORE INTO organizations (id, name, slug) VALUES (?, ?, ?)')
+      .bind(ORG_ID, 'SMD Services', 'smd-services')
+      .run()
+    await db
+      .prepare('INSERT INTO entities (id, org_id, name, slug) VALUES (?, ?, ?, ?)')
+      .bind(ENTITY_ID, ORG_ID, 'Contacts Route Biz', 'contacts-route-biz')
+      .run()
+    await db
+      .prepare(
+        `INSERT INTO contacts (id, org_id, entity_id, name, email, phone, title, role)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+      )
+      .bind(
+        CONTACT_ID,
+        ORG_ID,
+        ENTITY_ID,
+        'Dana Owner',
+        'dana@example.com',
+        '602-555-0100',
+        'Owner',
+        'decision_maker'
+      )
+      .run()
+  })
+
+  it('rejects a request with no admin session (401, no mutation)', async () => {
+    const res = await callRoute({
+      contactId: CONTACT_ID,
+      fields: { _method: 'DELETE' },
+      locals: { session: undefined } as unknown as App.Locals,
+    })
+    expect(res.status).toBe(401)
+    expect(await readContact(db, CONTACT_ID)).not.toBeNull()
+  })
+
+  it('400s when the id param is missing', async () => {
+    const res = await callRoute({ contactId: undefined, fields: { name: 'X' } })
+    expect(res.status).toBe(400)
+  })
+
+  it('redirects to not_found for an unknown contact', async () => {
+    const res = await callRoute({ contactId: 'nope', fields: { name: 'X' } })
+    expect(res.status).toBe(302)
+    expect(res.headers.get('Location')).toBe('/admin/entities?error=not_found')
+  })
+
+  it('org scoping: a contact in another org reads as not_found and is not mutated', async () => {
+    await db
+      .prepare('INSERT INTO organizations (id, name, slug) VALUES (?, ?, ?)')
+      .bind('org-other', 'Other Org', 'other-org')
+      .run()
+    await db
+      .prepare('INSERT INTO entities (id, org_id, name, slug) VALUES (?, ?, ?, ?)')
+      .bind('entity-other', 'org-other', 'Other Biz', 'other-biz')
+      .run()
+    await db
+      .prepare(
+        `INSERT INTO contacts (id, org_id, entity_id, name) VALUES (?, 'org-other', 'entity-other', 'Foreign Contact')`
+      )
+      .bind('contact-foreign')
+      .run()
+
+    const res = await callRoute({
+      contactId: 'contact-foreign',
+      fields: { _method: 'DELETE' },
+    })
+    expect(res.headers.get('Location')).toBe('/admin/entities?error=not_found')
+    expect(await readContact(db, 'contact-foreign')).not.toBeNull()
+  })
+
+  it('_method=DELETE deletes the contact and redirects to the entity page', async () => {
+    const res = await callRoute({ contactId: CONTACT_ID, fields: { _method: 'DELETE' } })
+    expect(res.status).toBe(302)
+    expect(res.headers.get('Location')).toBe(`/admin/entities/${ENTITY_ID}?contact_deleted=1`)
+    expect(await readContact(db, CONTACT_ID)).toBeNull()
+  })
+
+  it('sparse update: only the posted fields change; absent fields keep their values', async () => {
+    const res = await callRoute({
+      contactId: CONTACT_ID,
+      fields: { email: 'dana.new@example.com' },
+    })
+    expect(res.headers.get('Location')).toBe(`/admin/entities/${ENTITY_ID}?contact_updated=1`)
+
+    const row = await readContact(db, CONTACT_ID)
+    expect(row?.email).toBe('dana.new@example.com')
+    // Absent from the form -> untouched (undefined semantics).
+    expect(row?.phone).toBe('602-555-0100')
+    expect(row?.title).toBe('Owner')
+    expect(row?.role).toBe('decision_maker')
+    expect(row?.name).toBe('Dana Owner')
+  })
+
+  it('a posted-but-blank field CLEARS to null (null semantics)', async () => {
+    await callRoute({ contactId: CONTACT_ID, fields: { phone: '   ' } })
+    const row = await readContact(db, CONTACT_ID)
+    expect(row?.phone).toBeNull()
+    expect(row?.email).toBe('dana@example.com') // untouched
+  })
+
+  it('a blank name is rejected with missing_name and mutates nothing', async () => {
+    const res = await callRoute({
+      contactId: CONTACT_ID,
+      fields: { name: '  ', email: 'should-not-land@example.com' },
+    })
+    expect(res.headers.get('Location')).toBe(`/admin/entities/${ENTITY_ID}?error=missing_name`)
+    const row = await readContact(db, CONTACT_ID)
+    expect(row?.name).toBe('Dana Owner')
+    expect(row?.email).toBe('dana@example.com')
+  })
+
+  it('updates name and trims it', async () => {
+    await callRoute({ contactId: CONTACT_ID, fields: { name: '  Dana O.  ' } })
+    const row = await readContact(db, CONTACT_ID)
+    expect(row?.name).toBe('Dana O.')
+  })
+})

--- a/tests/portal-billing-manage.test.ts
+++ b/tests/portal-billing-manage.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Behavioral coverage for POST /api/portal/billing/manage (2026-08-14 code
+ * review, Testing #2 — this route creates live Stripe Billing Portal
+ * sessions and had zero coverage).
+ *
+ * Real migrated D1 + the real route handler; only two seams are faked:
+ * Stripe (createBillingPortalSession is mocked — no network) and Clerk
+ * (locals.auth()/currentUser(), same seam middleware-behavior.test.ts
+ * fakes). Every gate is exercised: sign-in bounce, slug allowlist,
+ * principal role gate, missing Stripe customer, the operator
+ * instance-addressed return path, the happy 303 to Stripe, and the
+ * Stripe-failure fallback.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import {
+  createTestD1,
+  runMigrations,
+  discoverNumericMigrations,
+} from '@venturecrane/crane-test-harness'
+import { resolve } from 'path'
+import type { D1Database } from '@cloudflare/workers-types'
+import { env as testEnv } from 'cloudflare:workers'
+
+import { ORG_ID } from '../src/lib/constants'
+
+const createBillingPortalSession = vi.fn()
+vi.mock('../src/lib/stripe/checkout', () => ({
+  createBillingPortalSession: (...args: unknown[]) => createBillingPortalSession(...args),
+}))
+
+// Import AFTER the mock so the route binds the mocked module.
+import { POST } from '../src/pages/api/portal/billing/manage'
+
+const migrationsDir = resolve(process.cwd(), 'migrations')
+
+const CLERK_ID = 'user_billing_manage'
+const USER_ID = 'u-billing-manage'
+const ENTITY_ID = 'entity-billing-manage'
+
+function makeLocals(opts: { signedIn?: boolean } = {}): App.Locals {
+  const signedIn = opts.signedIn ?? true
+  return {
+    auth: () => ({
+      userId: signedIn ? CLERK_ID : null,
+      orgId: null,
+      sessionId: null,
+    }),
+    currentUser: async () =>
+      signedIn
+        ? {
+            primaryEmailAddress: {
+              emailAddress: 'principal@example.com',
+              verification: { status: 'verified' },
+            },
+            emailAddresses: [
+              {
+                emailAddress: 'principal@example.com',
+                verification: { status: 'verified' },
+              },
+            ],
+            firstName: 'Prin',
+            lastName: 'Cipal',
+            username: null,
+          }
+        : null,
+    cfContext: undefined,
+  } as unknown as App.Locals
+}
+
+function makeRequest(fields: Record<string, string>): Request {
+  const form = new FormData()
+  for (const [k, v] of Object.entries(fields)) form.set(k, v)
+  return new Request('https://portal.smd.services/api/portal/billing/manage', {
+    method: 'POST',
+    body: form,
+  })
+}
+
+async function callRoute(
+  fields: Record<string, string>,
+  opts: { signedIn?: boolean } = {}
+): Promise<Response> {
+  // The route only reads locals + request.
+  return POST({
+    locals: makeLocals(opts),
+    request: makeRequest(fields),
+  } as unknown as Parameters<typeof POST>[0])
+}
+
+describe('POST /api/portal/billing/manage', () => {
+  let db: D1Database
+
+  beforeEach(async () => {
+    createBillingPortalSession.mockReset()
+    createBillingPortalSession.mockResolvedValue('https://billing.stripe.com/p/session_test_123')
+
+    db = createTestD1()
+    await runMigrations(db, { files: discoverNumericMigrations(migrationsDir) })
+
+    for (const k of Object.keys(testEnv)) delete (testEnv as unknown as Record<string, unknown>)[k]
+    Object.assign(testEnv, {
+      DB: db,
+      STRIPE_API_KEY: 'sk_test_fake',
+      PORTAL_BASE_URL: 'https://portal.smd.services',
+    })
+
+    await db
+      .prepare('INSERT OR IGNORE INTO organizations (id, name, slug) VALUES (?, ?, ?)')
+      .bind(ORG_ID, 'SMD Services', 'smd-services')
+      .run()
+    await db
+      .prepare('INSERT INTO entities (id, org_id, name, slug) VALUES (?, ?, ?, ?)')
+      .bind(ENTITY_ID, ORG_ID, 'Billing Manage Biz', 'billing-manage-biz')
+      .run()
+    // Clerk-bound user directly bound to the entity (single-user portal path).
+    await db
+      .prepare(
+        `INSERT INTO users (id, org_id, email, name, role, entity_id, clerk_user_id)
+         VALUES (?, ?, ?, ?, 'client', ?, ?)`
+      )
+      .bind(USER_ID, ORG_ID, 'principal@example.com', 'Prin Cipal', ENTITY_ID, CLERK_ID)
+      .run()
+  })
+
+  async function seedSubscription(opts: {
+    slug: string
+    settingsJson?: string | null
+    instanceSlug?: string | null
+  }): Promise<void> {
+    await db
+      .prepare(
+        `INSERT INTO subscriptions (id, org_id, entity_id, product_slug, instance_slug, status, settings_json)
+         VALUES (?, ?, ?, ?, ?, 'active', ?)`
+      )
+      .bind(
+        `sub-${opts.slug}-${opts.instanceSlug ?? 'default'}`,
+        ORG_ID,
+        ENTITY_ID,
+        opts.slug,
+        opts.instanceSlug ?? null,
+        opts.settingsJson ?? null
+      )
+      .run()
+  }
+
+  async function seedRole(role: string, slug: string): Promise<void> {
+    await db
+      .prepare(
+        `INSERT INTO product_roles (id, org_id, user_id, entity_id, product_slug, role)
+         VALUES (?, ?, ?, ?, ?, ?)`
+      )
+      .bind(`pr-${role}-${slug}`, ORG_ID, USER_ID, ENTITY_ID, slug, role)
+      .run()
+  }
+
+  it('bounces an unauthenticated request to sign-in and never calls Stripe', async () => {
+    const res = await callRoute({ product_slug: 'hosted-agent' }, { signedIn: false })
+    expect(res.status).toBe(303)
+    expect(res.headers.get('Location')).toBe('/auth/sign-in')
+    expect(createBillingPortalSession).not.toHaveBeenCalled()
+  })
+
+  it('rejects a product slug outside the allowlist', async () => {
+    const res = await callRoute({ product_slug: 'not-a-product' })
+    expect(res.status).toBe(303)
+    expect(res.headers.get('Location')).toBe('/portal?cs=billing_invalid')
+    expect(createBillingPortalSession).not.toHaveBeenCalled()
+  })
+
+  it('refuses a member who is not principal', async () => {
+    await seedSubscription({
+      slug: 'hosted-agent',
+      settingsJson: JSON.stringify({ stripe_customer_id: 'cus_test_1' }),
+    })
+    await seedRole('member', 'hosted-agent')
+
+    const res = await callRoute({ product_slug: 'hosted-agent' })
+    expect(res.status).toBe(303)
+    expect(res.headers.get('Location')).toBe('/portal/products/hosted-agent?cs=billing_forbidden')
+    expect(createBillingPortalSession).not.toHaveBeenCalled()
+  })
+
+  it('refuses when there is no subscription at all (no access resolves)', async () => {
+    await seedRole('principal', 'hosted-agent')
+    const res = await callRoute({ product_slug: 'hosted-agent' })
+    expect(res.headers.get('Location')).toBe('/portal/products/hosted-agent?cs=billing_forbidden')
+  })
+
+  it('reports billing_unavailable when the subscription has no Stripe customer id', async () => {
+    await seedSubscription({ slug: 'hosted-agent', settingsJson: null })
+    await seedRole('principal', 'hosted-agent')
+
+    const res = await callRoute({ product_slug: 'hosted-agent' })
+    expect(res.headers.get('Location')).toBe('/portal/products/hosted-agent?cs=billing_unavailable')
+    expect(createBillingPortalSession).not.toHaveBeenCalled()
+  })
+
+  it('happy path: principal + Stripe customer -> 303 to the Stripe portal session', async () => {
+    await seedSubscription({
+      slug: 'hosted-agent',
+      settingsJson: JSON.stringify({ stripe_customer_id: 'cus_test_1' }),
+    })
+    await seedRole('principal', 'hosted-agent')
+
+    const res = await callRoute({ product_slug: 'hosted-agent' })
+    expect(res.status).toBe(303)
+    expect(res.headers.get('Location')).toBe('https://billing.stripe.com/p/session_test_123')
+    expect(createBillingPortalSession).toHaveBeenCalledWith(
+      'sk_test_fake',
+      'cus_test_1',
+      'https://portal.smd.services/portal/products/hosted-agent'
+    )
+  })
+
+  it('operator with an instance returns to that instance settings page', async () => {
+    await seedSubscription({
+      slug: 'operator',
+      instanceSlug: 'acme-firm',
+      settingsJson: JSON.stringify({ stripe_customer_id: 'cus_op_1' }),
+    })
+    await seedRole('principal', 'operator')
+
+    const res = await callRoute({ product_slug: 'operator', instance: 'acme-firm' })
+    expect(res.status).toBe(303)
+    expect(createBillingPortalSession).toHaveBeenCalledWith(
+      'sk_test_fake',
+      'cus_op_1',
+      'https://portal.smd.services/portal/products/operator/acme-firm/settings'
+    )
+  })
+
+  it('falls back to billing_error when Stripe throws, never a 500', async () => {
+    await seedSubscription({
+      slug: 'hosted-agent',
+      settingsJson: JSON.stringify({ stripe_customer_id: 'cus_test_1' }),
+    })
+    await seedRole('principal', 'hosted-agent')
+    createBillingPortalSession.mockRejectedValue(new Error('stripe down'))
+
+    const res = await callRoute({ product_slug: 'hosted-agent' })
+    expect(res.status).toBe(303)
+    expect(res.headers.get('Location')).toBe('/portal/products/hosted-agent?cs=billing_error')
+  })
+})

--- a/tests/quotes-money-math.test.ts
+++ b/tests/quotes-money-math.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Behavioral coverage for the quote revenue path (2026-08-14 code review,
+ * Testing #1): the money math (total_hours, total_price, deposit_amount)
+ * and the VALID_TRANSITIONS state machine executed against a real migrated
+ * D1 — not source-text matched. tests/quotes.test.ts remains the
+ * architecture-guard suite; this file is the one that fails when the
+ * computation itself regresses.
+ *
+ * Send-gating on authored content and the SignWell acceptance guard are
+ * covered in tests/quotes-authored-content.test.ts and
+ * tests/lifecycle-guards.test.ts; not duplicated here.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  createTestD1,
+  runMigrations,
+  discoverNumericMigrations,
+} from '@venturecrane/crane-test-harness'
+import { resolve } from 'path'
+import type { D1Database } from '@cloudflare/workers-types'
+
+import { createEntity } from '../src/lib/db/entities'
+import {
+  createQuote,
+  updateQuote,
+  updateQuoteStatus,
+  parseLineItems,
+  VALID_TRANSITIONS,
+  type Quote,
+  type QuoteStatus,
+} from '../src/lib/db/quotes'
+
+const migrationsDir = resolve(process.cwd(), 'migrations')
+const ORG_ID = 'org-money-math'
+const ASSESSMENT_ID = 'assess-money-math'
+
+const AUTHORED = {
+  schedule: [{ label: 'Phase 1', body: 'Discovery.' }],
+  deliverables: [{ title: 'Report', body: 'A written summary.' }],
+}
+
+describe('quote money math (real D1)', () => {
+  let db: D1Database
+  let entityId: string
+
+  beforeEach(async () => {
+    db = createTestD1()
+    await runMigrations(db, { files: discoverNumericMigrations(migrationsDir) })
+    await db
+      .prepare('INSERT INTO organizations (id, name, slug) VALUES (?, ?, ?)')
+      .bind(ORG_ID, 'Money Math Org', 'money-math-org')
+      .run()
+    const entity = await createEntity(db, ORG_ID, { name: 'Money Math Biz', stage: 'proposing' })
+    entityId = entity.id
+    await db
+      .prepare(
+        `INSERT INTO assessments (id, org_id, entity_id, status) VALUES (?, ?, ?, 'completed')`
+      )
+      .bind(ASSESSMENT_ID, ORG_ID, entityId)
+      .run()
+  })
+
+  function baseQuote(extra: Partial<Parameters<typeof createQuote>[2]> = {}) {
+    return createQuote(db, ORG_ID, {
+      entityId,
+      assessmentId: ASSESSMENT_ID,
+      lineItems: [
+        { problem: 'Scheduling chaos', description: 'Design dispatch flow', estimated_hours: 10 },
+        { problem: 'Lead follow-up', description: 'CRM configuration', estimated_hours: 15 },
+        { problem: 'Reporting', description: 'Weekly numbers view', estimated_hours: 5 },
+      ],
+      rate: 175,
+      originatingSignalId: null,
+      ...extra,
+    })
+  }
+
+  it('createQuote: total_hours sums line items, total_price = hours x rate, deposit defaults to 50%', async () => {
+    const q = await baseQuote()
+    expect(q.total_hours).toBe(30)
+    expect(q.total_price).toBe(30 * 175) // 5250
+    expect(q.deposit_pct).toBe(0.5)
+    expect(q.deposit_amount).toBe(2625)
+    expect(q.status).toBe('draft')
+    expect(q.version).toBe(1)
+  })
+
+  it('createQuote: explicit depositPct is applied to the computed total', async () => {
+    const q = await baseQuote({ depositPct: 0.4 })
+    expect(q.deposit_pct).toBe(0.4)
+    expect(q.deposit_amount).toBe(5250 * 0.4) // 2100
+  })
+
+  it('createQuote: empty line items produce zero totals, not NaN', async () => {
+    const q = await baseQuote({ lineItems: [] })
+    expect(q.total_hours).toBe(0)
+    expect(q.total_price).toBe(0)
+    expect(q.deposit_amount).toBe(0)
+  })
+
+  it('updateQuote: changing line items alone recomputes totals with the stored rate and pct', async () => {
+    const q = await baseQuote()
+    const updated = await updateQuote(db, ORG_ID, q.id, {
+      lineItems: [{ problem: 'One thing', description: 'Just this', estimated_hours: 8 }],
+    })
+    expect(updated?.total_hours).toBe(8)
+    expect(updated?.total_price).toBe(8 * 175) // 1400
+    expect(updated?.deposit_amount).toBe(700) // 50% of new total
+    expect(updated?.rate).toBe(175)
+    expect(updated?.version).toBe(2) // pricing change bumps version
+  })
+
+  it('updateQuote: changing rate alone recomputes against the STORED line items', async () => {
+    const q = await baseQuote()
+    const updated = await updateQuote(db, ORG_ID, q.id, { rate: 200 })
+    expect(updated?.total_hours).toBe(30)
+    expect(updated?.total_price).toBe(6000)
+    expect(updated?.deposit_amount).toBe(3000)
+    expect(parseLineItems(updated!.line_items)).toHaveLength(3)
+  })
+
+  it('updateQuote: changing depositPct alone recomputes deposit from the EXISTING total', async () => {
+    const q = await baseQuote()
+    const updated = await updateQuote(db, ORG_ID, q.id, { depositPct: 0.25 })
+    expect(updated?.total_price).toBe(5250) // unchanged
+    expect(updated?.deposit_pct).toBe(0.25)
+    expect(updated?.deposit_amount).toBe(1312.5)
+  })
+
+  it('updateQuote: items + rate + pct together compute from the new values', async () => {
+    const q = await baseQuote()
+    const updated = await updateQuote(db, ORG_ID, q.id, {
+      lineItems: [{ problem: 'P', description: 'D', estimated_hours: 20 }],
+      rate: 250,
+      depositPct: 0.3,
+    })
+    expect(updated?.total_hours).toBe(20)
+    expect(updated?.total_price).toBe(5000)
+    expect(updated?.deposit_amount).toBe(1500)
+  })
+
+  it('updateQuote: attribution-only edit changes no totals and does not bump version', async () => {
+    const q = await baseQuote()
+    const updated = await updateQuote(db, ORG_ID, q.id, { originatingSignalId: null })
+    expect(updated?.version).toBe(1)
+    expect(updated?.total_price).toBe(5250)
+  })
+
+  it('updateQuote: unknown quote id returns null', async () => {
+    expect(await updateQuote(db, ORG_ID, 'nope', { rate: 200 })).toBeNull()
+  })
+})
+
+describe('quote status state machine (real D1)', () => {
+  let db: D1Database
+  let entityId: string
+
+  beforeEach(async () => {
+    db = createTestD1()
+    await runMigrations(db, { files: discoverNumericMigrations(migrationsDir) })
+    await db
+      .prepare('INSERT INTO organizations (id, name, slug) VALUES (?, ?, ?)')
+      .bind(ORG_ID, 'Money Math Org', 'money-math-org')
+      .run()
+    const entity = await createEntity(db, ORG_ID, { name: 'Transitions Biz', stage: 'proposing' })
+    entityId = entity.id
+    await db
+      .prepare(
+        `INSERT INTO assessments (id, org_id, entity_id, status) VALUES (?, ?, ?, 'completed')`
+      )
+      .bind(ASSESSMENT_ID, ORG_ID, entityId)
+      .run()
+  })
+
+  /** A sendable draft: authored content present so the send gate passes. */
+  function sendableDraft(): Promise<Quote> {
+    return createQuote(db, ORG_ID, {
+      entityId,
+      assessmentId: ASSESSMENT_ID,
+      lineItems: [{ problem: 'P', description: 'D', estimated_hours: 10 }],
+      rate: 175,
+      originatingSignalId: null,
+      ...AUTHORED,
+    })
+  }
+
+  it('draft -> sent stamps sent_at and expires_at exactly 5 days later', async () => {
+    const q = await sendableDraft()
+    const before = Date.now()
+    const sent = await updateQuoteStatus(db, ORG_ID, q.id, 'sent')
+    expect(sent?.status).toBe('sent')
+    expect(sent?.sent_at).toBeTruthy()
+    expect(sent?.expires_at).toBeTruthy()
+    const sentAt = new Date(sent!.sent_at!).getTime()
+    expect(sentAt).toBeGreaterThanOrEqual(before - 1000)
+    expect(new Date(sent!.expires_at!).getTime() - sentAt).toBe(5 * 24 * 60 * 60 * 1000)
+  })
+
+  it('draft -> superseded and sent -> declined/expired are permitted', async () => {
+    const a = await sendableDraft()
+    expect((await updateQuoteStatus(db, ORG_ID, a.id, 'superseded'))?.status).toBe('superseded')
+
+    const b = await sendableDraft()
+    await updateQuoteStatus(db, ORG_ID, b.id, 'sent')
+    expect((await updateQuoteStatus(db, ORG_ID, b.id, 'declined'))?.status).toBe('declined')
+
+    const c = await sendableDraft()
+    await updateQuoteStatus(db, ORG_ID, c.id, 'sent')
+    expect((await updateQuoteStatus(db, ORG_ID, c.id, 'expired'))?.status).toBe('expired')
+  })
+
+  it('draft -> accepted is rejected (must go through sent)', async () => {
+    const q = await sendableDraft()
+    await expect(updateQuoteStatus(db, ORG_ID, q.id, 'accepted')).rejects.toThrow(
+      /Invalid status transition: draft -> accepted/
+    )
+  })
+
+  it('terminal states reject every outbound transition', async () => {
+    // Exercise the runtime guard for each terminal status against each
+    // target the map declares invalid — the matrix itself, not its source.
+    const terminals: QuoteStatus[] = ['declined', 'expired', 'superseded']
+    for (const terminal of terminals) {
+      const q = await sendableDraft()
+      if (terminal === 'superseded') {
+        await updateQuoteStatus(db, ORG_ID, q.id, 'superseded')
+      } else {
+        await updateQuoteStatus(db, ORG_ID, q.id, 'sent')
+        await updateQuoteStatus(db, ORG_ID, q.id, terminal)
+      }
+      expect(VALID_TRANSITIONS[terminal]).toEqual([])
+      for (const target of ['draft', 'sent', 'accepted'] as QuoteStatus[]) {
+        await expect(updateQuoteStatus(db, ORG_ID, q.id, target)).rejects.toThrow(
+          /Invalid status transition/
+        )
+      }
+    }
+  })
+
+  it('unknown quote id returns null instead of throwing', async () => {
+    expect(await updateQuoteStatus(db, ORG_ID, 'missing', 'sent')).toBeNull()
+  })
+
+  it('org scoping: a quote is not transitionable through another org id', async () => {
+    const q = await sendableDraft()
+    expect(await updateQuoteStatus(db, 'org-other', q.id, 'sent')).toBeNull()
+    // And the real row is untouched.
+    const still = await db
+      .prepare('SELECT status FROM quotes WHERE id = ?')
+      .bind(q.id)
+      .first<{ status: string }>()
+    expect(still?.status).toBe('draft')
+  })
+})

--- a/tests/sow-template-props.test.ts
+++ b/tests/sow-template-props.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Behavioral coverage for the SOW data-shaping layer (2026-08-14 code
+ * review, Testing #3): the props the signed contract PDF is rendered
+ * from, exercised through the real generate-pdf route against a real
+ * migrated D1. Forme WASM cannot load under vitest (tests/sow-render.test.ts
+ * stays skipped for the byte-level render), so the render seam
+ * (createSOWRevisionForQuote) is mocked to CAPTURE the assembled
+ * SOWTemplateProps — everything upstream of the WASM boundary runs real:
+ * payment-schedule selection (40-hour milestone threshold, 40/30/30 vs
+ * deposit-pct two-part), currency formatting, deliverables-over-line-items
+ * preference, and the fabrication gates (no contact name / no authored
+ * overview -> refuse to render; the pre-#378 'Business Owner' fallback
+ * must never come back).
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import {
+  createTestD1,
+  runMigrations,
+  discoverNumericMigrations,
+} from '@venturecrane/crane-test-harness'
+import { resolve } from 'path'
+import type { D1Database } from '@cloudflare/workers-types'
+import { env as testEnv } from 'cloudflare:workers'
+
+import { ORG_ID } from '../src/lib/constants'
+import { createEntity } from '../src/lib/db/entities'
+import { createQuote, updateQuote } from '../src/lib/db/quotes'
+import type { SOWTemplateProps } from '../src/lib/pdf/sow-template'
+
+const createSOWRevisionForQuote = vi.fn()
+vi.mock('../src/lib/sow/service', () => ({
+  createSOWRevisionForQuote: (args: unknown) => createSOWRevisionForQuote(args),
+}))
+
+// Import AFTER the mock so the route binds the mocked module.
+import { POST } from '../src/pages/api/admin/quotes/[id]'
+
+const migrationsDir = resolve(process.cwd(), 'migrations')
+const ASSESSMENT_ID = 'assess-sow-props'
+
+function adminLocals(): App.Locals {
+  return {
+    session: {
+      userId: 'u-admin-sow',
+      orgId: ORG_ID,
+      role: 'admin',
+      email: 'admin@example.com',
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    },
+  } as unknown as App.Locals
+}
+
+async function generatePdf(quoteId: string): Promise<Response> {
+  const form = new FormData()
+  form.set('action', 'generate-pdf')
+  const request = new Request('https://admin.smd.services/api/admin/quotes/x', {
+    method: 'POST',
+    body: form,
+  })
+  return POST({
+    request,
+    locals: adminLocals(),
+    params: { id: quoteId },
+    redirect: (path: string, status?: number) =>
+      new Response(null, { status: status ?? 302, headers: { Location: path } }),
+  } as unknown as Parameters<typeof POST>[0])
+}
+
+function capturedProps(): SOWTemplateProps {
+  expect(createSOWRevisionForQuote).toHaveBeenCalledTimes(1)
+  const args = createSOWRevisionForQuote.mock.calls[0][0] as {
+    templateProps: SOWTemplateProps
+  }
+  return args.templateProps
+}
+
+describe('SOW template props (generate-pdf, real D1 upstream of WASM)', () => {
+  let db: D1Database
+  let entityId: string
+
+  beforeEach(async () => {
+    createSOWRevisionForQuote.mockReset()
+    createSOWRevisionForQuote.mockResolvedValue({ id: 'rev-1' })
+
+    db = createTestD1()
+    await runMigrations(db, { files: discoverNumericMigrations(migrationsDir) })
+    for (const k of Object.keys(testEnv)) delete (testEnv as unknown as Record<string, unknown>)[k]
+    Object.assign(testEnv, { DB: db, STORAGE: {} })
+
+    await db
+      .prepare('INSERT OR IGNORE INTO organizations (id, name, slug) VALUES (?, ?, ?)')
+      .bind(ORG_ID, 'SMD Services', 'smd-services')
+      .run()
+    const entity = await createEntity(db, ORG_ID, {
+      name: 'Sonoran Comfort HVAC',
+      stage: 'proposing',
+    })
+    entityId = entity.id
+    await db
+      .prepare(
+        `INSERT INTO assessments (id, org_id, entity_id, status) VALUES (?, ?, ?, 'completed')`
+      )
+      .bind(ASSESSMENT_ID, ORG_ID, entityId)
+      .run()
+  })
+
+  async function seedContact(name = 'Reyna Alvarez', title: string | null = 'Owner') {
+    await db
+      .prepare(`INSERT INTO contacts (id, org_id, entity_id, name, title) VALUES (?, ?, ?, ?, ?)`)
+      .bind('contact-sow', ORG_ID, entityId, name, title)
+      .run()
+  }
+
+  async function seedQuote(opts: {
+    hours: number
+    rate?: number
+    depositPct?: number
+    overview?: string | null
+    deliverables?: { title: string; body: string }[] | null
+    milestoneLabel?: string
+  }): Promise<string> {
+    const q = await createQuote(db, ORG_ID, {
+      entityId,
+      assessmentId: ASSESSMENT_ID,
+      lineItems: [
+        {
+          problem: 'Dispatch board',
+          description: 'Rebuild scheduling flow',
+          estimated_hours: opts.hours,
+        },
+      ],
+      rate: opts.rate ?? 175,
+      depositPct: opts.depositPct,
+      originatingSignalId: null,
+    })
+    await updateQuote(db, ORG_ID, q.id, {
+      engagementOverview:
+        opts.overview === undefined ? 'Dispatch redesign scoped in assessment.' : opts.overview,
+      ...(opts.deliverables !== undefined ? { deliverables: opts.deliverables } : {}),
+      ...(opts.milestoneLabel !== undefined ? { milestoneLabel: opts.milestoneLabel } : {}),
+    })
+    return q.id
+  }
+
+  it('two-part schedule below 40 hours: deposit/completion split by the quote deposit_pct', async () => {
+    await seedContact()
+    const quoteId = await seedQuote({ hours: 30, rate: 175, depositPct: 0.5 })
+
+    const res = await generatePdf(quoteId)
+    expect(res.headers.get('Location')).toContain('saved=1')
+
+    const props = capturedProps()
+    expect(props.payment.schedule).toBe('two_part')
+    expect(props.payment.totalPrice).toBe('$5,250')
+    expect(props.payment.deposit).toBe('$2,625')
+    expect(props.payment.completion).toBe('$2,625')
+  })
+
+  it('three-milestone schedule at >= 40 hours: 40/30/30 split with authored milestone label', async () => {
+    await seedContact()
+    const quoteId = await seedQuote({
+      hours: 40,
+      rate: 200, // total $8,000
+      milestoneLabel: 'pilot rollout',
+    })
+
+    await generatePdf(quoteId)
+
+    const props = capturedProps()
+    expect(props.payment.schedule).toBe('three_milestone')
+    expect(props.payment.totalPrice).toBe('$8,000')
+    expect(props.payment.deposit).toBe('$3,200') // 40%
+    expect(props.payment).toMatchObject({ milestone: '$2,400', completion: '$2,400' }) // 30/30
+    expect(props.payment.milestoneLabel).toBe('pilot rollout')
+  })
+
+  it('items prefer authored deliverables over raw line items', async () => {
+    await seedContact()
+    const quoteId = await seedQuote({
+      hours: 10,
+      deliverables: [{ title: 'Dispatch SOP', body: 'A documented dispatch procedure.' }],
+    })
+
+    await generatePdf(quoteId)
+
+    expect(capturedProps().items).toEqual([
+      { name: 'Dispatch SOP', description: 'A documented dispatch procedure.' },
+    ])
+  })
+
+  it('falls back to line items only when no deliverables are authored', async () => {
+    await seedContact()
+    const quoteId = await seedQuote({ hours: 10 })
+
+    await generatePdf(quoteId)
+
+    expect(capturedProps().items).toEqual([
+      { name: 'Dispatch board', description: 'Rebuild scheduling flow' },
+    ])
+  })
+
+  it('client block carries the real contact — never a fabricated placeholder', async () => {
+    await seedContact('Reyna Alvarez', 'Owner')
+    const quoteId = await seedQuote({ hours: 10 })
+
+    await generatePdf(quoteId)
+
+    const props = capturedProps()
+    expect(props.client.businessName).toBe('Sonoran Comfort HVAC')
+    expect(props.client.contactName).toBe('Reyna Alvarez')
+    expect(props.client.contactTitle).toBe('Owner')
+    expect(JSON.stringify(props)).not.toContain('Business Owner') // pre-#378 Pattern B fallback
+  })
+
+  it('refuses to render without a named primary contact (no fabricated signer)', async () => {
+    // No contact seeded.
+    const quoteId = await seedQuote({ hours: 10 })
+
+    const res = await generatePdf(quoteId)
+    expect(res.status).toBe(302)
+    expect(res.headers.get('Location')).toContain('add%20a%20primary%20contact')
+    expect(createSOWRevisionForQuote).not.toHaveBeenCalled()
+  })
+
+  it('refuses to render without an authored engagement overview (no borrowed copy)', async () => {
+    await seedContact()
+    const quoteId = await seedQuote({ hours: 10, overview: null })
+
+    const res = await generatePdf(quoteId)
+    expect(res.status).toBe(302)
+    expect(res.headers.get('Location')).toContain('author%20the%20engagement%20overview')
+    expect(createSOWRevisionForQuote).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
2026-08-14 code-review Testing findings (report: #2374). The quote money math and state machine were covered only by `readFileSync().toContain()` source-text matching — an instrument that cannot fail on behavioral regression — and three billing-adjacent surfaces had zero coverage.

**39 new cases, all against a real migrated D1:**

- `tests/quotes-money-math.test.ts` (15): total/deposit computation on create + the full update recalc matrix (items-only, rate-only, pct-only, combined), version-bump semantics, the complete VALID_TRANSITIONS matrix incl. terminal states, unknown-id null, and org scoping
- `tests/portal-billing-manage.test.ts` (8): every gate of POST /api/portal/billing/manage — sign-in bounce, slug allowlist, principal role gate, no-subscription, missing Stripe customer, operator instance-addressed return path, happy 303 to Stripe, Stripe-failure fallback. Stripe mocked at the `createBillingPortalSession` seam; Clerk faked at the same locals seam middleware-behavior uses
- `tests/admin-contacts-route.test.ts` (9): `_method=DELETE` override, sparse-update null-vs-undefined semantics, blank-name rejection, unauthenticated 401, org scoping (foreign-org contact unreachable and unmutated)
- `tests/sow-template-props.test.ts` (7): the signed-contract PDF's data shaping driven through the real generate-pdf route — 40-hour milestone threshold (40/30/30 vs deposit-pct two-part), currency formatting, deliverables-over-line-items preference, and the fabrication gates (no contact / no authored overview → refuse to render; the pre-#378 'Business Owner' fallback pinned absent). WASM byte-render stays build-validated (`sow-render.test.ts` unchanged); the mock captures props at the render seam.

`npm run verify` green end to end (281 test files + workers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLzzpTuYY8j3EaWbXfxz4x