### PR TITLE
feat(operator): the renderer fills the firm's own Word template (document_class); code owns typography (#2448 PR 1)

### DIFF
--- a/operator/connectors/smokeball/pyproject.toml
+++ b/operator/connectors/smokeball/pyproject.toml
@@ -9,6 +9,9 @@ dependencies = [
     # read_document text extraction (PDF + DOCX); both pure-Python.
     "pypdf>=4",
     "python-docx>=1.1",
+    # The format renderer reads the firm's document-library location off the
+    # seat's live customer.yaml (the registered config-as-data shape); pure Python.
+    "pyyaml>=6",
 ]
 
 # The console-script the overlay registry launches as `command` (absolute path to

--- a/operator/connectors/smokeball/smokeball_connector/docgrammar.py
+++ b/operator/connectors/smokeball/smokeball_connector/docgrammar.py
@@ -1,0 +1,243 @@
+"""The drafting content grammar: markdown -> structural blocks, nothing more.
+
+This module is the model-facing half of "code owns typography, the model fills
+content" (ADR 0083). It parses the small markdown subset the drafting lane
+writes into a flat list of blocks with inline runs. It decides NOTHING about
+fonts, spacing, or styles; ``docx_format`` does that per document class.
+
+The subset (documented once, in ``operator/templates/drafting/
+drafting-discipline.md`` Part IV):
+
+* ``#`` / ``##`` / ``###`` headings (the heading TEXT is content: a model writes
+  ``## I. Introduction`` and the numeral stays, because the body cross-references
+  it; the renderer styles the level and never renumbers),
+* paragraphs (blank-line separated) with ``**bold**`` / ``*italic*`` runs,
+* ``-`` / ``*`` bullets,
+* literal ``1.`` numbered items (the number is content; discovery item numbers
+  come from the propounded set, never from a counter),
+* pipe tables (``| a | b |``; an optional ``| --- | --- |`` separator after the
+  first row marks it as a header row),
+* a line that is exactly ``---`` outside a table is a horizontal rule,
+* ``{{...}}`` markers, preserved VERBATIM as their own runs. Markers contain
+  pipes (``{{FILL: date | proof of service}}``) and every shipped skeleton puts
+  them inside table cells, so markers are tokenized BEFORE any cell or emphasis
+  split and restored afterwards. Shredding a marker inside a table is a
+  Pattern-B failure (a cell that reads as a fact), which is why the order of
+  operations here is the whole point of the module.
+
+Anything else renders as plain paragraph text with its characters intact: the
+reader sees it, which remains the only acceptable failure mode in a document an
+attorney reviews.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+# Well-formed markers only; the content gate runs before the renderer so every
+# ``{{`` has its ``}}`` by the time text reaches this module.
+MARKER_RE = re.compile(r"\{\{.*?\}\}", re.DOTALL)
+_HEADING_RE = re.compile(r"^(#{1,3})\s+(.*)$")
+_BULLET_RE = re.compile(r"^[-*]\s+(.*)$")
+_NUMBERED_RE = re.compile(r"^(\d+[.)])\s+(.*)$")
+_HRULE_RE = re.compile(r"^-{3,}$")
+_TABLE_SEP_RE = re.compile(r"^\|?\s*:?-{3,}:?\s*(\|\s*:?-{3,}:?\s*)*\|?$")
+_EMPHASIS_RE = re.compile(r"(\*\*[^*]+\*\*|\*[^*]+\*)")
+
+# Private-use placeholders stand in for markers while cells/emphasis are split.
+_PLACEHOLDER = "{}"
+_PLACEHOLDER_RE = re.compile("(\\d+)")
+
+
+@dataclass(frozen=True)
+class Run:
+    """One inline run. ``marker`` runs are emitted literally and unstyled so a
+    marker is never restyled, hidden, or split by the emphasis pass."""
+
+    text: str
+    bold: bool = False
+    italic: bool = False
+    marker: bool = False
+
+
+@dataclass(frozen=True)
+class Heading:
+    level: int
+    runs: tuple[Run, ...]
+
+    @property
+    def text(self) -> str:
+        return "".join(r.text for r in self.runs)
+
+
+@dataclass(frozen=True)
+class Paragraph:
+    runs: tuple[Run, ...]
+
+    @property
+    def text(self) -> str:
+        return "".join(r.text for r in self.runs)
+
+
+@dataclass(frozen=True)
+class Bullet:
+    runs: tuple[Run, ...]
+
+
+@dataclass(frozen=True)
+class Numbered:
+    label: str  # the literal "1." / "2)" the author wrote
+    runs: tuple[Run, ...]
+
+
+@dataclass(frozen=True)
+class Table:
+    rows: tuple[tuple[tuple[Run, ...], ...], ...]
+    header: bool = False
+
+
+@dataclass(frozen=True)
+class HRule:
+    pass
+
+
+Block = Heading | Paragraph | Bullet | Numbered | Table | HRule
+
+
+@dataclass
+class _MarkerStash:
+    """Marker text tokenized out of a line, restorable by index."""
+
+    markers: list[str] = field(default_factory=list)
+
+    def stash(self, text: str) -> str:
+        def _sub(m: re.Match[str]) -> str:
+            self.markers.append(m.group(0))
+            return _PLACEHOLDER.format(len(self.markers) - 1)
+
+        return MARKER_RE.sub(_sub, text)
+
+    def runs(self, text: str) -> tuple[Run, ...]:
+        """Emphasis-split ``text`` (which may hold placeholders) into runs,
+        then restore each placeholder as a literal, unstyled marker run. The
+        emphasis pass sees the WHOLE line, so ``**LABEL {{marker}}:**`` (the
+        shipped skeletons' item-label shape) bolds the label text around the
+        marker; the marker itself stays verbatim and unstyled."""
+        out: list[Run] = []
+        for run in _emphasis_runs(text):
+            pos = 0
+            for m in _PLACEHOLDER_RE.finditer(run.text):
+                if m.start() > pos:
+                    out.append(Run(run.text[pos : m.start()], run.bold, run.italic))
+                out.append(Run(self.markers[int(m.group(1))], marker=True))
+                pos = m.end()
+            if pos < len(run.text):
+                out.append(Run(run.text[pos:], run.bold, run.italic))
+        return tuple(out)
+
+
+def _emphasis_runs(text: str) -> list[Run]:
+    runs: list[Run] = []
+    for part in _EMPHASIS_RE.split(text):
+        if not part:
+            continue
+        if part.startswith("**") and part.endswith("**") and len(part) > 4:
+            runs.append(Run(part[2:-2], bold=True))
+        elif part.startswith("*") and part.endswith("*") and len(part) > 2:
+            runs.append(Run(part[1:-1], italic=True))
+        else:
+            runs.append(Run(part))
+    return runs
+
+
+def inline_runs(text: str) -> tuple[Run, ...]:
+    """Runs for one line of text: markers verbatim, emphasis applied outside
+    them. The unit every block kind shares."""
+    stash = _MarkerStash()
+    return stash.runs(stash.stash(text))
+
+
+def _is_table_line(line: str) -> bool:
+    # Markers are stashed before this test so a pipe INSIDE a marker cannot
+    # make a prose line look like a table row.
+    stashed = _MarkerStash().stash(line)
+    return stashed.startswith("|") and stashed.count("|") >= 2
+
+
+def _split_cells(line: str) -> tuple[tuple[Run, ...], ...]:
+    stash = _MarkerStash()
+    stashed = stash.stash(line).strip()
+    if stashed.startswith("|"):
+        stashed = stashed[1:]
+    if stashed.endswith("|"):
+        stashed = stashed[:-1]
+    return tuple(stash.runs(cell.strip()) for cell in stashed.split("|"))
+
+
+def _table_sep(line: str) -> bool:
+    return bool(_TABLE_SEP_RE.match(line.strip()))
+
+
+def parse_document(markdown: str) -> list[Block]:
+    """Parse ``markdown`` into blocks. Pure; never raises on unknown syntax
+    (it degrades to a paragraph, visibly)."""
+    blocks: list[Block] = []
+    lines = markdown.splitlines()
+    i = 0
+    n = len(lines)
+    while i < n:
+        line = lines[i].strip()
+        if not line:
+            i += 1
+            continue
+        if _is_table_line(line):
+            rows: list[tuple[tuple[Run, ...], ...]] = []
+            header = False
+            while i < n and _is_table_line(lines[i].strip()):
+                cur = lines[i].strip()
+                if _table_sep(cur):
+                    header = len(rows) == 1
+                else:
+                    rows.append(_split_cells(cur))
+                i += 1
+            if rows:
+                blocks.append(Table(tuple(rows), header=header))
+            continue
+        if _HRULE_RE.match(line):
+            blocks.append(HRule())
+            i += 1
+            continue
+        heading = _HEADING_RE.match(line)
+        if heading:
+            blocks.append(Heading(len(heading.group(1)), inline_runs(heading.group(2).strip())))
+            i += 1
+            continue
+        bullet = _BULLET_RE.match(line)
+        if bullet:
+            blocks.append(Bullet(inline_runs(bullet.group(1).strip())))
+            i += 1
+            continue
+        numbered = _NUMBERED_RE.match(line)
+        if numbered:
+            blocks.append(Numbered(numbered.group(1), inline_runs(numbered.group(2).strip())))
+            i += 1
+            continue
+        blocks.append(Paragraph(inline_runs(line)))
+        i += 1
+    return blocks
+
+
+__all__ = [
+    "MARKER_RE",
+    "Block",
+    "Bullet",
+    "HRule",
+    "Heading",
+    "Numbered",
+    "Paragraph",
+    "Run",
+    "Table",
+    "inline_runs",
+    "parse_document",
+]

--- a/operator/connectors/smokeball/smokeball_connector/docx_base.py
+++ b/operator/connectors/smokeball/smokeball_connector/docx_base.py
@@ -1,0 +1,230 @@
+"""Base-document handling for the format renderer: open the firm's template (or
+the stock starter), clear its body, keep everything else; the named-style
+contract and the product-default look applied when a template lacks a style.
+
+Split out of ``docx_format`` for size only; ``docx_format`` re-exports what the
+tools and tests use. See that module's docstring for the doctrine.
+"""
+
+from __future__ import annotations
+
+import io
+import zipfile
+
+from .docx_format_types import DEFAULT_FONT, DEFAULT_SIZE_PT, NAMED_STYLES, FormatRefused, FormatReport
+
+# ---- Base document -------------------------------------------------------------
+
+_DOTX_MAIN = "application/vnd.openxmlformats-officedocument.wordprocessingml.template.main+xml"
+_DOCX_MAIN = "application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"
+
+
+def _dotx_to_docx_bytes(blob: bytes) -> bytes:
+    """python-docx rejects a ``.dotx`` (template content type). The only
+    difference that matters is one content-type string; rewrite it so the
+    firm's template opens as a document."""
+    src = zipfile.ZipFile(io.BytesIO(blob))
+    out = io.BytesIO()
+    with zipfile.ZipFile(out, "w", zipfile.ZIP_DEFLATED) as dst:
+        for item in src.infolist():
+            data = src.read(item.filename)
+            if item.filename == "[Content_Types].xml":
+                data = data.replace(_DOTX_MAIN.encode(), _DOCX_MAIN.encode())
+            dst.writestr(item, data)
+    return out.getvalue()
+
+
+def _is_dotx(blob: bytes) -> bool:
+    try:
+        with zipfile.ZipFile(io.BytesIO(blob)) as z:
+            return _DOTX_MAIN.encode() in z.read("[Content_Types].xml")
+    except (zipfile.BadZipFile, KeyError):
+        return False
+
+
+def open_as_base(blob: bytes | None, report: FormatReport):
+    """Open the firm's template (or the stock base) and clear its body, keeping
+    the final ``w:sectPr`` so page setup, headers and footers survive.
+
+    A multi-section document is refused: clearing the body would keep only the
+    LAST section's page setup and silently drop the rest, and that is exactly
+    the wrong letterhead on a client letter."""
+    from docx import Document
+    from docx.oxml.ns import qn
+
+    if blob is None:
+        # The STARTER: python-docx's stock base with the authored-standard
+        # docDefaults and the named-style contract defined, self-described in
+        # its properties so a firm opening it in Word knows what it is and that
+        # the styles are theirs to edit. Filed into a library via
+        # render_docx_template(document_class=...), it becomes provenance (b).
+        doc = Document()
+        _rewrite_doc_defaults(doc)
+        _ensure_named_styles(doc, report)
+        cp = doc.core_properties
+        cp.author = "SMD Operator"
+        cp.comments = (
+            "SMD starter template. Typography lives in this file's styles "
+            "(SMD Body, SMD Item Label, SMD Item Text, SMD Heading 1-3, SMD Caption, "
+            "SMD Signature): edit them in Word and the next draft follows."
+        )
+        return doc
+    if _is_dotx(blob):
+        blob = _dotx_to_docx_bytes(blob)
+        report.notes.append("base was a .dotx; opened as a document")
+    doc = Document(io.BytesIO(blob))
+    body = doc.element.body
+    sects = body.findall(qn("w:sectPr"))
+    if len(doc.sections) > 1 or len(sects) > 1:
+        raise FormatRefused(
+            f"the base template has {len(doc.sections)} sections; the renderer keeps one "
+            "section's page setup and would silently drop the rest. Use a single-section "
+            "template (a different first page is fine: that is a header setting, not a section)."
+        )
+    for child in list(body):
+        if child.tag != qn("w:sectPr"):
+            body.remove(child)
+    report.base_header_footer_text = _header_footer_text(doc)
+    return doc
+
+
+def _header_footer_text(doc) -> list[str]:
+    out: list[str] = []
+    for section in doc.sections:
+        parts = [section.header, section.footer]
+        # Only read first-page parts when the section declares them; touching
+        # them otherwise would CREATE empty parts in the firm's file.
+        if section.different_first_page_header_footer:
+            parts += [section.first_page_header, section.first_page_footer]
+        for part in parts:
+            if part.is_linked_to_previous:
+                continue
+            for p in part.paragraphs:
+                t = p.text.strip()
+                if t:
+                    out.append(t)
+    return out
+
+
+def _rewrite_doc_defaults(doc) -> None:
+    """python-docx's stock base carries Calibri 11 with 1.15 line spacing and
+    space-after in docDefaults; every paragraph inherits it. The starter look is
+    the authored standard instead."""
+    from docx.oxml import OxmlElement
+    from docx.oxml.ns import qn
+
+    styles_el = doc.styles.element
+    dd = styles_el.find(qn("w:docDefaults"))
+    if dd is None:
+        dd = OxmlElement("w:docDefaults")
+        styles_el.insert(0, dd)
+    for tag in ("w:rPrDefault", "w:pPrDefault"):
+        old = dd.find(qn(tag))
+        if old is not None:
+            dd.remove(old)
+    rpr_default = OxmlElement("w:rPrDefault")
+    rpr = OxmlElement("w:rPr")
+    fonts = OxmlElement("w:rFonts")
+    for attr in ("w:ascii", "w:hAnsi", "w:eastAsia", "w:cs"):
+        fonts.set(qn(attr), DEFAULT_FONT)
+    rpr.append(fonts)
+    sz = OxmlElement("w:sz")
+    sz.set(qn("w:val"), str(DEFAULT_SIZE_PT * 2))
+    rpr.append(sz)
+    szcs = OxmlElement("w:szCs")
+    szcs.set(qn("w:val"), str(DEFAULT_SIZE_PT * 2))
+    rpr.append(szcs)
+    rpr_default.append(rpr)
+    ppr_default = OxmlElement("w:pPrDefault")
+    ppr = OxmlElement("w:pPr")
+    spacing = OxmlElement("w:spacing")
+    spacing.set(qn("w:after"), "0")
+    spacing.set(qn("w:line"), "240")
+    spacing.set(qn("w:lineRule"), "auto")
+    ppr.append(spacing)
+    ppr_default.append(ppr)
+    dd.append(rpr_default)
+    dd.append(ppr_default)
+    # The stock Normal style also pins Calibri via the theme; make Normal follow.
+    normal = doc.styles["Normal"]
+    _set_font(normal.font, DEFAULT_FONT, DEFAULT_SIZE_PT)
+    normal.paragraph_format.space_after = None
+    normal.paragraph_format.line_spacing = None
+
+
+def _set_font(font, name: str, size_pt: float | None) -> None:
+    """``font.name`` sets only ascii/hAnsi; Word reads eastAsia/cs too, so set
+    all four or a theme font leaks through on some runs."""
+    from docx.oxml.ns import qn
+    from docx.shared import Pt
+
+    font.name = name
+    rpr = font.element.get_or_add_rPr()
+    fonts = rpr.find(qn("w:rFonts"))
+    if fonts is not None:
+        for attr in ("w:ascii", "w:hAnsi", "w:eastAsia", "w:cs"):
+            fonts.set(qn(attr), name)
+    if size_pt is not None:
+        font.size = Pt(size_pt)
+
+
+def has_style(doc, name: str) -> bool:
+    try:
+        doc.styles[name]
+        return True
+    except KeyError:
+        return False
+
+
+def _ensure_named_styles(doc, report: FormatReport) -> None:
+    """Define the named-style contract in a document WE own (the stock base /
+    a starter). Never called on a firm's file: their styles are theirs."""
+    from docx.enum.style import WD_STYLE_TYPE
+
+    for name in NAMED_STYLES:
+        if has_style(doc, name):
+            continue
+        style = doc.styles.add_style(name, WD_STYLE_TYPE.PARAGRAPH)
+        style.base_style = doc.styles["Normal"]
+        _apply_default_style_spec(style, name)
+    report.notes.append("named styles defined on the starter base")
+
+
+def _apply_default_style_spec(style, name: str) -> None:
+    """The product default look for each named style (the starter)."""
+    from docx.enum.text import WD_ALIGN_PARAGRAPH
+    from docx.shared import Inches, Pt
+
+    f, pf = style.font, style.paragraph_format
+    _set_font(f, DEFAULT_FONT, DEFAULT_SIZE_PT)
+    if name == "SMD Item Label":
+        f.bold = True
+        f.underline = True
+        f.all_caps = True
+        pf.space_before = Pt(12)
+    elif name == "SMD Item Text":
+        pf.first_line_indent = Inches(0.5)
+        pf.line_spacing = 2.0
+        pf.space_after = Pt(12)
+    elif name == "SMD Heading 1":
+        f.bold = True
+        pf.alignment = WD_ALIGN_PARAGRAPH.CENTER
+        pf.space_before = Pt(12)
+        pf.space_after = Pt(6)
+        pf.keep_with_next = True
+    elif name == "SMD Heading 2":
+        f.bold = True
+        f.underline = True
+        pf.left_indent = Inches(0.5)
+        pf.space_before = Pt(6)
+        pf.keep_with_next = True
+    elif name == "SMD Heading 3":
+        f.bold = True
+        pf.left_indent = Inches(1.0)
+        pf.keep_with_next = True
+    elif name == "SMD Caption":
+        pf.space_after = Pt(0)
+    elif name == "SMD Signature":
+        pf.left_indent = Inches(3.5)
+        pf.space_before = Pt(24)
+    # SMD Body: Normal + the default font; nothing else.

