### PR TITLE
fix(ci): the claim-origin watcher can start, and the release-watch survives a blip (#2441, #2442)

### DIFF
--- a/.github/workflows/hermes-release-watch.yml
+++ b/.github/workflows/hermes-release-watch.yml
@@ -39,8 +39,51 @@ jobs:
           [ -n "$BLESSED_TAG" ] || { echo "could not read blessed HERMES_UPSTREAM_TAG from Dockerfile" >&2; exit 1; }
 
           # Latest non-prerelease upstream release tag.
-          LATEST_TAG="$(gh api repos/NousResearch/hermes-agent/releases --jq '[.[] | select(.prerelease==false)][0].tag_name')"
-          [ -n "$LATEST_TAG" ] || { echo "could not read latest upstream release tag" >&2; exit 1; }
+          #
+          # Read it with retries, then from a SECOND endpoint, before giving up.
+          # Run #6 (2026-08-17) died on one bad second: a single `gh api` call came
+          # back empty, the job exited 1, and a weekly signal became a critical
+          # alert for a GitHub hiccup. The identical call returns v2026.8.18 today.
+          #
+          # This still fails loudly when upstream is genuinely unreadable — a
+          # renamed repo, a revoked token, a changed response shape — because that
+          # is the failure the watcher exists to catch: a watcher that quietly
+          # exits 0 on an unreadable upstream lets the pin rot invisibly, which is
+          # the exact drift ADR 0024 wrote this job to prevent (and the shape of
+          # ss#2441, a check that never ran and never said so). What changes is
+          # that a transient blip no longer counts as unreadable, and that a real
+          # failure now names WHICH read failed and what it returned.
+          read_latest_tag() {
+            local endpoint="$1" filter="$2" attempt out
+            for attempt in 1 2 3; do
+              # `|| true`: a non-zero gh must fall through to the retry, not abort
+              # the step under `set -e` from inside a command substitution.
+              out="$(gh api "$endpoint" --jq "$filter" 2>&1 || true)"
+              case "$out" in
+                v[0-9]*) printf '%s\n' "$out"; return 0 ;;
+              esac
+              echo "attempt $attempt on $endpoint returned: ${out:-<empty>}" >&2
+              [ "$attempt" -lt 3 ] && sleep $((attempt * 5))
+            done
+            return 1
+          }
+
+          LATEST_TAG="$(read_latest_tag \
+            'repos/NousResearch/hermes-agent/releases' \
+            '[.[] | select(.prerelease==false)][0].tag_name' || true)"
+
+          if [ -z "$LATEST_TAG" ]; then
+            # Different endpoint, same signal. Releases and tags fail independently.
+            echo "releases endpoint unreadable after 3 attempts; falling back to tags" >&2
+            LATEST_TAG="$(read_latest_tag \
+              'repos/NousResearch/hermes-agent/tags' \
+              '.[0].name' || true)"
+          fi
+
+          [ -n "$LATEST_TAG" ] || {
+            echo "could not read latest upstream release tag from releases OR tags after 3 attempts each — see the per-attempt output above" >&2
+            exit 1
+          }
 
           echo "blessed=$BLESSED_TAG latest=$LATEST_TAG"
 

--- a/.github/workflows/regression-claim-origin.yml
+++ b/.github/workflows/regression-claim-origin.yml
@@ -4,6 +4,30 @@ on:
   issues:
     types: [opened, labeled]
 
+# LOAD-BEARING, and the reason this workflow was dead for 104 days (ss#2441).
+#
+# The repo's `default_workflow_permissions` is `read`. A called reusable workflow
+# may only be granted permissions the CALLER already holds, and the called job in
+# crane-console declares `permissions: issues: write` because its whole job is to
+# post a comment. With no `permissions:` key here, the caller started at the
+# read-only default, the called workflow's request exceeded it, and GitHub refused
+# the run before any job existed: 2,059 runs from 2026-05-07 onward, every one a
+# `startup_failure`, zero successes, zero claim-origin comments ever posted.
+#
+# It never alerted because a `startup_failure` produces no job and no check run,
+# so the CI notification sink — which recorded 6,000+ events for this repo in the
+# same window, successes included — never saw it. A dead check is silent by
+# construction; only its output being ABSENT gives it away, and nobody counts
+# absences. Hence the structural test in tests/workflow-permissions.test.ts:
+# any delegating caller without this block fails at merge, not in 104 days.
+#
+# Every other issue-writing workflow here (escape-analysis-on-close, tick-acs-on-
+# merge, unmet-ac-on-close, ...) declares the same block and works, which is the
+# positive control proving an explicit grant does override the read-only default.
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   claim-origin:
     if: |

