### PR TITLE
fix(operator): the stored file name carries no extension, so the class template matches (#2448)

### DIFF
--- a/operator/connectors/smokeball/smokeball_connector/library.py
+++ b/operator/connectors/smokeball/smokeball_connector/library.py
@@ -201,6 +201,32 @@ def list_matter_files(client: Any, matter_id: str) -> list[dict[str, Any]]:
     return files
 
 
+def _strip_ext(name: str) -> str:
+    for ext in (".docx", ".dotx", ".docm", ".dotm"):
+        if name.endswith(ext):
+            return name[: -len(ext)]
+    return name
+
+
+def name_matches(entry: dict[str, Any], wanted: str) -> bool:
+    """Does this file entry carry the wanted file name?
+
+    OBSERVED (pilot tenant, 2026-08-20, probe H): Smokeball stores ``name``
+    WITHOUT the extension and carries ``fileExtension`` separately, so a file
+    uploaded as "Template - Discovery Set.docx" lists as
+    ``{"name": "Template - Discovery Set", "fileExtension": ".docx"}``. An
+    exact match on the full file name therefore never matches anything, which
+    is how the firm's template stayed unresolvable even once the folder was
+    found. Compare with and without the extension, on both sides, so an
+    authored ``templates`` entry works whether or not the firm typed ".docx".
+    """
+    name = str(entry.get("name") or "")
+    ext = str(entry.get("fileExtension") or "")
+    have = {_norm(name), _norm(name + ext), _norm(_strip_ext(name))}
+    want = {_norm(wanted), _norm(_strip_ext(wanted))}
+    return bool(have & want)
+
+
 def _entry_folder_id(entry: dict[str, Any]) -> str | None:
     """The folder a file entry sits in. Observed live on the pilot tenant
     (2026-08-19, vfy_01M0DTM2EGQZP9FZTM53S17CJ7): a file inside a folder
@@ -228,8 +254,8 @@ def resolve_template(client: Any, cfg: LibraryConfig, document_class: str) -> Re
     if not matter_id:
         return NotResolved(f"library matter {cfg.matter_number!r} not found")
     folder_id = find_folder_id(client, matter_id, cfg.folder_name or "")
-    want = _norm(cfg.template_name(document_class))
-    candidates = [e for e in list_matter_files(client, matter_id) if _norm(e.get("name")) == want]
+    want = cfg.template_name(document_class)
+    candidates = [e for e in list_matter_files(client, matter_id) if name_matches(e, want)]
     if folder_id:
         in_folder = [e for e in candidates if _entry_folder_id(e) == folder_id]
         if in_folder:
@@ -250,10 +276,9 @@ def is_library_file(entry: dict[str, Any], cfg: LibraryConfig, library_folder_id
     source (a header-only letterhead extracts to nothing and would refuse the
     whole draft). Match by the class-template naming convention, and by folder
     when the listing carries a folder id and the library folder is known."""
-    name = _norm(entry.get("name"))
-    if any(name == _norm(cfg.template_name(cls)) for cls in CLASS_TITLES):
+    if any(name_matches(entry, cfg.template_name(cls)) for cls in CLASS_TITLES):
         return True
-    if name.startswith("template - ") and name.endswith(".docx"):
+    if _norm(entry.get("name")).startswith("template - "):
         return True
     folder = _entry_folder_id(entry)
     return bool(library_folder_id and folder and folder == library_folder_id)

--- a/operator/connectors/smokeball/tests/test_library_resolution.py
+++ b/operator/connectors/smokeball/tests/test_library_resolution.py
@@ -202,6 +202,44 @@ class _TreeClient(_FakeClient):
         return super().get(path, **params)
 
 
+def test_stored_name_carries_no_extension_so_the_match_is_extension_agnostic() -> None:
+    """OBSERVED (probe H, 2026-08-20): Smokeball stores `name` WITHOUT the
+    extension and `fileExtension` separately. An exact full-name match never
+    matches anything, which is how the firm's template stayed unresolvable
+    even after the folder was found."""
+    from smokeball_connector.library import name_matches
+
+    stored = {"name": "Template - Discovery Set", "fileExtension": ".docx"}
+    assert name_matches(stored, "Template - Discovery Set.docx")
+    assert name_matches(stored, "Template - Discovery Set")
+    assert not name_matches(stored, "Template - Demand Letter.docx")
+    # an authored override typed either way resolves
+    authored = {"name": "Template - Demand Letter (Policy Limits)", "fileExtension": ".docx"}
+    assert name_matches(authored, "Template - Demand Letter (Policy Limits).docx")
+    assert name_matches(authored, "Template - Demand Letter (Policy Limits)")
+    # a file whose name really does carry the extension still matches
+    assert name_matches({"name": "Template - Memo.docx"}, "Template - Memo.docx")
+
+
+def test_resolution_against_the_stored_name_shape() -> None:
+    client = _TreeClient(
+        matters=[{"id": "m-ops", "number": "2026-OPS-001"}],
+        folders=[],
+        files=[
+            {
+                "id": "tpl",
+                "name": "Template - Discovery Set",
+                "fileExtension": ".docx",
+                "folder": {"id": "9898f74a-3ad9-4b79-b209-a2f0f0c3d7d8"},
+                "dateCreated": "2026-08-20",
+            }
+        ],
+        blob=b"PK-firm-template",
+    )
+    out = resolve_template(client, _CFG, "discovery_set")
+    assert isinstance(out, ResolvedTemplate) and out.file_id == "tpl"
+
+
 def test_folder_listing_tree_is_walked_not_read_flat() -> None:
     from smokeball_connector.library import find_folder_id
 


### PR DESCRIPTION
## Summary

Second live finding on pilot-smokeball, immediately after #2475 landed on the seat. The folder now resolves; the file inside it still did not:

```
PROBE-G matter: 3c191bed… folder: 9898f74a…            <- the tree fix works
PROBE-G formatApplied: templateUsed null, templateExpected true,
  notes ["firm template not used: no file named 'Template - Discovery Set.docx' in folder 'Document Library'"]
```

Smokeball stores `name` **without** the extension and `fileExtension` separately (probe H, same tenant):

```json
{ "id": "…", "name": "Template - Discovery Set", "fileExtension": ".docx", "folder": { "id": "9898f74a…" } }
```

So an exact full-name comparison matches nothing, and an authored `templates` override hits the same trap whichever way the firm types it. `name_matches` now compares with and without the extension on both sides; the record-check exclusion (`is_library_file`) uses it too, so a library file still never becomes a draft source.

## Linked issue

Refs #2448.

## Acceptance criteria status

| AC (verbatim from issue) | Status | Evidence |
| --- | --- | --- |
| (repo) Deterministic library resolution … -> the file named `templates[class]` or `Template - <Class>.docx` | met (second defect fixed) | `library.py:name_matches`; `tests/test_library_resolution.py::test_stored_name_carries_no_extension_so_the_match_is_extension_agnostic`, `::test_resolution_against_the_stored_name_shape`, pinned to entries observed on the tenant. Mutation-checked against the pre-fix exact comparison: 2 failed, 25 passed. (The two halves of the match are individually sufficient, so single-half mutations correctly do not bite; the meaningful mutation is the original comparison.) |
| (runtime) Provenance (b): a starter filed into the pilot library, a style edited in Word, the next draft honors it | deferred | needs this on the seat: reprovision, then re-run the chain. The starter is already filed in the pilot library as `Template - Discovery Set` (fileId 81b971d6) |

## Test plan

- Connector suite 341 passed; mutation check above.
- Runtime after merge: reprovision, re-run probe G (resolve -> render into the firm's template -> download and confirm the template's styles are in the draft).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Hqx3xnCwszXbqqqMxF7cf
