### PR TITLE
fix(provision): the manifest loop must not clobber per-customer msgraph credentials (ss#2258)

### DIFF
--- a/operator/bin/provision-customer.sh
+++ b/operator/bin/provision-customer.sh
@@ -955,13 +955,28 @@ import pathlib
 import sys
 import tomllib
 
-# Connectors whose operator-env credential NAMES differ from their runtime names
-# (a remap the flat loop cannot do) are staged by a dedicated block above; skip
-# them here so the loop does not warn that the runtime name is unset.
+# Connectors staged by a dedicated block above are SKIPPED here, for two
+# different reasons that end the same way:
+#   smokeball     the operator-env credential NAMES differ from the runtime
+#                 names (a remap this flat loop cannot do).
+#   msgraph-mail  the values are PER-CUSTOMER, sourced from msgraph_auth in
+#                 customer.yaml and the per-seat vault keys. This loop stages by
+#                 PLAIN NAME from the operator env, where /ss also carries
+#                 account-level MSGRAPH_CLIENT_ID / MSGRAPH_CLIENT_SECRET (the
+#                 smd-staging pair). Running msgraph-mail through the loop
+#                 OVERWROTE the correct per-customer staging with those globals
+#                 on the first client seat (ashton-price, 2026-08-18): the seat
+#                 booted with its own tenant + mailbox but the staging app id
+#                 and secret, and the poller 401ed (AADSTS7000229) every cycle.
+#                 The manifest itself says these four are per-customer; a flat
+#                 by-name loop structurally cannot honor that, so the dedicated
+#                 block is the only legal stager for this connector.
+# The loop must never stage a name whose value is per-customer. If a future
+# connector authors per-customer credentials, add it here in the same breath.
 # NOTE: keep this heredoc body free of apostrophes. macOS bash 3.2 mis-parses a
 # stray apostrophe inside a heredoc-in-command-substitution and consumes to EOF
 # (that aborted a reprovision on 2026-06-23).
-REMAP_HANDLED = {"smokeball"}
+REMAP_HANDLED = {"smokeball", "msgraph-mail"}
 root = pathlib.Path(sys.argv[1])
 for manifest in sorted(root.glob("*/manifest.toml")):
     if manifest.parent.name in REMAP_HANDLED:

--- a/tests/manifest-loop-percustomer-skip.test.ts
+++ b/tests/manifest-loop-percustomer-skip.test.ts
@@ -1,0 +1,94 @@
+/**
+ * The manifest-driven staging loop must never stage a per-customer credential.
+ *
+ * provision-customer.sh has two staging authorities for connector env:
+ *
+ *   1. dedicated per-connector blocks, which source PER-CUSTOMER values
+ *      (msgraph: parsed from customer.yaml msgraph_auth + the per-seat vault
+ *      keys; smokeball: an env-name remap), and
+ *   2. a generic manifest-driven loop that stages every `required_secrets`
+ *      runtime name FROM THE OPERATOR ENV BY PLAIN NAME.
+ *
+ * The loop runs second. For any name that also exists as an account-level
+ * global in /ss, last-write-wins means the global CLOBBERS the per-customer
+ * value. That was live on 2026-08-18: the first client seat (ashton-price)
+ * deployed with its own MSGRAPH_TENANT_ID + MSGRAPH_MAILBOX but smd-staging's
+ * MSGRAPH_CLIENT_ID + MSGRAPH_CLIENT_SECRET — the two names that had globals —
+ * and the delta poller 401ed (AADSTS7000229) on every cycle. The corruption was
+ * invisible on smd-staging itself, whose per-customer values ARE the globals.
+ *
+ * This test extracts the loop's embedded python verbatim from the script (the
+ * same extract-don't-restate discipline as msgraph-two-app-fence.test.ts — a
+ * restated copy would keep passing after the script regressed) and runs it
+ * against the real operator/connectors tree: msgraph-mail must not emit a
+ * single staging line, and the fixture connector proves the loop still stages
+ * what it is FOR (an SMD-owned static credential), so the skip cannot be
+ * "fixed" by breaking the loop entirely.
+ */
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { afterAll, describe, expect, it } from 'vitest'
+
+const SCRIPT = fileURLToPath(new URL('../operator/bin/provision-customer.sh', import.meta.url))
+const CONNECTORS_DIR = fileURLToPath(new URL('../operator/connectors', import.meta.url))
+
+/** The loop's python, verbatim from the heredoc between `python3 - "${_CONNECTORS_DIR}" <<'PY'` and `PY`. */
+function loopPython(): string {
+  const text = readFileSync(SCRIPT, 'utf8')
+  const open = text.indexOf(`python3 - "\${_CONNECTORS_DIR}" <<'PY'`)
+  expect(open, 'manifest-loop heredoc opener missing from provision-customer.sh').toBeGreaterThan(
+    -1
+  )
+  const bodyStart = text.indexOf('\n', open) + 1
+  const close = text.indexOf('\nPY\n', bodyStart)
+  expect(close, 'manifest-loop heredoc closer missing').toBeGreaterThan(bodyStart)
+  return text.slice(bodyStart, close)
+}
+
+function runLoop(connectorsDir: string): string[] {
+  const out = execFileSync('python3', ['-', connectorsDir], {
+    input: loopPython(),
+    encoding: 'utf8',
+  })
+  return out.split('\n').filter(Boolean)
+}
+
+const scratch = mkdtempSync(join(tmpdir(), 'manifest-loop-'))
+afterAll(() => rmSync(scratch, { recursive: true, force: true }))
+
+describe('manifest-driven staging loop: per-customer connectors are skipped', () => {
+  it('emits no staging line for msgraph-mail against the real connectors tree', () => {
+    const lines = runLoop(CONNECTORS_DIR)
+    const msgraph = lines.filter((l) => l.startsWith('msgraph-mail\t'))
+    expect(
+      msgraph,
+      'the loop would stage these BY PLAIN NAME from the operator env, where the ' +
+        'account-level MSGRAPH_CLIENT_ID/SECRET globals clobber the per-customer values'
+    ).toEqual([])
+  })
+
+  it('smokeball stays skipped too (the original remap case)', () => {
+    const lines = runLoop(CONNECTORS_DIR)
+    expect(lines.filter((l) => l.startsWith('smokeball\t'))).toEqual([])
+  })
+
+  it('still stages an SMD-owned static connector — the skip must not kill the loop', () => {
+    // A fixture connector shaped like the ones the loop exists for.
+    const dir = join(scratch, 'fixture-static')
+    mkdirSync(dir, { recursive: true })
+    writeFileSync(
+      join(dir, 'manifest.toml'),
+      [
+        '[connector]',
+        'auth_model = "static"',
+        '[[connector.required_secrets]]',
+        'runtime_env = "FIXTURE_STATIC_API_KEY"',
+      ].join('\n')
+    )
+    expect(runLoop(scratch)).toContain('fixture-static\tFIXTURE_STATIC_API_KEY')
+  })
+})


### PR DESCRIPTION
Found live during the first client-seat bring-up, ~30 minutes after #2421 deployed.

## The defect

`provision-customer.sh` has two staging authorities for connector env:

1. **Dedicated per-connector blocks** — per-customer values. The msgraph block parses `customer.yaml` `msgraph_auth` and the per-seat vault keys; it staged A&P's values correctly (reproduced under the identical `infisical run` env).
2. **The generic manifest-driven loop** — stages every `required_secrets` runtime name **from the operator env by plain name**: `stage_secret_from_env "${_secret_name}" "${!_secret_name:-}"`.

The loop runs second. `/ss` carries account-level `MSGRAPH_CLIENT_ID` / `MSGRAPH_CLIENT_SECRET` — the smd-staging pair — so the loop overwrote exactly the two names that had globals. `hermes-ashton-price` deployed with **its own tenant + mailbox but smd-staging's app id + secret**, and the delta poller 401ed every 45s with `AADSTS7000229` (no service principal for that app in the client's tenant).