--- a/tests/hermes-release-watch.test.ts
+++ b/tests/hermes-release-watch.test.ts
@@ -1,0 +1,172 @@
+/**
+ * The upstream read in the Hermes release-watch, run rather than described.
+ *
+ * Run #6 (2026-08-17) turned one bad second into a critical alert: a single
+ * `gh api .../releases` came back empty, the step exited 1, and a weekly signal
+ * job paged. The identical call returns v2026.8.18 today, so nothing upstream
+ * was actually wrong.
+ *
+ * The fix retries, then falls back to a second endpoint. The risk in that fix is
+ * the obvious one — make a watcher tolerant enough and it stops watching. So the
+ * test that matters here is the LAST one: both endpoints permanently unreadable
+ * must still fail the run, loudly, naming what it saw. A release-watch that
+ * exits 0 on an unreadable upstream lets the fleet pin rot invisibly, which is
+ * the drift ADR 0024 wrote this job to prevent and the exact shape of ss#2441.
+ *
+ * These execute the REAL step body extracted from the YAML, under the shell
+ * GitHub uses, against a `gh` stub whose per-call behaviour the test chooses.
+ * `sleep` is stubbed to a no-op so the production backoff stays real code rather
+ * than a test-only knob. Asserting on the body's text would only restate the
+ * wiring; running it is what can fail.
+ */
+import { execFileSync } from 'node:child_process'
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+const REPO_ROOT = fileURLToPath(new URL('..', import.meta.url))
+const WORKFLOW = join(REPO_ROOT, '.github', 'workflows', 'hermes-release-watch.yml')
+const STEP = 'Compare upstream latest vs blessed fleet pin'
+
+/** The `run:` body of a named step, dedented, exactly as GitHub runs it. */
+const stepBody = (name: string): string => {
+  const source = readFileSync(WORKFLOW, 'utf8')
+  const start = source.indexOf(`      - name: ${name}`)
+  expect(start).toBeGreaterThan(-1)
+  const body = source.slice(source.indexOf('run: |', start) + 'run: |\n'.length)
+  const lines: string[] = []
+  for (const line of body.split('\n')) {
+    if (line.trim() !== '' && !line.startsWith('          ')) break
+    lines.push(line.slice(10))
+  }
+  return lines.join('\n')
+}
+
+/**
+ * `releases` / `tags` are the tag each endpoint yields, or '' for an empty read.
+ * `releasesFailFor` makes the first N releases calls come back empty, so a
+ * transient blip is distinguishable from a broken endpoint.
+ */
+interface Scenario {
+  releases?: string
+  tags?: string
+  releasesFailFor?: number
+  blessed?: string
+}
+
+describe('the release-watch survives a blip and still fails on a dead upstream', () => {
+  let dir: string | undefined
+
+  afterEach(() => {
+    if (dir) rmSync(dir, { recursive: true, force: true })
+    dir = undefined
+  })
+
+  const runStep = (s: Scenario) => {
+    dir = mkdtempSync(join(tmpdir(), 'hermes-watch-'))
+    const bin = join(dir, 'bin')
+    mkdirSync(bin, { recursive: true })
+
+    // The Dockerfile grep the step opens first. Its own failure path is already
+    // explicit in the step; this just lets the upstream read be what is tested.
+    mkdirSync(join(dir, 'operator', 'templates'), { recursive: true })
+    writeFileSync(
+      join(dir, 'operator', 'templates', 'Dockerfile'),
+      `ARG HERMES_UPSTREAM_TAG=${s.blessed ?? 'v2026.7.1'} \n`
+    )
+
+    const counter = join(dir, 'releases-calls')
+    writeFileSync(counter, '0')
+
+    writeFileSync(
+      join(bin, 'gh'),
+      [
+        '#!/usr/bin/env bash',
+        // `gh api <endpoint> --jq <filter>` — the only calls under test. Every
+        // other subcommand (issue list/create, label create) succeeds quietly so
+        // the drift branch can run to completion.
+        'if [ "$1" = "api" ]; then',
+        '  case "$2" in',
+        '    *releases*)',
+        `      n=$(cat ${counter}); n=$((n + 1)); echo "$n" > ${counter}`,
+        `      if [ "$n" -le ${s.releasesFailFor ?? 0} ]; then exit 0; fi`,
+        `      printf '%s' '${s.releases ?? ''}'; [ -n '${s.releases ?? ''}' ] && echo`,
+        '      exit 0 ;;',
+        `    *tags*) printf '%s' '${s.tags ?? ''}'; [ -n '${s.tags ?? ''}' ] && echo; exit 0 ;;`,
+        '  esac',
+        'fi',
+        'if [ "$1" = "issue" ] && [ "$2" = "list" ]; then echo 0; exit 0; fi',
+        'exit 0',
+      ].join('\n')
+    )
+    chmodSync(join(bin, 'gh'), 0o755)
+
+    // No-op backoff: the retry timing is real production code, but a test should
+    // not spend 30s proving it.
+    writeFileSync(join(bin, 'sleep'), '#!/usr/bin/env bash\nexit 0\n')
+    chmodSync(join(bin, 'sleep'), 0o755)
+
+    writeFileSync(join(dir, 'step.sh'), stepBody(STEP))
+
+    // Merged streams: the step's diagnostics (which attempt saw what, the
+    // fallback notice) go to stderr on purpose, and they are half of what this
+    // change is for — a failure that cannot be read is the ss#2440 defect.
+    let stdout: string
+    let failed = false
+    try {
+      stdout = execFileSync('bash', ['-c', `bash "${join(dir, 'step.sh')}" 2>&1`], {
+        cwd: dir,
+        encoding: 'utf-8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+        env: { ...process.env, PATH: `${bin}:${process.env.PATH ?? ''}` },
+      })
+    } catch (err) {
+      failed = true
+      const e = err as { stdout?: string; stderr?: string }
+      stdout = `${e.stdout ?? ''}${e.stderr ?? ''}`
+    }
+    return { stdout, failed, releasesCalls: Number(readFileSync(counter, 'utf-8').trim()) }
+  }
+
+  it('reads the latest tag on a clean first attempt', () => {
+    const run = runStep({ releases: 'v2026.8.18' })
+    expect(run.failed).toBe(false)
+    expect(run.stdout).toContain('blessed=v2026.7.1 latest=v2026.8.18')
+    expect(run.releasesCalls).toBe(1)
+  })
+
+  it('recovers from the blip that killed run #6 instead of paging', () => {
+    // Two empty reads, then the same value the endpoint returns today.
+    const run = runStep({ releases: 'v2026.8.18', releasesFailFor: 2 })
+    expect(run.failed).toBe(false)
+    expect(run.stdout).toContain('latest=v2026.8.18')
+    expect(run.releasesCalls).toBe(3)
+  })
+
+  it('falls back to tags when releases is the endpoint that is broken', () => {
+    const run = runStep({ releases: '', tags: 'v2026.8.18' })
+    expect(run.failed).toBe(false)
+    expect(run.stdout).toContain('latest=v2026.8.18')
+    expect(run.stdout).toContain('falling back to tags')
+  })
+
+  it('reports no action when the fleet is already current', () => {
+    const run = runStep({ releases: 'v2026.7.1', blessed: 'v2026.7.1' })
+    expect(run.failed).toBe(false)
+    expect(run.stdout).toContain('Fleet is current with upstream')
+  })
+
+  it('STILL fails, and says what it saw, when upstream is genuinely unreadable', () => {
+    // The falsifier for the whole change. If retries and a fallback ever turn a
+    // dead upstream green, the watcher has become the thing it watches for.
+    const run = runStep({ releases: '', tags: '' })
+    expect(run.failed).toBe(true)
+    expect(run.stdout).toContain('could not read latest upstream release tag')
+    expect(run.stdout).toContain('<empty>')
+    // Three on releases, three on tags — it gave up, it did not give up early.
+    expect(run.releasesCalls).toBe(3)
+  })
+})

