### PR TITLE
feat(operator): the document library files format templates the firm edits in Word (#2448 PR 3)

### DIFF
--- a/docs/adr/0083-authorship-model-output-classes.md
+++ b/docs/adr/0083-authorship-model-output-classes.md
@@ -172,3 +172,50 @@ Amended acceptance criteria:
 - [ ] (repo) `work_product` and `record` still refuse on a broken control; `staff` proceeds; outbound drafts
 - [ ] (runtime) A staff-class send reaches its recipient on a seat whose declared staff spec is not installed, observed as the recipient
 - [ ] (runtime) The broken control raises an alert that reaches a person, once, and resolves when a spec is installed
+
+## Amendment — 2026-08-19: format provenance realized as the firm's Word template (ss#2448)
+
+Decision 3 said the typography tier is code's, not the model's, and named #2068's
+deterministic `.docx` renderer as the design. It is now built, with one refinement to
+where the authored format LIVES: **in the firm's own Word template, in the firm's
+Document Library in its practice-management system, and nowhere else.** A drafting
+skill files a draft through `mcp_smokeball_render_docx_draft` with a `document_class`;
+the tool resolves the class template deterministically from the seat's authored
+library location (`self_initiation.document_library.{matter_number, folder_name,
+templates}`, read off the live customer.yaml by the connector; the model never picks a
+template), opens it as the base document (page setup, headers and footers, styles
+survive; body cleared), writes the content in using a small contract of named
+paragraph styles (`SMD Body`, `SMD Item Label`, `SMD Item Text`, `SMD Heading 1-3`,
+`SMD Caption`, `SMD Signature`), and reports what it applied (`formatApplied`). A
+template that lacks a named style gets the class's product default applied inline, and
+the fallback is named in the delivery note. No firm template authored: the starter, a
+Times New Roman 12 base with the named styles defined, self-described in its document
+properties, which the establishment turn files into the library for the firm to edit.
+
+Two provenances, equally: the firm's own template or letterhead dropped into the folder
+under the class's file name, or the starter we file for them. A style edited in Word
+takes effect on the next draft; there is no config publish and no reboot, because
+typography is not config. customer.yaml carries the library location and an optional
+per-class file-name override only, never a font or a spacing.
+
+The critique that shaped this (three independent reviews, 2026-08-19) removed every
+place the renderer would have invented legal content: it numbers nothing, labels
+nothing, and inserts no declaration. Item numbers come from the propounded set; the
+35-interrogatory rule is an aggregate across the matter and attorney-reserved; a
+statute-bound declaration is jurisdiction-specific, and inserting one for a firm in
+another state would be fabricated client-facing content. The sentence in Decision 3
+that called that declaration "a mechanically checkable condition" stands as a statement
+about the CONDITION; the TEXT is the firm's, authored into its skeleton, never the
+renderer's. The model writes labels, numerals, caption, signature block, and proof of
+service as content, exactly as the skeletons show; the renderer styles them.
+
+`output_classes.<class>.format_spec` (the text-shape assertion set) is unchanged and
+stays `none` on the seats that author it so: that system checks the shape of staff mail
+and digests; Word format is the drafting lane's renderer, which is what those seats'
+authored comment already said owns work-product shape.
+
+Evidence: PR #2449 (renderer, merged e1297712), #2452 (observed wire shape), #2454
+(the five drafters deliver through the tool); pilot-smokeball v138 booted on the build
+(vfy_01M0DTETJ7SKV5DKJ5YH33T2SG), a class-rendered document filed on a rehearsal matter,
+downloaded byte-identical and opened by the Captain (vfy_01M0DTM2EGQZP9FZTM53S17CJ7,
+vfy_01M0DW05DHTTK09MP4PRDEXNBC).

--- a/docs/handbook/operator-platform.md
+++ b/docs/handbook/operator-platform.md
@@ -16,6 +16,8 @@ sources:
     href: https://github.com/venturecrane/ss-console/blob/main/docs/adr/0011-multi-persona-per-customer.md
   - label: ADR 0019 - customer.yaml to profile translation
     href: https://github.com/venturecrane/ss-console/blob/main/docs/adr/0019-customer-yaml-to-profile-config-translation.md
+  - label: ADR 0083 - Authorship model and output classes (format amendment 2026-08-19)
+    href: https://github.com/venturecrane/ss-console/blob/main/docs/adr/0083-authorship-model-output-classes.md
 ---
 
 ## What the Operator runs on
@@ -67,6 +69,10 @@ v1 ships at `personas[]` length 1; the validator enforces this until a v2 unlock
 The bridge between the SMD product surface and the Hermes runtime is a translation step. SMD authors a `customer.yaml` (storage and authoring covered in `/admin/playbook/knowledge-memory`), which speaks the product's vocabulary - customer, persona, connector, entitlement. Hermes speaks a different vocabulary - profile, model, MCP server, personality file. The `hermes-smd bootstrap` CLI in the overlay performs that translation at Machine startup (ADR 0019).
 
 For each persona, bootstrap creates the profile directory, writes `SOUL.md` (identity, tone, escalation rules) and `config.yaml` (model pin, memory config, MCP server bindings from `connectors{}`, the four overlay plugins enabled with their per-plugin config), and symlinks the enabled skills into the profile. The translation is deterministic (same input produces byte-identical output) and idempotent (re-running it changes nothing). A `customer-sync` sidecar polls R2 for config changes; non-structural changes (escalation contacts, entitlement edits such as persona exposure and skill initiation, scope edits) reload without a restart, while structural changes (adding a persona, swapping a connector backend) are logged for a Captain re-provision so that OAuth tokens on the volume are never disturbed (ADR 0019).
+
+## Documents come back in the firm's format, and the format lives in Word
+
+A drafting skill files work product as a real Word document through the Smokeball connector (`mcp_smokeball_render_docx_draft` with a `document_class`), and the connector renders the content into the firm's own Word template for that class when the firm's Document Library holds one (resolved deterministically from `self_initiation.document_library` in `customer.yaml`: the library matter by number, the folder by name, the file by the class's name), else onto a Times New Roman starter with the named styles defined. Letterhead, page setup, fonts, spacing, item labels, headings, caption tables, and page numbers are the renderer's; the model writes content only, including the labels' own numbers, the caption, the signature block, and the proof of service, and the renderer adds no text. Typography is not config: the firm edits a style in Word and the next draft follows, with no publish and no reboot. The establishment turn files a starter template per class for the firm to edit, or the firm drops its own letterhead into the folder under the class's file name (ADR 0083, 2026-08-19 amendment; `operator/connectors/smokeball/smokeball_connector/docx_format.py`, `library.py`).
 
 ## The system, not a feature
 

--- a/operator/connectors/smokeball/smokeball_connector/docgrammar.py
+++ b/operator/connectors/smokeball/smokeball_connector/docgrammar.py
@@ -43,7 +43,11 @@ _BULLET_RE = re.compile(r"^[-*]\s+(.*)$")
 _NUMBERED_RE = re.compile(r"^(\d+[.)])\s+(.*)$")
 _HRULE_RE = re.compile(r"^-{3,}$")
 _TABLE_SEP_RE = re.compile(r"^\|?\s*:?-{3,}:?\s*(\|\s*:?-{3,}:?\s*)*\|?$")
-_EMPHASIS_RE = re.compile(r"(\*\*[^*]+\*\*|\*[^*]+\*)")
+# Emphasis and code spans. Backticks are markdown SYNTAX, like ``**``: the shipped
+# skeletons wrap markers in them (`` `{{FILL: ...}}` ``) for human readers, and a
+# Word document must not carry literal backticks. A code span renders as its
+# plain text; nothing inside it is styled.
+_EMPHASIS_RE = re.compile(r"(\*\*[^*]+\*\*|\*[^*]+\*|`[^`]+`)")
 
 # Private-use placeholders stand in for markers while cells/emphasis are split.
 _PLACEHOLDER = "{}"
@@ -146,6 +150,8 @@ def _emphasis_runs(text: str) -> list[Run]:
             runs.append(Run(part[2:-2], bold=True))
         elif part.startswith("*") and part.endswith("*") and len(part) > 2:
             runs.append(Run(part[1:-1], italic=True))
+        elif part.startswith("`") and part.endswith("`") and len(part) > 2:
+            runs.append(Run(part[1:-1]))
         else:
             runs.append(Run(part))
     return runs

--- a/operator/connectors/smokeball/tests/test_docgrammar.py
+++ b/operator/connectors/smokeball/tests/test_docgrammar.py
@@ -80,9 +80,19 @@ def test_bullets_numbered_and_rules() -> None:
 
 
 def test_four_or_deeper_hashes_and_unknown_syntax_degrade_to_paragraphs() -> None:
-    blocks = parse_document("#### too deep\n> quote\n`code`")
+    blocks = parse_document("#### too deep\n> quote")
     assert all(isinstance(b, Paragraph) for b in blocks)
-    assert [b.text for b in blocks] == ["#### too deep", "> quote", "`code`"]
+    assert [b.text for b in blocks] == ["#### too deep", "> quote"]
+
+
+def test_code_spans_render_as_plain_text_without_backticks() -> None:
+    """The shipped skeletons wrap markers in backticks for human readers; a Word
+    document must not carry them, and the marker inside stays a marker."""
+    runs = inline_runs("Dated: `{{FILL: date | service date}}` and `plain`.")
+    assert _texts(runs) == ["Dated: ", "{{FILL: date | service date}}", " and ", "plain", "."]
+    assert runs[1].marker and not runs[3].marker and not runs[3].bold
+    (table,) = parse_document("| Set served | `{{FILL: date | proof of service}}` |")
+    assert table.rows[0][1][0].text == "{{FILL: date | proof of service}}"
 
 
 def test_blank_lines_separate_and_are_dropped() -> None:

--- a/operator/contracts/customer-yaml-blocks.yaml
+++ b/operator/contracts/customer-yaml-blocks.yaml
@@ -184,12 +184,16 @@ top_level:
   self_initiation:
     status: implemented
     materializer: >-
-      no translate step by design — the block's runtime consumer is the
-      operator-self-initiation skill, which reads it directly off the seat's
-      own /var/lib/smd-config/customer.yaml via read_file at turn time (the
-      routine_names materialization shape, proven agent-readable by #2222
-      probe vfy_01KZPBXY9D). Reaches the seat through the existing R2
-      publish -> boot fetch of customer.yaml itself.
+      no translate step by design — the block's runtime consumers read it
+      directly off the seat's own /var/lib/smd-config/customer.yaml at turn
+      time (the routine_names materialization shape, proven agent-readable by
+      #2222 probe vfy_01KZPBXY9D): the operator-self-initiation skill via
+      read_file, and, since #2448, the Smokeball connector's format renderer
+      (smokeball_connector/library.py, a connector-process read of the same
+      file, proven on the pilot by vfy_01M0DTM2EGQZP9FZTM53S17CJ7), which
+      resolves `document_library.{matter_number, folder_name, templates}` to
+      the firm's per-class Word template. Reaches the seat through the
+      existing R2 publish -> boot fetch of customer.yaml itself.
     note: >-
       The seat's authored initiation sequence (ss#2220 rescoped, Captain
       2026-08-11): `sequence` is the ordered list of acts one admin request

--- a/operator/customers/_template/customer.yaml
+++ b/operator/customers/_template/customer.yaml
@@ -259,6 +259,18 @@ escalation:
 #   document_library:
 #     matter_hint: '[the ops matter the library lives on — authored after the blessing]'
 #     folder_name: 'Document Library'
+#     # Format templates (#2448). The Smokeball connector's renderer resolves the
+#     # firm's per-class Word template from here at render time: matter_number
+#     # (the library matter's NUMBER, a stable human key) -> folder_name -> the
+#     # file named templates[<class>], else "Template - <Class>.docx". Classes:
+#     # discovery_set, discovery_response, demand_letter, mediation_brief, memo,
+#     # letter. Typography lives ONLY in those .docx files (the firm edits them in
+#     # Word; no config change, no reboot). Either provenance: the firm's own
+#     # template/letterhead dropped into the folder under that name, or the
+#     # starter the establishment turn files for the firm to edit.
+#     matter_number: '[the library matter number, e.g. 2026-OPS-001]'
+#     templates:
+#       letter: '[optional: the firm letterhead file name in the folder]'
 
 # ---- VOICE LIBRARY ----
 voice_library:

--- a/operator/customers/pilot-smokeball/customer.yaml
+++ b/operator/customers/pilot-smokeball/customer.yaml
@@ -965,6 +965,17 @@ self_initiation:
   document_library:
     matter_hint: '2026-OPS-001 (the internal operations matter)'
     folder_name: 'Document Library'
+    # The Smokeball connector's renderer resolves the firm's per-class Word
+    # template from here, deterministically, the same way every time (#2448):
+    # this matter (by its number) -> this folder -> the file named
+    # templates[<class>] or the convention "Template - <Class>.docx". Read off
+    # the live customer.yaml by the connector at render time (config-as-data;
+    # no translate step). Typography lives ONLY in those .docx files: a style
+    # edited in Word takes effect on the next draft.
+    matter_number: '2026-OPS-001'
+    templates:
+      demand_letter: 'Template - Demand Letter (Policy Limits)'
+      discovery_response: 'Template - Discovery Responses (RFP and FROG Combined)'
 
 # ---- VOICE COHORTS ----
 # The audience classes this seat's voice profiles are partitioned by. An

--- a/operator/skills/document-library-establishment/SKILL.md
+++ b/operator/skills/document-library-establishment/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   template per blessed item, structure only, with every case-specific value left as a visible
   marker, and it reports a template delivered only after reading the filed document back.
   Firm-level establishment is refused for anyone who is not an Operator admin.
-version: 0.1.0
+version: 0.2.0
 author: SMD Services
 license: MIT
 platforms: [linux, macos]
@@ -174,6 +174,22 @@ Two or three exemplars of one type is better than one, because a structure deriv
 single document cannot tell what is invariant from what that document happened to do. Say how
 many you have per type; one is workable and the admin should know it is one.
 
+**The format half of each template (#2448).** Every template you file is also the firm's
+FORMAT template for its document class: when a drafter later files a draft of that class,
+the renderer opens the library template as the base document and writes the draft into it,
+so the template's fonts, spacing, indents, letterhead and named styles (`SMD Body`,
+`SMD Item Label`, `SMD Item Text`, `SMD Heading 1-3`, `SMD Caption`, `SMD Signature`) become
+the draft's. Typography lives only in that .docx; a style the firm edits in Word takes
+effect on the next draft. So, per proposed template, name its **document class** (one of
+`discovery_set`, `discovery_response`, `demand_letter`, `mediation_brief`, `memo`, `letter`),
+and say which of two provenances it will have: **the firm's own file**, if the admin points
+you at a template or letterhead already in the folder (or drops one in under the class's file
+name), which you leave exactly as it is; or **the starter**, a Times New Roman 12 base with the
+named styles defined, which you file for the firm to open and adjust in Word. Say plainly
+which it is. Where you observed the firm's own typography in the exemplars (font, spacing,
+heading look), report it as an observation for the admin, never as something you will impose:
+the starter is a starting point, the firm's Word edit is the authority.
+
 **The storage location.** Propose a new folder, suggested name **"Document Library"**, on a
 matter you name from the survey.
 
@@ -248,10 +264,19 @@ exemplars do not establish, that is a marker, never a plausible sentence.
 
 ### 6. Render each template, and respect the gate
 
-`mcp_smokeball_render_docx_template(matter_id, file_name, skeleton_markdown, folder_id)`. You
-pass the skeleton's **text**; the .docx bytes are built in tool code from bytes you never saw.
-`file_name` gains a `.docx` suffix if it lacks one, and the returned `fileName` is the name
-actually filed.
+`mcp_smokeball_render_docx_template(matter_id, file_name, skeleton_markdown, folder_id,
+document_class)`. You pass the skeleton's **text** and the template's **document class**; the
+.docx bytes are built in tool code from bytes you never saw. With the class the tool renders
+the skeleton onto the class starter (the named styles defined, Times New Roman 12, a page
+number in the footer) or, when the library already holds a template for that class, INTO
+that file, keeping its letterhead and styles; the return carries `formatApplied` saying
+which. `file_name` gains a `.docx` suffix if it lacks one, and the returned `fileName` is the
+name actually filed. **Name each template by the convention `Template - <Class>.docx`**
+(`Template - Discovery Set.docx`, `Template - Demand Letter.docx`, and so on) unless the
+blessing named it otherwise; the renderer finds a class's template by that name, and a
+differently named one is authored into `self_initiation.document_library.templates` by PR
+after the blessing, so say the name you filed under in the report. Never upload bytes
+yourself and never rename a file the firm placed in the folder.
 
 **The content gate refuses; it never repairs.** Before anything is rendered or uploaded the
 markdown is checked, and the whole violation list comes back in `refusals` with `fileId` null.
@@ -310,6 +335,9 @@ Per template, in the admin's own terms:
 - the **fileId**,
 - the **sha256** and **sizeBytes** the tool returned,
 - **where it is**: the matter and folder it was filed into,
+- **its document class and format provenance**, from the tool's `formatApplied`: rendered
+  onto the starter (tell the admin: open it in Word, adjust the styles, and every future
+  draft of that class follows), or rendered into the firm's own file (name it),
 - **confirmed by read-back**, or **filed and awaiting materialization**, in those words.
 
 Then the things that did not work, plainly and not at the bottom:

--- a/operator/templates/drafting/drafting-discipline.md
+++ b/operator/templates/drafting/drafting-discipline.md
@@ -213,6 +213,7 @@ chooses a font, a margin, or a spacing.
 | pipe tables (`\| a \| b \|`; a `\| --- \|` row after the first marks a header row); the FIRST table of a court document is the caption                | real tables; a caption table gets the caption look                                                                                 |
 | `---` on its own line                                                                                                                                 | a horizontal rule                                                                                                                  |
 | `{{FILL: … \| source}}`, `{{NOT IN RECORD: …}}`, `{{ATTORNEY: …}}`                                                                                    | emitted verbatim, unstyled, render-visible; markers survive inside table cells and bold spans                                      |
+| `` `backticked text` `` (the skeletons wrap markers this way for human readers)                                                                       | the backticks are syntax and are dropped; the text inside renders plain, a marker inside stays a marker                            |
 
 Everything else renders as plain text with its characters intact, never
 dropped. Write the caption, the signature block, and the proof of service as

--- a/tests/self-initiation-sequence.test.ts
+++ b/tests/self-initiation-sequence.test.ts
@@ -42,8 +42,23 @@ const CONDUCTOR = 'operator-self-initiation'
 
 interface SelfInitiation {
   sequence?: string[]
-  document_library?: { matter_hint?: string; folder_name?: string }
+  document_library?: {
+    matter_hint?: string
+    folder_name?: string
+    matter_number?: string
+    templates?: Record<string, string>
+  }
 }
+
+/** The renderer's document classes (smokeball_connector/docx_format.py DOCUMENT_CLASSES). */
+const DOCUMENT_CLASSES = [
+  'discovery_set',
+  'discovery_response',
+  'demand_letter',
+  'mediation_brief',
+  'memo',
+  'letter',
+] as const
 
 function loadSeat(slug: keyof typeof SEAT_PATHS) {
   const raw = parseYaml(readFileSync(SEAT_PATHS[slug], 'utf-8')) as Record<string, unknown>
@@ -102,6 +117,33 @@ describe('self_initiation <-> seat-binding drift gate', () => {
           `${slug}: self_initiation.document_library authored without folder_name — ` +
             `the status probe has no search key`
         ).toBe(true)
+      })
+
+      it('document_library format-template keys are well-shaped for the renderer (#2448)', () => {
+        const lib = selfInitiation?.document_library
+        if (!lib) return
+        if (lib.matter_number !== undefined) {
+          expect(
+            typeof lib.matter_number === 'string' && lib.matter_number.trim().length > 0,
+            `${slug}: document_library.matter_number must be a non-empty string (the library matter's number)`
+          ).toBe(true)
+        }
+        if (lib.templates !== undefined) {
+          for (const [cls, name] of Object.entries(lib.templates)) {
+            expect(
+              (DOCUMENT_CLASSES as readonly string[]).includes(cls),
+              `${slug}: document_library.templates names unknown class '${cls}' (known: ${DOCUMENT_CLASSES.join(', ')})`
+            ).toBe(true)
+            expect(
+              typeof name === 'string' && name.trim().length > 0,
+              `${slug}: document_library.templates.${cls} must be a non-empty file name`
+            ).toBe(true)
+          }
+          expect(
+            lib.matter_number !== undefined,
+            `${slug}: document_library.templates authored without matter_number — the renderer cannot resolve the library matter`
+          ).toBe(true)
+        }
       })
     })
   }


