### PR TITLE
fix(operator): the folder listing is a TREE, so the firm's template resolves (#2448)

### DIFF
--- a/operator/connectors/smokeball/smokeball_connector/library.py
+++ b/operator/connectors/smokeball/smokeball_connector/library.py
@@ -147,13 +147,39 @@ def find_matter_id(client: Any, matter_number: str) -> str | None:
         offset += 500
 
 
+def _walk_folders(nodes: Any) -> list[dict[str, Any]]:
+    """Every folder in a folder listing, at any depth.
+
+    OBSERVED SHAPE (pilot tenant, 2026-08-20): the response is a TREE, not a
+    flat list. ``value`` holds one root node carrying ``folders: [...]`` and
+    ``files: [...]``; the root itself has no ``name``. A flat read finds
+    nothing, which is exactly how the firm's template silently failed to
+    resolve on the first live run (every draft fell back to the starter and
+    said so). Walk it, and treat a node with a name and an id as a folder at
+    any depth.
+    """
+    out: list[dict[str, Any]] = []
+    stack = list(nodes) if isinstance(nodes, list) else [nodes]
+    while stack:
+        node = stack.pop()
+        if not isinstance(node, dict):
+            continue
+        if node.get("id") and node.get("name"):
+            out.append(node)
+        for key in ("folders", "children", "subFolders"):
+            child = node.get(key)
+            if isinstance(child, list):
+                stack.extend(child)
+    return out
+
+
 def find_folder_id(client: Any, matter_id: str, folder_name: str) -> str | None:
     try:
         resp = client.get(f"/matters/{matter_id}/documents/folders", Limit=500, Offset=0)
     except Exception:  # noqa: BLE001
         return None
     want = _norm(folder_name)
-    for f in _listing(resp):
+    for f in _walk_folders(_listing(resp)):
         if _norm(f.get("name")) == want:
             return str(f.get("id"))
     return None

--- a/operator/connectors/smokeball/tests/test_library_resolution.py
+++ b/operator/connectors/smokeball/tests/test_library_resolution.py
@@ -164,6 +164,82 @@ _LIVE_ENTRY_AT_ROOT = {
 }
 
 
+# The folder listing is a TREE, pinned to the payload observed on the pilot
+# tenant 2026-08-20 (probe F). ``value`` holds one root node with `folders` and
+# `files`; the root has no name. A flat read finds nothing, and that is exactly
+# how the firm's template silently failed to resolve on the first live run.
+_LIVE_FOLDER_LISTING = {
+    "href": "https://stagingapi.smokeball.com/matters/3c19.../documents/folders",
+    "offset": 0,
+    "limit": 50,
+    "size": 2,
+    "value": [
+        {
+            "folders": [
+                {
+                    "href": "https://stagingapi.smokeball.com/matters/3c19.../documents/folders/9898...",
+                    "id": "9898f74a-3ad9-4b79-b209-a2f0f0c3d7d8",
+                    "name": "Document Library",
+                }
+            ],
+            "files": [
+                {
+                    "id": "df59b111-1bb2-4af0-b7e0-69454ff080be",
+                    "name": "Operator Self-Test Report 2026-08-11",
+                }
+            ],
+        }
+    ],
+}
+
+
+class _TreeClient(_FakeClient):
+    """A client whose folder listing is the observed tree."""
+
+    def get(self, path: str, **params):
+        if path.endswith("/documents/folders"):
+            return _LIVE_FOLDER_LISTING
+        return super().get(path, **params)
+
+
+def test_folder_listing_tree_is_walked_not_read_flat() -> None:
+    from smokeball_connector.library import find_folder_id
+
+    client = _TreeClient(matters=[], folders=[], files=[])
+    assert find_folder_id(client, "m-ops", "Document Library") == "9898f74a-3ad9-4b79-b209-a2f0f0c3d7d8"
+    assert find_folder_id(client, "m-ops", "document library") == "9898f74a-3ad9-4b79-b209-a2f0f0c3d7d8"
+    assert find_folder_id(client, "m-ops", "Nope") is None
+
+
+def test_nested_subfolders_are_reachable() -> None:
+    from smokeball_connector.library import _walk_folders
+
+    tree = [{"folders": [{"id": "a", "name": "A", "folders": [{"id": "b", "name": "B"}]}]}]
+    assert {f["id"] for f in _walk_folders(tree)} == {"a", "b"}
+
+
+def test_resolution_end_to_end_against_the_observed_tree_and_entry_shapes() -> None:
+    """The whole chain on the shapes the tenant actually returns: matter by
+    number, folder by name out of the tree, file by convention inside it."""
+    client = _TreeClient(
+        matters=[{"id": "m-ops", "number": "2026-OPS-001"}],
+        folders=[],
+        files=[
+            {
+                "id": "tpl",
+                "name": "Template - Discovery Set.docx",
+                "folder": {"id": "9898f74a-3ad9-4b79-b209-a2f0f0c3d7d8"},
+                "dateCreated": "2026-08-20",
+            }
+        ],
+        blob=b"PK-firm-template",
+    )
+    out = resolve_template(client, _CFG, "discovery_set")
+    assert isinstance(out, ResolvedTemplate)
+    assert out.file_id == "tpl" and out.folder_id == "9898f74a-3ad9-4b79-b209-a2f0f0c3d7d8"
+    assert out.bytes == b"PK-firm-template"
+
+
 def test_observed_wire_shape_folder_object_is_read_and_root_files_have_none() -> None:
     from smokeball_connector.library import _entry_folder_id
 


