### PR TITLE
feat(operator): boot-smoke proves the matter-mixing read fence discriminates (ss#2167)

### DIFF
--- a/operator/bin/boot-smoke-test.sh
+++ b/operator/bin/boot-smoke-test.sh
@@ -182,6 +182,21 @@ ssh_exec "curator-disabled" "/opt/hermes/.venv/bin/python3 /app/ensure-curator-d
 # credential, exactly what ADR 0045 closes). No-op when no skills_disabled authored.
 ssh_exec "disabled-skills-pruned" "/opt/hermes/.venv/bin/python3 /app/ensure-disabled-skills.py --check /var/lib/smd-config/customer.yaml /opt/data"
 
+# ---------- Step 8c: the matter-mixing READ fence discriminates (ss#2167) ----------
+# The fence refuses a session holding one matter's substance from reading a
+# second matter's. It is what stops a draft containing two clients' facts from
+# ever being COMPOSED — every other matter control fires when a send is
+# attempted, by which point that draft exists and is in a paralegal's queue, and
+# the firm finding it there is the event the engagement does not survive whether
+# or not it was sent.
+#
+# The probe asserts BOTH directions on purpose: a second matter is refused, AND
+# the same matter is still readable. Asserting only the refusal would pass
+# against a fence that refused every content read — not a safe fence, a bricked
+# Operator the firm switches off. It also fails the boot if the overlay pin
+# predates ss#2167, which is the cross-repo drift this catches.
+ssh_exec "matter-mixing-fence" "/opt/hermes/.venv/bin/python3 /app/matter-mixing-fence-probe.py"
+
 # ---------- Step 9: audit ledger is broker-owned and NOT agent-writable (OP-P1-4) ----------
 # The immutable ledger must be owned by the broker uid (workspace-broker), the
 # dir setgid 2750, and the agent uid (hermes) must be physically unable to write

--- a/operator/templates/Dockerfile
+++ b/operator/templates/Dockerfile
@@ -1010,6 +1010,12 @@ COPY operator/templates/r2-account-key-strip-probe.py /app/r2-account-key-strip-
 # manifest<=map check, run where both the baked manifest and the installed overlay
 # are present).
 COPY operator/templates/connector-classification-probe.py /app/connector-classification-probe.py
+# ss#2167: boot-smoke asserts the matter-mixing READ fence is installed and
+# discriminates (refuses a second matter, allows the same one). The capture path
+# it depends on swallows exceptions by contract, so a broken fence is otherwise
+# indistinguishable from a clean fleet — no error, no alert, sends simply stop
+# being checked.
+COPY operator/templates/matter-mixing-fence-probe.py /app/matter-mixing-fence-probe.py
 
 # NOTE: customer.yaml is NOT copied into the image. It lives on the Fly
 # volume at /opt/data/customer.yaml; bootstrap.sh fetches it from R2 on

--- a/operator/templates/matter-mixing-fence-probe.py
+++ b/operator/templates/matter-mixing-fence-probe.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Boot-smoke probe: the matter-mixing read fence is installed and DISCRIMINATES
+(ss#2167).
+
+Run at boot with the Hermes venv python, where the overlay is pip-installed so
+``shared.matter_gate`` is importable.
+
+WHY THIS EXISTS, and why it asserts both directions
+---------------------------------------------------
+The fence refuses a session that already holds one matter's substance from
+reading a second matter's. It is the control that stops a draft containing two
+clients' facts from ever being COMPOSED — every other matter control on the seat
+fires when a send is attempted, by which point that draft exists and is sitting
+in a paralegal's queue, and the firm finding it there is the event the engagement
+does not survive whether or not it was ever sent.
+
+The capture path it depends on (``matter_binding.record_from_read``) swallows
+every exception by contract, because a hook must never raise into the tool path.
+That is correct and it means a broken fence is INDISTINGUISHABLE FROM A CLEAN
+FLEET: no error, no alert, every send simply stops being checked. So the fence
+needs a probe that runs the real code and fails the boot when it stops working.
+
+Two assertions, and the second matters as much as the first:
+
+  1. A second matter's memo read is REFUSED.
+  2. Re-reading the SAME matter is ALLOWED.
+
+A probe asserting only (1) would pass against a fence that refused every content
+read — which is not a safe fence, it is a bricked Operator that the firm would
+switch off within a day. Asserting only (2) would pass against a fence that was
+entirely open. Both, or this has measured nothing.
+
+Exit 0 when the fence behaves. Non-zero, loudly, otherwise.
+"""
+
+from __future__ import annotations
+
+import sys
+
+SESSION = "boot-smoke-matter-mixing"
+MATTER_A = "aaaaaaaa-0000-0000-0000-boot0000000a"
+MATTER_B = "bbbbbbbb-0000-0000-0000-boot0000000b"
+MEMOS = "mcp_smokeball_get_memos_on_matter"
+
+
+def fail(message: str) -> None:
+    print(f"FAIL: matter-mixing fence: {message}", file=sys.stderr)
+    sys.exit(1)
+
+
+def main() -> None:
+    try:
+        from shared import matter_binding, matter_gate
+    except Exception as exc:  # noqa: BLE001
+        fail(f"cannot import the fence at all ({exc!r}) — the overlay pin predates ss#2167")
+
+    mode = matter_gate.multi_matter_mode()
+    if mode != "block":
+        # Not a failure: `report` and `off` are authorable operator states. But it
+        # must be VISIBLE in the boot log, because in either state a mixed draft
+        # can be composed and nothing downstream will say so.
+        print(f"SKIP: SMD_MULTI_MATTER_MODE={mode} — the read fence is open by configuration")
+        return
+
+    # Clean any residue so the probe measures itself, not a previous run.
+    matter_binding.drop(SESSION)
+
+    # The session reads matter A's memos.
+    matter_binding.record_from_read(
+        SESSION, "{}", tool_name=MEMOS, args={"matter_id": MATTER_A}
+    )
+
+    held = matter_binding.membership_for(SESSION).content_read_matters()
+    if MATTER_A not in held:
+        fail(
+            "the content read was not captured, so the fence has nothing to compare "
+            "against and would never refuse anything (record_from_read is failing "
+            "silently — its exception handler is by design, which is exactly why "
+            "this probe exists)"
+        )
+
+    # 1. The second matter must be refused.
+    refusal = matter_gate.content_read_refusal(SESSION, MEMOS, {"matter_id": MATTER_B})
+    if refusal is None:
+        fail(
+            "a SECOND matter's memo read was permitted — a draft mixing two clients' "
+            "matters can be composed on this seat"
+        )
+
+    # 2. The same matter must still be readable, or the Operator cannot work.
+    same = matter_gate.content_read_refusal(SESSION, MEMOS, {"matter_id": MATTER_A})
+    if same is not None:
+        fail(
+            "re-reading the SAME matter was refused — the fence is not discriminating, "
+            f"it is refusing everything ({same})"
+        )
+
+    matter_binding.drop(SESSION)
+    print("PASS: matter-mixing fence refuses a second matter and allows the same one")
+
+
+if __name__ == "__main__":
+    main()

--- a/operator/templates/matter-mixing-fence-probe.py
+++ b/operator/templates/matter-mixing-fence-probe.py
@@ -113,8 +113,48 @@ def main() -> None:
             f"it is refusing everything ({same})"
         )
 
+    # 3. The WIRE spelling must reach the fence too.
+    #
+    # This assertion exists because the probe above could not have caught the
+    # ss#2444 regression. Hermes v0.19 renamed MCP tools
+    # ``mcp_<server>_<tool>`` -> ``mcp__<server>__<tool>``. The fence's tool set
+    # is keyed on the legacy spelling, so on a v0.20 seat without the boundary
+    # translation ``is_content_read()`` returns False and the fence silently
+    # ISN'T THERE — no refusal, no error. Every assertion above uses the
+    # canonical spelling directly, so all of them would have passed while the
+    # real read path was unfenced. The instrument could not observe its own
+    # layer.
+    #
+    # So drive the wire form through the same canonicalizer the fan-out uses.
+    # If a future Hermes rename escapes that translation, this fails the boot
+    # instead of leaving the fence quietly inert.
     matter_binding.drop(SESSION)
-    print("PASS: matter-mixing fence refuses a second matter and allows the same one")
+    try:
+        from shared.mcp_tool_names import canonical_tool_name
+    except Exception as exc:  # noqa: BLE001
+        fail(f"cannot import the tool-name canonicalizer ({exc!r}) — overlay predates ss#2444")
+
+    wire_memos = "mcp__smokeball__get_memos_on_matter"
+    if not matter_binding.is_content_read(canonical_tool_name(wire_memos)):
+        fail(
+            f"the wire tool name {wire_memos} does not canonicalize into the content-read "
+            "set — the fence is inert for every real read on this seat (ss#2444 class)"
+        )
+
+    matter_binding.record_from_read(
+        SESSION, "{}", tool_name=canonical_tool_name(wire_memos), args={"matter_id": MATTER_A}
+    )
+    if matter_gate.content_read_refusal(SESSION, canonical_tool_name(wire_memos), {"matter_id": MATTER_B}) is None:
+        fail(
+            "a second matter read under the WIRE tool spelling was permitted — the fence "
+            "does not cover the names this Hermes version actually sends"
+        )
+
+    matter_binding.drop(SESSION)
+    print(
+        "PASS: matter-mixing fence refuses a second matter, allows the same one, "
+        "and covers the v0.19+ wire tool spelling"
+    )
 
 
 if __name__ == "__main__":

--- a/operator/templates/matter-mixing-fence-probe.py
+++ b/operator/templates/matter-mixing-fence-probe.py
@@ -30,6 +30,24 @@ read — which is not a safe fence, it is a bricked Operator that the firm would
 switch off within a day. Asserting only (2) would pass against a fence that was
 entirely open. Both, or this has measured nothing.
 
+WHAT THIS PROBE DOES NOT COVER — the boundary, stated so nobody mistakes it
+--------------------------------------------------------------------------
+The fence lives at the MCP TOOL SEAM (``enforce.evaluate_tool_call``). It sees a
+matter-content read only when that read arrives as a tool call. Anything that
+reaches matter content by another route is outside it:
+
+* a script or probe on the seat calling the connector client directly
+  (``client.get()`` / ``download_file``) rather than through the tool layer;
+* any future in-process path that fetches document or memo content without a
+  tool call.
+
+That is not a defect in the fence, and widening it to a process-level control is
+not proposed — the AGENT acts through the tool layer, and the direct-client paths
+that exist today are Captain-driven and read-only (``execute_code`` is
+taint-gated, so the agent cannot open one). But "every matter-content read is
+fenced" is a **tool-layer** claim, and writing it without that qualifier is how a
+boundary gets forgotten and later mistaken for coverage.
+
 Exit 0 when the fence behaves. Non-zero, loudly, otherwise.
 """
 


### PR DESCRIPTION
A boot-smoke probe for the matter-mixing read fence (overlay [#282](https://github.com/venturecrane/hermes-smd-overlay/pull/282), proven live on pilot-smokeball today).

The fence refuses a session that already holds one matter's substance from reading a second matter's, so a draft carrying two clients' facts is never composed. Every *other* matter control fires when a send is attempted — by which point the mixed draft exists and is in a paralegal's queue. A firm finding that draft is the event the engagement does not survive, whether or not it was ever sent. `draft_for_review` does not prevent that discovery; it schedules it.

**No `OVERLAY_REF` bump needed.** This PR originally held one. It turned out ss#2453 pins `ab352d5b`, which already contains the fence at `0abfa26` — verified with `git merge-base --is-ancestor`. Every seat built from main since #2453 already carries it. Only the probe was missing.

## Why a boot probe rather than trusting the unit tests

`matter_binding.record_from_read` swallows every exception by contract — a hook must never raise into the tool path. That is correct, and it means **a broken fence is indistinguishable from a clean fleet**: no error, no alert, sends simply stop being checked.

That is not hypothetical. During this work, Hermes v0.19's tool rename (`mcp_x_y` → `mcp__x__y`) would have left `is_content_read()` never matching, making the fence **silently inert on exactly the reads it exists to catch** — caught by ss#2444, fixed at the boundary in overlay#283.

## It asserts three things, and the controls carry as much weight as the refusal

| Assertion | Why it is needed |
|---|---|
| A second matter's memo read is **refused** | The control itself |
| Re-reading the **same** matter is **allowed** | Without this, the probe passes against a fence that refuses every content read — not a safe fence, a bricked Operator the firm switches off within a day |
| The **v0.19+ wire spelling** canonicalizes and is fenced | Without this the probe cannot observe the ss#2444 failure class at all — see below |

The third exists because **this probe could not originally observe its own failure.** Every assertion used the canonical spelling directly, so on a renamed runtime it would have passed while the live read path was unfenced — the same defect class the probe was written to catch, one level up.

## Verified, not assumed

Five mutants, each caught with the correct message:

| Mutant | Probe result |
|---|---|
| Fence forced **open** | `FAIL: a SECOND matter's memo read was permitted` |
| Fence forced **shut** | `FAIL: re-reading the SAME matter was refused — it is refusing everything` |
| Capture silently no-ops | `FAIL: the content read was not captured … failing silently` |
| Overlay at `0abfa26` (fence, no wire translation) | `FAIL: cannot import the tool-name canonicalizer — overlay predates ss#2444` |
| `SMD_MULTI_MATTER_MODE=off` | `SKIP` with a visible line (not a silent pass) |

And on the real seat: `PASS: matter-mixing fence refuses a second matter, allows the same one, and covers the v0.19+ wire tool spelling` — `vfy_01M0EGXTWKX2K2BGAXN6DX0GHN`.

## The fence is proven reachable, not just installed

On a real email turn from an authored admin, the pilot Operator read matter `2026-PI-105`'s memos (reporting real facts — trial date, FSC date, memo date) and then refused `2026-PI-102`, saying so itself:

> *"Reading memos from 2026-PI-105 first triggered the ss#2167 matter-mixing fence… The 2026-PI-102 memos are available but need to be read in a separate session."*

`vfy_01M0EHCTV498PFJ0EY5W0ANXKV`. Two `MATTER_MIXING_FENCE` ledger rows, both `session_resolution=keyed`.

## Boundary — this is a TOOL-layer control

The fence sits at the MCP tool seam, so it sees a matter-content read only when that read arrives as a tool call. A script calling the connector client directly (`client.get()` / `download_file`) never touches it. Not a defect — the agent acts through the tool layer and `execute_code` is taint-gated — but *"every matter-content read is fenced"* is a tool-layer claim, and it is written into the probe docstring so the limit stays known rather than being mistaken for coverage.

## Session-keying census

Across 8,611 audit rows on the pilot, every recorded resolution (1,552) is `keyed`. Zero `ambiguous`, zero `none`, zero `process_singleton` — so the fence's documented fail-open path is unobserved on this seat. Not *impossible*: the other 7,059 rows carry no stamp, because the field is only written where a trust decision was recorded. `vfy_01M0EHDBRDVNX2EZEH9D93MBH2`.

`npm run verify` passes (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HH1Ss72yNyw5kU4SBryM2U
