### PR TITLE
fix(operator): the skill-reconciler is exec-launched, so its environ cannot carry the account R2 key (#2420)

### DIFF
--- a/operator/bin/tests/test_deploy_ordering.py
+++ b/operator/bin/tests/test_deploy_ordering.py
@@ -166,22 +166,36 @@ def test_webhook_gate_launched_with_r2_key_scrubbed() -> None:
     )
 
 
-def test_disabled_skills_reconciler_subshell_scrubs_r2() -> None:
-    """SEC-23: the disabled-skills reconciler subshell is forked ~300 lines before
-    the parent's R2 strip, so it must scrub the account-wide R2 key from its OWN
-    environ — else its /proc/<pid>/environ leaks the key to a same-uid code-executing
-    agent while it lives. This guard fails if the `unset` inside the subshell
-    is removed."""
+def test_disabled_skills_reconciler_launched_with_r2_key_scrubbed() -> None:
+    """SEC-23, corrected by ss#2420: the disabled-skills reconciler must be
+    LAUNCHED via ``env -u R2_ACCESS_KEY_ID -u R2_SECRET_ACCESS_KEY bash -c``,
+    never as a forked ``( ) &`` subshell with an inner ``unset``.
+
+    The prior form (which THIS test used to pin) did not work: a fork is never
+    exec'd, so its /proc/<pid>/environ stays the exec-time snapshot and the
+    ``unset`` inside it scrubs only the shell's variable table. The lingering
+    fork held the account-wide key for its whole 120-300s converge window at
+    the agent uid — the actual producer of every ss#2420 first-smoke FAIL,
+    proven live on pilot-smokeball 2026-08-19 (pid 1055, `bash /app/bootstrap.sh`,
+    hermes uid, R2 names in environ; the exec'd gateway clean). Same mechanism,
+    same fix shape as the webhook-gate launch, whose test sits above this one.
+    This guard fails if the launch reverts to a bare fork."""
     lines = _code_lines(_BOOTSTRAP)
-    # ss#2230 replaced the fixed 6x5s window with a convergent while-loop; the
-    # anchor follows the loop, the SEC-23 assertion is unchanged.
     loop_idx = _first_index(lines, r'while \[ "\$\{_ticks\}" -lt 60 \]')
     assert loop_idx != -1, "could not find the disabled-skills reconciler loop"
     window = "\n".join(lines[max(0, loop_idx - 6) : loop_idx])