Diagnosed from the seat itself: `/proc` env showed `client = 9301fd6f…` (smd-staging's READ app) beside A&P's tenant, and the Fly digest for `MSGRAPH_CLIENT_ID` matched smd-staging's app digest exactly while the tenant digests differed.

**Why no test or seat ever caught it:** on smd-staging the per-customer values ARE the globals, so the clobber is a no-op there. It took the first seat where they differ.

## The fix

`msgraph-mail` joins `smokeball` in the loop's skip set. Different reason, same conclusion — smokeball's env names need a remap the flat loop can't do; msgraph-mail's values are per-customer, which a stage-by-plain-name loop structurally cannot honor. The manifest itself already documents all four values as per-customer. The dedicated block is the only legal stager for this connector.

## Proof

`tests/manifest-loop-percustomer-skip.test.ts` extracts the loop's embedded python **verbatim** from the script (same extract-don't-restate discipline as `msgraph-two-app-fence.test.ts`) and drives it against the real connectors tree:

| assertion | pre-fix | post-fix |
| --- | --- | --- |
| msgraph-mail emits no staging line | **FAIL** | PASS |
| smokeball stays skipped | PASS | PASS |
| a fixture static connector still stages | PASS | PASS |

The fixture case is what stops the skip from being satisfied by breaking the loop entirely.

`npm run verify` exit 0; neighboring provisioner suites (`msgraph-two-app-fence`, `provision-source-guard`) green.

## Runtime follow-up (not in this PR)

The seat still holds the clobbered values until reprovisioned with this fix — that's the immediate next motion on ss#2258. Whether the smd-staging Graph secret warrants rotation after ~35 min deployed on a client-facing Machine is tracked separately (sandbox-scoped, mailbox-fenced, never successfully authed from that seat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YMQcxGtkEyrCvYxEAi8Y5e