--- a/operator/connectors/smokeball/smokeball_connector/docx_format.py
+++ b/operator/connectors/smokeball/smokeball_connector/docx_format.py
@@ -1,0 +1,385 @@
+"""Render drafting content INTO a firm's Word template: code owns typography.
+
+This is the typographic half of ADR 0083 ("the model fills content into a
+structure; code owns typography and required elements"). ``docgrammar`` gives
+us blocks; this module decides how each block LOOKS for a given document class,
+and it takes that decision from exactly one place when it can: **the firm's own
+Word template**, a ``.docx`` in the firm's Document Library. The renderer opens
+that file as the base document (page setup, headers/footers/letterhead, styles,
+numbering and theme all survive), clears its body, and writes the content back
+in using a small contract of NAMED PARAGRAPH STYLES. A template that defines a
+named style wins; a template that lacks one gets the class's product default
+applied inline, and the fallback is reported. Nothing is written back into the
+firm's file, ever.
+
+Why typography lives ONLY in the .docx: a firm edits a style in Word and the
+next draft honors it. No config publish, no reboot, no SMD in the loop. That is
+the difference between "formatted by us" and "formatted the way the firm
+formats", and it is the same sentence as "the firm authors its own posture".
+
+Why this module never invents legal content: item numbers come from the
+propounded set; the 35-interrogatory rule is an aggregate across the matter and
+attorney-reserved; a statute-bound declaration is jurisdiction-specific. The
+model writes labels, numerals, captions, signature blocks, and proof of
+service exactly as the skeletons do today; this module STYLES them (a line that
+looks like an item label gets the label style) and adds nothing. Content stays
+under the drafting gates; typography is code.
+
+Named style contract (a firm's template may define any subset):
+  SMD Body, SMD Item Label, SMD Item Text, SMD Heading 1/2/3, SMD Caption,
+  SMD Signature
+
+Refusals (the only ones): a multi-section base document (the body clear would
+silently keep the LAST section's page setup and drop the rest; a wrong
+letterhead on a client letter is worse than an honest "not yet").
+"""
+
+from __future__ import annotations
+
+import io
+import re
+from dataclasses import dataclass
+
+from . import docgrammar as g
+from .docx_base import has_style, open_as_base
+from .docx_format_types import (
+    DEFAULT_FONT,
+    DEFAULT_SIZE_PT,
+    NAMED_STYLES,
+    FormatRefused,
+    FormatReport,
+)
+
+# ---- Document classes and their styling rules --------------------------------
+
+DOCUMENT_CLASSES = (
+    "discovery_set",
+    "discovery_response",
+    "demand_letter",
+    "mediation_brief",
+    "memo",
+    "letter",
+)
+
+# Label shapes the renderer STYLES (it never writes them). Anchored at line
+# start, whole-line by construction of the skeletons ("**SPECIAL INTERROGATORY
+# NO. 7:**"). A mid-paragraph mention is prose and stays body text.
+_DISCOVERY_LABEL = re.compile(
+    r"^(?:RESPONSE TO |SUPPLEMENTAL RESPONSE TO )?"
+    r"(?:SPECIAL INTERROGATOR(?:Y|IES)|FORM INTERROGATOR(?:Y|IES)|"
+    r"REQUESTS? FOR (?:PRODUCTION|ADMISSION|INSPECTION)|INSPECTION DEMANDS?|"
+    r"DEMANDS? FOR (?:PRODUCTION|INSPECTION))"
+    r"\s+NO\.?\s*\S",
+    re.IGNORECASE,
+)
+_DEFINITION_LABEL = re.compile(r"^DEFINITIONS?\b", re.IGNORECASE)
+_LABEL_MAX_CHARS = 90
+
+
+@dataclass(frozen=True)
+class ClassRules:
+    """Per-class styling decisions. Typography values here are the PRODUCT
+    DEFAULTS used only when the base template lacks the named style; they are
+    deliberately the authored standards of the first engagements (plain Word,
+    not pleading paper) and are labeled as starters the firm edits in Word."""
+
+    label_patterns: tuple[re.Pattern[str], ...] = ()
+    # Paragraphs following a label (until the next label/heading/table) are item
+    # text: first-line indented, with the "between items" spacing as spacing
+    # after the paragraph (the authored standard: double-spaced BETWEEN requests,
+    # not more).
+    item_text: bool = False
+    caption_table_first: bool = False  # first table is the caption (court docs)
+    heading_align: tuple[str, str, str] = ("center", "left", "left")
+    heading_underline: tuple[bool, bool, bool] = (False, True, False)
+    heading_indent_in: tuple[float, float, float] = (0.0, 0.5, 1.0)
+    page_numbers: bool = True
+    body_line_spacing: float = 1.0  # multiple
+    item_line_spacing: float = 2.0
+    item_space_after_pt: float = 0.0
+    first_line_indent_in: float = 0.5
+
+
+CLASS_RULES: dict[str, ClassRules] = {
+    "discovery_set": ClassRules(
+        label_patterns=(_DISCOVERY_LABEL, _DEFINITION_LABEL),
+        item_text=True,
+        caption_table_first=True,
+        item_line_spacing=2.0,
+        item_space_after_pt=12.0,
+    ),
+    "discovery_response": ClassRules(
+        label_patterns=(_DISCOVERY_LABEL, _DEFINITION_LABEL),
+        item_text=True,
+        caption_table_first=True,
+        item_line_spacing=2.0,
+        item_space_after_pt=12.0,
+    ),
+    "demand_letter": ClassRules(page_numbers=True, heading_align=("left", "left", "left")),
+    "mediation_brief": ClassRules(
+        caption_table_first=True,
+        heading_align=("center", "left", "left"),
+        heading_underline=(False, True, False),
+        body_line_spacing=2.0,
+    ),
+    "memo": ClassRules(heading_align=("left", "left", "left"), page_numbers=True),
+    "letter": ClassRules(heading_align=("left", "left", "left"), page_numbers=False),
+}
+
+# ---- Rendering -----------------------------------------------------------------
+
+
+def render_document(
+    markdown: str,
+    document_class: str,
+    base_bytes: bytes | None,
+    report: FormatReport | None = None,
+) -> tuple[bytes, FormatReport]:
+    """Render ``markdown`` for ``document_class`` into ``base_bytes`` (the firm's
+    template) or the stock starter base. Pure: no network, no client."""
+    if document_class not in CLASS_RULES:
+        raise ValueError(f"unknown document_class {document_class!r}; known: {', '.join(DOCUMENT_CLASSES)}")
+    rules = CLASS_RULES[document_class]
+    report = report or FormatReport(document_class=document_class)
+    doc = open_as_base(base_bytes, report)
+    writer = _Writer(doc, rules, report)
+    for block in g.parse_document(markdown):
+        writer.write(block)
+    if rules.page_numbers:
+        writer.ensure_page_number()
+    buf = io.BytesIO()
+    doc.save(buf)
+    return buf.getvalue(), report
+
+
+class _Writer:
+    def __init__(self, doc, rules: ClassRules, report: FormatReport) -> None:
+        self.doc = doc
+        self.rules = rules
+        self.report = report
+        self.in_item = False
+        self.tables_seen = 0
+
+    # -- style application ------------------------------------------------------
+
+    def _para(self, style_name: str):
+        """Add a paragraph in ``style_name`` if the base defines it; otherwise a
+        plain paragraph the caller formats inline (and the fallback is logged)."""
+        if has_style(self.doc, style_name):
+            self.report.styles_honored.append(style_name)
+            return self.doc.add_paragraph(style=style_name), True
+        self.report.fallbacks.append(style_name)
+        return self.doc.add_paragraph(), False
+
+    def _runs(self, para, runs: tuple[g.Run, ...], *, caps: bool = False, bold: bool = False, underline: bool = False) -> None:
+        for r in runs:
+            run = para.add_run(r.text)
+            if r.marker:
+                continue  # literal, unstyled, render-visible
+            if r.bold or bold:
+                run.bold = True
+            if r.italic:
+                run.italic = True
+            if underline:
+                run.underline = True
+            if caps:
+                run.font.all_caps = True
+
+    # -- blocks ------------------------------------------------------------------
+
+    def write(self, block: g.Block) -> None:
+        if isinstance(block, g.Heading):
+            self._heading(block)
+        elif isinstance(block, g.Paragraph):
+            self._paragraph(block)
+        elif isinstance(block, g.Bullet):
+            self._bullet(block)
+        elif isinstance(block, g.Numbered):
+            self._numbered(block)
+        elif isinstance(block, g.Table):
+            self._table(block)
+        elif isinstance(block, g.HRule):
+            self._hrule()
+
+    def _heading(self, block: g.Heading) -> None:
+        from docx.enum.text import WD_ALIGN_PARAGRAPH
+        from docx.shared import Inches, Pt
+
+        self.in_item = False
+        self.report.blocks_styled["headings"] += 1
+        level = block.level
+        para, styled = self._para(f"SMD Heading {level}")
+        if styled:
+            self._runs(para, block.runs)
+            return
+        align = self.rules.heading_align[level - 1]
+        para.alignment = {"center": WD_ALIGN_PARAGRAPH.CENTER, "left": WD_ALIGN_PARAGRAPH.LEFT}[align]
+        para.paragraph_format.left_indent = Inches(self.rules.heading_indent_in[level - 1])
+        para.paragraph_format.space_before = Pt(12 if level == 1 else 6)
+        para.paragraph_format.keep_with_next = True
+        self._runs(para, block.runs, bold=True, underline=self.rules.heading_underline[level - 1])
+
+    def _is_label(self, text: str) -> bool:
+        # A label is a SHORT line that starts with a label phrase ("SPECIAL
+        # INTERROGATORY NO. 7:"); a prose sentence that happens to open with the
+        # same words is body text. The length cap is the tie-breaker.
+        t = text.strip().strip("*").strip()
+        return len(t) <= _LABEL_MAX_CHARS and any(p.match(t) for p in self.rules.label_patterns)
+
+    def _paragraph(self, block: g.Paragraph) -> None:
+        from docx.shared import Inches, Pt
+
+        if self._is_label(block.text):
+            self.report.blocks_styled["labels"] += 1
+            self.in_item = True
+            para, styled = self._para("SMD Item Label")
+            if styled:
+                self._runs(para, block.runs)
+            else:
+                para.paragraph_format.space_before = Pt(12)
+                self._runs(para, block.runs, caps=True, bold=True, underline=True)
+            return
+        if self.in_item and self.rules.item_text:
+            para, styled = self._para("SMD Item Text")
+            if not styled:
+                pf = para.paragraph_format
+                pf.first_line_indent = Inches(self.rules.first_line_indent_in)
+                pf.line_spacing = self.rules.item_line_spacing
+                pf.space_after = Pt(self.rules.item_space_after_pt)
+            self._runs(para, block.runs)
+            return
+        para, styled = self._para("SMD Body")
+        if not styled and self.rules.body_line_spacing != 1.0:
+            para.paragraph_format.line_spacing = self.rules.body_line_spacing
+        self._runs(para, block.runs)
+
+    def _bullet(self, block: g.Bullet) -> None:
+        from docx.shared import Inches
+
+        if has_style(self.doc, "List Bullet"):
+            para = self.doc.add_paragraph(style="List Bullet")
+            self._runs(para, block.runs)
+            return
+        para = self.doc.add_paragraph()
+        para.paragraph_format.left_indent = Inches(0.5)
+        para.paragraph_format.first_line_indent = Inches(-0.25)
+        para.add_run("•\t")
+        self._runs(para, block.runs)
+
+    def _numbered(self, block: g.Numbered) -> None:
+        from docx.shared import Inches
+
+        para, _ = self._para("SMD Body")
+        para.paragraph_format.left_indent = Inches(0.5)
+        para.paragraph_format.first_line_indent = Inches(-0.5)
+        para.add_run(f"{block.label}\t")
+        self._runs(para, block.runs)
+
+    def _table(self, block: g.Table) -> None:
+        self.in_item = False
+        self.tables_seen += 1
+        self.report.blocks_styled["tables"] += 1
+        ncols = max(len(row) for row in block.rows)
+        table = self.doc.add_table(rows=len(block.rows), cols=ncols)
+        caption = self.rules.caption_table_first and self.tables_seen == 1
+        _set_table_borders(table, inside_vertical_only=caption)
+        for r_idx, row in enumerate(block.rows):
+            for c_idx in range(ncols):
+                cell = table.cell(r_idx, c_idx)
+                runs = row[c_idx] if c_idx < len(row) else ()
+                para = cell.paragraphs[0]
+                if caption and has_style(self.doc, "SMD Caption"):
+                    para.style = self.doc.styles["SMD Caption"]
+                    self.report.styles_honored.append("SMD Caption")
+                self._runs(para, runs, bold=(block.header and r_idx == 0))
+        # Breathing room after a table: an empty body paragraph.
+        self.doc.add_paragraph()
+
+    def _hrule(self) -> None:
+        from docx.oxml import OxmlElement
+        from docx.oxml.ns import qn
+
+        self.in_item = False
+        para = self.doc.add_paragraph()
+        ppr = para._p.get_or_add_pPr()
+        pbdr = OxmlElement("w:pBdr")
+        bottom = OxmlElement("w:bottom")
+        bottom.set(qn("w:val"), "single")
+        bottom.set(qn("w:sz"), "6")
+        bottom.set(qn("w:space"), "1")
+        bottom.set(qn("w:color"), "auto")
+        pbdr.append(bottom)
+        ppr.append(pbdr)
+
+    # -- footer --------------------------------------------------------------------
+
+    def ensure_page_number(self) -> None:
+        """Add a centered PAGE field to the footer when the base has no footer
+        text at all. A base with its own footer (a letterhead's address line, a
+        firm's own page numbering) is left exactly as the firm built it."""
+        from docx.enum.text import WD_ALIGN_PARAGRAPH
+        from docx.oxml import OxmlElement
+        from docx.oxml.ns import qn
+
+        section = self.doc.sections[0]
+        footer = section.footer
+        existing = "".join(p.text for p in footer.paragraphs).strip()
+        if existing or _footer_has_field(footer):
+            return
+        para = footer.paragraphs[0] if footer.paragraphs else footer.add_paragraph()
+        para.alignment = WD_ALIGN_PARAGRAPH.CENTER
+        run = para.add_run()
+        for kind, text in (("begin", None), (None, "PAGE"), ("end", None)):
+            if kind:
+                el = OxmlElement("w:fldChar")
+                el.set(qn("w:fldCharType"), kind)
+            else:
+                el = OxmlElement("w:instrText")
+                el.set(qn("xml:space"), "preserve")
+                el.text = f" {text} "
+            run._r.append(el)
+        self.report.notes.append("page number field added to the footer")
+
+
+def _footer_has_field(footer) -> bool:
+    from docx.oxml.ns import qn
+
+    return footer._element.find(f".//{qn('w:fldChar')}") is not None or footer._element.find(f".//{qn('w:fldSimple')}") is not None
+
+
+def _set_table_borders(table, *, inside_vertical_only: bool) -> None:
+    """Explicit ``w:tblBorders`` via lxml: a firm template rarely defines
+    ``Table Grid``, so never rely on a table style existing. A caption table
+    gets the classic look (a vertical rule between the columns, nothing else);
+    every other table gets a thin grid."""
+    from docx.oxml import OxmlElement
+    from docx.oxml.ns import qn
+
+    tbl_pr = table._tbl.tblPr
+    borders = OxmlElement("w:tblBorders")
+    edges = ("insideV",) if inside_vertical_only else ("top", "left", "bottom", "right", "insideH", "insideV")
+    for edge in edges:
+        el = OxmlElement(f"w:{edge}")
+        el.set(qn("w:val"), "single")
+        el.set(qn("w:sz"), "4")
+        el.set(qn("w:space"), "0")
+        el.set(qn("w:color"), "auto")
+        borders.append(el)
+    for old in tbl_pr.findall(qn("w:tblBorders")):
+        tbl_pr.remove(old)
+    tbl_pr.append(borders)
+
+
+__all__ = [
+    "CLASS_RULES",
+    "DEFAULT_FONT",
+    "DEFAULT_SIZE_PT",
+    "DOCUMENT_CLASSES",
+    "NAMED_STYLES",
+    "ClassRules",
+    "FormatRefused",
+    "FormatReport",
+    "has_style",
+    "open_as_base",
+    "render_document",
+]

