### PR TITLE
fix(broker): a bare-domain entry in scope.domain_blocks actually blocks (ss#2258)

### DIFF
--- a/operator/workspace_broker/recipient_policy.py
+++ b/operator/workspace_broker/recipient_policy.py
@@ -148,6 +148,53 @@ def split_authored(entries: Any) -> tuple[set[str], set[str]]:
     return exact, domains
 
 
+def split_blocks(entries: Any) -> set[str]:
+    """Domains denied to this seat, parsed from ``scope.domain_blocks``.
+
+    Deliberately NOT ``split_authored``, because the allow list and the deny
+    list need OPPOSITE failure directions and one parser cannot have both:
+
+    * On an ALLOW list, an entry we cannot confidently read must be DROPPED. A
+      bare ``firm.example`` written where ``@firm.example`` was meant would
+      otherwise turn a typo into a whole-domain grant — a silent widening.
+    * On a DENY list, that same entry must BLOCK. Dropping it fails OPEN, the
+      one direction a deny control must never fail.
+
+    Sharing ``split_authored`` gave the deny list the allow list's failure
+    direction, and the consequence was live: ``domain_blocks: ['firm.example']``
+    parsed to nothing and fenced nobody, while ``authored_policy``'s own
+    docstring and ``tests/customer-yaml-validator.test.ts`` both presented the
+    bare form as the way to write one. Found 2026-08-18 while fencing the first
+    production client seat away from its own firm during bring-up; the config
+    would have looked correct, validated, and protected no one.
+
+    So every spelling an author might reasonably use resolves to a domain here:
+    ``@firm.example``, bare ``firm.example``, and ``someone@firm.example`` — a
+    full address blocks its whole domain, the conservative reading of a block
+    list and what this module has always promised.
+    """
+    blocked: set[str] = set()
+    for entry in entries or []:
+        if isinstance(entry, dict):
+            entry = entry.get("address")
+        if not isinstance(entry, str):
+            continue
+        raw = canonicalize(entry)
+        if not raw:
+            continue
+        if raw.startswith("@"):
+            candidate = raw[1:]
+        elif "@" in raw:
+            # A full address, possibly in display form. Block its domain.
+            candidate = domain_of(normalize_address(raw)) or domain_of(raw)
+        else:
+            # A bare domain. On this list — and ONLY this list — that blocks.
+            candidate = raw
+        if candidate:
+            blocked.add(candidate)
+    return blocked
+
+
 @dataclass(frozen=True)
 class RecipientPolicy:
     """The authored counterparty surface for one seat, read from customer.yaml."""
@@ -198,21 +245,24 @@ def authored_policy(customer_path: Path) -> RecipientPolicy:
     An **empty** authored surface yields a policy that permits nothing. That is
     deliberate: a seat whose config names no counterparty has no one to write to,
     and "unconfigured" must read as a safety state, never as permission.
+
+    The allow inputs and ``domain_blocks`` are parsed by DIFFERENT functions on
+    purpose — see ``split_blocks``. An ambiguous entry must be dropped from an
+    allow list and honoured on a deny list, and until 2026-08-18 both went
+    through ``split_authored``, so an authored bare-domain block silently fenced
+    nobody.
     """
     scope = _scope(customer_path)
     roster_exact, roster_domains = split_authored(scope.get("outbound_roster"))
     inbound_exact, inbound_domains = split_authored(scope.get("inbound_allow_from"))
     admin_exact, admin_domains = split_authored(scope.get("admins"))
-    blocked_exact, blocked_domains = split_authored(scope.get("domain_blocks"))
     return RecipientPolicy(
         exact=frozenset(roster_exact | inbound_exact | admin_exact),
         domains=frozenset(roster_domains | inbound_domains | admin_domains),
-        # A bare domain in domain_blocks ("evil.com") and an @-prefixed one both
-        # block the domain; a full address there blocks its domain too, which is
-        # the conservative reading of a block list.
-        blocked_domains=frozenset(
-            blocked_domains | {domain_of(a) for a in blocked_exact if domain_of(a)}
-        ),
+        # A bare domain in domain_blocks ("evil.com"), an @-prefixed one, and a
+        # full address all block the domain — the conservative reading of a
+        # block list.
+        blocked_domains=frozenset(split_blocks(scope.get("domain_blocks"))),
         reply_exact=frozenset(inbound_exact),
         reply_domains=frozenset(inbound_domains),
     )
@@ -225,4 +275,5 @@ __all__ = [
     "domain_of",
     "normalize_address",
     "split_authored",
+    "split_blocks",
 ]

--- a/operator/workspace_broker/tests/test_recipient_policy_blocks.py
+++ b/operator/workspace_broker/tests/test_recipient_policy_blocks.py
@@ -1,0 +1,115 @@
+"""``scope.domain_blocks`` must fence in every spelling an author might use.
+
+A deny control that silently no-ops is worse than no deny control, because the
+config reads as protection and the validator agrees. That is what shipped:
+``domain_blocks`` was parsed by ``split_authored``, which drops any entry that
+neither starts with ``@`` nor parses as an address, so a bare ``firm.example``
+resolved to nothing and fenced nobody — while ``authored_policy``'s docstring
+and ``tests/customer-yaml-validator.test.ts`` both showed the bare form as the
+way to write one.
+
+Found 2026-08-18 while fencing the first production client seat away from its
+own firm during bring-up. The existing coverage
+(``test_domain_blocks_override_an_allow``) used the ``@``-prefixed form, which
+worked, so the gap was invisible.
+
+The asymmetry test at the bottom is the one that must never be "fixed" by making
+both lists share a parser again: on an ALLOW list a bare domain must still be
+dropped, or a typo becomes a whole-domain grant.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+# Only `authored_policy` is imported at module scope, deliberately. The spelling
+# tests below must fail on the OLD code by asserting a firm address is fenced and
+# finding it reachable — a module-level import of the new helper would turn that
+# behavioural failure into a collection error, which proves only that a function
+# was added, not that anything was ever broken.
+from ..recipient_policy import authored_policy
+
+# A whole-domain inbound grant plus principals in admins — the shape of a real
+# law-firm seat, which is what makes the block the only way to fence the firm.
+FIRM_YAML = """
+scope:
+  inbound_allow_from:
+    - '@examplefirm.example'
+    - scott@smd.services
+  admins:
+    - chris@examplefirm.example
+  domain_blocks:
+{blocks}
+"""
+
+FIRM_MEMBER = "chris@examplefirm.example"
+OURS = "scott@smd.services"
+
+
+def _policy(tmp_path: Path, blocks: str):
+    path = tmp_path / "customer.yaml"
+    path.write_text(FIRM_YAML.format(blocks=blocks), encoding="utf-8")
+    return authored_policy(path)
+
+
+def test_the_firm_is_reachable_with_no_block(tmp_path: Path) -> None:
+    """Without this, every assertion below could pass on a broken fence."""
+    policy = _policy(tmp_path, "    []")
+    assert policy.allows_recipient(FIRM_MEMBER)
+    assert policy.allows_reply_to(FIRM_MEMBER)
+
+
+@pytest.mark.parametrize(
+    "spelling",
+    [
+        "    - '@examplefirm.example'",  # the form that always worked
+        "    - 'examplefirm.example'",  # bare — silently did nothing
+        "    - 'someone@examplefirm.example'",  # full address blocks its domain
+        "    - 'EXAMPLEFIRM.EXAMPLE'",  # case must not evade
+        "    - '  examplefirm.example  '",  # nor whitespace
+    ],
+)
+def test_every_spelling_fences_the_firm(tmp_path: Path, spelling: str) -> None:
+    policy = _policy(tmp_path, spelling)
+    assert not policy.allows_recipient(FIRM_MEMBER)
+    assert not policy.allows_reply_to(FIRM_MEMBER)
+
+
+def test_a_block_does_not_fence_everyone(tmp_path: Path) -> None:
+    """Deny the firm, keep talking to us — a block that blocked all would be no
+    use for a bring-up fence and would hide a total failure as a success."""
+    policy = _policy(tmp_path, "    - 'examplefirm.example'")
+    assert policy.allows_recipient(OURS)
+    assert policy.allows_reply_to(OURS)
+
+
+def test_deny_overrides_an_explicit_admin_entry(tmp_path: Path) -> None:
+    """chris@ is named in admins, so he is in `exact`, not merely domain-granted.
+    The block must still win, or fencing a firm would mean editing the roster and
+    retracting what the engagement authored."""
+    policy = _policy(tmp_path, "    - 'examplefirm.example'")
+    assert FIRM_MEMBER in policy.exact
+    assert not policy.allows_recipient(FIRM_MEMBER)
+
+
+def test_a_bare_domain_on_an_ALLOW_list_still_grants_nothing() -> None:
+    """The asymmetry, stated so a future refactor cannot quietly undo it.
+
+    `split_blocks` reads a bare domain as a domain; `split_authored` must keep
+    dropping it. Sharing one parser in the other direction would turn a typo in
+    inbound_allow_from into a whole-domain grant.
+    """
+    from ..recipient_policy import split_authored, split_blocks
+
+    exact, domains = split_authored(["examplefirm.example"])
+    assert not exact and not domains
+
+    assert split_blocks(["examplefirm.example"]) == {"examplefirm.example"}
+
+
+def test_unusable_block_entries_are_dropped_not_guessed() -> None:
+    from ..recipient_policy import split_blocks
+
+    assert split_blocks([None, 42, "", "   ", "@"]) == set()


### PR DESCRIPTION
`scope.domain_blocks` was parsed by `split_authored`, which drops any entry that neither starts with `@` nor parses as an address. So the bare form —

```yaml
domain_blocks: ['firm.example']
```

resolved to nothing and fenced nobody. Silently. The config read as protection, the validator agreed, and the deny control was inert.

That spelling is not a stretch of the schema. `authored_policy`'s own docstring promised it — *"A bare domain in domain_blocks ('evil.com') and an @-prefixed one both block the domain"* — and `tests/customer-yaml-validator.test.ts:111` demonstrates `domain_blocks: ['opposing-counsel.example.com']`. The existing coverage, `test_domain_blocks_override_an_allow`, happened to use the `@`-prefixed spelling, which worked, so the gap was invisible.

The module's own `canonicalize` docstring already warned about this exact direction: *"on `domain_blocks` a mismatch **fails open**."*

## Why a separate parser and not a patch to `split_authored`

The two lists need **opposite failure directions**, and one parser cannot have both:

| list | an entry we cannot confidently read | why |
| --- | --- | --- |
| allow (`outbound_roster`, `inbound_allow_from`, `admins`) | must be **dropped** | a bare `firm.example` written where `@firm.example` was meant would become a whole-domain grant and widen the fence |
| deny (`domain_blocks`) | must **block** | dropping it fails **open**, the one direction a deny control must never fail |

So `split_blocks` is new and `split_authored` is untouched. `test_a_bare_domain_on_an_ALLOW_list_still_grants_nothing` pins the asymmetry so a later refactor cannot quietly re-merge them.

Every spelling an author might reasonably use now resolves to a domain on the deny list: `@firm.example`, bare `firm.example`, and `someone@firm.example` (a full address blocks its whole domain — the conservative reading, and what the module always promised).

## How it was found

Fencing the first production client seat away from its own firm during bring-up. That seat's principals are reachable through a whole-domain grant in `inbound_allow_from` that `tests/customer-commitments.test.ts:449` requires us to keep — it encodes a client commitment that firm staff get real answers. So blocking was the only lever available, and the documented spelling for it did nothing.

## Falsifier

Against the **pre-fix** module the new suite fails **6 of 10**, three of them behaviourally: they assert a firm address is fenced and find it reachable. The two helper-specific tests import `split_blocks` inside the test body rather than at module scope, deliberately — a module-level import would turn those behavioural failures into a collection error, which proves only that a function was added, not that anything was broken.

Post-fix: 10/10, whole broker suite **302 passed**, `npm run verify` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YMQcxGtkEyrCvYxEAi8Y5e
