### PR TITLE
feat(operator): the closeout register says what it did not look at, so silence cannot read as completeness (#2455 PR 3)

### DIFF
--- a/operator/customers/pilot-smokeball/customer.yaml
+++ b/operator/customers/pilot-smokeball/customer.yaml
@@ -530,6 +530,10 @@ personas:
           # fail-closed class: unauthored, stall flags are simply withheld and
           # the register says so, while tracking and chasing continue.
           stall_days: 60 # PLACEHOLDER(rehearsal)
+          # How often the standing register is produced on its own. Also NOT
+          # fail-closed: unauthored, there is no periodic run and the register
+          # rides along with other wakes, saying so on its own face.
+          register_days: 7 # PLACEHOLDER(rehearsal)
       - name: settlement-statement-feeder # person-invoked; figures from authored data only
         version: pending
         initiation:

--- a/operator/skills/lien-ledger-tracker/SKILL.md
+++ b/operator/skills/lien-ledger-tracker/SKILL.md
@@ -105,6 +105,56 @@ system, so grouping falls back to a normalized display name. That grouping is a
 **proposal** - the register shows both raw spellings and a person confirms. Two contact
 records are never silently merged into one.
 
+## The register - the standing picture, and what it refuses to imply
+
+The chase moves individual files; the register is how a person sees the whole
+position at once. It is assembled by the same pass that plans the chases, from the
+same reads, so the two can never tell different stories about the same week.
+
+It carries: the set ranked oldest-first, the largest recorded exposures, providers
+ranked by what they hold across matters, the coverage counts, and a plain list of
+what could not be seen.
+
+Four disciplines, and each of them is the difference between a register a firm can
+act on and one that quietly overstates:
+
+1. **Blank is never zero.** A matter whose settlement detail has not been read this
+   cycle shows no figure and is labelled `not read`. A matter that WAS read and owes
+   nothing shows a real 0.00. Those are different facts and the register never
+   collapses them. This is the single most dangerous rounding available here: a
+   0.00 on an unread file reads as a cleared file.
+2. **Coverage is a count, on the face.** Every register states how many matters are
+   at the trigger status, how many had their detail opened, and how many did not.
+   Silence about coverage reads as completeness.
+3. **Every ranking names its rule.** "Oldest opened first; recorded exposure shown
+   only where the detail has been read this cycle." Nobody should have to infer why
+   a row is at the top.
+4. **What is missing is named, with the reason.** Quiet time is not available: the
+   matter record carries no last-activity field, so the set is ranked by age
+   instead, and the register says exactly that rather than passing age off as
+   activity. The client trust ledger is not held in the practice-management system,
+   so no balance appears and no file is ever called closed on its strength.
+
+Closure is never asserted from the register. A matter whose obligations all read
+zero is a **closure candidate** for a person to confirm against the trust ledger,
+not a closed file.
+
+### Cadence
+
+`register_days` sets how often the standing picture is produced on its own. It is
+not in the fail-closed class: unauthored, there is no periodic run and the register
+simply rides along whenever the Operator wakes for other work, and it says that
+about itself. An invented reporting cadence would be a commitment nobody made.
+
+### Delivery
+
+The register goes in the body of what the Operator sends, top slices first, with
+the coverage counts. It is deliberately not filed as one cross-matter document:
+a memo naming matters other than the one it is filed on is refused by the write
+path, and pointing the reader at a memo on a housekeeping matter puts two clicks
+in front of the person the report is for. When file attachment reaches this
+channel, the full set becomes an attachment and the body keeps the top slices.
+
 ## The attorney owns the number - the skill logs it (the line that keeps this safe)
 
 Whether a lien can be reduced, and to what figure, is a **legal and factual

--- a/operator/skills/lien-ledger-tracker/pre_run.py
+++ b/operator/skills/lien-ledger-tracker/pre_run.py
@@ -142,6 +142,11 @@ _HOLD_LABEL = "sct-chase-hold"
 # "chase N" numerator the outreach copies.
 STALL_SOURCE_PREFIX = "__sct_stall__"
 
+# The periodic register. Its own sentinel so "when did the firm last get the
+# standing picture" is a fact rather than an inference from chase activity.
+REGISTER_SOURCE_ID = "__sct_register__"
+_REGISTER_LABEL = "sct-register"
+
 # Provider-chase family. The group's cadence and attempt count live here.
 PROVIDER_SOURCE_PREFIX = "__sct_provider__"
 _PROVIDER_LABEL = "sct-provider-chase"
@@ -181,6 +186,24 @@ class Obligation:
         return self.balance > 0
 
 
+@dataclass(frozen=True)
+class CohortRow:
+    """One matter at the trigger status, from the bulk pass.
+
+    The matter record carries NO last-activity field (only opened/closed dates,
+    vfy_01M0E061XAJRNB2194NC6KM0R1), so the register ranks the cohort by AGE and
+    says plainly that quiet time is not available at this altitude. It is not
+    silently substituted with the opened date wearing another label.
+    """
+
+    matter_id: str
+    number: str
+    title: str
+    clients: str
+    responsible: str
+    opened: str
+
+
 class ObligationSource(Protocol):
     def pull_obligations(self) -> "ObligationPull":
         ...
@@ -201,6 +224,7 @@ class ObligationPull:
     deep_read: int
     unreadable: int = 0
     name_keyed: int = 0  # obligations that fell back to a name-derived key
+    cohort: tuple[CohortRow, ...] = ()
 
 
 # ---------------------------------------------------------------------------
@@ -215,6 +239,7 @@ class CloseoutConfig:
     trigger_status: str | None = None
     chase_cadence_days: int | None = None
     stall_days: int | None = None
+    register_days: int | None = None
 
     @property
     def authored(self) -> bool:
@@ -299,6 +324,7 @@ def load_closeout_config(customer_yaml_path: str | None = None) -> tuple[Closeou
         trigger_status=_status_or_none(settings.get("trigger_status")),
         chase_cadence_days=_pos_int_or_none(settings.get("chase_cadence_days")),
         stall_days=_pos_int_or_none(settings.get("stall_days")),
+        register_days=_pos_int_or_none(settings.get("register_days")),
     )
     esc = data.get("escalation") if isinstance(data, dict) else None
     refire_days = _pos_int(
@@ -370,6 +396,7 @@ ACTION_SURFACE_CONFIG = "surface_config_missing"
 ACTION_SURFACE_NO_OBLIGATIONS = "surface_no_obligations_read"
 ACTION_SURFACE_HOLD = "surface_hold"
 ACTION_SURFACE_STALL = "surface_stall"
+ACTION_EMIT_REGISTER = "emit_register"
 ACTION_SUPPRESS = "suppress"
 
 
@@ -399,6 +426,7 @@ class WakeDecision:
     pre_run_inputs_digest: bytes
     plans: tuple[ChasePlan, ...] = ()
     extra_metadata: dict = field(default_factory=dict)
+    register: dict | None = None
 
 
 def _hold_active(hold_state) -> bool:
@@ -459,6 +487,119 @@ def obligation_key(ledger, obligation: Obligation) -> str:
 
 def provider_key(ledger, group: str) -> str:
     return ledger.item_key("", PROVIDER_SOURCE_PREFIX + group, _PROVIDER_LABEL, "")
+
+
+REGISTER_TOP_N = 20
+
+
+def _age_days(opened: str, today: date) -> int | None:
+    try:
+        return (today - date.fromisoformat(opened[:10])).days
+    except (TypeError, ValueError):
+        return None
+
+
+def build_register(
+    pull: ObligationPull, config: CloseoutConfig, today: date
+) -> dict:
+    """The standing picture, bounded and honest about its own edges.
+
+    Three disciplines, all of them the difference between a register a firm can
+    act on and one that quietly overstates:
+
+    * Blank is never zero. A matter whose settlement detail has not been read
+      carries ``outstanding: None`` and ``detail: "not read"``, never 0.00.
+    * Every ranking names its rule on the artifact, so nobody has to infer why a
+      row is at the top.
+    * What we could not see is listed, with the reason. A register that omits
+      its own gaps reads as complete.
+    """
+    by_matter: dict[str, list[Obligation]] = {}
+    for obligation in pull.obligations:
+        by_matter.setdefault(obligation.matter_id, []).append(obligation)
+
+    rows = []
+    for row in pull.cohort:
+        members = by_matter.get(row.matter_id)
+        outstanding = (
+            round(sum(m.balance for m in members), 2) if members is not None else None
+        )
+        rows.append(
+            {
+                "matter": row.number,
+                "client": row.clients,
+                "responsible": row.responsible,
+                "opened": row.opened,
+                "age_days": _age_days(row.opened, today),
+                "obligations": len(members) if members is not None else None,
+                "outstanding": outstanding,
+                "detail": "read" if members is not None else "not read",
+            }
+        )
+
+    read_rows = [r for r in rows if r["detail"] == "read"]
+    groups: dict[str, dict] = {}
+    for obligation in pull.obligations:
+        if not obligation.outstanding:
+            continue
+        group = groups.setdefault(
+            normalize_provider_name(obligation.provider_display),
+            {"provider": obligation.provider_display, "matters": set(), "outstanding": 0.0},
+        )
+        group["matters"].add(obligation.matter_id)
+        group["outstanding"] = round(group["outstanding"] + obligation.balance, 2)
+
+    providers = sorted(
+        (
+            {
+                "provider": g["provider"],
+                "matters": len(g["matters"]),
+                "outstanding": g["outstanding"],
+            }
+            for g in groups.values()
+        ),
+        key=lambda g: -g["outstanding"],
+    )
+
+    unavailable = [
+        "quiet time: the matter record carries no last-activity field, so the "
+        "cohort is ranked by age instead",
+        "client trust ledger balance: not held in the practice-management system",
+    ]
+    if config.stall_days is None:
+        unavailable.append("stall flags: no stall threshold is authored for this firm")
+    if config.register_days is None:
+        unavailable.append(
+            "a periodic cadence for this register: none is authored, so it appears "
+            "only when the Operator wakes for other work"
+        )
+
+    return {
+        "as_of": today.isoformat(),
+        "ranking_rule": (
+            "oldest opened first across the whole set; recorded exposure shown only "
+            "where the settlement detail has been read this cycle"
+        ),
+        "coverage": {
+            "matters_at_status": pull.cohort_size,
+            "detail_read": len(read_rows),
+            "detail_not_read": max(0, pull.cohort_size - len(read_rows)),
+            "unreadable": pull.unreadable,
+            "obligations": len(pull.obligations),
+            "name_keyed_obligations": pull.name_keyed,
+        },
+        "recorded_outstanding_total": round(
+            sum(r["outstanding"] or 0.0 for r in read_rows), 2
+        ),
+        "oldest": sorted(
+            rows, key=lambda r: (r["age_days"] is None, -(r["age_days"] or 0))
+        )[:REGISTER_TOP_N],
+        "largest_recorded_exposure": sorted(
+            read_rows, key=lambda r: -(r["outstanding"] or 0.0)
+        )[:REGISTER_TOP_N],
+        "providers_by_exposure": providers[:REGISTER_TOP_N],
+        "unavailable": unavailable,
+    }
 
 
 def decide(
@@ -572,6 +713,28 @@ def decide(
             )
         )
 
+    # The periodic register. Its own sentinel and its own cadence, because "the
+    # firm last saw the standing picture on X" must not be inferred from whether
+    # a chase happened to fall due. Unauthored cadence degrades: no periodic
+    # wake, and the register still rides along whenever the turn wakes.
+    if config.register_days is not None:
+        register_key = ledger.item_key("", REGISTER_SOURCE_ID, _REGISTER_LABEL, "")
+        register_state = states.get(register_key)
+        if _chase_due(register_state, today, cadence_days=config.register_days):
+            plans.append(
+                ChasePlan(
+                    item_key=register_key,
+                    action=ACTION_EMIT_REGISTER,
+                    attempt=ledger.next_attempt(register_state),
+                    last_chased=(
+                        register_state.last_raised_date.isoformat()
+                        if register_state is not None
+                        and register_state.last_raised_date is not None
+                        else None
+                    ),
+                )
+            )
+
     coverage = {
         "cohort_size": pull.cohort_size,
         "deep_read": pull.deep_read,
@@ -587,6 +750,7 @@ def decide(
             decision_basis="closeout_chase_due",
             pre_run_inputs_digest=raw_inputs_for_digest,
             plans=tuple(plans),
+            register=build_register(pull, config, today),
             extra_metadata={
                 **coverage,
                 "provider_chases_due": len(chases),
@@ -638,6 +802,8 @@ def _emit_wake(decision: "WakeDecision | None" = None, *, basis: str | None = No
             payload["plans"] = [_plan_to_dict(p) for p in decision.plans]
         if decision.extra_metadata:
             payload["coverage"] = decision.extra_metadata
+        if decision.register is not None:
+            payload["register"] = decision.register
     print(json.dumps(payload))
     return 0
 
@@ -717,11 +883,13 @@ async def run_once(
         ledger_events = ledger.read_ledger()
 
     obligations: list[Obligation] = []
+    cohort_rows: list[CohortRow] = []
     cohort = deep = unreadable = name_keyed = 0
     raw_input_blob: bytes = b""
     for source in sources:
         pulled = source.pull_obligations()
         obligations.extend(pulled.obligations)
+        cohort_rows.extend(pulled.cohort)
         cohort += pulled.cohort_size
         deep += pulled.deep_read
         unreadable += pulled.unreadable
@@ -737,6 +905,7 @@ async def run_once(
             deep_read=deep,
             unreadable=unreadable,
             name_keyed=name_keyed,
+            cohort=tuple(cohort_rows),
         ),
         config,
         ledger,
@@ -858,6 +1027,27 @@ def _listing(payload) -> list:
     return []
 
 
+def _names(value) -> str:
+    """Join a person/entity collection into a display string, taking whatever
+    name field the record actually carries. Never composed from parts we did not
+    read; an unnamed entry contributes nothing rather than a placeholder."""
+    if isinstance(value, str):
+        return value.strip()
+    if not isinstance(value, list):
+        return ""
+    out = []
+    for entry in value:
+        if isinstance(entry, str) and entry.strip():
+            out.append(entry.strip())
+        elif isinstance(entry, dict):
+            for key in ("displayName", "DisplayName", "name", "Name", "fullName"):
+                candidate = entry.get(key)
+                if isinstance(candidate, str) and candidate.strip():
+                    out.append(candidate.strip())
+                    break
+    return ", ".join(out)
+
+
 def _as_float(value) -> float:
     try:
         return float(str(value).replace(",", ""))
@@ -909,6 +1099,21 @@ def parse_pull(raw: dict) -> tuple[ObligationPull, str | None]:
         return ObligationPull((), len(rows), 0), "unrecognized layouts envelope"
     errors = raw.get("layoutErrors") if isinstance(raw.get("layoutErrors"), dict) else {}
 
+    cohort: list[CohortRow] = []
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        cohort.append(
+            CohortRow(
+                matter_id=str(row.get("id") or ""),
+                number=str(row.get("number") or ""),
+                title=str(row.get("title") or row.get("description") or ""),
+                clients=_names(row.get("clients")),
+                responsible=_names(row.get("personResponsible")),
+                opened=str(row.get("openedDate") or "")[:10],
+            )
+        )
+
     obligations: list[Obligation] = []
     name_keyed = 0
     for matter_id, payload in layouts.items():
@@ -948,6 +1153,7 @@ def parse_pull(raw: dict) -> tuple[ObligationPull, str | None]:
             deep_read=len(layouts),
             unreadable=len(errors),
             name_keyed=name_keyed,
+            cohort=tuple(cohort),
         ),
         None,
     )

--- a/operator/skills/lien-ledger-tracker/test_closeout_pre_run.py
+++ b/operator/skills/lien-ledger-tracker/test_closeout_pre_run.py
@@ -54,13 +54,21 @@ def _obligation(matter: str, key: str, display: str, balance: float, **kw) -> ob
     )
 
 
-def _pull(obligations, *, cohort=10, deep=10, unreadable=0, name_keyed=0):
+def _pull(obligations, *, cohort=10, deep=10, unreadable=0, name_keyed=0, rows=()):
     return gate.ObligationPull(
         obligations=tuple(obligations),
         cohort_size=cohort,
         deep_read=deep,
         unreadable=unreadable,
         name_keyed=name_keyed,
+        cohort=tuple(rows),
+    )
+
+
+def _row(matter, number, opened, client="A Client", responsible="R. Attorney"):
+    return gate.CohortRow(
+        matter_id=matter, number=number, title=f"{number} - {client}",
+        clients=client, responsible=responsible, opened=opened,
     )
 
 
@@ -422,3 +430,172 @@ def test_targeting_ignores_another_skills_events():
 def test_targeting_rejects_a_matter_id_that_is_not_id_shaped():
     bad = _event("../../etc/passwd", "sct:x", "sct-obligation", "fired", "2026-08-01T00:00:00Z")
     assert gate.matters_with_open_obligations([bad]) == []
+
+
+# ------------------------------------------------------------------- register
+
+
+REGISTERED = gate.CloseoutConfig(
+    trigger_status="Pending", chase_cadence_days=14, stall_days=60, register_days=7
+)
+
+
+def _register(obligations, rows, config=REGISTERED, cohort=None):
+    pull = _pull(obligations, cohort=cohort if cohort is not None else len(rows), rows=rows)
+    return gate.build_register(pull, config, TODAY)
+
+
+def test_a_matter_whose_detail_was_not_read_shows_blank_never_zero():
+    """The single most dangerous rounding in this feature: an unread matter that
+    reports 0.00 reads as a cleared file."""
+    reg = _register([], [_row(MATTER_A, "2026-SC-202", "2007-06-11")])
+    row = reg["oldest"][0]
+    assert row["detail"] == "not read"
+    assert row["outstanding"] is None and row["obligations"] is None
+
+
+def test_a_read_matter_with_nothing_owed_shows_a_real_zero():
+    reg = _register(
+        [_obligation(MATTER_A, ENTITY_1, "Valley Health Plan", 0.0)],
+        [_row(MATTER_A, "2026-SC-206", "2024-02-05")],
+    )
+    row = reg["oldest"][0]
+    assert row["detail"] == "read"
+    assert row["outstanding"] == 0.0, "read-and-clear is a zero, not a blank"
+
+
+def test_the_cohort_is_ranked_oldest_first_and_says_so():
+    reg = _register([], [
+        _row(MATTER_A, "new", "2024-01-01"),
+        _row(MATTER_B, "old", "2007-06-11"),
+    ])
+    assert [r["matter"] for r in reg["oldest"]] == ["old", "new"]
+    assert "oldest opened first" in reg["ranking_rule"]
+
+
+def test_coverage_states_how_much_of_the_set_was_actually_opened():
+    reg = _register(
+        [_obligation(MATTER_A, ENTITY_1, "Valley Health Plan", 100.0)],
+        [_row(MATTER_A, "read", "2020-01-01"), _row(MATTER_B, "unread", "2019-01-01")],
+        cohort=165,
+    )
+    cov = reg["coverage"]
+    assert cov["matters_at_status"] == 165
+    assert cov["detail_read"] == 1
+    assert cov["detail_not_read"] == 164
+
+
+def test_the_register_names_what_it_could_not_see():
+    reg = _register([], [_row(MATTER_A, "m", "2020-01-01")])
+    joined = " | ".join(reg["unavailable"])
+    assert "quiet time" in joined, "the matter record carries no last-activity field"
+    assert "trust ledger" in joined, "trust balances are not in the practice-management system"
+
+
+def test_an_unauthored_stall_threshold_is_declared_not_defaulted():
+    config = gate.CloseoutConfig(trigger_status="Pending", chase_cadence_days=14)
+    reg = _register([], [_row(MATTER_A, "m", "2020-01-01")], config=config)
+    assert any("stall" in u for u in reg["unavailable"])
+
+
+def test_an_unauthored_register_cadence_is_declared_and_the_register_still_appears():
+    config = gate.CloseoutConfig(trigger_status="Pending", chase_cadence_days=14)
+    reg = _register([], [_row(MATTER_A, "m", "2020-01-01")], config=config)
+    assert any("periodic cadence" in u for u in reg["unavailable"])
+    assert reg["oldest"], "the register still renders; only its cadence is unauthored"
+
+
+def test_providers_are_ranked_by_exposure_across_matters():
+    reg = _register([
+        _obligation(MATTER_A, ENTITY_1, "Valley Health Plan", 21400.0),
+        _obligation(MATTER_B, ENTITY_1, "Valley Health Plan", 8900.0),
+        _obligation(MATTER_A, "id-c", "Cedar Ridge Orthopedics", 18400.0),
+    ], [_row(MATTER_A, "a", "2021-01-01"), _row(MATTER_B, "b", "2022-01-01")])
+    top = reg["providers_by_exposure"][0]
+    assert top["provider"] == "Valley Health Plan"
+    assert top["matters"] == 2 and top["outstanding"] == 30300.0
+
+
+def test_a_cleared_provider_does_not_occupy_the_exposure_ranking():
+    reg = _register(
+        [_obligation(MATTER_A, ENTITY_1, "Valley Health Plan", 0.0)],
+        [_row(MATTER_A, "a", "2021-01-01")],
+    )
+    assert reg["providers_by_exposure"] == []
+
+
+def test_the_recorded_total_counts_only_what_was_read():
+    reg = _register(
+        [_obligation(MATTER_A, ENTITY_1, "Valley Health Plan", 1234.56)],
+        [_row(MATTER_A, "read", "2021-01-01"), _row(MATTER_B, "unread", "2020-01-01")],
+    )
+    assert reg["recorded_outstanding_total"] == 1234.56
+
+
+def test_the_register_slices_are_bounded():
+    rows = [_row(f"m-{i}", f"n-{i}", "2020-01-01") for i in range(60)]
+    reg = _register([], rows)
+    assert len(reg["oldest"]) == gate.REGISTER_TOP_N
+
+
+def test_a_periodic_register_wakes_on_its_own_cadence():
+    decision = _decide(_pull([], cohort=0, deep=0), config=REGISTERED)
+    assert decision.wake is True
+    assert any(p.action == gate.ACTION_EMIT_REGISTER for p in decision.plans)
+
+
+def test_the_periodic_register_does_not_re_fire_inside_its_window():
+    events = [_event("", gate.REGISTER_SOURCE_ID, "sct-register", "fired", "2026-08-18T00:00:00Z")]
+    decision = _decide(_pull([], cohort=0, deep=0), events=events, config=REGISTERED)
+    assert decision.wake is False
+
+
+def test_without_an_authored_cadence_there_is_no_periodic_register_wake():
+    config = gate.CloseoutConfig(trigger_status="Pending", chase_cadence_days=14)
+    decision = _decide(_pull([], cohort=0, deep=0), config=config)
+    assert decision.wake is False, "no invented reporting cadence"
+
+
+def test_a_waking_decision_carries_the_register_payload():
+    decision = _decide(
+        _pull([_obligation(MATTER_A, ENTITY_1, "Valley Health Plan", 100.0)],
+              rows=[_row(MATTER_A, "2026-SC-201", "2021-03-15")]),
+        config=REGISTERED,
+    )
+    assert decision.wake is True
+    assert decision.register is not None
+    assert decision.register["coverage"]["detail_read"] == 1
+
+
+def test_names_are_taken_from_the_record_never_composed():
+    assert gate._names([{"displayName": "Dean Halverson"}]) == "Dean Halverson"
+    assert gate._names([{"id": "x"}]) == "", "an unnamed entry contributes nothing"
+    assert gate._names([{"name": "A"}, {"displayName": "B"}]) == "A, B"
+
+
+def test_the_register_reads_the_committed_wire_fixtures_end_to_end():
+    raw = {
+        "cohort": [
+            {"id": "m-201", "number": "2026-SC-201", "title": "t",
+             "clients": [{"displayName": "Dean Halverson"}],
+             "personResponsible": [{"displayName": "R. Attorney"}],
+             "openedDate": "2021-03-15"},
+            {"id": "m-202", "number": "2026-SC-202", "title": "t",
+             "clients": [{"displayName": "Adaeze Okonkwo"}],
+             "personResponsible": [{"displayName": "R. Attorney"}],
+             "openedDate": "2007-06-11"},
+        ],
+        "layouts": {"m-201": _wire("2026-SC-201")},
+        "layoutErrors": {},
+    }
+    pull, problem = gate.parse_pull(raw)
+    assert problem is None
+    reg = gate.build_register(pull, REGISTERED, TODAY)
+    assert reg["coverage"] == {
+        "matters_at_status": 2, "detail_read": 1, "detail_not_read": 1,
+        "unreadable": 0, "obligations": 4, "name_keyed_obligations": 0,
+    }
+    oldest = reg["oldest"][0]
+    assert oldest["matter"] == "2026-SC-202" and oldest["detail"] == "not read"
+    assert oldest["client"] == "Adaeze Okonkwo"
+    assert reg["largest_recorded_exposure"][0]["matter"] == "2026-SC-201"


### PR DESCRIPTION
PR 3 of #2455 (Settlement Closeout). The standing register. Repo layer; runtime rows wait on the seeded sandbox and the reprovision freeze.

## What it is

The chase moves individual files; the register is how a person sees the whole position at once. It is assembled by the same pass that plans the chases, from the same reads, so the two can never tell different stories about the same week.

It carries the set ranked oldest first, the largest recorded exposures, providers ranked by what they hold across matters, the coverage counts, and a plain list of what could not be seen.

## Four disciplines, and why each one is load-bearing

**Blank is never zero.** A matter whose settlement detail was not opened this cycle shows no figure and is labelled `not read`. A matter that *was* read and owes nothing shows a real `0.00`. That is the most dangerous rounding available in this feature — a `0.00` on an unread file reads as a cleared file, on a compliance backlog.

**Coverage is a count, on the face.** Every register states how many matters are at the trigger status, how many had their detail opened, and how many did not. Silence about coverage reads as completeness, which is the failure this whole featureset exists to avoid.

**Every ranking names its rule.** "Oldest opened first; recorded exposure shown only where the detail has been read this cycle."

**What is missing is named, with the reason.** Quiet time is not available at this altitude: the matter record carries **no last-activity field at all** (`vfy_01M0E061XAJRNB2194NC6KM0R1` — the only date-like fields are opened, closed, and lead-opened). So the set is ranked by age and the register says exactly that, rather than passing age off as activity. The client trust ledger is not held in the practice-management system, so no balance appears and no file is called closed on its strength. A fully-cleared matter is a closure **candidate** for a person to confirm.

## Cadence degrades rather than failing closed

`register_days` sets how often the standing picture is produced on its own. Unauthored, there is no periodic run, the register rides along whenever the Operator wakes for other work, and it says so about itself. An invented reporting cadence would be a commitment nobody made.

## A deviation from the approved plan, and why

The plan put the register in `matter-status-digest`. That skill specifies its **entire fetch phase** as `execute_code`, which the seats refuse by posture — their own `customer.yaml` says so in as many words: "the ADR 0021 Stream-A execute_code fetch skills are inert here by posture". `daily-needs-you-digest` was moved off that path; this one never was. The register would have inherited an inert host.

Filed as #2461. The register lives here instead, where the obligation data already is and where the read path is proven (`vfy_01M0DXM3DNCMVMB89NEJW1PWRS`). One weekly pass now produces both the chase plans and the register, from one read of the data.

## Also corrected against the record

The plan asserted the cheap cohort pass could yield `lastUpdated` and that client names would be capped by the connector's caption budget. Neither holds: there is no last-activity field to read, and the rows carry `clients` 165/165 and `personResponsible` 164/165 directly, and the caption budget binds the MCP tool path rather than the connector-venv path this gate uses. Same verify.

## Guards proven, not assumed

`vfy_01M0E0H60Y98J9BDESBM74Z7ZN` — ten register disciplines, each broken one at a time, each failing its guard, each passing on restore: reporting an unread matter as zero, fabricating a figure for one, miscounting coverage, dropping the unavailable list, defaulting an unauthored stall threshold, inventing a reporting cadence, reversing the ranking, letting a cleared provider hold an exposure slot, emitting unbounded, and composing a placeholder name.

One mutation initially passed both clean and mutated: an unread row sums as zero, so it could not move the total, and its real harm was the coverage count. Re-paired to the guard it actually attacks, plus a separate mutation that fabricates a figure for unread rows. That is the second guard this session that had measured nothing until its mutation was corrected.

729 operator tests and five registration gates green.

## Next

Runtime proofs: the seeded sandbox, then the reprovision once the Hermes v0.20 freeze lifts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JWYNgm8hwTVtNC4Kr1z1Zj