-    assert re.search(r"\bunset\b.*\bR2_ACCESS_KEY_ID\b", window), (
-        "the disabled-skills reconciler subshell must `unset R2_ACCESS_KEY_ID "
-        "R2_SECRET_ACCESS_KEY` before its loop (SEC-23) so its /proc/environ does "
-        "not leak the account-wide key while it lives."
+    assert re.search(
+        r"env -u R2_ACCESS_KEY_ID -u R2_SECRET_ACCESS_KEY bash -c", window
+    ), (
+        "the disabled-skills reconciler must be launched via "
+        "`env -u R2_ACCESS_KEY_ID -u R2_SECRET_ACCESS_KEY bash -c …` — an exec "
+        "that rebuilds a clean environ. A forked `( ) &` subshell keeps the "
+        "account-wide key in /proc/environ for its whole life regardless of any "
+        "inner `unset` (ss#2420)."
+    )
+    assert "(" not in window.replace("$((", "").replace("))", ""), (
+        "a `(` immediately before the reconciler loop suggests the launch "
+        "reverted to a forked subshell — the exact ss#2420 leak shape."
     )
 
 

--- a/operator/templates/bootstrap.sh
+++ b/operator/templates/bootstrap.sh
@@ -519,21 +519,24 @@ log "Disabled skill guard passed"
 # race), under a 300s ceiling. A rehydration later than 300s would still win;
 # boot smoke's own --check step remains the arbiter either way (Law 12 — the
 # gate can still fail, and did, which is how this defect was found).
-(
-  # SEC-23: strip the account-wide R2 key from THIS subshell's environ. The
-  # subshell is forked here, ~300 lines before the parent's `unset` (below), so
-  # without this its /proc/<pid>/environ would expose the account-wide key to a
-  # same-uid code-executing agent while it lives. ensure-disabled-skills.py
-  # operates on local HERMES_HOME skill dirs and never needs R2.
-  unset R2_ACCESS_KEY_ID R2_SECRET_ACCESS_KEY
+# SEC-23, corrected (ss#2420): run the converge loop in an EXEC'd shell with the
+# account-wide R2 key scrubbed. The original `( ... ) &` fork carried the key in
+# /proc/<pid>/environ for its whole 120-300s life REGARDLESS of the `unset`
+# inside it — a fork is never exec'd, so its environ stays the exec-time
+# snapshot (the same mechanism the webhook-gate launch below documents). That
+# lingering fork is what the r2-account-key-strip probe caught on every cold
+# boot, misread four times as a gateway-up race. `env -u … bash -c` EXECs,
+# rebuilding a fresh environ without the key; ensure-disabled-skills.py
+# operates on local HERMES_HOME skill dirs and never needs R2.
+env -u R2_ACCESS_KEY_ID -u R2_SECRET_ACCESS_KEY bash -c '
   _clean_streak=0
   _ticks=0
   while [ "${_ticks}" -lt 60 ]; do
     _ticks=$((_ticks + 1))
     sleep 5
-    /opt/hermes/.venv/bin/python3 /app/ensure-disabled-skills.py "${CUSTOMER_YAML}" "${HERMES_HOME}" \
+    /opt/hermes/.venv/bin/python3 /app/ensure-disabled-skills.py "$1" "$2" \
       || true
-    if /opt/hermes/.venv/bin/python3 /app/ensure-disabled-skills.py --check "${CUSTOMER_YAML}" "${HERMES_HOME}" \
+    if /opt/hermes/.venv/bin/python3 /app/ensure-disabled-skills.py --check "$1" "$2" \
       > /dev/null 2>&1; then
       _clean_streak=$((_clean_streak + 1))
       [ "${_clean_streak}" -ge 3 ] && [ "${_ticks}" -ge 24 ] && break
@@ -541,7 +544,7 @@ log "Disabled skill guard passed"
       _clean_streak=0
     fi
   done
-) &
+' _ "${CUSTOMER_YAML}" "${HERMES_HOME}" &
 
 # Step 7c: fail closed if Telegram would run without an allowlist (ADR 0033).
 # TELEGRAM_BOT_TOKEN alone auto-enables Hermes' Telegram platform, and the pinned


### PR DESCRIPTION
The real #2420 — found when #2430's runtime observation failed in 3 seconds, which is the offender exit path, not the race the retry targets. Full evidence chain on the issue (comment of 2026-08-19) and in `vfy_01M0BSTDR0X8283JR8R1TPFYES`.

## What was actually wrong

The skill-reconciler (ss#2230 converge loop) was launched as a forked `( ... ) &` subshell. A fork is never exec'd: its `/proc/<pid>/environ` stays the exec-time snapshot, so the SEC-23 inner `unset` scrubbed only the shell's variable table while the environ kept the account-wide R2 key — name and value — for the whole 120–300s converge window, at the agent uid, on every boot of every seat. The ~75s first smoke run caught the fork alive (probe exit 1, a REAL offender); warm re-runs passed because it had exited. The smoke wrapper swallowing probe stderr is how four occurrences got filed as a gateway-up race.

Proven live on pilot-smokeball: pid 1055 `bash /app/bootstrap.sh`, uid hermes, PPid = the exec'd gateway; gateway environ itself clean (envcount=70, no R2 names).

## The fix

The webhook-gate pattern already in this file: `env -u R2_ACCESS_KEY_ID -u R2_SECRET_ACCESS_KEY bash -c '…' _ "${CUSTOMER_YAML}" "${HERMES_HOME}" &` — an exec that rebuilds a clean environ. Loop body unchanged; args passed as argv.

`test_disabled_skills_reconciler_subshell_scrubs_r2` (which pinned the ineffective unset-in-fork as the mitigation) is replaced by `test_disabled_skills_reconciler_launched_with_r2_key_scrubbed`, proven able to fail: run against origin/main's bootstrap it FAILs; against this branch, 9/9 pass. `bash -n` clean.

## AC state (issue #2420)

- [x] (repo) retry/backoff — shipped in #2430 (harmless and correct; its falsifier held on the real offender)
- [x] (repo) genuine failure still immediate — #2430's `test_wait_never_swallows_a_real_offender`
- [ ] (runtime) fresh reprovision passes its FIRST smoke run — to be observed on the next reprovision after this merges; closes on the issue with the vfy id

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V5sDHLGttrvoh4LhKo4YLb
