### PR TITLE
fix(operator): a register-only wake stops reporting itself as a held matter (#2455)

### DIFF
--- a/operator/skills/lien-ledger-tracker/pre_run.py
+++ b/operator/skills/lien-ledger-tracker/pre_run.py
@@ -744,17 +744,33 @@ def decide(
         "stall_days_authored": config.stall_days is not None,
     }
     if plans:
+        # Count each action for itself. Deriving one count by subtracting another
+        # from the total was wrong the moment a third action existed: a
+        # register-only wake reported itself as a held matter, which is a metric
+        # asserting something that did not happen, in a row the audit keeps.
         chases = [p for p in plans if p.action == ACTION_CHASE_PROVIDER]
+        holds = [p for p in plans if p.action == ACTION_SURFACE_HOLD]
+        registers = [p for p in plans if p.action == ACTION_EMIT_REGISTER]
+        # The basis names what is actually due, most actionable first. A wake
+        # that says "chase due" when only the periodic register came around
+        # misdescribes the run to anyone reading the heartbeat afterwards.
+        if chases:
+            basis = "closeout_chase_due"
+        elif holds:
+            basis = "closeout_hold_surface_due"
+        else:
+            basis = "closeout_register_due"
         return WakeDecision(
             wake=True,
-            decision_basis="closeout_chase_due",
+            decision_basis=basis,
             pre_run_inputs_digest=raw_inputs_for_digest,
             plans=tuple(plans),
             register=build_register(pull, config, today),
             extra_metadata={
                 **coverage,
                 "provider_chases_due": len(chases),
-                "hold_surface_due": len(plans) - len(chases),
+                "hold_surface_due": len(holds),
+                "register_due": len(registers),
                 "matters_in_chases": sorted({m for p in chases for m in p.matters}),
             },
         )

--- a/operator/skills/lien-ledger-tracker/test_closeout_pre_run.py
+++ b/operator/skills/lien-ledger-tracker/test_closeout_pre_run.py
@@ -599,3 +599,57 @@ def test_the_register_reads_the_committed_wire_fixtures_end_to_end():
     assert oldest["matter"] == "2026-SC-202" and oldest["detail"] == "not read"
     assert oldest["client"] == "Adaeze Okonkwo"
     assert reg["largest_recorded_exposure"][0]["matter"] == "2026-SC-201"
+
+
+# ------------------------------------------- decision summary (found on seat)
+
+
+def test_a_register_only_wake_is_not_reported_as_a_held_matter():
+    """Found by running the gate on the real seat: the hold count was derived by
+    subtracting chases from the total, so the periodic register counted itself as
+    a held matter, in a number the audit heartbeat keeps."""
+    decision = _decide(_pull([], cohort=0, deep=0), config=REGISTERED)
+    assert decision.wake is True
+    assert decision.extra_metadata["hold_surface_due"] == 0
+    assert decision.extra_metadata["register_due"] == 1
+    assert decision.extra_metadata["provider_chases_due"] == 0
+
+
+def test_a_register_only_wake_says_so_in_its_basis():
+    decision = _decide(_pull([], cohort=0, deep=0), config=REGISTERED)
+    assert decision.decision_basis == "closeout_register_due"
+
+
+def test_a_hold_only_wake_says_so_in_its_basis():
+    events = [_event(MATTER_A, gate.HOLD_SOURCE_ID, "sct-chase-hold", "fired", "2026-08-01T00:00:00Z")]
+    config = gate.CloseoutConfig(trigger_status="Pending", chase_cadence_days=14, stall_days=60)
+    decision = _decide(
+        _pull([_obligation(MATTER_A, ENTITY_1, "Valley Health Plan", 100.0)]),
+        events=events, config=config,
+    )
+    assert decision.decision_basis == "closeout_hold_surface_due"
+    assert decision.extra_metadata["hold_surface_due"] == 1
+
+
+def test_a_chase_takes_precedence_in_the_basis():
+    decision = _decide(
+        _pull([_obligation(MATTER_A, ENTITY_1, "Valley Health Plan", 100.0)]),
+        config=REGISTERED,
+    )
+    assert decision.decision_basis == "closeout_chase_due"
+    assert decision.extra_metadata["provider_chases_due"] == 1
+    assert decision.extra_metadata["register_due"] == 1, (
+        "the register still rides along; it simply is not what the wake is called after"
+    )
+
+
+def test_every_plan_action_is_counted_by_itself():
+    """No count is derived by subtracting another from the total."""
+    events = [_event(MATTER_B, gate.HOLD_SOURCE_ID, "sct-chase-hold", "fired", "2026-08-01T00:00:00Z")]
+    decision = _decide(_pull([
+        _obligation(MATTER_A, ENTITY_1, "Valley Health Plan", 100.0),
+        _obligation(MATTER_B, "id-b", "Cedar Ridge Orthopedics", 200.0),
+    ]), events=events, config=REGISTERED)
+    meta = decision.extra_metadata
+    counted = meta["provider_chases_due"] + meta["hold_surface_due"] + meta["register_due"]
+    assert counted == len(decision.plans), "every plan is accounted for by its own action"


### PR DESCRIPTION
Found by running the gate on the real seat rather than by a test (`vfy_01M0EK3Z4XEF2AR15RN4C9F161`).

The first live run on pilot-smokeball emitted `"decision_basis": "closeout_chase_due"` with `"hold_surface_due": 1` while nothing was due but the periodic register: no chase, no hold, and no matters at the trigger status at all.

## Two causes, one shape

The hold count was derived by subtracting chases from the total plan count. Correct while there were exactly two kinds of plan; a lie the moment a third existed. And the basis was a constant, so every wake described itself as a chase regardless of what came due.

Both land in the audit heartbeat metadata, which is the record a person reads afterwards to ask what the Operator did that week. **A count asserting a held matter that does not exist** is the failure this featureset spends its whole design budget avoiding, one layer over from where it was being guarded.

## The fix

Every action is counted by itself; no count is derived from another. The basis names what is genuinely due, most actionable first: a chase, else a hold surface, else the register. The register still rides along on a chase wake, it simply is not what the wake is named after.

## Why the unit tests missed it

They only ever exercised plan sets that were all chases or all holds, so the third action never met the subtraction. Five guards added for the register-only and mixed cases, including one asserting the per-action counts sum to the number of plans, so a fourth action cannot reintroduce this class silently.

Three proven falsifiable by reintroducing each defect exactly as it shipped (`vfy_01M0EK494VX2BYRFMPN0P960E0`). 734 operator tests green.

## What the seat run did and did not prove

Proven on the real machine: config load from the trusted volume, ledger module load, the connector-venv pull against the live tenant, the decision, and the register build.

Not proven: any data-dependent behaviour. pilot holds zero matters at the trigger status, so the cohort was honestly empty and no obligation, chase, grouping or ranking path was exercised. Those still need the seeded sandbox, and the re-proof of this fix rides the same reprovision that picks the seed up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JWYNgm8hwTVtNC4Kr1z1Zj