### PR TITLE
feat(operator): a heading follows the firms own Heading style, so editing it in Word reaches the next draft (ss#2448)

### DIFF
--- a/operator/connectors/smokeball/smokeball_connector/docx_base.py
+++ b/operator/connectors/smokeball/smokeball_connector/docx_base.py
@@ -176,6 +176,50 @@ def has_style(doc, name: str) -> bool:
         return False
 
 
+def usable_paragraph_style(doc, name: str) -> str | None:
+    """The name if the base defines it as a paragraph style we can safely apply,
+    else None with nothing raised.
+
+    ``has_style`` alone is not enough once we delegate to a FIRM's own style
+    names, because three real shapes make a present style unusable:
+
+    1. **Not a paragraph style.** python-docx raises ``ValueError`` (not
+       ``KeyError``) when a character or table style is assigned to a paragraph,
+       so a firm with a character style named "Heading 2" would kill the whole
+       render rather than degrade. The hazard predates delegation: ``_bullet``
+       and ``_table`` test ``has_style`` and assign directly.
+    2. **Outline numbering.** Firms routinely link Heading 1/2 to a multilevel
+       list. Our drafting grammar has the model write the numeral itself
+       ("## I. Introduction"), so a numbered base style yields "1.1 I.
+       Introduction" on a filed document. Numbering is inherited, so the
+       ``base_style`` chain is walked, not just the style itself.
+    3. **Latent styles.** A .docx saved by Word carries ``w:style`` elements
+       only for styles in use; the rest live in ``w:latentStyles`` and are
+       invisible to ``doc.styles``. Nothing to do about it here beyond not
+       claiming the style exists — which is why the caller reports the gap as
+       something the firm can fix in Word.
+    """
+    from docx.enum.style import WD_STYLE_TYPE
+    from docx.oxml.ns import qn
+
+    try:
+        style = doc.styles[name]
+    except KeyError:
+        return None
+    if getattr(style, "type", None) != WD_STYLE_TYPE.PARAGRAPH:
+        return None
+    seen: set[int] = set()
+    node = style
+    while node is not None and id(node) not in seen:
+        seen.add(id(node))
+        element = getattr(node, "element", None)
+        if element is not None and element.find(qn("w:pPr")) is not None:
+            if element.find(qn("w:pPr")).find(qn("w:numPr")) is not None:
+                return None
+        node = getattr(node, "base_style", None)
+    return name
+
+
 def _ensure_named_styles(doc, report: FormatReport) -> None:
     """Define the named-style contract in a document WE own (the stock base /
     a starter). Never called on a firm's file: their styles are theirs."""

--- a/operator/connectors/smokeball/smokeball_connector/docx_format.py
+++ b/operator/connectors/smokeball/smokeball_connector/docx_format.py
@@ -41,11 +41,12 @@ import re
 from dataclasses import dataclass
 
 from . import docgrammar as g
-from .docx_base import has_style, open_as_base
+from .docx_base import has_style, open_as_base, usable_paragraph_style
 from .docx_format_types import (
     DEFAULT_FONT,
     DEFAULT_SIZE_PT,
     NAMED_STYLES,
+    ROLE_FALLBACK,
     FormatRefused,
     FormatReport,
 )
@@ -162,14 +163,51 @@ class _Writer:
 
     # -- style application ------------------------------------------------------
 
+    def _resolve_style(self, role: str) -> tuple[str | None, bool]:
+        """``(style to apply, delegated?)`` for a role, or ``(None, False)`` to
+        format inline.
+
+        Three states, in order. Our named style if the base defines it. Else the
+        base's OWN conventional equivalent, when the role has one — that is what
+        makes "edit the style in Word and the next draft follows" true for a
+        firm template that never heard of our names. Else inline.
+        """
+        if usable_paragraph_style(self.doc, role):
+            self.report.styles_honored.append(role)
+            return role, False
+        alt = ROLE_FALLBACK.get(role)
+        if alt and usable_paragraph_style(self.doc, alt):
+            self.report.styles_delegated[role] = alt
+            return alt, True
+        self.report.fallbacks.append(role)
+        if alt:
+            # An instruction the firm can act on, not a diagnostic string.
+            note = f"the base defines neither {role!r} nor {alt!r}; add {alt!r} in Word to control this level"
+            if note not in self.report.notes:
+                self.report.notes.append(note)
+        return None, False
+
     def _para(self, style_name: str):
-        """Add a paragraph in ``style_name`` if the base defines it; otherwise a
-        plain paragraph the caller formats inline (and the fallback is logged)."""
-        if has_style(self.doc, style_name):
-            self.report.styles_honored.append(style_name)
-            return self.doc.add_paragraph(style=style_name), True
-        self.report.fallbacks.append(style_name)
-        return self.doc.add_paragraph(), False
+        """Add a paragraph for ``style_name``.
+
+        Returns ``(paragraph, styled)`` where ``styled`` is True only when our
+        OWN named style carried it. A delegated paragraph reports ``False`` on
+        purpose: the firm's style supplies font and colour, but the class's
+        layout (indents, the double-spacing between discovery items, a centered
+        pleading heading) is a court requirement code still owns, so the caller
+        must keep applying it. See ``_heading``.
+        """
+        applied, delegated = self._resolve_style(style_name)
+        if applied is None:
+            return self.doc.add_paragraph(), False
+        try:
+            return self.doc.add_paragraph(style=applied), not delegated
+        except (KeyError, ValueError):
+            # A style that resolved but will not apply degrades to inline; it
+            # never kills the render.
+            self.report.fallbacks.append(style_name)
+            self.report.styles_delegated.pop(style_name, None)
+            return self.doc.add_paragraph(), False
 
     def _runs(self, para, runs: tuple[g.Run, ...], *, caps: bool = False, bold: bool = False, underline: bool = False) -> None:
         for r in runs:
@@ -208,15 +246,27 @@ class _Writer:
         self.in_item = False
         self.report.blocks_styled["headings"] += 1
         level = block.level
-        para, styled = self._para(f"SMD Heading {level}")
+        role = f"SMD Heading {level}"
+        para, styled = self._para(role)
         if styled:
             self._runs(para, block.runs)
             return
+        delegated = role in self.report.styles_delegated
+        # Layout stays ours even when the firm's own heading style carries the
+        # typography: a mediation brief's level-1 heading is CENTERED because
+        # the court expects it there, and a firm's built-in Heading 1 is
+        # left-aligned. Font, size and colour come from their style; placement
+        # does not.
         align = self.rules.heading_align[level - 1]
         para.alignment = {"center": WD_ALIGN_PARAGRAPH.CENTER, "left": WD_ALIGN_PARAGRAPH.LEFT}[align]
         para.paragraph_format.left_indent = Inches(self.rules.heading_indent_in[level - 1])
-        para.paragraph_format.space_before = Pt(12 if level == 1 else 6)
         para.paragraph_format.keep_with_next = True
+        if delegated:
+            # Emphasis is the firm style's business; forcing bold/underline over
+            # it would defeat the edit we just made possible.
+            self._runs(para, block.runs)
+            return
+        para.paragraph_format.space_before = Pt(12 if level == 1 else 6)
         self._runs(para, block.runs, bold=True, underline=self.rules.heading_underline[level - 1])
 
     def _is_label(self, text: str) -> bool:
@@ -256,10 +306,14 @@ class _Writer:
     def _bullet(self, block: g.Bullet) -> None:
         from docx.shared import Inches
 
-        if has_style(self.doc, "List Bullet"):
-            para = self.doc.add_paragraph(style="List Bullet")
-            self._runs(para, block.runs)
-            return
+        if usable_paragraph_style(self.doc, "List Bullet"):
+            try:
+                para = self.doc.add_paragraph(style="List Bullet")
+                self.report.styles_honored.append("List Bullet")
+                self._runs(para, block.runs)
+                return
+            except (KeyError, ValueError):
+                self.report.fallbacks.append("List Bullet")
         para = self.doc.add_paragraph()
         para.paragraph_format.left_indent = Inches(0.5)
         para.paragraph_format.first_line_indent = Inches(-0.25)
@@ -288,9 +342,12 @@ class _Writer:
                 cell = table.cell(r_idx, c_idx)
                 runs = row[c_idx] if c_idx < len(row) else ()
                 para = cell.paragraphs[0]
-                if caption and has_style(self.doc, "SMD Caption"):
-                    para.style = self.doc.styles["SMD Caption"]
-                    self.report.styles_honored.append("SMD Caption")
+                if caption and usable_paragraph_style(self.doc, "SMD Caption"):
+                    try:
+                        para.style = self.doc.styles["SMD Caption"]
+                        self.report.styles_honored.append("SMD Caption")
+                    except (KeyError, ValueError):
+                        self.report.fallbacks.append("SMD Caption")
                 self._runs(para, runs, bold=(block.header and r_idx == 0))
         # Breathing room after a table: an empty body paragraph.
         self.doc.add_paragraph()
@@ -376,10 +433,12 @@ __all__ = [
     "DEFAULT_SIZE_PT",
     "DOCUMENT_CLASSES",
     "NAMED_STYLES",
+    "ROLE_FALLBACK",
     "ClassRules",
     "FormatRefused",
     "FormatReport",
     "has_style",
     "open_as_base",
     "render_document",
+    "usable_paragraph_style",
 ]

--- a/operator/connectors/smokeball/smokeball_connector/docx_format_types.py
+++ b/operator/connectors/smokeball/smokeball_connector/docx_format_types.py
@@ -20,6 +20,30 @@ NAMED_STYLES = (
     "SMD Signature",
 )
 
+# When a firm's own template does not define one of our named styles, fall back
+# to the CONVENTIONAL Word style that means the same thing, so a style the firm
+# edits in Word still reaches the draft. Deliberately three rows.
+#
+# Everything else is NOT here, each for cause:
+#
+#   SMD Body, SMD Item Text -> Normal
+#       Pointless at best, destructive at worst. A plain paragraph already
+#       resolves to Normal, so font and size follow the firm's template today;
+#       what the inline branch adds is the class's LAYOUT (first-line indent,
+#       the double-spacing between discovery items, space-after). Delegating
+#       would suppress that and serve a single-spaced discovery set.
+#   SMD Caption -> Caption
+#       Different meanings that share a word. Ours is the pleading CASE-caption
+#       table; Word's is a figure/table caption, typically 9pt italic and
+#       theme-coloured. Delegating puts a pleading caption in 9pt italic blue.
+#   SMD Item Label, SMD Signature
+#       No conventional Word equivalent exists. Inline is the honest answer.
+ROLE_FALLBACK: dict[str, str] = {
+    "SMD Heading 1": "Heading 1",
+    "SMD Heading 2": "Heading 2",
+    "SMD Heading 3": "Heading 3",
+}
+
 
 class FormatRefused(RuntimeError):
     """The base document cannot be used as a template; nothing is rendered."""
@@ -31,7 +55,14 @@ class FormatReport:
     construction: every fallback is listed, the base's header/footer text is
     surfaced (it bypasses every content gate), and ``templateExpected`` lets
     the note say "the firm's template did not resolve" instead of a null that
-    reads like "never configured"."""
+    reads like "never configured".
+
+    Three states per role, and the difference is what the firm can control:
+    ``stylesHonored`` (the base defines our named style), ``stylesDelegated``
+    (role -> the base's own conventional style; a firm edit to THAT style
+    reaches the next draft), and ``fallbacks`` (formatted inline, so the
+    typography is fixed in this document and a later template edit will not
+    move it)."""
 
     document_class: str
     template_used: dict[str, Any] | None = None
@@ -39,6 +70,7 @@ class FormatReport:
     class_template_name: str | None = None
     base_header_footer_text: list[str] = field(default_factory=list)
     styles_honored: list[str] = field(default_factory=list)
+    styles_delegated: dict[str, str] = field(default_factory=dict)
     fallbacks: list[str] = field(default_factory=list)
     blocks_styled: dict[str, int] = field(default_factory=lambda: {"labels": 0, "tables": 0, "headings": 0})
     notes: list[str] = field(default_factory=list)
@@ -52,6 +84,7 @@ class FormatReport:
             "classTemplateName": d["class_template_name"],
             "baseHeaderFooterText": d["base_header_footer_text"],
             "stylesHonored": sorted(set(d["styles_honored"])),
+            "stylesDelegated": d["styles_delegated"],
             "fallbacks": sorted(set(d["fallbacks"])),
             "blocksStyled": d["blocks_styled"],
             "notes": d["notes"],

--- a/operator/connectors/smokeball/tests/test_render_document.py
+++ b/operator/connectors/smokeball/tests/test_render_document.py
@@ -302,3 +302,143 @@ def test_report_round_trips_template_used_and_expected_flags() -> None:
 
 def test_class_rules_cover_every_class() -> None:
     assert set(CLASS_RULES) == set(DOCUMENT_CLASSES)
+
+
+# --- Heading delegation to the firm's own styles (ss#2448) ---------------------
+#
+# The promise is "the firm edits its Word template and the next draft follows".
+# For a firm template that never heard of our SMD names, the shipped renderer
+# formatted headings INLINE, so the typography was frozen into each draft and a
+# later template edit moved nothing (observed on pilot,
+# vfy_01M0GK1SS4CZKGHMV8R1CFAZSG). Delegating the heading roles to Word's own
+# Heading 1-3 makes the promise true by construction.
+#
+# Deliberately narrow. Body and item text are NOT delegated: a plain paragraph
+# already resolves to Normal, so font follows the firm today, and the inline
+# branch is carrying the class's court-required LAYOUT.
+
+
+def test_a_heading_delegates_to_the_bases_own_heading_style() -> None:
+    """The base defines Heading 2 but not SMD Heading 2: use theirs."""
+    base = make_firm_template(drop_styles=("List Bullet", "Table Grid"))  # keeps Heading 1-3
+    report = FormatReport(document_class="mediation_brief")
+    blob, report = render_document("## II. Argument\n\nText.\n", "mediation_brief", base, report)
+    d = report.to_dict()
+    assert d["stylesDelegated"] == {"SMD Heading 2": "Heading 2"}
+    assert "SMD Heading 2" not in d["fallbacks"]
+    doc = Document(io.BytesIO(blob))
+    para = next(p for p in doc.paragraphs if "Argument" in p.text)
+    assert para.style.name == "Heading 2"
+
+
+def test_a_delegated_heading_still_carries_the_classs_required_layout() -> None:
+    """The firm's style supplies font; the COURT expects a centered level-1
+    heading on a mediation brief and a firm's built-in Heading 1 is left."""
+    from docx.enum.text import WD_ALIGN_PARAGRAPH
+
+    base = make_firm_template(drop_styles=("List Bullet", "Table Grid"))
+    report = FormatReport(document_class="mediation_brief")
+    blob, _ = render_document("# I. Introduction\n\nText.\n", "mediation_brief", base, report)
+    doc = Document(io.BytesIO(blob))
+    para = next(p for p in doc.paragraphs if "Introduction" in p.text)
+    assert para.style.name == "Heading 1"
+    assert para.alignment == WD_ALIGN_PARAGRAPH.CENTER
+    # ...and emphasis is left to the firm's style rather than forced over it.
+    assert not any(r.bold for r in para.runs)
+
+
+def test_a_base_defining_neither_still_goes_inline_and_says_what_to_add() -> None:
+    base = make_firm_template()  # drops Heading 1-3 by default
+    report = FormatReport(document_class="mediation_brief")
+    _blob, report = render_document("## II. Argument\n\nText.\n", "mediation_brief", base, report)
+    d = report.to_dict()
+    assert d["stylesDelegated"] == {}
+    assert "SMD Heading 2" in d["fallbacks"]
+    assert any("add 'Heading 2' in Word" in n for n in d["notes"])
+
+
+def test_item_text_is_never_delegated_so_a_served_set_keeps_its_double_spacing() -> None:
+    """THE REGRESSION A WIDER LADDER WOULD HAVE SHIPPED. Delegating SMD Item
+    Text to Normal suppresses the inline branch that carries the authored
+    double-spacing between requests, and a discovery set is SERVED."""
+    base = make_firm_template(drop_styles=("List Bullet", "Table Grid"))
+    report = FormatReport(document_class="discovery_set")
+    blob, report = render_document(DISCOVERY_MD, "discovery_set", base, report)
+    assert "SMD Item Text" not in report.to_dict()["stylesDelegated"]
+    doc = Document(io.BytesIO(blob))
+    answers = [p for p in doc.paragraphs if p.text.startswith("Identify each person")]
+    assert answers, "expected the item text paragraph"
+    assert answers[0].paragraph_format.line_spacing == 2.0
+
+
+def test_a_character_style_named_like_a_heading_does_not_kill_the_render() -> None:
+    """python-docx raises ValueError (not KeyError) assigning a character style
+    to a paragraph, and has_style catches only KeyError."""
+    doc = Document()
+    for name in ("Heading 1", "Heading 2", "Heading 3"):
+        doc.styles[name].element.getparent().remove(doc.styles[name].element)
+    doc.styles.add_style("Heading 2", WD_STYLE_TYPE.CHARACTER)
+    buf = io.BytesIO()
+    doc.save(buf)
+    report = FormatReport(document_class="mediation_brief")
+    blob, report = render_document("## II. Argument\n\nText.\n", "mediation_brief", buf.getvalue(), report)
+    d = report.to_dict()
+    assert d["stylesDelegated"] == {}
+    assert "SMD Heading 2" in d["fallbacks"]
+    assert blob
+
+
+def test_an_outline_numbered_heading_is_not_delegated_to() -> None:
+    """The model writes the numeral itself ("## I. Introduction"), so a firm's
+    multilevel-list Heading 2 would render "1.1 I. Introduction"."""
+    from docx.oxml import OxmlElement
+    from docx.oxml.ns import qn
+
+    doc = Document()
+    style = doc.styles["Heading 2"]
+    ppr = style.element.get_or_add_pPr()
+    num_pr = OxmlElement("w:numPr")
+    num_id = OxmlElement("w:numId")
+    num_id.set(qn("w:val"), "1")
+    num_pr.append(num_id)
+    ppr.append(num_pr)
+    buf = io.BytesIO()
+    doc.save(buf)
+    report = FormatReport(document_class="mediation_brief")
+    _blob, report = render_document("## II. Argument\n\nText.\n", "mediation_brief", buf.getvalue(), report)
+    d = report.to_dict()
+    assert d["stylesDelegated"] == {}, "a numbered base style must not be delegated to"
+    assert "SMD Heading 2" in d["fallbacks"]
+
+
+def test_numbering_inherited_through_the_base_style_chain_is_also_refused() -> None:
+    from docx.oxml import OxmlElement
+    from docx.oxml.ns import qn
+
+    doc = Document()
+    parent = doc.styles.add_style("Numbered Parent", WD_STYLE_TYPE.PARAGRAPH)
+    ppr = parent.element.get_or_add_pPr()
+    num_pr = OxmlElement("w:numPr")
+    num_id = OxmlElement("w:numId")
+    num_id.set(qn("w:val"), "1")
+    num_pr.append(num_id)
+    ppr.append(num_pr)
+    doc.styles["Heading 2"].base_style = parent
+    buf = io.BytesIO()
+    doc.save(buf)
+    report = FormatReport(document_class="mediation_brief")
+    _blob, report = render_document("## II. Argument\n\nText.\n", "mediation_brief", buf.getvalue(), report)
+    assert report.to_dict()["stylesDelegated"] == {}
+
+
+def test_our_own_named_style_still_wins_over_the_bases_equivalent() -> None:
+    base = make_firm_template(
+        drop_styles=("List Bullet", "Table Grid"),
+        named_styles={"SMD Heading 2": {"font": "Courier New", "size": 15}},
+    )
+    report = FormatReport(document_class="mediation_brief")
+    blob, report = render_document("## II. Argument\n\nText.\n", "mediation_brief", base, report)
+    d = report.to_dict()
+    assert d["stylesDelegated"] == {} and "SMD Heading 2" in d["stylesHonored"]
+    doc = Document(io.BytesIO(blob))
+    assert next(p for p in doc.paragraphs if "Argument" in p.text).style.name == "SMD Heading 2"

--- a/operator/skills/demand-letter-drafter/SKILL.md
+++ b/operator/skills/demand-letter-drafter/SKILL.md
@@ -13,7 +13,7 @@ description: >-
   never rounds or smooths a number. Time-limited demand mechanics under Code of Civil Procedure
   section 999 are surfaced as attorney decision points, never as a final acceptance deadline. It
   never sends the letter to a carrier or to anyone outside the firm by any path.
-version: 0.2.0
+version: 0.2.1
 author: SMD Services
 license: MIT
 platforms: [linux, macos]
@@ -387,8 +387,9 @@ The itemized report and the held-out list go into the **matter memo**
 (`agentmail`) is a **citation-free pointer**, not the letter: plain words naming the
 matter by number, that the demand draft is ready, where it lives, what is reserved for
 the attorney, what the record does not establish, and one honest sentence from the
-tool's `formatApplied` (the firm's template, or the starter and why; any named styles
-the template lacks). The letter's own RE line references a statute by section, so
+tool's `formatApplied` (the firm's template, or the starter and why; which roles took
+the template's own styles, and which were formatted inline and so will not follow a
+later edit to the template). The letter's own RE line references a statute by section, so
 emailing the body would fight the mail channel's citation gate by construction. Write
 the pointer citation-free on the first draft.
 

