### PR TITLE
fix(provision): channel gates parse the yaml — comments are not authoring (ss#2258)

### DIFF
--- a/operator/bin/provision-customer.sh
+++ b/operator/bin/provision-customer.sh
@@ -652,8 +652,44 @@ stage_secret_from_env CLIO_TOKENS_ENC_B64    "${CLIO_TOKENS_ENC_B64:-}"    "base
 # overwrites a customer's own webhook secret with the global one and inbound email
 # silently stops verifying — the 2026-06-12 inbound failure, generalized to every
 # multi-customer AgentMail seat.
-if grep -qE 'adapter:[[:space:]]*agentmail|backend:[[:space:]]*mcp:agentmail' \
-    "${CUSTOMER_DIR}/customer.yaml" 2>/dev/null; then
+
+# ---------- authored-connector facts: parse once, comments are not authoring ----
+# Every channel gate below used to `grep -qE` the RAW customer.yaml, which reads
+# COMMENTS as config. That fired live on 2026-08-18: ashton-price authors no
+# agentmail connector, but its history comment contains the literal string
+# `adapter: agentmail`, so every reprovision re-staged the org-wide AgentMail
+# key onto a seat with no AgentMail channel — the exact credential shape behind
+# the ss#2258 incident, resurrected by prose. Parse the yaml once and let every
+# gate consume the DERIVED facts; a comment cannot reach them.
+#
+# The heredoc body stays free of apostrophes (macOS bash 3.2 heredoc-in-$()
+# hazard — see the manifest-loop note below).
+# >>> authored-channel-facts
+_AUTHORED_CHANNELS="$(
+  uv run --quiet --with pyyaml python3 - "${CUSTOMER_YAML}" <<'PY'
+import sys
+
+import yaml
+
+with open(sys.argv[1]) as f:
+    c = yaml.safe_load(f) or {}
+for conn in (c.get("connectors") or {}).values():
+    if not isinstance(conn, dict):
+        continue
+    for key in ("adapter", "backend", "webhook_url"):
+        value = str(conn.get(key) or "").strip()
+        if value:
+            print(f"{key}={value}")
+PY
+)"
+authored_channel() {
+  # authored_channel <ERE> — true iff a REAL connector field matches. Gates test
+  # this derived list, never the raw yaml.
+  printf '%s\n' "${_AUTHORED_CHANNELS}" | grep -qE "$1"
+}
+# <<< authored-channel-facts
+
+if authored_channel '^adapter=agentmail$|^backend=mcp:agentmail$'; then
   # PER-SEAT, and it has to be. Both keys are scoped to ONE inbox at the vendor
   # (ss#2258), so a single shared value is no longer merely untidy — staging one
   # seat's key onto another gives that seat a credential for a mailbox it does
@@ -693,8 +729,7 @@ fi
 # preferring the per-customer <NAME>__<CUSTOMER_ID> so a reprovision of one seat
 # never pulls another tenant's secret. The connector reads all four as env vars
 # (MSGRAPH_TENANT_ID / MSGRAPH_CLIENT_ID / MSGRAPH_CLIENT_SECRET / MSGRAPH_MAILBOX).
-if grep -qE 'adapter:[[:space:]]*msgraph|backend:[[:space:]]*mcp:msgraph-mail' \
-    "${CUSTOMER_DIR}/customer.yaml" 2>/dev/null; then
+if authored_channel '^adapter=msgraph$|^backend=mcp:msgraph-mail$'; then
   MSG_PARSE_PY="
 import yaml
 with open('${CUSTOMER_YAML}') as f:
@@ -809,7 +844,7 @@ fi
 # bill is Anthropic" true). Staged ONLY for a customer whose customer.yaml binds a
 # native:brave-* backend. Missing at boot => the provider stays unavailable
 # (Hermes falls back / no web search), fail-closed, no crashloop.
-if grep -qE 'backend:[[:space:]]*.?native:brave' "${CUSTOMER_DIR}/customer.yaml" 2>/dev/null; then
+if authored_channel '^backend=native:brave'; then
   stage_secret_from_env BRAVE_SEARCH_API_KEY "${BRAVE_SEARCH_API_KEY:-}" "Brave Search API key (native brave-free provider; web search)"
 fi
 