--- a/operator/connectors/smokeball/smokeball_connector/docx_format_types.py
+++ b/operator/connectors/smokeball/smokeball_connector/docx_format_types.py
@@ -1,0 +1,56 @@
+"""Shared types and constants for the format renderer (no python-docx import)."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+# Product default typography (the starter look). One place, by design.
+DEFAULT_FONT = "Times New Roman"
+DEFAULT_SIZE_PT = 12
+
+NAMED_STYLES = (
+    "SMD Body",
+    "SMD Item Label",
+    "SMD Item Text",
+    "SMD Heading 1",
+    "SMD Heading 2",
+    "SMD Heading 3",
+    "SMD Caption",
+    "SMD Signature",
+)
+
+
+class FormatRefused(RuntimeError):
+    """The base document cannot be used as a template; nothing is rendered."""
+
+
+@dataclass
+class FormatReport:
+    """What the renderer actually applied, for the delivery note. Honest by
+    construction: every fallback is listed, the base's header/footer text is
+    surfaced (it bypasses every content gate), and ``templateExpected`` lets
+    the note say "the firm's template did not resolve" instead of a null that
+    reads like "never configured"."""
+
+    document_class: str
+    template_used: dict[str, Any] | None = None
+    template_expected: bool = False
+    base_header_footer_text: list[str] = field(default_factory=list)
+    styles_honored: list[str] = field(default_factory=list)
+    fallbacks: list[str] = field(default_factory=list)
+    blocks_styled: dict[str, int] = field(default_factory=lambda: {"labels": 0, "tables": 0, "headings": 0})
+    notes: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        d = asdict(self)
+        return {
+            "class": d["document_class"],
+            "templateUsed": d["template_used"],
+            "templateExpected": d["template_expected"],
+            "baseHeaderFooterText": d["base_header_footer_text"],
+            "stylesHonored": sorted(set(d["styles_honored"])),
+            "fallbacks": sorted(set(d["fallbacks"])),
+            "blocksStyled": d["blocks_styled"],
+            "notes": d["notes"],
+        }

--- a/operator/connectors/smokeball/smokeball_connector/extract.py
+++ b/operator/connectors/smokeball/smokeball_connector/extract.py
@@ -26,7 +26,7 @@ def extract_text(blob: bytes, *, file_name: str = "", file_extension: str = "") 
     ext = (file_extension or "").lower().lstrip(".")
     if blob.startswith(_PDF_MAGIC) or ext == "pdf":
         return _pdf_text(blob)
-    if blob.startswith(_ZIP_MAGIC) and (ext in ("docx", "") or _looks_like_docx(blob)):
+    if blob.startswith(_ZIP_MAGIC) and (ext in ("docx", "dotx", "docm", "dotm", "") or _looks_like_docx(blob)):
         return _docx_text(blob)
     if ext in ("txt", "text", "md", "csv", "log", "eml"):
         return blob.decode("utf-8", "replace")
@@ -59,6 +59,14 @@ def _pdf_text(blob: bytes) -> str:
 def _docx_text(blob: bytes) -> str:
     from docx import Document
 
+    from .docx_base import _dotx_to_docx_bytes, _is_dotx
+
+    # A Word TEMPLATE (.dotx/.dotm) is a .docx with one content-type string
+    # changed; python-docx refuses it as-is. A firm's letterhead template filed
+    # on a matter must extract like any other document, not poison every
+    # record check on that matter.
+    if _is_dotx(blob):
+        blob = _dotx_to_docx_bytes(blob)
     try:
         doc = Document(io.BytesIO(blob))
     except Exception as exc:  # noqa: BLE001 - malformed DOCX must fail closed, not crash the server

--- a/operator/connectors/smokeball/smokeball_connector/library.py
+++ b/operator/connectors/smokeball/smokeball_connector/library.py
@@ -1,0 +1,240 @@
+"""Deterministic resolution of the firm's format template for a document class.
+
+The model never chooses typography, and that includes never choosing WHICH
+template. This module resolves the one class template from the authored
+library location, the same way every time:
+
+    customer.yaml  self_initiation.document_library.{matter_number, folder_name,
+                   templates?}            (the live seat copy, world-readable)
+      -> the library matter (by its matter number)
+      -> the library folder (by name)
+      -> the file named ``templates[class]`` or ``Template - <Class>.docx``
+      -> its bytes (``client.download_file``)
+
+"Not resolved" is a first-class, reported outcome, never a refusal: the draft
+still files, on the starter base, and ``FormatReport.template_expected`` lets
+the delivery note say plainly that the firm's template did not resolve and why.
+A rename, a moved folder, an unauthored location: each is a sentence in the
+note, not a silent fallback that reads like "never configured".
+
+The live customer.yaml is the registered "config-as-data" shape (the block the
+self-initiation conductor reads the same way); a connector process cannot rely
+on env inheritance from the gateway, so the path is a fixed default with an env
+override for tests and local runs.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+DEFAULT_CUSTOMER_YAML = "/var/lib/smd-config/customer.yaml"
+CUSTOMER_YAML_ENV = "SMD_CUSTOMER_YAML_PATH"
+
+CLASS_TITLES: dict[str, str] = {
+    "discovery_set": "Discovery Set",
+    "discovery_response": "Discovery Response",
+    "demand_letter": "Demand Letter",
+    "mediation_brief": "Mediation Brief",
+    "memo": "Memo",
+    "letter": "Letter",
+}
+
+
+@dataclass(frozen=True)
+class LibraryConfig:
+    authored: bool
+    matter_number: str | None = None
+    folder_name: str | None = None
+    templates: dict[str, str] = field(default_factory=dict)
+    source: str = ""
+
+    def template_name(self, document_class: str) -> str:
+        custom = self.templates.get(document_class)
+        if custom:
+            return custom if custom.lower().endswith(".docx") else f"{custom}.docx"
+        return f"Template - {CLASS_TITLES.get(document_class, document_class)}.docx"
+
+
+def load_library_config(path: str | None = None) -> LibraryConfig:
+    """Read the library location from the seat's live customer.yaml. Missing
+    file, missing block, or an unparseable file all mean "not authored"; the
+    reason is carried in ``source`` for the report."""
+    path = path or os.environ.get(CUSTOMER_YAML_ENV) or DEFAULT_CUSTOMER_YAML
+    try:
+        with open(path, encoding="utf-8") as fh:
+            raw = fh.read()
+    except OSError as exc:
+        return LibraryConfig(authored=False, source=f"customer.yaml not readable at {path}: {exc.__class__.__name__}")
+    try:
+        import yaml
+
+        data = yaml.safe_load(raw) or {}
+    except Exception as exc:  # noqa: BLE001 - an unparseable config is "not authored", reported
+        return LibraryConfig(authored=False, source=f"customer.yaml not parseable: {exc.__class__.__name__}")
+    block = ((data.get("self_initiation") or {}).get("document_library")) if isinstance(data, dict) else None
+    if not isinstance(block, dict):
+        return LibraryConfig(authored=False, source="self_initiation.document_library not authored")
+    templates = block.get("templates") or {}
+    if not isinstance(templates, dict):
+        templates = {}
+    number = block.get("matter_number")
+    return LibraryConfig(
+        authored=bool(number) and bool(block.get("folder_name")),
+        matter_number=str(number).strip() if number else None,
+        folder_name=str(block.get("folder_name")).strip() if block.get("folder_name") else None,
+        templates={str(k): str(v) for k, v in templates.items()},
+        source=path,
+    )
+
+
+@dataclass(frozen=True)
+class ResolvedTemplate:
+    bytes: bytes
+    name: str
+    file_id: str
+    matter_id: str
+    folder_id: str | None
+
+
+@dataclass(frozen=True)
+class NotResolved:
+    reason: str
+    matter_id: str | None = None
+    folder_id: str | None = None
+
+
+def _listing(resp: Any) -> list[dict[str, Any]]:
+    if isinstance(resp, list):
+        return [e for e in resp if isinstance(e, dict)]
+    if isinstance(resp, dict):
+        for key in ("value", "items", "results", "data"):
+            if isinstance(resp.get(key), list):
+                return [e for e in resp[key] if isinstance(e, dict)]
+    return []
+
+
+def _norm(s: Any) -> str:
+    return re.sub(r"\s+", " ", str(s or "")).strip().casefold()
+
+
+def find_matter_id(client: Any, matter_number: str) -> str | None:
+    """Exact match on the matter ``number`` field. Search first (cheap), then
+    page the listing; the number is the stable human-legible key a firm
+    authors, never an internal id."""
+    want = _norm(matter_number)
+    try:
+        resp = client.get("/matters", Search=matter_number, Limit=50, Offset=0)
+        for m in _listing(resp):
+            if _norm(m.get("number")) == want:
+                return str(m.get("id"))
+    except Exception:  # noqa: BLE001 - fall through to paging
+        pass
+    offset = 0
+    while True:
+        try:
+            resp = client.get("/matters", Limit=500, Offset=offset)
+        except Exception:  # noqa: BLE001
+            return None
+        items = _listing(resp)
+        for m in items:
+            if _norm(m.get("number")) == want:
+                return str(m.get("id"))
+        if len(items) < 500:
+            return None
+        offset += 500
+
+
+def find_folder_id(client: Any, matter_id: str, folder_name: str) -> str | None:
+    try:
+        resp = client.get(f"/matters/{matter_id}/documents/folders", Limit=500, Offset=0)
+    except Exception:  # noqa: BLE001
+        return None
+    want = _norm(folder_name)
+    for f in _listing(resp):
+        if _norm(f.get("name")) == want:
+            return str(f.get("id"))
+    return None
+
+
+def list_matter_files(client: Any, matter_id: str) -> list[dict[str, Any]]:
+    files: list[dict[str, Any]] = []
+    offset = 0
+    while True:
+        try:
+            resp = client.get(f"/matters/{matter_id}/documents/files", Limit=500, Offset=offset)
+        except Exception:  # noqa: BLE001
+            break
+        items = _listing(resp)
+        files.extend(items)
+        if len(items) < 500:
+            break
+        offset += 500
+    return files
+
+
+def _entry_folder_id(entry: dict[str, Any]) -> str | None:
+    for key in ("folderId", "folder_id", "parentFolderId"):
+        if entry.get(key):
+            return str(entry[key])
+    return None
+
+
+def resolve_template(client: Any, cfg: LibraryConfig, document_class: str) -> ResolvedTemplate | NotResolved:
+    """The one class template, or the reason there is none. Never raises on a
+    missing piece; a transport error downloading a FOUND template does raise,
+    because silently rendering on the starter when the firm's file exists would
+    misreport the format."""
+    if not cfg.authored:
+        return NotResolved(f"document library location not authored ({cfg.source or 'self_initiation.document_library'})")
+    matter_id = find_matter_id(client, cfg.matter_number or "")
+    if not matter_id:
+        return NotResolved(f"library matter {cfg.matter_number!r} not found")
+    folder_id = find_folder_id(client, matter_id, cfg.folder_name or "")
+    want = _norm(cfg.template_name(document_class))
+    candidates = [e for e in list_matter_files(client, matter_id) if _norm(e.get("name")) == want]
+    if folder_id:
+        in_folder = [e for e in candidates if _entry_folder_id(e) == folder_id]
+        if in_folder:
+            candidates = in_folder
+    if not candidates:
+        where = f"folder {cfg.folder_name!r}" if folder_id else f"matter {cfg.matter_number!r} (folder {cfg.folder_name!r} not found)"
+        return NotResolved(f"no file named {cfg.template_name(document_class)!r} in {where}", matter_id=matter_id, folder_id=folder_id)
+    # Newest wins when a firm re-uploads under the same name.
+    candidates.sort(key=lambda e: str(e.get("dateCreated") or e.get("createdDate") or ""), reverse=True)
+    chosen = candidates[0]
+    file_id = str(chosen.get("id") or chosen.get("fileId"))
+    _meta, blob = client.download_file(matter_id, file_id)
+    return ResolvedTemplate(bytes=blob, name=str(chosen.get("name")), file_id=file_id, matter_id=matter_id, folder_id=folder_id)
+
+
+def is_library_file(entry: dict[str, Any], cfg: LibraryConfig, library_folder_id: str | None) -> bool:
+    """Templates are not record: a library file must never be a record-check
+    source (a header-only letterhead extracts to nothing and would refuse the
+    whole draft). Match by the class-template naming convention, and by folder
+    when the listing carries a folder id and the library folder is known."""
+    name = _norm(entry.get("name"))
+    if any(name == _norm(cfg.template_name(cls)) for cls in CLASS_TITLES):
+        return True
+    if name.startswith("template - ") and name.endswith(".docx"):
+        return True
+    folder = _entry_folder_id(entry)
+    return bool(library_folder_id and folder and folder == library_folder_id)
+
+
+__all__ = [
+    "CLASS_TITLES",
+    "CUSTOMER_YAML_ENV",
+    "DEFAULT_CUSTOMER_YAML",
+    "LibraryConfig",
+    "NotResolved",
+    "ResolvedTemplate",
+    "find_folder_id",
+    "find_matter_id",
+    "is_library_file",
+    "list_matter_files",
+    "load_library_config",
+    "resolve_template",
+]

