### PR TITLE
fix(operator): the class-template refusal drops an em dash from copy an attorney can read (ss#2490)

### DIFF
--- a/operator/connectors/smokeball/smokeball_connector/server.py
+++ b/operator/connectors/smokeball/smokeball_connector/server.py
@@ -1635,7 +1635,7 @@ def render_docx_template(
         if wanted and not names_agree(file_name, str(wanted)):
             refusal = (
                 f"filed name {file_name!r} is not this class's template name {wanted!r}, so the "
-                "renderer would never open it. File it as that name — or, if the firm wants a "
+                "renderer would never open it. File it as that name. If the firm wants a "
                 "different one, have self_initiation.document_library.templates authored by PR "
                 "FIRST and then file under the authored name."
             )


### PR DESCRIPTION
## Summary

Caught reading the refusal off the live seat rather than off the diff (vfy_01M0H2SRJCW1G7XB88M0A2QKM7). The string shipped in #2493 carried an em dash, and house style forbids one in anything a client reads.

This one is not internal. A drafter surfaces the refusal in its delivery note, so the text reaches the requesting attorney's mailbox.

```
- File it as that name — or, if the firm wants a different one, have ...
+ File it as that name. If the firm wants a different one, have ...
```

## Why CI did not catch it

`tests/forbidden-strings.test.ts` scans TypeScript and markdown; it does not scan connector Python. That gap is real and wider than this fix, so I am not closing it here with a hurried grep — a scanner that covers Python emitted strings without flagging every docstring and comment needs its own change.

## Linked issue

Refs #2490.

## Acceptance criteria status

| AC | Status | Evidence |
| --- | --- | --- |
| (repo) No em dash in copy a client can read | met | the diff; 396 connector tests still pass |

## Test plan

396 connector tests in the CI-shaped per-connector venv. The refusal is otherwise unchanged and the two sentences say the same thing, so no test needed updating — which is itself worth noting: no existing test asserted the punctuation, and none is added here for the same reason the scanner gap is left open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Hqx3xnCwszXbqqqMxF7cf
