### PR TITLE
fix(tooling): the sprint-worker signal file stops dirtying every worktree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,11 @@ scripts/.generated/
 node_modules
 .claude/read-log/
 .stitch/shadow-firm/
+
+# Sprint-worker completion signal. Each worker writes result.json to its
+# worktree root and the orchestrator reads it for success/failure/crash
+# detection (.claude/agents/sprint-worker.md, .claude/commands/orchestrate.md).
+# It is per-run state, never repo content: while it was tracked, every parallel
+# worker's write registered as a dirty tracked file, which tripped the
+# worktree-doctor safety gate and blocked automatic orphan cleanup.
+/result.json

--- a/result.json
+++ b/result.json
@@ -1,7 +1,0 @@
-{
-  "status": "success",
-  "pr_url": "",
-  "files_changed": ["docs/spikes/forme-wasm-pdf.md"],
-  "verify_passed": true,
-  "summary": "Forme WASM PDF generation is viable in Cloudflare Workers. The 5.2 MB WASM bundle compresses to 2.5 MB gzipped, well within the 10 MB paid-plan limit. Render times are 20-40ms (vs. 3-second requirement). JSX component model maps directly to SOW template use case. No fallback path needed. Alternatives evaluated: pdf-lib (no layout engine), Browser Rendering API (6s latency, $0.09/hr), jsPDF (manual coordinates), @react-pdf/renderer (incompatible with Workers)."
-}

--- a/tests/worker-signal-hygiene.test.ts
+++ b/tests/worker-signal-hygiene.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Guard test for the sprint-worker completion signal (result.json).
+ *
+ * Why this exists (2026-08-19, the ten-orphan worktree cleanup): a stale
+ * result.json from the #93 Forme WASM PDF spike sat TRACKED at the repo root
+ * while the parallel-worker harness uses that same filename as its per-run
+ * completion signal. Every sprint worker writes result.json to its worktree
+ * root (.claude/agents/sprint-worker.md step 7) and the orchestrator reads it
+ * for success/failure/crash detection (.claude/commands/orchestrate.md).
+ *
+ * The collision was silent and structural: because the file was tracked, each
+ * worker's write registered as a modification to a tracked file, so every
+ * finished worktree reported dirty. crane_worktree_doctor's safety gates then
+ * correctly refused to remove any of them, and ten orphans accumulated across
+ * two days until they were cleaned by hand. The gate was working; it was being
+ * fed junk. Untracking the artifact and ignoring the path fixes the class.
+ *
+ * This is a repo-hygiene invariant, not a doctrine law: per-run state must
+ * never be repo content, or the isolation machinery cannot tell finished work
+ * from unfinished work.
+ *
+ * @see .claude/agents/sprint-worker.md
+ * @see .claude/commands/orchestrate.md
+ */
+import { describe, it, expect } from 'vitest'
+import { execFileSync } from 'node:child_process'
+
+const SIGNAL = 'result.json'
+
+function git(args: string[]): { code: number; out: string } {
+  try {
+    return { code: 0, out: execFileSync('git', args, { encoding: 'utf8' }) }
+  } catch (err) {
+    const e = err as { status?: number; stdout?: string }
+    return { code: e.status ?? 1, out: e.stdout ?? '' }
+  }
+}
+
+describe('sprint-worker completion signal stays out of the repo', () => {
+  it('result.json is not tracked at the repo root', () => {
+    const { out } = git(['ls-files', '--', SIGNAL])
+    expect(
+      out.trim(),
+      `${SIGNAL} is tracked again. A tracked signal file makes every finished ` +
+        `sprint-worker worktree read as dirty, which blocks automatic orphan ` +
+        `cleanup. Remove it with: git rm --cached ${SIGNAL}`
+    ).toBe('')
+  })
+
+  it('a root result.json is gitignored, so a worker write never dirties the tree', () => {
+    // check-ignore exits 0 when the path IS ignored, 1 when it is not.
+    const { code } = git(['check-ignore', '--quiet', '--', SIGNAL])
+    expect(
+      code,
+      `${SIGNAL} is no longer ignored. Restore the /result.json entry in ` +
+        `.gitignore, or parallel sprint workers will leave every worktree dirty.`
+    ).toBe(0)
+  })
+})


### PR DESCRIPTION
## What

`result.json` was tracked at the repo root while the parallel-worker harness uses that same filename as its per-run completion signal. Untrack the artifact, ignore the path, pin both halves with a test.

## Why

The two uses collided silently:

- **The harness contract:** each sprint worker writes `result.json` to its worktree root (`.claude/agents/sprint-worker.md` step 7); the orchestrator reads it for success / failure / crash detection (`.claude/commands/orchestrate.md`).
- **The stray artifact:** a `result.json` was committed once, in PR #93 (the Forme WASM PDF spike), and never touched again.

Because the artifact was tracked, every worker's write registered as a modification to a tracked file, so each finished worktree reported dirty. `crane_worktree_doctor`'s safety gates then correctly refused to remove any of them.

Ten orphan worktrees accumulated across two days and were cleaned by hand this session (`vfy_01M0DMHSVBAGZSS8RMW1K378SH`); all ten proved fully absorbed into main. The gate was not broken. It was being fed junk, so it failed closed exactly as designed and cleanup never ran automatically.

## Nothing is lost

The deleted file's only content was a summary of `docs/spikes/forme-wasm-pdf.md`, which is unchanged at 214 lines. The harness contract is untouched: workers still write, and the orchestrator still reads, the same path.

## Evidence

Simulating a worker write on a clean tree after the change:

```
$ printf '{"status":"success"}\n' > result.json
$ git status --porcelain
        <empty>
```

The signal is now invisible to git, so a finished worktree reads clean and the doctor can auto-clean it.

## Falsifier (Law 12)

`tests/worker-signal-hygiene.test.ts` was confirmed to fail against the real defect, not just pass:

| Mutation | Result |
|---|---|
| `git add -f result.json` | tracked-check **RED** |
| delete `/result.json` from `.gitignore` | ignore-check **RED** |
| both restored | **GREEN** (2 passed) |

Each assertion fails independently on the defect it guards.

## Verify

`npm run verify` exit 0 — 4,573 tests passed, 0 lint errors (13 pre-existing warnings untouched). Dependencies were refreshed with `npm ci` first; the pre-existing install was stale against `package-lock.json`, and `knip` was missing until it was reinstalled.

## AC

- [x] `result.json` untracked at repo root
- [x] root `result.json` gitignored, so worker writes leave a clean tree
- [x] harness contract unchanged (worker writes, orchestrator reads, same path)
- [x] regression guard added, both assertions proven falsifiable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4WzivZDzEUzaKxAfk2Nnj