--- a/operator/skills/discovery-response-drafter/SKILL.md
+++ b/operator/skills/discovery-response-drafter/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   supplying one, and reports a coverage diff showing that every propounded item received a
   response. It never serves, never files, never signs or fills a client verification, never
   decides objection strategy, and is never routine-initiated.
-version: 0.2.0
+version: 0.2.1
 author: SMD Services
 license: MIT
 platforms: [linux, macos]
@@ -328,8 +328,9 @@ held_out_file_names, document_class="discovery_response")`. The tool runs the
   number, the sets drafted, where the draft lives, and the plain-words state of the
   coverage diff, the held-out list, and any unresolved markers, plus one honest
   sentence from the tool's `formatApplied` (the firm's template, or the starter and
-  why; any named styles the template lacks). No section numbers, no rule-format
-  strings.
+  why; which roles took the template's own styles, and which were formatted inline
+  and so will not follow a later edit to the template). No section numbers, no
+  rule-format strings.
 
 Delivered with the draft, always:
 

--- a/operator/skills/follow-up-discovery-drafter/SKILL.md
+++ b/operator/skills/follow-up-discovery-drafter/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   deficient, never serves or files anything, never writes a request that asserts a
   fact the record does not establish, and never self-authorizes discovery past the
   statutory numerical limits.
-version: 0.2.0
+version: 0.2.1
 author: SMD Services
 license: MIT
 platforms: [linux, macos]
@@ -315,7 +315,8 @@ held_out_file_names, document_class="discovery_set")`: the tool gates, then
    (`create_draft` on the Operator's own inbox, internal) is a citation-free pointer:
    the matter number, what was drafted, where it lives, the specific decision points
    waiting on the attorney, and one honest sentence from the tool's `formatApplied`
-   (the firm's template, or the starter and why; any named styles the template lacks).
+   (the firm's template, or the starter and why; which roles took the template's own
+   styles, and which were formatted inline and so will not follow a later template edit).
    Open a tracked item with `create_task` assigned to the requesting attorney so the
    draft does not sit. **Nothing is served, filed, or sent outside the firm.**
 

--- a/operator/skills/mediation-brief-drafter/SKILL.md
+++ b/operator/skills/mediation-brief-drafter/SKILL.md
@@ -12,7 +12,7 @@ description: >-
   the edge of the record and stopped. Every quotation is verified verbatim, contiguous, and paired
   with the question it actually answered; every factual sentence carries a record cite; a fact the
   record does not establish stays a visible NOT IN RECORD marker and is never filled.
-version: 0.2.0
+version: 0.2.1
 author: SMD Services
 license: MIT
 platforms: [linux, macos]
@@ -417,8 +417,9 @@ held_out_file_names, document_class="mediation_brief")`: the tool runs the recor
 7. **Deliver** to the requesting attorney, internal only: where the brief lives, the
    itemized what-was-done report, the held-out list, the flagged-characterizations
    list, the NOT IN RECORD list, the ATTORNEY-marker list, and one honest sentence
-   from the tool's `formatApplied` (the firm's template, or the starter and why; any
-   named styles the template lacks). Log the run with `create_memo` and confirm the
+   from the tool's `formatApplied` (the firm's template, or the starter and why; which
+   roles took the template's own styles, and which were formatted inline and so will
+   not follow a later edit to the template). Log the run with `create_memo` and confirm the
    write by read-back per the pack write posture. The draft is staged for the
    attorney; it is not filed with any tribunal, not submitted, and not exchanged.
 

--- a/operator/skills/meet-and-confer-drafter/SKILL.md
+++ b/operator/skills/meet-and-confer-drafter/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: meet-and-confer-drafter
 description: Drafts a meet-and-confer letter on discovery responses. For internal review, it covers deficiencies the responsible attorney has flagged in the opposing side's responses (interrogatories, RFP, RFA), and notes the window to move to compel further responses. It never sends to opposing counsel on its own. Because the firm sometimes handles meet-and-confer informally first, it brings the go/no-go decision to the attorney rather than firing off a letter. Never identifies or adjudicates the deficiencies itself, never computes the compel deadline as final, and never asserts a fact it cannot see in the record.
-version: 0.2.0
+version: 0.2.1
 author: SMD Services
 license: MIT
 platforms: [linux, macos]
@@ -197,7 +197,8 @@ draft_markdown, folder_id, held_out_file_names, document_class="letter")`, which
    letter: plain words naming the matter, the set, where the draft lives (the
    matter file), the proposed dates flagged as needing confirmation, one honest
    sentence from the tool's `formatApplied` (the firm's template, or the starter and
-   why), and the explicit choice — send now, informal-first, or not yet. Emailing
+   why; which roles took the template's own styles and which were formatted inline),
+   and the explicit choice — send now, informal-first, or not yet. Emailing
    the letter body itself fights the mail channel's citation gate by construction (7+
    refused attempts observed live, 2026-07-05, L2 finding F6) and violates the
    redraft-once rule; the pointer email passes on the first try because it

