### PR TITLE
fix(operator): library resolver reads the observed file-entry shape (folder: {id}), pinned from the pilot tenant (#2448)

### DIFF
--- a/operator/connectors/smokeball/smokeball_connector/library.py
+++ b/operator/connectors/smokeball/smokeball_connector/library.py
@@ -176,6 +176,15 @@ def list_matter_files(client: Any, matter_id: str) -> list[dict[str, Any]]:
 
 
 def _entry_folder_id(entry: dict[str, Any]) -> str | None:
+    """The folder a file entry sits in. Observed live on the pilot tenant
+    (2026-08-19, vfy_01M0DTM2EGQZP9FZTM53S17CJ7): a file inside a folder
+    carries ``folder: {id, href}`` and a root file carries no ``folder`` key at
+    all; ``folderId`` never appears. Both spellings are read so the resolver
+    survives either shape; the matter-level ``/documents/files`` listing does
+    include files inside folders."""
+    folder = entry.get("folder")
+    if isinstance(folder, dict) and folder.get("id"):
+        return str(folder["id"])
     for key in ("folderId", "folder_id", "parentFolderId"):
         if entry.get(key):
             return str(entry[key])

--- a/operator/connectors/smokeball/tests/test_library_resolution.py
+++ b/operator/connectors/smokeball/tests/test_library_resolution.py
@@ -139,6 +139,54 @@ def test_missing_matter_folder_and_file_each_name_their_reason() -> None:
     assert "folder 'Document Library' not found" in resolve_template(no_folder, _CFG, "memo").reason
 
 
+_LIVE_ENTRY_IN_FOLDER = {
+    # Pinned to the wire shape observed on the pilot tenant 2026-08-19
+    # (vfy_01M0DTM2EGQZP9FZTM53S17CJ7). Not a guess.
+    "href": "https://stagingapi.smokeball.com/matters/3c19.../documents/files/1410...",
+    "id": "14105616-27d2-45f3-b212-40a12714060a",
+    "versionId": "14105616-27d2-45f3-b212-40a12714060a36F5...",
+    "folder": {"id": "9898f74a-3ad9-4b79-b209-a2f0f0c3d7d8", "href": "https://stagingapi.smokeball.com/matters/3c19.../documents/folders/9898..."},
+    "matter": {"id": "3c191bed-cdda-48b9-a6ed-a51a349f3f94", "href": "https://stagingapi.smokeball.com/matters/3c19..."},
+    "name": "Template - Demand Letter (Policy Limits)",
+    "fileExtension": ".docx",
+    "dateCreated": "2026-08-11T20:11:06.264423Z",
+    "sizeBytes": 39150,
+    "additionalData": {},
+    "isUploaded": True,
+    "isDeleted": False,
+}
+_LIVE_ENTRY_AT_ROOT = {
+    "id": "df59b111-1bb2-4af0-b7e0-69454ff080be",
+    "matter": {"id": "3c191bed-cdda-48b9-a6ed-a51a349f3f94"},
+    "name": "Operator Self-Test Report 2026-08-11",
+    "fileExtension": ".docx",
+    "dateCreated": "2026-08-11T18:53:04.899418Z",
+}
+
+
+def test_observed_wire_shape_folder_object_is_read_and_root_files_have_none() -> None:
+    from smokeball_connector.library import _entry_folder_id
+
+    assert _entry_folder_id(_LIVE_ENTRY_IN_FOLDER) == "9898f74a-3ad9-4b79-b209-a2f0f0c3d7d8"
+    assert _entry_folder_id(_LIVE_ENTRY_AT_ROOT) is None
+    cfg = LibraryConfig(authored=True, matter_number="2026-OPS-001", folder_name="Document Library", source="t")
+    assert is_library_file(_LIVE_ENTRY_IN_FOLDER, cfg, "9898f74a-3ad9-4b79-b209-a2f0f0c3d7d8")
+    assert not is_library_file(_LIVE_ENTRY_AT_ROOT, cfg, "9898f74a-3ad9-4b79-b209-a2f0f0c3d7d8")
+
+
+def test_resolver_prefers_the_folder_copy_using_the_observed_folder_object_shape() -> None:
+    root_copy = dict(_LIVE_ENTRY_IN_FOLDER, id="root", name="Template - Demand Letter.docx", dateCreated="2026-09-01")
+    root_copy.pop("folder")
+    in_folder = dict(_LIVE_ENTRY_IN_FOLDER, id="lib", name="Template - Demand Letter.docx", dateCreated="2026-01-01")
+    client = _FakeClient(
+        matters=[{"id": "m-ops", "number": "2026-OPS-001"}],
+        folders=[{"id": "9898f74a-3ad9-4b79-b209-a2f0f0c3d7d8", "name": "Document Library"}],
+        files=[root_copy, in_folder],
+    )
+    out = resolve_template(client, _CFG, "demand_letter")
+    assert isinstance(out, ResolvedTemplate) and out.file_id == "lib"
+
+
 def test_library_files_are_recognized_by_name_and_by_folder() -> None:
     assert is_library_file({"name": "Template - Memo.docx"}, _CFG, None)
     assert is_library_file({"name": "template - anything.docx"}, _CFG, None)


### PR DESCRIPTION
## Summary

Seat step of #2448 PR 1 (probe A on pilot-smokeball, vfy_01M0DTM2EGQZP9FZTM53S17CJ7): a Smokeball file entry inside a folder carries `folder: {id, href}`; a root file has no `folder` key; `folderId` never appears; the matter-level `/documents/files` listing includes files inside folders. The resolver and the record-check exclusion read `folderId`; they now read the folder object first. Both observed entries are pinned as fixtures (ADR 0053 posture: runtime fixtures are OBSERVED wire shapes, not guesses).

## Linked issue

Refs #2448.

## Acceptance criteria status

| AC (verbatim from issue) | Status | Evidence |
| --- | --- | --- |
| (repo) Deterministic library resolution ... `Template - <Class>.docx` | met (shape correction) | `library.py:_entry_folder_id`; `tests/test_library_resolution.py::test_observed_wire_shape_folder_object_is_read_and_root_files_have_none`, `::test_resolver_prefers_the_folder_copy_using_the_observed_folder_object_shape` |
| (runtime) Build installed on the proving seat; connector uid + tool surface confirmed | met | vfy_01M0DTETJ7SKV5DKJ5YH33T2SG (v138 booted healthy, substrate + classification probes PASSED), vfy_01M0DTM2EGQZP9FZTM53S17CJ7 (uid 10000 hermes; document_class present in the served tool doc) |
| (runtime) A class-rendered draft filed on a rehearsal matter, downloaded, and opened in Word by a person in the starter format | deferred | render + download + sha match proven (vfy_01M0DTM2EGQZP9FZTM53S17CJ7, matter 2026-PI-106, file 96cfdd51); the Word open is the Captain's step on the delivered artifact |

## Test plan

- connector suite: 335 passed (333 + 2 pins).
- No seat change needed for this fix to matter today (the pilot library is unauthored, `matter_number` lands in PR 3); it will ride the next reprovision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Hqx3xnCwszXbqqqMxF7cf