### PR TITLE
feat(smokeball): land the (matterNumber, email) join for pair seeding (ss#2167)

### DIFF
--- a/operator/connectors/smokeball/smokeball_connector/server.py
+++ b/operator/connectors/smokeball/smokeball_connector/server.py
@@ -364,6 +364,119 @@ def _attach_parties(client: Any, matter: Any) -> None:
         return
 
 
+# ---- Matter-party join on the ROLES reads (ADR 0086 / ss#2167) ------------
+#
+# ADR 0086 names ``get_roles_on_matter`` / ``get_relationships_on_matter`` the
+# canonical seeding sources for matter membership — they are the reads that
+# answer "who is on this matter". THE VENDOR PAYLOAD DOES NOT CARRY THE JOIN.
+# ``/matters/{id}/roles`` is a sub-resource: each record names its contact by id
+# and the matter appears only in the request path, so a role record carries
+# neither the party's ADDRESS (which is on the contact) nor the matter's NUMBER
+# (which is on the matter). Both halves of the (matterNumber, email) pair are one
+# fetch away and nothing was performing that fetch, so the reads that describe
+# matter membership taught the membership register nothing at all.
+#
+# So the connector attaches it, in the ``_attach_matter_ref`` fail-safe shape: an
+# unresolved contact, an unresolved matter, or an address-less party attaches
+# NOTHING to that record. A record with no ``party_of_matter`` key supplies no
+# membership, which is precisely the *unresolved* verdict the gate must reach
+# when it cannot see — never "not a party".
+#
+# The key is explicit and single-purpose (``party_of_matter``) rather than a bare
+# ``matterId``, because the overlay's capture walks every dict in a payload: an
+# inferred join ("this dict has a matter id and an email, so they must be
+# related") is exactly the cross-product inference that pair provenance exists to
+# refuse. This key is an assertion made in code from a resolved fetch.
+#
+# NOTE ON COMPLETENESS, deliberately absent: no ``*_complete`` flag is attached
+# here. Seeding from roles can only ADD proven parties, which makes the gate more
+# permissive and can never manufacture a mismatch. Closing a set is what enables a
+# withhold, and a roles listing is not provably the whole membership of a matter
+# (Smokeball pages it, and a party can exist with no role record). ss#2264's
+# contact axis and ``parties_complete`` remain the only two closers.
+_ROLE_PARTY_MAX_LOOKUPS = 40
+
+#: Where a role / relationship record can name its contact. Checked in order; an
+#: unrecognized shape resolves nothing and the record is left untouched.
+_ROLE_CONTACT_KEYS: tuple[str, ...] = ("contactId", "contact_id", "contact", "party")
+
+
+def _role_contact_id(record: Any) -> str:
+    """The contact id a role/relationship record refers to, or ``""``.
+
+    Deliberately does NOT fall back to the record's own ``id``: that is the ROLE
+    id, and resolving it as a contact would either 404 (harmless) or, worse,
+    collide with a real contact id and attach a WRONG address to a matter. A
+    wrong party is the one output this whole control exists to prevent.
+    """
+    if not isinstance(record, dict):
+        return ""
+    for key in _ROLE_CONTACT_KEYS:
+        value = record.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+        if isinstance(value, dict):
+            inner = value.get("id")
+            if isinstance(inner, str) and inner.strip():
+                return inner.strip()
+    return ""
+
+
+def _iter_role_records(resp: Any) -> list[dict]:
+    """The role/relationship records in a response envelope.
+
+    Handles the two shapes the connector sees elsewhere — a HATEOAS envelope
+    (``{"value": [...]}``) and a bare list — plus a single record. An
+    unrecognized shape yields nothing, which attaches nothing.
+    """
+    if isinstance(resp, dict):
+        items = resp.get("value")
+        if isinstance(items, list):
+            return [i for i in items if isinstance(i, dict)]
+        return [resp]
+    if isinstance(resp, list):
+        return [i for i in resp if isinstance(i, dict)]
+    return []
+
+
+def _attach_matter_party_join(client: Any, matter_id: str, resp: Any) -> None:
+    """Mutate a roles / relationships response in place, landing
+    ``(party_of_matter, matterNumber, email)`` on each record whose contact
+    resolves to an address.
+
+    Fail-safe in every direction: a failed contact fetch, a party with no email,
+    an exhausted lookup budget, or an unresolvable matter number all leave the
+    record exactly as the vendor returned it.
+    """
+    if not matter_id:
+        return
+    try:
+        records = _iter_role_records(resp)
+        if not records:
+            return
+        contact_cache: dict[str, dict | None] = {}
+        matter_cache: dict[str, dict[str, str] | None] = {}
+        budget = [_ROLE_PARTY_MAX_LOOKUPS]
+        ref = _resolve_matter_ref(client, matter_id, matter_cache, None)
+        number = (ref or {}).get("number")
+        for record in records:
+            contact_id = _role_contact_id(record)
+            if not contact_id:
+                continue
+            party = _resolve_party(client, contact_id, contact_cache, budget)
+            if party is None:
+                continue  # unresolved: attach nothing rather than a half-fact
+            email = party.get("email")
+            if not email:
+                continue  # a party we cannot address supplies no membership
+            record["party_of_matter"] = matter_id
+            record["email"] = email
+            if isinstance(number, str) and number:
+                record["matterNumber"] = number
+    except Exception:  # noqa: BLE001 — enrichment must never break the read path
+        return
+
+
 # ---- Matter-ref enrichment (tasks, events, memos, files) ------------------
 # A task or event carries its matter as ``matter: {href, id, rel}`` — a GUID and
 # nothing else. The human-readable number lives on the matter record. Rendering
@@ -1031,16 +1144,33 @@ def get_staff(staff_id: str) -> Any:
 # ---- Roles / relationships ------------------------------------------------
 @server.tool()
 def get_roles_on_matter(matter_id: str) -> Any:
-    """Get the roles (parties) on a matter."""
-    return _get_client().get(f"/matters/{matter_id}/roles")
+    """Get the roles (parties) on a matter.
+
+    Each record is enriched with ``party_of_matter``, ``matterNumber`` and the
+    party's ``email`` where they resolve (ADR 0086 / ss#2167) — this read is the
+    canonical "who is on this matter", and the outbound matter-identity gate
+    needs the ADDRESS to answer "is this recipient a party?". Fail-safe: an
+    unresolved contact or matter attaches nothing to that record."""
+    client = _get_client()
+    resp = client.get(f"/matters/{matter_id}/roles")
+    _attach_matter_party_join(client, matter_id, resp)
+    return resp
 
 
 @server.tool()
 def get_relationships_on_matter(matter_id: str, role_id: str) -> Any:
     """Get the relationships attached to a role on a matter. (The API nests
     relationships under a role, so role_id is required — a connect-step
-    refinement of the surface-doc single-arg signature.)"""
-    return _get_client().get(f"/matters/{matter_id}/roles/{role_id}/relationships")
+    refinement of the surface-doc single-arg signature.)
+
+    Enriched with the same ``(party_of_matter, matterNumber, email)`` join as
+    ``get_roles_on_matter``: a relationship is how opposing counsel and adjusters
+    attach to a matter, and those are exactly the OUTSIDE recipients ADR 0086
+    requires to pair."""
+    client = _get_client()
+    resp = client.get(f"/matters/{matter_id}/roles/{role_id}/relationships")
+    _attach_matter_party_join(client, matter_id, resp)
+    return resp
 
 
 # ---- Files / documents ----------------------------------------------------

--- a/operator/connectors/smokeball/tests/test_matter_role_party_join.py
+++ b/operator/connectors/smokeball/tests/test_matter_role_party_join.py
@@ -1,0 +1,222 @@
+"""The (matterNumber, email) join on the ROLES reads (ADR 0086 / ss#2167).
+
+``get_roles_on_matter`` / ``get_relationships_on_matter`` are the reads that
+answer "who is on this matter", and ADR 0086 names them the canonical seeding
+sources for outbound matter membership. The vendor payload does not carry the
+join: a role record names its contact by id, and the matter appears only in the
+request path. So the address lives on the contact, the number lives on the
+matter, and the record itself carries neither.
+
+What is locked here is the same rule ``parties_complete`` is built on, applied to
+this shape: **an unresolved party must never be indistinguishable from a genuine
+non-party.** A record that cannot be resolved is left exactly as the vendor
+returned it, so the membership register learns nothing from it and the gate
+reaches *unresolved* — never "not a party".
+
+No live Smokeball calls: an ``httpx.MockTransport`` serves scripted responses so
+the real resolution logic runs.
+"""
+
+from __future__ import annotations
+
+import httpx
+
+from smokeball_connector import server as srv
+from smokeball_connector.client import SmokeballClient
+
+MATTER_ID = "54bc1371-1111-2222-3333-444444444444"
+NUMBER = "PI-2026-0001"
+
+
+def _mock_client(handler) -> SmokeballClient:
+    client = SmokeballClient(
+        region="us", environment="staging", client_id="cid", client_secret="sec", api_key="apikey"
+    )
+    client._http = httpx.Client(transport=httpx.MockTransport(handler))
+    return client
+
+
+def _handler(contacts: dict[str, dict], matter: dict | None = None):
+    def handle(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if path.endswith("/oauth2/token"):
+            return httpx.Response(
+                200, json={"access_token": "tok", "expires_in": 3600, "token_type": "Bearer"}
+            )
+        if "/contacts/" in path:
+            cid = path.rsplit("/", 1)[-1]
+            if cid in contacts:
+                return httpx.Response(200, json=contacts[cid])
+            return httpx.Response(404, json={"error": "not found"})
+        if "/matters/" in path:
+            if matter is None:
+                return httpx.Response(404, json={"error": "not found"})
+            return httpx.Response(200, json=matter)
+        return httpx.Response(200, json={"ok": True})
+
+    return handle
+
+
+def _person(last: str, email: str | None = None) -> dict:
+    person: dict = {"firstName": "Given", "lastName": last}
+    if email is not None:
+        person["email"] = email
+    return {"person": person}
+
+
+def _matter_record() -> dict:
+    return {"id": MATTER_ID, "number": NUMBER}
+
+
+def _roles_envelope() -> dict:
+    """The vendor shape: a role names its contact by id and nothing else."""
+    return {
+        "value": [
+            {"id": "role-1", "name": "Client", "contactId": "c1"},
+            {"id": "role-2", "name": "Defendant", "contactId": "d1"},
+        ]
+    }
+
+
+# ---- the join itself --------------------------------------------------------
+
+
+def test_role_records_carry_matter_number_and_party_email() -> None:
+    client = _mock_client(
+        _handler(
+            {"c1": _person("Alvarez", "alvarez@example.com"), "d1": _person("Draper", "d@x.io")},
+            _matter_record(),
+        )
+    )
+    resp = _roles_envelope()
+    srv._attach_matter_party_join(client, MATTER_ID, resp)
+
+    by_role = {r["id"]: r for r in resp["value"]}
+    assert by_role["role-1"]["party_of_matter"] == MATTER_ID
+    assert by_role["role-1"]["email"] == "alvarez@example.com"
+    assert by_role["role-1"]["matterNumber"] == NUMBER
+    assert by_role["role-2"]["email"] == "d@x.io"
+
+
+def test_addresses_are_lowercased_for_recipient_comparison() -> None:
+    client = _mock_client(
+        _handler({"c1": _person("Alvarez", "Alvarez@Example.COM")}, _matter_record())
+    )
+    resp = {"value": [{"id": "role-1", "contactId": "c1"}]}
+    srv._attach_matter_party_join(client, MATTER_ID, resp)
+    assert resp["value"][0]["email"] == "alvarez@example.com"
+
+
+def test_a_nested_contact_ref_resolves_too() -> None:
+    # The relationships sub-resource nests its contact as an object rather than
+    # a bare id; both spellings must land the same join.
+    client = _mock_client(_handler({"c9": _person("Bell", "b@x.io")}, _matter_record()))
+    resp = [{"id": "rel-1", "contact": {"id": "c9", "href": "/contacts/c9"}}]
+    srv._attach_matter_party_join(client, MATTER_ID, resp)
+    assert resp[0]["party_of_matter"] == MATTER_ID
+    assert resp[0]["email"] == "b@x.io"
+
+
+def test_a_bare_record_is_enriched_without_an_envelope() -> None:
+    client = _mock_client(_handler({"c1": _person("Bell", "b@x.io")}, _matter_record()))
+    resp = {"id": "role-1", "contactId": "c1"}
+    srv._attach_matter_party_join(client, MATTER_ID, resp)
+    assert resp["email"] == "b@x.io"
+
+
+# ---- unresolved must never read as non-membership ---------------------------
+
+
+def test_failed_contact_lookup_attaches_nothing_to_that_record() -> None:
+    # d1 404s. The record must come back exactly as the vendor sent it, so the
+    # membership register learns nothing and the gate stays *unresolved*.
+    client = _mock_client(_handler({"c1": _person("Alvarez", "a@x.io")}, _matter_record()))
+    resp = _roles_envelope()
+    srv._attach_matter_party_join(client, MATTER_ID, resp)
+    by_role = {r["id"]: r for r in resp["value"]}
+    assert "party_of_matter" not in by_role["role-2"]
+    assert "email" not in by_role["role-2"]
+    # The resolvable sibling is still enriched — one miss does not void the read.
+    assert by_role["role-1"]["email"] == "a@x.io"
+
+
+def test_party_without_an_address_attaches_nothing() -> None:
+    client = _mock_client(_handler({"c1": _person("Alvarez")}, _matter_record()))
+    resp = {"value": [{"id": "role-1", "contactId": "c1"}]}
+    srv._attach_matter_party_join(client, MATTER_ID, resp)
+    assert "party_of_matter" not in resp["value"][0]
+
+
+def test_an_unresolvable_matter_number_still_lands_the_id_join() -> None:
+    # The number is a convenience for bodies that cite it; the id join is the
+    # membership fact. A missing number must not withhold the fact.
+    client = _mock_client(_handler({"c1": _person("Alvarez", "a@x.io")}, None))
+    resp = {"value": [{"id": "role-1", "contactId": "c1"}]}
+    srv._attach_matter_party_join(client, MATTER_ID, resp)
+    record = resp["value"][0]
+    assert record["party_of_matter"] == MATTER_ID
+    assert "matterNumber" not in record
+
+
+def test_a_role_id_is_never_resolved_as_a_contact() -> None:
+    # A role's own `id` is a ROLE id. Resolving it as a contact could attach a
+    # WRONG address to a matter, which is the one output this control exists to
+    # prevent.
+    client = _mock_client(_handler({"role-1": _person("Wrong", "wrong@x.io")}, _matter_record()))
+    resp = {"value": [{"id": "role-1", "name": "Client"}]}
+    srv._attach_matter_party_join(client, MATTER_ID, resp)
+    assert "email" not in resp["value"][0]
+
+
+def test_enrichment_never_breaks_the_read() -> None:
+    class Boom:
+        def get(self, *a, **k):
+            raise RuntimeError("vendor down")
+
+    resp = _roles_envelope()
+    srv._attach_matter_party_join(Boom(), MATTER_ID, resp)  # must not raise
+    assert "party_of_matter" not in resp["value"][0]
+
+
+def test_no_completeness_flag_is_ever_attached() -> None:
+    # Seeding from roles may only ADD proven parties. A completeness flag here
+    # would let a paged or role-less party list close a matter and withhold a
+    # correct send while naming its recipient an outsider.
+    client = _mock_client(
+        _handler(
+            {"c1": _person("Alvarez", "a@x.io"), "d1": _person("Draper", "d@x.io")},
+            _matter_record(),
+        )
+    )
+    resp = _roles_envelope()
+    srv._attach_matter_party_join(client, MATTER_ID, resp)
+    serialized = repr(resp)
+    assert "complete" not in serialized
+
+
+# ---- the tools carry the enrichment ----------------------------------------
+
+
+def test_get_roles_on_matter_returns_the_enriched_payload(monkeypatch) -> None:
+    client = _mock_client(_handler({"c1": _person("Alvarez", "a@x.io")}, _matter_record()))
+
+    def _roles_response(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if path.endswith("/oauth2/token"):
+            return httpx.Response(
+                200, json={"access_token": "tok", "expires_in": 3600, "token_type": "Bearer"}
+            )
+        if path.endswith("/roles"):
+            return httpx.Response(200, json=_roles_envelope())
+        if "/contacts/" in path:
+            return httpx.Response(200, json=_person("Alvarez", "a@x.io"))
+        if "/matters/" in path:
+            return httpx.Response(200, json=_matter_record())
+        return httpx.Response(200, json={"ok": True})
+
+    client._http = httpx.Client(transport=httpx.MockTransport(_roles_response))
+    monkeypatch.setattr(srv, "_get_client", lambda: client)
+
+    out = srv.get_roles_on_matter(MATTER_ID)
+    assert out["value"][0]["party_of_matter"] == MATTER_ID
+    assert out["value"][0]["matterNumber"] == NUMBER


### PR DESCRIPTION
## Summary

ADR 0086 names `get_roles_on_matter` / `get_relationships_on_matter` the canonical seeding sources for outbound matter membership — the reads that answer "who is on this matter". **The vendor payload does not carry the join.** `/matters/{id}/roles` is a sub-resource: each record names its contact by id and the matter appears only in the request path, so the party's ADDRESS (on the contact) and the matter's NUMBER (on the matter) are both absent from the record. Both were one fetch away and nothing performed that fetch, so the reads that describe matter membership taught the membership register nothing at all.

This lands the join, in the `_attach_matter_ref` fail-safe shape. The overlay half that consumes it is venturecrane/hermes-smd-overlay#271.

## Changes

- `operator/connectors/smokeball/smokeball_connector/server.py:367-471` — `_attach_matter_party_join`, `_role_contact_id`, `_iter_role_records`. Each role/relationship record gains `party_of_matter`, `matterNumber`, and the party's `email` **only** when they resolve. An unresolved contact, an address-less party, an exhausted lookup budget, or an unresolvable matter leaves the record exactly as the vendor returned it — no key, no membership, and the gate reaches *unresolved* rather than "not a party".
- `server.py:1146-1172` — `get_roles_on_matter` / `get_relationships_on_matter` run the enrichment. Relationships matter as much as roles: a relationship is how opposing counsel and adjusters attach to a matter, and those are exactly the OUTSIDE recipients ADR 0086 requires to pair. They sit on neither `clientIds` nor `otherSideIds`, so `_attach_parties` never saw them.
- `operator/connectors/smokeball/tests/test_matter_role_party_join.py` — 11 cases.

Two deliberate non-features, both stated in the code:

- **No completeness flag.** Seeding from roles may only ADD proven parties. Closing a set is what enables a withhold, and a roles listing is not provably the whole membership of a matter (it pages; a party can exist with no role record). `parties_complete` and the ss#2264 contact axis stay the only two closers.
- **A role's own `id` is never resolved as a contact.** It is a ROLE id; resolving it could attach a WRONG address to a matter, which is the one output this control exists to prevent (`test_a_role_id_is_never_resolved_as_a_contact`).

## Acceptance criteria

| AC | Status | Evidence |
|---|---|---|
| (repo, connector) Field-shape confirmation: `get_roles_on_matter` / `get_relationships_on_matter` carry (matterNumber, email) in one record; connector enrichment added where they don't | met | They do NOT. `server.py:977-987` (pre-change) returned `/matters/{id}/roles` raw; the endpoint is a sub-resource with no matter and no address. Enrichment added at `server.py:367-475`, wired at `server.py:1146-1172` |
| (repo) Unresolved never reads as non-membership | met | `tests/test_matter_role_party_join.py:130-178` — failed lookup, address-less party, unresolvable number, role-id-as-contact, vendor-down all attach nothing |
| (runtime) Kill-test pair on a product seat: cross-matter send REFUSES and correct-pairing send PASSES | **not met — not proven in this PR** | Needs a rebuilt seat on an overlay ref containing hermes-smd-overlay#271, then `crane_verify` both directions |

## Test Plan

- [x] `operator/connectors/smokeball` suite in its own venv (the CI shape): 257 passed
- [x] Mutation companion — dropping the `email` attach (with `--reinstall-package`, since the venv installs a COPY) fails 5 of the 11 new cases; reverted and re-green
- [x] `npm ci && npm run verify` — exit 0
- [x] `operator` pytest suites — 1384 passed, 1 pre-existing failure unrelated to this change (`adapter/evidence/tests/test_packet.py::test_build_emits_targz_with_every_expected_file`, reproduced on a clean tree with the change stashed)

Refs #2167, ADR 0086.

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V5sDHLGttrvoh4LhKo4YLb


---

**Rebased on `38a21930`** (lane E's #2394, same file). The overlap was one section-header line; lane E's helper shapes (`_item_matter_id`, the `matter_id` kwarg on `_attach_matter_refs_to_list`) live on the tasks/events/memos/files path and are untouched here. Connector suite re-run after `uv pip install --reinstall-package` (the venv installs a COPY, so a source edit is otherwise not under test): 270 passed.