--- a/operator/templates/drafting/drafting-discipline.md
+++ b/operator/templates/drafting/drafting-discipline.md
@@ -198,9 +198,18 @@ firm's own Word template for that class when one is authored in the firm's
 Document Library (it resolves the template itself, the same way every time; you
 never pick one), else onto the SMD starter base. The firm's template carries the
 typography: letterhead, fonts, spacing, the named styles `SMD Body`, `SMD Item
-Label`, `SMD Item Text`, `SMD Heading 1-3`, `SMD Caption`, `SMD Signature`. A
-style the firm edits in Word takes effect on the next draft. Nothing you write
-chooses a font, a margin, or a spacing.
+Label`, `SMD Item Text`, `SMD Heading 1-3`, `SMD Caption`, `SMD Signature`.
+Nothing you write chooses a font, a margin, or a spacing.
+
+**Which of the firm's edits reach the next draft is per-element, and
+`formatApplied` reports it rather than promising it.** Three states. A role the
+template styles by name (`stylesHonored`) follows that style. A heading the
+template does not name falls to the template's OWN `Heading 1-3`
+(`stylesDelegated`), so a firm that edits those in Word still moves the next
+draft. Anything else is formatted inline (`fallbacks`), which means its
+typography is fixed in that document and a later template edit will not move it.
+Say which, from the report; do not tell a firm that editing a style will change
+their drafts when the report says that element was inline.
 
 **What you write** is the content grammar, and only this:
 
@@ -223,8 +232,9 @@ typography.
 
 **The delivery note states `formatApplied` honestly:** which template was used
 (or the starter), `templateExpected` (the library is authored but the class
-template did not resolve: say so, and why), the fallbacks (named styles the
-template lacks), and the template's own header/footer text (it bypasses every
-content gate, so the attorney sees it named). A `formatApplied.notes` entry
-that says the firm's template was not used is a sentence in your note, not a
-detail to omit.
+template did not resolve: say so, and why), `stylesDelegated` (roles that took
+the template's own style), the fallbacks (roles formatted inline), and the
+template's own header/footer text (it bypasses every content gate, so the
+attorney sees it named). A `formatApplied.notes` entry that says the firm's
+template was not used, or that names a style the firm could add in Word to
+control a level, is a sentence in your note, not a detail to omit.


### PR DESCRIPTION
## Summary

The promise is "the firm edits its Word template and the next draft follows". For a firm template that never heard of our `SMD *` style names, headings did not follow: `_para` emitted a plain paragraph and `_heading` formatted it inline, freezing the typography into each draft (vfy_01M0GK1SS4CZKGHMV8R1CFAZSG).

**A correction to how I first reported this, since it changes the fix.** Body text was *not* frozen. A plain `add_paragraph()` carries no `pStyle`, so it already resolves to `Normal` — font and size already follow the firm's template today. What is stuck is placement and emphasis, and the case that matters is the heading.

Stacked on #2493 (review that first).

## The ladder: three rows, and no more

```
SMD Heading 1/2/3  ->  the base's own Heading 1/2/3
```

Everything else was considered and rejected:

| Rejected row | Why |
| --- | --- |
| `SMD Body`, `SMD Item Text -> Normal` | No-op at best, destructive at worst. The inline branch carries the class's **layout**; delegating drops `first_line_indent`, `line_spacing 2.0` and `space_after` from a **served** discovery set. |
| `SMD Caption -> Caption` | Two meanings sharing a word. Ours is the pleading case-caption table; Word's is a figure caption, typically 9pt italic and theme-coloured. |
| `SMD Item Label`, `SMD Signature` | No conventional Word equivalent. Inline is the honest answer. |

A delegated heading **keeps** the class's alignment, indent and keep-with-next: a mediation brief's level-1 heading is centered by court expectation, and a firm's built-in `Heading 1` is left-aligned. Font and colour come from their style; placement does not. Emphasis is left to their style rather than forced over it.

## Three guards

Delegating to a name we do not control is not safe by default.

- **`usable_paragraph_style` rejects a non-paragraph style.** python-docx raises `ValueError`, not `KeyError`, so a firm with a *character* style named `Heading 2` would have killed the render. **This hazard is live today** at `_bullet` and `_table`, which tested `has_style` and assigned directly; both now route through the resolver.
- **Numbering refusal.** Our grammar has the model write the numeral itself (`## I. Introduction`), so an outline-numbered `Heading 2` would file `1.1 I. Introduction`. The `base_style` chain is walked, since numbering inherits.
- **Application is wrapped.** A style that resolves but will not apply degrades to inline rather than failing the render.