@@ -845,7 +880,7 @@ stage_secret_from_env GOOGLE_SERVICE_ACCOUNT_JSON "${GOOGLE_SERVICE_ACCOUNT_JSON
 # directly. A prod seat whose SMOKEBALL_PROD_* creds are not yet in the operator env
 # simply warns+skips → the connector is unwired this boot (boot-before-token), and
 # wires once the creds land.
-if grep -qE 'backend:[[:space:]]*mcp:smokeball' "${CUSTOMER_DIR}/customer.yaml" 2>/dev/null; then
+if authored_channel '^backend=mcp:smokeball$'; then
   SB_PARSE_PY="
 import yaml
 with open('${CUSTOMER_YAML}') as f:
@@ -917,7 +952,7 @@ print(str(sb.get('account_id') or '').strip())
   #     ${_sb_cid}); a per-customer override exists only for the rare case the signing
   #     ClientId differs in byte form from the OAuth client id (confirm vs a real
   #     delivery). Without these the smokeball route fail-closes (gate 401).
-  if grep -qE 'webhook_url:.*/webhooks/smokeball' "${CUSTOMER_DIR}/customer.yaml" 2>/dev/null; then
+  if authored_channel '^webhook_url=.*/webhooks/smokeball$'; then
     _SB_WH_KEY="WEBHOOK_SECRET_SMOKEBALL__$(printf '%s' "${CUSTOMER_ID}" | tr '[:lower:]-' '[:upper:]_' | tr -cd 'A-Z0-9_')"
     _SB_WH_SECRET="${!_SB_WH_KEY:-${WEBHOOK_SECRET_SMOKEBALL:-}}"
     stage_secret_from_env WEBHOOK_SECRET_SMOKEBALL "${_SB_WH_SECRET}" "Smokeball webhook HMAC key == subscription key, raw bytes (per-customer ${_SB_WH_KEY}, else global)"

