### PR TITLE
fix(operator): a surfaced verification blocker is ledger state — a held item can never plan a chase (#2402)

### DIFF
--- a/operator/skills/client-verification-tracker/SKILL.md
+++ b/operator/skills/client-verification-tracker/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   connective chase for the firm's most-slipped discovery step. Never decides which responses need
   verification, never sends to the signer without authenticated attorney approval, never signs,
   and never asserts a signature it cannot see.
-version: 0.3.0
+version: 0.4.0
 author: SMD Services
 license: MIT
 platforms: [linux, macos]
@@ -279,6 +279,26 @@ Two ledger raise events matter for the chase:
   fires **once**, not on every wake. A `resolved` event (written on a confident
   signed-document close) is likewise terminal.
 
+**The hold (ss #2402): a surfaced blocker is ledger state, never just an email.**
+When a turn finds an item **unsafe to chase** — the founding case is an
+unresolvable signer (e.g. conflicting Minor/Deceased sub-roles on the plaintiff),
+but any surface-and-ask condition on the item qualifies — it does three things in
+that turn: (1) appends a `fired` event on the item's **hold sentinel** (derive
+with `matter_id` = the item's matter, `source_id` = `__hold__<task_id>`, `label`
+= `chase-hold`, `authored_date` = null — the prefix is the cross-side contract
+with `pre_run.py`'s `hold_source_id`), (2) surfaces the blocker to a person, and
+(3) sends **no chase**. From then on the gate refuses to plan a chase **or a
+hand-off** for that item and re-surfaces the hold every `escalation.refire_days`
+instead — the hold cannot be forgotten by the next wake, because the next wake
+reads it. On 2026-08-11 this hold lived only in an email, and the 2026-08-14
+wake staged a chase to the very signer the seat had declared unconfirmed.
+Releasing the hold is itself an observed fact, never an assumption: only when a
+turn has **confirmation from a person or from the matter record** (the roles
+now resolve to one signer, or the responsible attorney named the signer) does it
+append `resolved` on the hold sentinel — same derive-then-handle — after which
+the chase plans again on the normal cadence. An `acked` hold stays blocking (ack
+means "seen", not "fixed"); it only snoozes the re-surface.
+
 The **internal escalation-to-a-person** (both the ceiling hand-off and the
 "cadence/attempt-count not authored" surface) therefore follows the same
 fire-once + re-fire-window, terminal-aware rule the deadline lane uses — it
@@ -302,7 +322,9 @@ surface), never a silent default.
    `clientIds[]`) and the roles/relationships (`get_roles_on_matter`,
    `get_relationships_on_matter`) to determine, for each plaintiff, the correct
    **signer** (party / GAL / successor). Do not proceed on a matter whose signer is
-   ambiguous — surface and ask.
+   ambiguous — **write the hold** (a `fired` on the item's hold sentinel; see "The
+   hold" above), surface, and ask. A surfaced blocker with no hold event is the
+   ss #2402 defect: the next wake will not know it exists.
 2. **Prepare** — for each plaintiff/response-set the attorney has flagged for
    verification, draft the plain-language verification request in the firm's voice
    from the pack template (`verification-request.md`). Connective artifact, not work
@@ -320,8 +342,8 @@ surface), never a silent default.
    authored cadence/ceiling (see "The state ledger" above). **The wake line in
    the Script Output block is the turn's work list (#2226):** when it carries
    `plans`, each entry names the `matter_id`, `task_id`, and `action`
-   (`chase` / `handoff` / `surface_config_missing`) the gate found due, with
-   the attempt number a chase carries. Start from those entries — verify each
+   (`chase` / `handoff` / `surface_config_missing` / `surface_hold`) the gate
+   found due, with the attempt number a chase carries. Start from those entries — verify each
    live (`list_tasks(matter_id, is_completed=false)`, `get_files_on_matter`)
    and act per the branches below. The gate sees every open verification task
    through a global pull; the escalation ledger only knows items that have