--- a/tests/workflow-permissions.test.ts
+++ b/tests/workflow-permissions.test.ts
@@ -1,0 +1,124 @@
+/**
+ * ss#2441. A caller that delegates to a reusable workflow must grant permissions.
+ *
+ * `Regression Claim-Origin` failed 2,059 out of 2,059 runs — every run from
+ * 2026-05-07 onward, zero successes, zero claim-origin comments ever posted. The
+ * caller declared no `permissions:` block, so it started at this repo's
+ * read-only `default_workflow_permissions`; the called workflow's job in
+ * crane-console declares `permissions: issues: write` because posting a comment
+ * is its entire job; a called workflow may only be granted what the caller
+ * already holds; GitHub refused the run at startup. `startup_failure`, zero
+ * jobs, 404 on the logs endpoint, every time.
+ *
+ * It ran silently for 104 days because a `startup_failure` produces no job and
+ * no check run, so the CI notification sink never emitted anything for it —
+ * 6,214 events recorded for this repo in the same window, successes included,
+ * and not one of them a Regression Claim-Origin run. The only evidence a dead
+ * check leaves is the ABSENCE of its output, and nobody counts absences.
+ *
+ * So the guard cannot be "watch for red". It has to be structural, at merge
+ * time: a delegating caller with no `permissions:` block is refused here, on the
+ * file, before it can spend another 104 days proving nothing. The falsifier is
+ * the pre-fix `regression-claim-origin.yml`, reconstructed inline below — this
+ * test fails against it, which is the only reason to believe it would fail
+ * against the next one.
+ */
+import { readFileSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+const WORKFLOW_DIR = fileURLToPath(new URL('../.github/workflows', import.meta.url))
+
+/**
+ * True when the workflow has at least one job that IS a reusable-workflow call.
+ *
+ * A job-level `uses:` is a job property, so it sits at exactly four spaces under
+ * the two-space job key. A step-level `uses:` is a list item inside `steps:` and
+ * always carries a `- `. Matching the job-property indent is what separates
+ * "this workflow delegates" from "this workflow runs actions" — and every
+ * workflow in this repo runs actions, so getting that wrong would either demand
+ * a permissions block from all of them or from none.
+ */
+const delegatesToReusableWorkflow = (source: string): boolean => /^ {4}uses:/m.test(source)
+
+/** True when the workflow declares a `permissions:` key at workflow or job level. */
+const declaresPermissions = (source: string): boolean => /^ {0,4}permissions:/m.test(source)
+
+const workflowFiles = readdirSync(WORKFLOW_DIR).filter((f) => /\.ya?ml$/.test(f))
+const delegatingFiles = workflowFiles.filter((f) =>
+  delegatesToReusableWorkflow(readFileSync(join(WORKFLOW_DIR, f), 'utf8'))
+)
+
+describe('workflows that call a reusable workflow declare their permissions', () => {
+  it('finds workflow files to check at all', () => {
+    // Without this, a bad path would empty the loop below and every assertion
+    // would vacuously pass — the ss#2280 shape this whole file exists to refuse.
+    expect(workflowFiles.length).toBeGreaterThan(10)
+  })
+
+  it('finds at least one delegating caller in this repo', () => {
+    // The per-file assertions below are generated from this list. If the
+    // detector silently stops matching — a YAML reformat, an indent change —
+    // the loop empties and the suite goes green having checked nothing. That is
+    // the same "absence reads as success" failure that hid ss#2441 for 104 days.
+    expect(delegatingFiles).toContain('regression-claim-origin.yml')
+  })
+
+  for (const file of delegatingFiles) {
+    const source = readFileSync(join(WORKFLOW_DIR, file), 'utf8')
+
+    it(`${file} grants the permissions its called workflow needs`, () => {
+      expect(
+        declaresPermissions(source),
+        `${file} calls a reusable workflow but declares no permissions:. This repo's ` +
+          'default_workflow_permissions is read, a called workflow cannot be granted more ' +
+          'than its caller holds, and the run is refused at startup — silently, because a ' +
+          'startup_failure produces no check run for anything to alert on (ss#2441).'
+      ).toBe(true)
+    })
+  }
+
+  it('detects a delegating caller that declares nothing (the ss#2441 file, pre-fix)', () => {
+    // The exact shape that produced 2,059 startup failures.
+    const preFix = [
+      'name: Regression Claim-Origin',
+      '',
+      'on:',
+      '  issues:',
+      '    types: [opened, labeled]',
+      '',
+      'jobs:',
+      '  claim-origin:',
+      "    if: contains(github.event.issue.labels.*.name, 'regression')",
+      '    uses: venturecrane/crane-console/.github/workflows/regression-claim-origin-reusable.yml@abc123',
+      '    secrets:',
+      '      CRANE_RELAY_KEY: ${{ secrets.CRANE_RELAY_KEY }}',
+      '',
+    ].join('\n')
+
+    expect(delegatesToReusableWorkflow(preFix)).toBe(true)
+    expect(declaresPermissions(preFix)).toBe(false)
+  })
+
+  it('does not mistake a step-level action for a reusable-workflow call', () => {
+    // If it did, it would demand a permissions block from every workflow in the
+    // repo, the rule would be noise, and the real signal would be routed around.
+    const stepsOnly = [
+      'name: Verify',
+      '',
+      'on: [push]',
+      '',
+      'jobs:',
+      '  check:',
+      '    runs-on: ubuntu-latest',
+      '    steps:',
+      '      - uses: actions/checkout@v4',
+      '      - run: npm ci',
+      '',
+    ].join('\n')
+
+    expect(delegatesToReusableWorkflow(stepsOnly)).toBe(false)
+  })
+})


### PR DESCRIPTION
Clears the two workflows behind the four critical CI alerts on main, and closes the class the first one belongs to. The third alert pair (`escape-analysis-on-close` reopening #2420) needed no code — #2420 now carries a gate-accepted escape analysis and run #38 is green (`vfy_01M0DEDR5XCDZCV752NVGXVMKP`).

## Regression Claim-Origin has never once run (#2441)

**2,059 of 2,059 runs are `startup_failure`** — every run since 2026-05-07, zero successes ever, zero claim-origin comments ever posted.

```
?status=success         -> 0
?status=failure         -> 0
?status=startup_failure -> 2059
```

The caller declared no `permissions:` block, so it started at this repo's read-only `default_workflow_permissions`. The called workflow's job declares `issues: write` — posting a comment is its entire job. A called workflow may only be granted what its caller holds, so GitHub refused the run before any job existed: no job, no check run, 404 on the logs endpoint, every time. `venturecrane/crane-console`'s copy of the same caller is **43/43 dead** the same way.

Positive control for the mechanism, inside this repo: every *other* issue-writing workflow here (`escape-analysis-on-close`, `tick-acs-on-merge`, `unmet-ac-on-close`, `hermes-release-watch`) declares `permissions: issues: write` explicitly and writes to issues successfully under the same read-only default. This is the only workflow that delegates, and the only one that dies.

**Why 104 days of silence.** A `startup_failure` produces no check run, so the CI notification sink never emitted anything for it — 6,214 events recorded for this repo over the same window, successes included, not one of them a Regression Claim-Origin run. A dead check leaves only the *absence* of its output, and nobody counts absences. Watching for red could never have caught this, so the guard is structural and runs at merge: `tests/workflow-permissions.test.ts` refuses any delegating caller without a permissions block.

## hermes-release-watch pages on one bad second (#2442)

Run #6 failed on `could not read latest upstream release tag`. Nothing upstream was wrong — the identical call returns `v2026.8.18` and 28 releases today. One `gh api` call, empty result, `exit 1`, critical alert.

Now: three attempts with backoff, then the tags endpoint (releases and tags fail independently), with each attempt's actual output printed. It **still fails loudly** when upstream is genuinely unreadable — a watcher that exits 0 on a dead upstream lets the fleet pin rot invisibly, which is the drift ADR 0024 wrote this job to prevent and the exact shape of #2441.

## Falsifiers

Both suites were run against the pre-fix files. Neither is a check that cannot fail.

| Suite | Against the fix | Against the pre-fix file |
|---|---|---|
| `tests/workflow-permissions.test.ts` | 7 passed | **1 failed** — `regression-claim-origin.yml calls a reusable workflow but declares no permissions:` |
| `tests/hermes-release-watch.test.ts` | 5 passed | **3 failed** — blip-recovery, tags-fallback, and the diagnostic on total failure |

`tests/workflow-permissions.test.ts` also asserts its own detector still matches (`expect(delegatingFiles).toContain('regression-claim-origin.yml')`), so a YAML reformat that silently empties the per-file loop fails rather than going green having checked nothing.

`tests/hermes-release-watch.test.ts` executes the **real step body** extracted from the YAML against a stubbed `gh`, following the `tests/terminal-state-reconcile.test.ts` pattern. `sleep` is stubbed on PATH so the production backoff stays real code rather than a test-only knob.

`npm run verify` exits 0 (`npm ci` first — the worktree was 19 days stale).

## Acceptance criteria

**#2441**
- [x] (repo) The caller declares `permissions: contents: read, issues: write`
- [x] (repo) A structural test fails any workflow calling a reusable workflow without a `permissions:` block, shown failing on the pre-fix file
- [ ] (runtime) A `regression`-labeled issue produces a green run and an actual claim-origin comment — provable only after merge
- [ ] Sister repos carrying the same dead caller identified and filed (crane-console confirmed 43/43)

**#2442**
- [x] (repo) The upstream read retries with backoff
- [x] (repo) A second endpoint is consulted before giving up
- [x] (repo) A genuinely unreadable upstream still fails, naming which read failed and what it returned
- [x] (repo) A test executes the real step body against a stubbed `gh` across five scenarios
- [ ] (runtime) A `workflow_dispatch` run on main completes green against the live upstream — provable only after merge

Both runtime ACs are proved immediately after merge, on main, and their `crane_verify` IDs posted to the issues before either closes.

## Also filed from this session

- #2440 — `boot-smoke ssh_exec` discards the probe's stderr and exit code, which is how #2420's correct red got read as a race for a day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T4nne6ikC4yinawwNWFgVh
