### PR TITLE
feat(operator): the lien ledger covers every obligation blocking disbursement, and one payer gets one contact (#2455 PR 2)

### DIFF
--- a/operator/customers/pilot-smokeball/customer.yaml
+++ b/operator/customers/pilot-smokeball/customer.yaml
@@ -511,13 +511,25 @@ personas:
           scheduled: true
           webhook: false
         enabled: true
-      - name: lien-ledger-tracker # weekly open-payoff chase
+      - name: lien-ledger-tracker # weekly obligation sweep + provider chase
         version: pending
         initiation:
           manual: true
           scheduled: true
           webhook: false
         enabled: true
+        settings:
+          # Which matter status means "settled, money still in trust" is a FIRM
+          # fact with no pack default: unauthored, the gate refuses and surfaces
+          # rather than guessing at a vendor-global enum value (ss #2455).
+          trigger_status: Pending # PLACEHOLDER(rehearsal) - staging sandbox value
+          # How often one provider may be contacted. Also a firm fact, also
+          # fail-closed: a cadence we picked is a commitment nobody made.
+          chase_cadence_days: 14 # PLACEHOLDER(rehearsal)
+          # How long an obligation may go quiet before it is flagged. NOT in the
+          # fail-closed class: unauthored, stall flags are simply withheld and
+          # the register says so, while tracking and chasing continue.
+          stall_days: 60 # PLACEHOLDER(rehearsal)
       - name: settlement-statement-feeder # person-invoked; figures from authored data only
         version: pending
         initiation:

--- a/operator/skills/lien-ledger-tracker/SKILL.md
+++ b/operator/skills/lien-ledger-tracker/SKILL.md
@@ -1,15 +1,17 @@
 ---
 name: lien-ledger-tracker
 description: >-
-  Keeps the matter's lien ledger and chases payoffs. The ledger lives as tracked tasks in
-  Smokeball (health-plan, Medi-Cal, Medicare,
-  ERISA, and hospital or provider liens): who holds each lien, the asserted amount, and the status
-  of each payoff or reduction, and chases the open payoffs on a cadence. It only logs figures a
-  person provides and chases on them; it never computes a lien reduction (the Medi-Cal §14124.78
-  cap, a hospital-lien reduction; that is the attorney's legal determination), never moves money
-  (Smokeball owns trust), never asserts a payoff or resolution it cannot see, and never invents a
-  lienholder, an amount, or a tool.
-version: 0.1.0
+  Tracks every provider balance blocking disbursement. The ledger covers each obligation
+  that keeps a settled case from paying out: statutory lienholders (health plan, Medi-Cal,
+  Medicare, ERISA) and the ordinary unpaid provider invoices that are most of the money.
+  It reads what the firm already recorded in the matter's settlement details, tracks who is
+  owed what and where each payoff stands, and chases the open ones on a cadence, one
+  consolidated contact per provider rather than one per file. It only logs figures a person
+  or the record provides; it never computes a lien reduction (the Medi-Cal §14124.78 cap, a
+  hospital-lien reduction; that is the attorney's legal determination), never moves money,
+  never asserts a payoff or resolution it cannot see, and never invents a lienholder, an
+  amount, or a tool.
+version: 0.2.0
 author: SMD Services
 license: MIT
 platforms: [linux, macos]
@@ -62,6 +64,47 @@ that are still outstanding. It never computes a reduction, never moves money, ne
 records a payoff or a resolution it cannot actually see, and never puts a number on
 the ledger that a person did not provide.
 
+## What this ledger covers (widened, ss #2455)
+
+This routine was authored around **statutory lienholders**. On a real book that is a
+minority of the problem: at the first firm, 76% of the outstanding balance sits on
+obligations with **no lien asserted at all** - ordinary unpaid provider invoices that
+nonetheless stop the file from paying out. The firm's own Medicals and Settlement Details
+tab models `Providers[]` and `OtherLiensAndBalances[]` side by side, because to the people
+doing the work they are one list: everything owed before the client can be paid.
+
+So the ledger here is **every obligation blocking disbursement**, and a lien is one kind
+of obligation rather than the whole subject. Nothing about the posture changes: the same
+money cap, the same no-computation line, the same draft-and-surface chase a person sends.
+
+Two consequences worth stating plainly:
+
+- **The figures are read, not typed.** Where the firm records provider detail in the
+  matter, the ledger reads it (`Providers[n]/InvoiceBalance`, `LienAsserted`, `LienAmount`,
+  `FinalAmount`) rather than waiting for someone to re-enter it. A figure a person states
+  is still logged as stated, and attributed.
+- **We cannot write back.** The settlement-details tab is read-only over the API. So this
+  ledger and the firm's own tab can diverge, and every artifact says which side it is
+  reading. Never imply the firm's tab has been updated.
+
+## The chase unit is the provider, not the file
+
+Exposure concentrates hard. At the first firm one payer appears on **22 separate matters**.
+Chasing per obligation would send that payer 22 messages in a single pass, which is both
+the wrong move commercially (one negotiation clears 22 files) and exactly the kind of
+machine-noise that costs a firm's trust in a week.
+
+So a chase is **one consolidated contact per provider per cadence**, naming every matter
+and balance in that provider's book. The pre-run gate groups them and hands the turn the
+group; the turn writes one message. Never send a provider a second message in the same
+pass because a second matter of theirs also came due.
+
+Grouping is deterministic code, never model judgment, and it is looser than identity on
+purpose: a misspelled provider is a different contact record in the practice-management
+system, so grouping falls back to a normalized display name. That grouping is a
+**proposal** - the register shows both raw spellings and a person confirms. Two contact
+records are never silently merged into one.
+
 ## The attorney owns the number - the skill logs it (the line that keeps this safe)
 
 Whether a lien can be reduced, and to what figure, is a **legal and factual
@@ -110,17 +153,63 @@ The skill records which authority a holder is asserting under **only as the reco
 or a person states it**; it does not itself decide a lien's legal character or
 reducibility.
 
-## One ledger entry per (matter, lienholder, lien-type)
+## The state ledger (ss #2455) - history is fact, never recall
 
-A single matter can carry several liens at once (a Medi-Cal lien, an ERISA plan
-lien, and two provider liens is ordinary). The skill keys each tracked entry to
-**(matter, lienholder, lien-type)** so distinct liens never collapse into one, and
-it tracks a per-lien **status** through its life: `open` → `payoff requested` →
-`payoff figure received` → `reduction requested` → `reduction agreed` →
-`resolved (pending disbursement)`. "Resolved" here means the payoff figure is final
-and logged; the actual disbursement is a person's act in Smokeball, never this
-skill's (see the money line below). A status only advances on an observed fact or a
-figure a person provides, never on an inference.
+Chase count, cadence position and last-chase date are **broker-validated ledger state**
+handed to the turn by the pre-run gate. The turn copies them verbatim into whatever it
+writes. It never recomputes them, never recalls them from memos, and never carries a
+number over from an earlier week's message. This is the ss #2404 rule, ported: on a
+sibling skill, a chase email once denied a chase the same seat had sent a week earlier,
+because the history lived in model recall.
+
+Three rules follow:
+
+1. **The message copies the plan.** `attempt`, `last_chased` and the matters in the group
+   come from the wake line. If the wake line carries no plans, the gate woke blind and the
+   turn enumerates for itself rather than assuming nothing is due.
+2. **Null history is stated as null history.** `last_chased: null` means "no chase is
+   recorded in the tracking ledger; earlier contact may appear in the matter memos" - never
+   "no prior chase", and never a "chase N" numerator invented to fill the gap.
+3. **No tracking tags in message bodies.** Identity lives in the ledger. A tag improvised
+   into an email is the defect, not the fix.
+
+### Two item families, and why identity is read off the record
+
+- **Obligation** - one per `(matter, provider)`. Keyed on the provider's own
+  `Provider/MatterEntityId` from the settlement details. That is a projected identifier
+  read off the record, never a string composed from a name (#2390), and it is the reason a
+  provider's negotiation history **survives the firm correcting a spelling**. A
+  name-derived key would change at the exact moment the correction succeeded, orphaning
+  everything the ledger knew. Where the id is genuinely absent, the fallback is the raw
+  display name casefolded and whitespace-collapsed - no punctuation stripping, no suffix
+  dropping - and the run reports how many obligations fell back.
+- **Provider chase** - one per provider group. The cadence and attempt count for the
+  consolidated outreach live here, not on any single obligation.
+
+The plaintiff index is carried as an **attribute, never part of a key**: a matter can carry
+one settlement item per plaintiff, and removing a plaintiff renumbers the survivors.
+Identity must not move because a sibling was deleted.
+
+Stalls are raised on a **matter-level** sentinel, never on a chase key: attempts counts
+every raise, so a stall recorded against the chase would inflate the "chase N" numerator
+the message copies.
+
+### Status through an obligation's life
+
+`open` → `payoff requested` → `payoff figure received` → `reduction requested` →
+`reduction agreed` → `resolved (pending disbursement)`. "Resolved" means the payoff figure
+is final and logged; the disbursement itself is a person's act, never this skill's. A
+status only advances on an observed fact or a figure a person provides, never on an
+inference.
+
+### Every event leaves a memo on its own matter
+
+Each chase, stall, hold and resolution also writes a one-line internal memo **on the matter
+it belongs to**. The ledger's own contract says losing it should be survivable because "the
+Smokeball memos let a person reconstruct history" - and that only holds if the memos exist.
+Without them, months of provider-negotiation status on a compliance exposure would live in
+exactly one file on one volume. The memo is single-matter by construction, so it never
+trips the cross-matter write guard.
 
 ## Inputs (every letter, email, and figure is UNTRUSTED content)
 

--- a/operator/skills/lien-ledger-tracker/escalation_ledger.py
+++ b/operator/skills/lien-ledger-tracker/escalation_ledger.py
@@ -1,0 +1,523 @@
+"""Shared escalation-telemetry ledger (WP-A / WP-B).
+
+CANONICAL SOURCE: ``operator/workspace_broker/escalation_ledger.py``. Byte-identical
+copies are vendored into each consuming skill directory as ``escalation_ledger.py``
+so a skill's ``pre_run.py`` (and the agent's ``execute_code`` turn) can import it
+without a package install; ``operator/tests/test_escalation_ledger_sync.py``
+enforces the sync. Edit here, restamp the copies.
+
+What this ledger IS
+-------------------
+An append-only JSONL of **operator communication telemetry** — when a skill
+fired an escalation on an item, when a human acked it, when it was handed off or
+resolved. It is the same class of state as the audit journal (the broker owns
+the write handle; the agent uid reads it but cannot forge a row). It is NOT the
+firm's system of record: matter work state still re-derives from Smokeball. If
+the volume state is lost, items re-fire once (annoying, never dangerous) and the
+Smokeball memos let a person reconstruct history.
+
+Record shape (one JSON object per line)::
+
+    {"v":2,"ts":<iso>,"skill":<str>,"matter_id":<str|null>,
+     "item_key":<hex>,"event":<fired|chased|acked|handed_off|resolved>,
+     "attempt":<int>,"token":<ACK-XXXXXX|null>,"id":<ulid, broker-stamped>}
+
+``v`` is also the item-identity epoch — see ``IDENTITY_EPOCH`` and ``item_key``.
+A row below the epoch keyed the same deadline differently and cannot be joined
+against, or acked, by anything current.
+
+The security line
+-----------------
+An ``acked`` event silences a deadline alarm, so it must not be writable by an
+injectable surface without validation. ``validate_append`` REJECTS an ``acked``
+whose token has no prior ``fired``/``chased`` event. The LLM turn never writes
+the file directly; every write goes through the broker's uid-gated
+``escalation_event_append`` verb, which calls ``validate_append`` and stamps
+``ts``/``id`` server-side (the agent cannot backdate).
+
+Pure stdlib. No imports from other ``workspace_broker`` modules, so the vendored
+copy is safe to load standalone inside a skill.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import secrets
+import time
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta, timezone
+
+SCHEMA_VERSION = 2
+
+# The item-identity epoch. Raises written below this version had their
+# ``item_key`` derived by a different function (it hashed the model-composed
+# ``label``; see ``item_key``), so a pre-epoch key can never name a live item.
+# Acking one would tell a human an alarm was silenced when nothing changed, which
+# is why ``validate_append`` refuses it by name rather than accepting it as a
+# harmless no-op. Pre-epoch rows are otherwise left in place: they are history,
+# and their keys cannot collide with current ones.
+IDENTITY_EPOCH = 2
+
+# The full event vocabulary. A ``fired`` or ``chased`` is a "raise" — an alarm
+# surfaced to a human; an ``acked`` references a prior raise; ``handed_off`` and
+# ``resolved`` are terminal for autonomous re-firing.
+EVENTS: tuple[str, ...] = ("fired", "chased", "acked", "handed_off", "resolved")
+RAISING_EVENTS: tuple[str, ...] = ("fired", "chased")
+_REQUIRED_KEYS: tuple[str, ...] = ("ts", "skill", "item_key", "event")
+
+# Agent read path (broker writes the same inode via the /run/smd-audit bind).
+# Override with SMD_ESCALATION_LEDGER_PATH (tests, and the broker's write side).
+DEFAULT_LEDGER_PATH = "/opt/data/audit/escalation-ledger.jsonl"
+
+# Crockford base32 minus I L O U — the human types the token back off an email.
+_CROCKFORD = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+
+
+def ledger_path() -> str:
+    """The escalation ledger path: env override, else the agent-read default."""
+    return os.environ.get("SMD_ESCALATION_LEDGER_PATH") or DEFAULT_LEDGER_PATH
+
+
+def _now_iso() -> str:
+    dt = datetime.now(timezone.utc)
+    return dt.strftime("%Y-%m-%dT%H:%M:%S.") + f"{dt.microsecond // 1000:03d}Z"
+
+
+# Placeholders a caller may hand in for a component it could not READ off the
+# source record. ``_matter_id_of`` in both skills' ``pre_run.py`` emits
+# "unknown-matter" when the Smokeball payload carries no resolvable matter link.
+# A sentinel is a fabricated component: an identity built on one moves the moment
+# the real value arrives, so it cannot carry a per-item ACK code
+# (see ``has_stable_identity``). It is NOT excluded from ``item_key`` — the item
+# still fires, it just acks with the blanket code.
+UNKNOWN_SENTINELS: frozenset[str] = frozenset({"unknown-matter"})
+
+
+def _normalize_id(value) -> str:
+    """Canonical form of an identifier component of the item key.
+
+    The connector reads Smokeball GUIDs off the wire and passes them through
+    verbatim (``_source_id_of`` returns ``str(value)``); the agent's tool arg is
+    schema-typed ``string`` and the model may pad or re-case what it retypes. Two
+    spellings of ONE id must not be two items, so both sides fold here — strip,
+    then case-fold. Smokeball ids are ASCII GUIDs, where case carries no meaning
+    and two ids differing only in case cannot exist.
+    """
+    if value is None:
+        return ""
+    return str(value).strip().casefold()
+
+
+def _as_iso_date(value) -> str:
+    """Canonical ``YYYY-MM-DD`` for the date component of the item key, or ``""``
+    when the caller's identity convention omits it (the verification chase does).
+
+    Every caller spells this differently and all of them mean one day. ``pre_run``
+    reads a ``date`` off the record; the append tool's ``authored_date`` is a
+    schema ``string``, so the model has written the bare day, the full timestamp
+    the Smokeball payload carried, and (via ``execute_code``) a ``datetime``
+    handed straight through — which the old ``isinstance(value, date)`` branch
+    turned into ``2026-08-11T14:32:07+00:00``, since ``datetime`` subclasses
+    ``date``. Each spelling was its own item.
+
+    The date is taken AS WRITTEN — no timezone conversion. The connector's
+    ``_parse_iso_date`` reads ``value[:10]``, so a 23:00-0700 record is the 11th
+    on both sides; shifting to UTC here would fork the join it exists to make.
+
+    Unparseable input RAISES rather than hashing verbatim: a component the module
+    cannot canonicalize is exactly how "tomorrow" and "2026-08-11" became two
+    identities, and a rejected tool arg is visible to the turn while it can still
+    be fixed. Silent acceptance is not.
+    """
+    if value is None:
+        return ""
+    if isinstance(value, datetime):  # MUST precede date — datetime subclasses it
+        return value.date().isoformat()
+    if isinstance(value, date):
+        return value.isoformat()
+    text = str(value).strip()
+    if not text:
+        return ""
+    try:
+        return date.fromisoformat(text).isoformat()
+    except ValueError:
+        pass
+    try:
+        return datetime.fromisoformat(text.replace("Z", "+00:00")).date().isoformat()
+    except ValueError:
+        raise ValueError(
+            f"authored_date {value!r} is not an ISO-8601 date or datetime; pass "
+            "YYYY-MM-DD (or null when the skill's identity convention omits the "
+            "date). An uncanonical date component forks item identity — the same "
+            "deadline becomes two items and every ACK code names one of them."
+        ) from None
+
+
+# ---------------------------------------------------------------------------
+# Item identity + token
+# ---------------------------------------------------------------------------
+
+
+def item_key(matter_id, source_id, label, authored_date) -> str:
+    """Stable per-item key: sha256 hex of (matter_id, Smokeball task/event id,
+    authored date). The ``source_id`` is the load-bearing anti-collision field —
+    two same-day tasks on one matter differ only by it. Callers pass
+    ``source_id=None`` ONLY for items with no stable id; those get no per-item
+    token and render in the blanket-ack-only group (see ``has_stable_identity``).
+
+    ``label`` is ACCEPTED AND DELIBERATELY IGNORED (ss #2151). It was in the hash
+    until the identity epoch below, and it is model-composed free text: ``pre_run``
+    assigns it from a closed set (``task-deadline`` / ``court-date``) while the
+    agent's turn writes a descriptor it invents that run (``settlement-offer-lapsed``,
+    ``rfa-confirm-service-date``). The two halves therefore hashed the SAME deadline
+    to different keys, so the ledger join never matched: on the pilot seat, 160
+    events had produced 128 item states, and NONE of them corresponded to any open
+    Smokeball task. Fire-once and the seven-day ack snooze were both inert — every
+    in-range item re-fired every run and every per-item ACK code named a phantom.
+
+    The parameter survives only so the two call sites (this repo's ``pre_run.py``
+    and the overlay's escalation plugin) keep working without a lockstep cross-repo
+    signature change. Nothing may put it back in the hash;
+    ``test_item_key_ignores_label`` is the guard.
+
+    Every surviving component is NORMALIZED before hashing (ss #2289): ids are
+    stripped and case-folded, the date is canonicalized to ``YYYY-MM-DD`` and an
+    unparseable one raises. The residual of the same defect: ``label`` was not the
+    only key component the model typed by hand — ``matter_id``, ``source_id`` and
+    ``authored_date`` are all free-text tool args (see the append tool's schema),
+    so ``2026-08-11`` and ``2026-08-11T00:00:00Z`` were two items on one deadline
+    and nothing rejected the second.
+    """
+    raw = "\x1f".join(
+        (
+            _normalize_id(matter_id),
+            _normalize_id(source_id),
+            _as_iso_date(authored_date),
+        )
+    )
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+
+
+def has_stable_identity(source_id, matter_id) -> bool:
+    """True iff this item's identity tuple is built ENTIRELY from values read off
+    the source, so it can hold a per-item ACK token. Otherwise the item is
+    blanket-ack only: it still fires, it just has no code of its own.
+
+    Two ways to fail. No ``source_id`` — the item has no stable Smokeball id, and
+    a token keyed on the matter alone would silence every item on that matter.
+    Or a sentinel in either position — ``pre_run``'s ``_matter_id_of`` emits
+    ``"unknown-matter"`` when the payload carries no resolvable matter link, and
+    a key with a fabricated component moves the moment the real value arrives, so
+    the code printed today names nothing tomorrow.
+
+    ``matter_id`` is REQUIRED, not defaulted (ss #2289 fix 2). The guard used to
+    test ``source_id`` against the sentinel — but ``_source_id_of`` never emits
+    it and ``_matter_id_of`` does, so the exclusion could not fire on any row the
+    connector writes: a control pointed at the wrong field measures nothing. An
+    optional second argument would have restored exactly that hole for any caller
+    that omitted it.
+    """
+    if not _normalize_id(source_id):
+        return False
+    return not ({_normalize_id(source_id), _normalize_id(matter_id)} & UNKNOWN_SENTINELS)
+
+
+def token_for(key_hex: str) -> str:
+    """A short human-typable ack token derived from the item_key. Deterministic:
+    any reader recomputes it, so a reply quoting ``ACK-7Q3M2K`` maps back to its
+    item without a lookup table. Six Crockford chars ~= 1e9 space; collisions
+    across a firm's live item set are negligible and would only under-ack (the
+    confirmation reply enumerates what was acked, so a mismatch stays visible)."""
+    digest = hashlib.sha256(("ack-token:" + key_hex).encode("utf-8")).digest()
+    n = int.from_bytes(digest[:5], "big")
+    out = []
+    for _ in range(6):
+        n, rem = divmod(n, 32)
+        out.append(_CROCKFORD[rem])
+    return "ACK-" + "".join(reversed(out))
+
+
+# ---------------------------------------------------------------------------
+# Event construction + (de)serialization
+# ---------------------------------------------------------------------------
+
+
+def make_event(
+    *,
+    skill: str,
+    matter_id,
+    item_key: str,
+    event: str,
+    attempt: int,
+    token: str | None = None,
+    ts: str | None = None,
+) -> dict:
+    """Build a well-formed event dict. ``ts`` is normally left None so the broker
+    stamps it server-side (the agent cannot backdate)."""
+    if event not in EVENTS:
+        raise ValueError(f"unknown escalation event {event!r}; expected one of {EVENTS}")
+    row: dict = {
+        "v": SCHEMA_VERSION,
+        "ts": ts,
+        "skill": str(skill),
+        "matter_id": None if matter_id is None else str(matter_id),
+        "item_key": str(item_key),
+        "event": event,
+        "attempt": int(attempt),
+        "token": None if token is None else str(token),
+    }
+    return row
+
+
+def serialize_event(event: dict) -> str:
+    """One canonical JSON line (no trailing newline)."""
+    return json.dumps(event, sort_keys=True, separators=(",", ":"), default=str)
+
+
+def _valid_event(obj) -> bool:
+    if not isinstance(obj, dict):
+        return False
+    for key in _REQUIRED_KEYS:
+        if key not in obj:
+            return False
+    return obj.get("event") in EVENTS
+
+
+def read_ledger(path: str | None = None) -> list[dict]:
+    """Read every parseable event from the JSONL, oldest first.
+
+    Corrupt or unparseable lines are SKIPPED, never guessed at — fail-noisy: a
+    dropped line means that item is treated as if it had no such event (an ack
+    we cannot read stays un-acked, so a deadline keeps firing rather than going
+    silent). A missing file is an empty ledger (first run).
+    """
+    path = path or ledger_path()
+    try:
+        with open(path, encoding="utf-8") as handle:
+            raw_lines = handle.readlines()
+    except FileNotFoundError:
+        return []
+    except OSError:
+        return []
+    events: list[dict] = []
+    for line in raw_lines:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except (ValueError, TypeError):
+            continue
+        if _valid_event(obj):
+            events.append(obj)
+    return events
+
+
+# ---------------------------------------------------------------------------
+# Per-item state derivation
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ItemState:
+    """Ledger-derived state for one item_key. ``attempts`` counts raises
+    (fired + chased). ``acked`` is reset by any raise that follows an ack, so a
+    re-surfaced item is awaiting a fresh ack, not still silenced by the old one.
+    """
+
+    item_key: str
+    matter_id: str | None = None
+    token: str | None = None
+    last_raised_ts: str | None = None
+    last_raised_date: date | None = None
+    attempts: int = 0
+    acked: bool = False
+    last_acked_date: date | None = None
+    handed_off: bool = False
+    resolved: bool = False
+
+
+def _parse_ts_date(ts) -> date | None:
+    if not isinstance(ts, str) or len(ts) < 10:
+        return None
+    try:
+        return date.fromisoformat(ts[:10])
+    except ValueError:
+        return None
+
+
+def derive_state(events) -> dict[str, ItemState]:
+    """Fold events (any order) into per-item_key state. Events are sorted by
+    ``ts`` so ack-then-refire vs refire-then-ack resolve deterministically."""
+    ordered = sorted(events, key=lambda e: str(e.get("ts") or ""))
+    states: dict[str, ItemState] = {}
+    for event in ordered:
+        key = str(event.get("item_key") or "")
+        if not key:
+            continue
+        state = states.get(key)
+        if state is None:
+            state = ItemState(item_key=key)
+            states[key] = state
+        if event.get("matter_id") is not None:
+            state.matter_id = str(event.get("matter_id"))
+        if event.get("token") is not None:
+            state.token = str(event.get("token"))
+        kind = event.get("event")
+        ts = event.get("ts")
+        if kind in RAISING_EVENTS:
+            state.attempts += 1
+            state.last_raised_ts = ts if isinstance(ts, str) else state.last_raised_ts
+            parsed = _parse_ts_date(ts)
+            if parsed is not None:
+                state.last_raised_date = parsed
+            # A fresh raise supersedes any prior ack: the item is loud again.
+            state.acked = False
+        elif kind == "acked":
+            state.acked = True
+            parsed = _parse_ts_date(ts)
+            if parsed is not None:
+                state.last_acked_date = parsed
+        elif kind == "handed_off":
+            state.handed_off = True
+        elif kind == "resolved":
+            state.resolved = True
+    return states
+
+
+def next_attempt(state: ItemState | None) -> int:
+    """The attempt number the next raise on this item will carry."""
+    return 1 if state is None else state.attempts + 1
+
+
+def should_fire(
+    state: ItemState | None,
+    today: date,
+    *,
+    refire_days: int,
+    ack_snooze_days: int,
+) -> bool:
+    """Should this in-range item raise an alarm on today's tick?
+
+    - never raised            -> fire (attempt 1)
+    - resolved / handed_off   -> never (terminal; a person owns it)
+    - acked, still unresolved -> re-surface only after ``ack_snooze_days``
+                                 (ack is a snooze, not a tombstone)
+    - raised, not acked       -> re-fire only after ``refire_days``
+                                 (fire once, not daily)
+    """
+    if state is None:
+        return True
+    if state.resolved or state.handed_off:
+        return False
+    if state.acked:
+        if state.last_acked_date is None:
+            return True
+        return today >= state.last_acked_date + timedelta(days=max(0, ack_snooze_days))
+    if state.last_raised_date is None:
+        return True
+    return today >= state.last_raised_date + timedelta(days=max(0, refire_days))
+
+
+# ---------------------------------------------------------------------------
+# Append (broker-side write path)
+# ---------------------------------------------------------------------------
+
+
+def is_pre_identity_epoch(event) -> bool:
+    """True for a raise written before the ss #2151 identity fix. PUBLIC so the
+    overlay's escalation plugin resolves ack tokens against the same rule the
+    broker validates with — a second implementation there would be a second
+    authority over one decision, and the two would disagree the first time
+    either changed. Its ``item_key``
+    came from a different derivation (it hashed the model-composed label), so it
+    can never name a live item. Acking one would tell a human an alarm was
+    silenced when nothing changed — the exact class of false report the fix
+    exists to end. A row with a missing or unparseable ``v`` is treated as
+    pre-epoch: unknown provenance is not evidence of a current key."""
+    try:
+        return int(event.get("v") or 1) < IDENTITY_EPOCH
+    except (TypeError, ValueError):
+        return True
+
+
+def validate_append(existing_events, new_event: dict) -> None:
+    """Raise ValueError unless ``new_event`` is a well-formed event that may be
+    appended. The load-bearing rule: an ``acked`` MUST reference a prior
+    ``fired``/``chased`` with the same token (or item_key) — you cannot ack an
+    alarm that never rang."""
+    if not isinstance(new_event, dict):
+        raise ValueError("escalation event must be an object")
+    kind = new_event.get("event")
+    if kind not in EVENTS:
+        raise ValueError(f"unknown escalation event {kind!r}; expected one of {EVENTS}")
+    if not str(new_event.get("item_key") or "").strip():
+        raise ValueError("escalation event requires a non-empty item_key")
+    if not str(new_event.get("skill") or "").strip():
+        raise ValueError("escalation event requires a skill")
+    if kind == "acked":
+        token = new_event.get("token")
+        key = str(new_event.get("item_key") or "")
+        raised = False
+        stale_only = False
+        for prior in existing_events:
+            if prior.get("event") not in RAISING_EVENTS:
+                continue
+            if token is not None and prior.get("token") == token:
+                pass
+            elif prior.get("item_key") == key:
+                pass
+            else:
+                continue
+            if is_pre_identity_epoch(prior):
+                # Matches, but its key came from the superseded derivation, so it
+                # names nothing live. Keep looking for a current raise.
+                stale_only = True
+                continue
+            raised = True
+            break
+        if not raised:
+            if stale_only:
+                raise ValueError(
+                    "that ACK code was issued before the item-identity fix (ss #2151) and no "
+                    "longer names a live item; the deadline will re-raise with a current code. "
+                    "Do not report it as acknowledged"
+                )
+            raise ValueError("acked event has no prior fired/chased raise for its token/item_key")
+
+
+def _ulid() -> str:
+    ts = int(time.time() * 1000)
+    n = (ts << 80) | secrets.randbits(80)
+    out = []
+    for _ in range(26):
+        n, rem = divmod(n, 32)
+        out.append(_CROCKFORD[rem])
+    return "".join(reversed(out))
+
+
+def stamp_event(event: dict) -> dict:
+    """Return a copy with a server-stamped ``ts`` (if absent) and a fresh ``id``.
+    Called by the broker so the caller cannot backdate or set the id."""
+    stamped = dict(event)
+    stamped["ts"] = _now_iso()
+    stamped["id"] = _ulid()
+    stamped.setdefault("v", SCHEMA_VERSION)
+    return stamped
+
+
+def append_line(path: str, event: dict) -> None:
+    """Append one serialized event to the JSONL, creating the file world-readable
+    (0644) so the agent-uid read seam can consume it. Caller serializes writes
+    (the broker holds a lock); this function does no locking of its own."""
+    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+    newly_created = not os.path.exists(path)
+    with open(path, "a", encoding="utf-8") as handle:
+        handle.write(serialize_event(event) + "\n")
+    if newly_created:
+        try:
+            os.chmod(path, 0o644)
+        except OSError:
+            pass

--- a/operator/skills/lien-ledger-tracker/pre_run.py
+++ b/operator/skills/lien-ledger-tracker/pre_run.py
@@ -1,166 +1,1100 @@
 #!/usr/bin/env python3
-"""Shared cron pre-run gate — the empty-seat wake suppressor (ADR 0021 Stream B).
+"""lien-ledger-tracker pre-run gate — the settlement-closeout obligation ledger (ss #2455).
 
-CANONICAL SOURCE: ``operator/templates/pre_run_gate.py``. The copies stamped
-into skill directories as ``pre_run.py`` MUST be byte-identical to this file —
-``operator/tests/test_pre_run_gate.py`` enforces the sync. Edit here, restamp.
+Runs BEFORE the Hermes cron daemon wakes the agent. Decides whether any provider
+still owed money on a settled-undistributed matter needs chasing today, and hands
+the woken turn the STATE its outreach must copy — so "chase 3, last chased July 2"
+is broker-validated ledger fact, never model recall.
 
-What this gate decides
-----------------------
-Scheduled tracker/watch/chase skills re-derive their work from the matter set
-in the practice-management system (they keep no local state — the matter is
-the system of record). On a seat with ZERO open matters there is provably no
-work for any of them, so waking the model is pure token burn. This gate:
+What changed, and why this skill graduated
+------------------------------------------
+The firm's #1 job is the settled-but-undistributed backlog: cases where the money
+is in trust and cannot be released because provider bills are un-negotiated. Two
+facts reshaped this skill for it.
 
-  1. Probes Smokeball for open matters (one ``GET /matters?Status=Open&Limit=1``
-     via the connector's own venv — the connector package is not importable
-     from the Hermes venv this script runs in).
-  2. Any open matter, any probe failure, any unknown response envelope, any
-     heartbeat-write failure → ``{"wakeAgent": true}`` (fail-open; the agent
-     wakes exactly as it would with no gate).
-  3. Zero open matters → writes a SUPPRESSED_WAKE heartbeat row through the
-     broker's uid-gated ``suppressed_wake_append`` verb, THEN emits
-     ``{"wakeAgent": false}``. Suppress-without-heartbeat never happens
-     (mirror-don't-gate): if the broker write fails, the agent wakes.
+  1. SCOPE. This routine was authored around statutory lienholders. At the first
+     firm, 76% of the outstanding balance sits on obligations with NO lien
+     asserted — ordinary unpaid provider invoices. The firm's own practice-
+     management tab models ``Providers[]`` and ``OtherLiensAndBalances[]`` side
+     by side, so the ledger here is every obligation blocking disbursement, not
+     only the ones that happen to carry a lien.
+  2. SOURCE. The obligations are structured and readable
+     (``GET /matters/{id}/layouts`` → ``PersonalInjurySettlementDetailsItem``),
+     one item PER PLAINTIFF. They no longer have to be figures a person types in.
 
-What this gate deliberately does NOT decide
--------------------------------------------
-It is NOT a per-skill "is there work" check. A hydrated seat (any open
-matter) always wakes — deeper UpdatedSince/state-delta gates are follow-on
-work once the Smokeball ``updated_since`` wire format is verified at connect.
-Lead-stage and inbound-driven work is unaffected either way: webhook and
-inbound wakes are ungated by design.
+The chase unit is the PROVIDER, not the obligation
+--------------------------------------------------
+Exposure concentrates hard: at the first firm a single payer appears on 22
+separate matters. Chasing per obligation would send that payer 22 messages in one
+pass, which is both the wrong commercial move (one negotiation clears 22 files)
+and the kind of machine-noise that ends a pilot. So the ledger carries two item
+families:
 
-Skill identity
+  * OBLIGATION items, keyed ``(matter_id, "sct:<provider entity id>")`` — what is
+    owed, and whether it has cleared. One per matter per provider.
+  * PROVIDER-CHASE items, keyed ``("", "__sct_provider__<normalized name>")`` —
+    the outreach cadence and attempt count for ONE consolidated contact covering
+    every matter that provider appears on.
+
+A provider group plans at most one chase per run, and the plan carries every
+matter in the group so the turn writes one message naming all of them.
+
+Identity is read off the record, never composed
+-----------------------------------------------
+``item_key`` hashes (matter_id, source_id, authored_date) and IGNORES label
+(ss #2151), so the provider must ride ``source_id``. It rides
+``Providers[n]/Provider/MatterEntityId`` — the practice-management system's own
+per-provider identifier, observed populated on every provider row. That matters
+beyond tidiness: a name-derived key would change the day the firm corrects a
+spelling, orphaning that obligation's whole negotiation history at the moment the
+correction succeeded. Where the id is genuinely absent the fallback is the raw
+display name, casefold and whitespace-collapsed only — no punctuation stripping,
+no suffix dropping, no fuzzy matching — and the absence is reported, never
+silently papered over.
+
+Cross-matter GROUPING is a different question from identity, and it is
+deliberately looser: a misspelled provider is a different contact record with a
+different entity id, so grouping falls back to the normalized display name. That
+grouping is a proposal the register shows with both raw spellings; it never
+silently merges two ledger identities.
+
+Wake / suppress decision
+------------------------
+  (a) CHASE DUE — a provider group holds at least one unresolved obligation with
+      a positive balance, and either has never been chased or its last chase is
+      at least ``chase_cadence_days`` old. The plan carries ``attempt``,
+      ``last_chased`` and the matters in the group. No attempt ceiling: the
+      chase runs on cadence until the balance clears; escalation is stall-based.
+  (d) HELD — the ledger carries an open per-MATTER hold: a turn found the matter
+      unsafe to chase. A held matter's obligations never join a chase group, and
+      the hold re-surfaces on the re-fire window until a turn resolves it.
+  (f) STALLED — a matter whose obligations have all gone quiet longer than
+      ``stall_days``. Matter-level on purpose: a quiet matter is one thing to
+      tell a person, and a per-obligation stall sentinel would roughly double a
+      ledger every skill on the seat parses whole on every run.
+
+Seat-level:
+
+  (c) CONFIG MISSING — ``trigger_status`` or ``chase_cadence_days`` unauthored.
+      Both are firm facts with no pack default: which status means
+      settled-undistributed, and how often this firm wants a payer contacted.
+      Fail-closed, surfaced once, re-surfaced every ``escalation.refire_days``
+      until authored (#1899). ``stall_days`` is NOT in this class — unauthored,
+      it degrades: no stall flags, and tracking and chasing continue.
+  (g) NO OBLIGATIONS READ — the trigger-status cohort is non-empty but every
+      deep read came back with no provider detail. At a real firm that is most
+      likely a layout or permissions mismatch, and with zero obligations every
+      wake would otherwise suppress forever. Surfaced on its own sentinel.
+
+Everything else → a ``SUPPRESSED_WAKE`` heartbeat through the broker, then
+``{"wakeAgent": false}``.
+
+Fail direction
 --------------
-The scheduler stages this file to ``<profile>/scripts/<skill>/pre_run.py`` and
-runs it with cwd = that directory, so the skill name is the cwd basename. That
-keeps every stamped copy byte-identical.
+- Ledger unreadable → FIRE-OPEN (wake).
+- Pull failure, unrecognized envelope, or a full page (the cohort may be
+  truncated) → FIRE-OPEN (wake).
+- Deep-read budget exhausted → NOT a failure: plan what was read, and report the
+  shortfall as coverage so the turn can state it. A partial view that says it is
+  partial beats a raised run.
+- Config unreadable / unauthored → fail-CLOSED surface (c).
 
-Verification hook
------------------
-``pre_run.py --assume-empty`` skips the Smokeball probe and behaves as if the
-seat were empty — it exercises the heartbeat write + suppress path end-to-end
-on a live Machine without needing an actually-empty tenant. The cron daemon
-never passes arguments, so this path cannot trigger on a scheduled fire.
+``decide()`` is pure (no I/O) and unit-tested with fake inputs. ``run_once()``
+wires the real source, the broker heartbeat and stdout.
+
+Exit codes:
+    0 — decision emitted (wake or suppress)
 """
 
 from __future__ import annotations
 
+import asyncio
+import hashlib
 import json
 import os
+import re
 import socket
 import subprocess
 import sys
+from dataclasses import dataclass, field
+from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
+from typing import Protocol, Sequence
 
-# Timeout budget: the Hermes scheduler kills the whole script at 120s
-# (cron/scheduler.py _DEFAULT_SCRIPT_TIMEOUT); the probe gets well under that.
-_PROBE_TIMEOUT_SECONDS = 45
-_HEARTBEAT_TIMEOUT_SECONDS = 10
+SKILL_NAME = "lien-ledger-tracker"
 
-_CONNECTOR_PYTHON_DEFAULT = "/opt/connectors/smokeball/.venv/bin/python"
+# Seat-level sentinels, namespaced __sct_* (settlement closeout). item_key
+# ignores label and derive_state joins on the key alone, so a sentinel source_id
+# shared with another skill would share one ledger identity: acking their config
+# surface would silence ours.
+_CONFIG_SENTINEL_SOURCE_ID = "__sct_config__"
+_CONFIG_SENTINEL_LABEL = "sct-config-missing"
+_NO_OBLIGATIONS_SENTINEL_SOURCE_ID = "__sct_no_obligations__"
+_NO_OBLIGATIONS_SENTINEL_LABEL = "sct-no-obligations-read"
 
-# Runs inside the connector venv, where smokeball_connector IS importable and
-# build_client_from_env() owns auth (token mint + refresh-token self-heal).
-# Envelope parsing is deliberately defensive: the live /matters list shape is
-# connect-time-unverified, so an unrecognized shape reports null → wake.
-_PROBE_SNIPPET = """\
-import json
-from smokeball_connector.client import build_client_from_env
+# Per-matter hold: a turn found this matter unsafe to chase. Matter-level so it
+# survives an obligation being cleared, re-added, or re-keyed.
+HOLD_SOURCE_ID = "__sct_hold__"
+_HOLD_LABEL = "sct-chase-hold"
 
-r = build_client_from_env().get("/matters", Status="Open", Limit=1)
-items = None
-if isinstance(r, list):
-    items = r
-elif isinstance(r, dict):
-    for key in ("items", "value", "results", "matters", "data"):
-        v = r.get(key)
-        if isinstance(v, list):
-            items = v
-            break
-print(json.dumps({"openMatterCount": len(items) if items is not None else None}))
-"""
+# Matter-level stall. Kept OFF the obligation and provider keys on purpose:
+# attempts counts every raise, so a stall fired on a chase key would inflate the
+# "chase N" numerator the outreach copies.
+STALL_SOURCE_PREFIX = "__sct_stall__"
+
+# Provider-chase family. The group's cadence and attempt count live here.
+PROVIDER_SOURCE_PREFIX = "__sct_provider__"
+_PROVIDER_LABEL = "sct-provider-chase"
+
+# Obligation family: one per (matter, provider).
+_OBLIGATION_SOURCE_PREFIX = "sct:"
+_OBLIGATION_LABEL = "sct-obligation"
 
 
-def _emit(wake: bool) -> int:
-    print(json.dumps({"wakeAgent": wake}))
+# ---------------------------------------------------------------------------
+# Obligation source protocol.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Obligation:
+    """One provider's outstanding position on one settled-undistributed matter.
+
+    ``provider_key`` is the practice-management entity id where one exists; the
+    display name, casefold+collapsed, only where it does not. ``id_source`` says
+    which, so a run can report how much of its own identity is second-best.
+    ``plaintiff_index`` is carried as an ATTRIBUTE, never part of the key:
+    removing a plaintiff renumbers the survivors, and identity must not move
+    because a sibling was deleted.
+    """
+
+    matter_id: str
+    provider_key: str
+    provider_display: str
+    balance: float
+    plaintiff_index: int = 0
+    lien_asserted: bool = False
+    id_source: str = "entity_id"  # entity_id | display_name
+
+    @property
+    def outstanding(self) -> bool:
+        return self.balance > 0
+
+
+class ObligationSource(Protocol):
+    def pull_obligations(self) -> "ObligationPull":
+        ...
+
+
+@dataclass(frozen=True)
+class ObligationPull:
+    """What one pull observed.
+
+    ``cohort_size`` is every matter at the trigger status; ``deep_read`` is how
+    many of them we actually opened this run. The gap is the coverage the turn
+    must state — a register that does not say how much it looked at reads as
+    complete when it is not.
+    """
+
+    obligations: tuple[Obligation, ...]
+    cohort_size: int
+    deep_read: int
+    unreadable: int = 0
+    name_keyed: int = 0  # obligations that fell back to a name-derived key
+
+
+# ---------------------------------------------------------------------------
+# Config. trigger_status and chase_cadence_days are CLIENT-COMMITMENT facts with
+# no pack default (ADR 0035). stall_days degrades instead: an unauthored stall
+# threshold withholds stall flags and says so, and never stops the tracking.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CloseoutConfig:
+    trigger_status: str | None = None
+    chase_cadence_days: int | None = None
+    stall_days: int | None = None
+
+    @property
+    def authored(self) -> bool:
+        return bool(self.trigger_status) and self.chase_cadence_days is not None
+
+    @property
+    def missing(self) -> list[str]:
+        gaps = []
+        if not self.trigger_status:
+            gaps.append("trigger_status")
+        if self.chase_cadence_days is None:
+            gaps.append("chase_cadence_days")
+        return gaps
+
+
+_DEFAULT_REFIRE_DAYS = 3
+_STATUS_RE = re.compile(r"^[A-Za-z][A-Za-z0-9 _-]{0,63}$")
+
+
+def _pos_int_or_none(value):
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int) and value > 0:
+        return value
+    return None
+
+
+def _pos_int(value, fallback: int) -> int:
+    if isinstance(value, bool):
+        return fallback
+    if isinstance(value, int) and value > 0:
+        return value
+    return fallback
+
+
+def _status_or_none(value):
+    """A status crosses into a subprocess environment, so it is shape-checked
+    here rather than trusted for being authored."""
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    return text if _STATUS_RE.match(text) else None
+
+
+def _find_skill_settings(data) -> dict:
+    if not isinstance(data, dict):
+        return {}
+    personas = data.get("personas")
+    if not isinstance(personas, list):
+        return {}
+    for persona in personas:
+        if not isinstance(persona, dict):
+            continue
+        skills = persona.get("skills")
+        if not isinstance(skills, list):
+            continue
+        for entry in skills:
+            if not isinstance(entry, dict) or entry.get("name") != SKILL_NAME:
+                continue
+            settings = entry.get("settings")
+            return settings if isinstance(settings, dict) else {}
+    return {}
+
+
+def load_closeout_config(customer_yaml_path: str | None = None) -> tuple[CloseoutConfig, int]:
+    """Read (CloseoutConfig, refire_days) from the trusted-volume customer.yaml.
+    Missing file / PyYAML / parse failure → unauthored (fail-closed)."""
+    path = customer_yaml_path or os.environ.get("SMD_CUSTOMER_YAML_PATH")
+    if not path:
+        return CloseoutConfig(), _DEFAULT_REFIRE_DAYS
+    try:
+        import yaml
+    except ImportError:
+        return CloseoutConfig(), _DEFAULT_REFIRE_DAYS
+    try:
+        with open(path, encoding="utf-8") as handle:
+            data = yaml.safe_load(handle) or {}
+    except (OSError, yaml.YAMLError):
+        return CloseoutConfig(), _DEFAULT_REFIRE_DAYS
+    settings = _find_skill_settings(data)
+    config = CloseoutConfig(
+        trigger_status=_status_or_none(settings.get("trigger_status")),
+        chase_cadence_days=_pos_int_or_none(settings.get("chase_cadence_days")),
+        stall_days=_pos_int_or_none(settings.get("stall_days")),
+    )
+    esc = data.get("escalation") if isinstance(data, dict) else None
+    refire_days = _pos_int(
+        esc.get("refire_days") if isinstance(esc, dict) else None, _DEFAULT_REFIRE_DAYS
+    )
+    return config, refire_days
+
+
+# ---------------------------------------------------------------------------
+# Escalation ledger — vendored byte-identical copy (test_escalation_ledger_sync).
+# ---------------------------------------------------------------------------
+
+
+def _load_ledger_module():
+    import importlib.util
+
+    candidates = [Path(__file__).resolve().parent]
+    for base in ("/opt/data/skills", "/app/skills"):
+        candidates.append(Path(base) / SKILL_NAME)
+    for cand in candidates:
+        module_path = cand / "escalation_ledger.py"
+        if module_path.is_file():
+            spec = importlib.util.spec_from_file_location(
+                "escalation_ledger_vendored_llt", module_path
+            )
+            if spec is None or spec.loader is None:
+                continue
+            module = importlib.util.module_from_spec(spec)
+            sys.modules[spec.name] = module
+            spec.loader.exec_module(module)
+            return module
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Grouping. Deterministic code, never model judgment (#2390).
+# ---------------------------------------------------------------------------
+
+_GROUP_STRIP_RE = re.compile(r"[^a-z0-9 ]+")
+_GROUP_NOISE_RE = re.compile(r"\b(inc|llc|llp|pc|corp|co|the|of|and|dba)\b")
+
+
+def normalize_provider_name(name: str) -> str:
+    """Collapse a display name to a grouping token.
+
+    Used ONLY for cross-matter grouping and for the fallback identity when the
+    record carries no entity id. Never used to merge two entity ids: a firm that
+    keeps two contact records is telling us something, and the register proposes
+    the merge with both raw spellings rather than deciding it here.
+    """
+    text = _GROUP_STRIP_RE.sub(" ", (name or "").casefold())
+    text = _GROUP_NOISE_RE.sub(" ", text)
+    return " ".join(text.split())
+
+
+def fallback_provider_key(name: str) -> str:
+    """Identity of last resort: casefold and whitespace-collapse only. No
+    punctuation stripping and no suffix dropping, so the key stays a faithful
+    function of what the record says."""
+    return " ".join((name or "").casefold().split())
+
+
+# ---------------------------------------------------------------------------
+# Decision engine — pure, no I/O.
+# ---------------------------------------------------------------------------
+
+ACTION_CHASE_PROVIDER = "chase_provider"
+ACTION_SURFACE_CONFIG = "surface_config_missing"
+ACTION_SURFACE_NO_OBLIGATIONS = "surface_no_obligations_read"
+ACTION_SURFACE_HOLD = "surface_hold"
+ACTION_SURFACE_STALL = "surface_stall"
+ACTION_SUPPRESS = "suppress"
+
+
+@dataclass(frozen=True)
+class ChasePlan:
+    """One consolidated provider outreach, or one surface.
+
+    ``matters`` carries every matter the outreach must name, so the turn writes
+    one message for the group instead of one per obligation.
+    """
+
+    item_key: str
+    action: str
+    attempt: int
+    provider_display: str = ""
+    provider_group: str = ""
+    matter_id: str = ""
+    matters: tuple[str, ...] = ()
+    outstanding_total: float = 0.0
+    last_chased: str | None = None
+
+
+@dataclass(frozen=True)
+class WakeDecision:
+    wake: bool
+    decision_basis: str
+    pre_run_inputs_digest: bytes
+    plans: tuple[ChasePlan, ...] = ()
+    extra_metadata: dict = field(default_factory=dict)
+
+
+def _hold_active(hold_state) -> bool:
+    if hold_state is None or hold_state.attempts == 0:
+        return False
+    return not hold_state.resolved
+
+
+def _chase_due(state, today: date, *, cadence_days: int) -> bool:
+    if state is None or state.last_raised_date is None:
+        return True
+    return today >= state.last_raised_date + timedelta(days=max(0, cadence_days))
+
+
+def _seat_sentinel_decision(
+    ledger,
+    states,
+    *,
+    source_id: str,
+    label: str,
+    action: str,
+    basis_surface: str,
+    basis_quiet: str,
+    today: date,
+    refire_days: int,
+    raw_inputs_for_digest: bytes,
+    extra: dict,
+) -> WakeDecision:
+    """Fire-once + re-fire-window on a stable seat sentinel (#1899)."""
+    key = ledger.item_key("", source_id, label, "")
+    state = states.get(key)
+    if not ledger.should_fire(
+        state, today, refire_days=refire_days, ack_snooze_days=refire_days
+    ):
+        return WakeDecision(
+            wake=False,
+            decision_basis=basis_quiet,
+            pre_run_inputs_digest=raw_inputs_for_digest,
+            extra_metadata=extra,
+        )
+    return WakeDecision(
+        wake=True,
+        decision_basis=basis_surface,
+        pre_run_inputs_digest=raw_inputs_for_digest,
+        plans=(ChasePlan(item_key=key, action=action, attempt=ledger.next_attempt(state)),),
+        extra_metadata=extra,
+    )
+
+
+def obligation_key(ledger, obligation: Obligation) -> str:
+    return ledger.item_key(
+        obligation.matter_id,
+        _OBLIGATION_SOURCE_PREFIX + obligation.provider_key,
+        _OBLIGATION_LABEL,
+        None,
+    )
+
+
+def provider_key(ledger, group: str) -> str:
+    return ledger.item_key("", PROVIDER_SOURCE_PREFIX + group, _PROVIDER_LABEL, "")
+
+
+def decide(
+    pull: ObligationPull,
+    config: CloseoutConfig,
+    ledger,
+    events: Sequence[dict],
+    *,
+    raw_inputs_for_digest: bytes,
+    today: date,
+    refire_days: int,
+) -> WakeDecision:
+    """Pure decision: does any provider need chasing today?"""
+    states = ledger.derive_state(events)
+
+    # (c) Seat-level: the firm facts are unauthored → fail-closed surface.
+    if not config.authored:
+        return _seat_sentinel_decision(
+            ledger,
+            states,
+            source_id=_CONFIG_SENTINEL_SOURCE_ID,
+            label=_CONFIG_SENTINEL_LABEL,
+            action=ACTION_SURFACE_CONFIG,
+            basis_surface="closeout_config_unauthored_surface",
+            basis_quiet="closeout_config_unauthored_within_refire_window",
+            today=today,
+            refire_days=refire_days,
+            raw_inputs_for_digest=raw_inputs_for_digest,
+            extra={"missing": config.missing, "cohort_size": pull.cohort_size},
+        )
+
+    # (g) Seat-level: a cohort exists but nothing in it carried obligations.
+    if not pull.obligations and pull.cohort_size > 0 and pull.deep_read > 0:
+        return _seat_sentinel_decision(
+            ledger,
+            states,
+            source_id=_NO_OBLIGATIONS_SENTINEL_SOURCE_ID,
+            label=_NO_OBLIGATIONS_SENTINEL_LABEL,
+            action=ACTION_SURFACE_NO_OBLIGATIONS,
+            basis_surface="no_obligations_read_surface",
+            basis_quiet="no_obligations_read_within_refire_window",
+            today=today,
+            refire_days=refire_days,
+            raw_inputs_for_digest=raw_inputs_for_digest,
+            extra={
+                "cohort_size": pull.cohort_size,
+                "deep_read": pull.deep_read,
+                "unreadable": pull.unreadable,
+            },
+        )
+
+    plans: list[ChasePlan] = []
+    held_matters: set[str] = set()
+
+    # (d) HELD — surface once per held matter, and fence its obligations out of
+    # every chase group below.
+    for matter_id in sorted({o.matter_id for o in pull.obligations}):
+        hold_key = ledger.item_key(matter_id, HOLD_SOURCE_ID, _HOLD_LABEL, None)
+        hold_state = states.get(hold_key)
+        if not _hold_active(hold_state):
+            continue
+        held_matters.add(matter_id)
+        if not hold_state.handed_off and ledger.should_fire(
+            hold_state, today, refire_days=refire_days, ack_snooze_days=refire_days
+        ):
+            plans.append(
+                ChasePlan(
+                    item_key=hold_key,
+                    action=ACTION_SURFACE_HOLD,
+                    attempt=ledger.next_attempt(hold_state),
+                    matter_id=matter_id,
+                    matters=(matter_id,),
+                )
+            )
+
+    # (a) CHASE — group the live obligations by provider and plan ONE outreach.
+    groups: dict[str, list[Obligation]] = {}
+    for obligation in pull.obligations:
+        if obligation.matter_id in held_matters or not obligation.outstanding:
+            continue
+        if states.get(obligation_key(ledger, obligation)) is not None:
+            state = states[obligation_key(ledger, obligation)]
+            if state.resolved or state.handed_off:
+                continue
+        groups.setdefault(normalize_provider_name(obligation.provider_display), []).append(
+            obligation
+        )
+
+    cadence_days = int(config.chase_cadence_days or 0)
+    for group in sorted(groups):
+        members = groups[group]
+        key = provider_key(ledger, group)
+        state = states.get(key)
+        if state is not None and (state.resolved or state.handed_off):
+            continue
+        if not _chase_due(state, today, cadence_days=cadence_days):
+            continue
+        last = None
+        if state is not None and state.last_raised_date is not None:
+            last = state.last_raised_date.isoformat()
+        plans.append(
+            ChasePlan(
+                item_key=key,
+                action=ACTION_CHASE_PROVIDER,
+                attempt=ledger.next_attempt(state),
+                provider_display=members[0].provider_display,
+                provider_group=group,
+                matters=tuple(sorted({m.matter_id for m in members})),
+                outstanding_total=round(sum(m.balance for m in members), 2),
+                last_chased=last,
+            )
+        )
+
+    coverage = {
+        "cohort_size": pull.cohort_size,
+        "deep_read": pull.deep_read,
+        "unreadable": pull.unreadable,
+        "obligations": len(pull.obligations),
+        "name_keyed_obligations": pull.name_keyed,
+        "stall_days_authored": config.stall_days is not None,
+    }
+    if plans:
+        chases = [p for p in plans if p.action == ACTION_CHASE_PROVIDER]
+        return WakeDecision(
+            wake=True,
+            decision_basis="closeout_chase_due",
+            pre_run_inputs_digest=raw_inputs_for_digest,
+            plans=tuple(plans),
+            extra_metadata={
+                **coverage,
+                "provider_chases_due": len(chases),
+                "hold_surface_due": len(plans) - len(chases),
+                "matters_in_chases": sorted({m for p in chases for m in p.matters}),
+            },
+        )
+    return WakeDecision(
+        wake=False,
+        decision_basis="no_closeout_chase_due",
+        pre_run_inputs_digest=raw_inputs_for_digest,
+        extra_metadata=coverage,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Runtime entrypoint.
+# ---------------------------------------------------------------------------
+
+
+def _next_scheduled_at(now: datetime, schedule_hours: int = 168) -> str:
+    return (now + timedelta(hours=schedule_hours)).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def _plan_to_dict(plan: ChasePlan) -> dict:
+    return {
+        "item_key": plan.item_key,
+        "action": plan.action,
+        "attempt": plan.attempt,
+        "provider_display": plan.provider_display,
+        "provider_group": plan.provider_group,
+        "matter_id": plan.matter_id,
+        "matters": list(plan.matters),
+        "outstanding_total": plan.outstanding_total,
+        "last_chased": plan.last_chased,
+    }
+
+
+def _emit_wake(decision: "WakeDecision | None" = None, *, basis: str | None = None) -> int:
+    """Print the wake line WITH its plans (ss #2226): the plans are the woken
+    turn's work list, and a chase plan carries the state its message copies.
+    Fail-open callers pass ``basis`` so the turn knows it woke blind."""
+    payload: dict = {"wakeAgent": True}
+    resolved_basis = decision.decision_basis if decision is not None else basis
+    if resolved_basis:
+        payload["decision_basis"] = resolved_basis
+    if decision is not None:
+        if decision.plans:
+            payload["plans"] = [_plan_to_dict(p) for p in decision.plans]
+        if decision.extra_metadata:
+            payload["coverage"] = decision.extra_metadata
+    print(json.dumps(payload))
     return 0
 
 
-def _skill_name() -> str:
-    return Path.cwd().name or "unknown-skill"
+def _plan_counts(decision: "WakeDecision") -> dict:
+    if not decision.plans:
+        return {}
+    return {"plans_total": len(decision.plans)}
 
 
-def probe_open_matter_count() -> int | None:
-    """Return the open-matter count, or None when it cannot be determined."""
-    connector_python = os.environ.get(
-        "SMD_CONNECTOR_VENV_PYTHON", _CONNECTOR_PYTHON_DEFAULT
-    )
-    if not Path(connector_python).exists():
-        sys.stderr.write(f"[pre_run] connector python missing: {connector_python}\n")
-        return None
+async def _try_write_emitted_wake(
+    audit_writer_factory,
+    decision: "WakeDecision",
+    *,
+    skill_name: str,
+    now: datetime,
+) -> None:
+    """Best-effort EMITTED_WAKE row (#2253) — an audit failure never gates a
+    wake. The suppress path is deliberately the other way round."""
     try:
-        result = subprocess.run(
-            # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-tainted-env-args.dangerous-subprocess-use-tainted-env-args — argv[0] is the module-constant connector-venv interpreter, overridable only via SMD_CONNECTOR_VENV_PYTHON, which comes from the Machine's own boot env (same trust domain as this file; the test seam). The snippet argument is a module constant; no request/agent-controlled data reaches argv.
-            [connector_python, "-c", _PROBE_SNIPPET],
+        writer = audit_writer_factory()
+        if writer is None:
+            return
+        await writer.write_emitted_wake(
+            skill_name=skill_name,
+            pre_run_inputs=decision.pre_run_inputs_digest,
+            decision_basis=decision.decision_basis,
+            next_scheduled_at=_next_scheduled_at(now),
+            extra_metadata={**decision.extra_metadata, **_plan_counts(decision)},
+        )
+    except Exception:  # noqa: BLE001 — observability never gates the wake
+        pass
+
+
+def _emit_suppress() -> int:
+    print(json.dumps({"wakeAgent": False}))
+    return 0
+
+
+def _obligation_to_dict(obligation: Obligation) -> dict:
+    return {
+        "matter_id": obligation.matter_id,
+        "provider_key": obligation.provider_key,
+        "provider_display": obligation.provider_display,
+        "balance": obligation.balance,
+        "plaintiff_index": obligation.plaintiff_index,
+        "lien_asserted": obligation.lien_asserted,
+        "id_source": obligation.id_source,
+    }
+
+
+async def run_once(
+    sources: Sequence[ObligationSource],
+    audit_writer_factory,
+    *,
+    today: date | None = None,
+    now: datetime | None = None,
+    config: CloseoutConfig | None = None,
+    refire_days: int | None = None,
+    ledger_module=None,
+    ledger_events: Sequence[dict] | None = None,
+) -> int:
+    """Driver. Fail-open on ledger loss; a config-read failure is the unauthored
+    path and is handled inside ``decide``."""
+    now = now or datetime.now(timezone.utc)
+    today = today or now.date()
+    if config is None or refire_days is None:
+        loaded_config, loaded_refire = load_closeout_config()
+        config = config or loaded_config
+        refire_days = refire_days if refire_days is not None else loaded_refire
+
+    ledger = ledger_module if ledger_module is not None else _load_ledger_module()
+    if ledger is None:
+        sys.stderr.write("[pre_run] escalation ledger unavailable; waking\n")
+        return _emit_wake(basis="ledger_unavailable_fail_open")
+    if ledger_events is None:
+        ledger_events = ledger.read_ledger()
+
+    obligations: list[Obligation] = []
+    cohort = deep = unreadable = name_keyed = 0
+    raw_input_blob: bytes = b""
+    for source in sources:
+        pulled = source.pull_obligations()
+        obligations.extend(pulled.obligations)
+        cohort += pulled.cohort_size
+        deep += pulled.deep_read
+        unreadable += pulled.unreadable
+        name_keyed += pulled.name_keyed
+        raw_input_blob += json.dumps(
+            [_obligation_to_dict(o) for o in pulled.obligations], sort_keys=True
+        ).encode("utf-8")
+
+    decision = decide(
+        ObligationPull(
+            obligations=tuple(obligations),
+            cohort_size=cohort,
+            deep_read=deep,
+            unreadable=unreadable,
+            name_keyed=name_keyed,
+        ),
+        config,
+        ledger,
+        ledger_events,
+        raw_inputs_for_digest=raw_input_blob,
+        today=today,
+        refire_days=refire_days,
+    )
+    if decision.wake:
+        await _try_write_emitted_wake(
+            audit_writer_factory, decision, skill_name=SKILL_NAME, now=now
+        )
+        return _emit_wake(decision)
+
+    writer = audit_writer_factory()
+    if writer is None:
+        return _emit_wake(basis="no_audit_writer_fail_open")
+    try:
+        await writer.write_suppressed_wake(
+            skill_name=SKILL_NAME,
+            pre_run_inputs=decision.pre_run_inputs_digest,
+            decision_basis=decision.decision_basis,
+            next_scheduled_at=_next_scheduled_at(now),
+            extra_metadata=decision.extra_metadata,
+        )
+    except Exception:  # noqa: BLE001 — any audit failure → wake
+        return _emit_wake(basis="suppress_heartbeat_failed_fail_open")
+    return _emit_suppress()
+
+
+# ---------------------------------------------------------------------------
+# Production wiring — the connector-venv pull + broker heartbeat writer.
+# ---------------------------------------------------------------------------
+
+_CONNECTOR_PYTHON_DEFAULT = "/opt/connectors/smokeball/.venv/bin/python"
+_PULL_TIMEOUT_SECONDS = 240  # sized to the deep-read fan-out, not the bulk list
+_HEARTBEAT_TIMEOUT_SECONDS = 10
+_PULL_PAGE_LIMIT = 500
+
+# How many never-before-read matters one run may open. This is an integrity
+# control on our own API budget, not a client entitlement, so a pack default is
+# doctrine-consistent (ADR 0062). It bounds wall clock too: the deep pass is N
+# sequential round trips inside one subprocess timeout.
+DEEP_READS_PER_RUN = 12
+
+_SETTLEMENT_DESIGN_MARKER = "SettlementDetailsItem"
+_GUID_RE = re.compile(r"^[0-9a-fA-F-]{8,64}$")
+
+# argv stays a module constant; the two run-varying inputs cross as environment
+# so nothing request-shaped reaches the command line. Both are shape-checked
+# before they are set.
+_PULL_SNIPPET = """\
+import json, os
+
+from smokeball_connector.client import build_client_from_env
+
+client = build_client_from_env()
+status = os.environ.get("SMD_SCT_STATUS", "")
+wanted = [m for m in os.environ.get("SMD_SCT_MATTERS", "").split(",") if m]
+budget = int(os.environ.get("SMD_SCT_BUDGET", "0") or 0)
+
+out = {"status": status}
+try:
+    out["cohort"] = client.get("/matters", Status=status, Limit=500)
+except Exception as exc:
+    out["cohortError"] = str(exc)[:300]
+    print(json.dumps(out, default=str))
+    raise SystemExit(0)
+
+
+def listing(payload):
+    if isinstance(payload, list):
+        return payload
+    if isinstance(payload, dict):
+        for key in ("items", "value", "results", "data"):
+            if isinstance(payload.get(key), list):
+                return payload[key]
+    return []
+
+
+rows = listing(out["cohort"])
+known = {str(r.get("id")) for r in rows if isinstance(r, dict)}
+targets = [m for m in wanted if m in known]
+seen = set(targets)
+# Bootstrap and top-up with matters never read before, most recently opened
+# first: that is where the structured detail actually lives, so the budget is
+# not spent producing empty rows.
+extra = sorted(
+    (r for r in rows if isinstance(r, dict) and str(r.get("id")) not in seen),
+    key=lambda r: str(r.get("openedDate") or ""),
+    reverse=True,
+)
+for row in extra:
+    if len(targets) >= len(wanted) + budget:
+        break
+    targets.append(str(row.get("id")))
+
+layouts = {}
+errors = {}
+for matter_id in targets:
+    try:
+        layouts[matter_id] = client.get("/matters/" + matter_id + "/layouts")
+    except Exception as exc:
+        errors[matter_id] = str(exc)[:200]
+out["layouts"] = layouts
+out["layoutErrors"] = errors
+print(json.dumps(out, default=str))
+"""
+
+
+def _listing(payload) -> list:
+    if isinstance(payload, list):
+        return payload
+    if isinstance(payload, dict):
+        for key in ("items", "value", "results", "data"):
+            value = payload.get(key)
+            if isinstance(value, list):
+                return value
+    return []
+
+
+def _as_float(value) -> float:
+    try:
+        return float(str(value).replace(",", ""))
+    except (TypeError, ValueError):
+        return 0.0
+
+
+_PROVIDER_INDEX_RE = re.compile(r"^Providers\[(\d+)\]/(.+)$")
+
+
+def parse_settlement_item(item: dict) -> list[dict]:
+    """Explode one per-plaintiff settlement item into provider dicts.
+
+    Deliberately per item: flattening the items of a multi-plaintiff matter into
+    one map is what collapsed provider detail in the one-off generator, because
+    ``Providers[0]`` means a different provider under each plaintiff.
+    """
+    by_index: dict[int, dict] = {}
+    for value in item.get("values") or []:
+        if not isinstance(value, dict):
+            continue
+        match = _PROVIDER_INDEX_RE.match(str(value.get("key") or ""))
+        if not match:
+            continue
+        by_index.setdefault(int(match.group(1)), {})[match.group(2)] = value.get("value")
+    return [by_index[i] for i in sorted(by_index)]
+
+
+def parse_pull(raw: dict) -> tuple[ObligationPull, str | None]:
+    """Pure parse of the connector pull. Returns (pull, problem).
+
+    A non-None problem means the view is unusable and the caller MUST wake. A
+    partial deep read is NOT a problem: it is reported as coverage, because a
+    partial view that says so is worth more than a raised run.
+    """
+    if raw.get("cohortError"):
+        return ObligationPull((), 0, 0), f"pull error: cohortError={raw['cohortError']}"
+    rows = _listing(raw.get("cohort"))
+    if raw.get("cohort") is not None and not isinstance(raw.get("cohort"), (list, dict)):
+        return ObligationPull((), 0, 0), "unrecognized cohort envelope"
+    if len(rows) >= _PULL_PAGE_LIMIT:
+        return (
+            ObligationPull((), len(rows), 0),
+            f"cohort returned a full page ({len(rows)} rows); the set may be truncated",
+        )
+
+    layouts = raw.get("layouts")
+    if not isinstance(layouts, dict):
+        return ObligationPull((), len(rows), 0), "unrecognized layouts envelope"
+    errors = raw.get("layoutErrors") if isinstance(raw.get("layoutErrors"), dict) else {}
+
+    obligations: list[Obligation] = []
+    name_keyed = 0
+    for matter_id, payload in layouts.items():
+        for item in _listing(payload):
+            if not isinstance(item, dict):
+                continue
+            if _SETTLEMENT_DESIGN_MARKER not in str(item.get("layoutDesignId") or ""):
+                continue
+            plaintiff_index = item.get("parentIndex")
+            for provider in parse_settlement_item(item):
+                display = str(provider.get("Provider/DisplayName") or "").strip()
+                if not display:
+                    continue
+                entity_id = str(provider.get("Provider/MatterEntityId") or "").strip()
+                if entity_id:
+                    key, source = entity_id, "entity_id"
+                else:
+                    key, source = fallback_provider_key(display), "display_name"
+                    name_keyed += 1
+                obligations.append(
+                    Obligation(
+                        matter_id=str(matter_id),
+                        provider_key=key,
+                        provider_display=display,
+                        balance=_as_float(provider.get("InvoiceBalance")),
+                        plaintiff_index=(
+                            plaintiff_index if isinstance(plaintiff_index, int) else 0
+                        ),
+                        lien_asserted=str(provider.get("LienAsserted") or "").lower() == "true",
+                        id_source=source,
+                    )
+                )
+    return (
+        ObligationPull(
+            obligations=tuple(obligations),
+            cohort_size=len(rows),
+            deep_read=len(layouts),
+            unreadable=len(errors),
+            name_keyed=name_keyed,
+        ),
+        None,
+    )
+
+
+def matters_with_open_obligations(events: Sequence[dict]) -> list[str]:
+    """Matter ids this skill still has unresolved obligations on.
+
+    Read off the ledger's own ``matter_id`` field rather than recovered from the
+    key, which is a hash and cannot be reversed. Resolved and handed-off items
+    drop out so a cleared matter stops consuming deep-read budget.
+    """
+    open_matters: dict[str, bool] = {}
+    for event in events:
+        if not isinstance(event, dict) or event.get("skill") != SKILL_NAME:
+            continue
+        matter_id = event.get("matter_id")
+        if not isinstance(matter_id, str) or not matter_id:
+            continue
+        if event.get("event") in ("resolved", "handed_off"):
+            open_matters[matter_id] = False
+        elif event.get("event") in ("fired", "chased"):
+            open_matters.setdefault(matter_id, True)
+            if open_matters[matter_id] is False:
+                open_matters[matter_id] = True
+    return sorted(m for m, still_open in open_matters.items() if still_open and _GUID_RE.match(m))
+
+
+class SmokeballSubprocessSource:
+    """ObligationSource over a connector-venv subprocess pull."""
+
+    def __init__(self, status: str, deep_matters: Sequence[str], budget: int) -> None:
+        self._status = status
+        self._deep_matters = [m for m in deep_matters if _GUID_RE.match(m)]
+        self._budget = max(0, int(budget))
+
+    def pull_obligations(self) -> ObligationPull:
+        connector_python = os.environ.get(
+            "SMD_CONNECTOR_VENV_PYTHON", _CONNECTOR_PYTHON_DEFAULT
+        )
+        env = {
+            **os.environ,
+            "SMD_SCT_STATUS": self._status,
+            "SMD_SCT_MATTERS": ",".join(self._deep_matters),
+            "SMD_SCT_BUDGET": str(self._budget),
+        }
+        result = subprocess.run(  # raises on timeout → caller wakes
+            # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-tainted-env-args.dangerous-subprocess-use-tainted-env-args — argv[0] is the module-constant connector-venv interpreter, overridable only via SMD_CONNECTOR_VENV_PYTHON from the Machine's own boot env (same trust domain; the test seam). The snippet is a module constant, and the two run-varying inputs cross as shape-checked environment values, never argv.
+            [connector_python, "-c", _PULL_SNIPPET],
             capture_output=True,
             text=True,
-            timeout=_PROBE_TIMEOUT_SECONDS,
+            timeout=_PULL_TIMEOUT_SECONDS,
+            env=env,
         )
-    except subprocess.TimeoutExpired:
-        sys.stderr.write("[pre_run] smokeball probe timed out\n")
-        return None
-    except Exception as exc:  # noqa: BLE001 — any probe failure → unknown → wake
-        sys.stderr.write(f"[pre_run] smokeball probe failed: {exc}\n")
-        return None
-    if result.returncode != 0:
-        sys.stderr.write(
-            f"[pre_run] smokeball probe exit {result.returncode}: "
-            f"{(result.stderr or '').strip()[:500]}\n"
-        )
-        return None
-    try:
-        payload = json.loads((result.stdout or "").strip().splitlines()[-1])
-        count = payload.get("openMatterCount")
-    except Exception:  # noqa: BLE001 — malformed probe output → unknown → wake
-        sys.stderr.write("[pre_run] smokeball probe output unparseable\n")
-        return None
-    if isinstance(count, bool) or not isinstance(count, int):
-        return None
-    return count
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"smokeball pull exit {result.returncode}: "
+                f"{(result.stderr or '').strip()[:500]}"
+            )
+        raw = json.loads((result.stdout or "").strip().splitlines()[-1])
+        pull, problem = parse_pull(raw)
+        if problem:
+            raise RuntimeError(problem)
+        return pull
 
 
-def write_suppressed_wake_heartbeat(skill_name: str) -> bool:
-    """Append the SUPPRESSED_WAKE row via the broker. True only on ack."""
-    socket_path = os.environ.get("SMD_AUDIT_BROKER_SOCKET") or os.environ.get(
-        "SMD_WORKSPACE_BROKER_SOCKET"
-    )
-    if not socket_path:
-        sys.stderr.write("[pre_run] no broker socket in env; cannot heartbeat\n")
-        return False
-    request = {
-        "action": "suppressed_wake_append",
-        "row": {
-            "action_type": "SUPPRESSED_WAKE",
-            "actor": "agent",
-            "actor_role": "agent",
-            "skill_name": skill_name,
-            "metadata": json.dumps(
-                {
-                    "decision_basis": "empty_seat:no_open_matters",
-                    "platform": "cron-pre-run",
-                    "customer": os.environ.get("CUSTOMER_SLUG", ""),
-                },
-                sort_keys=True,
-                separators=(",", ":"),
-            ),
-        },
-    }
-    try:
+class BrokerSuppressedWakeWriter:
+    """Heartbeat writer over the broker's uid-gated verbs (#2253)."""
+
+    def __init__(self, socket_path: str, customer_slug: str) -> None:
+        self._socket_path = socket_path
+        self._customer_slug = customer_slug
+
+    async def write_suppressed_wake(
+        self,
+        *,
+        skill_name: str,
+        pre_run_inputs: bytes,
+        decision_basis: str,
+        next_scheduled_at: str,
+        extra_metadata: dict | None = None,
+    ) -> str:
+        return self._append(
+            verb="suppressed_wake_append",
+            action_type="SUPPRESSED_WAKE",
+            skill_name=skill_name,
+            pre_run_inputs=pre_run_inputs,
+            decision_basis=decision_basis,
+            next_scheduled_at=next_scheduled_at,
+            extra_metadata=extra_metadata,
+        )
+
+    async def write_emitted_wake(
+        self,
+        *,
+        skill_name: str,
+        pre_run_inputs: bytes,
+        decision_basis: str,
+        next_scheduled_at: str,
+        extra_metadata: dict | None = None,
+    ) -> str:
+        return self._append(
+            verb="emitted_wake_append",
+            action_type="EMITTED_WAKE",
+            skill_name=skill_name,
+            pre_run_inputs=pre_run_inputs,
+            decision_basis=decision_basis,
+            next_scheduled_at=next_scheduled_at,
+            extra_metadata=extra_metadata,
+        )
+
+    def _append(
+        self,
+        *,
+        verb: str,
+        action_type: str,
+        skill_name: str,
+        pre_run_inputs: bytes,
+        decision_basis: str,
+        next_scheduled_at: str,
+        extra_metadata: dict | None,
+    ) -> str:
+        request = {
+            "action": verb,
+            "row": {
+                "action_type": action_type,
+                "actor": "agent",
+                "actor_role": "agent",
+                "skill_name": skill_name,
+                "input_digest": hashlib.sha256(pre_run_inputs).hexdigest(),
+                "metadata": json.dumps(
+                    {
+                        "decision_basis": decision_basis,
+                        "next_scheduled_at": next_scheduled_at,
+                        "platform": "cron-pre-run",
+                        "customer": self._customer_slug,
+                        **(extra_metadata or {}),
+                    },
+                    sort_keys=True,
+                    separators=(",", ":"),
+                    default=str,
+                ),
+            },
+        }
         with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
             sock.settimeout(_HEARTBEAT_TIMEOUT_SECONDS)
-            sock.connect(socket_path)
+            sock.connect(self._socket_path)
             sock.sendall(json.dumps(request).encode("utf-8") + b"\n")
             raw = b""
             while not raw.endswith(b"\n"):
@@ -169,34 +1103,67 @@ def write_suppressed_wake_heartbeat(skill_name: str) -> bool:
                     break
                 raw += chunk
         response = json.loads(raw.decode("utf-8"))
-        if response.get("ok") is True:
-            return True
-        sys.stderr.write(f"[pre_run] heartbeat rejected: {response}\n")
-        return False
-    except Exception as exc:  # noqa: BLE001 — any heartbeat failure → wake
-        sys.stderr.write(f"[pre_run] heartbeat write failed: {exc}\n")
-        return False
+        if response.get("ok") is not True:
+            raise RuntimeError(f"heartbeat rejected: {response}")
+        return str(response.get("id", ""))
 
 
-def decide_and_emit(count: int | None, skill_name: str) -> int:
-    """Pure-ish core: count → wake/suppress emission (heartbeat before suppress)."""
-    if count is None or count > 0:
-        return _emit(wake=True)
-    if not write_suppressed_wake_heartbeat(skill_name):
-        # Mirror-don't-gate: a silent suppress with no audit trail is
-        # indistinguishable from a broken pre_run. Wake instead — the full
-        # agent run is observable and the failure becomes visible.
-        return _emit(wake=True)
-    return _emit(wake=False)
+def _writer_factory():
+    socket_path = os.environ.get("SMD_AUDIT_BROKER_SOCKET") or os.environ.get(
+        "SMD_WORKSPACE_BROKER_SOCKET"
+    )
+    if not socket_path:
+        return None
+    return BrokerSuppressedWakeWriter(socket_path, os.environ.get("CUSTOMER_SLUG", ""))
 
 
-def main(argv: list[str] | None = None) -> int:
-    argv = sys.argv[1:] if argv is None else argv
-    skill_name = _skill_name()
-    if "--assume-empty" in argv:
-        sys.stderr.write("[pre_run] --assume-empty: skipping smokeball probe\n")
-        return decide_and_emit(0, skill_name)
-    return decide_and_emit(probe_open_matter_count(), skill_name)
+def main() -> int:
+    customer_slug = os.environ.get("CUSTOMER_SLUG")
+    if not customer_slug:
+        sys.stderr.write("[pre_run] CUSTOMER_SLUG unset; falling back to wake\n")
+        return _emit_wake(basis="customer_slug_unset_fail_open")
+    config, refire_days = load_closeout_config()
+    today = datetime.now(timezone.utc).date()
+    if not config.authored:
+        # No status to query on. Run the pure path so the unauthored surface
+        # still fires on its window rather than the run failing on an empty query.
+        ledger = _load_ledger_module()
+        events = ledger.read_ledger() if ledger is not None else []
+        source_less = ObligationPull((), 0, 0)
+        if ledger is None:
+            return _emit_wake(basis="ledger_unavailable_fail_open")
+        decision = decide(
+            source_less,
+            config,
+            ledger,
+            events,
+            raw_inputs_for_digest=b"",
+            today=today,
+            refire_days=refire_days,
+        )
+        return _emit_wake(decision) if decision.wake else _emit_suppress()
+    try:
+        ledger = _load_ledger_module()
+        events = ledger.read_ledger() if ledger is not None else []
+        source = SmokeballSubprocessSource(
+            config.trigger_status or "",
+            matters_with_open_obligations(events),
+            DEEP_READS_PER_RUN,
+        )
+        return asyncio.run(
+            run_once(
+                [source],
+                _writer_factory,
+                today=today,
+                config=config,
+                refire_days=refire_days,
+                ledger_module=ledger,
+                ledger_events=events,
+            )
+        )
+    except Exception as exc:  # noqa: BLE001 — any wiring failure → wake
+        sys.stderr.write(f"[pre_run] lien-ledger pre_run failed ({exc}); waking\n")
+        return _emit_wake(basis="pre_run_crashed_fail_open")
 
 
 if __name__ == "__main__":

--- a/operator/skills/lien-ledger-tracker/test_closeout_pre_run.py
+++ b/operator/skills/lien-ledger-tracker/test_closeout_pre_run.py
@@ -1,0 +1,424 @@
+"""lien-ledger-tracker pre-run gate tests (ss #2455).
+
+``decide()`` is pure, so every branch is exercised with fake inputs. The parse
+tests run against the committed wire fixtures, which were generated from the
+same authored seed a person keys into the sandbox, so a parser that agrees with
+the fixtures agrees with what the sandbox will hold.
+
+What each group is really guarding:
+
+  identity   a provider's history must survive the firm correcting a typo
+  grouping   one payer on N matters is ONE outreach, never N
+  fencing    a held matter never joins a chase group
+  config     firm facts fail closed; a stall threshold degrades instead
+  coverage   a partial deep read reports the gap rather than reading as complete
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import pathlib
+import sys
+from datetime import date
+
+import pytest
+
+SKILL_DIR = pathlib.Path(__file__).resolve().parent
+WIRE_DIR = SKILL_DIR.parents[1] / "fixtures/law-firm/pi/lien-ledger-tracker/seed/wire"
+
+
+def _load(name: str, path: pathlib.Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+ledger = _load("llt_ledger_under_test", SKILL_DIR / "escalation_ledger.py")
+gate = _load("llt_pre_run_under_test", SKILL_DIR / "pre_run.py")
+
+TODAY = date(2026, 8, 19)
+AUTHORED = gate.CloseoutConfig(trigger_status="Pending", chase_cadence_days=14, stall_days=60)
+
+MATTER_A = "aaaaaaaa-1111-2222-3333-444444444444"
+MATTER_B = "bbbbbbbb-1111-2222-3333-444444444444"
+ENTITY_1 = "e1a4c0d2-7b31-4a90-9c55-2f8d61b0a331"
+
+
+def _obligation(matter: str, key: str, display: str, balance: float, **kw) -> object:
+    return gate.Obligation(
+        matter_id=matter, provider_key=key, provider_display=display, balance=balance, **kw
+    )
+
+
+def _pull(obligations, *, cohort=10, deep=10, unreadable=0, name_keyed=0):
+    return gate.ObligationPull(
+        obligations=tuple(obligations),
+        cohort_size=cohort,
+        deep_read=deep,
+        unreadable=unreadable,
+        name_keyed=name_keyed,
+    )
+
+
+def _decide(pull, events=(), config=AUTHORED, today=TODAY, refire=3):
+    return gate.decide(
+        pull, config, ledger, list(events),
+        raw_inputs_for_digest=b"x", today=today, refire_days=refire,
+    )
+
+
+def _event(matter_id, source_id, label, event, ts, attempt=1):
+    return {
+        "v": 2, "ts": ts, "skill": gate.SKILL_NAME, "matter_id": matter_id,
+        "item_key": ledger.item_key(matter_id, source_id, label, None),
+        "event": event, "attempt": attempt, "token": None, "id": f"id-{ts}",
+    }
+
+
+# --------------------------------------------------------------------- config
+
+
+def test_unauthored_firm_facts_fail_closed_and_name_what_is_missing():
+    decision = _decide(_pull([]), config=gate.CloseoutConfig())
+    assert decision.wake is True
+    assert decision.decision_basis == "closeout_config_unauthored_surface"
+    assert decision.extra_metadata["missing"] == ["trigger_status", "chase_cadence_days"]
+
+
+def test_a_partially_authored_config_is_still_unauthored():
+    decision = _decide(_pull([]), config=gate.CloseoutConfig(trigger_status="Pending"))
+    assert decision.wake is True
+    assert decision.extra_metadata["missing"] == ["chase_cadence_days"]
+
+
+def test_unauthored_stall_days_does_not_stop_the_chase():
+    """stall_days degrades; it is not in the fail-closed class."""
+    config = gate.CloseoutConfig(trigger_status="Pending", chase_cadence_days=14)
+    decision = _decide(
+        _pull([_obligation(MATTER_A, ENTITY_1, "Valley Health Plan", 1200.0)]), config=config
+    )
+    assert decision.wake is True
+    assert decision.decision_basis == "closeout_chase_due"
+    assert decision.extra_metadata["stall_days_authored"] is False
+
+
+def test_a_status_that_is_not_a_plain_token_is_treated_as_unauthored(tmp_path):
+    """The status crosses into a subprocess environment, so it is shape-checked."""
+    yaml = pytest.importorskip("yaml")
+    doc = {
+        "personas": [
+            {"skills": [{"name": gate.SKILL_NAME, "settings": {
+                "trigger_status": "Pending; rm -rf /", "chase_cadence_days": 14}}]}
+        ]
+    }
+    path = tmp_path / "customer.yaml"
+    path.write_text(yaml.safe_dump(doc), encoding="utf-8")
+    config, _ = gate.load_closeout_config(str(path))
+    assert config.trigger_status is None
+    assert config.authored is False
+
+
+def test_authored_config_round_trips_from_the_seat_file(tmp_path):
+    yaml = pytest.importorskip("yaml")
+    doc = {
+        "escalation": {"refire_days": 5},
+        "personas": [
+            {"skills": [{"name": gate.SKILL_NAME, "settings": {
+                "trigger_status": "Pending", "chase_cadence_days": 14, "stall_days": 60}}]}
+        ],
+    }
+    path = tmp_path / "customer.yaml"
+    path.write_text(yaml.safe_dump(doc), encoding="utf-8")
+    config, refire = gate.load_closeout_config(str(path))
+    assert (config.trigger_status, config.chase_cadence_days, config.stall_days) == (
+        "Pending", 14, 60)
+    assert config.authored is True
+    assert refire == 5
+
+
+# ------------------------------------------------------------------- grouping
+
+
+def test_one_payer_across_two_matters_is_one_chase_naming_both():
+    """The whole point: a payer on N matters gets one message, not N."""
+    decision = _decide(_pull([
+        _obligation(MATTER_A, ENTITY_1, "Valley Health Plan", 21400.0),
+        _obligation(MATTER_B, ENTITY_1, "Valley Health Plan", 8900.0),
+    ]))
+    chases = [p for p in decision.plans if p.action == gate.ACTION_CHASE_PROVIDER]
+    assert len(chases) == 1
+    assert chases[0].matters == (MATTER_A, MATTER_B)
+    assert chases[0].outstanding_total == 30300.0
+
+
+def test_a_misspelled_payer_still_groups_with_its_correct_spelling():
+    """Grouping is looser than identity on purpose: a typo is a separate contact
+    record, so grouping falls back to the normalized name."""
+    decision = _decide(_pull([
+        _obligation(MATTER_A, ENTITY_1, "Valley Health Plan", 100.0),
+        _obligation(MATTER_B, "9f77b512", "Valley Health Plan, Inc.", 200.0),
+    ]))
+    chases = [p for p in decision.plans if p.action == gate.ACTION_CHASE_PROVIDER]
+    assert len(chases) == 1, "corporate suffix and punctuation must not split the group"
+
+
+def test_near_named_but_distinct_providers_do_not_group():
+    decision = _decide(_pull([
+        _obligation(MATTER_A, "id-a", "Sierra Imaging", 100.0),
+        _obligation(MATTER_B, "id-b", "Open Sierra Imaging", 200.0),
+    ]))
+    chases = [p for p in decision.plans if p.action == gate.ACTION_CHASE_PROVIDER]
+    assert len(chases) == 2, "two different businesses must not be merged into one chase"
+
+
+def test_cleared_obligations_never_enter_a_chase_group():
+    decision = _decide(_pull([_obligation(MATTER_A, ENTITY_1, "Valley Health Plan", 0.0)]))
+    assert decision.wake is False
+    assert decision.decision_basis == "no_closeout_chase_due"
+
+
+# ------------------------------------------------------------------- identity
+
+
+def test_obligation_identity_survives_a_provider_name_correction():
+    """The defect this design exists to avoid: correcting a typo must not orphan
+    the obligation's history."""
+    before = _obligation(MATTER_A, ENTITY_1, "Valley Helath Plan", 100.0)
+    after = _obligation(MATTER_A, ENTITY_1, "Valley Health Plan", 100.0)
+    assert gate.obligation_key(ledger, before) == gate.obligation_key(ledger, after)
+
+
+def test_identity_does_not_move_when_a_sibling_plaintiff_is_removed():
+    """plaintiff_index is an attribute, never part of the key."""
+    first = _obligation(MATTER_A, ENTITY_1, "Valley Health Plan", 100.0, plaintiff_index=1)
+    renumbered = _obligation(MATTER_A, ENTITY_1, "Valley Health Plan", 100.0, plaintiff_index=0)
+    assert gate.obligation_key(ledger, first) == gate.obligation_key(ledger, renumbered)
+
+
+def test_two_providers_on_one_matter_are_two_identities():
+    a = _obligation(MATTER_A, "id-a", "Cedar Ridge Orthopedics", 100.0)
+    b = _obligation(MATTER_A, "id-b", "Mercy General ER", 100.0)
+    assert gate.obligation_key(ledger, a) != gate.obligation_key(ledger, b)
+
+
+def test_the_same_provider_on_two_matters_are_two_identities():
+    a = _obligation(MATTER_A, ENTITY_1, "Valley Health Plan", 100.0)
+    b = _obligation(MATTER_B, ENTITY_1, "Valley Health Plan", 100.0)
+    assert gate.obligation_key(ledger, a) != gate.obligation_key(ledger, b)
+
+
+def test_the_name_fallback_keeps_the_raw_string():
+    """No punctuation stripping and no suffix dropping in identity."""
+    assert gate.fallback_provider_key("  Dr. Zawada, Inc. ") == "dr. zawada, inc."
+    assert gate.fallback_provider_key("Dr Zawada") != gate.fallback_provider_key("Dr. Zawada")
+
+
+def test_sentinel_namespaces_do_not_collide_with_a_sibling_skill():
+    """item_key ignores label, so a shared source_id would share one identity."""
+    ours = ledger.item_key("", gate._CONFIG_SENTINEL_SOURCE_ID, "sct-config-missing", "")
+    theirs = ledger.item_key("", "__mrc_chase_config__", "sct-config-missing", "")
+    assert ours != theirs
+
+
+# -------------------------------------------------------------------- fencing
+
+
+def test_a_held_matter_never_joins_a_chase_group():
+    """Fencing is unconditional; re-surfacing the hold is on the window."""
+    events = [_event(MATTER_A, gate.HOLD_SOURCE_ID, "sct-chase-hold", "fired", "2026-08-18T00:00:00Z")]
+    decision = _decide(_pull([
+        _obligation(MATTER_A, ENTITY_1, "Valley Health Plan", 100.0),
+        _obligation(MATTER_B, ENTITY_1, "Valley Health Plan", 200.0),
+    ]), events=events)
+    chases = [p for p in decision.plans if p.action == gate.ACTION_CHASE_PROVIDER]
+    assert len(chases) == 1
+    assert chases[0].matters == (MATTER_B,), "the held matter is fenced out of the group"
+    assert chases[0].outstanding_total == 200.0
+    assert not any(p.action == gate.ACTION_SURFACE_HOLD for p in decision.plans), (
+        "the hold was raised yesterday; re-surfacing it today would be spam"
+    )
+
+
+def test_a_stale_hold_re_surfaces_once_its_window_has_passed():
+    """A held matter must not go permanently dark on one missed notice (#1899)."""
+    events = [_event(MATTER_A, gate.HOLD_SOURCE_ID, "sct-chase-hold", "fired", "2026-08-01T00:00:00Z")]
+    decision = _decide(
+        _pull([_obligation(MATTER_A, ENTITY_1, "Valley Health Plan", 100.0)]), events=events
+    )
+    holds = [p for p in decision.plans if p.action == gate.ACTION_SURFACE_HOLD]
+    assert len(holds) == 1
+    assert holds[0].matter_id == MATTER_A
+    assert not any(p.action == gate.ACTION_CHASE_PROVIDER for p in decision.plans)
+
+
+def test_a_resolved_hold_stops_fencing():
+    events = [
+        _event(MATTER_A, gate.HOLD_SOURCE_ID, "sct-chase-hold", "fired", "2026-08-01T00:00:00Z"),
+        _event(MATTER_A, gate.HOLD_SOURCE_ID, "sct-chase-hold", "resolved", "2026-08-02T00:00:00Z"),
+    ]
+    decision = _decide(
+        _pull([_obligation(MATTER_A, ENTITY_1, "Valley Health Plan", 100.0)]), events=events
+    )
+    chases = [p for p in decision.plans if p.action == gate.ACTION_CHASE_PROVIDER]
+    assert len(chases) == 1 and chases[0].matters == (MATTER_A,)
+
+
+# -------------------------------------------------------------------- cadence
+
+
+def test_a_chase_inside_the_cadence_window_does_not_re_fire():
+    events = [_event("", gate.PROVIDER_SOURCE_PREFIX + "valley health plan",
+                     "sct-provider-chase", "chased", "2026-08-18T00:00:00Z")]
+    decision = _decide(
+        _pull([_obligation(MATTER_A, ENTITY_1, "Valley Health Plan", 100.0)]), events=events
+    )
+    assert decision.wake is False
+
+
+def test_a_chase_past_the_cadence_window_carries_its_attempt_and_last_chased():
+    events = [_event("", gate.PROVIDER_SOURCE_PREFIX + "valley health plan",
+                     "sct-provider-chase", "chased", "2026-07-01T00:00:00Z")]
+    decision = _decide(
+        _pull([_obligation(MATTER_A, ENTITY_1, "Valley Health Plan", 100.0)]), events=events
+    )
+    chase = next(p for p in decision.plans if p.action == gate.ACTION_CHASE_PROVIDER)
+    assert chase.attempt == 2
+    assert chase.last_chased == "2026-07-01"
+
+
+def test_a_stall_raise_does_not_inflate_the_chase_attempt_count():
+    """Stalls live on their own matter-level sentinel for exactly this reason."""
+    events = [
+        _event("", gate.PROVIDER_SOURCE_PREFIX + "valley health plan",
+               "sct-provider-chase", "chased", "2026-07-01T00:00:00Z"),
+        _event(MATTER_A, gate.STALL_SOURCE_PREFIX + MATTER_A, "sct-stall",
+               "fired", "2026-07-15T00:00:00Z"),
+    ]
+    decision = _decide(
+        _pull([_obligation(MATTER_A, ENTITY_1, "Valley Health Plan", 100.0)]), events=events
+    )
+    chase = next(p for p in decision.plans if p.action == gate.ACTION_CHASE_PROVIDER)
+    assert chase.attempt == 2, "the stall must not be counted as a chase"
+
+
+# ------------------------------------------------------------------- coverage
+
+
+def test_every_decision_reports_what_it_actually_looked_at():
+    decision = _decide(_pull(
+        [_obligation(MATTER_A, ENTITY_1, "Valley Health Plan", 100.0)],
+        cohort=165, deep=12, unreadable=1, name_keyed=2,
+    ))
+    meta = decision.extra_metadata
+    assert meta["cohort_size"] == 165 and meta["deep_read"] == 12
+    assert meta["unreadable"] == 1 and meta["name_keyed_obligations"] == 2
+
+
+def test_a_cohort_with_no_readable_obligations_surfaces_rather_than_going_quiet():
+    decision = _decide(_pull([], cohort=165, deep=12))
+    assert decision.wake is True
+    assert decision.decision_basis == "no_obligations_read_surface"
+
+
+def test_an_empty_cohort_is_simply_quiet():
+    decision = _decide(_pull([], cohort=0, deep=0))
+    assert decision.wake is False
+    assert decision.decision_basis == "no_closeout_chase_due"
+
+
+# ---------------------------------------------------------------------- parse
+
+
+def _wire(number: str):
+    return json.loads((WIRE_DIR / f"{number}.json").read_text(encoding="utf-8"))
+
+
+def _parse(number: str, cohort=6):
+    raw = {"cohort": [{"id": f"m-{i}"} for i in range(cohort)],
+           "layouts": {number: _wire(number)}, "layoutErrors": {}}
+    pull, problem = gate.parse_pull(raw)
+    assert problem is None, problem
+    return pull
+
+
+def test_parse_reads_the_modal_matter_from_the_committed_fixture():
+    pull = _parse("2026-SC-201")
+    assert len(pull.obligations) == 4
+    assert all(o.id_source == "entity_id" for o in pull.obligations)
+    assert pull.name_keyed == 0
+
+
+def test_parse_keeps_multi_plaintiff_providers_apart():
+    """Flattening the per-plaintiff items is the collapse this guards."""
+    pull = _parse("2026-SC-203")
+    assert len(pull.obligations) == 2
+    assert {o.plaintiff_index for o in pull.obligations} == {0, 1}
+    assert len({o.provider_key for o in pull.obligations}) == 2
+
+
+def test_parse_of_the_empty_medicals_matter_yields_no_obligations():
+    pull = _parse("2026-SC-202")
+    assert pull.obligations == ()
+    assert pull.deep_read == 1, "the matter WAS read; it simply holds nothing"
+
+
+def test_parse_reads_a_real_zero_as_cleared_not_missing():
+    pull = _parse("2026-SC-206")
+    assert len(pull.obligations) == 2
+    assert all(o.balance == 0.0 and not o.outstanding for o in pull.obligations)
+
+
+def test_a_full_cohort_page_is_a_problem_not_a_view():
+    raw = {"cohort": [{"id": f"m-{i}"} for i in range(500)], "layouts": {}}
+    _, problem = gate.parse_pull(raw)
+    assert problem and "truncated" in problem
+
+
+def test_a_cohort_error_is_a_problem():
+    _, problem = gate.parse_pull({"cohortError": "boom"})
+    assert problem and "cohortError" in problem
+
+
+def test_a_provider_row_with_no_entity_id_falls_back_and_says_so():
+    item = {
+        "layoutDesignId": "PersonalInjurySettlementDetailsItem",
+        "parentIndex": 0,
+        "values": [
+            {"key": "Providers[0]/Provider/DisplayName", "value": "Nameless Clinic"},
+            {"key": "Providers[0]/InvoiceBalance", "value": "500.00"},
+        ],
+    }
+    pull, problem = gate.parse_pull(
+        {"cohort": [{"id": "m-1"}], "layouts": {MATTER_A: [item]}, "layoutErrors": {}}
+    )
+    assert problem is None
+    assert pull.name_keyed == 1
+    assert pull.obligations[0].id_source == "display_name"
+
+
+# ------------------------------------------------------- deep-read targeting
+
+
+def test_open_obligations_are_recovered_from_the_ledgers_own_matter_field():
+    """The key is a hash and cannot be reversed, so targeting reads matter_id."""
+    events = [
+        _event(MATTER_A, "sct:" + ENTITY_1, "sct-obligation", "fired", "2026-08-01T00:00:00Z"),
+        _event(MATTER_B, "sct:" + ENTITY_1, "sct-obligation", "fired", "2026-08-01T00:00:00Z"),
+        _event(MATTER_B, "sct:" + ENTITY_1, "sct-obligation", "resolved", "2026-08-05T00:00:00Z"),
+    ]
+    assert gate.matters_with_open_obligations(events) == [MATTER_A]
+
+
+def test_targeting_ignores_another_skills_events():
+    foreign = _event(MATTER_A, "x", "y", "fired", "2026-08-01T00:00:00Z")
+    foreign["skill"] = "medical-records-chaser"
+    assert gate.matters_with_open_obligations([foreign]) == []
+
+
+def test_targeting_rejects_a_matter_id_that_is_not_id_shaped():
+    bad = _event("../../etc/passwd", "sct:x", "sct-obligation", "fired", "2026-08-01T00:00:00Z")
+    assert gate.matters_with_open_obligations([bad]) == []

--- a/operator/tests/test_escalation_ledger_sync.py
+++ b/operator/tests/test_escalation_ledger_sync.py
@@ -31,6 +31,7 @@ VENDORED_SKILLS = (
     "daily-needs-you-digest",
     "client-verification-tracker",
     "medical-records-chaser",
+    "lien-ledger-tracker",
 )
 
 

--- a/operator/tests/test_pre_run_gate.py
+++ b/operator/tests/test_pre_run_gate.py
@@ -23,14 +23,14 @@ _TEMPLATE = _OPERATOR_ROOT / "templates" / "pre_run_gate.py"
 # deadline-miss-escalator keeps its bespoke deadline pre_run and is NOT here;
 # client-verification-tracker graduated to its own bespoke cadence gate (WP-B,
 # #1889) and medical-records-chaser to its ledger-backed cadence gate
-# (ss #2404) — neither is on the shared template any longer.
+# (ss #2404), and lien-ledger-tracker to its settlement-closeout obligation
+# ledger (ss #2455) — none of the three is on the shared template any longer.
 GATED_SKILLS = (
     "daily-needs-you-digest",
     "discovery-response-tracker",
     "motion-calendar-tracker",
     "service-confirmation-watcher",
     "medical-chronology-maintainer",
-    "lien-ledger-tracker",
     "mediation-settlement-tracker",
     "minors-compromise-packet",
     "trial-binder-assembler",

--- a/src/lib/portal/operator/facets/skills/skill-summaries.ts
+++ b/src/lib/portal/operator/facets/skills/skill-summaries.ts
@@ -68,7 +68,7 @@ export const SKILL_SUMMARIES: Record<string, string> = {
   'intake-to-system-sync':
     'Syncs a converted lead from your intake CRM into Smokeball, with dedupe and conflict checks.',
   'lien-ledger-tracker':
-    'Keeps the matter lien ledger current and chases open payoffs. Logs figures you provide, never computes a reduction or moves money.',
+    'Tracks every provider balance blocking disbursement and chases the open ones, one contact per provider. Never computes a reduction or moves money.',
   'matter-document-review':
     "Reads a matter's documents and surfaces highlights, timelines, and gaps for an attorney. Never drafts legal work product.",
   'matter-inbox-router':


### PR DESCRIPTION
PR 2 of #2455 (Settlement Closeout). The obligation ledger and the provider-consolidated chase. Repo layer only; the runtime rows wait on the seeded sandbox and the Hermes v0.20 reprovision freeze.

## Three things changed, each for a measured reason

**Scope.** This routine was authored around statutory lienholders. 76% of the outstanding balance at the first firm sits on obligations with **no lien asserted** — ordinary unpaid provider invoices that still stop the file from paying out. The firm's own settlement tab models `Providers[]` and `OtherLiensAndBalances[]` side by side, because to the people doing the work they are one list. The ledger now covers every obligation blocking disbursement; a lien is one kind of obligation, not the whole subject.

**The chase unit.** One payer appears on 22 separate matters. Per-obligation chasing would have sent that payer 22 messages in a single pass — the wrong commercial move (one negotiation clears 22 files) and the kind of machine-noise that costs a firm's trust in a week. A chase is now one consolidated contact per provider per cadence, naming every matter and balance in that provider's book.

**History.** The skill graduates off the shared empty-seat gate onto a ledger-backed one. `attempt`, `last_chased` and the group's matters are handed to the turn, and the message copies them. Same rule and same reason as the records-chaser graduation (#2404): a chase asserting its own history from memory eventually contradicts a message the seat itself sent.

## Identity is read off the record

Obligations key on the provider's own `Provider/MatterEntityId`, observed populated on production layouts (`vfy_01M0DXZ33QCTE7R58GF2WJ1ZB1`). That is what makes a provider's negotiation history survive the firm correcting a spelling — a name-derived key would change at the exact moment the correction succeeded, orphaning everything the ledger knew. The plaintiff index is an attribute and never part of a key, because removing a plaintiff renumbers the survivors.

Cross-matter grouping is deliberately looser and is a **proposal, not a decision**: a misspelled provider is a different contact record, so grouping falls back to a normalized name and the register shows both spellings for a person to confirm. Two contact records are never silently merged.

## Configuration: three firm facts, two fail-closed

`trigger_status` and `chase_cadence_days` refuse when unauthored and surface on the re-fire window — which status means settled-undistributed, and how often one provider may be contacted, are commitments nobody made if we pick them. `stall_days` degrades instead: unauthored, stall flags are withheld and the artifact says so while tracking and chasing continue.

## No overlay dependency

The scheduled path reads through the connector venv in the pre-run subprocess, the same seam the records chaser already uses (`vfy_01M0DXM3DNCMVMB89NEJW1PWRS`). No MCP tool, no `action_classes.py` line, no `OVERLAY_REF` bump, and none of the boot-kill risk an unclassified tool carries. An exhausted deep-read budget is reported as coverage, never raised.

## Guards proven, not assumed

`vfy_01M0DZN3E2KN8MXWAWTRP96JR6` — eight design invariants, each broken one at a time in `pre_run.py`, each failing its guard, each passing on restore: per-obligation chasing, unfenced holds, name-keyed identity, plaintiff index in the key, a collapsed multi-plaintiff parse, a silent config default, an ignored cadence, and an eager provider merge.

Worth recording: the multi-plaintiff mutation initially reported clean/mutated both green — it did not reproduce the defect, so that guard had measured nothing. Replaced with a mutation that drops all but the first per-plaintiff item, which is the historical data loss, and the guard fired.

712 operator tests plus the four registration gates green.

## Client-visible

The portal skill summary is updated to match the widened scope. The routine is still named "Lien ledger" to the firm; whether that should change is on the turn-on checklist in #2455 and is not decided here. A&P's `customer.yaml` is untouched.

## Next

PR 3: the settled-undistributed register section in `matter-status-digest`. Then the runtime proofs, once the sandbox is keyed and the reprovision freeze lifts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JWYNgm8hwTVtNC4Kr1z1Zj
