### PR TITLE
fix(operator): a class template filed under a name the renderer will not open is refused (ss#2490)

### DIFF
--- a/operator/connectors/smokeball/smokeball_connector/docx_format_types.py
+++ b/operator/connectors/smokeball/smokeball_connector/docx_format_types.py
@@ -36,6 +36,7 @@ class FormatReport:
     document_class: str
     template_used: dict[str, Any] | None = None
     template_expected: bool = False
+    class_template_name: str | None = None
     base_header_footer_text: list[str] = field(default_factory=list)
     styles_honored: list[str] = field(default_factory=list)
     fallbacks: list[str] = field(default_factory=list)
@@ -48,6 +49,7 @@ class FormatReport:
             "class": d["document_class"],
             "templateUsed": d["template_used"],
             "templateExpected": d["template_expected"],
+            "classTemplateName": d["class_template_name"],
             "baseHeaderFooterText": d["base_header_footer_text"],
             "stylesHonored": sorted(set(d["styles_honored"])),
             "fallbacks": sorted(set(d["fallbacks"])),

--- a/operator/connectors/smokeball/smokeball_connector/library.py
+++ b/operator/connectors/smokeball/smokeball_connector/library.py
@@ -208,6 +208,18 @@ def _strip_ext(name: str) -> str:
     return name
 
 
+def names_agree(a: str, b: str) -> bool:
+    """Do two file names name the same file, ignoring case, surrounding space,
+    and the extension?
+
+    The renderer resolves a class's template by NAME, so a template filed under
+    any other name is inert. This is the comparison the write path uses to
+    refuse that outcome (#2490), and it normalizes exactly the way
+    ``name_matches`` does so the check and the lookup can never disagree.
+    """
+    return _norm(_strip_ext(a)) == _norm(_strip_ext(b))
+
+
 def name_matches(entry: dict[str, Any], wanted: str) -> bool:
     """Does this file entry carry the wanted file name?
 

--- a/operator/connectors/smokeball/smokeball_connector/server.py
+++ b/operator/connectors/smokeball/smokeball_connector/server.py
@@ -1492,6 +1492,7 @@ def _render_with_format(markdown: str, document_class: str | None) -> tuple[byte
     report = FormatReport(document_class=document_class)
     cfg = load_library_config()
     report.template_expected = cfg.authored
+    report.class_template_name = cfg.template_name(document_class)
     base: bytes | None = None
     try:
         resolved = resolve_template(_get_client(), cfg, document_class)
@@ -1592,6 +1593,17 @@ def render_docx_template(
     text): state it honestly in the delivery note. Omit ``document_class`` for
     the legacy stock render, unchanged.
 
+    **The class's template has ONE name, and this tool enforces it.** With a
+    ``document_class``, ``formatApplied.classTemplateName`` is the name the
+    renderer will look for, and filing under any other name is REFUSED rather
+    than filed-and-warned: a template the renderer never opens is worse than no
+    template, because the delivery note reads as if the format were live. If
+    the firm wants a different name, the mapping is authored in
+    ``self_initiation.document_library.templates`` by PR FIRST, and the tool
+    then insists on that authored name. A file the firm placed itself is never
+    renamed and never overwritten; re-filing under the same name supersedes,
+    because the resolver takes the newest.
+
     Classified INTERNAL_WRITE at the overlay: the Operator writing a template
     into the firm's own record. Nothing leaves the firm."""
     from .render import TemplateContentRefused, check_template_content
@@ -1610,6 +1622,23 @@ def render_docx_template(
             "refusals": [str(v) for v in exc.violations],
         }
     data, format_applied, refusal = _render_with_format(skeleton_markdown, document_class)
+    if not refusal and document_class and format_applied:
+        # ONE NAMING AUTHORITY (#2490). The renderer finds a class's template by
+        # the name `LibraryConfig.template_name` returns; a template filed under
+        # any other name is never opened, and the delivery note would still call
+        # it live. Prose in the skill body is what let those two drift apart, so
+        # the check is mechanical here. This is a file WE are creating, so its
+        # name is ours to insist on; a file the firm placed is never renamed.
+        from .library import names_agree
+
+        wanted = format_applied.get("classTemplateName")
+        if wanted and not names_agree(file_name, str(wanted)):
+            refusal = (
+                f"filed name {file_name!r} is not this class's template name {wanted!r}, so the "
+                "renderer would never open it. File it as that name — or, if the firm wants a "
+                "different one, have self_initiation.document_library.templates authored by PR "
+                "FIRST and then file under the authored name."
+            )
     if refusal:
         return {
             "matterId": matter_id,

--- a/operator/connectors/smokeball/tests/test_library_resolution.py
+++ b/operator/connectors/smokeball/tests/test_library_resolution.py
@@ -498,3 +498,85 @@ def test_every_class_files_on_the_starter(monkeypatch, tmp_path, cls: str) -> No
     _stub_record_check(monkeypatch)
     out = server.render_docx_draft("m-1", "Draft", DISCOVERY_MD, document_class=cls)
     assert out["fileId"] == "file-88" and out["formatApplied"]["class"] == cls
+
+
+# --- One naming authority (ss#2490) -------------------------------------------
+#
+# The renderer resolves a class's template BY NAME, so a template filed under any
+# other name is inert while the delivery note still reads as if the format were
+# live. Found on pilot 2026-08-20: three templates filed, one live
+# (vfy_01M0GHR4T1V6HG46BVX3S61BCC). The skill body said "name it by the
+# convention unless the blessing named it otherwise", which assumed no override
+# existed yet — an ordering assumption that is false on any seat configured in an
+# earlier cycle. Prose could not close it; these pin the mechanical check.
+
+
+def _authored_with_override(tmp_path, monkeypatch) -> None:
+    path = _write_yaml(
+        tmp_path,
+        "self_initiation:\n"
+        "  document_library:\n"
+        "    matter_number: '2026-OPS-001'\n"
+        "    folder_name: 'Document Library'\n"
+        "    templates:\n"
+        "      demand_letter: 'Firm Demand Shell'\n",
+    )
+    monkeypatch.setenv(CUSTOMER_YAML_ENV, path)
+
+
+def test_names_agree_ignores_case_space_and_extension() -> None:
+    from smokeball_connector.library import names_agree
+
+    assert names_agree("Template - Letter.docx", "Template - Letter")
+    assert names_agree(" template - letter ", "Template - Letter.docx")
+    assert not names_agree("Template - Letter.docx", "Template - Demand Letter.docx")
+
+
+def test_class_template_name_is_reported_so_the_skill_need_not_guess(monkeypatch, tmp_path) -> None:
+    _authored_with_override(tmp_path, monkeypatch)
+    captured: list[httpx.Request] = []
+    monkeypatch.setattr(server, "_get_client", lambda: _mock_client(_handler(captured)))
+    out = server.render_docx_template("m-1", "Firm Demand Shell.docx", "# Shell\n", document_class="demand_letter")
+    assert out["formatApplied"]["classTemplateName"] == "Firm Demand Shell.docx"
+    assert out["refusals"] == []
+
+
+def test_filing_a_class_template_under_a_name_the_renderer_will_not_open_is_refused(monkeypatch, tmp_path) -> None:
+    """THE ss#2490 REGRESSION. The convention name looks right and is wrong here,
+    because this seat authors an override. Refused, not filed-and-warned."""
+    _authored_with_override(tmp_path, monkeypatch)
+    captured: list[httpx.Request] = []
+    monkeypatch.setattr(server, "_get_client", lambda: _mock_client(_handler(captured)))
+    out = server.render_docx_template("m-1", "Template - Demand Letter.docx", "# Shell\n", document_class="demand_letter")
+    assert out["fileId"] is None
+    assert out["refusals"] and "Firm Demand Shell.docx" in out["refusals"][0]
+    # The falsifier that matters: NOTHING was uploaded. A warning-only fix would
+    # still have PUT the bytes, which is exactly the state that shipped.
+    assert not [r for r in captured if r.method == "PUT"]
+
+
+def test_the_convention_name_is_accepted_when_no_override_is_authored(monkeypatch, tmp_path) -> None:
+    _authored(tmp_path, monkeypatch)
+    captured: list[httpx.Request] = []
+    monkeypatch.setattr(server, "_get_client", lambda: _mock_client(_handler(captured)))
+    out = server.render_docx_template("m-1", "Template - Demand Letter.docx", "# Shell\n", document_class="demand_letter")
+    assert out["refusals"] == [] and out["fileId"] == "file-88"
+
+
+def test_a_draft_is_never_subject_to_the_class_template_name(monkeypatch, tmp_path) -> None:
+    """The guard is for templates only. A DRAFT is named for the matter and must
+    keep its own name, or every drafting lane breaks."""
+    _authored_with_override(tmp_path, monkeypatch)
+    captured: list[httpx.Request] = []
+    monkeypatch.setattr(server, "_get_client", lambda: _mock_client(_handler(captured)))
+    _stub_record_check(monkeypatch)
+    out = server.render_docx_draft("m-1", "DRAFT Demand - Alvarez", DISCOVERY_MD, document_class="demand_letter")
+    assert out["refusals"] == [] and out["fileId"] == "file-88"
+
+
+def test_no_document_class_means_no_name_opinion(monkeypatch, tmp_path) -> None:
+    _authored_with_override(tmp_path, monkeypatch)
+    captured: list[httpx.Request] = []
+    monkeypatch.setattr(server, "_get_client", lambda: _mock_client(_handler(captured)))
+    out = server.render_docx_template("m-1", "Anything At All.docx", "# Shell\n")
+    assert out["refusals"] == [] and "formatApplied" not in out

--- a/operator/skills/document-library-establishment/SKILL.md
+++ b/operator/skills/document-library-establishment/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   template per blessed item, structure only, with every case-specific value left as a visible
   marker, and it reports a template delivered only after reading the filed document back.
   Firm-level establishment is refused for anyone who is not an Operator admin.
-version: 0.2.0
+version: 0.3.0
 author: SMD Services
 license: MIT
 platforms: [linux, macos]
@@ -271,12 +271,26 @@ the skeleton onto the class starter (the named styles defined, Times New Roman 1
 number in the footer) or, when the library already holds a template for that class, INTO
 that file, keeping its letterhead and styles; the return carries `formatApplied` saying
 which. `file_name` gains a `.docx` suffix if it lacks one, and the returned `fileName` is the
-name actually filed. **Name each template by the convention `Template - <Class>.docx`**
-(`Template - Discovery Set.docx`, `Template - Demand Letter.docx`, and so on) unless the
-blessing named it otherwise; the renderer finds a class's template by that name, and a
-differently named one is authored into `self_initiation.document_library.templates` by PR
-after the blessing, so say the name you filed under in the report. Never upload bytes
-yourself and never rename a file the firm placed in the folder.
+name actually filed.
+
+**The class's template has exactly one name, and the tool tells you what it is.** The
+return carries `formatApplied.classTemplateName` — the name the renderer will look for
+when it drafts this class. File under that name. Filing under any other name is refused,
+not filed-with-a-warning, because a template the renderer never opens is worse than no
+template at all: the firm edits it in Word, nothing changes in any draft, and nothing
+anywhere says why. That is ss#2490, found live on 2026-08-20 with three templates filed
+and one live.
+
+So: **read `classTemplateName` off the return and use it.** Do not assume the convention
+`Template - <Class>.docx` — a seat whose firm keeps templates under their own names has
+`self_initiation.document_library.templates` authored, and then the authored name is the
+one name. If the blessing asks for a name that is neither, that mapping is authored by PR
+**first**; you file afterwards, under the authored name. Say in the report the name you
+filed under.
+
+Never upload bytes yourself and never rename a file the firm placed in the folder. If a
+class already has a template and the firm wants it rebuilt, filing under the same name is
+the rebuild: the resolver takes the newest, and nothing is destroyed.
 
 **The content gate refuses; it never repairs.** Before anything is rendered or uploaded the
 markdown is checked, and the whole violation list comes back in `refusals` with `fileId` null.


### PR DESCRIPTION
## Summary

Establishment filed three class templates on pilot last night and reported all three live. One was (vfy_01M0GHR4T1V6HG46BVX3S61BCC). The other two were filed under the convention name while the seat authors a `templates` override naming different files, so `resolve_template` never opened them.

The failure mode is the one the loud `templateExpected` reporting was added to prevent (#2475), reappearing one layer up: a firm edits `Template - Demand Letter.docx` in Word, no draft changes, and nothing anywhere says why.

## Root cause: an ordering assumption, not an unconditional instruction

`document-library-establishment/SKILL.md` said to file by the convention "unless the blessing named it otherwise", and described the override being authored by PR **after** the blessing. That is correct for a first-time establishment and wrong for every re-run on a seat configured in an earlier cycle — which is exactly the state pilot was in.

Prose is what let the two halves drift, so the fix is mechanical.

## Changes

- `formatApplied.classTemplateName` reports the name the renderer will look for, computed by the same `LibraryConfig.template_name` the resolver uses.
- `render_docx_template` **refuses** a class-template write under any other name and names the one it wants. Filed-and-warned was the shipped state, and it is the state that produced the false delivery note.
- `library.names_agree` normalizes case, whitespace, and extension exactly as `name_matches` does, so the write check and the lookup cannot disagree.
- The skill reads `classTemplateName` off the return rather than guessing; a firm wanting a different name has the mapping authored by PR **first**.

Scoped deliberately: drafts keep their matter-derived names, and a file the firm placed is never renamed or overwritten. Re-filing under the same name is the rebuild path — the resolver takes the newest (`library.py:266`).

## What this PR does NOT do

An earlier revision of the plan added a no-clobber guard on the target name. Dropped after critique and verification: `client.add_file` (`client.py:358-374`) POSTs metadata and receives a **new** `fileId` — there is no overwrite path, so the guard could not fail (Law 12), and it would have blocked both the legitimate rebuild and the style-edit re-file.

## Linked issue

Closes #2490. Refs #2448.

## Acceptance criteria status

| AC (verbatim from issue) | Status | Evidence |
| --- | --- | --- |
| (repo) Establishment resolves the target file name through the same path the renderer uses | met | `server.py` computes `classTemplateName` from `LibraryConfig.template_name`; `library.names_agree` shares `_norm`/`_strip_ext` with `name_matches` |
| (repo) When establishment files for a class whose override names a different file, the note says so explicitly rather than claiming the new file is live | met (stronger) | the write is refused, not annotated — `test_filing_a_class_template_under_a_name_the_renderer_will_not_open_is_refused` |
| (repo) Test: a seat config with an override + an establishment file lands on ONE name | met | `test_class_template_name_is_reported_so_the_skill_need_not_guess`, `test_the_convention_name_is_accepted_when_no_override_is_authored` |
| (runtime) On a seat with an authored override, run establishment and confirm by sha the renderer resolves to the file just filed | deferred to the runtime pass | needs the reprovision; runs with PR 2's proof |

## Test plan

- 388 pass in the CI-shaped per-connector venv (`uv venv` + `_sdk` + connector, as `operator-substrate.yml` builds it).
- **Falsifier.** With the refusal disabled and the venv **reinstalled**, `test_filing_...is_refused` fails 1/33. The reinstall is load-bearing: `uv pip install ./smokeball` installs a **copy**, so a source-only mutation leaves the test running against the unmutated build and every mutation appears to pass. The assertion that actually bites is `assert not [r for r in captured if r.method == "PUT"]` — a warning-only fix still uploads the bytes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Hqx3xnCwszXbqqqMxF7cf