### PR DESCRIPTION
## Summary

PR 3 of #2448. The document-library establishment turn now files each blessed template as a FORMAT template: rendered into the class starter (`render_docx_template` with `document_class`), named by the convention `Template - <Class>.docx`, reported with its format provenance, and handed to the admin with the operative sentence — open it in Word, adjust the styles, every future draft of that class follows. A firm's own template/letterhead dropped into the folder under the class's name is used as-is, never renamed (the two provenances of #2448). The renderer's library resolution is now authored: `self_initiation.document_library` gains `matter_number` and an optional per-class `templates` map; the pilot authors `2026-OPS-001` and maps its two existing 08-11 templates; drift-tested; the block registry names the connector as a second config-as-data reader. Parser: backticked code spans render as plain text (the skeletons wrap markers in backticks for readers; a Word document must not carry them). ADR 0083 carries the realization amendment; the handbook platform page carries the paragraph.

## Linked issue

Refs #2448 (PR 3 of 3, repo rows).

## Acceptance criteria status

| AC (verbatim from issue) | Status | Evidence |
| --- | --- | --- |
| (repo) Establishment files class starters into the library (`render_docx_template` with `document_class`); `matter_number`/`templates` fields authored + validated; ADR 0083 append; handbook line | met | `operator/skills/document-library-establishment/SKILL.md` (proposal + render + report sections); `operator/customers/pilot-smokeball/customer.yaml`, `_template/customer.yaml`; `tests/self-initiation-sequence.test.ts` (+2 guards); `operator/contracts/customer-yaml-blocks.yaml`; `docs/adr/0083-*.md` amendment; `docs/handbook/operator-platform.md`; console validator OK on the pilot yaml |
| (repo) skeleton touch-ups (carried from PR 2) | met | backtick code-span rule in `docgrammar.py` + `test_docgrammar.py` + the grammar table row: the shipped skeletons now render clean without edits to their text |
| (runtime) Provenance (b): a starter filed into the pilot library, a style edited in Word and re-uploaded, the next draft honors it | deferred | needs a reprovision (skills + customer.yaml image-baked/published) after the Hermes v0.20 promotion (#2453) lands; then the establishment turn + Word-edit proof |
| (runtime) Provenance (a): a real Word-authored letterhead file as `Template - Letter.docx`; a letter-class draft renders into it, opened in Word | deferred | same reprovision; the Captain authors the letterhead file in Word |
| (runtime) Email-driven drafting request files a class-rendered draft (PR 2's row) | deferred | same reprovision |

## Deferred

All three runtime rows ride the first pilot reprovision after #2453 merges (the seat is the Hermes-promotion session's right now). They are the remaining rows of #2448 and are tracked there.

## Test plan

- Connector suite 336 passed; `operator` pytest (bin/tests, skills, drafting tests) 688 passed; `npm run verify` green (incl. handbook integrity + the extended drift test); `npx tsx scripts/validate-customer-yaml.ts` OK on the pilot yaml.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Hqx3xnCwszXbqqqMxF7cf
