### PR TITLE
fix(operator): records-chase history is ledger state the email copies — never model recall (#2404)

### DIFF
--- a/operator/customers/pilot-smokeball/customer.yaml
+++ b/operator/customers/pilot-smokeball/customer.yaml
@@ -451,6 +451,14 @@ personas:
           scheduled: true
           webhook: false
         enabled: true
+        # PLACEHOLDER(christa): the chase cadence awaits the firm's answer. The
+        # 7 here is seed-authored, not invented: the pilot's roster-task note
+        # itself says "Chase cadence: weekly until the records land in the
+        # matter" (seed/seed_data.py, records-roster-alvarez). Unauthored is
+        # fail-closed: no cadence, no chase, a re-fired surface instead
+        # (ss #2404; same contract as client-verification-tracker's dials).
+        settings:
+          chase_cadence_days: 7 # PLACEHOLDER(christa): days between records chases
       - name: medical-chronology-maintainer # checks for newly landed records
         version: pending
         initiation:

--- a/operator/skills/medical-records-chaser/SKILL.md
+++ b/operator/skills/medical-records-chaser/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: medical-records-chaser
 description: Chases outstanding medical records from providers. Watches for the plaintiff's medical records landing in the Smokeball matter (records arrive through YoCierge, imported into the matter — observed via document reads, not a YoCierge tool), tracks which requested providers are still outstanding, and chases the provider or records vendor on a cadence until the records are in. Never decides which providers to request, never infers providers from treatment, never diagnoses or characterizes treatment, never drafts a demand, and never asserts a record was received unless the matching document is observed in the matter.
-version: 0.1.0
+version: 0.2.0
 author: SMD Services
 license: MIT
 platforms: [linux, macos]
@@ -175,15 +175,90 @@ never Shape B (the firm's file-naming convention is unconfirmed).
    item with `create_task` (assigned to the responsible staff, keyed to
    `(matter, provider, request)`, dated to a **near-term administrative confirm-by
    date**, stated as such and distinct from any legal deadline).
-5. **Track + re-chase** — a scheduled job re-checks open records tasks
-   (`list_tasks(matter_id, is_completed=false)`) and re-reads `get_files_on_matter`:
+5. **Track + re-chase** — the bespoke `pre_run.py` gates the scheduled wake off
+   the escalation ledger + the authored cadence (see "The state ledger" below).
+   **The wake line's `plans` are the turn's work list AND the email's state
+   (ss #2404):** each `chase` entry names the `matter_id`, `task_id`, the
+   `attempt` this chase would be, `last_chased` (the date of the last chase
+   the seat staged, from the ledger — or null when the ledger holds none), and
+   `days_past_confirm_by` (computed by the gate from the tracking task's
+   authored confirm-by date). Verify each entry live
+   (`list_tasks(matter_id, is_completed=false)`, `get_files_on_matter`), then:
    - a matching record has landed and is matched with confidence → mark received
-     (`update_task`), log (`create_memo`), and let it fall into the daily digest.
+     (`update_task`), log (`create_memo`), append a `resolved` ledger event, and
+     let it fall into the daily digest.
    - still outstanding → chase on the cadence (quiet by design; tell the attorney
-     only if it stalls). Never auto-mark received on a say-so or an ambiguous match.
+     only if it stalls). After the chase is **staged or sent** (the `send_message`
+     call succeeded — at `draft_for_review` that means a held draft exists), log
+     (`create_memo`) AND append a `chased` ledger event via the
+     `escalation_append` tool's derive-then-handle two-step (ss #2304), identity
+     = (`matter_id`, the roster task's stable id, label `records-chase`,
+     `authored_date` null). Never append a `chased` for a send that did not
+     happen. Never auto-mark received on a say-so or an ambiguous match.
+   - plan action `surface_hold` → the matter is held (no authored roster, a
+     roster without addresses, an ambiguous receipt match). Re-check the blocking
+     fact live first: cleanly resolved → append `resolved` on the hold sentinel;
+     still blocked → re-surface to a person AND append a fresh `fired` on the
+     hold sentinel in the same turn (the raise starts the next quiet window).
+     Send no chase.
+   - plan action `surface_config_missing` / `surface_no_roster_tasks` → surface
+     the seat-level condition (cadence not authored / open tasks carry no roster
+     marker) and append a `fired` on that sentinel; hold quiet through the
+     re-fire window. Never default a cadence and never treat zero roster matches
+     as "nothing due".
+     When the wake line carries **no plans** (a fail-open `decision_basis`), the
+     gate woke blind: enumerate the roster tasks yourself and act per the branches
+     above — and state in any email that ledger state was unavailable this run
+     rather than asserting counts or dates from recall.
 6. **Escalate** — if records are still outstanding as a demand-prep or
-   statute-of-limitations date the deadline lane surfaced approaches, raise it to the
-   responsible attorney. The skill **reads** that date; it never computes it.
+   statute-of-limitations date the deadline lane surfaced approaches, or the
+   provider/vendor is non-responsive past the cadence, raise it to the
+   responsible attorney. The skill **reads** the deadline; it never computes it.
+   A stall raise is recorded on its own sentinel — identity
+   (`matter_id`, `__mrc_stall__<task_id>`, label `mrc-stall`, null) — **never on
+   the chase item's key**: attempts count every raise, so a stall `fired` on the
+   chase key would inflate the "chase N" numerator the email copies.
+
+## The state ledger (ss #2404) — the email copies it, never recalls it
+
+The chase's history lives in the shared **escalation ledger** (vendored
+byte-identical as `escalation_ledger.py`; the same broker-owned state the
+verification tracker and deadline lanes use). Item identity is the roster
+task's stable Smokeball id via
+`item_key(matter_id, task_id, "records-chase", null)` — derive with the
+`escalation_append` tool (`derive_only: true`), then write with the returned
+handle; never build a key by hand (ss #2304).
+
+Three rules, each the direct product of the 2026-08-18 defect (the Valley
+Imaging email that asserted "last chase staged July 13, no chase in five
+weeks" three days after its own August 11 chase, threaded by an improvised
+`[op-mrc:...]` tag that drifted weekly):
+
+1. **The email copies the plan's state verbatim.** "Chase N" is the plan's
+   `attempt`; the last-chase date is the plan's `last_chased`; the overdue
+   figure is the plan's `days_past_confirm_by`, phrased as "days past the
+   confirm-by date on the tracking task" (it anchors to the admin confirm-by
+   date, which the firm may refresh — never phrase it as "records N days
+   overdue"). Never recompute, never recall, never carry over from an earlier
+   week's email.
+2. **Null history is stated as null history.** When `last_chased` is null the
+   ledger has no recorded chase for this item — which is NOT the same as "no
+   chase ever happened" (pre-ledger chases live in matter memos; a recreated
+   roster task also starts a fresh identity). Write "first chase recorded in
+   the tracking ledger; earlier chases may appear in the matter memos" and
+   omit any "chase N" numerator. Never write "no prior chase" or "no chase in
+   the last N weeks" from a null.
+3. **No email-body tracking tags.** The `[op-mrc:...]` tag is retired;
+   identity lives in the ledger, and the memos on the matter remain the
+   firm-visible mirror (loss-safety: if the ledger is lost, items re-fire once
+   and the memos let a person reconstruct history).
+
+Every chase email keeps the **forwardable chase letter** (Shape A's blockquote
+in `references/output-format.md`) — the 2026-08-18 emails dropped it, which
+turned an actionable artifact into a nag. Sentinel namespaces here are
+per-skill (`__mrc_*`) because `item_key` ignores the label and the ledger is
+shared: reusing another skill's sentinel source id would let an ack on their
+sentinel silence ours, and their matter-hold block our chases.
 
 ## The autonomy dial (live; the firm turns it)
 
@@ -230,6 +305,14 @@ ceiling, which silently defeats the graduation.
   send by the firm's method. (ADR 0035/0037/0073.)
 - **Never move or compute a deadline** — it reads the date the deadline lane
   surfaced.
+- **Never state chase history from recall** — "chase N", the last-chase date,
+  and the overdue figure come from the wake plan's ledger state, copied
+  verbatim; a null history is stated as "first chase recorded in the tracking
+  ledger", never as "no prior chase" (ss #2404).
+- **Never chase a held matter, and never hold in prose only** — a surfaced
+  blocker is written to the ledger as the matter's hold (`fired` on the
+  `__mrc_hold__` sentinel) in the same turn; only an observed resolution writes
+  the `resolved` that releases it (the ss #2402 rule).
 
 ## Training output (built into every run)
 

--- a/operator/skills/medical-records-chaser/escalation_ledger.py
+++ b/operator/skills/medical-records-chaser/escalation_ledger.py
@@ -1,0 +1,523 @@
+"""Shared escalation-telemetry ledger (WP-A / WP-B).
+
+CANONICAL SOURCE: ``operator/workspace_broker/escalation_ledger.py``. Byte-identical
+copies are vendored into each consuming skill directory as ``escalation_ledger.py``
+so a skill's ``pre_run.py`` (and the agent's ``execute_code`` turn) can import it
+without a package install; ``operator/tests/test_escalation_ledger_sync.py``
+enforces the sync. Edit here, restamp the copies.
+
+What this ledger IS
+-------------------
+An append-only JSONL of **operator communication telemetry** — when a skill
+fired an escalation on an item, when a human acked it, when it was handed off or
+resolved. It is the same class of state as the audit journal (the broker owns
+the write handle; the agent uid reads it but cannot forge a row). It is NOT the
+firm's system of record: matter work state still re-derives from Smokeball. If
+the volume state is lost, items re-fire once (annoying, never dangerous) and the
+Smokeball memos let a person reconstruct history.
+
+Record shape (one JSON object per line)::
+
+    {"v":2,"ts":<iso>,"skill":<str>,"matter_id":<str|null>,
+     "item_key":<hex>,"event":<fired|chased|acked|handed_off|resolved>,
+     "attempt":<int>,"token":<ACK-XXXXXX|null>,"id":<ulid, broker-stamped>}
+
+``v`` is also the item-identity epoch — see ``IDENTITY_EPOCH`` and ``item_key``.
+A row below the epoch keyed the same deadline differently and cannot be joined
+against, or acked, by anything current.
+
+The security line
+-----------------
+An ``acked`` event silences a deadline alarm, so it must not be writable by an
+injectable surface without validation. ``validate_append`` REJECTS an ``acked``
+whose token has no prior ``fired``/``chased`` event. The LLM turn never writes
+the file directly; every write goes through the broker's uid-gated
+``escalation_event_append`` verb, which calls ``validate_append`` and stamps
+``ts``/``id`` server-side (the agent cannot backdate).
+
+Pure stdlib. No imports from other ``workspace_broker`` modules, so the vendored
+copy is safe to load standalone inside a skill.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import secrets
+import time
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta, timezone
+
+SCHEMA_VERSION = 2
+
+# The item-identity epoch. Raises written below this version had their
+# ``item_key`` derived by a different function (it hashed the model-composed
+# ``label``; see ``item_key``), so a pre-epoch key can never name a live item.
+# Acking one would tell a human an alarm was silenced when nothing changed, which
+# is why ``validate_append`` refuses it by name rather than accepting it as a
+# harmless no-op. Pre-epoch rows are otherwise left in place: they are history,
+# and their keys cannot collide with current ones.
+IDENTITY_EPOCH = 2
+
+# The full event vocabulary. A ``fired`` or ``chased`` is a "raise" — an alarm
+# surfaced to a human; an ``acked`` references a prior raise; ``handed_off`` and
+# ``resolved`` are terminal for autonomous re-firing.
+EVENTS: tuple[str, ...] = ("fired", "chased", "acked", "handed_off", "resolved")
+RAISING_EVENTS: tuple[str, ...] = ("fired", "chased")
+_REQUIRED_KEYS: tuple[str, ...] = ("ts", "skill", "item_key", "event")
+
+# Agent read path (broker writes the same inode via the /run/smd-audit bind).
+# Override with SMD_ESCALATION_LEDGER_PATH (tests, and the broker's write side).
+DEFAULT_LEDGER_PATH = "/opt/data/audit/escalation-ledger.jsonl"
+
+# Crockford base32 minus I L O U — the human types the token back off an email.
+_CROCKFORD = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+
+
+def ledger_path() -> str:
+    """The escalation ledger path: env override, else the agent-read default."""
+    return os.environ.get("SMD_ESCALATION_LEDGER_PATH") or DEFAULT_LEDGER_PATH
+
+
+def _now_iso() -> str:
+    dt = datetime.now(timezone.utc)
+    return dt.strftime("%Y-%m-%dT%H:%M:%S.") + f"{dt.microsecond // 1000:03d}Z"
+
+
+# Placeholders a caller may hand in for a component it could not READ off the
+# source record. ``_matter_id_of`` in both skills' ``pre_run.py`` emits
+# "unknown-matter" when the Smokeball payload carries no resolvable matter link.
+# A sentinel is a fabricated component: an identity built on one moves the moment
+# the real value arrives, so it cannot carry a per-item ACK code
+# (see ``has_stable_identity``). It is NOT excluded from ``item_key`` — the item
+# still fires, it just acks with the blanket code.
+UNKNOWN_SENTINELS: frozenset[str] = frozenset({"unknown-matter"})
+
+
+def _normalize_id(value) -> str:
+    """Canonical form of an identifier component of the item key.
+
+    The connector reads Smokeball GUIDs off the wire and passes them through
+    verbatim (``_source_id_of`` returns ``str(value)``); the agent's tool arg is
+    schema-typed ``string`` and the model may pad or re-case what it retypes. Two
+    spellings of ONE id must not be two items, so both sides fold here — strip,
+    then case-fold. Smokeball ids are ASCII GUIDs, where case carries no meaning
+    and two ids differing only in case cannot exist.
+    """
+    if value is None:
+        return ""
+    return str(value).strip().casefold()
+
+
+def _as_iso_date(value) -> str:
+    """Canonical ``YYYY-MM-DD`` for the date component of the item key, or ``""``
+    when the caller's identity convention omits it (the verification chase does).
+
+    Every caller spells this differently and all of them mean one day. ``pre_run``
+    reads a ``date`` off the record; the append tool's ``authored_date`` is a
+    schema ``string``, so the model has written the bare day, the full timestamp
+    the Smokeball payload carried, and (via ``execute_code``) a ``datetime``
+    handed straight through — which the old ``isinstance(value, date)`` branch
+    turned into ``2026-08-11T14:32:07+00:00``, since ``datetime`` subclasses
+    ``date``. Each spelling was its own item.
+
+    The date is taken AS WRITTEN — no timezone conversion. The connector's
+    ``_parse_iso_date`` reads ``value[:10]``, so a 23:00-0700 record is the 11th
+    on both sides; shifting to UTC here would fork the join it exists to make.
+
+    Unparseable input RAISES rather than hashing verbatim: a component the module
+    cannot canonicalize is exactly how "tomorrow" and "2026-08-11" became two
+    identities, and a rejected tool arg is visible to the turn while it can still
+    be fixed. Silent acceptance is not.
+    """
+    if value is None:
+        return ""
+    if isinstance(value, datetime):  # MUST precede date — datetime subclasses it
+        return value.date().isoformat()
+    if isinstance(value, date):
+        return value.isoformat()
+    text = str(value).strip()
+    if not text:
+        return ""
+    try:
+        return date.fromisoformat(text).isoformat()
+    except ValueError:
+        pass
+    try:
+        return datetime.fromisoformat(text.replace("Z", "+00:00")).date().isoformat()
+    except ValueError:
+        raise ValueError(
+            f"authored_date {value!r} is not an ISO-8601 date or datetime; pass "
+            "YYYY-MM-DD (or null when the skill's identity convention omits the "
+            "date). An uncanonical date component forks item identity — the same "
+            "deadline becomes two items and every ACK code names one of them."
+        ) from None
+
+
+# ---------------------------------------------------------------------------
+# Item identity + token
+# ---------------------------------------------------------------------------
+
+
+def item_key(matter_id, source_id, label, authored_date) -> str:
+    """Stable per-item key: sha256 hex of (matter_id, Smokeball task/event id,
+    authored date). The ``source_id`` is the load-bearing anti-collision field —
+    two same-day tasks on one matter differ only by it. Callers pass
+    ``source_id=None`` ONLY for items with no stable id; those get no per-item
+    token and render in the blanket-ack-only group (see ``has_stable_identity``).
+
+    ``label`` is ACCEPTED AND DELIBERATELY IGNORED (ss #2151). It was in the hash
+    until the identity epoch below, and it is model-composed free text: ``pre_run``
+    assigns it from a closed set (``task-deadline`` / ``court-date``) while the
+    agent's turn writes a descriptor it invents that run (``settlement-offer-lapsed``,
+    ``rfa-confirm-service-date``). The two halves therefore hashed the SAME deadline
+    to different keys, so the ledger join never matched: on the pilot seat, 160
+    events had produced 128 item states, and NONE of them corresponded to any open
+    Smokeball task. Fire-once and the seven-day ack snooze were both inert — every
+    in-range item re-fired every run and every per-item ACK code named a phantom.
+
+    The parameter survives only so the two call sites (this repo's ``pre_run.py``
+    and the overlay's escalation plugin) keep working without a lockstep cross-repo
+    signature change. Nothing may put it back in the hash;
+    ``test_item_key_ignores_label`` is the guard.
+
+    Every surviving component is NORMALIZED before hashing (ss #2289): ids are
+    stripped and case-folded, the date is canonicalized to ``YYYY-MM-DD`` and an
+    unparseable one raises. The residual of the same defect: ``label`` was not the
+    only key component the model typed by hand — ``matter_id``, ``source_id`` and
+    ``authored_date`` are all free-text tool args (see the append tool's schema),
+    so ``2026-08-11`` and ``2026-08-11T00:00:00Z`` were two items on one deadline
+    and nothing rejected the second.
+    """
+    raw = "\x1f".join(
+        (
+            _normalize_id(matter_id),
+            _normalize_id(source_id),
+            _as_iso_date(authored_date),
+        )
+    )
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+
+
+def has_stable_identity(source_id, matter_id) -> bool:
+    """True iff this item's identity tuple is built ENTIRELY from values read off
+    the source, so it can hold a per-item ACK token. Otherwise the item is
+    blanket-ack only: it still fires, it just has no code of its own.
+
+    Two ways to fail. No ``source_id`` — the item has no stable Smokeball id, and
+    a token keyed on the matter alone would silence every item on that matter.
+    Or a sentinel in either position — ``pre_run``'s ``_matter_id_of`` emits
+    ``"unknown-matter"`` when the payload carries no resolvable matter link, and
+    a key with a fabricated component moves the moment the real value arrives, so
+    the code printed today names nothing tomorrow.
+
+    ``matter_id`` is REQUIRED, not defaulted (ss #2289 fix 2). The guard used to
+    test ``source_id`` against the sentinel — but ``_source_id_of`` never emits
+    it and ``_matter_id_of`` does, so the exclusion could not fire on any row the
+    connector writes: a control pointed at the wrong field measures nothing. An
+    optional second argument would have restored exactly that hole for any caller
+    that omitted it.
+    """
+    if not _normalize_id(source_id):
+        return False
+    return not ({_normalize_id(source_id), _normalize_id(matter_id)} & UNKNOWN_SENTINELS)
+
+
+def token_for(key_hex: str) -> str:
+    """A short human-typable ack token derived from the item_key. Deterministic:
+    any reader recomputes it, so a reply quoting ``ACK-7Q3M2K`` maps back to its
+    item without a lookup table. Six Crockford chars ~= 1e9 space; collisions
+    across a firm's live item set are negligible and would only under-ack (the
+    confirmation reply enumerates what was acked, so a mismatch stays visible)."""
+    digest = hashlib.sha256(("ack-token:" + key_hex).encode("utf-8")).digest()
+    n = int.from_bytes(digest[:5], "big")
+    out = []
+    for _ in range(6):
+        n, rem = divmod(n, 32)
+        out.append(_CROCKFORD[rem])
+    return "ACK-" + "".join(reversed(out))
+
+
+# ---------------------------------------------------------------------------
+# Event construction + (de)serialization
+# ---------------------------------------------------------------------------
+
+
+def make_event(
+    *,
+    skill: str,
+    matter_id,
+    item_key: str,
+    event: str,
+    attempt: int,
+    token: str | None = None,
+    ts: str | None = None,
+) -> dict:
+    """Build a well-formed event dict. ``ts`` is normally left None so the broker
+    stamps it server-side (the agent cannot backdate)."""
+    if event not in EVENTS:
+        raise ValueError(f"unknown escalation event {event!r}; expected one of {EVENTS}")
+    row: dict = {
+        "v": SCHEMA_VERSION,
+        "ts": ts,
+        "skill": str(skill),
+        "matter_id": None if matter_id is None else str(matter_id),
+        "item_key": str(item_key),
+        "event": event,
+        "attempt": int(attempt),
+        "token": None if token is None else str(token),
+    }
+    return row
+
+
+def serialize_event(event: dict) -> str:
+    """One canonical JSON line (no trailing newline)."""
+    return json.dumps(event, sort_keys=True, separators=(",", ":"), default=str)
+
+
+def _valid_event(obj) -> bool:
+    if not isinstance(obj, dict):
+        return False
+    for key in _REQUIRED_KEYS:
+        if key not in obj:
+            return False
+    return obj.get("event") in EVENTS
+
+
+def read_ledger(path: str | None = None) -> list[dict]:
+    """Read every parseable event from the JSONL, oldest first.
+
+    Corrupt or unparseable lines are SKIPPED, never guessed at — fail-noisy: a
+    dropped line means that item is treated as if it had no such event (an ack
+    we cannot read stays un-acked, so a deadline keeps firing rather than going
+    silent). A missing file is an empty ledger (first run).
+    """
+    path = path or ledger_path()
+    try:
+        with open(path, encoding="utf-8") as handle:
+            raw_lines = handle.readlines()
+    except FileNotFoundError:
+        return []
+    except OSError:
+        return []
+    events: list[dict] = []
+    for line in raw_lines:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except (ValueError, TypeError):
+            continue
+        if _valid_event(obj):
+            events.append(obj)
+    return events
+
+
+# ---------------------------------------------------------------------------
+# Per-item state derivation
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ItemState:
+    """Ledger-derived state for one item_key. ``attempts`` counts raises
+    (fired + chased). ``acked`` is reset by any raise that follows an ack, so a
+    re-surfaced item is awaiting a fresh ack, not still silenced by the old one.
+    """
+
+    item_key: str
+    matter_id: str | None = None
+    token: str | None = None
+    last_raised_ts: str | None = None
+    last_raised_date: date | None = None
+    attempts: int = 0
+    acked: bool = False
+    last_acked_date: date | None = None
+    handed_off: bool = False
+    resolved: bool = False
+
+
+def _parse_ts_date(ts) -> date | None:
+    if not isinstance(ts, str) or len(ts) < 10:
+        return None
+    try:
+        return date.fromisoformat(ts[:10])
+    except ValueError:
+        return None
+
+
+def derive_state(events) -> dict[str, ItemState]:
+    """Fold events (any order) into per-item_key state. Events are sorted by
+    ``ts`` so ack-then-refire vs refire-then-ack resolve deterministically."""
+    ordered = sorted(events, key=lambda e: str(e.get("ts") or ""))
+    states: dict[str, ItemState] = {}
+    for event in ordered:
+        key = str(event.get("item_key") or "")
+        if not key:
+            continue
+        state = states.get(key)
+        if state is None:
+            state = ItemState(item_key=key)
+            states[key] = state
+        if event.get("matter_id") is not None:
+            state.matter_id = str(event.get("matter_id"))
+        if event.get("token") is not None:
+            state.token = str(event.get("token"))
+        kind = event.get("event")
+        ts = event.get("ts")
+        if kind in RAISING_EVENTS:
+            state.attempts += 1
+            state.last_raised_ts = ts if isinstance(ts, str) else state.last_raised_ts
+            parsed = _parse_ts_date(ts)
+            if parsed is not None:
+                state.last_raised_date = parsed
+            # A fresh raise supersedes any prior ack: the item is loud again.
+            state.acked = False
+        elif kind == "acked":
+            state.acked = True
+            parsed = _parse_ts_date(ts)
+            if parsed is not None:
+                state.last_acked_date = parsed
+        elif kind == "handed_off":
+            state.handed_off = True
+        elif kind == "resolved":
+            state.resolved = True
+    return states
+
+
+def next_attempt(state: ItemState | None) -> int:
+    """The attempt number the next raise on this item will carry."""
+    return 1 if state is None else state.attempts + 1
+
+
+def should_fire(
+    state: ItemState | None,
+    today: date,
+    *,
+    refire_days: int,
+    ack_snooze_days: int,
+) -> bool:
+    """Should this in-range item raise an alarm on today's tick?
+
+    - never raised            -> fire (attempt 1)
+    - resolved / handed_off   -> never (terminal; a person owns it)
+    - acked, still unresolved -> re-surface only after ``ack_snooze_days``
+                                 (ack is a snooze, not a tombstone)
+    - raised, not acked       -> re-fire only after ``refire_days``
+                                 (fire once, not daily)
+    """
+    if state is None:
+        return True
+    if state.resolved or state.handed_off:
+        return False
+    if state.acked:
+        if state.last_acked_date is None:
+            return True
+        return today >= state.last_acked_date + timedelta(days=max(0, ack_snooze_days))
+    if state.last_raised_date is None:
+        return True
+    return today >= state.last_raised_date + timedelta(days=max(0, refire_days))
+
+
+# ---------------------------------------------------------------------------
+# Append (broker-side write path)
+# ---------------------------------------------------------------------------
+
+
+def is_pre_identity_epoch(event) -> bool:
+    """True for a raise written before the ss #2151 identity fix. PUBLIC so the
+    overlay's escalation plugin resolves ack tokens against the same rule the
+    broker validates with — a second implementation there would be a second
+    authority over one decision, and the two would disagree the first time
+    either changed. Its ``item_key``
+    came from a different derivation (it hashed the model-composed label), so it
+    can never name a live item. Acking one would tell a human an alarm was
+    silenced when nothing changed — the exact class of false report the fix
+    exists to end. A row with a missing or unparseable ``v`` is treated as
+    pre-epoch: unknown provenance is not evidence of a current key."""
+    try:
+        return int(event.get("v") or 1) < IDENTITY_EPOCH
+    except (TypeError, ValueError):
+        return True
+
+
+def validate_append(existing_events, new_event: dict) -> None:
+    """Raise ValueError unless ``new_event`` is a well-formed event that may be
+    appended. The load-bearing rule: an ``acked`` MUST reference a prior
+    ``fired``/``chased`` with the same token (or item_key) — you cannot ack an
+    alarm that never rang."""
+    if not isinstance(new_event, dict):
+        raise ValueError("escalation event must be an object")
+    kind = new_event.get("event")
+    if kind not in EVENTS:
+        raise ValueError(f"unknown escalation event {kind!r}; expected one of {EVENTS}")
+    if not str(new_event.get("item_key") or "").strip():
+        raise ValueError("escalation event requires a non-empty item_key")
+    if not str(new_event.get("skill") or "").strip():
+        raise ValueError("escalation event requires a skill")
+    if kind == "acked":
+        token = new_event.get("token")
+        key = str(new_event.get("item_key") or "")
+        raised = False
+        stale_only = False
+        for prior in existing_events:
+            if prior.get("event") not in RAISING_EVENTS:
+                continue
+            if token is not None and prior.get("token") == token:
+                pass
+            elif prior.get("item_key") == key:
+                pass
+            else:
+                continue
+            if is_pre_identity_epoch(prior):
+                # Matches, but its key came from the superseded derivation, so it
+                # names nothing live. Keep looking for a current raise.
+                stale_only = True
+                continue
+            raised = True
+            break
+        if not raised:
+            if stale_only:
+                raise ValueError(
+                    "that ACK code was issued before the item-identity fix (ss #2151) and no "
+                    "longer names a live item; the deadline will re-raise with a current code. "
+                    "Do not report it as acknowledged"
+                )
+            raise ValueError("acked event has no prior fired/chased raise for its token/item_key")
+
+
+def _ulid() -> str:
+    ts = int(time.time() * 1000)
+    n = (ts << 80) | secrets.randbits(80)
+    out = []
+    for _ in range(26):
+        n, rem = divmod(n, 32)
+        out.append(_CROCKFORD[rem])
+    return "".join(reversed(out))
+
+
+def stamp_event(event: dict) -> dict:
+    """Return a copy with a server-stamped ``ts`` (if absent) and a fresh ``id``.
+    Called by the broker so the caller cannot backdate or set the id."""
+    stamped = dict(event)
+    stamped["ts"] = _now_iso()
+    stamped["id"] = _ulid()
+    stamped.setdefault("v", SCHEMA_VERSION)
+    return stamped
+
+
+def append_line(path: str, event: dict) -> None:
+    """Append one serialized event to the JSONL, creating the file world-readable
+    (0644) so the agent-uid read seam can consume it. Caller serializes writes
+    (the broker holds a lock); this function does no locking of its own."""
+    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+    newly_created = not os.path.exists(path)
+    with open(path, "a", encoding="utf-8") as handle:
+        handle.write(serialize_event(event) + "\n")
+    if newly_created:
+        try:
+            os.chmod(path, 0o644)
+        except OSError:
+            pass

--- a/operator/skills/medical-records-chaser/pre_run.py
+++ b/operator/skills/medical-records-chaser/pre_run.py
@@ -1,166 +1,887 @@
 #!/usr/bin/env python3
-"""Shared cron pre-run gate — the empty-seat wake suppressor (ADR 0021 Stream B).
+"""medical-records-chaser pre-run gate — the ledger graduation (ss #2404).
 
-CANONICAL SOURCE: ``operator/templates/pre_run_gate.py``. The copies stamped
-into skill directories as ``pre_run.py`` MUST be byte-identical to this file —
-``operator/tests/test_pre_run_gate.py`` enforces the sync. Edit here, restamp.
+Runs BEFORE the Hermes cron daemon wakes the agent. Decides whether any open
+records-request roster item actually needs a chase today, and hands the woken
+turn the STATE the email must copy — so the chase's history is broker-validated
+ledger fact, never model recall.
 
-What this gate decides
-----------------------
-Scheduled tracker/watch/chase skills re-derive their work from the matter set
-in the practice-management system (they keep no local state — the matter is
-the system of record). On a seat with ZERO open matters there is provably no
-work for any of them, so waking the model is pure token burn. This gate:
+Why this skill graduated off the shared empty-seat gate
+-------------------------------------------------------
+The founding defect (ss #2404): the 2026-08-18 Valley Imaging chase email
+asserted "the last chase staged for this matter was July 13" and "no chase in
+the last five weeks" — contradicting the seat's own 2026-08-11 chase email for
+the same matter. Chase count, cadence position, and last-chase date were
+re-derived by the model from matter memos each run and asserted from recall,
+threaded by a model-improvised ``[op-mrc:...]`` email tag whose schema drifted
+week to week (it appears nowhere in this repo — the model invented it each
+run). The Sutter chain happened to remember correctly the same day; recall is
+per-run luck, and this gate replaces it. The template is the sibling
+``client-verification-tracker/pre_run.py`` (WP-B, #1889), including its #2402
+matter-level hold.
 
-  1. Probes Smokeball for open matters (one ``GET /matters?Status=Open&Limit=1``
-     via the connector's own venv — the connector package is not importable
-     from the Hermes venv this script runs in).
-  2. Any open matter, any probe failure, any unknown response envelope, any
-     heartbeat-write failure → ``{"wakeAgent": true}`` (fail-open; the agent
-     wakes exactly as it would with no gate).
-  3. Zero open matters → writes a SUPPRESSED_WAKE heartbeat row through the
-     broker's uid-gated ``suppressed_wake_append`` verb, THEN emits
-     ``{"wakeAgent": false}``. Suppress-without-heartbeat never happens
-     (mirror-don't-gate): if the broker write fails, the agent wakes.
+Wake / suppress decision
+------------------------
+For each open roster item (a firm-authored records-request tracking task):
 
-What this gate deliberately does NOT decide
--------------------------------------------
-It is NOT a per-skill "is there work" check. A hydrated seat (any open
-matter) always wakes — deeper UpdatedSince/state-delta gates are follow-on
-work once the Smokeball ``updated_since`` wire format is verified at connect.
-Lead-stage and inbound-driven work is unaffected either way: webhook and
-inbound wakes are ungated by design.
+  (a) CHASE DUE — cadence authored, the last ``chased`` raise is at least
+      ``chase_cadence_days`` old (or there is no prior chase and the tracking
+      task's confirm-by date has arrived). The plan carries ``attempt`` (the
+      chase number this chase would be), ``last_chased`` (the date of the last
+      ``chased`` raise, or null when the ledger holds none), and
+      ``days_past_confirm_by`` (computed HERE, from the task's authored due
+      date — never by the turn). NO attempt ceiling: the records chase runs on
+      cadence until the records land; escalation is stall-based and turn-owned
+      (SKILL.md "Escalation").
+  (d) HELD — the ledger carries an open per-MATTER hold (a ``fired`` raise on
+      this skill's hold sentinel, ``HOLD_SOURCE_ID``): a turn found the matter
+      unsafe to chase (no authored roster, roster without addresses, ambiguous
+      receipt match pending a human). A held matter NEVER plans a chase;
+      the hold re-surfaces on the re-fire window until a turn writes
+      ``resolved`` on it (the ss #2402 rule, ported).
 
-Skill identity
+Plus two seat-level conditions:
+
+  (c) CONFIG MISSING — ``chase_cadence_days`` is not authored: a
+      client-commitment number with NO pack default. Fail-closed: wake once to
+      surface it, remember the surface on a ledger sentinel, re-surface every
+      ``escalation.refire_days`` until authored (#1899).
+  (e) NO ROSTER TASKS — the pull returned open tasks on the seat but ZERO
+      carry the roster marker. On a real firm this most likely means the
+      firm's task convention does not match the connect-authored marker — and
+      with zero items every wake would otherwise suppress forever, which is
+      the worst fail direction (permanent silent darkness). Surface it on the
+      same fire-once + re-fire-window rule, on its own sentinel.
+
+Everything else -> a ``SUPPRESSED_WAKE`` heartbeat through the broker, then
+``{"wakeAgent": false}``. The heartbeat IS the dead-man's-switch.
+
+Sentinel namespaces are PER-SKILL on purpose
+--------------------------------------------
+``item_key`` hashes (matter_id, source_id, authored_date) and IGNORES label
+(ss #2151), and ``derive_state`` joins on item_key alone — so two skills using
+the same sentinel source_id would share one ledger identity: acking the
+verification tracker's config sentinel would silence THIS skill's config
+surface, and a verification signer-hold would block records chases. Every
+sentinel here is therefore namespaced ``__mrc_*``, distinct from the
+verification tracker's ``__chase_config__`` / ``__hold__``. Stall escalations
+the turn raises must use ``STALL_SOURCE_PREFIX`` for the same reason: a
+``fired`` on the chase item's own key would inflate the chase counter
+(attempts counts fired+chased), so the numerator "chase N" would drift.
+
+Fail direction
 --------------
-The scheduler stages this file to ``<profile>/scripts/<skill>/pre_run.py`` and
-runs it with cwd = that directory, so the skill name is the cwd basename. That
-keeps every stamped copy byte-identical.
+- Ledger unreadable -> FIRE-OPEN (wake). Never silently skip a chase.
+- Smokeball pull failure / unrecognized envelope / a full 500-row page (the
+  subset may be truncated; trusting it could silently drop providers) ->
+  FIRE-OPEN (wake).
+- Config unreadable / unauthored -> fail-CLOSED hold + re-fired surface (c).
 
-Verification hook
------------------
-``pre_run.py --assume-empty`` skips the Smokeball probe and behaves as if the
-seat were empty — it exercises the heartbeat write + suppress path end-to-end
-on a live Machine without needing an actually-empty tenant. The cron daemon
-never passes arguments, so this path cannot trigger on a scheduled fire.
+``decide()`` is a pure function (no I/O), unit-tested with fake inputs.
+``run_once()`` wires the real roster source + broker heartbeat + stdout.
+
+Exit codes:
+    0 — decision emitted (wake or suppress)
 """
 
 from __future__ import annotations
 
+import asyncio
+import hashlib
 import json
 import os
 import socket
 import subprocess
 import sys
+from dataclasses import dataclass, field
+from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
+from typing import Protocol, Sequence
 
-# Timeout budget: the Hermes scheduler kills the whole script at 120s
-# (cron/scheduler.py _DEFAULT_SCRIPT_TIMEOUT); the probe gets well under that.
-_PROBE_TIMEOUT_SECONDS = 45
-_HEARTBEAT_TIMEOUT_SECONDS = 10
+SKILL_NAME = "medical-records-chaser"
 
-_CONNECTOR_PYTHON_DEFAULT = "/opt/connectors/smokeball/.venv/bin/python"
+# Seat-level sentinels (namespaced __mrc_* — see the module docstring).
+_CONFIG_SENTINEL_SOURCE_ID = "__mrc_chase_config__"
+_CONFIG_SENTINEL_LABEL = "mrc-chase-config-missing"
+_NO_ROSTER_SENTINEL_SOURCE_ID = "__mrc_no_roster__"
+_NO_ROSTER_SENTINEL_LABEL = "mrc-no-roster-tasks"
 
-# Runs inside the connector venv, where smokeball_connector IS importable and
-# build_client_from_env() owns auth (token mint + refresh-token self-heal).
-# Envelope parsing is deliberately defensive: the live /matters list shape is
-# connect-time-unverified, so an unrecognized shape reports null → wake.
-_PROBE_SNIPPET = """\
-import json
-from smokeball_connector.client import build_client_from_env
+# Per-matter hold sentinel (the ss #2402 rule, ported; matter-level for the
+# same reason as the sibling: the blocker is a fact about the matter, and it
+# must survive the tracking task being completed, deleted, or recreated).
+HOLD_SOURCE_ID = "__mrc_hold__"
+_HOLD_LABEL = "mrc-chase-hold"
 
-r = build_client_from_env().get("/matters", Status="Open", Limit=1)
-items = None
-if isinstance(r, list):
-    items = r
-elif isinstance(r, dict):
-    for key in ("items", "value", "results", "matters", "data"):
-        v = r.get(key)
-        if isinstance(v, list):
-            items = v
-            break
-print(json.dumps({"openMatterCount": len(items) if items is not None else None}))
-"""
+# Stall escalations the TURN raises (provider non-responsive, attorney should
+# assess a records subpoena) must be keyed here, never on the chase item's own
+# key — attempts counts every raise, and a stall ``fired`` on the item key
+# would inflate the "chase N" numerator the email copies.
+STALL_SOURCE_PREFIX = "__mrc_stall__"
 
 
-def _emit(wake: bool) -> int:
-    print(json.dumps({"wakeAgent": wake}))
+# ---------------------------------------------------------------------------
+# Roster-item source protocol — the real adapter reads the firm-authored
+# records-request roster tasks (one open task per provider request).
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RosterItem:
+    """One open records-request roster task the firm maintains.
+
+    Item identity is the roster task's STABLE Smokeball id (``task_id``);
+    ``authored_date`` stays None — the confirm-by date on the task is an admin
+    date the firm may refresh, and a re-dated task must not change identity
+    (the sibling's rule). ``confirm_by`` is the task's authored due date: it
+    seeds the FIRST chase and anchors ``days_past_confirm_by``. Once the item
+    has a ``chased`` raise, cadence is measured from that raise instead.
+    """
+
+    matter_id: str
+    task_id: str | None
+    confirm_by: date
+    authored_date: date | None = None
+    label: str = "records-chase"
+
+
+class RosterSource(Protocol):
+    def pull_open_roster_items(self) -> "RosterPull":
+        ...
+
+
+@dataclass(frozen=True)
+class RosterPull:
+    """What one pull observed: the marker-matched items AND the total open-task
+    count, so ``decide()`` can distinguish an empty seat (quiet) from a seat
+    whose tasks carry no marker (surface — condition (e))."""
+
+    items: tuple[RosterItem, ...]
+    open_task_count: int
+
+
+# ---------------------------------------------------------------------------
+# Chase config — a CLIENT-COMMITMENT number. No pack default: unset is
+# fail-closed hold + re-fired surface, never a silent interval (ADR 0035).
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ChaseConfig:
+    chase_cadence_days: int | None = None  # days between chases; None = unauthored
+
+    @property
+    def authored(self) -> bool:
+        return self.chase_cadence_days is not None
+
+
+_DEFAULT_REFIRE_DAYS = 3
+
+
+def _pos_int_or_none(value):
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int) and value > 0:
+        return value
+    return None
+
+
+def _pos_int(value, fallback: int) -> int:
+    if isinstance(value, bool):
+        return fallback
+    if isinstance(value, int) and value > 0:
+        return value
+    return fallback
+
+
+def _find_skill_settings(data) -> dict:
+    if not isinstance(data, dict):
+        return {}
+    personas = data.get("personas")
+    if not isinstance(personas, list):
+        return {}
+    for persona in personas:
+        if not isinstance(persona, dict):
+            continue
+        skills = persona.get("skills")
+        if not isinstance(skills, list):
+            continue
+        for entry in skills:
+            if not isinstance(entry, dict) or entry.get("name") != SKILL_NAME:
+                continue
+            settings = entry.get("settings")
+            return settings if isinstance(settings, dict) else {}
+    return {}
+
+
+def load_chase_config(customer_yaml_path: str | None = None) -> tuple[ChaseConfig, int]:
+    """Read (ChaseConfig, refire_days) from the trusted volume customer.yaml.
+    Missing file / PyYAML / parse failure -> unauthored (fail-closed)."""
+    path = customer_yaml_path or os.environ.get("SMD_CUSTOMER_YAML_PATH")
+    if not path:
+        return ChaseConfig(), _DEFAULT_REFIRE_DAYS
+    try:
+        import yaml
+    except ImportError:
+        return ChaseConfig(), _DEFAULT_REFIRE_DAYS
+    try:
+        with open(path, encoding="utf-8") as handle:
+            data = yaml.safe_load(handle) or {}
+    except (OSError, yaml.YAMLError):
+        return ChaseConfig(), _DEFAULT_REFIRE_DAYS
+    settings = _find_skill_settings(data)
+    config = ChaseConfig(
+        chase_cadence_days=_pos_int_or_none(settings.get("chase_cadence_days"))
+    )
+    esc = data.get("escalation") if isinstance(data, dict) else None
+    refire_days = _pos_int(
+        esc.get("refire_days") if isinstance(esc, dict) else None, _DEFAULT_REFIRE_DAYS
+    )
+    return config, refire_days
+
+
+# ---------------------------------------------------------------------------
+# Escalation ledger — vendored byte-identical copy (test_escalation_ledger_sync).
+# ---------------------------------------------------------------------------
+
+
+def _load_ledger_module():
+    import importlib.util
+
+    candidates = [Path(__file__).resolve().parent]
+    for base in ("/opt/data/skills", "/app/skills"):
+        candidates.append(Path(base) / SKILL_NAME)
+    for cand in candidates:
+        module_path = cand / "escalation_ledger.py"
+        if module_path.is_file():
+            spec = importlib.util.spec_from_file_location(
+                "escalation_ledger_vendored_mrc", module_path
+            )
+            if spec is None or spec.loader is None:
+                continue
+            module = importlib.util.module_from_spec(spec)
+            sys.modules[spec.name] = module
+            spec.loader.exec_module(module)
+            return module
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Decision engine — pure, no I/O.
+# ---------------------------------------------------------------------------
+
+ACTION_CHASE = "chase"  # a provider chase is due
+ACTION_SURFACE_CONFIG = "surface_config_missing"  # seat-level, refire window
+ACTION_SURFACE_NO_ROSTER = "surface_no_roster_tasks"  # seat-level, refire window
+ACTION_SURFACE_HOLD = "surface_hold"  # matter held; re-surface, never chase
+ACTION_SUPPRESS = "suppress"
+
+
+@dataclass(frozen=True)
+class ItemPlan:
+    """What the next turn should do for one item — including the STATE the
+    email must copy verbatim (``attempt``, ``last_chased``,
+    ``days_past_confirm_by``): the turn never recomputes or recalls these."""
+
+    matter_id: str
+    task_id: str | None
+    item_key: str
+    action: str
+    attempt: int
+    last_chased: str | None = None  # ISO date of the last chased raise, or None
+    days_past_confirm_by: int | None = None  # computed here, never by the turn
+
+
+@dataclass(frozen=True)
+class WakeDecision:
+    wake: bool
+    decision_basis: str
+    pre_run_inputs_digest: bytes
+    plans: tuple[ItemPlan, ...] = ()
+    extra_metadata: dict = field(default_factory=dict)
+
+
+def _hold_active(hold_state) -> bool:
+    """Same semantics as the sibling (ss #2402): any raise and not resolved
+    blocks; acked blocks (snoozes the surface); handed_off blocks and is quiet."""
+    if hold_state is None or hold_state.attempts == 0:
+        return False
+    return not hold_state.resolved
+
+
+def _chase_due(state, confirm_by: date, today: date, *, cadence_days: int) -> bool:
+    if state is None or state.last_raised_date is None:
+        return today >= confirm_by
+    return today >= state.last_raised_date + timedelta(days=max(0, cadence_days))
+
+
+def _seat_sentinel_decision(
+    ledger,
+    states,
+    *,
+    source_id: str,
+    label: str,
+    action: str,
+    basis_surface: str,
+    basis_quiet: str,
+    today: date,
+    refire_days: int,
+    raw_inputs_for_digest: bytes,
+    extra: dict,
+) -> WakeDecision:
+    """Shared shape for the two seat-level surfaces (config missing, no roster
+    tasks): fire-once + re-fire-window on a stable sentinel (#1899)."""
+    key = ledger.item_key("", source_id, label, "")
+    state = states.get(key)
+    if not ledger.should_fire(
+        state, today, refire_days=refire_days, ack_snooze_days=refire_days
+    ):
+        return WakeDecision(
+            wake=False,
+            decision_basis=basis_quiet,
+            pre_run_inputs_digest=raw_inputs_for_digest,
+            extra_metadata=extra,
+        )
+    return WakeDecision(
+        wake=True,
+        decision_basis=basis_surface,
+        pre_run_inputs_digest=raw_inputs_for_digest,
+        plans=(
+            ItemPlan(
+                matter_id="",
+                task_id=None,
+                item_key=key,
+                action=action,
+                attempt=ledger.next_attempt(state),
+            ),
+        ),
+        extra_metadata=extra,
+    )
+
+
+def decide(
+    pull: RosterPull,
+    config: ChaseConfig,
+    ledger,
+    events: Sequence[dict],
+    *,
+    raw_inputs_for_digest: bytes,
+    today: date,
+    refire_days: int,
+) -> WakeDecision:
+    """Pure decision: does any roster item need a chase today?"""
+    states = ledger.derive_state(events)
+    items = pull.items
+
+    # (c) Seat-level: cadence unauthored → fail-closed hold + re-fired surface.
+    if not config.authored:
+        return _seat_sentinel_decision(
+            ledger,
+            states,
+            source_id=_CONFIG_SENTINEL_SOURCE_ID,
+            label=_CONFIG_SENTINEL_LABEL,
+            action=ACTION_SURFACE_CONFIG,
+            basis_surface="chase_config_unauthored_surface",
+            basis_quiet="chase_config_unauthored_within_refire_window",
+            today=today,
+            refire_days=refire_days,
+            raw_inputs_for_digest=raw_inputs_for_digest,
+            extra={
+                "open_item_count": len(items),
+                "missing": ["chase_cadence_days"],
+            },
+        )
+
+    # (e) Seat-level: open tasks exist but none carry the roster marker. Zero
+    # items must never read as "nothing due" — at a real firm this is most
+    # likely a marker-convention mismatch, and silence would be permanent.
+    if not items and pull.open_task_count > 0:
+        return _seat_sentinel_decision(
+            ledger,
+            states,
+            source_id=_NO_ROSTER_SENTINEL_SOURCE_ID,
+            label=_NO_ROSTER_SENTINEL_LABEL,
+            action=ACTION_SURFACE_NO_ROSTER,
+            basis_surface="no_roster_tasks_surface",
+            basis_quiet="no_roster_tasks_within_refire_window",
+            today=today,
+            refire_days=refire_days,
+            raw_inputs_for_digest=raw_inputs_for_digest,
+            extra={"open_task_count": pull.open_task_count},
+        )
+
+    cadence_days = int(config.chase_cadence_days or 0)
+    plans: list[ItemPlan] = []
+    for item in items:
+        key = ledger.item_key(item.matter_id, item.task_id, item.label, item.authored_date)
+        state = states.get(key)
+        if state is not None and (state.resolved or state.handed_off):
+            continue
+        # (d) HELD — an open hold on this MATTER blocks the chase for every
+        # roster item on it. One surface per held matter per wake.
+        hold_key = ledger.item_key(item.matter_id, HOLD_SOURCE_ID, _HOLD_LABEL, None)
+        hold_state = states.get(hold_key)
+        if _hold_active(hold_state):
+            already_surfacing = any(p.item_key == hold_key for p in plans)
+            if (
+                not already_surfacing
+                and not hold_state.handed_off
+                and ledger.should_fire(
+                    hold_state, today, refire_days=refire_days, ack_snooze_days=refire_days
+                )
+            ):
+                plans.append(
+                    ItemPlan(
+                        matter_id=item.matter_id,
+                        task_id=item.task_id,
+                        item_key=hold_key,
+                        action=ACTION_SURFACE_HOLD,
+                        attempt=ledger.next_attempt(hold_state),
+                    )
+                )
+            continue
+        # (a) Chase due?
+        if _chase_due(state, item.confirm_by, today, cadence_days=cadence_days):
+            last = None
+            if state is not None and state.last_raised_date is not None:
+                last = state.last_raised_date.isoformat()
+            plans.append(
+                ItemPlan(
+                    matter_id=item.matter_id,
+                    task_id=item.task_id,
+                    item_key=key,
+                    action=ACTION_CHASE,
+                    attempt=ledger.next_attempt(state),
+                    last_chased=last,
+                    days_past_confirm_by=max(0, (today - item.confirm_by).days),
+                )
+            )
+    if plans:
+        chases = sum(1 for p in plans if p.action == ACTION_CHASE)
+        holds = sum(1 for p in plans if p.action == ACTION_SURFACE_HOLD)
+        return WakeDecision(
+            wake=True,
+            decision_basis="records_chase_due",
+            pre_run_inputs_digest=raw_inputs_for_digest,
+            plans=tuple(plans),
+            extra_metadata={
+                "chase_due": chases,
+                "hold_surface_due": holds,
+                "open_item_count": len(items),
+                "items": [
+                    {
+                        "matter_id": p.matter_id,
+                        "action": p.action,
+                        "attempt": p.attempt,
+                        "last_chased": p.last_chased,
+                        "days_past_confirm_by": p.days_past_confirm_by,
+                    }
+                    for p in plans
+                ],
+            },
+        )
+    return WakeDecision(
+        wake=False,
+        decision_basis="no_records_chase_due",
+        pre_run_inputs_digest=raw_inputs_for_digest,
+        extra_metadata={"open_item_count": len(items)},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Runtime entrypoint.
+# ---------------------------------------------------------------------------
+
+
+def _next_scheduled_at(now: datetime, schedule_hours: int = 24) -> str:
+    return (now + timedelta(hours=schedule_hours)).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def _emit_wake(decision: "WakeDecision | None" = None, *, basis: str | None = None) -> int:
+    """Print the wake line WITH the decision's plans (ss #2226): the plans are
+    the woken turn's work list, and for a chase they carry the state the email
+    copies. Fail-open callers pass ``basis`` so the agent knows it woke blind
+    and must enumerate the roster itself."""
+    payload: dict = {"wakeAgent": True}
+    resolved_basis = decision.decision_basis if decision is not None else basis
+    if resolved_basis:
+        payload["decision_basis"] = resolved_basis
+    if decision is not None and decision.plans:
+        payload["plans"] = [
+            {
+                "matter_id": p.matter_id,
+                "task_id": p.task_id,
+                "item_key": p.item_key,
+                "action": p.action,
+                "attempt": p.attempt,
+                "last_chased": p.last_chased,
+                "days_past_confirm_by": p.days_past_confirm_by,
+            }
+            for p in decision.plans
+        ]
+    print(json.dumps(payload))
     return 0
 
 
-def _skill_name() -> str:
-    return Path.cwd().name or "unknown-skill"
+def _plan_counts(decision: "WakeDecision") -> dict:
+    if not decision.plans:
+        return {}
+    return {"plans_total": len(decision.plans)}
 
 
-def probe_open_matter_count() -> int | None:
-    """Return the open-matter count, or None when it cannot be determined."""
-    connector_python = os.environ.get(
-        "SMD_CONNECTOR_VENV_PYTHON", _CONNECTOR_PYTHON_DEFAULT
+async def _try_write_emitted_wake(
+    audit_writer_factory,
+    decision: "WakeDecision",
+    *,
+    skill_name: str,
+    now: datetime,
+) -> None:
+    """Best-effort EMITTED_WAKE row (#2253) — an audit failure never gates the
+    wake; see the sibling's docstring for the full rationale."""
+    try:
+        writer = audit_writer_factory()
+        if writer is None:
+            return
+        await writer.write_emitted_wake(
+            skill_name=skill_name,
+            pre_run_inputs=decision.pre_run_inputs_digest,
+            decision_basis=decision.decision_basis,
+            next_scheduled_at=_next_scheduled_at(now),
+            extra_metadata={**decision.extra_metadata, **_plan_counts(decision)},
+        )
+    except Exception:  # noqa: BLE001 — observability never gates the wake
+        pass
+
+
+def _emit_suppress() -> int:
+    print(json.dumps({"wakeAgent": False}))
+    return 0
+
+
+def _item_to_dict(item: RosterItem) -> dict:
+    return {
+        "matter_id": item.matter_id,
+        "task_id": item.task_id,
+        "authored_date": item.authored_date.isoformat() if item.authored_date else None,
+        "confirm_by": item.confirm_by.isoformat(),
+        "label": item.label,
+    }
+
+
+async def run_once(
+    sources: Sequence[RosterSource],
+    audit_writer_factory,
+    *,
+    today: date | None = None,
+    now: datetime | None = None,
+    config: ChaseConfig | None = None,
+    refire_days: int | None = None,
+    ledger_module=None,
+    ledger_events: Sequence[dict] | None = None,
+) -> int:
+    """Driver. Fail-open on ledger loss; config-read failure is the unauthored
+    path (handled in ``decide``)."""
+    now = now or datetime.now(timezone.utc)
+    today = today or now.date()
+    if config is None or refire_days is None:
+        loaded_config, loaded_refire = load_chase_config()
+        config = config or loaded_config
+        refire_days = refire_days if refire_days is not None else loaded_refire
+
+    ledger = ledger_module if ledger_module is not None else _load_ledger_module()
+    if ledger is None:
+        sys.stderr.write("[pre_run] escalation ledger unavailable; waking\n")
+        return _emit_wake(basis="ledger_unavailable_fail_open")
+    if ledger_events is None:
+        ledger_events = ledger.read_ledger()
+
+    all_items: list[RosterItem] = []
+    open_task_count = 0
+    raw_input_blob: bytes = b""
+    for source in sources:
+        pulled = source.pull_open_roster_items()
+        all_items.extend(pulled.items)
+        open_task_count += pulled.open_task_count
+        raw_input_blob += json.dumps(
+            [_item_to_dict(i) for i in pulled.items], sort_keys=True
+        ).encode("utf-8")
+
+    decision = decide(
+        RosterPull(items=tuple(all_items), open_task_count=open_task_count),
+        config,
+        ledger,
+        ledger_events,
+        raw_inputs_for_digest=raw_input_blob,
+        today=today,
+        refire_days=refire_days,
     )
-    if not Path(connector_python).exists():
-        sys.stderr.write(f"[pre_run] connector python missing: {connector_python}\n")
+    if decision.wake:
+        await _try_write_emitted_wake(
+            audit_writer_factory, decision, skill_name=SKILL_NAME, now=now
+        )
+        return _emit_wake(decision)
+
+    writer = audit_writer_factory()
+    if writer is None:
+        return _emit_wake(basis="no_audit_writer_fail_open")
+    try:
+        await writer.write_suppressed_wake(
+            skill_name=SKILL_NAME,
+            pre_run_inputs=decision.pre_run_inputs_digest,
+            decision_basis=decision.decision_basis,
+            next_scheduled_at=_next_scheduled_at(now),
+            extra_metadata=decision.extra_metadata,
+        )
+    except Exception:  # noqa: BLE001 — any audit failure → wake
+        return _emit_wake(basis="suppress_heartbeat_failed_fail_open")
+    return _emit_suppress()
+
+
+# ---------------------------------------------------------------------------
+# Production wiring — the connector-venv pull + broker heartbeat writer.
+# ---------------------------------------------------------------------------
+
+_CONNECTOR_PYTHON_DEFAULT = "/opt/connectors/smokeball/.venv/bin/python"
+_PULL_TIMEOUT_SECONDS = 60
+_HEARTBEAT_TIMEOUT_SECONDS = 10
+_PULL_PAGE_LIMIT = 500
+
+# The firm-authored records-request roster tasks carry this marker in their
+# subject (connect-step contract; the pilot's seed convention is
+# "Medical records outstanding - <provider> (request roster)"). A seat whose
+# open tasks NEVER match the marker surfaces condition (e) rather than going
+# quietly dark — the marker being wrong must be loud.
+_ROSTER_SUBJECT_MARKER = "request roster"
+
+_PULL_SNIPPET = """\
+import json
+
+from smokeball_connector.client import build_client_from_env
+
+client = build_client_from_env()
+out = {}
+try:
+    out["tasks"] = client.get("/tasks", IsCompleted=False, Limit=500)
+except Exception as exc:
+    out["tasksError"] = str(exc)[:300]
+print(json.dumps(out, default=str))
+"""
+
+_TASK_DATE_KEYS = ("dueDate", "DueDate", "due_date")
+_TASK_SUBJECT_KEYS = ("subject", "Subject", "name", "Name", "title", "Title", "description")
+_MATTER_ID_KEYS = ("matterId", "MatterId", "matter_id")
+_SOURCE_ID_KEYS = ("id", "Id", "taskId", "TaskId")
+
+
+def _extract_items(payload) -> list | None:
+    if isinstance(payload, list):
+        return payload
+    if isinstance(payload, dict):
+        for key in ("items", "value", "results", "tasks", "data"):
+            value = payload.get(key)
+            if isinstance(value, list):
+                return value
+    return None
+
+
+def _parse_iso_date(value) -> date | None:
+    if not isinstance(value, str) or len(value) < 10:
         return None
     try:
-        result = subprocess.run(
-            # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-tainted-env-args.dangerous-subprocess-use-tainted-env-args — argv[0] is the module-constant connector-venv interpreter, overridable only via SMD_CONNECTOR_VENV_PYTHON, which comes from the Machine's own boot env (same trust domain as this file; the test seam). The snippet argument is a module constant; no request/agent-controlled data reaches argv.
-            [connector_python, "-c", _PROBE_SNIPPET],
+        return date.fromisoformat(value[:10])
+    except ValueError:
+        return None
+
+
+def _first_date(item: dict, keys: Sequence[str]) -> date | None:
+    for key in keys:
+        parsed = _parse_iso_date(item.get(key))
+        if parsed is not None:
+            return parsed
+    return None
+
+
+def _first_str(item: dict, keys: Sequence[str]) -> str:
+    for key in keys:
+        value = item.get(key)
+        if isinstance(value, str) and value.strip():
+            return value
+    return ""
+
+
+def _matter_id_of(item: dict) -> str:
+    # Nested matter link object first (ss #1915 — the flat-key miss forked
+    # every item identity onto "unknown-matter").
+    matter = item.get("matter") or item.get("Matter")
+    if isinstance(matter, dict):
+        nested = matter.get("id") or matter.get("Id")
+        if isinstance(nested, str) and nested:
+            return nested
+    for key in _MATTER_ID_KEYS:
+        value = item.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return "unknown-matter"
+
+
+def _source_id_of(item: dict) -> str | None:
+    for key in _SOURCE_ID_KEYS:
+        value = item.get(key)
+        if isinstance(value, (str, int)) and str(value).strip():
+            return str(value)
+    return None
+
+
+def _is_roster_task(subject: str) -> bool:
+    return _ROSTER_SUBJECT_MARKER in subject.lower()
+
+
+def parse_pull(raw: dict, *, today: date) -> tuple[RosterPull, str | None]:
+    """Pure parse of the connector pull. Returns (pull, problem).
+
+    A non-None problem means the view is partial or unrecognizable and the
+    caller MUST wake — including a FULL page (exactly the page limit): the
+    subset may be truncated, and trusting it could silently drop providers.
+    A roster task with no due date seeds its first chase to today."""
+    if raw.get("tasksError"):
+        return RosterPull((), 0), f"pull error: tasksError={raw['tasksError']}"
+    tasks = _extract_items(raw.get("tasks"))
+    if tasks is None:
+        return RosterPull((), 0), "unrecognized pull envelope"
+    if len(tasks) >= _PULL_PAGE_LIMIT:
+        return (
+            RosterPull((), len(tasks)),
+            f"pull returned a full page ({len(tasks)} rows); subset may be truncated",
+        )
+    items: list[RosterItem] = []
+    for task in tasks:
+        if not isinstance(task, dict):
+            continue
+        subject = _first_str(task, _TASK_SUBJECT_KEYS)
+        if not _is_roster_task(subject):
+            continue
+        due = _first_date(task, _TASK_DATE_KEYS) or today
+        items.append(
+            RosterItem(
+                matter_id=_matter_id_of(task),
+                task_id=_source_id_of(task),
+                confirm_by=due,
+                authored_date=None,
+                label="records-chase",
+            )
+        )
+    return RosterPull(tuple(items), len(tasks)), None
+
+
+class SmokeballSubprocessSource:
+    """RosterSource over a connector-venv subprocess pull."""
+
+    def __init__(self, today: date) -> None:
+        self._today = today
+
+    def pull_open_roster_items(self) -> RosterPull:
+        connector_python = os.environ.get(
+            "SMD_CONNECTOR_VENV_PYTHON", _CONNECTOR_PYTHON_DEFAULT
+        )
+        result = subprocess.run(  # raises on timeout → caller wakes
+            # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-tainted-env-args.dangerous-subprocess-use-tainted-env-args — argv[0] is the module-constant connector-venv interpreter, overridable only via SMD_CONNECTOR_VENV_PYTHON from the Machine's own boot env (same trust domain; the test seam). The snippet is a module constant; no request/agent-controlled data reaches argv.
+            [connector_python, "-c", _PULL_SNIPPET],
             capture_output=True,
             text=True,
-            timeout=_PROBE_TIMEOUT_SECONDS,
+            timeout=_PULL_TIMEOUT_SECONDS,
         )
-    except subprocess.TimeoutExpired:
-        sys.stderr.write("[pre_run] smokeball probe timed out\n")
-        return None
-    except Exception as exc:  # noqa: BLE001 — any probe failure → unknown → wake
-        sys.stderr.write(f"[pre_run] smokeball probe failed: {exc}\n")
-        return None
-    if result.returncode != 0:
-        sys.stderr.write(
-            f"[pre_run] smokeball probe exit {result.returncode}: "
-            f"{(result.stderr or '').strip()[:500]}\n"
-        )
-        return None
-    try:
-        payload = json.loads((result.stdout or "").strip().splitlines()[-1])
-        count = payload.get("openMatterCount")
-    except Exception:  # noqa: BLE001 — malformed probe output → unknown → wake
-        sys.stderr.write("[pre_run] smokeball probe output unparseable\n")
-        return None
-    if isinstance(count, bool) or not isinstance(count, int):
-        return None
-    return count
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"smokeball pull exit {result.returncode}: "
+                f"{(result.stderr or '').strip()[:500]}"
+            )
+        raw = json.loads((result.stdout or "").strip().splitlines()[-1])
+        pull, problem = parse_pull(raw, today=self._today)
+        if problem:
+            raise RuntimeError(problem)
+        return pull
 
 
-def write_suppressed_wake_heartbeat(skill_name: str) -> bool:
-    """Append the SUPPRESSED_WAKE row via the broker. True only on ack."""
-    socket_path = os.environ.get("SMD_AUDIT_BROKER_SOCKET") or os.environ.get(
-        "SMD_WORKSPACE_BROKER_SOCKET"
-    )
-    if not socket_path:
-        sys.stderr.write("[pre_run] no broker socket in env; cannot heartbeat\n")
-        return False
-    request = {
-        "action": "suppressed_wake_append",
-        "row": {
-            "action_type": "SUPPRESSED_WAKE",
-            "actor": "agent",
-            "actor_role": "agent",
-            "skill_name": skill_name,
-            "metadata": json.dumps(
-                {
-                    "decision_basis": "empty_seat:no_open_matters",
-                    "platform": "cron-pre-run",
-                    "customer": os.environ.get("CUSTOMER_SLUG", ""),
-                },
-                sort_keys=True,
-                separators=(",", ":"),
-            ),
-        },
-    }
-    try:
+class BrokerSuppressedWakeWriter:
+    """Heartbeat writer over the broker's uid-gated verbs (#2253)."""
+
+    def __init__(self, socket_path: str, customer_slug: str) -> None:
+        self._socket_path = socket_path
+        self._customer_slug = customer_slug
+
+    async def write_suppressed_wake(
+        self,
+        *,
+        skill_name: str,
+        pre_run_inputs: bytes,
+        decision_basis: str,
+        next_scheduled_at: str,
+        extra_metadata: dict | None = None,
+    ) -> str:
+        return self._append(
+            verb="suppressed_wake_append",
+            action_type="SUPPRESSED_WAKE",
+            skill_name=skill_name,
+            pre_run_inputs=pre_run_inputs,
+            decision_basis=decision_basis,
+            next_scheduled_at=next_scheduled_at,
+            extra_metadata=extra_metadata,
+        )
+
+    async def write_emitted_wake(
+        self,
+        *,
+        skill_name: str,
+        pre_run_inputs: bytes,
+        decision_basis: str,
+        next_scheduled_at: str,
+        extra_metadata: dict | None = None,
+    ) -> str:
+        return self._append(
+            verb="emitted_wake_append",
+            action_type="EMITTED_WAKE",
+            skill_name=skill_name,
+            pre_run_inputs=pre_run_inputs,
+            decision_basis=decision_basis,
+            next_scheduled_at=next_scheduled_at,
+            extra_metadata=extra_metadata,
+        )
+
+    def _append(
+        self,
+        *,
+        verb: str,
+        action_type: str,
+        skill_name: str,
+        pre_run_inputs: bytes,
+        decision_basis: str,
+        next_scheduled_at: str,
+        extra_metadata: dict | None,
+    ) -> str:
+        request = {
+            "action": verb,
+            "row": {
+                "action_type": action_type,
+                "actor": "agent",
+                "actor_role": "agent",
+                "skill_name": skill_name,
+                "input_digest": hashlib.sha256(pre_run_inputs).hexdigest(),
+                "metadata": json.dumps(
+                    {
+                        "decision_basis": decision_basis,
+                        "next_scheduled_at": next_scheduled_at,
+                        "platform": "cron-pre-run",
+                        "customer": self._customer_slug,
+                        **(extra_metadata or {}),
+                    },
+                    sort_keys=True,
+                    separators=(",", ":"),
+                    default=str,
+                ),
+            },
+        }
         with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
             sock.settimeout(_HEARTBEAT_TIMEOUT_SECONDS)
-            sock.connect(socket_path)
+            sock.connect(self._socket_path)
             sock.sendall(json.dumps(request).encode("utf-8") + b"\n")
             raw = b""
             while not raw.endswith(b"\n"):
@@ -169,34 +890,43 @@ def write_suppressed_wake_heartbeat(skill_name: str) -> bool:
                     break
                 raw += chunk
         response = json.loads(raw.decode("utf-8"))
-        if response.get("ok") is True:
-            return True
-        sys.stderr.write(f"[pre_run] heartbeat rejected: {response}\n")
-        return False
-    except Exception as exc:  # noqa: BLE001 — any heartbeat failure → wake
-        sys.stderr.write(f"[pre_run] heartbeat write failed: {exc}\n")
-        return False
+        if response.get("ok") is not True:
+            raise RuntimeError(f"heartbeat rejected: {response}")
+        return str(response.get("id", ""))
 
 
-def decide_and_emit(count: int | None, skill_name: str) -> int:
-    """Pure-ish core: count → wake/suppress emission (heartbeat before suppress)."""
-    if count is None or count > 0:
-        return _emit(wake=True)
-    if not write_suppressed_wake_heartbeat(skill_name):
-        # Mirror-don't-gate: a silent suppress with no audit trail is
-        # indistinguishable from a broken pre_run. Wake instead — the full
-        # agent run is observable and the failure becomes visible.
-        return _emit(wake=True)
-    return _emit(wake=False)
+def _writer_factory():
+    socket_path = os.environ.get("SMD_AUDIT_BROKER_SOCKET") or os.environ.get(
+        "SMD_WORKSPACE_BROKER_SOCKET"
+    )
+    if not socket_path:
+        return None
+    return BrokerSuppressedWakeWriter(
+        socket_path, os.environ.get("CUSTOMER_SLUG", "")
+    )
 
 
-def main(argv: list[str] | None = None) -> int:
-    argv = sys.argv[1:] if argv is None else argv
-    skill_name = _skill_name()
-    if "--assume-empty" in argv:
-        sys.stderr.write("[pre_run] --assume-empty: skipping smokeball probe\n")
-        return decide_and_emit(0, skill_name)
-    return decide_and_emit(probe_open_matter_count(), skill_name)
+def main() -> int:
+    customer_slug = os.environ.get("CUSTOMER_SLUG")
+    if not customer_slug:
+        sys.stderr.write("[pre_run] CUSTOMER_SLUG unset; falling back to wake\n")
+        return _emit_wake(basis="customer_slug_unset_fail_open")
+    config, refire_days = load_chase_config()
+    today = datetime.now(timezone.utc).date()
+    source = SmokeballSubprocessSource(today)
+    try:
+        return asyncio.run(
+            run_once(
+                [source],
+                _writer_factory,
+                today=today,
+                config=config,
+                refire_days=refire_days,
+            )
+        )
+    except Exception as exc:  # noqa: BLE001 — any wiring failure → wake
+        sys.stderr.write(f"[pre_run] records-chaser pre_run failed ({exc}); waking\n")
+        return _emit_wake(basis="pre_run_crashed_fail_open")
 
 
 if __name__ == "__main__":

--- a/operator/skills/medical-records-chaser/references/output-format.md
+++ b/operator/skills/medical-records-chaser/references/output-format.md
@@ -9,7 +9,12 @@ The decision determines the shape. Every tracked item is keyed to
 # Records Chase — <provider> — <patient / plaintiff> — matter <id> — YYYY-MM-DD
 
 **Requested:** <date records were requested, from the authored roster>
-**Status:** outstanding (<N> days); nudge <#> of <max>
+**Status:** outstanding; <N> days past the confirm-by date on the tracking task
+(the plan's `days_past_confirm_by`, copied verbatim); chase <#> (the plan's
+`attempt`) — or, when the plan's `last_chased` is null, "first chase recorded
+in the tracking ledger" with no numerator (ss #2404)
+**Last chase staged:** <the plan's `last_chased` date, or the null-history
+sentence — never a recalled date>
 **Decision:** cadence due — chase <sent | drafted, per the authored external_send
 ceiling> to <provider | records vendor>.
 

--- a/operator/skills/medical-records-chaser/test_records_chaser_pre_run.py
+++ b/operator/skills/medical-records-chaser/test_records_chaser_pre_run.py
@@ -1,0 +1,619 @@
+"""Tests for medical-records-chaser/pre_run.py (ss #2404 ledger graduation).
+
+Exercises the bespoke cadence gate that graduated this skill off the shared
+empty-seat template: cadence suppression + refire, the plan STATE the email
+must copy (attempt / last_chased / days_past_confirm_by — the Aug 11→18
+Valley Imaging contradiction class), the unauthored-config sentinel, the
+no-roster-tasks sentinel (zero marker matches must be loud, never quiet), the
+ported matter-level hold (ss #2402), the stall-sentinel isolation (a stall
+raise must not inflate the chase numerator), ledger-unavailable fire-open, and
+the full-page truncation guard.
+
+Mirrors `client-verification-tracker/test_verification_pre_run.py`.
+
+Run from repo root:
+
+    cd operator && python -m pytest \\
+        skills/medical-records-chaser/test_records_chaser_pre_run.py -v
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import io
+import json
+import sys
+from contextlib import redirect_stdout
+from datetime import date, timedelta
+from pathlib import Path
+
+_HERE = Path(__file__).resolve()
+sys.path.insert(0, str(_HERE.parents[2]))
+
+_PRE_RUN_PATH = _HERE.parent / "pre_run.py"
+_spec = importlib.util.spec_from_file_location("mrc_pre_run", _PRE_RUN_PATH)
+assert _spec is not None and _spec.loader is not None
+_pre_run = importlib.util.module_from_spec(_spec)
+sys.modules["mrc_pre_run"] = _pre_run
+_spec.loader.exec_module(_pre_run)
+
+ChaseConfig = _pre_run.ChaseConfig
+RosterItem = _pre_run.RosterItem
+RosterPull = _pre_run.RosterPull
+decide = _pre_run.decide
+run_once = _pre_run.run_once
+load_chase_config = _pre_run.load_chase_config
+parse_pull = _pre_run.parse_pull
+ACTION_CHASE = _pre_run.ACTION_CHASE
+ACTION_SURFACE_CONFIG = _pre_run.ACTION_SURFACE_CONFIG
+ACTION_SURFACE_NO_ROSTER = _pre_run.ACTION_SURFACE_NO_ROSTER
+ACTION_SURFACE_HOLD = _pre_run.ACTION_SURFACE_HOLD
+HOLD_SOURCE_ID = _pre_run.HOLD_SOURCE_ID
+STALL_SOURCE_PREFIX = _pre_run.STALL_SOURCE_PREFIX
+
+# The vendored ledger — real events so tests exercise the true item_key join.
+_LEDGER_PATH = _HERE.parent / "escalation_ledger.py"
+_lspec = importlib.util.spec_from_file_location("mrc_ledger_test", _LEDGER_PATH)
+_ledger = importlib.util.module_from_spec(_lspec)
+sys.modules["mrc_ledger_test"] = _ledger
+_lspec.loader.exec_module(_ledger)
+
+
+# ---------------------------------------------------------------------------
+# Fakes + helpers
+# ---------------------------------------------------------------------------
+
+
+class FakeSource:
+    def __init__(self, pull: RosterPull):
+        self._pull = pull
+
+    def pull_open_roster_items(self) -> RosterPull:
+        return self._pull
+
+
+TODAY = date(2026, 8, 18)
+_CFG = ChaseConfig(chase_cadence_days=7)
+_REFIRE = 3
+
+
+def _item(
+    *,
+    matter_id: str = "m-1",
+    task_id: str | None = "task-1",
+    confirm_by: date | None = None,
+) -> RosterItem:
+    return RosterItem(
+        matter_id=matter_id,
+        task_id=task_id,
+        confirm_by=confirm_by or (TODAY - timedelta(days=38)),
+    )
+
+
+def _pull(*items: RosterItem, open_task_count: int | None = None) -> RosterPull:
+    return RosterPull(
+        items=tuple(items),
+        open_task_count=len(items) if open_task_count is None else open_task_count,
+    )
+
+
+def _chased_event(item, *, ts, attempt):
+    key = _ledger.item_key(item.matter_id, item.task_id, item.label, item.authored_date)
+    return _ledger.make_event(
+        skill="medical-records-chaser",
+        matter_id=item.matter_id,
+        item_key=key,
+        event="chased",
+        attempt=attempt,
+        token=_ledger.token_for(key),
+        ts=ts,
+    )
+
+
+def _resolved_event(item, *, ts):
+    key = _ledger.item_key(item.matter_id, item.task_id, item.label, item.authored_date)
+    return _ledger.make_event(
+        skill="medical-records-chaser",
+        matter_id=item.matter_id,
+        item_key=key,
+        event="resolved",
+        attempt=0,
+        ts=ts,
+    )
+
+
+def _hold_event(item, *, event="fired", ts, attempt=1):
+    key = _ledger.item_key(item.matter_id, HOLD_SOURCE_ID, "mrc-chase-hold", None)
+    return _ledger.make_event(
+        skill="medical-records-chaser",
+        matter_id=item.matter_id,
+        item_key=key,
+        event=event,
+        attempt=attempt,
+        ts=ts,
+    )
+
+
+def _stall_event(item, *, ts, attempt=1):
+    key = _ledger.item_key(
+        item.matter_id, STALL_SOURCE_PREFIX + str(item.task_id), "mrc-stall", None
+    )
+    return _ledger.make_event(
+        skill="medical-records-chaser",
+        matter_id=item.matter_id,
+        item_key=key,
+        event="fired",
+        attempt=attempt,
+        ts=ts,
+    )
+
+
+def _decide(pull, events, *, config=_CFG, today=TODAY):
+    return decide(
+        pull,
+        config,
+        _ledger,
+        events,
+        raw_inputs_for_digest=b"x",
+        today=today,
+        refire_days=_REFIRE,
+    )
+
+
+def _run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def _capture_stdout(coro) -> tuple[int, str]:
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        code = _run(coro)
+    return code, buf.getvalue().strip()
+
+
+# ---------------------------------------------------------------------------
+# decide() — cadence + the plan state the email copies (condition a)
+# ---------------------------------------------------------------------------
+
+
+def test_new_item_first_chase_due_when_confirm_by_arrived():
+    d = _decide(_pull(_item()), [])
+    assert d.wake is True
+    (plan,) = d.plans
+    assert plan.action == ACTION_CHASE
+    assert plan.attempt == 1
+    assert plan.last_chased is None  # no ledger history: the email must NOT
+    # claim "no prior chase" (memos may hold pre-ledger chases) — SKILL.md rule
+    assert plan.days_past_confirm_by == 38
+
+
+def test_new_item_not_due_before_confirm_by():
+    d = _decide(_pull(_item(confirm_by=TODAY + timedelta(days=3))), [])
+    assert d.wake is False
+
+
+def test_chase_suppressed_within_cadence_window():
+    item = _item()
+    events = [_chased_event(item, ts="2026-08-15T09:00:00.000Z", attempt=1)]
+    d = _decide(_pull(item), events)
+    assert d.wake is False
+    assert d.decision_basis == "no_records_chase_due"
+
+
+def test_chase_refires_after_cadence_with_ledger_state_in_plan():
+    # THE defect test (Aug 11 → Aug 18): the second wake's plan must carry the
+    # first chase's date and the correct attempt number — the email copies
+    # these, so consecutive emails cannot contradict each other.
+    item = _item()
+    events = [_chased_event(item, ts="2026-08-11T15:11:00.000Z", attempt=1)]
+    d = _decide(_pull(item), events)
+    assert d.wake is True
+    (plan,) = d.plans
+    assert plan.action == ACTION_CHASE
+    assert plan.attempt == 2
+    assert plan.last_chased == "2026-08-11"  # never "July 13", never recall
+    assert plan.days_past_confirm_by == 38
+
+
+def test_attempt_numbering_counts_prior_chases():
+    item = _item()
+    events = [
+        _chased_event(item, ts="2026-07-28T09:00:00.000Z", attempt=1),
+        _chased_event(item, ts="2026-08-04T09:00:00.000Z", attempt=2),
+        _chased_event(item, ts="2026-08-11T09:00:00.000Z", attempt=3),
+    ]
+    d = _decide(_pull(item), events)
+    (plan,) = d.plans
+    assert plan.attempt == 4
+    assert plan.last_chased == "2026-08-11"
+
+
+def test_stall_raise_on_its_sentinel_does_not_inflate_the_chase_numerator():
+    # A stall escalation is keyed on STALL_SOURCE_PREFIX+task, never the chase
+    # item key — otherwise "chase N" drifts (critique issue 4).
+    item = _item()
+    events = [
+        _chased_event(item, ts="2026-08-04T09:00:00.000Z", attempt=1),
+        _stall_event(item, ts="2026-08-05T09:00:00.000Z"),
+    ]
+    d = _decide(_pull(item), events, today=date(2026, 8, 12))
+    (plan,) = d.plans
+    assert plan.attempt == 2  # not 3
+
+
+def test_resolved_item_is_terminal():
+    item = _item()
+    events = [
+        _chased_event(item, ts="2026-08-04T09:00:00.000Z", attempt=1),
+        _resolved_event(item, ts="2026-08-10T09:00:00.000Z"),
+    ]
+    d = _decide(_pull(item), events)
+    assert d.wake is False
+
+
+def test_days_past_confirm_by_never_negative():
+    item = _item(confirm_by=TODAY)
+    d = _decide(_pull(item), [])
+    (plan,) = d.plans
+    assert plan.days_past_confirm_by == 0
+
+
+# ---------------------------------------------------------------------------
+# decide() — unauthored config (condition c)
+# ---------------------------------------------------------------------------
+
+
+def _config_sentinel_fired(*, ts, attempt=1):
+    key = _ledger.item_key("", "__mrc_chase_config__", "mrc-chase-config-missing", "")
+    return _ledger.make_event(
+        skill="medical-records-chaser",
+        matter_id=None,
+        item_key=key,
+        event="fired",
+        attempt=attempt,
+        ts=ts,
+    )
+
+
+def test_unauthored_config_surfaces_and_never_chases():
+    d = _decide(_pull(_item()), [], config=ChaseConfig())
+    assert d.wake is True
+    assert [p.action for p in d.plans] == [ACTION_SURFACE_CONFIG]
+
+
+def test_unauthored_config_quiet_within_refire_window():
+    d = _decide(
+        _pull(_item()),
+        [_config_sentinel_fired(ts="2026-08-16T09:00:00.000Z")],
+        config=ChaseConfig(),
+    )
+    assert d.wake is False
+    assert d.decision_basis == "chase_config_unauthored_within_refire_window"
+
+
+def test_unauthored_config_resurfaces_after_refire_window():
+    d = _decide(
+        _pull(_item()),
+        [_config_sentinel_fired(ts="2026-08-14T09:00:00.000Z")],
+        config=ChaseConfig(),
+    )
+    assert d.wake is True
+    assert d.plans[0].attempt == 2
+
+
+def test_verification_trackers_config_sentinel_does_not_collide():
+    # The sibling skill's config sentinel uses source "__chase_config__";
+    # ours is "__mrc_chase_config__". An ack on THEIRS must not snooze OURS —
+    # item_key ignores label, so distinct source_ids are the only fence.
+    their_key = _ledger.item_key("", "__chase_config__", "chase-config-missing", "")
+    events = [
+        _ledger.make_event(
+            skill="client-verification-tracker",
+            matter_id=None,
+            item_key=their_key,
+            event="fired",
+            attempt=1,
+            ts="2026-08-17T09:00:00.000Z",
+        ),
+    ]
+    d = _decide(_pull(_item()), events, config=ChaseConfig())
+    assert d.wake is True  # our sentinel has no history; it surfaces
+    assert d.plans[0].attempt == 1
+
+
+# ---------------------------------------------------------------------------
+# decide() — no roster tasks (condition e): zero marker matches must be LOUD
+# ---------------------------------------------------------------------------
+
+
+def _no_roster_sentinel_fired(*, ts, attempt=1):
+    key = _ledger.item_key("", "__mrc_no_roster__", "mrc-no-roster-tasks", "")
+    return _ledger.make_event(
+        skill="medical-records-chaser",
+        matter_id=None,
+        item_key=key,
+        event="fired",
+        attempt=attempt,
+        ts=ts,
+    )
+
+
+def test_open_tasks_but_zero_marker_matches_surfaces():
+    d = _decide(RosterPull(items=(), open_task_count=12), [])
+    assert d.wake is True
+    assert [p.action for p in d.plans] == [ACTION_SURFACE_NO_ROSTER]
+
+
+def test_no_roster_surface_respects_refire_window():
+    d = _decide(
+        RosterPull(items=(), open_task_count=12),
+        [_no_roster_sentinel_fired(ts="2026-08-17T09:00:00.000Z")],
+    )
+    assert d.wake is False
+    assert d.decision_basis == "no_roster_tasks_within_refire_window"
+
+
+def test_truly_empty_seat_suppresses_quietly():
+    d = _decide(RosterPull(items=(), open_task_count=0), [])
+    assert d.wake is False
+    assert d.decision_basis == "no_records_chase_due"
+
+
+# ---------------------------------------------------------------------------
+# decide() — matter-level hold (condition d, the ss #2402 rule ported)
+# ---------------------------------------------------------------------------
+
+
+def test_hold_blocks_a_due_chase_and_resurfaces():
+    item = _item()
+    events = [_hold_event(item, ts="2026-08-14T09:00:00.000Z")]
+    d = _decide(_pull(item), events)
+    assert d.wake is True
+    assert [p.action for p in d.plans] == [ACTION_SURFACE_HOLD]
+
+
+def test_hold_quiet_within_refire_window_still_blocks():
+    item = _item()
+    events = [_hold_event(item, ts="2026-08-17T09:00:00.000Z")]
+    d = _decide(_pull(item), events)
+    assert d.wake is False
+
+
+def test_resolved_hold_releases_the_chase():
+    item = _item()
+    events = [
+        _hold_event(item, ts="2026-08-10T09:00:00.000Z"),
+        _hold_event(item, event="resolved", ts="2026-08-16T09:00:00.000Z"),
+    ]
+    d = _decide(_pull(item), events)
+    assert d.wake is True
+    assert [p.action for p in d.plans] == [ACTION_CHASE]
+
+
+def test_hold_survives_tracking_task_recreation():
+    original = _item(task_id="task-1")
+    events = [_hold_event(original, ts="2026-08-17T09:00:00.000Z")]
+    replacement = _item(task_id="task-9")
+    d = _decide(_pull(replacement), events)
+    assert d.wake is False  # held and inside the refire window: quiet, no chase
+
+
+def test_verification_hold_does_not_block_records_chases():
+    # The sibling's hold sentinel is "__hold__"; ours is "__mrc_hold__". A
+    # signer-ambiguity hold on the matter must not silence the records chase —
+    # distinct source_ids are the fence (item_key ignores label and skill).
+    item = _item()
+    their_hold_key = _ledger.item_key(item.matter_id, "__hold__", "chase-hold", None)
+    events = [
+        _ledger.make_event(
+            skill="client-verification-tracker",
+            matter_id=item.matter_id,
+            item_key=their_hold_key,
+            event="fired",
+            attempt=1,
+            ts="2026-08-14T09:00:00.000Z",
+        ),
+    ]
+    d = _decide(_pull(item), events)
+    assert d.wake is True
+    assert [p.action for p in d.plans] == [ACTION_CHASE]
+
+
+def test_held_matter_with_two_items_surfaces_once():
+    a = _item(task_id="task-1")
+    b = _item(task_id="task-2")
+    events = [_hold_event(a, ts="2026-08-14T09:00:00.000Z")]
+    d = _decide(_pull(a, b), events)
+    assert d.wake is True
+    assert [p.action for p in d.plans] == [ACTION_SURFACE_HOLD]
+
+
+# ---------------------------------------------------------------------------
+# run_once() — wake line carries the plan state; fail-open on ledger loss
+# ---------------------------------------------------------------------------
+
+
+class _NullWriterFactory:
+    def __call__(self):
+        return None
+
+
+def test_run_once_wake_line_carries_the_email_state():
+    item = _item()
+    events = [_chased_event(item, ts="2026-08-11T15:11:00.000Z", attempt=1)]
+    code, out = _capture_stdout(
+        run_once(
+            [FakeSource(_pull(item))],
+            _NullWriterFactory(),
+            today=TODAY,
+            config=_CFG,
+            refire_days=_REFIRE,
+            ledger_module=_ledger,
+            ledger_events=events,
+        )
+    )
+    assert code == 0
+    payload = json.loads(out)
+    assert payload["wakeAgent"] is True
+    (plan,) = payload["plans"]
+    assert plan["attempt"] == 2
+    assert plan["last_chased"] == "2026-08-11"
+    assert plan["days_past_confirm_by"] == 38
+
+
+def test_run_once_fires_open_when_ledger_unavailable(monkeypatch):
+    monkeypatch.setattr(_pre_run, "_load_ledger_module", lambda: None)
+    code, out = _capture_stdout(
+        run_once(
+            [FakeSource(_pull(_item()))],
+            _NullWriterFactory(),
+            today=TODAY,
+            config=_CFG,
+            refire_days=_REFIRE,
+        )
+    )
+    assert code == 0
+    payload = json.loads(out)
+    assert payload["wakeAgent"] is True
+    assert payload["decision_basis"] == "ledger_unavailable_fail_open"
+
+
+def test_run_once_no_writer_falls_back_to_wake_on_suppress():
+    # Nothing due, but no heartbeat writer → mirror-don't-gate: wake.
+    code, out = _capture_stdout(
+        run_once(
+            [FakeSource(RosterPull((), 0))],
+            _NullWriterFactory(),
+            today=TODAY,
+            config=_CFG,
+            refire_days=_REFIRE,
+            ledger_module=_ledger,
+            ledger_events=[],
+        )
+    )
+    payload = json.loads(out)
+    assert payload["wakeAgent"] is True
+    assert payload["decision_basis"] == "no_audit_writer_fail_open"
+
+
+# ---------------------------------------------------------------------------
+# parse_pull()
+# ---------------------------------------------------------------------------
+
+
+def _task(subject: str, *, task_id="t-1", matter="m-1", due="2026-07-11"):
+    return {"id": task_id, "subject": subject, "matter": {"id": matter}, "dueDate": due}
+
+
+def test_parse_pull_subsets_roster_tasks_by_marker():
+    raw = {
+        "tasks": [
+            _task("Medical records outstanding - Valley Imaging Center (request roster)"),
+            _task("Client verification outstanding - FROG responses", task_id="t-2"),
+            _task("Chase Medi-Cal lien payoff", task_id="t-3"),
+        ]
+    }
+    pull, problem = parse_pull(raw, today=TODAY)
+    assert problem is None
+    assert pull.open_task_count == 3
+    assert len(pull.items) == 1
+    assert pull.items[0].task_id == "t-1"
+    assert pull.items[0].matter_id == "m-1"
+    assert pull.items[0].confirm_by == date(2026, 7, 11)
+
+
+def test_parse_pull_dateless_roster_task_seeds_today():
+    raw = {"tasks": [{"id": "t-1", "subject": "x (request roster)", "matter": {"id": "m-1"}}]}
+    pull, problem = parse_pull(raw, today=TODAY)
+    assert problem is None
+    assert pull.items[0].confirm_by == TODAY
+
+
+def test_parse_pull_error_key_is_a_problem():
+    pull, problem = parse_pull({"tasksError": "boom"}, today=TODAY)
+    assert problem is not None
+
+
+def test_parse_pull_unrecognized_envelope_is_a_problem():
+    pull, problem = parse_pull({"tasks": {"weird": True}}, today=TODAY)
+    assert problem is not None
+
+
+def test_parse_pull_full_page_is_a_problem():
+    # A full 500-row page may be truncated; trusting the subset could silently
+    # drop providers (critique issue 7). Fail open instead.
+    raw = {"tasks": [_task(f"x (request roster)", task_id=f"t-{i}") for i in range(500)]}
+    pull, problem = parse_pull(raw, today=TODAY)
+    assert problem is not None
+    assert "full page" in problem
+
+
+# ---------------------------------------------------------------------------
+# load_chase_config()
+# ---------------------------------------------------------------------------
+
+
+def _write_yaml(tmp_path, body: str):
+    path = tmp_path / "customer.yaml"
+    path.write_text(body, encoding="utf-8")
+    return str(path)
+
+
+def test_load_chase_config_reads_per_skill_settings(tmp_path, monkeypatch):
+    path = _write_yaml(
+        tmp_path,
+        """
+personas:
+  - name: operator
+    skills:
+      - name: medical-records-chaser
+        settings:
+          chase_cadence_days: 7
+escalation:
+  refire_days: 4
+""",
+    )
+    monkeypatch.setenv("SMD_CUSTOMER_YAML_PATH", path)
+    config, refire = load_chase_config()
+    assert config.chase_cadence_days == 7
+    assert config.authored is True
+    assert refire == 4
+
+
+def test_load_chase_config_unauthored_when_settings_absent(tmp_path, monkeypatch):
+    path = _write_yaml(
+        tmp_path,
+        """
+personas:
+  - name: operator
+    skills:
+      - name: medical-records-chaser
+""",
+    )
+    monkeypatch.setenv("SMD_CUSTOMER_YAML_PATH", path)
+    config, _ = load_chase_config()
+    assert config.authored is False
+
+
+def test_load_chase_config_unauthored_on_missing_file(monkeypatch):
+    monkeypatch.setenv("SMD_CUSTOMER_YAML_PATH", "/nonexistent/customer.yaml")
+    config, _ = load_chase_config()
+    assert config.authored is False
+
+
+def test_load_chase_config_rejects_nonpositive(tmp_path, monkeypatch):
+    path = _write_yaml(
+        tmp_path,
+        """
+personas:
+  - name: operator
+    skills:
+      - name: medical-records-chaser
+        settings:
+          chase_cadence_days: 0
+""",
+    )
+    monkeypatch.setenv("SMD_CUSTOMER_YAML_PATH", path)
+    config, _ = load_chase_config()
+    assert config.authored is False

--- a/operator/tests/test_escalation_ledger_sync.py
+++ b/operator/tests/test_escalation_ledger_sync.py
@@ -30,6 +30,7 @@ VENDORED_SKILLS = (
     "deadline-miss-escalator",
     "daily-needs-you-digest",
     "client-verification-tracker",
+    "medical-records-chaser",
 )
 
 

--- a/operator/tests/test_pre_run_gate.py
+++ b/operator/tests/test_pre_run_gate.py
@@ -22,14 +22,14 @@ _TEMPLATE = _OPERATOR_ROOT / "templates" / "pre_run_gate.py"
 # The always-wake PI-pack skills gated by the empty-seat gate (#1748).
 # deadline-miss-escalator keeps its bespoke deadline pre_run and is NOT here;
 # client-verification-tracker graduated to its own bespoke cadence gate (WP-B,
-# #1889) and is likewise no longer on the shared template.
+# #1889) and medical-records-chaser to its ledger-backed cadence gate
+# (ss #2404) — neither is on the shared template any longer.
 GATED_SKILLS = (
     "daily-needs-you-digest",
     "discovery-response-tracker",
     "motion-calendar-tracker",
     "service-confirmation-watcher",
     "medical-chronology-maintainer",
-    "medical-records-chaser",
     "lien-ledger-tracker",
     "mediation-settlement-tracker",
     "minors-compromise-packet",


### PR DESCRIPTION
## What the client experiences

The weekly records-chase email can no longer contradict last week's. "Chase N", "last chase staged <date>", and the overdue figure are projected from broker-validated ledger state carried in the wake plan and copied verbatim by the turn — the Aug 11 → Aug 18 Valley Imaging contradiction ("last chase staged July 13", three days after its own Aug 11 chase) becomes structurally impossible to produce from recall.

## Mechanism (template: client-verification-tracker WP-B #1889 + the #2402 hold)

- **Bespoke pre_run** replaces the shared empty-seat gate: pull open tasks in the connector venv, subset by the roster-task subject marker (`"request roster"` — the pilot seed convention, a connect-step contract), plan a chase per due item carrying `{attempt, last_chased, days_past_confirm_by}` from ledger + task state, computed in code.
- **Matter-level hold ported** (ss #2402), namespaced `__mrc_hold__`: `item_key` ignores label, so per-skill sentinel source ids are the only fence — tests pin that a verification hold does not block records chases and vice versa, and that the hold survives tracking-task recreation.
- **No-roster sentinel:** open tasks with zero marker matches surface on the refire window instead of suppressing forever (permanent silent darkness was the worst fail direction at a real firm).
- **Full-page pulls fail open** (a 500-row page may be truncated; a trusted subset could silently drop providers).
- **Stall raises are namespaced** (`__mrc_stall__<task>`) so the "chase N" numerator cannot inflate — attempts count every raise on a key.
- **SKILL.md 0.2.0:** copy-plan-verbatim; null history is "first chase recorded in the tracking ledger" (never "no prior chase" — pre-ledger history lives in memos, and a recreated task starts a fresh identity); overdue figure is phrased against the tracking task's confirm-by date (the anchor the firm may refresh), never "records N days overdue"; `chased` appended only after the send/stage succeeded, defined as staged-not-delivered; the improvised `[op-mrc:...]` tag retired; the forwardable chase letter (dropped in the Aug 18 regression) pinned into every chase email.
- **Pilot customer.yaml:** `chase_cadence_days: 7` with seed-note provenance stated (`PLACEHOLDER(christa)`); unauthored fails closed with a re-fired surface, proven by tests.

All 9 findings from the /critique pass are addressed in this PR (reachability contract and critique on #2404).

## Acceptance

- [x] Second-wake plan carries the first chase's date and attempt (the defect test)
- [x] Stall raise does not inflate the chase numerator (test)
- [x] Zero marker matches with open tasks surfaces; empty seat stays quiet (tests)
- [x] Hold blocks/resurfaces/releases; survives task recreation; cross-skill sentinel isolation (tests)
- [x] Unauthored cadence fails closed with refire; nonpositive/missing config rejected (tests)
- [x] Full-page pull is a problem → wake (test)
- [x] operator suite 103 green; repo `npm run verify` green
- [ ] (runtime) Kill-test on the pilot seat per the #2404 contract: provenance-guarded reprovision, then two consecutive scheduled wakes observed with consistent, ledger-matching emails — deferred until the #2392 pass clears the seat

Part of #2404 (does not close it — the runtime rows remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLzzpTuYY8j3EaWbXfxz4x
