### PR TITLE
fix(broker): reply verifies the sender with the READ credential — replies work under the two-app fence (overlay#280)

### DIFF
--- a/operator/templates/entrypoint.sh
+++ b/operator/templates/entrypoint.sh
@@ -325,6 +325,29 @@ else
   log "MSGRAPH_SEND_CLIENT_SECRET unset; broker msgraph verbs stay fail-closed"
 fi
 
+# overlay#280: the broker ALSO carries the READ app's credential (the same
+# registration the gateway keeps — Mail.ReadWrite, no Mail.Send), because the
+# reply verb's sender-verification GET is 403 on the send app under the two-app
+# fence. Reading is the lower privilege and the agent already holds this exact
+# credential, so nothing widens; without this file no reply can ever transmit
+# on a two-app seat. Export is unconditional so launch_broker()'s env -i
+# allowlist line below always references a set variable.
+export SMD_MSGRAPH_READ_CREDENTIAL_PATH="${BROKER_DIR}/msgraph-read.json"
+if [ -n "${MSGRAPH_CLIENT_SECRET:-}" ]; then
+  PYTHONPATH="/opt/workspace-broker" \
+    /opt/workspace-broker/.venv/bin/python -c \
+    'import os; from pathlib import Path; from workspace_broker.msgraph_auth import materialize_read_credential; materialize_read_credential(Path(os.environ["SMD_MSGRAPH_READ_CREDENTIAL_PATH"]))'
+  [ -f "${SMD_MSGRAPH_READ_CREDENTIAL_PATH}" ] || {
+    log "FATAL: msgraph read credential was staged but not materialized"
+    exit 1
+  }
+  chown workspace-broker:workspace-broker "${SMD_MSGRAPH_READ_CREDENTIAL_PATH}"
+  chmod 0600 "${SMD_MSGRAPH_READ_CREDENTIAL_PATH}"
+  log "msgraph read credential materialized to the broker store (reply sender-verification)"
+else
+  log "MSGRAPH_CLIENT_SECRET unset; broker msgraph reply verb stays fail-closed"
+fi
+
 # The broker is the SECOND principal that BOTH the Google capability path AND the
 # OP-P1-4 audit_append path depend on. Define its launch ONCE; the supervisor
 # below uses it for the first start and every respawn. env -i with a fixed
@@ -351,6 +374,7 @@ launch_broker() {
     SMD_ESTABLISH_SPOOL_DIR="${SMD_ESTABLISH_SPOOL_DIR}" \
     SMD_AGENTMAIL_CREDENTIAL_PATH="${SMD_AGENTMAIL_CREDENTIAL_PATH}" \
     SMD_MSGRAPH_CREDENTIAL_PATH="${SMD_MSGRAPH_CREDENTIAL_PATH}" \
+    SMD_MSGRAPH_READ_CREDENTIAL_PATH="${SMD_MSGRAPH_READ_CREDENTIAL_PATH}" \
     /opt/workspace-broker/.venv/bin/python \
     -m workspace_broker.server
 }

--- a/operator/workspace_broker/msgraph_auth.py
+++ b/operator/workspace_broker/msgraph_auth.py
@@ -26,13 +26,26 @@ gateway today would not harden the seat; it would blind it.
 
 The way out is TWO app registrations in the tenant — a read-only one
 (``Mail.ReadWrite``, no ``Mail.Send``) whose credential the agent holds, and a
-send-capable one (``Mail.Send``) whose secret only ever reaches this file, both
-pinned to the one mailbox by an Exchange ``ApplicationAccessPolicy``. That is a
-tenant action requiring admin consent, so on a client seat it is the client's to
+send-capable one (``Mail.Send``) whose secret only ever reaches the broker store,
+both pinned to the one mailbox by an Exchange ``ApplicationAccessPolicy``. That is
+a tenant action requiring admin consent, so on a client seat it is the client's to
 grant. As of 2026-08-13 it is REQUIRED rather than hoped for: the Captain made two
 registrations a precondition of the channel, and ``provision-customer.sh`` refuses
 to stand up an msgraph seat whose ``MSGRAPH_SEND_*`` values are unstaged, equal to
 the read app's, or half-staged.
+
+THE BROKER HOLDS BOTH CREDENTIALS; THE AGENT HOLDS ONLY THE READ APP.
+
+The reply verb must verify the ORIGINAL SENDER itself (a caller that could name
+the sender could name any sender), and under the two-app fence the send app
+cannot read — its ``GET /messages/{id}`` is 403 by construction, observed live
+on the first production two-app seat (hermes-ashton-price 2026-08-19,
+overlay#280). So the broker store carries a SECOND file: the read app's
+credential, materialized from the same ``MSGRAPH_*`` env the gateway keeps.
+This grants the broker nothing novel — reading is the LOWER privilege, and the
+agent already holds this exact credential — while keeping the send secret where
+it always was. Do not "simplify" the read file away: without it no reply can
+ever transmit on a two-app seat.
 
 So the position on a seat that provisioned successfully:
 
@@ -73,9 +86,19 @@ SEND_ENV = (
     "MSGRAPH_SEND_CLIENT_SECRET",
 )
 
+#: The read app's credential — the SAME registration the gateway/agent already
+#: holds (Mail.ReadWrite, no Mail.Send). The broker needs it because the reply
+#: verb's sender-verification GET cannot run on the send app under the two-app
+#: fence (overlay#280).
+READ_ENV = (
+    "MSGRAPH_TENANT_ID",
+    "MSGRAPH_CLIENT_ID",
+    "MSGRAPH_CLIENT_SECRET",
+)
 
-def materialize_credential(credential_path: Path) -> None:
-    """Write the Graph send credential into the broker-owned store, 0600.
+
+def _materialize(env_names: tuple[str, ...], credential_path: Path, label: str) -> None:
+    """Write one Graph credential into the broker-owned store, 0600.
 
     Mirrors ``google_auth`` / ``agentmail_auth``: root calls this under the broker
     venv while it still holds the secrets in env, then chowns the file to the
@@ -83,33 +106,50 @@ def materialize_credential(credential_path: Path) -> None:
     later dropped.
 
     None of the three present ⇒ no-op. A seat with no msgraph connector never
-    stages them, and absence becomes a fail-closed refusal at send time.
+    stages them, and absence becomes a fail-closed refusal at use time.
 
     SOME but not all present ⇒ raise. A half-staged credential is a provisioning
-    mistake, and the seat must not boot believing it has a send path it does not
+    mistake, and the seat must not boot believing it has a path it does not
     have. Names only in the error; never a value.
     """
-    present = {name: (os.environ.get(name) or "").strip() for name in SEND_ENV}
+    tenant, client, secret = env_names
+    present = {name: (os.environ.get(name) or "").strip() for name in env_names}
     missing = [name for name, value in present.items() if not value]
-    if len(missing) == len(SEND_ENV):
+    if len(missing) == len(env_names):
         return
     if missing:
         raise RuntimeError(
-            "msgraph send credential is partially staged; refusing to boot a seat "
-            f"with a half-wired send path. Missing: {', '.join(sorted(missing))}"
+            f"msgraph {label} credential is partially staged; refusing to boot a seat "
+            f"with a half-wired {label} path. Missing: {', '.join(sorted(missing))}"
         )
     credential_path.write_text(
         json.dumps(
             {
-                "tenant_id": present["MSGRAPH_SEND_TENANT_ID"],
-                "client_id": present["MSGRAPH_SEND_CLIENT_ID"],
-                "client_secret": present["MSGRAPH_SEND_CLIENT_SECRET"],
+                "tenant_id": present[tenant],
+                "client_id": present[client],
+                "client_secret": present[secret],
             },
             separators=(",", ":"),
         ),
         encoding="utf-8",
     )
     credential_path.chmod(0o600)
+
+
+def materialize_credential(credential_path: Path) -> None:
+    """The send app's credential (``MSGRAPH_SEND_*``) → the broker store."""
+    _materialize(SEND_ENV, credential_path, "send")
+
+
+def materialize_read_credential(credential_path: Path) -> None:
+    """The read app's credential (``MSGRAPH_*``) → the broker store.
+
+    Written by the ROOT entrypoint only: the broker itself runs under ``env -i``
+    with an allowlist that deliberately excludes secrets, so calling this from
+    the broker process is a guaranteed no-op (all-absent → return) — kept there
+    for shape parity with the send path, nothing more. The file on disk is what
+    survives respawns."""
+    _materialize(READ_ENV, credential_path, "read")
 
 
 def load_credential(credential_path: Path) -> dict[str, str]:

--- a/operator/workspace_broker/msgraph_ops.py
+++ b/operator/workspace_broker/msgraph_ops.py
@@ -16,6 +16,15 @@ the credential holder writes rather than the caller.
   addresses — and would do it carrying a clean audit row, which is worse than no
   row at all.
 
+TWO CREDENTIALS, ONE VERB (overlay#280). Under the two-app fence the send app
+holds ``Mail.Send`` only, so the sender-verification GET above can never succeed
+on the send credential — 403 by construction, observed live on the first
+production two-app seat. The GET therefore runs on the READ app's credential
+(the same registration the agent already holds; reading is the lower privilege)
+from a second broker-store file, and the POST stays on the send credential.
+Absent read credential ⇒ the reply fails closed: verifying the sender is the
+load-bearing step and must not be skipped or delegated to the caller.
+
 WHY THE BROKER SPEAKS GRAPH ITSELF rather than importing the overlay's client:
 the overlay runs in the agent's address space and this process exists to be
 outside it. A shared import would be a shared dependency across the boundary the
@@ -169,17 +178,22 @@ class MsGraphOps:
         credential_path: Path,
         customer_path: Path,
         *,
+        read_credential_path: Path | None = None,
         graph_base: str = GRAPH_BASE,
         token_host: str = TOKEN_HOST,
         opener: Any | None = None,
     ) -> None:
         self._credential_path = credential_path
+        self._read_credential_path = read_credential_path
         self._customer_path = customer_path
         self._graph_base = graph_base.rstrip("/")
         self._token_host = token_host.rstrip("/")
         self._opener = opener
-        self._token: str | None = None
-        self._token_deadline = 0.0
+        # One token cache PER CREDENTIAL FILE. A shared cache would let reply()'s
+        # read-token mint (the GET runs first) leak onto the send POST — the
+        # send would then carry a token that cannot send, failing at Graph with
+        # a confusing 403 that looks like the fence misfiring.
+        self._tokens: dict[str, tuple[str, float]] = {}
 
     # -- identity ----------------------------------------------------------
 
@@ -201,13 +215,16 @@ class MsGraphOps:
 
     # -- transport ---------------------------------------------------------
 
-    def _bearer(self) -> str:
-        if self._token and time.monotonic() < self._token_deadline:
-            return self._token
-        credential = load_credential(self._credential_path)
+    def _bearer(self, credential_path: Path | None = None, *, role: str = "send") -> str:
+        path = credential_path or self._credential_path
+        cache_key = str(path)
+        cached = self._tokens.get(cache_key)
+        if cached and time.monotonic() < cached[1]:
+            return cached[0]
+        credential = load_credential(path)
         if not credential:
             raise MsGraphTransportError(
-                "no msgraph send credential in the broker store; refusing to send"
+                f"no msgraph {role} credential in the broker store; refusing to {role}"
             )
         data = urllib.parse.urlencode(
             {
@@ -249,18 +266,26 @@ class MsGraphOps:
             raise MsGraphTransportError("msgraph token response carried no access_token")
         expires_in = parsed.get("expires_in")
         lifetime = expires_in if isinstance(expires_in, int) else 3600
-        self._token = token
-        self._token_deadline = time.monotonic() + max(lifetime - _TOKEN_SKEW_S, 0)
+        deadline = time.monotonic() + max(lifetime - _TOKEN_SKEW_S, 0)
+        self._tokens[cache_key] = (token, deadline)
         return token
 
-    def _request(self, path: str, method: str, body: dict[str, Any] | None) -> dict[str, Any]:
+    def _request(
+        self,
+        path: str,
+        method: str,
+        body: dict[str, Any] | None,
+        *,
+        credential_path: Path | None = None,
+        role: str = "send",
+    ) -> dict[str, Any]:
         data = json.dumps(body).encode() if body is not None else None
         request = urllib.request.Request(
             self._graph_base + path,
             data=data,
             method=method,
             headers={
-                "Authorization": f"Bearer {self._bearer()}",
+                "Authorization": f"Bearer {self._bearer(credential_path, role=role)}",
                 "Accept": "application/json",
                 **({"Content-Type": "application/json"} if data else {}),
             },
@@ -376,6 +401,14 @@ class MsGraphOps:
         so the check that matters is on the ORIGINAL SENDER, fetched here rather
         than taken from the caller. A caller that could name the sender could name
         any sender.
+
+        The fetch runs on the READ credential: under the two-app fence the send
+        app cannot read (overlay#280), and skipping or delegating the fetch is
+        not an option — it is the load-bearing check. No read credential means
+        no reply, fail-closed. Scope honesty: this GET defends against a caller
+        naming the sender; it does not defend against an agent that PATCHes the
+        stored message's from/replyTo with its own Mail.ReadWrite — that is a
+        pre-existing property of replying to mutable message objects.
         """
         message_id = str(payload.get("message_id") or "").strip()
         if not message_id:
@@ -383,7 +416,19 @@ class MsGraphOps:
         comment = str(payload.get("comment") or "").strip()
         if not comment:
             raise MsGraphRefused("refusing to send an empty reply")
-        source = self._request(self._mail_path("messages", message_id), "GET", None)
+        if self._read_credential_path is None:
+            raise MsGraphTransportError(
+                "reply requires the broker read credential to verify the sender "
+                "under the two-app fence (overlay#280); this seat staged none — "
+                "reprovision materializes it"
+            )
+        source = self._request(
+            self._mail_path("messages", message_id),
+            "GET",
+            None,
+            credential_path=self._read_credential_path,
+            role="read",
+        )
         sender = normalize_address(source.get("from") or source.get("sender"))
         if not sender:
             raise MsGraphRefused(

--- a/operator/workspace_broker/server.py
+++ b/operator/workspace_broker/server.py
@@ -30,6 +30,7 @@ from .establishment import EstablishmentStore
 from .google_auth import materialize_credential
 from .job_ledger import LEASE_TTL_SECONDS, JobLedgerWriter, now_and_lease_cutoff
 from .msgraph_auth import materialize_credential as materialize_msgraph_credential
+from .msgraph_auth import materialize_read_credential as materialize_msgraph_read_credential
 from .msgraph_ops import MsGraphOps, MsGraphRefused, MsGraphTransportError
 from .msgraph_ops import collect_recipients as collect_msgraph_recipients
 from .operations import WorkspaceOperations
@@ -208,7 +209,20 @@ class Broker:
         if msgraph_credential and self.ledger is not None:
             graph_credential = Path(msgraph_credential)
             materialize_msgraph_credential(graph_credential)
-            self.msgraph = MsGraphOps(graph_credential, self.customer_path)
+            # overlay#280: the reply verb's sender-verification GET cannot run on
+            # the send app under the two-app fence, so the broker also carries the
+            # read app's credential in a second file. The ROOT entrypoint is the
+            # only real writer (this process runs under env -i without secrets, so
+            # the materialize call below is a shape-parity no-op); the file on
+            # disk is what survives respawns.
+            read_credential_env = os.environ.get("SMD_MSGRAPH_READ_CREDENTIAL_PATH")
+            read_credential: Path | None = None
+            if read_credential_env:
+                read_credential = Path(read_credential_env)
+                materialize_msgraph_read_credential(read_credential)
+            self.msgraph = MsGraphOps(
+                graph_credential, self.customer_path, read_credential_path=read_credential
+            )
         else:
             self.msgraph = None
 

--- a/operator/workspace_broker/tests/test_msgraph_send.py
+++ b/operator/workspace_broker/tests/test_msgraph_send.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 import json
 import sys
+import urllib.parse
 from pathlib import Path
 
 import pytest
@@ -131,6 +132,9 @@ class FakeGraph:
 
     def __init__(self, *, source_from: str | None = None) -> None:
         self.calls: list[tuple[str, str, dict | None]] = []
+        #: (url, Authorization header) per Graph call — how the two-credential
+        #: tests see WHICH app's token each request actually carried.
+        self.auths: list[tuple[str, str]] = []
         self._source_from = source_from
 
     def __call__(self, request, timeout=None):  # noqa: ANN001 - urllib signature
@@ -143,7 +147,15 @@ class FakeGraph:
             body = json.loads(raw.decode())
         self.calls.append((request.method, url, body))
         if url.endswith("/token"):
-            return _Response(json.dumps({"access_token": "tok", "expires_in": 3600}))
+            # The token is DERIVED FROM THE CLIENT_ID so a cache that leaks one
+            # credential's token onto the other credential's request is visible
+            # in the Authorization header rather than invisibly "working".
+            form = urllib.parse.parse_qs((raw or b"").decode())
+            client_id = (form.get("client_id") or ["?"])[0]
+            return _Response(
+                json.dumps({"access_token": f"tok-{client_id}", "expires_in": 3600})
+            )
+        self.auths.append((url, request.get_header("Authorization") or ""))
         if request.method == "GET" and "/messages/" in url:
             return _Response(
                 json.dumps({"from": {"emailAddress": {"address": self._source_from or ""}}})
@@ -154,20 +166,44 @@ class FakeGraph:
     def graph_posts(self) -> list[tuple[str, str, dict | None]]:
         return [c for c in self.calls if c[0] == "POST" and not c[1].endswith("/token")]
 
+    def token_client_ids(self) -> list[str]:
+        return [
+            urllib.parse.parse_qs(c[2]["form"]).get("client_id", ["?"])[0]
+            for c in self.calls
+            if c[1].endswith("/token") and c[2]
+        ]
 
-def _seat(tmp_path: Path, yaml_text: str = STAGING_YAML) -> tuple[Path, Path]:
+
+def _seat(tmp_path: Path, yaml_text: str = STAGING_YAML) -> tuple[Path, Path, Path]:
     customer = tmp_path / "customer.yaml"
     customer.write_text(yaml_text)
     credential = tmp_path / "msgraph.json"
     credential.write_text(
-        json.dumps({"tenant_id": "tid", "client_id": "cid", "client_secret": "shh"})
+        json.dumps({"tenant_id": "tid", "client_id": "cid-send", "client_secret": "shh"})
     )
-    return customer, credential
+    # The two-app fence's second file: the READ app's credential, distinct
+    # client_id so token routing is observable (overlay#280).
+    read_credential = tmp_path / "msgraph-read.json"
+    read_credential.write_text(
+        json.dumps({"tenant_id": "tid", "client_id": "cid-read", "client_secret": "shh2"})
+    )
+    return customer, credential, read_credential
 
 
-def _ops(tmp_path: Path, http: FakeGraph, yaml_text: str = STAGING_YAML) -> MsGraphOps:
-    customer, credential = _seat(tmp_path, yaml_text)
-    return MsGraphOps(credential, customer, opener=http)
+def _ops(
+    tmp_path: Path,
+    http: FakeGraph,
+    yaml_text: str = STAGING_YAML,
+    *,
+    with_read_credential: bool = True,
+) -> MsGraphOps:
+    customer, credential, read_credential = _seat(tmp_path, yaml_text)
+    return MsGraphOps(
+        credential,
+        customer,
+        read_credential_path=read_credential if with_read_credential else None,
+        opener=http,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -392,6 +428,55 @@ def test_reply_refuses_when_the_sender_cannot_be_determined(tmp_path: Path) -> N
         ops.reply({"message_id": "AAMk123", "comment": "sure"})
 
 
+# ---------------------------------------------------------------------------
+# Two credentials, one verb (overlay#280) — the GET reads, the POST sends
+# ---------------------------------------------------------------------------
+
+
+def test_reply_fetches_with_the_read_token_and_posts_with_the_send_token(
+    tmp_path: Path,
+) -> None:
+    """The incident: on a two-app seat the send app cannot read, so a reply whose
+    sender-verification GET rides the send token 403s forever. The GET must carry
+    the READ app's token and the POST the SEND app's — asserted from the actual
+    Authorization headers, so a shared token cache (the GET mints first and would
+    poison the POST) cannot pass."""
+    http = FakeGraph(source_from="scott@smd.services")
+    ops = _ops(tmp_path, http)
+    ops.reply({"message_id": "AAMk123", "comment": "sure"})
+    auth_by_kind = {("GET" if "/messages/" in url and not url.endswith("/reply") else "POST"): auth
+                    for url, auth in http.auths}
+    assert auth_by_kind["GET"] == "Bearer tok-cid-read"
+    assert auth_by_kind["POST"] == "Bearer tok-cid-send"
+
+
+def test_reply_mints_two_distinct_tokens(tmp_path: Path) -> None:
+    http = FakeGraph(source_from="scott@smd.services")
+    ops = _ops(tmp_path, http)
+    ops.reply({"message_id": "AAMk123", "comment": "sure"})
+    assert sorted(http.token_client_ids()) == ["cid-read", "cid-send"]
+
+
+def test_send_mints_exactly_one_token_and_it_is_the_send_apps(tmp_path: Path) -> None:
+    """send() is untouched by the two-credential split: one mint, the send app's."""
+    http = FakeGraph()
+    ops = _ops(tmp_path, http)
+    ops.send({"to": ["scott@smd.services"], "body_text": "x"})
+    assert http.token_client_ids() == ["cid-send"]
+    assert http.auths[0][1] == "Bearer tok-cid-send"
+
+
+def test_reply_fails_closed_without_a_read_credential(tmp_path: Path) -> None:
+    """No read credential means the sender cannot be verified, and an unverified
+    reply lane is an exfiltration primitive — so nothing is attempted at all."""
+    http = FakeGraph(source_from="scott@smd.services")
+    ops = _ops(tmp_path, http, with_read_credential=False)
+    with pytest.raises(MsGraphTransportError) as exc:
+        ops.reply({"message_id": "AAMk123", "comment": "sure"})
+    assert "read credential" in str(exc.value)
+    assert http.calls == []  # not even a token mint
+
+
 @pytest.mark.parametrize(
     "message_id",
     [
@@ -511,7 +596,7 @@ def test_the_client_secret_never_appears_in_a_token_error(tmp_path: Path) -> Non
     def _reject(request, timeout=None):  # noqa: ANN001
         raise urllib.error.HTTPError(request.full_url, 401, "Unauthorized", {}, None)
 
-    customer, credential = _seat(tmp_path)
+    customer, credential, _read = _seat(tmp_path)
     ops = MsGraphOps(credential, customer, opener=_reject)
     with pytest.raises(MsGraphTransportError) as exc:
         ops.send({"to": ["scott@smd.services"], "body_text": "x"})
@@ -606,7 +691,7 @@ def test_a_transport_failure_is_not_recorded_as_a_refusal(tmp_path: Path) -> Non
             return _Response(json.dumps({"access_token": "tok", "expires_in": 3600}))
         raise urllib.error.HTTPError(request.full_url, 503, "nope", {}, None)
 
-    customer, credential = _seat(tmp_path)
+    customer, credential, _read = _seat(tmp_path)
     broker = Broker.__new__(Broker)
     broker.customer_slug = SEAT
     broker.gateway_pid = GATEWAY_PID


### PR DESCRIPTION
Closes the Lane-0 blocker observed live on hermes-ashton-price: the reply verb's sender-verification GET ran on the SEND app's token, which cannot read under the two-app fence — 403 on every reply. The broker store gains the READ app's credential (same registration the agent already holds; nothing widens); GET on the read token, POST on the send token; fail-closed without the read file. env -i allowlist carries the new path (the critique's shipping blocker). 306 broker tests pass incl. Authorization-header routing assertions with per-client_id tokens. Scope honesty in reply()'s docstring: the GET defends against caller-named senders, not against Mail.ReadWrite PATCHes of the stored message (pre-existing property).

Runtime proof after merge: reprovision hermes-ashton-price, Captain sends one fresh email, the routed turn's reply auto-delivers to his inbox (ss#2258 SMD batch Lane 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YMQcxGtkEyrCvYxEAi8Y5e