## Honesty surface

`formatApplied` now reports three states per role — `stylesHonored`, `stylesDelegated` (role → the base's style), `fallbacks` (inline) — and the difference is exactly what the firm can control. Part IV and the five drafter delivery notes now say *which*, instead of promising that editing a style always works: that is a first-person promise about behaviour under conditions we do not control (latent styles, numbering, style type). When a base defines neither name, the note is an instruction the firm can act on.

## Linked issue

Refs #2448.

## Acceptance criteria status

| AC | Status | Evidence |
| --- | --- | --- |
| (repo) A heading paragraph carries a style the firm's template defines | met | `test_a_heading_delegates_to_the_bases_own_heading_style` |
| (repo) A delegated heading keeps the class's court-required layout | met | `test_a_delegated_heading_still_carries_the_classs_required_layout` |
| (repo) `formatApplied` reports ours / theirs / inline per role | met | `stylesDelegated` in `FormatReport.to_dict`; asserted across the new tests |
| (repo) Item text is never delegated (the served-set regression) | met | `test_item_text_is_never_delegated_so_a_served_set_keeps_its_double_spacing` |
| (repo) Character style, outline numbering, inherited numbering all degrade to inline | met | three tests; the character-style one reproduces the real `ValueError` when both layers are removed |
| (runtime) A style edited in the template, re-filed, and the next draft honors it | deferred to the runtime pass | needs the reprovision — the Heading 2 proof described below |

## Test plan

- 396 connector tests; 317 skills/templates tests.
- **Falsifiers**, each with the venv **reinstalled** (it installs a copy, so a source-only mutation proves nothing):
  - ladder emptied → **3 fail**
  - style-type check and numbering walk disabled → **2 fail**
  - the character-style test passed under that mutation because the `try/except` still caught it, so both layers were disabled → it fails with the real `ValueError: assigned style is type CHARACTER (2), need type PARAGRAPH (1)`, which is the crash the guard prevents.

## Runtime proof to follow

Reprovision, then edit **`Heading 2`** in the resolved template to a distinct font, re-file under the same name, email a fresh drafting request, and read the heading's font off the filed draft. The falsifier is named in advance: `SMD Item Label`, which has no ladder row, must keep `Normal`'s font under a `Heading 2`-only edit — if everything moves, the instrument is measuring style inheritance rather than delegation.

Not proven on pilot: the latent-style, numbering and character-style hazards. Pilot's bases descend from python-docx defaults and carry the full 36-style vocabulary (vfy_01M0GMZGCKDR7YQXZVGS3Q0TEX), so the seat is structurally blind to them. They are proven in repo tests against the `make_firm_template()` fixture, which deliberately removes `Heading 1-3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Hqx3xnCwszXbqqqMxF7cf