--- a/tests/provisioner-gates-parse-not-grep.test.ts
+++ b/tests/provisioner-gates-parse-not-grep.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Channel gates in provision-customer.sh parse the yaml; comments are not authoring.
+ *
+ * Five gates used to decide "does this seat bind channel X?" by `grep -qE` over
+ * the RAW customer.yaml — which reads comments as config. Live consequence
+ * (2026-08-18): ashton-price authors no agentmail connector, but its history
+ * comment contains the literal `adapter: agentmail`, so every reprovision
+ * re-staged the org-wide AgentMail key — the ss#2258-shaped credential —
+ * onto a seat with no AgentMail channel, and it had to be manually unset after
+ * each run. Same class as the manifest-loop clobber (#2426): a config decision
+ * made without parsing the config.
+ *
+ * The fix parses connectors once (the authored-channel-facts block) and every
+ * gate consumes the derived list via `authored_channel`. Two layers of proof:
+ *
+ *  1. STRUCTURAL (always runs, fails on the pre-fix script): no gate greps the
+ *     raw yaml for adapter/backend/webhook_url any more, the sentinel block
+ *     exists, and all five gates consume authored_channel.
+ *  2. BEHAVIOURAL (runs where `uv` is available — dev machines; skipped in a
+ *     runner without uv): the sentinel block is extracted VERBATIM and driven
+ *     against fixture yamls — the A&P comment-trap case must not trigger, and
+ *     genuinely-authored fixtures for each gate must trigger. The msgraph
+ *     positive fixture matters most: breaking that gate would fail silently
+ *     until the next real reprovision (critic finding, 2026-08-18).
+ */
+import { execFileSync, execSync } from 'node:child_process'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { afterAll, describe, expect, it } from 'vitest'
+
+const SCRIPT = fileURLToPath(new URL('../operator/bin/provision-customer.sh', import.meta.url))
+const src = readFileSync(SCRIPT, 'utf8')
+
+describe('structural: gates no longer grep the raw yaml', () => {
+  it('no channel gate greps customer.yaml for adapter/backend/webhook_url', () => {
+    const rawGates = src
+      .split('\n')
+      .filter((l) => /grep -qE '(adapter|backend|webhook_url):/.test(l))
+      .filter((l) => l.includes('customer.yaml'))
+    expect(
+      rawGates,
+      'these lines read COMMENTS as authoring — the A&P history comment re-staged the AgentMail key this way'
+    ).toEqual([])
+  })
+
+  it('the authored-channel-facts block exists and all five gates consume it', () => {
+    expect(src).toContain('# >>> authored-channel-facts')
+    expect(src).toContain('# <<< authored-channel-facts')
+    const uses = src.match(/if authored_channel '/g) ?? []
+    // agentmail, msgraph, brave, smokeball, smokeball-webhook_url
+    expect(uses.length).toBeGreaterThanOrEqual(5)
+  })
+
+  it('the facts block is defined before its first consumer', () => {
+    expect(src.indexOf('# <<< authored-channel-facts')).toBeLessThan(
+      src.indexOf("if authored_channel '")
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Behavioural: drive the extracted block against fixtures. Needs `uv` (the
+// block's own interpreter). Structural assertions above still guard when
+// this half is skipped.
+// ---------------------------------------------------------------------------
+
+function hasUv(): boolean {
+  try {
+    execSync('uv --version', { stdio: 'ignore' })
+    return true
+  } catch {
+    return false
+  }
+}
+
+function factsBlock(): string {
+  const start = src.indexOf('# >>> authored-channel-facts')
+  const end = src.indexOf('# <<< authored-channel-facts')
+  expect(start).toBeGreaterThan(-1)
+  expect(end).toBeGreaterThan(start)
+  return src.slice(start, end)
+}
+
+/** Run the verbatim facts block against a fixture yaml, then query authored_channel. */
+function channelMatches(yaml: string, regex: string): boolean {
+  const dir = mkdtempSync(join(tmpdir(), 'gates-'))
+  scratchDirs.push(dir)
+  const yamlPath = join(dir, 'customer.yaml')
+  writeFileSync(yamlPath, yaml)
+  const harness = [
+    'set -euo pipefail',
+    `CUSTOMER_YAML=${JSON.stringify(yamlPath)}`,
+    factsBlock(),
+    // Distinct tokens, deliberately: an earlier draft used MATCH/NOMATCH with
+    // `out.includes('MATCH')` — which is true for BOTH ("NOMATCH".includes("MATCH")),
+    // so every negative case passed as positive. A predicate that cannot go
+    // false measures nothing.
+    `if authored_channel ${JSON.stringify(regex)}; then echo GATE_OPEN; else echo GATE_CLOSED; fi`,
+  ].join('\n')
+  const out = execFileSync('bash', ['-c', harness], { encoding: 'utf8' })
+  expect(
+    out.includes('GATE_OPEN') || out.includes('GATE_CLOSED'),
+    'harness produced no verdict'
+  ).toBe(true)
+  return out.includes('GATE_OPEN')
+}
+
+const scratchDirs: string[] = []
+afterAll(() => scratchDirs.forEach((d) => rmSync(d, { recursive: true, force: true })))
+
+const AGENTMAIL_RE = '^adapter=agentmail$|^backend=mcp:agentmail$'
+const MSGRAPH_RE = '^adapter=msgraph$|^backend=mcp:msgraph-mail$'
+
+// The A&P shape that produced the incident: the literal gate pattern lives in a
+// COMMENT while the connectors author only msgraph.
+const AP_SHAPED = `
+connectors:
+  # This block once authored \`adapter: agentmail\` while the note said the firm
+  # runs M365 — kept verbatim because prose must not be authoring.
+  Email:
+    adapter: msgraph
+    backend: mcp:msgraph-mail
+    enabled: true
+    msgraph_auth:
+      tenant_id: 'e4ad47eb-0000-0000-0000-000000000000'
+      client_id: '03c32f5c-0000-0000-0000-000000000000'
+      mailbox: operator@example.com
+`
+
+describe.skipIf(!hasUv())('behavioural: the extracted block, driven', () => {
+  it('the A&P comment trap does NOT trigger the agentmail gate', () => {
+    expect(channelMatches(AP_SHAPED, AGENTMAIL_RE)).toBe(false)
+  })
+
+  it('the same fixture DOES trigger the msgraph gate (the silent-failure direction)', () => {
+    expect(channelMatches(AP_SHAPED, MSGRAPH_RE)).toBe(true)
+  })
+
+  it('a genuinely authored agentmail connector still triggers', () => {
+    const yaml = 'connectors:\n  Email:\n    adapter: agentmail\n    backend: mcp:agentmail\n'
+    expect(channelMatches(yaml, AGENTMAIL_RE)).toBe(true)
+  })
+
+  it('brave and smokeball-webhook gates match authored fields only', () => {
+    const yaml = [
+      'connectors:',
+      '  # backend: mcp:smokeball  <- comment, must not count',
+      '  Search:',
+      "    backend: 'native:brave-free'",
+      '  PracticeManagement:',
+      '    backend: mcp:smokeball',
+      "    webhook_url: 'https://x.fly.dev/webhooks/smokeball'",
+      '',
+    ].join('\n')
+    expect(channelMatches(yaml, '^backend=native:brave')).toBe(true)
+    expect(channelMatches(yaml, '^backend=mcp:smokeball$')).toBe(true)
+    expect(channelMatches(yaml, '^webhook_url=.*/webhooks/smokeball$')).toBe(true)
+    expect(
+      channelMatches('# backend: mcp:smokeball\nconnectors: {}\n', '^backend=mcp:smokeball$')
+    ).toBe(false)
+  })
+})


### PR DESCRIPTION
Closes the second half of the 2026-08-18 provisioner defect class (first half: #2426). Task #26 on the session board.

## The defect

Five gates decided "does this seat bind channel X?" by `grep -qE` over the **raw** `customer.yaml` — agentmail, msgraph, brave, smokeball, and the smokeball `webhook_url` sub-gate. A grep over raw yaml reads comments as config.

Observed live: `ashton-price` authors **no** agentmail connector, but its history comment contains the literal `adapter: agentmail` — so every reprovision re-staged the org-wide `AGENTMAIL_API_KEY` (the ss#2258-shaped credential) onto a seat with no AgentMail channel, requiring a manual `fly secrets unset` after each run.

## The fix

One `authored-channel-facts` block parses connectors once (uv + pyyaml — the interpreter the msgraph value-parse already uses) and emits `key=value` lines for `adapter` / `backend` / `webhook_url` of **real connector fields only**. All five gates consume the derived list via `authored_channel()`; a comment cannot reach it. Sentinels delimit the block for extraction-driven testing, same convention as `msgraph-two-app-fence`.

## Proof

`tests/provisioner-gates-parse-not-grep.test.ts`, two layers:

- **Structural** (always runs; CI-safe without uv): no gate greps the raw yaml; the block exists, precedes its first consumer, all five gates consume it. **Pre-fix: 7/7 fail.**
- **Behavioural** (where uv exists): the sentinel block extracted **verbatim** and driven — the A&P comment-trap does not fire the agentmail gate; the *same fixture* still fires the msgraph gate (breaking that gate would stay silent until the next real reprovision — critic finding); genuinely-authored fixtures fire for agentmail, brave, smokeball, and webhook_url; comment-only fixtures don't.

One test-harness confession, pinned in a comment: an early draft's verdict predicate was `out.includes('MATCH')` with `MATCH`/`NOMATCH` tokens — true for both, so every negative case passed as positive. Caught by driving a known-false fixture; the tokens are now `GATE_OPEN`/`GATE_CLOSED` with a no-verdict guard.

`npm run verify` exit 0; `manifest-loop-percustomer-skip` and `msgraph-two-app-fence` suites green alongside.

## What this unblocks

The next `reprovision.sh ashton-price` should stage **no** AgentMail key at all — the post-deploy probe list for the redeploy asserts exactly that, and treats a reappearance as a regression to stop on, not unset around.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YMQcxGtkEyrCvYxEAi8Y5e