### PR DESCRIPTION
## Summary

Found by the first live run of the whole #2448 chain on pilot-smokeball, minutes ago: the firm's class template never resolved. Every draft fell back to the starter and said so loudly (`templateExpected: true`, `"firm template not used: no file named 'Template - Discovery Set.docx' in matter '2026-OPS-001' (folder 'Document Library' not found)"`) while that folder plainly exists and the template had just been filed into it.

`GET /matters/{id}/documents/folders` returns a **tree**, not a flat list:

```json
{ "size": 2, "value": [ { "folders": [ { "id": "9898f74a…", "name": "Document Library" } ],
                          "files":   [ { "id": "df59b111…", "name": "Operator Self-Test Report 2026-08-11" } ] } ] }
```

The root node has no `name`, so a flat read matches nothing. `find_folder_id` read it flat. `_walk_folders` now walks it at any depth.

The design's loud-fallback behavior is what made this visible in one run instead of looking like "the firm just has no template" — worth noting, because that was a critique-driven choice.

## Linked issue

Refs #2448.

## Acceptance criteria status

| AC (verbatim from issue) | Status | Evidence |
| --- | --- | --- |
| (repo) Deterministic library resolution from the seat's live customer.yaml … -> matter -> folder -> `Template - <Class>.docx`; "not resolved" is reported (`templateExpected`), never silent | met (defect fixed) | `library.py:_walk_folders` + `find_folder_id`; `tests/test_library_resolution.py::test_folder_listing_tree_is_walked_not_read_flat`, `::test_nested_subfolders_are_reachable`, `::test_resolution_end_to_end_against_the_observed_tree_and_entry_shapes` (pinned to the payload observed on the tenant, probe F 2026-08-20). Mutation-checked: with the old flat read the pinned test fails (1 failed, 7 passed) |
| (runtime) Provenance (b): a starter filed into the pilot library, a style edited in Word and re-uploaded, the next draft honors it | deferred | needs this fix on the seat: reprovision, then re-run the chain (a starter is already filed at `Template - Discovery Set.docx`, fileId 81b971d6) |

## Test plan

- Connector suite 339 passed. Mutation check above.
- Runtime: reprovision pilot after merge and re-run the probe chain (file/resolve/render-into-template); the template is already in the library from the run that found this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Hqx3xnCwszXbqqqMxF7cf
