### PR TITLE
fix(operator): strip probe waits for the gateway on a cold boot, and only for that (#2420)

### DIFF
--- a/operator/bin/boot-smoke-test.sh
+++ b/operator/bin/boot-smoke-test.sh
@@ -233,7 +233,13 @@ ssh_exec "activation-handler-not-agent-writable" "setpriv --reuid=hermes --regid
 # the running Machine. Runs as root (reads agent-uid /proc/environ); the probe
 # excludes root processes (PID 1 + the config applier legitimately keep the key)
 # and never echoes the value.
-ssh_exec "r2-account-key-stripped-from-agent" "/opt/hermes/.venv/bin/python3 /app/r2-account-key-strip-probe.py"
+# --wait-gateway-s: on a cold boot this step lands ~75s after boot, before the
+# gateway has spawned, and the probe's vacuous-zero fail-closed rule (exit 3)
+# FATALed a healthy deploy (ss#2420, seen on both 2026-08-18 reprovisions). The
+# wait retries ONLY the no-agent-process verdict; a real offender still fails
+# the instant a scan sees it. Later strip probes need no wait — once this one
+# passes, the gateway is up.
+ssh_exec "r2-account-key-stripped-from-agent" "/opt/hermes/.venv/bin/python3 /app/r2-account-key-strip-probe.py --wait-gateway-s 120"
 
 # ss#2258, the same proof for the AgentMail SEND credential. This is the one
 # check that would have caught the incident class before a client ever saw it:

--- a/operator/templates/r2-account-key-strip-probe.py
+++ b/operator/templates/r2-account-key-strip-probe.py
@@ -21,10 +21,18 @@ R2 config object.
 The key VALUE is never printed — only the offending pid + comm, so the probe
 output is safe in a CI transcript.
 
-Usage:  r2-account-key-strip-probe.py [agent-username] [VAR ...]
+Usage:  r2-account-key-strip-probe.py [--wait-gateway-s N] [agent-username] [VAR ...]
         defaults: agent-username=hermes  VARs=R2_ACCESS_KEY_ID R2_SECRET_ACCESS_KEY
 Intended to be invoked by boot-smoke-test.sh via:
         /opt/hermes/.venv/bin/python3 /app/r2-account-key-strip-probe.py
+
+``--wait-gateway-s N`` retries ONLY the "no agent-uid process yet" verdict for up
+to N seconds (ss#2420: on a cold boot, smoke reaches this probe ~75s after boot,
+before the gateway has spawned, and the vacuous-zero fail-closed rule fired a
+false FATAL on a healthy deploy). The wait never applies to a real finding: a
+scan that sees an offender exits 1 the moment it sees it, and a missing user or
+unreadable /proc stays an immediate failure — those are configuration defects,
+not races.
 """
 
 from __future__ import annotations
@@ -32,9 +40,13 @@ from __future__ import annotations
 import os
 import pwd
 import sys
+import time
 
 _DEFAULT_USER = "hermes"
 _DEFAULT_VARS = ("R2_ACCESS_KEY_ID", "R2_SECRET_ACCESS_KEY")
+
+# Re-scan cadence while waiting for the gateway to come up.
+_WAIT_POLL_S = 3.0
 
 
 def _proc_uid(proc_root: str, pid: str) -> int | None:
@@ -106,9 +118,48 @@ def scan(
     return agent_procs, offenders
 
 
+def wait_scan(
+    proc_root: str,
+    target_uid: int,
+    var_names: list[str],
+    *,
+    wait_s: float = 0.0,
+    uid_of=_proc_uid,
+    sleep=time.sleep,
+    monotonic=time.monotonic,
+) -> tuple[int, list[str]]:
+    """``scan``, retrying ONLY the zero-agent-process verdict for up to ``wait_s``.
+
+    An offender ends the wait the instant any scan sees it (the retry must never
+    swallow the real signal — ss#2420 AC), and a scan that finds a clean agent
+    process ends it too. Only "nothing to scan yet" keeps polling; when the
+    deadline passes it is returned as-is for main() to fail loud (exit 3).
+    ``sleep``/``monotonic`` are injectable so tests drive the loop without
+    real time passing.
+    """
+    deadline = monotonic() + wait_s
+    while True:
+        agent_procs, offenders = scan(proc_root, target_uid, var_names, uid_of=uid_of)
+        if offenders or agent_procs > 0 or monotonic() >= deadline:
+            return agent_procs, offenders
+        sleep(_WAIT_POLL_S)
+
+
 def main(argv: list[str]) -> int:
-    username = argv[1] if len(argv) > 1 else _DEFAULT_USER
-    var_names = argv[2:] if len(argv) > 2 else list(_DEFAULT_VARS)
+    args = argv[1:]
+    wait_s = 0.0
+    if args and args[0] == "--wait-gateway-s":
+        if len(args) < 2:
+            print("FAIL: --wait-gateway-s requires a seconds value", file=sys.stderr)
+            return 2
+        try:
+            wait_s = float(args[1])
+        except ValueError:
+            print(f"FAIL: --wait-gateway-s value {args[1]!r} is not a number", file=sys.stderr)
+            return 2
+        args = args[2:]
+    username = args[0] if args else _DEFAULT_USER
+    var_names = list(args[1:]) if len(args) > 1 else list(_DEFAULT_VARS)
 
     try:
         target_uid = pwd.getpwnam(username).pw_uid
@@ -120,7 +171,7 @@ def main(argv: list[str]) -> int:
     # guard that cannot inspect /proc has proved nothing. (Also makes this a clean
     # failure on a host without procfs, e.g. a dev macOS box, instead of a crash.)
     try:
-        agent_procs, offenders = scan("/proc", target_uid, var_names)
+        agent_procs, offenders = wait_scan("/proc", target_uid, var_names, wait_s=wait_s)
     except OSError as exc:
         print(f"FAIL: cannot enumerate the process table at /proc ({exc.strerror})", file=sys.stderr)
         return 4

--- a/operator/templates/tests/test_r2_account_key_strip_probe.py
+++ b/operator/templates/tests/test_r2_account_key_strip_probe.py
@@ -114,3 +114,106 @@ def test_unreadable_proc_root_raises_for_main_to_fail_closed(tmp_path):
     missing = tmp_path / "no-such-proc"
     with pytest.raises(OSError):
         probe.scan(str(missing), _AGENT_UID, _KEYS, uid_of=_uid_map({}))
+
+
+# ---- the cold-boot wait (ss#2420) -----------------------------------------
+#
+# wait_scan retries ONLY the "no agent process yet" verdict. The three cases
+# that matter: a real offender ends the wait instantly (the retry must not
+# swallow the signal), a gateway that comes up mid-wait turns a false FATAL
+# into a pass, and a gateway that never comes up still fails loud at the
+# deadline. Time is injected; no test sleeps.
+
+
+class _FakeClock:
+    def __init__(self):
+        self.now = 0.0
+        self.sleeps: list[float] = []
+
+    def monotonic(self) -> float:
+        return self.now
+
+    def sleep(self, s: float) -> None:
+        self.sleeps.append(s)
+        self.now += s
+
+
+def test_wait_never_swallows_a_real_offender(tmp_path):
+    # Offender present from the first scan: exit path must be immediate — zero
+    # sleeps — even with a generous wait budget.
+    _mkproc(tmp_path, 100, {"R2_ACCESS_KEY_ID": _FAKE_VALUE}, comm="hermes")
+    clock = _FakeClock()
+    count, offenders = probe.wait_scan(
+        str(tmp_path),
+        _AGENT_UID,
+        _KEYS,
+        wait_s=120.0,
+        uid_of=_uid_map({100: _AGENT_UID}),
+        sleep=clock.sleep,
+        monotonic=clock.monotonic,
+    )
+    assert count == 1
+    assert len(offenders) == 1
+    assert clock.sleeps == []
+
+
+def test_gateway_arriving_mid_wait_turns_into_a_pass(tmp_path):
+    # No agent process for the first two scans, then the gateway appears clean.
+    _mkproc(tmp_path, 100, {"PATH": "/usr/bin"}, comm="hermes")
+    clock = _FakeClock()
+    calls = {"n": 0}
+
+    def uid_of(_proc_root: str, pid: str):
+        # The process exists on disk the whole time; ownership resolves to the
+        # agent uid only from the third scan on — the cold-boot shape.
+        calls["n"] += 1
+        return _AGENT_UID if calls["n"] >= 3 else None
+
+    count, offenders = probe.wait_scan(
+        str(tmp_path),
+        _AGENT_UID,
+        _KEYS,
+        wait_s=120.0,
+        uid_of=uid_of,
+        sleep=clock.sleep,
+        monotonic=clock.monotonic,
+    )
+    assert count == 1
+    assert offenders == []
+    assert len(clock.sleeps) == 2
+
+
+def test_gateway_never_arriving_still_fails_loud_at_the_deadline(tmp_path):
+    # Nothing but root processes, forever: the wait must END, returning the
+    # zero-count verdict main() turns into exit 3 — never spin, never pass.
+    _mkproc(tmp_path, 1, {"R2_ACCESS_KEY_ID": _FAKE_VALUE}, comm="entrypoint")
+    clock = _FakeClock()
+    count, offenders = probe.wait_scan(
+        str(tmp_path),
+        _AGENT_UID,
+        _KEYS,
+        wait_s=30.0,
+        uid_of=_uid_map({1: _ROOT_UID}),
+        sleep=clock.sleep,
+        monotonic=clock.monotonic,
+    )
+    assert count == 0
+    assert offenders == []
+    assert clock.now >= 30.0
+
+
+def test_zero_wait_keeps_the_original_single_scan_behavior(tmp_path):
+    # Direct calls without the flag are unchanged: one scan, immediate verdict.
+    clock = _FakeClock()
+    count, offenders = probe.wait_scan(
+        str(tmp_path),
+        _AGENT_UID,
+        _KEYS,
+        wait_s=0.0,
+        uid_of=_uid_map({}),
+        sleep=clock.sleep,
+        monotonic=clock.monotonic,
+    )
+    assert count == 0
+    assert offenders == []
+    assert clock.sleeps == []


### PR DESCRIPTION
Closes the false-FATAL half of #2420.

## What

`r2-account-key-strip-probe.py` gains `--wait-gateway-s N`: it retries ONLY the "no agent-uid process yet" verdict (the vacuous-zero fail-closed rule, exit 3) on a 3s cadence up to N seconds. Boot-smoke passes `--wait-gateway-s 120` on the FIRST strip-probe call site; the AgentMail and msgraph strip probes keep immediate semantics because once the first passes, the gateway is provably up.

## Why

On both 2026-08-18 pilot reprovisions, smoke reached the strip probe ~75s after a cold boot — before the gateway spawned — and FATALed a healthy deploy. A false red trains the operator to re-run and trust the second answer, which is how a real red eventually gets skimmed. The vacuous-zero rule itself is correct and stays: no agent process means nothing was proven; the fix moves WHEN we conclude that, not WHAT we conclude.

## What the wait can never do (Law 12)

- A scan that sees an offender exits 1 the instant it sees it — pinned by `test_wait_never_swallows_a_real_offender` (zero sleeps, generous budget).
- A missing agent user or unreadable `/proc` stays an immediate failure — configuration defects, not races.
- A gateway that never comes up still ends in the loud exit 3 at the deadline (`test_gateway_never_arriving_still_fails_loud_at_the_deadline`).
- Direct probe invocations without the flag are byte-identical in behavior (`test_zero_wait_keeps_the_original_single_scan_behavior`).

Time is injected in all four new tests; nothing sleeps in CI.

## AC state

- [x] (repo) The strip probes retry with a short backoff (or wait for gateway-up) before failing the smoke test — Evidence: `operator/templates/r2-account-key-strip-probe.py` `wait_scan`, call site in `boot-smoke-test.sh`
- [x] (repo) A genuine key-present failure still fails immediately, shown by a test — Evidence: `test_wait_never_swallows_a_real_offender`
- [ ] (runtime) A fresh reprovision passes its first smoke run end to end — held for the next reprovision after this merges; will be closed on the issue with the vfy id

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V5sDHLGttrvoh4LhKo4YLb
