### PR TITLE
fix(operator): probe artifacts are fenced at both ingestion seams and carry a teardown contract (#2403)

### DIFF
--- a/operator/CLAUDE.md
+++ b/operator/CLAUDE.md
@@ -42,3 +42,30 @@ Load these ADRs before any Operator architectural work:
 Connectors are wired by `customer.yaml.connectors{}` backend prefix: `mcp:` (vendor or vetted-community MCP server), `build:` (Python adapter we maintain), `synthetic:` (no_pm substrate). Composio is dropped (ADR 0020, 2026-05-30 revision) — we connect to MCPs directly, and long-tail vendors with no first-party MCP get a `build:` adapter.
 
 The 2026-05-24 realignment burial is complete. Removed: `smd.hooks.*` dual-surface scaffolding, Honcho interceptor, Curator interceptor, GEPA boot-check (ADR 0018 superseded), in-tree YAML validator, the pre-realignment MS Graph adapter, and the `clio/` / `dotloop/` / `shipstation/` connector dirs whose MCP-first decisions superseded them. Author-built connectors we must write ourselves (no vendor/community MCP exists) are MCP servers living in `operator/connectors/` in this tree, per ADR 0053 — Smokeball is the first. The overlay repo (`venturecrane/hermes-smd-overlay`) stays substrate-only.
+
+## Probe artifacts in a tenant (ss #2403 — the 28745d01 lesson)
+
+Any rehearsal, self-test, or kill-test that writes an artifact into a customer
+or pilot tenant (a Smokeball task, memo, event, or file) follows this contract.
+It exists because a rehearsal probe task outlived its test on the pilot: the
+2026-08-14 digest flagged it as "a machine-authored probe task; its own note
+instructs deletion after witnessing", and 37 minutes later the verification
+chase cited that same task as its live tracking anchor.
+
+1. **Stamp at creation.** The subject starts with `[SMD-PROBE <ISO-8601 UTC
+creation stamp>]`, e.g. `[SMD-PROBE 2026-08-18T17:00Z] drafting prove-out`.
+   The connector's `[Operator]` provenance stamp may precede it. The stamp is
+   deliberately subject-visible: firm staff reading the task list are the other
+   consumer that can mistake a probe for real work. (Before first use on a new
+   tenant, create-and-read-back one stamped task — this vendor has form for
+   munging text, e.g. names truncate at the first period.)
+2. **Tear down in the same session.** A probe artifact is deleted — for tasks,
+   completed via `update_task(is_completed=True)`; the connector has no task
+   delete — before the session reports its test done, with a negative probe
+   (gone-means-gone rule 2). "Its note says to delete it later" is the
+   anti-pattern this contract replaces.
+3. **Ingestion is fenced either way.** `list_tasks` drops probe-marked rows by
+   default and counts the drop (`probeArtifactsExcluded`); the tracker/chaser
+   pre_run pulls exclude them too. The match is position-anchored — only a
+   subject that STARTS with the marker is a probe — so real work cannot be
+   hidden by quoting it. Never widen the match.

--- a/operator/connectors/smokeball/smokeball_connector/server.py
+++ b/operator/connectors/smokeball/smokeball_connector/server.py
@@ -615,6 +615,69 @@ _MATTER_NUMBER_RE = re.compile(r"\b(?:\d{4}-[A-Z]{2}-\d{3,4}|[A-Z]{2}-\d{4}-\d{4
 
 _PROVENANCE_MARK = "[Operator]"
 
+# Rehearsal / self-test artifacts written into a tenant carry this subject
+# marker (ss #2403): ``[SMD-PROBE <ISO-8601 creation stamp>]``, at the start of
+# the subject (after the ``[Operator]`` provenance stamp create_task adds).
+# The 2026-08-14 incident: a rehearsal probe task outlived its test, the digest
+# itself flagged it as "a machine-authored probe task; its own note instructs
+# deletion after witnessing", and 37 minutes later the verification chase cited
+# it as its real tracking anchor. The marker is deliberately subject-visible —
+# firm staff reading the task list are the OTHER consumer that can mistake a
+# probe for real work; a note-only token would hide it from exactly them.
+#
+# ``list_tasks`` drops marked rows by default so the agent turn never ingests
+# a probe as work (``include_probe_artifacts=True`` is the census/teardown
+# opt-in), and the drop is COUNTED on the response envelope — a filter that
+# can hide rows silently is a suppression channel, and a deadline watcher that
+# goes quiet is the dangerous failure. The match is position-anchored (only a
+# subject that STARTS with the marker, provenance stamp aside, is a probe);
+# a mid-subject occurrence does not match, so real work cannot be hidden by
+# quoting the marker.
+_PROBE_MARK = "[SMD-PROBE"
+
+
+def _is_probe_subject(subject: Any) -> bool:
+    """True iff the subject is marked as a rehearsal/self-test probe artifact."""
+    if not isinstance(subject, str):
+        return False
+    text = subject.lstrip()
+    if text.upper().startswith(_PROVENANCE_MARK.upper()):
+        text = text[len(_PROVENANCE_MARK) :].lstrip()
+    return text.upper().startswith(_PROBE_MARK.upper())
+
+
+def _task_subject_of(item: Any) -> str:
+    if not isinstance(item, dict):
+        return ""
+    for key in ("subject", "Subject", "name", "Name", "title", "Title"):
+        value = item.get(key)
+        if isinstance(value, str) and value.strip():
+            return value
+    return ""
+
+
+def _drop_probe_tasks(resp: Any) -> Any:
+    """Remove probe-marked rows from a /tasks response, loudly.
+
+    Only the dict (HATEOAS ``{"value": [...]}``) envelope gains the
+    ``probeArtifactsExcluded`` count key; a bare-list response is filtered in
+    place (its shape cannot carry a count without breaking consumers).
+    """
+    if isinstance(resp, dict):
+        for key in ("value", "items", "results", "tasks", "data"):
+            rows = resp.get(key)
+            if isinstance(rows, list):
+                kept = [r for r in rows if not _is_probe_subject(_task_subject_of(r))]
+                excluded = len(rows) - len(kept)
+                if excluded:
+                    resp[key] = kept
+                    resp["probeArtifactsExcluded"] = excluded
+                return resp
+        return resp
+    if isinstance(resp, list):
+        return [r for r in resp if not _is_probe_subject(_task_subject_of(r))]
+    return resp
+
 
 class MatterReferenceMismatch(RuntimeError):
     """Raised when composed text names a matter other than the one written to."""
@@ -871,9 +934,17 @@ def list_tasks(
     updated_since: str | None = None,
     limit: int = 500,
     offset: int = 0,
+    include_probe_artifacts: bool = False,
 ) -> Any:
     """List tasks (authored court/filing deadlines carry a due date). Filter by
     matter and completion state.
+
+    Rehearsal/self-test probe artifacts (subjects marked ``[SMD-PROBE ...]``)
+    are EXCLUDED by default and the exclusion is counted on the response as
+    ``probeArtifactsExcluded`` (ss #2403 — a probe task once outlived its test
+    and became a live chase's tracking anchor). Pass
+    ``include_probe_artifacts=True`` only for a probe census or teardown; probe
+    rows are never work.
 
     Each item is enriched with ``matterNumber`` and ``matterCaption`` resolved
     from its own ``matter.id`` (best-effort, bounded). Cite those fields — never
@@ -888,6 +959,8 @@ def list_tasks(
         Limit=limit,
         Offset=offset,
     )
+    if not include_probe_artifacts:
+        resp = _drop_probe_tasks(resp)
     _attach_matter_refs_to_list(client, resp)
     return resp
 

--- a/operator/connectors/smokeball/tests/test_probe_artifact_filter.py
+++ b/operator/connectors/smokeball/tests/test_probe_artifact_filter.py
@@ -1,0 +1,90 @@
+"""Probe-artifact exclusion on list_tasks (ss #2403).
+
+A rehearsal probe task once outlived its test and became a live chase's
+tracking anchor. Marked rows (``[SMD-PROBE ...]`` at the start of the subject,
+provenance stamp aside) are dropped by default and the drop is COUNTED —
+a filter that can hide rows silently is a suppression channel. The match is
+position-anchored: a mid-subject occurrence is NOT a probe, so real work
+cannot be hidden by quoting the marker.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from smokeball_connector import server
+
+
+class _TasksClient:
+    def __init__(self, payload) -> None:
+        self._payload = payload
+
+    def get(self, path: str, **params):
+        if path == "/tasks":
+            return self._payload
+        return {}
+
+
+def _wire(monkeypatch, payload):
+    monkeypatch.setattr(server, "_get_client", lambda: _TasksClient(payload))
+
+
+def _task(subject: str, task_id: str = "t-1"):
+    return {"id": task_id, "subject": subject}
+
+
+def test_probe_rows_dropped_and_counted(monkeypatch):
+    _wire(
+        monkeypatch,
+        {
+            "value": [
+                _task("[Operator] [SMD-PROBE 2026-08-18T14:00Z] drafting prove-out", "t-p"),
+                _task("[Operator] Client verification outstanding - FROG Set One", "t-r"),
+            ]
+        },
+    )
+    resp = server.list_tasks()
+    assert [t["id"] for t in resp["value"]] == ["t-r"]
+    assert resp["probeArtifactsExcluded"] == 1
+
+
+def test_unstamped_probe_subject_also_dropped(monkeypatch):
+    _wire(monkeypatch, {"value": [_task("[SMD-PROBE 2026-08-18T14:00Z] x", "t-p")]})
+    resp = server.list_tasks()
+    assert resp["value"] == []
+    assert resp["probeArtifactsExcluded"] == 1
+
+
+def test_mid_subject_marker_is_not_a_probe(monkeypatch):
+    # Falsifier: only a position-anchored marker matches — a real task that
+    # QUOTES the marker must not be hidden.
+    _wire(monkeypatch, {"value": [_task("Review the [SMD-PROBE] cleanup contract", "t-r")]})
+    resp = server.list_tasks()
+    assert [t["id"] for t in resp["value"]] == ["t-r"]
+    assert "probeArtifactsExcluded" not in resp
+
+
+def test_opt_in_returns_probe_rows(monkeypatch):
+    _wire(monkeypatch, {"value": [_task("[SMD-PROBE 2026-08-18T14:00Z] x", "t-p")]})
+    resp = server.list_tasks(include_probe_artifacts=True)
+    assert [t["id"] for t in resp["value"]] == ["t-p"]
+    assert "probeArtifactsExcluded" not in resp
+
+
+def test_bare_list_envelope_filtered(monkeypatch):
+    _wire(
+        monkeypatch,
+        [
+            _task("[SMD-PROBE 2026-08-18T14:00Z] x", "t-p"),
+            _task("Real task", "t-r"),
+        ],
+    )
+    resp = server.list_tasks()
+    assert [t["id"] for t in resp] == ["t-r"]
+
+
+def test_no_probes_leaves_envelope_untouched(monkeypatch):
+    _wire(monkeypatch, {"value": [_task("Real task", "t-r")]})
+    resp = server.list_tasks()
+    assert [t["id"] for t in resp["value"]] == ["t-r"]
+    assert "probeArtifactsExcluded" not in resp

--- a/operator/skills/client-verification-tracker/pre_run.py
+++ b/operator/skills/client-verification-tracker/pre_run.py
@@ -827,7 +827,25 @@ def _source_id_of(item: dict) -> str | None:
     return None
 
 
+# Rehearsal/self-test artifacts carry "[SMD-PROBE <stamp>]" at the start of
+# the subject (after the connector's "[Operator]" provenance stamp) — ss #2403:
+# a probe task outlived its test and became THIS skill's live tracking anchor
+# (task 28745d01, 2026-08-14). Probe rows are never tracked verifications.
+# Position-anchored: a real task quoting the marker mid-subject is not hidden.
+_PROBE_MARK = "[SMD-PROBE"
+_PROVENANCE_MARK = "[Operator]"
+
+
+def _is_probe_subject(subject: str) -> bool:
+    text = subject.lstrip()
+    if text.upper().startswith(_PROVENANCE_MARK.upper()):
+        text = text[len(_PROVENANCE_MARK) :].lstrip()
+    return text.upper().startswith(_PROBE_MARK.upper())
+
+
 def _is_verification_task(subject: str) -> bool:
+    if _is_probe_subject(subject):
+        return False
     return _VERIFICATION_SUBJECT_MARKER in subject.lower()
 
 

--- a/operator/skills/client-verification-tracker/test_verification_pre_run.py
+++ b/operator/skills/client-verification-tracker/test_verification_pre_run.py
@@ -783,6 +783,33 @@ def test_parse_pull_filters_to_verification_tasks():
     assert items[0].next_chase_due == date(2026, 7, 20)
 
 
+def test_parse_pull_excludes_probe_artifacts():
+    # ss #2403: task 28745d01 was a rehearsal probe THIS skill ingested as its
+    # live tracking anchor. A probe-marked task is never a verification item;
+    # a real one quoting the marker mid-subject is kept (position-anchored).
+    raw = {
+        "tasks": {
+            "items": [
+                {
+                    "matterId": "m-1",
+                    "id": "t-p",
+                    "subject": "[Operator] [SMD-PROBE 2026-08-18T14:00Z] verification probe",
+                    "dueDate": "2026-07-20",
+                },
+                {
+                    "matterId": "m-1",
+                    "id": "t-r",
+                    "subject": "Verification chase: quote the [SMD-PROBE] marker",
+                    "dueDate": "2026-07-20",
+                },
+            ]
+        }
+    }
+    items, problem = parse_pull(raw, today=TODAY)
+    assert problem is None
+    assert [i.task_id for i in items] == ["t-r"]
+
+
 def test_parse_pull_dateless_verification_seeds_first_chase_today():
     raw = {"tasks": {"items": [{"matterId": "m-1", "id": "t-1", "subject": "verification tracking"}]}}
     items, problem = parse_pull(raw, today=TODAY)

--- a/operator/skills/deadline-miss-escalator/pre_run.py
+++ b/operator/skills/deadline-miss-escalator/pre_run.py
@@ -628,6 +628,29 @@ print(json.dumps(out, default=str))
 
 _TASK_DATE_KEYS = ("dueDate", "DueDate", "due_date")
 _EVENT_DATE_KEYS = ("startTime", "StartTime", "startDate", "start", "from")
+_SUBJECT_KEYS = ("subject", "Subject", "name", "Name", "title", "Title")
+
+# Rehearsal/self-test artifacts carry "[SMD-PROBE <stamp>]" at the start of the
+# subject (after the connector's "[Operator]" provenance stamp) — ss #2403: a
+# probe task outlived its test and became a live chase's tracking anchor. Probe
+# rows are never deadlines. Position-anchored on purpose: a real task QUOTING
+# the marker mid-subject must not be hidden (a deadline watcher that can be
+# silenced by subject text is the dangerous failure).
+_PROBE_MARK = "[SMD-PROBE"
+_PROVENANCE_MARK = "[Operator]"
+
+
+def _is_probe_item(item: dict) -> bool:
+    subject = ""
+    for key in _SUBJECT_KEYS:
+        value = item.get(key)
+        if isinstance(value, str) and value.strip():
+            subject = value
+            break
+    text = subject.lstrip()
+    if text.upper().startswith(_PROVENANCE_MARK.upper()):
+        text = text[len(_PROVENANCE_MARK) :].lstrip()
+    return text.upper().startswith(_PROBE_MARK.upper())
 _MATTER_ID_KEYS = ("matterId", "MatterId", "matter_id", "id")
 # The Smokeball task/event id, extracted INDEPENDENTLY of matter id (a task's
 # own ``id`` is not its matter) — the anti-collision half of item identity.
@@ -717,6 +740,8 @@ def parse_pull(raw: dict) -> tuple[list[MatterDeadline], str | None]:
         for item in items:
             if not isinstance(item, dict):
                 continue
+            if _is_probe_item(item):
+                continue  # ss #2403: probe artifacts are never deadlines
             total_items += 1
             authored = _first_date(item, keys)
             if authored is None:

--- a/operator/skills/deadline-miss-escalator/test_escalator_pre_run.py
+++ b/operator/skills/deadline-miss-escalator/test_escalator_pre_run.py
@@ -411,6 +411,40 @@ def test_parse_pull_bare_list_envelope() -> None:
     assert len(deadlines) == 1
 
 
+def test_parse_pull_excludes_probe_artifacts() -> None:
+    # ss #2403: a rehearsal probe task is never a deadline, [Operator]-stamped
+    # or not. But a real task QUOTING the marker mid-subject is kept — the
+    # match is position-anchored so subject text cannot silence a deadline.
+    raw = {
+        "tasks": [
+            {
+                "id": "t-p",
+                "matterId": "m-1",
+                "subject": "[Operator] [SMD-PROBE 2026-08-18T14:00Z] drafting prove-out",
+                "dueDate": "2026-07-20",
+            },
+            {
+                "id": "t-p2",
+                "matterId": "m-1",
+                "subject": "[SMD-PROBE 2026-08-18T14:00Z] unstamped probe",
+                "dueDate": "2026-07-20",
+            },
+            {
+                "id": "t-r",
+                "matterId": "m-1",
+                "subject": "Review the [SMD-PROBE] cleanup contract",
+                "dueDate": "2026-07-21",
+            },
+        ],
+        "events": [],
+    }
+    deadlines, problem = parse_pull(raw)
+    assert problem is None
+    assert [(d.task_id, d.authored_date.isoformat()) for d in deadlines] == [
+        ("t-r", "2026-07-21")
+    ]
+
+
 def test_parse_pull_error_key_is_a_problem() -> None:
     raw = {"tasks": {"items": []}, "events": {"items": []}, "eventsError": "boom"}
     deadlines, problem = parse_pull(raw)

--- a/operator/skills/medical-records-chaser/pre_run.py
+++ b/operator/skills/medical-records-chaser/pre_run.py
@@ -731,7 +731,24 @@ def _source_id_of(item: dict) -> str | None:
     return None
 
 
+# Rehearsal/self-test artifacts carry "[SMD-PROBE <stamp>]" at the start of
+# the subject (after the connector's "[Operator]" provenance stamp) — ss #2403.
+# Probe rows are never roster items. Position-anchored: a real task quoting
+# the marker mid-subject is not hidden.
+_PROBE_MARK = "[SMD-PROBE"
+_PROVENANCE_MARK = "[Operator]"
+
+
+def _is_probe_subject(subject: str) -> bool:
+    text = subject.lstrip()
+    if text.upper().startswith(_PROVENANCE_MARK.upper()):
+        text = text[len(_PROVENANCE_MARK) :].lstrip()
+    return text.upper().startswith(_PROBE_MARK.upper())
+
+
 def _is_roster_task(subject: str) -> bool:
+    if _is_probe_subject(subject):
+        return False
     return _ROSTER_SUBJECT_MARKER in subject.lower()
 
 

--- a/operator/skills/medical-records-chaser/test_records_chaser_pre_run.py
+++ b/operator/skills/medical-records-chaser/test_records_chaser_pre_run.py
@@ -523,6 +523,23 @@ def test_parse_pull_subsets_roster_tasks_by_marker():
     assert pull.items[0].confirm_by == date(2026, 7, 11)
 
 
+def test_parse_pull_excludes_probe_artifacts():
+    # ss #2403: a probe task is never a roster item; a real roster task quoting
+    # the marker mid-subject is kept (position-anchored match).
+    raw = {
+        "tasks": [
+            _task(
+                "[Operator] [SMD-PROBE 2026-08-18T14:00Z] records (request roster)",
+                task_id="t-p",
+            ),
+            _task("Medical records outstanding - Valley Imaging Center (request roster)"),
+        ]
+    }
+    pull, problem = parse_pull(raw, today=TODAY)
+    assert problem is None
+    assert [i.task_id for i in pull.items] == ["t-1"]
+
+
 def test_parse_pull_dateless_roster_task_seeds_today():
     raw = {"tasks": [{"id": "t-1", "subject": "x (request roster)", "matter": {"id": "m-1"}}]}
     pull, problem = parse_pull(raw, today=TODAY)


### PR DESCRIPTION
## What the client experiences

A rehearsal or self-test artifact left in the firm's Smokeball can never again become the Operator's real work: probe-marked tasks are invisible to every ingestion path (loudly — the exclusion is counted), and every future probe carries a teardown obligation in the authoring contract itself.

## The defect

Task 28745d01 (a rehearsal probe whose own note instructs deletion after witnessing) outlived its test; the 2026-08-14 digest identified it as a probe, and 37 minutes later the verification chase cited it as its live tracking anchor. Full evidence + /wired contract + /critique on #2403.

## Mechanism (three layers)

1. **Marker + teardown contract** (`operator/CLAUDE.md`): `[SMD-PROBE <ISO stamp>]` at the start of the subject (after the connector's `[Operator]` provenance stamp); teardown in the same session — tasks are **completed**, not deleted (the connector has no task-delete verb, a /critique finding that made the original "sweep-delete" plan unimplementable); negative probe per gone-means-gone rule 2.
2. **Turn seam** — connector `list_tasks` drops marked rows by default and counts the drop (`probeArtifactsExcluded`); `include_probe_artifacts=True` is the census/teardown opt-in. Position-anchored match: a real task quoting the marker is NOT hidden (falsifier test) — a deadline watcher that subject-text can silence is the dangerous failure.
3. **Gate seam** — the three pre_run pulls (escalator, verification tracker, records chaser) exclude marked rows; the gates call the REST client directly and never pass through the tool filter, so both seams are needed.

## Deferred, tracked on #2403 (runtime rows)

Tenant census; legacy sweep of 28745d01 (it predates the marker; sequenced AFTER the #2402 kill-test that targets it, which waits on the #2392 pass); ledger snooze of the legacy item; the stale-probe daily surface (rides the #2405 escalator projection change — same code region).

## Acceptance

- [x] Connector filter drops + counts probe rows; opt-in returns them; mid-subject quote is not hidden (6 tests)
- [x] All three gate parses exclude probe rows (tests per skill; 210 operator tests green)
- [x] Marker + teardown contract authored in operator/CLAUDE.md
- [x] Repo `npm run verify` green (pre-existing, unrelated: smokeball `test_stdio_serves_over_console_script` fails on clean HEAD in this dev setup — render_docx_draft absent from the console-script interpreter, the ss#2237 theme)
- [ ] (runtime) Census, legacy sweep with negative probes, ledger snooze — after the #2402 kill-test window

Part of #2403 (does not close it — the runtime rows remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLzzpTuYY8j3EaWbXfxz4x