@@ -338,9 +360,18 @@ surface), never a silent default.
    - matched with confidence (only once the firm's convention is confirmed) → close
      (`update_task`), log (`create_memo`), append a `resolved` ledger event, let it
      fall into the daily digest.
-   - not found / ambiguous / convention-unconfirmed, and the attempt count (the
+   - plan action `surface_hold` → the item is held (signer unresolved or another
+     surfaced blocker). Re-surface the blocker to a person, referencing the prior
+     surface; send **no chase and no hand-off**. Before re-surfacing, re-check the
+     blocking fact live (`get_roles_on_matter`): if it now resolves cleanly,
+     append `resolved` on the hold sentinel instead — the chase resumes on the
+     next wake. Never re-verify the signer from memory of an earlier turn.
+   - not found / ambiguous / convention-unconfirmed, and **no open hold on the
+     item**, and the attempt count (the
      `chased` raises in the ledger) is **below `escalate_after_attempts`**, and
-     `chase_cadence_days` is authored → chase the signer with
+     `chase_cadence_days` is authored → **re-run the step-1 signer resolution in
+     this turn** (metadata reads; a stale signer is the wrong-recipient defect),
+     then chase the signer with
      `mcp_agentmail_send_message` (never `reply_to_message`) on the authored cadence;
      after the send succeeds, log the attempt (`create_memo`) AND append a `chased`
      ledger event (attempt = the new count); tell the attorney only if it stalls
@@ -391,6 +422,10 @@ not an immutable invariant.
   surfaced.
 - **Never chase on an unauthored cadence** — no `chase_cadence_days`, no chase;
   surface "chase cadence not authored" and hold.
+- **Never chase a held item, and never hold an item in prose only** — a blocker a
+  turn surfaces (unresolved signer above all) is written to the ledger as the
+  item's hold (`fired` on the hold sentinel) in the same turn, and only an
+  observed resolution writes the `resolved` that releases it (ss #2402).
 - **Never nag indefinitely** — once unanswered attempts reach `escalate_after_attempts`,
   stop chasing the client and red-flag the responsible attorney (once — the ledger
   `handed_off` event makes the hand-off terminal, so it does not repeat on later wakes).

--- a/operator/skills/client-verification-tracker/SKILL.md
+++ b/operator/skills/client-verification-tracker/SKILL.md
@@ -280,24 +280,31 @@ Two ledger raise events matter for the chase:
   signed-document close) is likewise terminal.
 
 **The hold (ss #2402): a surfaced blocker is ledger state, never just an email.**
-When a turn finds an item **unsafe to chase** — the founding case is an
+When a turn finds a matter **unsafe to chase** — the founding case is an
 unresolvable signer (e.g. conflicting Minor/Deceased sub-roles on the plaintiff),
-but any surface-and-ask condition on the item qualifies — it does three things in
-that turn: (1) appends a `fired` event on the item's **hold sentinel** (derive
-with `matter_id` = the item's matter, `source_id` = `__hold__<task_id>`, `label`
-= `chase-hold`, `authored_date` = null — the prefix is the cross-side contract
-with `pre_run.py`'s `hold_source_id`), (2) surfaces the blocker to a person, and
-(3) sends **no chase**. From then on the gate refuses to plan a chase **or a
-hand-off** for that item and re-surfaces the hold every `escalation.refire_days`
-instead — the hold cannot be forgotten by the next wake, because the next wake
-reads it. On 2026-08-11 this hold lived only in an email, and the 2026-08-14
-wake staged a chase to the very signer the seat had declared unconfirmed.
-Releasing the hold is itself an observed fact, never an assumption: only when a
-turn has **confirmation from a person or from the matter record** (the roles
-now resolve to one signer, or the responsible attorney named the signer) does it
-append `resolved` on the hold sentinel — same derive-then-handle — after which
-the chase plans again on the normal cadence. An `acked` hold stays blocking (ack
-means "seen", not "fixed"); it only snoozes the re-surface.
+but any surface-and-ask condition qualifies — it does three things in that turn:
+(1) appends a `fired` event on the **matter's hold sentinel** (derive with
+`matter_id` = the matter, `source_id` = the literal `__hold__`, `label` =
+`chase-hold`, `authored_date` = null — these literals are the cross-side
+contract with `pre_run.py`'s `HOLD_SOURCE_ID`), (2) surfaces the blocker to a
+person, and (3) sends **no chase**. The hold is **matter-level by design**: the
+blocker is a fact about the matter's roles, so it must survive the tracking
+task being completed, deleted, or recreated, and on a multi-plaintiff matter it
+holds every verification chase rather than guessing which siblings are safe.
+From then on the gate refuses to plan a chase **or a hand-off** for any item on
+that matter and re-surfaces the hold every `escalation.refire_days` instead —
+the hold cannot be forgotten by the next wake, because the next wake reads it.
+**Each re-surface turn appends a fresh `fired` on the hold sentinel in the same
+turn** — that raise is what starts the next quiet window; a re-surface without
+the raise would fire again on every wake. On 2026-08-11 this hold lived only in
+an email, and the 2026-08-14 wake staged a chase to the very signer the seat
+had declared unconfirmed. Releasing the hold is itself an observed fact, never
+an assumption: only when a turn has **confirmation from a person or from the
+matter record** (the roles now resolve to one signer, or the responsible
+attorney named the signer) does it append `resolved` on the hold sentinel —
+same derive-then-handle — after which the chase plans again on the normal
+cadence. An `acked` hold stays blocking (ack means "seen", not "fixed"); it
+only snoozes the re-surface.
 
 The **internal escalation-to-a-person** (both the ceiling hand-off and the
 "cadence/attempt-count not authored" surface) therefore follows the same
@@ -360,12 +367,14 @@ surface), never a silent default.
    - matched with confidence (only once the firm's convention is confirmed) → close
      (`update_task`), log (`create_memo`), append a `resolved` ledger event, let it
      fall into the daily digest.
-   - plan action `surface_hold` → the item is held (signer unresolved or another
-     surfaced blocker). Re-surface the blocker to a person, referencing the prior
-     surface; send **no chase and no hand-off**. Before re-surfacing, re-check the
-     blocking fact live (`get_roles_on_matter`): if it now resolves cleanly,
-     append `resolved` on the hold sentinel instead — the chase resumes on the
-     next wake. Never re-verify the signer from memory of an earlier turn.
+   - plan action `surface_hold` → the matter is held (signer unresolved or another
+     surfaced blocker). Before re-surfacing, re-check the blocking fact live
+     (`get_roles_on_matter`): if it now resolves cleanly, append `resolved` on the
+     hold sentinel instead — the chase resumes on the next wake. Still blocked →
+     re-surface the blocker to a person, referencing the prior surface, AND append
+     a fresh `fired` on the hold sentinel in the same turn (the raise starts the
+     next quiet window; without it the hold fires on every wake). Send **no chase
+     and no hand-off**. Never re-verify the signer from memory of an earlier turn.
    - not found / ambiguous / convention-unconfirmed, and **no open hold on the
      item**, and the attempt count (the
      `chased` raises in the ledger) is **below `escalate_after_attempts`**, and

--- a/operator/skills/client-verification-tracker/pre_run.py
+++ b/operator/skills/client-verification-tracker/pre_run.py
@@ -26,6 +26,15 @@ For each open verification tracking item the skill maintains:
       the ledger holds no ``handed_off`` event yet: wake ONCE to stop chasing the
       client and hand the open item to the responsible attorney. A ``handed_off``
       item is terminal for autonomous wakes.
+  (d) HELD — the ledger carries an open per-item HOLD (a ``fired`` raise on the
+      item's hold sentinel; see ``hold_source_id``): the turn that inspected the
+      matter found it cannot chase safely (signer unresolved, or any other
+      surface-and-ask condition on the item). A held item NEVER plans a chase or
+      a hand-off; instead the hold re-surfaces to a person on the re-fire window
+      until a turn writes ``resolved`` on the hold sentinel (ss #2402 — on
+      2026-08-11 the turn surfaced "signer not confirmed" and three days later
+      the next wake planned a chase to the unconfirmed signer, because the hold
+      lived only in an email).
 
 Plus one seat-level condition:
 
@@ -92,6 +101,22 @@ SKILL_NAME = "client-verification-tracker"
 # (every refire_days until authored), never daily (#1899).
 _CONFIG_SENTINEL_SOURCE_ID = "__chase_config__"
 _CONFIG_SENTINEL_LABEL = "chase-config-missing"
+
+# Per-item hold sentinel (ss #2402). A turn that finds an item unsafe to chase
+# (signer unresolved is the founding case) appends a ``fired`` raise on the
+# item's HOLD identity — same matter, the source id below — via the broker
+# (derive-then-handle, ss #2304). ``decide()`` then refuses to plan a chase or
+# hand-off for the underlying item until a turn appends ``resolved`` on the
+# hold. The prefix is part of the cross-side contract: the turn and this gate
+# must derive the same key from the same components, so it is a module constant
+# here and cited verbatim in SKILL.md.
+_HOLD_SOURCE_PREFIX = "__hold__"
+_HOLD_LABEL = "chase-hold"
+
+
+def hold_source_id(task_id: str) -> str:
+    """The ledger ``source_id`` of the hold sentinel for one tracked item."""
+    return _HOLD_SOURCE_PREFIX + task_id
 
 
 # ---------------------------------------------------------------------------
@@ -282,6 +307,7 @@ def _load_ledger_module():
 ACTION_CHASE = "chase"  # a client nudge is due (attempt < ceiling)
 ACTION_HANDOFF = "handoff"  # ceiling reached; stop chasing, hand to the attorney (once)
 ACTION_SURFACE_CONFIG = "surface_config_missing"  # seat-level, on the refire window
+ACTION_SURFACE_HOLD = "surface_hold"  # item held (e.g. signer unresolved); re-surface, never chase
 ACTION_SUPPRESS = "suppress"  # nothing due for this item
 
 
@@ -304,6 +330,22 @@ class WakeDecision:
     pre_run_inputs_digest: bytes
     plans: tuple[ItemPlan, ...] = ()
     extra_metadata: dict = field(default_factory=dict)
+
+
+def _hold_active(hold_state) -> bool:
+    """True iff the item's hold sentinel blocks the chase.
+
+    A hold is open once it has any raise and is not ``resolved``. An ``acked``
+    hold stays BLOCKING — ack means "a person saw the surface", not "the
+    condition is fixed"; it only snoozes the re-surface (``should_fire``
+    handles that). ``handed_off`` likewise blocks and additionally ends
+    autonomous re-surfacing: a person owns the item. Only ``resolved`` —
+    written by the turn that confirmed the condition is fixed (e.g. the signer
+    is confirmed) — releases the chase.
+    """
+    if hold_state is None or hold_state.attempts == 0:
+        return False
+    return not hold_state.resolved
 
 
 def _chase_due(
@@ -392,6 +434,29 @@ def decide(
         # Terminal: resolved, or already handed off (a person owns it now).
         if state is not None and (state.resolved or state.handed_off):
             continue
+        # (d) HELD — an open hold on this item blocks chase AND hand-off (the
+        # ambiguity precedes the count). Re-surface on the re-fire window so a
+        # held item never goes permanently dark (#1899); release only on a
+        # ``resolved`` hold event (ss #2402).
+        if item.task_id is not None:
+            hold_key = ledger.item_key(
+                item.matter_id, hold_source_id(item.task_id), _HOLD_LABEL, None
+            )
+            hold_state = states.get(hold_key)
+            if _hold_active(hold_state):
+                if not hold_state.handed_off and ledger.should_fire(
+                    hold_state, today, refire_days=refire_days, ack_snooze_days=refire_days
+                ):
+                    plans.append(
+                        ItemPlan(
+                            matter_id=item.matter_id,
+                            task_id=item.task_id,
+                            item_key=hold_key,
+                            action=ACTION_SURFACE_HOLD,
+                            attempt=ledger.next_attempt(hold_state),
+                        )
+                    )
+                continue
         attempts = 0 if state is None else state.attempts
         if attempts >= ceiling:
             # (b) Ceiling reached, not yet handed off → wake once to hand off.
@@ -420,6 +485,7 @@ def decide(
     if actionable:
         chases = sum(1 for p in actionable if p.action == ACTION_CHASE)
         handoffs = sum(1 for p in actionable if p.action == ACTION_HANDOFF)
+        holds = sum(1 for p in actionable if p.action == ACTION_SURFACE_HOLD)
         return WakeDecision(
             wake=True,
             decision_basis="verification_action_due",
@@ -428,6 +494,7 @@ def decide(
             extra_metadata={
                 "chase_due": chases,
                 "handoff_due": handoffs,
+                "hold_surface_due": holds,
                 "open_item_count": len(items),
                 "items": [
                     {

--- a/operator/skills/client-verification-tracker/pre_run.py
+++ b/operator/skills/client-verification-tracker/pre_run.py
@@ -26,15 +26,16 @@ For each open verification tracking item the skill maintains:
       the ledger holds no ``handed_off`` event yet: wake ONCE to stop chasing the
       client and hand the open item to the responsible attorney. A ``handed_off``
       item is terminal for autonomous wakes.
-  (d) HELD — the ledger carries an open per-item HOLD (a ``fired`` raise on the
-      item's hold sentinel; see ``hold_source_id``): the turn that inspected the
-      matter found it cannot chase safely (signer unresolved, or any other
-      surface-and-ask condition on the item). A held item NEVER plans a chase or
-      a hand-off; instead the hold re-surfaces to a person on the re-fire window
-      until a turn writes ``resolved`` on the hold sentinel (ss #2402 — on
-      2026-08-11 the turn surfaced "signer not confirmed" and three days later
-      the next wake planned a chase to the unconfirmed signer, because the hold
-      lived only in an email).
+  (d) HELD — the ledger carries an open per-MATTER hold (a ``fired`` raise on
+      the matter's hold sentinel; see ``HOLD_SOURCE_ID``): a turn that
+      inspected the matter found it cannot chase safely (signer unresolved, or
+      any other surface-and-ask condition). A held matter NEVER plans a chase
+      or a hand-off for any of its verification items; instead the hold
+      re-surfaces to a person on the re-fire window until a turn writes
+      ``resolved`` on the hold sentinel (ss #2402 — on 2026-08-11 the turn
+      surfaced "signer not confirmed" and three days later the next wake
+      planned a chase to the unconfirmed signer, because the hold lived only
+      in an email).
 
 Plus one seat-level condition:
 
@@ -102,21 +103,28 @@ SKILL_NAME = "client-verification-tracker"
 _CONFIG_SENTINEL_SOURCE_ID = "__chase_config__"
 _CONFIG_SENTINEL_LABEL = "chase-config-missing"
 
-# Per-item hold sentinel (ss #2402). A turn that finds an item unsafe to chase
-# (signer unresolved is the founding case) appends a ``fired`` raise on the
-# item's HOLD identity — same matter, the source id below — via the broker
-# (derive-then-handle, ss #2304). ``decide()`` then refuses to plan a chase or
-# hand-off for the underlying item until a turn appends ``resolved`` on the
-# hold. The prefix is part of the cross-side contract: the turn and this gate
-# must derive the same key from the same components, so it is a module constant
-# here and cited verbatim in SKILL.md.
-_HOLD_SOURCE_PREFIX = "__hold__"
+# Per-MATTER hold sentinel (ss #2402). A turn that finds a matter unsafe to
+# chase (signer unresolved is the founding case) appends a ``fired`` raise on
+# the matter's HOLD identity — the matter id plus the fixed source id below —
+# via the broker (derive-then-handle, ss #2304). ``decide()`` then refuses to
+# plan a chase or hand-off for ANY verification item on that matter until a
+# turn appends ``resolved`` on the hold.
+#
+# The identity is deliberately MATTER-level, not task-level: the founding
+# blocker (conflicting Minor/Deceased sub-roles on the plaintiff) is a fact
+# about the matter's roles, not about one tracking task. A task-keyed hold
+# would evaporate the moment the tracking task is completed, deleted, or
+# recreated — the first wake on a replacement task would plan a chase straight
+# past the still-unresolved blocker. Matter-level is also fail-closed for
+# multi-plaintiff matters: one unresolved signer holds every verification
+# chase on the matter, and the re-surface asks a person rather than guessing
+# which sibling items are safe.
+#
+# The constants are the cross-side contract: the turn and this gate must
+# derive the same key from the same components, so they live here and are
+# cited verbatim in SKILL.md.
+HOLD_SOURCE_ID = "__hold__"
 _HOLD_LABEL = "chase-hold"
-
-
-def hold_source_id(task_id: str) -> str:
-    """The ledger ``source_id`` of the hold sentinel for one tracked item."""
-    return _HOLD_SOURCE_PREFIX + task_id
 
 
 # ---------------------------------------------------------------------------
@@ -434,29 +442,34 @@ def decide(
         # Terminal: resolved, or already handed off (a person owns it now).
         if state is not None and (state.resolved or state.handed_off):
             continue
-        # (d) HELD — an open hold on this item blocks chase AND hand-off (the
-        # ambiguity precedes the count). Re-surface on the re-fire window so a
-        # held item never goes permanently dark (#1899); release only on a
-        # ``resolved`` hold event (ss #2402).
-        if item.task_id is not None:
-            hold_key = ledger.item_key(
-                item.matter_id, hold_source_id(item.task_id), _HOLD_LABEL, None
-            )
-            hold_state = states.get(hold_key)
-            if _hold_active(hold_state):
-                if not hold_state.handed_off and ledger.should_fire(
+        # (d) HELD — an open hold on this MATTER blocks chase AND hand-off for
+        # every verification item on it (the ambiguity precedes the count, and
+        # it is a fact about the matter, so a recreated tracking task cannot
+        # slip past it). Re-surface on the re-fire window so a held matter
+        # never goes permanently dark (#1899); release only on a ``resolved``
+        # hold event (ss #2402). One surface per held matter per wake, even
+        # with several tracked items on it.
+        hold_key = ledger.item_key(item.matter_id, HOLD_SOURCE_ID, _HOLD_LABEL, None)
+        hold_state = states.get(hold_key)
+        if _hold_active(hold_state):
+            already_surfacing = any(p.item_key == hold_key for p in plans)
+            if (
+                not already_surfacing
+                and not hold_state.handed_off
+                and ledger.should_fire(
                     hold_state, today, refire_days=refire_days, ack_snooze_days=refire_days
-                ):
-                    plans.append(
-                        ItemPlan(
-                            matter_id=item.matter_id,
-                            task_id=item.task_id,
-                            item_key=hold_key,
-                            action=ACTION_SURFACE_HOLD,
-                            attempt=ledger.next_attempt(hold_state),
-                        )
+                )
+            ):
+                plans.append(
+                    ItemPlan(
+                        matter_id=item.matter_id,
+                        task_id=item.task_id,
+                        item_key=hold_key,
+                        action=ACTION_SURFACE_HOLD,
+                        attempt=ledger.next_attempt(hold_state),
                     )
-                continue
+                )
+            continue
         attempts = 0 if state is None else state.attempts
         if attempts >= ceiling:
             # (b) Ceiling reached, not yet handed off → wake once to hand off.

--- a/operator/skills/client-verification-tracker/test_verification_pre_run.py
+++ b/operator/skills/client-verification-tracker/test_verification_pre_run.py
@@ -50,6 +50,8 @@ parse_pull = _pre_run.parse_pull
 ACTION_CHASE = _pre_run.ACTION_CHASE
 ACTION_HANDOFF = _pre_run.ACTION_HANDOFF
 ACTION_SURFACE_CONFIG = _pre_run.ACTION_SURFACE_CONFIG
+ACTION_SURFACE_HOLD = _pre_run.ACTION_SURFACE_HOLD
+hold_source_id = _pre_run.hold_source_id
 
 # The vendored ledger module the skill loads at runtime — used here to mint real
 # events so the tests exercise the true item_key/state join.
@@ -336,6 +338,108 @@ def test_unauthored_config_never_chases():
     item = _item(next_chase_due=TODAY - timedelta(days=30))
     d = _decide([item], [], config=ChaseConfig())
     assert d.plans[0].action == ACTION_SURFACE_CONFIG  # never ACTION_CHASE
+
+
+# ---------------------------------------------------------------------------
+# decide() — per-item hold (condition d, ss #2402): an open hold blocks chase
+# AND hand-off; it re-surfaces on the re-fire window; only a resolved hold
+# releases the chase. Founding case: signer unresolved (2026-08-11 the turn
+# surfaced the hold in an email only, and the 2026-08-14 wake planned a chase
+# to the unconfirmed signer).
+# ---------------------------------------------------------------------------
+
+
+def _hold_event(item, *, event="fired", ts, attempt=1):
+    key = _ledger.item_key(
+        item.matter_id, hold_source_id(item.task_id), "chase-hold", None
+    )
+    return _ledger.make_event(
+        skill="client-verification-tracker",
+        matter_id=item.matter_id,
+        item_key=key,
+        event=event,
+        attempt=attempt,
+        ts=ts,
+    )
+
+
+def test_hold_blocks_a_due_chase_and_resurfaces():
+    # Chase long overdue, but a hold fired 4 days ago (refire window 3) →
+    # the plan is a re-surface of the hold, never a chase.
+    item = _item(next_chase_due=TODAY - timedelta(days=30))
+    events = [_hold_event(item, ts="2026-07-10T09:00:00.000Z")]
+    d = _decide([item], events)
+    assert d.wake is True
+    assert [p.action for p in d.plans] == [ACTION_SURFACE_HOLD]
+    assert d.plans[0].attempt == 2  # second surface, numbered from the ledger
+    assert d.extra_metadata["hold_surface_due"] == 1
+
+
+def test_hold_quiet_within_refire_window_still_blocks_chase():
+    # Hold surfaced yesterday → nothing re-fires, and the due chase stays blocked.
+    item = _item(next_chase_due=TODAY - timedelta(days=30))
+    events = [_hold_event(item, ts="2026-07-13T09:00:00.000Z")]
+    d = _decide([item], events)
+    assert d.wake is False
+    assert d.decision_basis == "no_verification_action_due"
+
+
+def test_acked_hold_snoozes_the_surface_but_still_blocks():
+    # Ack means "a person saw it", not "the signer is confirmed" → no chase.
+    item = _item(next_chase_due=TODAY - timedelta(days=30))
+    events = [
+        _hold_event(item, ts="2026-07-08T09:00:00.000Z"),
+        _hold_event(item, event="acked", ts="2026-07-13T09:00:00.000Z"),
+    ]
+    d = _decide([item], events)
+    assert d.wake is False
+
+
+def test_resolved_hold_releases_the_chase():
+    # The falsifier (Law 12): same item, hold resolved → the chase plans again.
+    item = _item(next_chase_due=TODAY - timedelta(days=30))
+    events = [
+        _hold_event(item, ts="2026-07-08T09:00:00.000Z"),
+        _hold_event(item, event="resolved", ts="2026-07-12T09:00:00.000Z"),
+    ]
+    d = _decide([item], events)
+    assert d.wake is True
+    assert [p.action for p in d.plans] == [ACTION_CHASE]
+
+
+def test_handed_off_hold_blocks_and_goes_quiet():
+    # A hold handed to a person: no chase, and no autonomous re-surface either.
+    item = _item(next_chase_due=TODAY - timedelta(days=30))
+    events = [
+        _hold_event(item, ts="2026-07-01T09:00:00.000Z"),
+        _hold_event(item, event="handed_off", ts="2026-07-02T09:00:00.000Z"),
+    ]
+    d = _decide([item], events)
+    assert d.wake is False
+
+
+def test_hold_blocks_the_ceiling_handoff_too():
+    # Attempts at ceiling AND a hold → the ambiguity precedes the count: no
+    # hand-off plan while the hold is open, only the hold surface.
+    item = _item(next_chase_due=TODAY - timedelta(days=30))
+    events = [
+        _chased_event(item, ts="2026-06-20T09:00:00.000Z", attempt=1),
+        _chased_event(item, ts="2026-06-25T09:00:00.000Z", attempt=2),
+        _chased_event(item, ts="2026-06-30T09:00:00.000Z", attempt=3),
+        _hold_event(item, ts="2026-07-10T09:00:00.000Z"),
+    ]
+    d = _decide([item], events)
+    assert d.wake is True
+    assert [p.action for p in d.plans] == [ACTION_SURFACE_HOLD]
+
+
+def test_hold_on_one_item_does_not_block_another():
+    held = _item(matter_id="m-1", task_id="task-1", next_chase_due=TODAY - timedelta(days=30))
+    free = _item(matter_id="m-2", task_id="task-2", next_chase_due=TODAY)
+    events = [_hold_event(held, ts="2026-07-13T09:00:00.000Z")]
+    d = _decide([held, free], events)
+    assert d.wake is True
+    assert {(p.matter_id, p.action) for p in d.plans} == {("m-2", ACTION_CHASE)}
 
 
 # ---------------------------------------------------------------------------

--- a/operator/skills/client-verification-tracker/test_verification_pre_run.py
+++ b/operator/skills/client-verification-tracker/test_verification_pre_run.py
@@ -51,7 +51,7 @@ ACTION_CHASE = _pre_run.ACTION_CHASE
 ACTION_HANDOFF = _pre_run.ACTION_HANDOFF
 ACTION_SURFACE_CONFIG = _pre_run.ACTION_SURFACE_CONFIG
 ACTION_SURFACE_HOLD = _pre_run.ACTION_SURFACE_HOLD
-hold_source_id = _pre_run.hold_source_id
+HOLD_SOURCE_ID = _pre_run.HOLD_SOURCE_ID
 
 # The vendored ledger module the skill loads at runtime — used here to mint real
 # events so the tests exercise the true item_key/state join.
@@ -341,18 +341,17 @@ def test_unauthored_config_never_chases():
 
 
 # ---------------------------------------------------------------------------
-# decide() — per-item hold (condition d, ss #2402): an open hold blocks chase
-# AND hand-off; it re-surfaces on the re-fire window; only a resolved hold
-# releases the chase. Founding case: signer unresolved (2026-08-11 the turn
-# surfaced the hold in an email only, and the 2026-08-14 wake planned a chase
-# to the unconfirmed signer).
+# decide() — per-MATTER hold (condition d, ss #2402): an open hold blocks
+# chase AND hand-off for every item on the matter; it re-surfaces on the
+# re-fire window; only a resolved hold releases the chase. Founding case:
+# signer unresolved (2026-08-11 the turn surfaced the hold in an email only,
+# and the 2026-08-14 wake planned a chase to the unconfirmed signer).
 # ---------------------------------------------------------------------------
 
 
 def _hold_event(item, *, event="fired", ts, attempt=1):
-    key = _ledger.item_key(
-        item.matter_id, hold_source_id(item.task_id), "chase-hold", None
-    )
+    # Matter-level identity: the hold names the MATTER, not the tracking task.
+    key = _ledger.item_key(item.matter_id, HOLD_SOURCE_ID, "chase-hold", None)
     return _ledger.make_event(
         skill="client-verification-tracker",
         matter_id=item.matter_id,
@@ -433,13 +432,34 @@ def test_hold_blocks_the_ceiling_handoff_too():
     assert [p.action for p in d.plans] == [ACTION_SURFACE_HOLD]
 
 
-def test_hold_on_one_item_does_not_block_another():
+def test_hold_on_one_matter_does_not_block_another():
     held = _item(matter_id="m-1", task_id="task-1", next_chase_due=TODAY - timedelta(days=30))
     free = _item(matter_id="m-2", task_id="task-2", next_chase_due=TODAY)
     events = [_hold_event(held, ts="2026-07-13T09:00:00.000Z")]
     d = _decide([held, free], events)
     assert d.wake is True
     assert {(p.matter_id, p.action) for p in d.plans} == {("m-2", ACTION_CHASE)}
+
+
+def test_hold_survives_tracking_task_recreation():
+    # The blocker is a fact about the MATTER. A hold written while task-1 was
+    # the tracking task must still block a REPLACEMENT task-9 on the same
+    # matter — a task-keyed hold would evaporate here and the first wake on
+    # the new task would chase straight past the unresolved signer.
+    original = _item(matter_id="m-1", task_id="task-1", next_chase_due=TODAY)
+    events = [_hold_event(original, ts="2026-07-13T09:00:00.000Z")]
+    replacement = _item(matter_id="m-1", task_id="task-9", next_chase_due=TODAY)
+    d = _decide([replacement], events)
+    assert d.wake is False  # within the refire window: quiet, and no chase
+
+
+def test_held_matter_with_two_items_surfaces_once():
+    a = _item(matter_id="m-1", task_id="task-1", next_chase_due=TODAY - timedelta(days=30))
+    b = _item(matter_id="m-1", task_id="task-2", next_chase_due=TODAY - timedelta(days=30))
+    events = [_hold_event(a, ts="2026-07-10T09:00:00.000Z")]
+    d = _decide([a, b], events)
+    assert d.wake is True
+    assert [p.action for p in d.plans] == [ACTION_SURFACE_HOLD]  # one, not two
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What the client experiences

The Operator can no longer chase a signer it has itself declared unconfirmed. Once a run surfaces "signer not confirmed" (or any blocker) on a matter, every later run knows the matter is held: it re-surfaces the blocker to a person on the refire window and sends no chase, until a run observes the blocker actually resolved.

## The defect (pilot-smokeball, smdurgan mailbox)

Aug 11: seat holds the Robert Chen chase — Minor and Deceased sub-roles both mapped, "chase is on hold pending your response." Aug 14: with no resolution anywhere, the seat stages that chase addressed to Robert Chen as self-verifier. The hold lived only in an email; the pre_run's next plan said `chase`, and the turn obeyed. Full evidence and the /wired reachability contract are on #2402.

## Mechanism (mirrors the #1899 config sentinel)

- Turn detects an unchaseable blocker → appends `fired` on the **matter's hold sentinel** (`matter_id`, `source_id` = literal `__hold__`, label `chase-hold`, `authored_date` null) via the broker (derive-then-handle, #2304).
- **Matter-level identity by design** (/critique r1): the founding blocker is a fact about the matter's roles, so the hold survives the tracking task being completed, deleted, or recreated — a task-keyed hold would let the first wake on a replacement task chase straight past the unresolved signer. On a multi-plaintiff matter it holds every verification chase (fail-closed), and a held matter surfaces once per wake, not once per item.
- `decide()` refuses `chase` AND `handoff` for any item on a held matter; plans `surface_hold` on the refire window instead — never forgotten, never permanently dark.
- Each re-surface turn appends a fresh `fired` (that raise starts the next quiet window; without it the hold would fire on every wake) and re-checks the blocking fact live first — a cleanly-resolving check writes `resolved` instead.
- Release is an observed fact only: `resolved` after roles resolve cleanly or the attorney names the signer. `acked` = seen, still blocking. `handed_off` = blocked and quiet (a person owns it).

## Acceptance

- [x] An item on a held matter never plans a chase or hand-off (test)
- [x] A hold survives tracking-task recreation on the matter (test — critique falsifier)
- [x] A hold re-surfaces after `refire_days`, snoozes on ack (still blocking), surfaces once per matter (tests)
- [x] Falsifier: the same matter with a resolved hold plans a chase again (test, Law 12)
- [x] `operator` suite (63) + repo `npm run verify` green
- [ ] (runtime) Kill-test on the pilot seat per the revised contract on #2402: staged-code provenance probe, manual-run-vs-cron pre_run path probe, hold armed by the turn, `surface_hold` plan observed, non-refire within the window observed, release driven by fixing the fixture roles (not a synthetic append), and the final chase observed at the PLAN layer then neutralized before any send — deferred until the #2392 runtime pass clears the seat; #2402 stays open to carry these proofs

Part of #2402 (does not close it — the runtime rows remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLzzpTuYY8j3EaWbXfxz4x