--- a/operator/connectors/smokeball/smokeball_connector/server.py
+++ b/operator/connectors/smokeball/smokeball_connector/server.py
@@ -1449,12 +1449,50 @@ def file_attachment_to_matter(
     return client.add_file(matter_id, file_name, blob, folder_id=folder_id)
 
 
+def _render_with_format(markdown: str, document_class: str | None) -> tuple[bytes, dict[str, Any] | None, str | None]:
+    """Shared by both render tools. Returns ``(bytes, formatApplied, refusal)``;
+    on a refusal ``bytes`` is empty and nothing must be uploaded."""
+    from .docx_format import DOCUMENT_CLASSES, FormatRefused, FormatReport, render_document
+    from .library import NotResolved, load_library_config, resolve_template
+    from .render import render_markdown_to_docx
+
+    if not document_class:
+        return render_markdown_to_docx(markdown), None, None
+    if document_class not in DOCUMENT_CLASSES:
+        return b"", None, (
+            f"unknown document_class {document_class!r}; one of: {', '.join(DOCUMENT_CLASSES)}"
+        )
+    report = FormatReport(document_class=document_class)
+    cfg = load_library_config()
+    report.template_expected = cfg.authored
+    base: bytes | None = None
+    try:
+        resolved = resolve_template(_get_client(), cfg, document_class)
+    except Exception as exc:  # noqa: BLE001 - a found template that would not download: say so, render on the starter
+        resolved = NotResolved(f"template found but could not be downloaded: {exc.__class__.__name__}")
+    if isinstance(resolved, NotResolved):
+        report.notes.append(f"firm template not used: {resolved.reason}")
+    else:
+        base = resolved.bytes
+        report.template_used = {
+            "name": resolved.name,
+            "fileId": resolved.file_id,
+            "sha256": hashlib.sha256(resolved.bytes).hexdigest(),
+        }
+    try:
+        data, report = render_document(markdown, document_class, base, report)
+    except FormatRefused as exc:
+        return b"", report.to_dict(), f"format refused: {exc}"
+    return data, report.to_dict(), None
+
+
 @server.tool()
 def render_docx_template(
     matter_id: str,
     file_name: str,
     skeleton_markdown: str,
     folder_id: str | None = None,
+    document_class: str | None = None,
 ) -> Any:
     """Render a document TEMPLATE (markdown skeleton) to a real Word .docx and
     file it on a matter. This is the only path that produces a .docx: the
@@ -1501,13 +1539,35 @@ def render_docx_template(
     tool does not poll: confirm the file exists with ``get_file``, and confirm
     it is the document with ``read_document``, before reporting it delivered.
 
+
+
+    **Firm format (``document_class``).** Pass ``document_class`` (one of
+    ``discovery_set``, ``discovery_response``, ``demand_letter``,
+    ``mediation_brief``, ``memo``, ``letter``) and the .docx is rendered INTO the
+    firm's own Word template for that class when one is authored in the firm's
+    Document Library (resolved here, deterministically, from the seat's
+    customer.yaml: you never pick a template), else onto the SMD starter base
+    (Times New Roman 12, the named styles defined). Code owns typography; you
+    write content only. The grammar you write is small: ``#``/``##``/``###``
+    headings (write the numeral yourself, ``## I. Introduction``; the renderer
+    styles the level and never renumbers), paragraphs with ``**bold**``/
+    ``*italic*``, ``-`` bullets, literal ``1.`` numbered items, pipe tables
+    (``| a | b |``, a ``| --- |`` row after the first makes it a header row;
+    the FIRST table in a court document is styled as the caption), ``---`` as a
+    horizontal rule, and ``{{...}}`` markers kept verbatim. A SHORT line that
+    starts with an item label (``**SPECIAL INTERROGATORY NO. 7:**``, ``REQUEST
+    FOR PRODUCTION NO. 3:``) is styled as a label and the paragraphs after it as
+    item text; write the label and its NUMBER yourself, from the propounded
+    set. Write the caption, signature block, and proof of service as content
+    exactly as the skeleton shows; nothing is added by code, including any
+    declaration or count. The return carries ``formatApplied`` (template used
+    or starter, ``templateExpected``, fallbacks, the template's header/footer
+    text): state it honestly in the delivery note. Omit ``document_class`` for
+    the legacy stock render, unchanged.
+
     Classified INTERNAL_WRITE at the overlay: the Operator writing a template
     into the firm's own record. Nothing leaves the firm."""
-    from .render import (
-        TemplateContentRefused,
-        check_template_content,
-        render_markdown_to_docx,
-    )
+    from .render import TemplateContentRefused, check_template_content
 
     if not file_name.lower().endswith(".docx"):
         file_name = f"{file_name}.docx"
@@ -1522,7 +1582,17 @@ def render_docx_template(
             "sizeBytes": None,
             "refusals": [str(v) for v in exc.violations],
         }
-    data = render_markdown_to_docx(skeleton_markdown)
+    data, format_applied, refusal = _render_with_format(skeleton_markdown, document_class)
+    if refusal:
+        return {
+            "matterId": matter_id,
+            "fileName": file_name,
+            "fileId": None,
+            "sha256": None,
+            "sizeBytes": None,
+            "refusals": [refusal],
+            "formatApplied": format_applied,
+        }
     result = add_file(
         matter_id,
         file_name,
@@ -1533,6 +1603,8 @@ def render_docx_template(
     out["sha256"] = hashlib.sha256(data).hexdigest()
     out["sizeBytes"] = len(data)
     out["refusals"] = []
+    if format_applied is not None:
+        out["formatApplied"] = format_applied
     return out
 
 
@@ -1544,13 +1616,21 @@ def _collect_matter_sources(matter_id: str) -> tuple[list[tuple[str, str]], list
     correctly quoted passage look fabricated to gate 2a, so the caller REFUSES
     on it rather than checking against a partial record."""
     from .extract import extract_text
+    from .library import find_folder_id, is_library_file, load_library_config
 
     client = _get_client()
     listing = client.get(f"/matters/{matter_id}/documents/files", Limit=500, Offset=0)
     entries = listing.get("value") if isinstance(listing, dict) else listing
+    # Templates are not record. A firm's letterhead template (header-only, so
+    # it extracts to nothing) or a .dotx filed in the Document Library would
+    # otherwise land in ``unextractable`` and refuse every draft on the matter.
+    lib_cfg = load_library_config()
+    lib_folder = find_folder_id(client, matter_id, lib_cfg.folder_name) if lib_cfg.folder_name else None
     sources: list[tuple[str, str]] = []
     unextractable: list[str] = []
     for entry in entries or []:
+        if is_library_file(entry, lib_cfg, lib_folder):
+            continue
         name = str(entry.get("name") or entry.get("id") or "document")
         try:
             _meta, blob = client.download_file(matter_id, entry["id"])
@@ -1574,6 +1654,7 @@ def render_docx_draft(
     draft_markdown: str,
     folder_id: str | None = None,
     held_out_file_names: list[str] | None = None,
+    document_class: str | None = None,
 ) -> Any:
     """Render a FILLED DRAFT (markdown) to a real Word .docx and file it on a
     matter, for attorney review. The sibling of ``render_docx_template``, and the
@@ -1622,16 +1703,35 @@ def render_docx_draft(
     tool does not poll: confirm with ``get_file``, and confirm it is the document
     with ``read_document``, before reporting it delivered.
 
+    **Firm format (``document_class``).** Pass ``document_class`` (one of
+    ``discovery_set``, ``discovery_response``, ``demand_letter``,
+    ``mediation_brief``, ``memo``, ``letter``) and the .docx is rendered INTO the
+    firm's own Word template for that class when one is authored in the firm's
+    Document Library (resolved here, deterministically, from the seat's
+    customer.yaml: you never pick a template), else onto the SMD starter base
+    (Times New Roman 12, the named styles defined). Code owns typography; you
+    write content only. The grammar you write is small: ``#``/``##``/``###``
+    headings (write the numeral yourself, ``## I. Introduction``; the renderer
+    styles the level and never renumbers), paragraphs with ``**bold**``/
+    ``*italic*``, ``-`` bullets, literal ``1.`` numbered items, pipe tables
+    (``| a | b |``, a ``| --- |`` row after the first makes it a header row;
+    the FIRST table in a court document is styled as the caption), ``---`` as a
+    horizontal rule, and ``{{...}}`` markers kept verbatim. A SHORT line that
+    starts with an item label (``**SPECIAL INTERROGATORY NO. 7:**``, ``REQUEST
+    FOR PRODUCTION NO. 3:``) is styled as a label and the paragraphs after it as
+    item text; write the label and its NUMBER yourself, from the propounded
+    set. Write the caption, signature block, and proof of service as content
+    exactly as the skeleton shows; nothing is added by code, including any
+    declaration or count. The return carries ``formatApplied`` (template used
+    or starter, ``templateExpected``, fallbacks, the template's header/footer
+    text): state it honestly in the delivery note. Omit ``document_class`` for
+    the legacy stock render, unchanged.
+
     Classified INTERNAL_WRITE at the overlay: the Operator saving its own work
     product into the firm's record. Nothing leaves the firm; delivery to anyone
     outside is a separate, separately-gated act."""
-    from .render import (
-        TemplateContentRefused,
-        check_draft_content,
-        render_markdown_to_docx,
-    )
-
     from .record_check import run_record_check
+    from .render import TemplateContentRefused, check_draft_content
 
     if not file_name.lower().endswith(".docx"):
         file_name = f"{file_name}.docx"
@@ -1671,7 +1771,17 @@ def render_docx_draft(
             "checkedSources": verdict.checked_sources,
         }
 
-    data = render_markdown_to_docx(draft_markdown)
+    data, format_applied, refusal = _render_with_format(draft_markdown, document_class)
+    if refusal:
+        return {
+            "matterId": matter_id,
+            "fileName": file_name,
+            "fileId": None,
+            "sha256": None,
+            "sizeBytes": None,
+            "refusals": [refusal],
+            "formatApplied": format_applied,
+        }
     result = add_file(
         matter_id,
         file_name,
@@ -1682,6 +1792,8 @@ def render_docx_draft(
     out["sha256"] = hashlib.sha256(data).hexdigest()
     out["sizeBytes"] = len(data)
     out["refusals"] = []
+    if format_applied is not None:
+        out["formatApplied"] = format_applied
     return out
 
 

--- a/operator/connectors/smokeball/tests/test_docgrammar.py
+++ b/operator/connectors/smokeball/tests/test_docgrammar.py
@@ -1,0 +1,103 @@
+"""docgrammar: structure only, markers verbatim through every split.
+
+The load-bearing cases are the ones a naive parser gets wrong in a way that
+reads as a FACT in the rendered document (Pattern B): a marker containing a
+pipe inside a table cell, a marker inside an emphasis span, a pipe inside a
+marker on a prose line.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from smokeball_connector.docgrammar import (
+    Bullet,
+    Heading,
+    HRule,
+    Numbered,
+    Paragraph,
+    Table,
+    inline_runs,
+    parse_document,
+)
+
+
+def _texts(runs):
+    return [r.text for r in runs]
+
+
+def test_marker_with_pipe_inside_a_table_cell_survives_intact() -> None:
+    md = "| Set served | {{FILL: date | proof of service on the set}} |\n| --- | --- |\n| Method | {{FILL: method | proof of service}} |"
+    (table,) = parse_document(md)
+    assert isinstance(table, Table)
+    assert table.header is True
+    assert len(table.rows) == 2
+    assert [len(row) for row in table.rows] == [2, 2]
+    cell = table.rows[0][1]
+    assert len(cell) == 1 and cell[0].marker
+    assert cell[0].text == "{{FILL: date | proof of service on the set}}"
+
+
+def test_a_pipe_inside_a_marker_does_not_make_prose_a_table_row() -> None:
+    md = "Served on {{FILL: date | proof of service}} by mail."
+    (para,) = parse_document(md)
+    assert isinstance(para, Paragraph)
+    assert para.text == md
+
+
+def test_emphasis_spans_a_marker_and_the_marker_stays_unstyled() -> None:
+    runs = inline_runs("**REQUEST FOR PRODUCTION NO. {{FILL: number | propounded set}}:**")
+    assert _texts(runs) == [
+        "REQUEST FOR PRODUCTION NO. ",
+        "{{FILL: number | propounded set}}",
+        ":",
+    ]
+    assert runs[0].bold and runs[2].bold
+    assert runs[1].marker and not runs[1].bold
+
+
+def test_markers_are_never_split_by_emphasis_characters_inside_them() -> None:
+    runs = inline_runs("before {{FILL: *odd* **text** | source}} after")
+    assert _texts(runs) == ["before ", "{{FILL: *odd* **text** | source}}", " after"]
+    assert runs[1].marker
+
+
+@pytest.mark.parametrize(
+    ("line", "kind", "level"),
+    [("# Title", Heading, 1), ("## I. Introduction", Heading, 2), ("### A. Facts", Heading, 3)],
+)
+def test_headings_keep_their_authored_numerals(line: str, kind, level: int) -> None:
+    (block,) = parse_document(line)
+    assert isinstance(block, kind)
+    assert block.level == level
+    assert block.text == line.lstrip("# ")
+
+
+def test_bullets_numbered_and_rules() -> None:
+    blocks = parse_document("- one\n* two\n1. first\n2) second\n---\n")
+    assert [type(b) for b in blocks] == [Bullet, Bullet, Numbered, Numbered, HRule]
+    assert blocks[2].label == "1." and blocks[3].label == "2)"
+
+
+def test_four_or_deeper_hashes_and_unknown_syntax_degrade_to_paragraphs() -> None:
+    blocks = parse_document("#### too deep\n> quote\n`code`")
+    assert all(isinstance(b, Paragraph) for b in blocks)
+    assert [b.text for b in blocks] == ["#### too deep", "> quote", "`code`"]
+
+
+def test_blank_lines_separate_and_are_dropped() -> None:
+    blocks = parse_document("para one\n\n\npara two")
+    assert [b.text for b in blocks] == ["para one", "para two"]
+
+
+def test_table_without_separator_has_no_header_row() -> None:
+    (table,) = parse_document("| a | b |\n| c | d |")
+    assert table.header is False
+    assert len(table.rows) == 2
+
+
+def test_bold_and_italic_runs_inside_cells() -> None:
+    (table,) = parse_document("| **Plaintiff**, | *v.* |")
+    (row,) = table.rows
+    assert row[0][0].bold and row[0][0].text == "Plaintiff"
+    assert row[1][0].italic and row[1][0].text == "v."

--- a/operator/connectors/smokeball/tests/test_library_resolution.py
+++ b/operator/connectors/smokeball/tests/test_library_resolution.py
@@ -1,0 +1,338 @@
+"""library.resolve_template + the render tools' ``document_class`` path.
+
+The resolution is the tool's, not the model's: the same customer.yaml, the
+same matter, the same folder, the same file name, every time. "Not resolved"
+is a reported outcome (the draft still files, on the starter base), never a
+refusal and never silent.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import textwrap
+
+import httpx
+import pytest
+from docx import Document
+
+from smokeball_connector import server
+from smokeball_connector.library import (
+    CUSTOMER_YAML_ENV,
+    LibraryConfig,
+    NotResolved,
+    ResolvedTemplate,
+    is_library_file,
+    load_library_config,
+    resolve_template,
+)
+from smokeball_connector.render import render_markdown_to_docx
+
+from .test_render_document import DISCOVERY_MD, make_firm_template
+
+_UPLOAD_URL = "https://s3.example.com/apiuploads/draft-2?X-Amz-Signature=deadbeef"
+_DOWNLOAD_URL = "https://s3.example.com/apidownloads/tpl-1?X-Amz-Signature=cafebabe"
+
+
+# ---- config -------------------------------------------------------------------------
+
+
+def _write_yaml(tmp_path, body: str) -> str:
+    p = tmp_path / "customer.yaml"
+    p.write_text(textwrap.dedent(body))
+    return str(p)
+
+
+def test_missing_customer_yaml_is_not_authored_with_a_reason(tmp_path) -> None:
+    cfg = load_library_config(str(tmp_path / "nope.yaml"))
+    assert cfg.authored is False
+    assert "not readable" in cfg.source
+
+
+def test_block_without_matter_number_is_not_authored(tmp_path) -> None:
+    path = _write_yaml(tmp_path, """
+        self_initiation:
+          document_library:
+            matter_hint: '2026-OPS-001 (the internal operations matter)'
+            folder_name: 'Document Library'
+    """)
+    cfg = load_library_config(path)
+    assert cfg.authored is False
+    assert cfg.folder_name == "Document Library"
+
+
+def test_authored_block_and_template_name_convention_and_override(tmp_path) -> None:
+    path = _write_yaml(tmp_path, """
+        self_initiation:
+          document_library:
+            matter_number: '2026-OPS-001'
+            folder_name: 'Document Library'
+            templates:
+              letter: 'Firm Letterhead'
+    """)
+    cfg = load_library_config(path)
+    assert cfg.authored is True and cfg.matter_number == "2026-OPS-001"
+    assert cfg.template_name("discovery_set") == "Template - Discovery Set.docx"
+    assert cfg.template_name("letter") == "Firm Letterhead.docx"
+
+
+def test_env_override_points_the_loader_at_a_file(tmp_path, monkeypatch) -> None:
+    path = _write_yaml(tmp_path, "self_initiation:\n  document_library:\n    matter_number: 'M-1'\n    folder_name: 'Lib'\n")
+    monkeypatch.setenv(CUSTOMER_YAML_ENV, path)
+    assert load_library_config().authored is True
+
+
+# ---- resolution against a fake client ------------------------------------------------
+
+
+class _FakeClient:
+    def __init__(self, *, matters, folders, files, blob: bytes = b"PK-template") -> None:
+        self.matters, self.folders, self.files, self.blob = matters, folders, files, blob
+        self.downloads: list[tuple[str, str]] = []
+
+    def get(self, path: str, **params):
+        if path == "/matters":
+            return {"value": self.matters}
+        if path.endswith("/documents/folders"):
+            return {"value": self.folders}
+        if path.endswith("/documents/files"):
+            return {"value": self.files}
+        raise AssertionError(path)
+
+    def download_file(self, matter_id: str, file_id: str):
+        self.downloads.append((matter_id, file_id))
+        return {"name": "x"}, self.blob
+
+
+_CFG = LibraryConfig(authored=True, matter_number="2026-OPS-001", folder_name="Document Library", source="test")
+
+
+def test_resolves_the_class_template_in_the_library_folder() -> None:
+    client = _FakeClient(
+        matters=[{"id": "m-ops", "number": "2026-OPS-001"}, {"id": "m-other", "number": "2026-OPS-0010"}],
+        folders=[{"id": "f-lib", "name": "Document Library"}],
+        files=[
+            {"id": "old", "name": "Template - Discovery Set.docx", "folderId": "f-lib", "dateCreated": "2026-01-01"},
+            {"id": "new", "name": "template - discovery set.docx", "folderId": "f-lib", "dateCreated": "2026-08-01"},
+            {"id": "root", "name": "Template - Discovery Set.docx", "folderId": None, "dateCreated": "2026-09-01"},
+        ],
+    )
+    out = resolve_template(client, _CFG, "discovery_set")
+    assert isinstance(out, ResolvedTemplate)
+    assert out.file_id == "new"  # newest IN THE FOLDER wins; the root copy is ignored when folder matches exist
+    assert out.matter_id == "m-ops" and out.folder_id == "f-lib"
+    assert client.downloads == [("m-ops", "new")]
+
+
+def test_not_authored_is_reported_not_raised() -> None:
+    out = resolve_template(_FakeClient(matters=[], folders=[], files=[]), LibraryConfig(authored=False, source="x"), "memo")
+    assert isinstance(out, NotResolved) and "not authored" in out.reason
+
+
+def test_missing_matter_folder_and_file_each_name_their_reason() -> None:
+    no_matter = _FakeClient(matters=[{"id": "m", "number": "OTHER"}], folders=[], files=[])
+    assert "not found" in resolve_template(no_matter, _CFG, "memo").reason
+    no_file = _FakeClient(matters=[{"id": "m", "number": "2026-OPS-001"}], folders=[{"id": "f", "name": "Document Library"}], files=[])
+    out = resolve_template(no_file, _CFG, "memo")
+    assert isinstance(out, NotResolved) and "Template - Memo.docx" in out.reason and out.folder_id == "f"
+    no_folder = _FakeClient(matters=[{"id": "m", "number": "2026-OPS-001"}], folders=[], files=[])
+    assert "folder 'Document Library' not found" in resolve_template(no_folder, _CFG, "memo").reason
+
+
+def test_library_files_are_recognized_by_name_and_by_folder() -> None:
+    assert is_library_file({"name": "Template - Memo.docx"}, _CFG, None)
+    assert is_library_file({"name": "template - anything.docx"}, _CFG, None)
+    assert is_library_file({"name": "Letterhead.docx", "folderId": "f-lib"}, _CFG, "f-lib")
+    assert not is_library_file({"name": "Police Report.pdf", "folderId": "f-docs"}, _CFG, "f-lib")
+
+
+# ---- the tools ---------------------------------------------------------------------------
+
+
+def _mock_client(handler) -> object:
+    from smokeball_connector.client import SmokeballClient
+
+    client = SmokeballClient(region="us", environment="staging", client_id="cid", client_secret="sec", api_key="apikey")
+    client._http = httpx.Client(transport=httpx.MockTransport(handler))
+    return client
+
+
+def _handler(captured: list[httpx.Request], *, template: bytes | None = None, listing_files: list | None = None):
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        path = request.url.path
+        if path.endswith("/oauth2/token"):
+            return httpx.Response(200, json={"access_token": "tok", "expires_in": 3600, "token_type": "Bearer"})
+        if request.method == "GET" and path == "/matters":
+            return httpx.Response(200, json={"value": [{"id": "m-ops", "number": "2026-OPS-001"}]})
+        if request.method == "GET" and path.endswith("/documents/folders"):
+            return httpx.Response(200, json={"value": [{"id": "f-lib", "name": "Document Library"}]})
+        if request.method == "GET" and path.endswith("/documents/files"):
+            return httpx.Response(200, json={"value": listing_files or []})
+        if request.method == "GET" and path.endswith("/download"):
+            return httpx.Response(200, json={"downloadUrl": _DOWNLOAD_URL, "name": "Template - Memo.docx", "fileExtension": ".docx", "sizeBytes": len(template or b"")})
+        if str(request.url) == _DOWNLOAD_URL:
+            return httpx.Response(200, content=template or b"")
+        if request.method == "POST" and path.endswith("/documents/files"):
+            return httpx.Response(202, json={"fileId": "file-88", "uploadUrl": _UPLOAD_URL})
+        if str(request.url) == _UPLOAD_URL:
+            return httpx.Response(200)
+        return httpx.Response(200, json={"ok": True})
+
+    return handler
+
+
+def _stub_record_check(monkeypatch) -> None:
+    from smokeball_connector import record_check as rc
+
+    monkeypatch.setattr(server, "_collect_matter_sources", lambda _m: ([("Src", "text")], []))
+    monkeypatch.setattr(rc, "run_record_check", lambda *a, **k: rc.RecordCheckResult(passed=True, disposition="pass", refusals=[], checked_sources=1))
+
+
+def _authored(tmp_path, monkeypatch) -> None:
+    path = _write_yaml(tmp_path, "self_initiation:\n  document_library:\n    matter_number: '2026-OPS-001'\n    folder_name: 'Document Library'\n")
+    monkeypatch.setenv(CUSTOMER_YAML_ENV, path)
+
+
+def _put_bytes(captured: list[httpx.Request]) -> bytes:
+    return next(r for r in captured if r.method == "PUT").content
+
+
+def test_no_document_class_is_the_stock_render_byte_for_byte(monkeypatch, tmp_path) -> None:
+    captured: list[httpx.Request] = []
+    monkeypatch.setattr(server, "_get_client", lambda: _mock_client(_handler(captured)))
+    _stub_record_check(monkeypatch)
+    out = server.render_docx_draft("m-1", "Draft", "Body text.")
+    assert "formatApplied" not in out
+    assert _put_bytes(captured) == render_markdown_to_docx("Body text.")
+
+
+def test_document_class_without_an_authored_library_renders_on_the_starter_and_says_so(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv(CUSTOMER_YAML_ENV, str(tmp_path / "absent.yaml"))
+    captured: list[httpx.Request] = []
+    monkeypatch.setattr(server, "_get_client", lambda: _mock_client(_handler(captured)))
+    _stub_record_check(monkeypatch)
+    out = server.render_docx_draft("m-1", "Draft", DISCOVERY_MD, document_class="discovery_set")
+    fa = out["formatApplied"]
+    assert out["fileId"] == "file-88" and out["refusals"] == []
+    assert fa["templateUsed"] is None and fa["templateExpected"] is False
+    assert any("not authored" in n for n in fa["notes"])
+    assert fa["blocksStyled"]["labels"] == 2
+    assert _put_bytes(captured) != render_markdown_to_docx(DISCOVERY_MD)  # the falsifier: class changes the bytes
+    assert hashlib.sha256(_put_bytes(captured)).hexdigest() == out["sha256"]
+
+
+def test_authored_library_but_no_template_file_is_expected_and_loud(monkeypatch, tmp_path) -> None:
+    _authored(tmp_path, monkeypatch)
+    captured: list[httpx.Request] = []
+    monkeypatch.setattr(server, "_get_client", lambda: _mock_client(_handler(captured, listing_files=[])))
+    _stub_record_check(monkeypatch)
+    out = server.render_docx_draft("m-1", "Draft", "Body.", document_class="memo")
+    fa = out["formatApplied"]
+    assert out["fileId"] == "file-88"
+    assert fa["templateExpected"] is True and fa["templateUsed"] is None
+    assert any("Template - Memo.docx" in n for n in fa["notes"])
+
+
+def test_firm_template_resolves_and_the_draft_renders_into_it(monkeypatch, tmp_path) -> None:
+    _authored(tmp_path, monkeypatch)
+    template = make_firm_template(header_text="ACME LAW, LLP")
+    listing = [{"id": "tpl-1", "name": "Template - Memo.docx", "folderId": "f-lib"}]
+    captured: list[httpx.Request] = []
+    monkeypatch.setattr(server, "_get_client", lambda: _mock_client(_handler(captured, template=template, listing_files=listing)))
+    _stub_record_check(monkeypatch)
+    out = server.render_docx_draft("m-1", "Draft", "Body.", document_class="memo")
+    fa = out["formatApplied"]
+    assert fa["templateUsed"] == {"name": "Template - Memo.docx", "fileId": "tpl-1", "sha256": hashlib.sha256(template).hexdigest()}
+    assert "ACME LAW, LLP" in fa["baseHeaderFooterText"]
+    doc = Document(io.BytesIO(_put_bytes(captured)))
+    assert doc.sections[0].header.paragraphs[0].text.startswith("ACME LAW, LLP")
+    assert [p.text for p in doc.paragraphs if p.text.strip()] == ["Body."]
+
+
+def test_multi_section_firm_template_is_refused_and_nothing_uploads(monkeypatch, tmp_path) -> None:
+    _authored(tmp_path, monkeypatch)
+    template = make_firm_template(sections=2)
+    listing = [{"id": "tpl-1", "name": "Template - Memo.docx", "folderId": "f-lib"}]
+    captured: list[httpx.Request] = []
+    monkeypatch.setattr(server, "_get_client", lambda: _mock_client(_handler(captured, template=template, listing_files=listing)))
+    _stub_record_check(monkeypatch)
+    out = server.render_docx_draft("m-1", "Draft", "Body.", document_class="memo")
+    assert out["fileId"] is None
+    assert out["refusals"] and "2 sections" in out["refusals"][0]
+    assert not [r for r in captured if r.method == "PUT"]
+
+
+def test_unknown_document_class_is_a_refusal_with_the_list(monkeypatch, tmp_path) -> None:
+    captured: list[httpx.Request] = []
+    monkeypatch.setattr(server, "_get_client", lambda: _mock_client(_handler(captured)))
+    _stub_record_check(monkeypatch)
+    out = server.render_docx_draft("m-1", "Draft", "Body.", document_class="pleading")
+    assert out["fileId"] is None and "discovery_set" in out["refusals"][0]
+    assert not [r for r in captured if r.method == "PUT"]
+
+
+def test_render_docx_template_with_a_class_renders_the_skeleton_on_the_starter(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv(CUSTOMER_YAML_ENV, str(tmp_path / "absent.yaml"))
+    captured: list[httpx.Request] = []
+    monkeypatch.setattr(server, "_get_client", lambda: _mock_client(_handler(captured)))
+    skeleton = "# SKELETON\n## I. Section\n{{FILL: thing | source}}\n"
+    out = server.render_docx_template("m-ops", "Template - Memo", skeleton, folder_id="f-lib", document_class="memo")
+    assert out["fileId"] == "file-88" and out["fileName"] == "Template - Memo.docx"
+    assert out["formatApplied"]["class"] == "memo"
+    doc = Document(io.BytesIO(_put_bytes(captured)))
+    assert "SMD Item Label" in [s.name for s in doc.styles]  # the starter carries the named styles for the firm to edit
+    assert any("{{FILL: thing | source}}" in p.text for p in doc.paragraphs)
+
+
+def test_template_tool_required_params_are_unchanged() -> None:
+    import inspect
+
+    sig = inspect.signature(server.render_docx_template)
+    assert [n for n, p in sig.parameters.items() if p.default is inspect.Parameter.empty] == ["matter_id", "file_name", "skeleton_markdown"]
+    sig = inspect.signature(server.render_docx_draft)
+    assert [n for n, p in sig.parameters.items() if p.default is inspect.Parameter.empty] == ["matter_id", "file_name", "draft_markdown"]
+
+
+def test_collect_matter_sources_skips_library_templates(monkeypatch, tmp_path) -> None:
+    """Templates are not record: a header-only letterhead extracts to nothing
+    and would otherwise refuse the whole record check."""
+    _authored(tmp_path, monkeypatch)
+    captured: list[httpx.Request] = []
+    listing = [
+        {"id": "tpl", "name": "Template - Memo.docx", "folderId": "f-lib"},
+        {"id": "lh", "name": "Letterhead.docx", "folderId": "f-lib"},
+        {"id": "rec", "name": "Police Report.txt", "folderId": "f-docs"},
+    ]
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        path = request.url.path
+        if path.endswith("/oauth2/token"):
+            return httpx.Response(200, json={"access_token": "tok", "expires_in": 3600, "token_type": "Bearer"})
+        if request.method == "GET" and path.endswith("/documents/folders"):
+            return httpx.Response(200, json={"value": [{"id": "f-lib", "name": "Document Library"}]})
+        if request.method == "GET" and path.endswith("/documents/files"):
+            return httpx.Response(200, json={"value": listing})
+        if request.method == "GET" and path.endswith("/download"):
+            return httpx.Response(200, json={"downloadUrl": _DOWNLOAD_URL, "name": "Police Report.txt", "fileExtension": ".txt", "sizeBytes": 11})
+        if str(request.url) == _DOWNLOAD_URL:
+            return httpx.Response(200, content=b"REPORT TEXT")
+        return httpx.Response(200, json={"ok": True})
+
+    monkeypatch.setattr(server, "_get_client", lambda: _mock_client(handler))
+    sources, unextractable = server._collect_matter_sources("m-ops")
+    assert sources == [("Police Report.txt", "REPORT TEXT")]
+    assert unextractable == []
+    downloaded = [r.url.path for r in captured if r.url.path.endswith("/download")]
+    assert downloaded and all("/rec/" in d for d in downloaded)
+
+
+@pytest.mark.parametrize("cls", ["discovery_set", "mediation_brief", "letter"])
+def test_every_class_files_on_the_starter(monkeypatch, tmp_path, cls: str) -> None:
+    monkeypatch.setenv(CUSTOMER_YAML_ENV, str(tmp_path / "absent.yaml"))
+    captured: list[httpx.Request] = []
+    monkeypatch.setattr(server, "_get_client", lambda: _mock_client(_handler(captured)))
+    _stub_record_check(monkeypatch)
+    out = server.render_docx_draft("m-1", "Draft", DISCOVERY_MD, document_class=cls)
+    assert out["fileId"] == "file-88" and out["formatApplied"]["class"] == cls

--- a/operator/connectors/smokeball/tests/test_read_document.py
+++ b/operator/connectors/smokeball/tests/test_read_document.py
@@ -150,3 +150,14 @@ def test_extract_text_unsupported_binary_fails_closed() -> None:
 def test_extract_text_malformed_pdf_fails_closed() -> None:
     with pytest.raises(UnsupportedDocumentError, match="PDF could not be parsed"):
         extract_text(b"%PDF-1.4 not actually a pdf", file_extension=".pdf")
+
+
+def test_extract_text_accepts_a_word_template_dotx() -> None:
+    """A firm's letterhead TEMPLATE (.dotx) filed on a matter must extract like
+    any other document; python-docx rejects the template content type as-is,
+    and before this a single .dotx on a matter refused every draft on it."""
+    from .test_render_document import make_firm_template
+
+    blob = make_firm_template(dotx=True, body_text="FIRM TEMPLATE BODY")
+    text = extract_text(blob, file_extension=".dotx")
+    assert "FIRM TEMPLATE BODY" in text

--- a/operator/connectors/smokeball/tests/test_render_document.py
+++ b/operator/connectors/smokeball/tests/test_render_document.py
@@ -1,0 +1,304 @@
+"""docx_format.render_document: code owns typography, the firm's template wins.
+
+Assertions run at two layers on purpose: python-docx's object model for what it
+models (styles, paragraph formats, sections) and the raw XML parts for what
+Word reads that python-docx does not model (table borders, the PAGE field,
+docDefaults, the four rFonts attributes). Nothing here opens Word; the Word
+open is a runtime row of the contract, performed by a person.
+
+The "firm template" is BUILT in-test (no checked-in binaries: a .docx in a PR
+is unreviewable and rots). It deliberately carries the pathologies of real
+firm files the spike found: no ``Heading 1`` / ``List Bullet`` / ``Table Grid``
+styles, a header with an image, non-default margins, an optional second
+section, an optional .dotx content type.
+"""
+
+from __future__ import annotations
+
+import io
+import struct
+import zipfile
+import zlib
+
+import pytest
+from docx import Document
+from docx.enum.style import WD_STYLE_TYPE
+from docx.shared import Inches, Pt
+
+from smokeball_connector.docx_format import (
+    CLASS_RULES,
+    DOCUMENT_CLASSES,
+    FormatRefused,
+    FormatReport,
+    render_document,
+)
+
+_DOCX_MAIN = "application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"
+_DOTX_MAIN = "application/vnd.openxmlformats-officedocument.wordprocessingml.template.main+xml"
+
+
+def _png_1x1() -> bytes:
+    def chunk(tag: bytes, data: bytes) -> bytes:
+        c = struct.pack(">I", len(data)) + tag + data
+        return c + struct.pack(">I", zlib.crc32(tag + data) & 0xFFFFFFFF)
+
+    ihdr = struct.pack(">IIBBBBB", 1, 1, 8, 2, 0, 0, 0)
+    raw = zlib.compress(b"\x00\xff\x00\x00")
+    return b"\x89PNG\r\n\x1a\n" + chunk(b"IHDR", ihdr) + chunk(b"IDAT", raw) + chunk(b"IEND", b"")
+
+
+def make_firm_template(
+    *,
+    header_text: str = "ACME LAW, LLP",
+    header_image: bool = True,
+    margins_in: float = 1.25,
+    named_styles: dict[str, dict] | None = None,
+    footer_text: str = "",
+    drop_styles: tuple[str, ...] = ("Heading 1", "Heading 2", "Heading 3", "List Bullet", "Table Grid"),
+    body_text: str = "OLD TEMPLATE BODY that must not survive",
+    sections: int = 1,
+    dotx: bool = False,
+) -> bytes:
+    doc = Document()
+    for s in doc.sections:
+        s.left_margin = s.right_margin = Inches(margins_in)
+    hdr = doc.sections[0].header
+    hp = hdr.paragraphs[0]
+    hp.text = header_text
+    if header_image:
+        hp.add_run().add_picture(io.BytesIO(_png_1x1()), width=Inches(0.2))
+    if footer_text:
+        doc.sections[0].footer.paragraphs[0].text = footer_text
+    doc.add_paragraph(body_text)
+    for extra in range(sections - 1):
+        doc.add_section()
+        doc.add_paragraph(f"section {extra + 2}")
+    for name, spec in (named_styles or {}).items():
+        st = doc.styles.add_style(name, WD_STYLE_TYPE.PARAGRAPH)
+        st.font.name = spec.get("font", "Arial")
+        st.font.size = Pt(spec.get("size", 14))
+        if spec.get("indent"):
+            st.paragraph_format.first_line_indent = Inches(spec["indent"])
+    for name in drop_styles:
+        try:
+            doc.styles[name].element.getparent().remove(doc.styles[name].element)
+        except KeyError:
+            pass
+    buf = io.BytesIO()
+    doc.save(buf)
+    data = buf.getvalue()
+    if dotx:
+        src = zipfile.ZipFile(io.BytesIO(data))
+        out = io.BytesIO()
+        with zipfile.ZipFile(out, "w") as dst:
+            for item in src.infolist():
+                payload = src.read(item.filename)
+                if item.filename == "[Content_Types].xml":
+                    payload = payload.replace(_DOCX_MAIN.encode(), _DOTX_MAIN.encode())
+                dst.writestr(item, payload)
+        data = out.getvalue()
+    return data
+
+
+DISCOVERY_MD = """| PLAINTIFF JANE DOE, | Case No. {{FILL: case number | operative pleading}} |
+| v. |  |
+| DEFENDANT ACME CORP. |  |
+
+# PLAINTIFF'S SPECIAL INTERROGATORIES TO DEFENDANT, SET ONE
+
+## DEFINITIONS
+"INCIDENT" means the collision described in the complaint.
+
+**SPECIAL INTERROGATORY NO. 1:**
+Identify each person who witnessed the INCIDENT.
+
+**SPECIAL INTERROGATORY NO. 2:**
+State all facts supporting your denial. {{NOT IN RECORD: prior denial}}
+
+| Provider | Balance |
+| --- | --- |
+| Dr. A | $1,200.00 |
+
+SPECIAL INTERROGATORY NO. 1 asks about witnesses, and this long prose sentence is body text because a label is a short line and this is not one of those.
+"""
+
+
+def _parts(data: bytes) -> dict[str, str]:
+    z = zipfile.ZipFile(io.BytesIO(data))
+    return {n: z.read(n).decode("utf-8", "replace") for n in z.namelist() if n.endswith(".xml")}
+
+
+def _styled(data: bytes) -> list[tuple[str, str]]:
+    doc = Document(io.BytesIO(data))
+    return [(p.style.name, p.text[:28]) for p in doc.paragraphs if p.text.strip()]
+
+
+# ---- starter base ------------------------------------------------------------
+
+
+def test_starter_base_rewrites_doc_defaults_to_the_authored_standard() -> None:
+    data, _ = render_document("Body.", "memo", None)
+    styles = _parts(data)["word/styles.xml"]
+    assert 'w:ascii="Times New Roman"' in styles and 'w:eastAsia="Times New Roman"' in styles
+    assert '<w:sz w:val="24"/>' in styles
+    assert 'w:line="240"' in styles
+
+
+def test_starter_base_defines_every_named_style_and_honors_them() -> None:
+    data, report = render_document(DISCOVERY_MD, "discovery_set", None)
+    r = report.to_dict()
+    assert r["fallbacks"] == []
+    assert {"SMD Item Label", "SMD Item Text", "SMD Heading 1", "SMD Heading 2", "SMD Body", "SMD Caption"} <= set(r["stylesHonored"])
+    assert r["blocksStyled"] == {"labels": 2, "tables": 2, "headings": 2}  # "## DEFINITIONS" is a heading
+
+
+def test_golden_discovery_set_sequence() -> None:
+    data, _ = render_document(DISCOVERY_MD, "discovery_set", None)
+    seq = _styled(data)
+    expected = [
+        ("SMD Heading 1", "PLAINTIFF'S SPECIAL"),
+        ("SMD Heading 2", "DEFINITIONS"),
+        ("SMD Body", '"INCIDENT" means'),
+        ("SMD Item Label", "SPECIAL INTERROGATORY NO. 1:"),
+        ("SMD Item Text", "Identify each person"),
+        ("SMD Item Label", "SPECIAL INTERROGATORY NO. 2:"),
+        ("SMD Item Text", "State all facts"),
+    ]
+    assert [(s, t.startswith(p)) for (s, t), (_, p) in zip(seq, expected)] == [(s, True) for s, _ in expected]
+    assert seq[-1][0] == "SMD Body"  # the long prose line is body, not a label
+
+
+def test_markers_survive_verbatim_inside_table_cells_and_items() -> None:
+    data, _ = render_document(DISCOVERY_MD, "discovery_set", None)
+    doc = Document(io.BytesIO(data))
+    caption = doc.tables[0]
+    assert caption.cell(0, 1).text == "Case No. {{FILL: case number | operative pleading}}"
+    assert any("{{NOT IN RECORD: prior denial}}" in p.text for p in doc.paragraphs)
+
+
+def test_caption_table_gets_only_the_inside_vertical_rule_and_data_tables_get_a_grid() -> None:
+    data, _ = render_document(DISCOVERY_MD, "discovery_set", None)
+    xml = _parts(data)["word/document.xml"]
+    borders = xml.split("<w:tblBorders>")
+    assert len(borders) == 3  # two tables
+    caption, data_table = borders[1].split("</w:tblBorders>")[0], borders[2].split("</w:tblBorders>")[0]
+    assert "<w:insideV" in caption and "<w:top" not in caption
+    assert all(f"<w:{e}" in data_table for e in ("top", "left", "bottom", "right", "insideH", "insideV"))
+
+
+def test_letter_class_first_table_is_a_plain_grid() -> None:
+    data, _ = render_document("| a | b |\n| c | d |", "letter", None)
+    xml = _parts(data)["word/document.xml"]
+    assert "<w:top" in xml.split("<w:tblBorders>")[1]
+
+
+def test_page_number_field_added_when_the_base_has_no_footer() -> None:
+    data, report = render_document("Body.", "memo", None)
+    parts = _parts(data)
+    footer = next(v for k, v in parts.items() if k.startswith("word/footer"))
+    assert 'w:fldCharType="begin"' in footer and "PAGE" in footer
+    assert "page number field added to the footer" in report.to_dict()["notes"]
+
+
+def test_letter_class_adds_no_page_number_by_default() -> None:
+    data, _ = render_document("Body.", "letter", None)
+    parts = _parts(data)
+    assert not any("PAGE" in v for k, v in parts.items() if k.startswith("word/footer"))
+
+
+@pytest.mark.parametrize("cls", DOCUMENT_CLASSES)
+def test_every_class_renders_the_same_content_without_error(cls: str) -> None:
+    data, report = render_document(DISCOVERY_MD, cls, None)
+    assert data[:2] == b"PK"
+    assert report.to_dict()["class"] == cls
+
+
+def test_unknown_class_is_a_value_error() -> None:
+    with pytest.raises(ValueError):
+        render_document("x", "pleading_paper", None)
+
+
+def test_mediation_brief_headings_centered_bold_roman_then_indented_underlined_letters() -> None:
+    data, _ = render_document("# I. INTRODUCTION\n## A. Parties\n### 1. Plaintiff\nBody.", "mediation_brief", None)
+    doc = Document(io.BytesIO(data))
+    h1, h2, h3 = doc.paragraphs[0], doc.paragraphs[1], doc.paragraphs[2]
+    assert h1.text == "I. INTRODUCTION" and h1.style.name == "SMD Heading 1"
+    assert h2.text == "A. Parties" and h2.style.name == "SMD Heading 2"
+    assert h3.style.name == "SMD Heading 3"
+    # the numerals are CONTENT: nothing was added or renumbered
+    assert [p.text for p in doc.paragraphs[:3]] == ["I. INTRODUCTION", "A. Parties", "1. Plaintiff"]
+
+
+# ---- firm-supplied base (provenance a) ------------------------------------------
+
+
+def test_firm_template_header_image_margins_and_footer_survive_and_body_is_cleared() -> None:
+    base = make_firm_template(header_text="ACME LAW, LLP", footer_text="123 Main St.")
+    data, report = render_document(DISCOVERY_MD, "discovery_set", base)
+    doc = Document(io.BytesIO(data))
+    assert doc.sections[0].header.paragraphs[0].text.startswith("ACME LAW, LLP")
+    assert doc.sections[0].left_margin == Inches(1.25)
+    assert any(n.startswith("word/media/") for n in zipfile.ZipFile(io.BytesIO(data)).namelist())
+    assert "OLD TEMPLATE BODY" not in "\n".join(p.text for p in doc.paragraphs)
+    r = report.to_dict()
+    assert "ACME LAW, LLP" in r["baseHeaderFooterText"] and "123 Main St." in r["baseHeaderFooterText"]
+    # the firm's own footer is left alone: no PAGE field injected over it
+    assert "page number field added to the footer" not in r["notes"]
+
+
+def test_firm_template_lacking_stock_styles_does_not_raise_and_falls_back_inline() -> None:
+    base = make_firm_template()  # Heading 1-3 / List Bullet / Table Grid removed
+    data, report = render_document(DISCOVERY_MD + "- a bullet\n", "discovery_set", base)
+    r = report.to_dict()
+    assert set(r["fallbacks"]) >= {"SMD Item Label", "SMD Item Text", "SMD Heading 1", "SMD Body"}
+    doc = Document(io.BytesIO(data))
+    label = next(p for p in doc.paragraphs if p.text == "SPECIAL INTERROGATORY NO. 1:")
+    assert all(run.bold and run.underline and run.font.all_caps for run in label.runs if run.text.strip())
+    item = next(p for p in doc.paragraphs if p.text.startswith("Identify each person"))
+    assert item.paragraph_format.first_line_indent == Inches(0.5)
+    assert item.paragraph_format.line_spacing == 2.0
+    bullet = next(p for p in doc.paragraphs if "a bullet" in p.text)
+    assert bullet.text.startswith("•")
+
+
+def test_firm_template_that_defines_a_named_style_wins_and_is_not_a_fallback() -> None:
+    base = make_firm_template(named_styles={"SMD Item Label": {"font": "Arial", "size": 14}})
+    data, report = render_document(DISCOVERY_MD, "discovery_set", base)
+    r = report.to_dict()
+    assert "SMD Item Label" in r["stylesHonored"] and "SMD Item Label" not in r["fallbacks"]
+    doc = Document(io.BytesIO(data))
+    label = next(p for p in doc.paragraphs if p.text == "SPECIAL INTERROGATORY NO. 1:")
+    assert label.style.name == "SMD Item Label"
+    assert doc.styles["SMD Item Label"].font.name == "Arial"  # the firm's definition, untouched
+
+
+def test_firm_styles_are_never_written_back() -> None:
+    base = make_firm_template()
+    data, _ = render_document("Body.", "memo", base)
+    styles = _parts(data)["word/styles.xml"]
+    assert "SMD Body" not in styles and "SMD Item Label" not in styles
+
+
+def test_dotx_base_opens_and_is_noted() -> None:
+    base = make_firm_template(dotx=True)
+    data, report = render_document("Body.", "memo", base)
+    assert data[:2] == b"PK"
+    assert any("dotx" in n for n in report.to_dict()["notes"])
+    assert _DOCX_MAIN in _parts(data)["[Content_Types].xml"]
+
+
+def test_multi_section_base_is_refused_and_nothing_is_rendered() -> None:
+    base = make_firm_template(sections=2)
+    with pytest.raises(FormatRefused, match="2 sections"):
+        render_document("Body.", "memo", base)
+
+
+def test_report_round_trips_template_used_and_expected_flags() -> None:
+    report = FormatReport(document_class="memo", template_used={"name": "Template - Memo.docx", "fileId": "f1", "sha256": "abc"}, template_expected=True)
+    _, out = render_document("Body.", "memo", None, report)
+    d = out.to_dict()
+    assert d["templateUsed"]["name"] == "Template - Memo.docx" and d["templateExpected"] is True
+
+
+def test_class_rules_cover_every_class() -> None:
+    assert set(CLASS_RULES) == set(DOCUMENT_CLASSES)

--- a/operator/templates/drafting/drafting-discipline.md
+++ b/operator/templates/drafting/drafting-discipline.md
@@ -182,9 +182,48 @@ premises, holding inadmissibility traps, no self-contradicting dates). Mechanica
 transcription sub-steps may run lighter, but the draft itself is never delegated
 below the seat's work-product model. The premium is ~$0.50 per document.
 
-## Part IV — Skeletons
+## Part IV — Skeletons and format
 
 Default skeletons ship in `operator/templates/drafting/skeletons/`. They are SMD
 defaults for rehearsal and demonstration; at onboarding the firm's own skeletons
 replace them per matter type. A skill invoked without a skeleton for its artifact
 class uses its default and says so in the delivery note.
+
+### Format: the firm's template, code's typography, your content (ADR 0083)
+
+A draft is filed as a real Word document through `mcp_smokeball_render_docx_draft`
+with a `document_class` (`discovery_set`, `discovery_response`, `demand_letter`,
+`mediation_brief`, `memo`, `letter`). The tool renders your content INTO the
+firm's own Word template for that class when one is authored in the firm's
+Document Library (it resolves the template itself, the same way every time; you
+never pick one), else onto the SMD starter base. The firm's template carries the
+typography: letterhead, fonts, spacing, the named styles `SMD Body`, `SMD Item
+Label`, `SMD Item Text`, `SMD Heading 1-3`, `SMD Caption`, `SMD Signature`. A
+style the firm edits in Word takes effect on the next draft. Nothing you write
+chooses a font, a margin, or a spacing.
+
+**What you write** is the content grammar, and only this:
+
+| You write                                                                                                                                             | The renderer does                                                                                                                  |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `#` / `##` / `###` headings, numeral included (`## I. Introduction`, `### A. Parties`)                                                                | styles the level per class (centered bold roman, indented bold-underlined letters); never renumbers                                |
+| paragraphs, `**bold**`, `*italic*`                                                                                                                    | body style                                                                                                                         |
+| a SHORT line that starts with an item label (`**SPECIAL INTERROGATORY NO. 7:**`, `REQUEST FOR PRODUCTION NO. 3:`), the number from the propounded set | label style (all-caps bold underlined), then the paragraphs after it as item text (first-line indent, the "between items" spacing) |
+| `-` bullets; literal `1.` numbered items                                                                                                              | list formatting; the number is content                                                                                             |
+| pipe tables (`\| a \| b \|`; a `\| --- \|` row after the first marks a header row); the FIRST table of a court document is the caption                | real tables; a caption table gets the caption look                                                                                 |
+| `---` on its own line                                                                                                                                 | a horizontal rule                                                                                                                  |
+| `{{FILL: … \| source}}`, `{{NOT IN RECORD: …}}`, `{{ATTORNEY: …}}`                                                                                    | emitted verbatim, unstyled, render-visible; markers survive inside table cells and bold spans                                      |
+
+Everything else renders as plain text with its characters intact, never
+dropped. Write the caption, the signature block, and the proof of service as
+content, exactly as the skeleton shows; the renderer adds NO text of its own,
+no count, no declaration, no label. Those are record and judgment, not
+typography.
+
+**The delivery note states `formatApplied` honestly:** which template was used
+(or the starter), `templateExpected` (the library is authored but the class
+template did not resolve: say so, and why), the fallbacks (named styles the
+template lacks), and the template's own header/footer text (it bypasses every
+content gate, so the attorney sees it named). A `formatApplied.notes` entry
+that says the firm's template was not used is a sentence in your note, not a
+detail to omit.


### PR DESCRIPTION
## Summary

PR 1 of the send-ready-documents feature (#2448, the #2068 family). `render_docx_draft` / `render_docx_template` accept an optional `document_class` (`discovery_set`, `discovery_response`, `demand_letter`, `mediation_brief`, `memo`, `letter`). The tool resolves the firm's class template deterministically from the seat's live customer.yaml and the Document Library folder in Smokeball, renders the content INTO that file (page setup, headers/footers/letterhead, styles survive; body cleared), and returns `formatApplied` (template used or starter, `templateExpected`, fallbacks, the template's header/footer text). No template authored: the SMD starter base (TNR 12, the named styles defined, self-described docProps). `document_class` absent: today's stock render, byte for byte.

The model writes content only (headings with their own numerals, paragraphs, bullets, literal numbered items, pipe tables with markers kept intact through the cell split, item labels carrying the propounded set's own numbers); the renderer styles (label / item text / heading / caption / body) and adds no text, no count, no declaration. One refusal: a multi-section base (it would silently drop sections). Record-check hygiene: library templates are excluded from sources; `.dotx` extracts instead of poisoning the matter.

No new tool names (no overlay change); the pinned `required` sets are untouched. New dep: `pyyaml` (pure Python) in the Smokeball connector venv.

## Linked issue

Refs #2448 (PR 1 of 3; repo rows below). Refs #2068.

## Acceptance criteria status

| AC (verbatim from issue) | Status | Evidence |
| --- | --- | --- |
| (repo) Renderer: `render_docx_draft` / `render_docx_template` accept `document_class`; content renders INTO the firm's template (headers/footers/letterhead, page setup, styles survive; body cleared), named-style contract honored with inline fallbacks reported; class absent = stock render byte for byte; multi-section base refused | met | `smokeball_connector/docx_format.py`, `docx_base.py`, `docx_format_types.py`, `docgrammar.py`; `server.py:_render_with_format`; tests `tests/test_render_document.py` (in-test firm template: header image, 1.25in margins, stock styles stripped, `.dotx`, 2 sections), `tests/test_library_resolution.py::test_no_document_class_is_the_stock_render_byte_for_byte` |
| (repo) Deterministic library resolution from the seat's live customer.yaml (`self_initiation.document_library.{matter_number, folder_name, templates}`) -> matter -> folder -> `Template - <Class>.docx`; "not resolved" is reported (`templateExpected`), never silent | met | `smokeball_connector/library.py`; `tests/test_library_resolution.py` (found / not authored / matter, folder, file missing each named / newest in folder wins / templateExpected loud) |
| (repo) Record-check hygiene: library templates excluded from sources; `.dotx` extracts | met | `server.py:_collect_matter_sources`, `extract.py`; `tests/test_library_resolution.py::test_collect_matter_sources_skips_library_templates`, `tests/test_read_document.py::test_extract_text_accepts_a_word_template_dotx` |
| (repo) Grammar documented once (drafting-discipline Part IV) and carried in the tool descriptions; the model writes labels/numerals/caption/signature/POS as content; the renderer styles only | met | `operator/templates/drafting/drafting-discipline.md` Part IV; both tool docstrings in `server.py` |
| (runtime) Build installed on the proving seat (reprovision); connector uid + tool surface confirmed | deferred | seat step after merge: `reprovision.sh pilot-smokeball` + `seat-probe.sh`; needs a `vfy_` |
| (runtime) A class-rendered draft filed on a rehearsal matter, downloaded, and opened in Word by a person in the starter format | deferred | seat step after merge; `get_download_url` -> Captain's Mac -> Word; needs a `vfy_` |
| (repo) All five drafters deliver through `render_docx_draft` with `document_class`... | deferred | PR 2 |
| (runtime) Email-driven drafting request from a rostered sender on the proving seat files a class-rendered draft | deferred | PR 2 |
| (repo) Establishment files class starters into the library; `matter_number`/`templates` fields authored + validated; ADR 0083 append; handbook line | deferred | PR 3 |
| (runtime) Provenance (b): a starter filed into the pilot library, a style edited in Word and re-uploaded, the next draft honors it | deferred | PR 3 |
| (runtime) Provenance (a): a real Word-authored letterhead file as `Template - Letter.docx`; a letter-class draft renders into it, opened in Word | deferred | PR 3 |

## Deferred ACs

The runtime rows are deferred to the seat step (reprovision of pilot-smokeball after merge) and to PRs 2 and 3, all tracked in #2448. No `scope-deferred` label: nothing here is TODO-in-source; the deferral is the plan's slicing, and every deferred row names its closer.

## What a reviewer should read first

- `docgrammar.py`: markers are tokenized BEFORE the pipe-table cell split (every shipped skeleton writes `{{FILL: x | source}}` inside a cell; shredding one is a Pattern-B failure).
- `docx_base.py::open_as_base`: body cleared keeping `w:sectPr`; stock docDefaults rewritten on the starter; `.dotx` content-type shim; `has_style()` guards every style use (firm templates usually lack `Heading 1` / `List Bullet`; the old renderer would have raised).
- `docx_format.py::_Writer`: label detection is a SHORT line starting with a label phrase; a prose sentence opening with the same words stays body.
- `library.py::resolve_template`: the tool resolves; the model never picks a template.

## Not in this PR (by contract)

Attachment on the reply; the pointer-note hold (#2367); per-person preferences (#2067); pleading paper; any jurisdiction-specific text inserted by code; new tool names; wiring `--propounded` / `--sprog-lint` through `run_record_check` (follow-up issue).

## Test plan

- `cd operator/connectors && uv venv /tmp/v && uv pip install --python /tmp/v/bin/python ./_sdk -e ./smokeball pytest && PATH=/tmp/v/bin:$PATH /tmp/v/bin/python -m pytest smokeball/tests -q` -> 333 passed (276 before; +57).
- `npm run verify` -> green (typecheck, prettier, eslint, knip, build, 4571 vitest).
- `operator/bin/tests` + `operator/templates/drafting/tests` -> 496 passed.
- Word check of a rendered artifact is a runtime row (deferred above); LibreOffice is not proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Hqx3xnCwszXbqqqMxF7cf
