### PR TITLE
fix(operator): a wedged gateway restarts itself instead of going silent until a human notices (ss#2488)

### DIFF
--- a/docs/runbooks/operator/incidents/2026-08-20-gateway-wedge-no-restart.md
+++ b/docs/runbooks/operator/incidents/2026-08-20-gateway-wedge-no-restart.md
@@ -1,0 +1,74 @@
+# Post-incident note: the Operator went silent for 33 minutes and only a human brought it back
+
+| Field                   | Value                                                                                                                                                                                                                                                                                       |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Incident date           | `2026-08-20` (evening MST; `2026-08-21` UTC)                                                                                                                                                                                                                                                |
+| Seat / surface          | `hermes-ashton-price` — the paying client's seat, mid go-live                                                                                                                                                                                                                               |
+| Severity                | No severity was assigned at the time. Assigned here against the ADR 0064 ladder in `docs/handbook/incident-response.md`: **SEV2** — total loss of the Operator on a paying seat, with no client-observable impact because the firm-address fence was still up. The issue carries `prio:P0`. |
+| Detected by             | A human. Every automated instrument on the seat reported healthy throughout.                                                                                                                                                                                                                |
+| Detection lag           | ~23 minutes from the last successful turn (03:02:01Z) to the watchdog's CRITICAL line (03:24:57Z), and ~38 minutes to the human restart (03:40:37Z). Nothing detected it in between.                                                                                                        |
+| Detection to resolution | ~16 minutes from the CRITICAL line to the manual restart. The seat was unreachable for 33 minutes in total.                                                                                                                                                                                 |
+| Client impact           | None observed. The firm-address fence (`domain_blocks`) was still up, so nobody at Ashton & Price could reach the Operator to notice. **That fence comes down in the next step of the go-live.**                                                                                            |
+| Status                  | Open — owned by [ss#2488](https://github.com/venturecrane/ss-console/issues/2488)                                                                                                                                                                                                           |
+
+**Sources.** ss#2488 (the filed issue, including the `gateway.log` and `gateway-exit-diag.log` excerpts, which this note does not re-derive); `vfy_01M0H7A2AZGGHZR3EM2FSZVB82` (the seat's Fly log buffer across the window, plus `fly status`); `vfy_01M0H7AFYWQ9EBZNGNFFMZNZKJ` (the Hermes source read at the pin the seat runs); `vfy_01M0H9BKDCTFKSC5WSS9Z9DYVG` (the live heartbeat and process tree on `hermes-smd`); `operator/customers/ashton-price/customer.yaml:102`; `operator/templates/entrypoint.sh`; `operator/templates/fly.toml.template`; Law 12 (a check that cannot fail has measured nothing).
+
+## What broke
+
+The gateway's asyncio event loop stopped. Hermes has a backstop for exactly this: an out-of-loop OS thread that probes the loop every 30s and, after three missed probes, dumps all thread stacks and hard-exits so a service manager can restart the process. It fired. It logged, verbatim:
+
+> Gateway event loop missed 3 consecutive liveness probes; dumping all thread stacks and exiting with code 75 so the service supervisor can restart it.
+
+It did not exit. The gateway pid stayed 655 until a human restarted it.
+
+**Three things the issue asserted, which the source at the pinned SHA contradicts.** They are recorded here because each one would have sent the next reader down a wrong path.
+
+1. **The exit was already unconditional.** At `v2026.8.18@e624e9fd` — the exact SHA in `customer.yaml:102` — `gateway/shutdown_watchdog.py:196` calls `os._exit(exit_code)` directly. There is no graceful asyncio shutdown on that path, so "a clean asyncio shutdown needs the very event loop that was wedged" cannot be the mechanism. The thread reached its `logger.critical` at line 173 (the line is in `gateway.log`) and never reached the `os._exit` two statements later. Between them sit exactly two calls: `faulthandler.dump_traceback(all_threads=True)` (line 183) and `mark_exited` (line 193). **Which of the two stalled was never established, and the evidence to establish it is gone.**
+
+2. **The 0-byte `gateway_faulthandler.log` was correct behaviour, not a missing diagnostic.** That file is written only by `faulthandler.register(SIGUSR2, file=…)` at `gateway/run.py:12169`. Nobody had ever sent SIGUSR2, so the file had never been written. The watchdog's own dump call passes no `file=` argument and therefore goes to **stderr**. It never landed there either: the seat's Fly log buffer covers 03:02:00Z to 03:49:01Z with unbroken 30-second coverage and contains zero traceback lines.
+
+3. **`gateway-exit-diag.log` cannot distinguish a watchdog that exited from one that hung.** `os._exit` bypasses `atexit` and never returns from `asyncio.run`, so a _successful_ watchdog exit writes nothing to that file either. The evidence that the exit did not happen is the pid, not the diag log.
+
+**And the defect the issue did not name, which is why nobody knew.** The seat's only Fly health check is `GET /health` on our own webhook gate, and that handler is a literal constant — `self._json(200, {"status": "ok", "platform": "webhook-gate"})` (overlay `webhook_gate.py:985` at pinned `OVERLAY_REF 7a8ba42`). It observes nothing about the gateway, and the gate runs in a **separate process** that was never wedged. It answered 200 every 30 seconds throughout the outage; `fly machine status` still prints that exact constant as the check output. The ADR 0023 control-plane heartbeat and the healthchecks.io dead-man ping are emitted from that same gate process, so they stayed green too. `fleet-alerts` does carry a work-liveness condition that would have caught this (`scheduler_max_overdue_seconds > 900s`, `workers/fleet-alerts/src/index.ts:384`) — except A&P's crons were turned off for go-live (ss#2332). Every liveness instrument on that seat was disarmed, three of them by construction and one by configuration.
+
+**Why nothing restarted it.** `entrypoint.sh` `exec`s the gateway as the container's main process under tini. The root respawn supervisor in that file covers the **broker**, not the gateway. `under_systemd=no`. Fly restarts a Machine when its process exits (`restart: [{policy: "on-failure"}]`), but not when a health check fails — and the health check was passing anyway.
+
+## How it was detected
+
+A human noticed the seat was unreachable and restarted the gateway by hand. The instrument that should have caught it reported healthy for the entire 33 minutes, and is still doing so.
+
+## Timeline as recorded
+
+| Time (UTC)  | Event                                                                                               | Source                                    |
+| ----------- | --------------------------------------------------------------------------------------------------- | ----------------------------------------- |
+| 03:02:01    | Establishment survey completes cleanly (203.3s, 11 API calls, response sent). Last successful work. | ss#2488, `gateway.log`                    |
+| 03:02:00    | Webhook gate answers `GET /health` 200. It continues every 30s, without a gap, to 03:49:01.         | `vfy_01M0H7A2AZGGHZR3EM2FSZVB82`          |
+| 03:02–03:24 | No poller tick, no housekeeping, no gateway log line of any kind.                                   | ss#2488                                   |
+| 03:24:57    | `CRITICAL gateway.shutdown_watchdog`: missed 3 liveness probes, "exiting with code 75".             | ss#2488, `gateway.log`                    |
+| 03:24:57    | No stack dump reaches stderr. No `gateway.exit_*` or `atexit.hook` record is written.               | `vfy_01M0H7A2AZGGHZR3EM2FSZVB82`          |
+| 03:24–03:40 | Machine `started`, gateway pid still 655, health check passing.                                     | ss#2488, `fly status`                     |
+| 03:40:02    | SIGINT received as a planned gateway stop — a human.                                                | ss#2488                                   |
+| 03:40:37    | `gateway.start` pid 657. The webhook gate process is **not** interrupted across this.               | ss#2488, `vfy_01M0H7A2AZGGHZR3EM2FSZVB82` |
+
+The 22-minute gap between the last turn and the watchdog's CRITICAL line is unexplained: three missed 30-second probes should trip it in roughly 90 seconds.
+
+## What changed to prevent recurrence
+
+- **Landed (repo layer only — this is not a wired claim, Law 9):** a root-side gateway liveness supervisor in `operator/templates/entrypoint.sh`, forked before the exec-drop in the same shape as the broker respawner. It watches the loop heartbeat Hermes already writes (an asyncio task on the very loop that wedges), escalates SIGUSR2 → SIGTERM → SIGKILL against the container main process, and bounds itself with a kill ledger on the volume so a flapping seat stops and pages instead of restarting forever. Behavioural coverage drives the extracted loop for real in `operator/templates/tests/test_gateway_liveness_supervisor.py`; `tests/operator-entrypoint.test.ts` locks the shape. Two new `boot-smoke-test.sh` checks assert the supervisor is _iterating_ and the heartbeat is _fresh_ — the second is the tripwire for the whole mechanism rotting silently if a future Hermes pin moves or drops the heartbeat.
+- **Open:** the runtime proof (wedge a non-client seat, observe an unattended restart) and the reprovision that puts any of this on `hermes-ashton-price`. Also open, and tracked separately: the false-green health surface. `/health` observes nothing, and the control-plane heartbeat carries no loop-liveness field, so a wedge that outlives the supervisor is still invisible. That is a second vertical slice (overlay payload field + a migration in the `0093_scheduler_observability` shape + a `fleet-alerts` condition). The supervisor's per-iteration tick file was designed as its input.
+
+## Shadow-firm scenario
+
+`not yet written` (#2389). A scenario for this would need to hold the gateway loop without killing the process, and it is only trusted once observed to FAIL against the unfixed state.
+
+## Ladder consequence
+
+None. No routine was demoted: the failure was in the runtime substrate, not in any routine's behaviour, and A&P's crons were already off for go-live (ss#2332).
+
+## Not recorded
+
+- **Which of the two calls stalled the watchdog thread** — `faulthandler.dump_traceback` or `mark_exited`. The stack dump that would have said went to stderr and never arrived, so the answer for this occurrence is unrecoverable.
+- **Why the watchdog took 22 minutes** to notice a loop it should trip in ~90 seconds.
+- **What wedged the loop in the first place.** Contemporaneous conditions only: `loadavg_1m=15.25` on 1 vCPU / 1024 MB, "system memory pressure is elevated" still logging every 60s after the restart, one zombie worker reaped on boot. No causal link is established by any source.
+- **How the gateway pid moved 655 → 657 without the container restarting.** The webhook gate process ran unbroken across 03:40, so tini's child cannot simply have exited and been replaced. The supervisor is deliberately built not to depend on the answer: it kills `SMD_GATEWAY_PID`, verifies the process actually went away, and falls back to the pid the heartbeat itself names.
+- **Whether the Fly health check was ever `critical`.** ss#2488 reports it as critical throughout; the log buffer shows the gate answering 200 to Fly's prober every 30s across the same window, and `fly status` reports "1 total, 1 passing". The discrepancy is not resolved here, and Fly retains no check history to resolve it with.

--- a/operator/bin/boot-smoke-test.sh
+++ b/operator/bin/boot-smoke-test.sh
@@ -251,6 +251,35 @@ ssh_exec "broker-respawn-supervised" "pid=\$(pgrep -f workspace_broker.server | 
 # entrypoint's SOCKET_PATH ever moves, this line moves with it.
 ssh_exec_script "broker-socket-answers-health" "setpriv --reuid=hermes --regid=hermes --init-groups /opt/hermes/.venv/bin/python3 -c \"import socket,os,json,sys; p=os.environ.get('SMD_WORKSPACE_BROKER_SOCKET') or '/run/smd-workspace-broker/broker.sock'; s=socket.socket(socket.AF_UNIX,socket.SOCK_STREAM); s.settimeout(5); s.connect(p); s.sendall(b'{\\\"action\\\":\\\"health\\\"}'+bytes([10])); r=json.loads(s.recv(65536).decode()); sys.exit(0 if r.get('ok') and r.get('credential_ready') and r.get('customer_ready') else 1)\""
 
+# ---------- Step 11c: the GATEWAY is supervised, and its loop is beating (P0 ss#2488) ----------
+# On 2026-08-20 the paying client's seat wedged for 33 minutes: Hermes' own
+# loop-liveness watchdog logged that it was exiting so a supervisor could restart
+# it, then did not exit, and nothing at any layer noticed. entrypoint.sh EXECS the
+# gateway as the container's main process, the respawner above covers the BROKER,
+# and Fly does not restart a Machine on a failing health check.
+#
+# Deliberately NOT a pid check. The broker note above already says why: a check
+# that "confirmed a process EXISTED rather than that it WORKED" is how the
+# 2026-07-16 scheduler outage ran eight days green. The supervisor touches
+# ${RUN_DIR}/tick at the top of EVERY iteration, so tick freshness fails if the
+# loop stops turning for any reason — including the one that would otherwise be
+# invisible, an inherited `set -e` killing the subshell on its first failed probe.
+ssh_exec "gateway-liveness-supervisor-ticking" "t=/run/smd-gateway-liveness/tick; [ -f \$t ] && [ \$(( \$(date -u +%s) - \$(stat -c %Y \$t) )) -lt 90 ]"
+
+# The supervisor is only as good as the signal it reads, and that signal is
+# UPSTREAM's: an asyncio task on the gateway loop rewrites this file every 30s.
+# This check is the tripwire for the whole mechanism rotting silently. The path
+# is not where the Hermes source implies — _process_hermes_home() reads
+# HERMES_HOME (/opt/data), but the file lands under the PROFILE home, which is
+# why the supervisor derives it from the gateway's argv. If a future pin drops
+# the heartbeat, moves it again, or disables it via `gateway.loop_watchdog`, the
+# supervisor would go quietly inert; this fails the provision instead.
+#
+# Bounded wait rather than a single shot: boot smoke is fail-fast and on a 1 vCPU
+# box the first beat can land well after this step runs. Same idea as the
+# --wait-gateway-s flag the R2 strip probe below uses.
+ssh_exec "gateway-loop-heartbeat-fresh" "n=0; while [ \$n -lt 36 ]; do for f in /opt/data/profiles/*/state/gateway.heartbeat; do [ -f \$f ] || continue; [ \$(( \$(date -u +%s) - \$(stat -c %Y \$f) )) -lt 120 ] && exit 0; done; n=\$((n+1)); sleep 5; done; exit 1"
+
 # ---------- Step 12: /app governance artifacts are root-owned, not agent-writable (SEC-31) ----------
 # The activation-gate source the gateway:startup hook force-loads
 # (/app/overlay-pack, incl. hooks/smd-overlay-activation/handler.py) must be owned

--- a/operator/templates/entrypoint.sh
+++ b/operator/templates/entrypoint.sh
@@ -138,6 +138,13 @@ rm -f /opt/data/customer.yaml
 AUDIT_DIR="/opt/data/audit"
 AUDIT_DB="${AUDIT_DIR}/audit.db"
 LEGACY_AUDIT_DB="/opt/data/audit.db"
+# The ss#2488 gateway-liveness kill ledger. Declared HERE, next to the audit
+# dir, purely so the chown sweep below can prune it: the supervisor that uses it
+# is defined much further down, but the sweep runs first and would otherwise
+# hand the agent ownership of its own restart budget on the second boot onward
+# (the dir is re-created root-owned every boot, but the `kills` FILE inside it
+# would already have flipped). Same reasoning, same fix, as the audit subtree.
+GATEWAY_LIVENESS_LEDGER_DIR="/opt/data/gateway-liveness"
 # Group-readable default so the broker's rollback journal is readable by the
 # hermes mode=ro read seam during a write window. Explicit chmods below for the
 # 0700/0600 broker paths are unaffected by this.
@@ -146,7 +153,7 @@ umask 027
 # Agent owns its data EXCEPT the broker-owned audit subtree (R1). This REPLACES
 # a plain `chown -R hermes:hermes /opt/data`, which would re-own the ledger back
 # to hermes on every reboot and silently false-close the tamper-resistance.
-find /opt/data -path "${AUDIT_DIR}" -prune -o -print0 | xargs -0 -r chown hermes:hermes
+find /opt/data \( -path "${AUDIT_DIR}" -o -path "${GATEWAY_LIVENESS_LEDGER_DIR}" \) -prune -o -print0 | xargs -0 -r chown hermes:hermes
 
 # NOTE: the broker reaches the ledger via the bind mount established below, NOT
 # by traversing /opt/data. The Hermes gateway chmods its home (/opt/data) to
@@ -579,6 +586,328 @@ if [ -n "${R2_ACCESS_KEY_ID:-}" ] && [ -n "${R2_BUCKET_CONFIG:-}" ] \
 else
   log "Root establishment intake NOT launched (R2 config creds absent, or establish_intake not in this overlay); establish_submit runs will queue unprocessed"
 fi
+
+# Root-side gateway liveness supervisor (P0 ss#2488). On 2026-08-20 the paying
+# client's seat wedged for 33 minutes and recovered only because a human
+# restarted it. Hermes' OWN loop-liveness watchdog fired and logged "...exiting
+# with code 75 so the service supervisor can restart it" — and then did not
+# exit. At the pin we run (v2026.8.18@e624e9fd) that path is already a hard
+# os._exit(75) (gateway/shutdown_watchdog.py:196), so there was no graceful
+# shutdown to blame: the thread reached its logger.critical (the line is in
+# gateway.log) and never reached the os._exit two statements later. That
+# module's docstring names why such a thing happens — "every asyncio-based
+# recovery path is structurally unable to fire: they need the same loop that is
+# stuck" — and the rule extends one step further: an IN-PROCESS recovery path
+# can be blocked by whatever blocked the process. Recovery has to come from
+# outside it. Nothing outside it existed: this entrypoint EXECS the gateway as
+# the container's main process, the supervisor above covers the BROKER, and Fly
+# does not restart a Machine on a failing health check.
+#
+# Two facts make the fix cheap. Hermes already rewrites a loop heartbeat every
+# 30s from an asyncio task ON the loop that wedges, so the file goes stale the
+# instant the loop freezes; and this entrypoint already forks root children that
+# survive the exec-drop. We were simply not reading the heartbeat.
+#
+# The path is PROBED, not read off the source. shutdown_watchdog's
+# _process_hermes_home() reads HERMES_HOME (= /opt/data here), but on a live
+# seat `stat /opt/data/state/gateway.heartbeat` is "No such file or directory" —
+# the file sits under the PROFILE home. Hence the argv-derived path below.
+# vfy_01M0H9BKDCTFKSC5WSS9Z9DYVG.
+GATEWAY_LIVENESS_RUN_DIR="/run/smd-gateway-liveness"
+# GATEWAY_LIVENESS_LEDGER_DIR is declared beside AUDIT_DIR at the top of this
+# file so the boot-time chown sweep can prune it. See the note there.
+GATEWAY_LIVENESS_PROFILES_DIR="${GATEWAY_LIVENESS_PROFILES_DIR:-/opt/data/profiles}"
+# The one seam that exists for the test harness rather than for the Machine:
+# templates/tests/test_gateway_liveness_supervisor.py drives the REAL loop text
+# extracted from this file against a fake process tree, which is the only way to
+# prove the state machine (the arming guard, the recovery re-check, the kill
+# ledger) rather than merely assert that its source contains certain words. It
+# also lets the suite run on a developer's macOS, which has no /proc at all.
+GATEWAY_LIVENESS_PROC_DIR="${GATEWAY_LIVENESS_PROC_DIR:-/proc}"
+# The module that WRITES the heartbeat, in the installed Hermes. Probed, not
+# assumed: hermes-smd-staging runs 0.18.0 (7c1a029) today, and that pin predates
+# the loop heartbeat entirely -- the module does not exist in its tree and no
+# heartbeat file exists on its volume (vfy_01M0HBR1NZHSRMWSFPSQM32D1E). On such
+# a pin "no heartbeat has ever appeared" means "this build has no heartbeat",
+# NOT "the gateway is wedged", and the boot-deadline path below would SIGKILL a
+# perfectly healthy seat every 15 minutes until the ledger stopped it. Same
+# import-gate discipline as the establishment intake above: a lagging pin
+# degrades to a LOUD not-watching line, never to a wrong action.
+GATEWAY_LIVENESS_HEARTBEAT_WRITER="${GATEWAY_LIVENESS_HEARTBEAT_WRITER:-/opt/hermes/gateway/shutdown_watchdog.py}"
+# Every threshold is per-seat tunable, same shape as SMD_ESTABLISH_POLL_SECONDS
+# above. 240s of staleness is 8 missed beats, and the margin is sized against
+# CPU STARVATION rather than out of deference to Hermes' own watchdog — that
+# watchdog took 22 minutes to notice this incident and then failed to exit, so
+# waiting on it buys nothing. The evidence for the margin is the incident: the
+# webhook gate answered /health every 30s on the dot throughout, so the box —
+# 1 vCPU at loadavg 15.25 — was never so starved that a 30s task could not run.
+SMD_GATEWAY_LIVENESS_POLL_SECONDS="${SMD_GATEWAY_LIVENESS_POLL_SECONDS:-30}"
+SMD_GATEWAY_LIVENESS_STALE_SECONDS="${SMD_GATEWAY_LIVENESS_STALE_SECONDS:-240}"
+SMD_GATEWAY_LIVENESS_DUMP_GRACE_SECONDS="${SMD_GATEWAY_LIVENESS_DUMP_GRACE_SECONDS:-20}"
+SMD_GATEWAY_LIVENESS_TERM_GRACE_SECONDS="${SMD_GATEWAY_LIVENESS_TERM_GRACE_SECONDS:-15}"
+SMD_GATEWAY_LIVENESS_BOOT_DEADLINE_SECONDS="${SMD_GATEWAY_LIVENESS_BOOT_DEADLINE_SECONDS:-900}"
+SMD_GATEWAY_LIVENESS_MAX_KILLS="${SMD_GATEWAY_LIVENESS_MAX_KILLS:-3}"
+SMD_GATEWAY_LIVENESS_KILL_WINDOW_SECONDS="${SMD_GATEWAY_LIVENESS_KILL_WINDOW_SECONDS:-3600}"
+SMD_GATEWAY_LIVENESS_KILL_VERIFY_SECONDS="${SMD_GATEWAY_LIVENESS_KILL_VERIFY_SECONDS:-10}"
+
+# /run is a root-owned tmpfs (the tick is per-boot and must not persist); the
+# kill ledger is on the volume because its whole job is to bound restarts ACROSS
+# restarts. Both root-owned, alongside /opt/data/audit as the precedent for a
+# non-agent directory on the volume. The ledger bounds availability, not
+# security: it sits under an agent-writable parent (/opt/data is hermes-owned,
+# and write+exec on a parent is enough to unlink a child — the same keystone
+# hole this file documents at the top), so a code-executing agent could remove
+# it and buy itself unlimited restarts. That is why the authoritative record of
+# every kill and every refusal is the log line, which reaches `fly logs` and
+# which the agent cannot reach at all.
+install -d -o root -g root -m 0700 "${GATEWAY_LIVENESS_RUN_DIR}"
+install -d -o root -g root -m 0700 "${GATEWAY_LIVENESS_LEDGER_DIR}"
+
+# Resolve the ACTIVE profile from the gateway's own argv, not by mtime-ordering
+# /opt/data/profiles/*. A seat may carry several persona homes (ADR 0011;
+# boot-smoke Step 6b reconciles the SET of them against personas[]), and only
+# one belongs to the running gateway. "Newest mtime" identifies it only while it
+# is healthy — precisely the assumption that stops holding in the scenario this
+# supervisor exists for, and it would fail SILENTLY by watching a file nobody
+# writes. An argv that no longer names hermes means the container is not in the
+# state this was written for: return empty and let the caller refuse, loudly.
+gateway_heartbeat_path() {
+  local cmdline="${GATEWAY_LIVENESS_PROC_DIR}/${SMD_GATEWAY_PID}/cmdline"
+  local tok prev='' profile='' seen_hermes=0
+  [ -r "${cmdline}" ] || return 1
+  # NUL-delimited `read -d` rather than `mapfile -d`, which needs bash >= 4.4.
+  # The Machine ships bash 5, but a boot-critical path should not carry a
+  # version dependency it does not need — and templates/tests drives this exact
+  # function, so it has to run on a developer's macOS too, where /bin/bash is
+  # still 3.2. The redirect (not a pipe) keeps the loop in this shell, so the
+  # assignments below survive it.
+  while IFS= read -r -d '' tok; do
+    case "${tok}" in *hermes*) seen_hermes=1 ;; esac
+    if [ "${prev}" = "-p" ] && [ -z "${profile}" ]; then profile="${tok}"; fi
+    prev="${tok}"
+  done < "${cmdline}"
+  [ "${seen_hermes}" -eq 1 ] || return 1
+  [ -n "${profile}" ] || return 1
+  printf '%s\n' "${GATEWAY_LIVENESS_PROFILES_DIR}/${profile}/state/gateway.heartbeat"
+}
+
+# Epoch first so the window comparison is integer arithmetic, no date parsing.
+gateway_liveness_record_kill() {
+  printf '%s %s %s\n' "$(date -u +%s)" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$1" \
+    >> "${GATEWAY_LIVENESS_LEDGER_DIR}/kills"
+}
+
+gateway_liveness_kill_budget_ok() {
+  local ledger="${GATEWAY_LIVENESS_LEDGER_DIR}/kills" cutoff now line ts count=0
+  [ -f "${ledger}" ] || return 0
+  now="$(date -u +%s)"
+  cutoff=$(( now - SMD_GATEWAY_LIVENESS_KILL_WINDOW_SECONDS ))
+  while IFS= read -r line; do
+    ts="${line%% *}"
+    case "${ts}" in ''|*[!0-9]*) continue ;; esac
+    [ "${ts}" -ge "${cutoff}" ] && count=$(( count + 1 ))
+  done < "${ledger}"
+  [ "${count}" -lt "${SMD_GATEWAY_LIVENESS_MAX_KILLS}" ]
+}
+
+gateway_liveness_heartbeat_pid() {
+  sed -n 's/.*"pid"[: ]*\([0-9][0-9]*\).*/\1/p' "$1" 2>/dev/null
+}
+
+# A refusal, or a supervisor that has gone inert, must never be silent — that is
+# the entire defect class this PR is about. Repeat on a 5-minute floor so the
+# condition shows continuously in `fly logs` without drowning the stream. Same
+# discipline as the establishment intake's NOT-launched line above: a silent
+# skip is indistinguishable from a healthy seat.
+gateway_liveness_nag() {
+  local now
+  now="$(date -u +%s)"
+  if [ $(( now - last_nag )) -ge 300 ]; then
+    log "GATEWAY LIVENESS: $*"
+    last_nag="${now}"
+  fi
+}
+
+# SIGUSR2 is what finally makes gateway_faulthandler.log non-empty: Hermes
+# registers an all-thread faulthandler dump on it (gateway/run.py) and nothing
+# ever sent the signal, which is why the "0-byte diagnostic" reported in ss#2488
+# is expected behaviour and not a defect. Best-effort, and DOUBLY gated, because
+# SIGUSR2's default disposition is TERMINATE: if a future pin drops that
+# registration, an unguarded send stops being a diagnostic and becomes an
+# unlogged kill that skips the recovery re-check and the kill ledger below.
+gateway_liveness_request_dump() {
+  local hbpid
+  hbpid="$(gateway_liveness_heartbeat_pid "$1")"
+  if [ "${hbpid}" != "${SMD_GATEWAY_PID}" ]; then
+    log "Gateway liveness: heartbeat names pid '${hbpid}', container main is ${SMD_GATEWAY_PID}; skipping the stack dump"
+    return 0
+  fi
+  if ! grep -q 'faulthandler.register' /opt/hermes/gateway/run.py 2>/dev/null; then
+    log "Gateway liveness: this Hermes pin registers no SIGUSR2 faulthandler; skipping the stack dump (sending it would terminate the process unlogged)"
+    return 0
+  fi
+  log "Gateway liveness: SIGUSR2 to ${SMD_GATEWAY_PID} for an all-thread stack dump (best-effort — a fully frozen process may never service it)"
+  kill -USR2 "${SMD_GATEWAY_PID}" 2>/dev/null
+}
+
+gateway_liveness_escalate() {
+  local reason="$1" hb hbpid
+  if ! gateway_liveness_kill_budget_ok; then
+    # A seat that flaps every few minutes on an environmental cause is not
+    # better than a seat that is down — it is the same outage plus churn, and it
+    # destroys in-flight work each cycle. Stop, and keep saying so, so that the
+    # next thing to touch this Machine is a human.
+    gateway_liveness_nag "REFUSING to restart (${reason}): ${SMD_GATEWAY_LIVENESS_MAX_KILLS} kill(s) already inside ${SMD_GATEWAY_LIVENESS_KILL_WINDOW_SECONDS}s. This seat is flapping and needs a human."
+    return 0
+  fi
+  gateway_liveness_record_kill "${reason}"
+  # SIGTERM first. It does nothing for a genuinely wedged loop — the handler
+  # would have to run ON that loop — and that is exactly the point: it costs
+  # 15s and buys a clean shutdown (audit WAL flushed, spool drained) in the
+  # false-positive case where the process is alive and healthy and we misread a
+  # starved heartbeat as a dead one.
+  log "GATEWAY LIVENESS: restarting the seat (${reason}) — SIGTERM to container main ${SMD_GATEWAY_PID}"
+  kill -TERM "${SMD_GATEWAY_PID}" 2>/dev/null
+  sleep "${SMD_GATEWAY_LIVENESS_TERM_GRACE_SECONDS}"
+  [ -d "${GATEWAY_LIVENESS_PROC_DIR}/${SMD_GATEWAY_PID}" ] || return 0
+  log "GATEWAY LIVENESS: SIGKILL to container main ${SMD_GATEWAY_PID}; tini exits non-zero and Fly replaces the Machine"
+  kill -KILL "${SMD_GATEWAY_PID}" 2>/dev/null
+  for _ in 1 2 3; do
+    sleep "${SMD_GATEWAY_LIVENESS_KILL_VERIFY_SECONDS}"
+    [ -d "${GATEWAY_LIVENESS_PROC_DIR}/${SMD_GATEWAY_PID}" ] || return 0
+  done
+  # Still alive 30s after SIGKILL. The kill target is the one thing ss#2488
+  # could NOT explain — the gateway pid moved 655 -> 657 while the container
+  # never restarted — so rather than assume, fall back to whatever pid the
+  # heartbeat itself names, and say plainly that the first target was wrong.
+  log "GATEWAY LIVENESS: ${SMD_GATEWAY_PID} SURVIVED SIGKILL for $(( SMD_GATEWAY_LIVENESS_KILL_VERIFY_SECONDS * 3 ))s — falling back to the pid named in the heartbeat"
+  hb="$(gateway_heartbeat_path)"
+  [ -n "${hb}" ] && [ -e "${hb}" ] || return 0
+  hbpid="$(gateway_liveness_heartbeat_pid "${hb}")"
+  case "${hbpid}" in
+    ''|*[!0-9]*) return 0 ;;
+    "${SMD_GATEWAY_PID}") return 0 ;;
+  esac
+  log "GATEWAY LIVENESS: SIGKILL to heartbeat-named pid ${hbpid}"
+  kill -KILL "${hbpid}" 2>/dev/null
+}
+
+(
+  # This loop MUST outlive every failing probe. entrypoint.sh runs under
+  # `set -euo pipefail` (line 4) and a backgrounded subshell INHERITS it, so a
+  # vanished heartbeat, a `stat` on a file mid-replace, a `kill` on a pid that
+  # just died, or arithmetic on an empty mtime would silently END the supervisor
+  # for the life of the container — the exact failure class this PR exists to
+  # fix, reproduced one level up and even harder to see. The broker loop above
+  # pays for the same hazard with an `if` guard (see its comment); this loop
+  # turns `set -e` off outright, because nearly every line in it is a probe that
+  # is ALLOWED to fail.
+  #
+  # On the `( ... ) &` secret-carry hazard (ss#2420): a fork keeps its parent's
+  # execve-time environ for life, and no `unset` rewrites it — which is why the
+  # skill reconciler and the webhook gate are exec'd with `env -u`. It does not
+  # apply here. Those two run at the AGENT uid, where a same-uid process can read
+  # /proc/<pid>/environ; this one stays root, like the appliers and the intake
+  # above, and the hermes uid cannot read a root process's environ at all. The
+  # supervisor also needs no credential of any kind — it reads a file mtime and
+  # sends signals.
+  set +e
+  if [ ! -f "${GATEWAY_LIVENESS_HEARTBEAT_WRITER}" ] || \
+     ! grep -q 'loop_heartbeat_forever' "${GATEWAY_LIVENESS_HEARTBEAT_WRITER}"; then
+    log "GATEWAY LIVENESS: NOT watching — this Hermes pin has no loop heartbeat (${GATEWAY_LIVENESS_HEARTBEAT_WRITER} absent or without loop_heartbeat_forever). A wedged gateway on this seat will NOT self-recover."
+    exit 0
+  fi
+  armed=0
+  stale_streak=0
+  last_nag=0
+  boot_epoch="$(date -u +%s)"
+  while true; do
+    # Tick FIRST, every iteration. This file is the supervisor's own liveness
+    # proof and boot-smoke asserts its freshness. A pid file would only prove a
+    # number was written once — the "check confirmed a process EXISTED rather
+    # than that it WORKED" shape boot-smoke-test.sh warns about after the
+    # 2026-07-16 scheduler outage ran eight days green on exactly that.
+    touch "${GATEWAY_LIVENESS_RUN_DIR}/tick"
+    sleep "${SMD_GATEWAY_LIVENESS_POLL_SECONDS}"
+    now="$(date -u +%s)"
+
+    hb="$(gateway_heartbeat_path)"
+    if [ -z "${hb}" ]; then
+      gateway_liveness_nag "cannot resolve the gateway profile from ${GATEWAY_LIVENESS_PROC_DIR}/${SMD_GATEWAY_PID}/cmdline; supervisor is INERT and this seat has no automatic recovery"
+      continue
+    fi
+
+    if [ ! -e "${hb}" ]; then
+      # No heartbeat yet. Never kill a slow boot — but do not hand a boot-time
+      # wedge to "Fly's job" either: the Fly check is served by the webhook
+      # gate's /health, which is a literal constant, and the process never
+      # exits. Left alone, this window is the original bug in miniature.
+      if [ "${armed}" -eq 0 ] && [ $(( now - boot_epoch )) -ge "${SMD_GATEWAY_LIVENESS_BOOT_DEADLINE_SECONDS}" ]; then
+        gateway_liveness_nag "gateway has written NO loop heartbeat in $(( now - boot_epoch ))s (deadline ${SMD_GATEWAY_LIVENESS_BOOT_DEADLINE_SECONDS}s); ${hb} absent"
+        gateway_liveness_escalate never-armed
+        # Restart the deadline clock. Without this the condition is still true
+        # on the next poll, and the ledger's whole budget burns in three ticks
+        # instead of bounding three genuinely separate attempts.
+        boot_epoch="$(date -u +%s)"
+      fi
+      continue
+    fi
+
+    mtime="$(stat -c %Y "${hb}" 2>/dev/null)"
+    case "${mtime}" in ''|*[!0-9]*) continue ;; esac
+    age=$(( now - mtime ))
+
+    if [ "${age}" -le "${SMD_GATEWAY_LIVENESS_STALE_SECONDS}" ]; then
+      [ "${armed}" -eq 0 ] && log "Gateway liveness supervisor ARMED (loop heartbeat ${hb} is ${age}s fresh)"
+      armed=1
+      stale_streak=0
+      continue
+    fi
+
+    if [ "${armed}" -eq 0 ]; then
+      # The volume PERSISTS, so a heartbeat from a PREVIOUS boot is on disk at
+      # every cold start. Arming on it would kill every boot, forever. Say so
+      # out loud — a silent skip here reads identically to a healthy seat.
+      gateway_liveness_nag "loop heartbeat ${hb} is ${age}s stale but has never been seen fresh this boot; NOT arming (stale beat from a previous boot)"
+      continue
+    fi
+
+    stale_streak=$(( stale_streak + 1 ))
+    if [ "${stale_streak}" -lt 2 ]; then
+      log "Gateway liveness: loop heartbeat ${age}s stale (sample ${stale_streak}); one more before acting"
+      continue
+    fi
+
+    log "GATEWAY WEDGE: loop heartbeat ${hb} is ${age}s stale across ${stale_streak} consecutive samples (threshold ${SMD_GATEWAY_LIVENESS_STALE_SECONDS}s)"
+    # Budget FIRST, before the dump. Signalling a process we have already
+    # decided not to restart is perturbation without a plan: the diagnostic
+    # dump was captured on the first kill in this window, and attempts 4..N
+    # add nothing but risk (SIGUSR2's default disposition is terminate) and a
+    # 20s sleep per cycle. escalate() re-checks the budget as the authoritative
+    # gate — it also guards the never-armed path, which does not come through
+    # here.
+    if ! gateway_liveness_kill_budget_ok; then
+      gateway_liveness_nag "REFUSING to restart (loop-wedge, heartbeat ${age}s stale): ${SMD_GATEWAY_LIVENESS_MAX_KILLS} kill(s) already inside ${SMD_GATEWAY_LIVENESS_KILL_WINDOW_SECONDS}s. This seat is flapping and needs a human."
+      stale_streak=0
+      continue
+    fi
+    gateway_liveness_request_dump "${hb}"
+    sleep "${SMD_GATEWAY_LIVENESS_DUMP_GRACE_SECONDS}"
+    # Never block on the dump, and never kill on a reading we did not
+    # re-confirm after it: the loop may have come back while we waited.
+    now="$(date -u +%s)"
+    mtime="$(stat -c %Y "${hb}" 2>/dev/null)"
+    case "${mtime}" in ''|*[!0-9]*) mtime=0 ;; esac
+    if [ $(( now - mtime )) -le "${SMD_GATEWAY_LIVENESS_STALE_SECONDS}" ]; then
+      log "Gateway liveness: loop recovered during the dump grace ($(( now - mtime ))s); NOT killing"
+      stale_streak=0
+      continue
+    fi
+    gateway_liveness_escalate loop-wedge
+    stale_streak=0
+  done
+) &
+log "Root gateway liveness supervisor forked (uid 0; watches the Hermes loop heartbeat and kills container main ${SMD_GATEWAY_PID} so Fly replaces the Machine; stale>${SMD_GATEWAY_LIVENESS_STALE_SECONDS}s, max ${SMD_GATEWAY_LIVENESS_MAX_KILLS} kill(s)/${SMD_GATEWAY_LIVENESS_KILL_WINDOW_SECONDS}s)"
 
 # MCP channel cross-process result/thread store (shared/mcp_result_store.py +
 # shared/mcp_thread_store.py). The webhook gate (:8643) and the agent's result-sink

--- a/operator/templates/tests/test_gateway_liveness_supervisor.py
+++ b/operator/templates/tests/test_gateway_liveness_supervisor.py
@@ -1,0 +1,352 @@
+"""Behavioural coverage for the root-side gateway liveness supervisor (P0 ss#2488).
+
+These tests EXTRACT the supervisor's real text out of ``entrypoint.sh`` and run
+it, rather than asserting that the file contains certain words. The distinction
+is the point. The defect that opened ss#2488 was a recovery path that logged its
+intent and never performed it; a test that greps the source for ``kill -KILL``
+would have passed against exactly that. The static assertions in
+``tests/operator-entrypoint.test.ts`` lock the SHAPE so it cannot be silently
+removed; this file proves the STATE MACHINE, which is where the bugs live:
+
+  * the arming guard (a stale heartbeat left on the persistent volume by the
+    PREVIOUS boot must never be treated as a wedge, or every cold start dies),
+  * loop survival under ``set -euo pipefail``, which a backgrounded subshell
+    inherits — the failure mode that would kill the supervisor on its first
+    vanished file and leave the seat with no recovery and no signal,
+  * the recovery re-check after the diagnostic grace,
+  * the kill ledger, which stops a flapping seat instead of restarting forever,
+  * profile resolution from the gateway's own argv rather than by mtime.
+
+The harness supplies ``log`` and a ``kill`` stub, and points the two seams
+(``GATEWAY_LIVENESS_PROC_DIR``, ``GATEWAY_LIVENESS_PROFILES_DIR``) at a tmpdir,
+so the suite runs on Linux CI and on a developer's macOS, which has no /proc.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+ENTRYPOINT = REPO_ROOT / "operator" / "templates" / "entrypoint.sh"
+
+# The extracted region: from the argv-resolution helper through the `) &` that
+# closes the backgrounded supervisor subshell. Anchored on comment text that is
+# load-bearing prose, so a rewrite that moves the block fails here loudly rather
+# than silently testing nothing.
+_START = "# Resolve the ACTIVE profile from the gateway's own argv"
+_END = "\n) &\n"
+
+GATEWAY_PID = "4242"
+
+
+def _extract_supervisor() -> str:
+    src = ENTRYPOINT.read_text()
+    start = src.find(_START)
+    assert start != -1, f"supervisor block start anchor not found in {ENTRYPOINT}"
+    end = src.find(_END, start)
+    assert end != -1, f"supervisor subshell end anchor not found in {ENTRYPOINT}"
+    return src[start : end + len(_END)]
+
+
+def test_extraction_anchors_still_match():
+    """If this fails, every other test in this file is measuring nothing."""
+    block = _extract_supervisor()
+    assert "gateway_heartbeat_path()" in block
+    assert "gateway_liveness_escalate()" in block
+    assert "set +e" in block
+    assert "while true; do" in block
+
+
+class Harness:
+    """A tmpdir world the extracted supervisor can run against."""
+
+    def __init__(self, tmp_path: Path):
+        self.root = tmp_path
+        self.run_dir = tmp_path / "run"
+        self.ledger_dir = tmp_path / "ledger"
+        self.proc_dir = tmp_path / "proc"
+        self.profiles_dir = tmp_path / "profiles"
+        self.log = tmp_path / "log.txt"
+        self.kills = tmp_path / "kills.txt"
+        for d in (self.run_dir, self.ledger_dir, self.proc_dir, self.profiles_dir):
+            d.mkdir(parents=True, exist_ok=True)
+        # A pin that DOES register a SIGUSR2 faulthandler, so the dump gate is
+        # exercised on its open branch unless a test says otherwise.
+        self.hermes_run_py = tmp_path / "run.py"
+        self.hermes_run_py.write_text("faulthandler.register(signal.SIGUSR2)\n")
+        # A pin that DOES write the loop heartbeat. hermes-smd-staging runs one
+        # that does not (0.18.0 / 7c1a029), which is why the capability gate
+        # exists at all.
+        self.heartbeat_writer = tmp_path / "shutdown_watchdog.py"
+        self.heartbeat_writer.write_text("async def loop_heartbeat_forever():\n    pass\n")
+        self.proc = None
+
+    def set_argv(self, *argv: str) -> None:
+        pid_dir = self.proc_dir / GATEWAY_PID
+        pid_dir.mkdir(parents=True, exist_ok=True)
+        (pid_dir / "cmdline").write_bytes(b"\0".join(a.encode() for a in argv) + b"\0")
+
+    def heartbeat_path(self, profile: str) -> Path:
+        return self.profiles_dir / profile / "state" / "gateway.heartbeat"
+
+    def write_heartbeat(self, profile: str, age_seconds: float = 0.0, pid: str = GATEWAY_PID) -> Path:
+        path = self.heartbeat_path(profile)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text('{"pid": %s, "updated_at": "x", "monotonic": 1.0}' % pid)
+        when = time.time() - age_seconds
+        os.utime(path, (when, when))
+        return path
+
+    def script(self, extra_env_lines: str = "") -> str:
+        block = _extract_supervisor()
+        return f"""#!/usr/bin/env bash
+# Mirror the real entrypoint's shell options EXACTLY. Without this the test
+# cannot detect the `set -e` hazard the supervisor's `set +e` exists to defuse.
+set -euo pipefail
+
+log() {{ echo "$*" >> "{self.log}"; }}
+
+# The Machine is Debian, so the supervisor correctly calls GNU `stat -c %Y`.
+# macOS ships BSD stat, which has no -c. Shim it HERE rather than weakening the
+# production call to a lowest-common-denominator form the Machine never needs —
+# and note the failure mode this papers over is silent: BSD stat writes usage to
+# stderr and returns empty, the supervisor's `case` guard treats that as
+# unreadable and continues, and every test would hang at "never armed" while the
+# code under test was perfectly fine.
+if ! stat -c %Y . >/dev/null 2>&1; then
+  stat() {{
+    if [ "$1" = "-c" ] && [ "$2" = "%Y" ]; then
+      shift 2
+      command stat -f %m "$@"
+    else
+      command stat "$@"
+    fi
+  }}
+fi
+
+# `kill` as a function shadows the builtin, so escalation is observable without
+# signalling anything real. It also MODELS reality: a delivered SIGTERM/SIGKILL
+# makes the process go away, so the fake /proc entry goes with it.
+kill() {{
+  echo "$*" >> "{self.kills}"
+  case "$1" in
+    -TERM|-KILL) rm -rf "{self.proc_dir}/{GATEWAY_PID}" ;;
+  esac
+  return 0
+}}
+
+SMD_GATEWAY_PID="{GATEWAY_PID}"
+GATEWAY_LIVENESS_RUN_DIR="{self.run_dir}"
+GATEWAY_LIVENESS_LEDGER_DIR="{self.ledger_dir}"
+GATEWAY_LIVENESS_PROC_DIR="{self.proc_dir}"
+GATEWAY_LIVENESS_PROFILES_DIR="{self.profiles_dir}"
+SMD_GATEWAY_LIVENESS_POLL_SECONDS=1
+SMD_GATEWAY_LIVENESS_STALE_SECONDS=3
+SMD_GATEWAY_LIVENESS_DUMP_GRACE_SECONDS=1
+SMD_GATEWAY_LIVENESS_TERM_GRACE_SECONDS=1
+SMD_GATEWAY_LIVENESS_BOOT_DEADLINE_SECONDS=3
+SMD_GATEWAY_LIVENESS_MAX_KILLS=2
+SMD_GATEWAY_LIVENESS_KILL_WINDOW_SECONDS=3600
+SMD_GATEWAY_LIVENESS_KILL_VERIFY_SECONDS=1
+GATEWAY_LIVENESS_HEARTBEAT_WRITER="{self.heartbeat_writer}"
+{extra_env_lines}
+
+{block}
+wait
+"""
+
+    def start(self, extra_env_lines: str = "") -> None:
+        path = self.root / "harness.sh"
+        # The dump gate greps the installed Hermes source; point it at the fake.
+        text = self.script(extra_env_lines).replace(
+            "/opt/hermes/gateway/run.py", str(self.hermes_run_py)
+        )
+        path.write_text(text)
+        path.chmod(0o755)
+        self.proc = subprocess.Popen(
+            ["bash", str(path)], stdout=subprocess.DEVNULL, stderr=subprocess.PIPE
+        )
+
+    def stop(self) -> None:
+        if self.proc and self.proc.poll() is None:
+            self.proc.kill()
+            self.proc.wait(timeout=10)
+
+    def log_text(self) -> str:
+        return self.log.read_text() if self.log.exists() else ""
+
+    def kill_text(self) -> str:
+        return self.kills.read_text() if self.kills.exists() else ""
+
+    def wait_for_log(self, pattern: str, timeout: float = 20.0) -> str:
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            text = self.log_text()
+            if re.search(pattern, text):
+                return text
+            if self.proc and self.proc.poll() is not None:
+                raise AssertionError(
+                    f"supervisor EXITED before matching {pattern!r}.\n"
+                    f"log:\n{text}\nstderr:\n{self.proc.stderr.read().decode()}"
+                )
+            time.sleep(0.2)
+        raise AssertionError(f"timed out waiting for {pattern!r}; log:\n{self.log_text()}")
+
+    def tick_mtime(self) -> float:
+        tick = self.run_dir / "tick"
+        return tick.stat().st_mtime if tick.exists() else 0.0
+
+
+@pytest.fixture
+def harness(tmp_path):
+    h = Harness(tmp_path)
+    h.set_argv("python", "/opt/hermes/.venv/bin/hermes", "-p", "crane", "gateway", "run")
+    yield h
+    h.stop()
+
+
+def test_arms_on_a_fresh_beat_then_restarts_the_seat_when_the_loop_wedges(harness):
+    """The whole point: a wedge becomes a restart with nobody in the loop."""
+    harness.write_heartbeat("crane", age_seconds=0)
+    harness.start()
+    harness.wait_for_log(r"ARMED")
+    # Stop refreshing the heartbeat — this is the wedge.
+    harness.wait_for_log(r"GATEWAY WEDGE")
+    harness.wait_for_log(r"SIGTERM to container main")
+    assert "-TERM 4242" in harness.kill_text()
+
+
+def test_never_arms_on_a_stale_beat_left_by_the_previous_boot(harness):
+    """The forced negative control.
+
+    /opt/data is a persistent volume, so a heartbeat from the LAST boot is on
+    disk at every cold start. Arming on it would SIGKILL the container on every
+    single boot. Asserting "nothing happened" would be a check that cannot fail,
+    so this asserts the guard FIRED — the specific not-arming line — and that no
+    signal was sent.
+    """
+    harness.write_heartbeat("crane", age_seconds=7200)
+    harness.start()
+    harness.wait_for_log(r"has never been seen fresh this boot; NOT arming")
+    time.sleep(4)
+    assert "GATEWAY WEDGE" not in harness.log_text()
+    assert harness.kill_text() == ""
+
+
+def test_loop_survives_a_vanished_heartbeat(harness):
+    """The heartbeat can disappear under the supervisor; it must keep watching.
+
+    The tick file is the proof of life: it is touched at the top of every
+    iteration, so a stalled loop stops advancing it.
+
+    Scope this honestly. A mutation run (2026-08-20, `set +e` deleted from the
+    subshell) showed this test still PASSING, because bash exempts a failing
+    non-final member of an `&&` list from errexit and the `[ -e ]` guard keeps
+    `stat` off a missing file. The behavioural detector for a removed `set +e`
+    is `test_is_inert_and_loud_when_argv_does_not_name_hermes` — there the
+    `hb="$(gateway_heartbeat_path)"` assignment carries the function's non-zero
+    status and errexit ends the subshell before it can log anything — plus the
+    literal assertion in `test_extraction_anchors_still_match`. Both failed
+    under that mutation. This one covers a different scenario and should not be
+    read as guarding errexit.
+    """
+    harness.write_heartbeat("crane", age_seconds=0)
+    harness.start()
+    harness.wait_for_log(r"ARMED")
+    harness.heartbeat_path("crane").unlink()
+    (harness.profiles_dir / "crane" / "state").rmdir()
+    before = harness.tick_mtime()
+    time.sleep(3)
+    assert harness.tick_mtime() > before, "supervisor stopped iterating after the heartbeat vanished"
+    assert harness.proc.poll() is None, "supervisor process exited"
+
+
+def test_does_not_kill_when_the_loop_recovers_during_the_dump_grace(harness):
+    harness.write_heartbeat("crane", age_seconds=0)
+    harness.start()
+    harness.wait_for_log(r"ARMED")
+    harness.wait_for_log(r"GATEWAY WEDGE")
+    # Recover while the supervisor waits on the stack dump.
+    harness.write_heartbeat("crane", age_seconds=0)
+    harness.wait_for_log(r"loop recovered during the dump grace; NOT killing|loop recovered during the dump grace")
+    assert "-TERM" not in harness.kill_text()
+
+
+def test_kill_ledger_refuses_once_the_budget_is_spent(harness):
+    """A seat flapping every few minutes is not better than one that is down."""
+    ledger = harness.ledger_dir / "kills"
+    now = int(time.time())
+    ledger.write_text(f"{now - 10} iso loop-wedge\n{now - 5} iso loop-wedge\n")
+    harness.write_heartbeat("crane", age_seconds=0)
+    harness.start()
+    harness.wait_for_log(r"ARMED")
+    harness.wait_for_log(r"REFUSING to restart")
+    assert harness.kill_text() == "", "refused escalation still signalled the process"
+
+
+def test_profile_comes_from_argv_not_from_mtime(harness):
+    """A seat may carry several persona homes; only one is the gateway's.
+
+    The decoy is written LAST, so an mtime-ordered resolver would watch it. The
+    argv-derived resolver must watch `crane` and therefore see a wedge.
+    """
+    harness.write_heartbeat("crane", age_seconds=0)
+    time.sleep(0.05)
+    harness.write_heartbeat("retired-persona", age_seconds=0)
+    harness.start()
+    harness.wait_for_log(r"ARMED")
+    text = harness.wait_for_log(r"GATEWAY WEDGE")
+    assert "profiles/crane/state/gateway.heartbeat" in text
+    assert "retired-persona" not in text
+
+
+def test_is_inert_and_loud_when_argv_does_not_name_hermes(harness):
+    """"Cannot evaluate" must never read as "healthy"."""
+    harness.set_argv("/bin/sh", "-c", "something-else")
+    harness.write_heartbeat("crane", age_seconds=7200)
+    harness.start()
+    harness.wait_for_log(r"supervisor is INERT")
+    assert harness.kill_text() == ""
+
+
+def test_refuses_to_watch_a_pin_that_has_no_loop_heartbeat(harness):
+    """The capability gate, found by probing a second seat rather than reading code.
+
+    hermes-smd-staging runs Hermes 0.18.0 (7c1a029) today. That pin predates the
+    loop heartbeat entirely: the module is absent from its tree and no heartbeat
+    file exists on its volume (vfy_01M0HBR1NZHSRMWSFPSQM32D1E). On such a pin
+    "no heartbeat has ever appeared" means the build has none, not that the
+    gateway is wedged — and without this gate the boot-deadline path would
+    SIGKILL a healthy seat every 15 minutes until the ledger stopped it.
+
+    Refusing must be LOUD. "Cannot evaluate" reading as "healthy" is the same
+    failure the Law 2 engagement guard fails closed against.
+    """
+    harness.heartbeat_writer.write_text("# 0.18.0: no loop heartbeat in this pin\n")
+    harness.write_heartbeat("crane", age_seconds=7200)
+    harness.start()
+    harness.wait_for_log(r"NOT watching")
+    time.sleep(3)
+    assert harness.kill_text() == ""
+    assert "ARMED" not in harness.log_text()
+
+
+def test_skips_the_dump_when_the_pin_registers_no_sigusr2_handler(harness):
+    """SIGUSR2's default disposition is terminate.
+
+    If a future Hermes pin drops `faulthandler.register`, an unguarded send stops
+    being a diagnostic and becomes an unlogged kill that skips the recovery
+    re-check and the kill ledger entirely.
+    """
+    harness.hermes_run_py.write_text("# no faulthandler registration in this pin\n")
+    harness.write_heartbeat("crane", age_seconds=0)
+    harness.start()
+    harness.wait_for_log(r"ARMED")
+    harness.wait_for_log(r"registers no SIGUSR2 faulthandler; skipping the stack dump")
+    assert "-USR2" not in harness.kill_text()

--- a/tests/operator-entrypoint.test.ts
+++ b/tests/operator-entrypoint.test.ts
@@ -195,3 +195,121 @@ describe('Operator customer Machine entrypoint — ADR 0009 / SEC-22 isolation b
     ).toBe(true)
   })
 })
+
+/**
+ * Regression guard: the root-side gateway liveness supervisor (P0 ss#2488).
+ *
+ * On 2026-08-20 the paying client's seat wedged for 33 minutes. Hermes' own
+ * loop-liveness watchdog logged "...exiting with code 75 so the service
+ * supervisor can restart it" and then did not exit — and there was no service
+ * supervisor to restart it: entrypoint EXECS the gateway as the container's main
+ * process, the respawner above covers the BROKER, and Fly does not restart a
+ * Machine on a failing health check.
+ *
+ * These are SHAPE locks only. The state machine itself — arming, the recovery
+ * re-check, the kill ledger, profile resolution — is driven for real in
+ * operator/templates/tests/test_gateway_liveness_supervisor.py, which extracts
+ * this block and runs it. A grep-only guard would have passed against the very
+ * defect that opened the issue: a recovery path that logs its intent and then
+ * never performs it.
+ *
+ * @see operator/templates/entrypoint.sh
+ * @see operator/templates/tests/test_gateway_liveness_supervisor.py
+ * @see docs/runbooks/operator/incidents/2026-08-20-gateway-wedge-no-restart.md
+ */
+describe('Operator customer Machine entrypoint — gateway liveness supervisor (ss#2488)', () => {
+  it('runs the watcher in a backgrounded while-true subshell', () => {
+    expect(ENTRYPOINT_CODE).toMatch(
+      /\(\s*set \+e[\s\S]*?while\s+true;?\s*do[\s\S]*?gateway_liveness_escalate[\s\S]*?done\s*\)\s*&/
+    )
+  })
+
+  it('disables the INHERITED errexit inside the subshell', () => {
+    // entrypoint.sh runs under `set -euo pipefail` and a backgrounded subshell
+    // inherits it, so ONE failed probe — a heartbeat read mid-replace, a `kill`
+    // on a pid that just died — would end the supervisor for the life of the
+    // container, silently, leaving the seat with no recovery at all. The broker
+    // loop above pays for the same hazard with an `if` guard; this one turns
+    // errexit off outright, because nearly every line in it is a probe that is
+    // allowed to fail.
+    const block = ENTRYPOINT_CODE.slice(
+      ENTRYPOINT_CODE.indexOf('gateway_heartbeat_path()'),
+      ENTRYPOINT_CODE.indexOf('Root gateway liveness supervisor launched')
+    )
+    expect(block.length, 'supervisor block must be present').toBeGreaterThan(0)
+    expect(block).toMatch(/\(\s*\n\s*set \+e/)
+  })
+
+  it('forks the supervisor while still root, BEFORE the exec-drop to hermes', () => {
+    const supervisorIdx = ENTRYPOINT_CODE.indexOf('gateway_liveness_escalate()')
+    const hermesExec = ENTRYPOINT_CODE.search(/exec\s+setpriv[\s\S]*?--reuid=hermes/)
+    expect(supervisorIdx, 'supervisor must be present').toBeGreaterThan(-1)
+    expect(
+      supervisorIdx < hermesExec,
+      'only a root process forked before the exec-drop can signal the gateway'
+    ).toBe(true)
+  })
+
+  it('is forked AFTER SMD_GATEWAY_PID is exported (its kill target)', () => {
+    const pidExport = ENTRYPOINT_CODE.indexOf('export SMD_GATEWAY_PID=')
+    const supervisorIdx = ENTRYPOINT_CODE.indexOf('gateway_heartbeat_path()')
+    expect(pidExport).toBeGreaterThan(-1)
+    expect(pidExport < supervisorIdx).toBe(true)
+  })
+
+  it('escalates SIGTERM before SIGKILL, and kills the container main process', () => {
+    // SIGTERM does nothing for a genuinely wedged loop — its handler would have
+    // to run ON that loop. It is there for the false-positive case, where it
+    // buys a clean shutdown (audit WAL flushed) instead of a hard kill.
+    expect(ENTRYPOINT_CODE).toMatch(/kill -TERM "\$\{SMD_GATEWAY_PID\}"/)
+    expect(ENTRYPOINT_CODE).toMatch(/kill -KILL "\$\{SMD_GATEWAY_PID\}"/)
+    const term = ENTRYPOINT_CODE.indexOf('kill -TERM "${SMD_GATEWAY_PID}"')
+    const hard = ENTRYPOINT_CODE.indexOf('kill -KILL "${SMD_GATEWAY_PID}"')
+    expect(term < hard, 'SIGTERM must precede SIGKILL').toBe(true)
+  })
+
+  it('bounds restarts with a ledger on the VOLUME, so a flapping seat stops', () => {
+    // The ledger has to survive the restart it records, or it bounds nothing.
+    expect(ENTRYPOINT_CODE).toMatch(/GATEWAY_LIVENESS_LEDGER_DIR="\/opt\/data\//)
+    expect(ENTRYPOINT_CODE).toMatch(/gateway_liveness_kill_budget_ok/)
+    expect(ENTRYPOINT_CODE).toMatch(/REFUSING to restart/)
+  })
+
+  it('never arms on a heartbeat it has not seen fresh this boot', () => {
+    // /opt/data persists, so a beat from the PREVIOUS boot is on disk at every
+    // cold start. Arming on it would SIGKILL the container on every boot.
+    expect(ENTRYPOINT_CODE).toMatch(/armed=0/)
+    expect(ENTRYPOINT_CODE).toMatch(/NOT arming/)
+  })
+
+  it('gates the SIGUSR2 stack dump on the handler actually being registered', () => {
+    // SIGUSR2's default disposition is TERMINATE. If a future pin drops
+    // faulthandler.register, an unguarded send stops being a diagnostic and
+    // becomes an unlogged kill that skips the recovery re-check and the ledger.
+    expect(ENTRYPOINT_CODE).toMatch(/grep -q 'faulthandler\.register'/)
+  })
+
+  it('resolves the profile from the gateway argv, never by mtime ordering', () => {
+    // A seat may carry several persona homes (ADR 0011); only one is the
+    // gateway's. "Newest mtime" identifies it only while it is healthy — the
+    // exact assumption that stops holding in the scenario this watches for.
+    expect(ENTRYPOINT_CODE).toMatch(
+      /\$\{GATEWAY_LIVENESS_PROC_DIR\}\/\$\{SMD_GATEWAY_PID\}\/cmdline/
+    )
+    expect(
+      /ls\s+-1t[\s\S]{0,120}gateway\.heartbeat/.test(ENTRYPOINT_CODE),
+      'must not pick the heartbeat by mtime'
+    ).toBe(false)
+  })
+
+  it('proves its own liveness with a per-iteration tick, not a pid file', () => {
+    // boot-smoke-test.sh Step 11 already records why: a check that confirmed a
+    // process EXISTED rather than that it WORKED is how the 2026-07-16
+    // scheduler outage ran eight days green.
+    expect(ENTRYPOINT_CODE).toMatch(/touch "\$\{GATEWAY_LIVENESS_RUN_DIR\}\/tick"/)
+    expect(
+      /supervisor\.pid/.test(ENTRYPOINT_CODE),
+      'a pid file would prove a number was written once, not that the loop turns'
+    ).toBe(false)
+  })
+})


### PR DESCRIPTION
On 2026-08-20 the paying client's seat was unreachable for 33 minutes and came
back only because a human restarted it. Hermes' own loop-liveness watchdog fired
and logged, verbatim:

> Gateway event loop missed 3 consecutive liveness probes; dumping all thread
> stacks and exiting with code 75 so the service supervisor can restart it.

It did not exit, and there was no service supervisor. `entrypoint.sh` **execs**
the gateway as the container's main process; the respawner already in that file
covers the **broker**; Fly restarts a Machine when its process exits, not when a
health check fails. So the log claimed recovery was underway while nothing at any
layer was going to recover it. Today that cost nothing only because the
firm-address fence was still up. That fence comes down next.

## Three things in ss#2488 that the source contradicts

Read at the exact pin the seat runs — `v2026.8.18@e624e9fd`, matching
`operator/customers/ashton-price/customer.yaml:102`, SHA confirmed by
`git rev-parse` (`vfy_01M0H7AFYWQ9EBZNGNFFMZNZKJ`):

1. **"Make the exit unconditional" is already done.** `shutdown_watchdog.py:196`
   calls `os._exit(75)` directly. There is no graceful asyncio path to harden, so
   the "a clean shutdown needs the wedged loop" theory does not hold. The thread
   reached `logger.critical` (line 173 — the line is in `gateway.log`) and never
   reached the `os._exit` two statements later. Between them sit exactly two
   calls: `faulthandler.dump_traceback(all_threads=True)` and `mark_exited`.
   Which one stalled was never established and the evidence is gone.
2. **The 0-byte `gateway_faulthandler.log` is correct behaviour.** That file is
   written only on SIGUSR2 (`gateway/run.py:12169`) and nobody had ever sent the
   signal. The watchdog's dump passes no `file=` and goes to stderr — where it
   also never landed: the seat's Fly log buffer covers 03:02:00Z–03:49:01Z with
   unbroken 30s coverage and zero traceback lines
   (`vfy_01M0H7A2AZGGHZR3EM2FSZVB82`).
3. **`gateway-exit-diag.log` cannot prove the exit did not happen.** `os._exit`
   bypasses `atexit` and never returns from `asyncio.run`, so a *successful*
   watchdog exit writes nothing there either. The pid staying 655 is the real
   evidence, and it stands.

The conclusion survives. The module's own docstring names the principle: an
asyncio recovery path cannot fire when the loop it needs is stuck. One step
further — an **in-process** recovery path can be blocked by whatever blocked the
process. Recovery has to come from outside it.

## What this adds

A root-side gateway liveness supervisor in `entrypoint.sh`, forked at the same
point and in the same shape as the broker respawner already there. It watches the
loop heartbeat Hermes already writes from an asyncio task **on the loop that
wedges**, so the file goes stale the instant the loop freezes. We were simply not
reading it.

`gateway.heartbeat` → 2 consecutive stale samples → SIGUSR2 (the signal that
finally makes `gateway_faulthandler.log` non-empty) → 20s grace → **re-check, so
a recovered loop is never killed** → SIGTERM → 15s → SIGKILL against
`SMD_GATEWAY_PID`. tini reaps, the container exits non-zero, Fly replaces the
Machine (`restart: [{policy: "on-failure"}]`, no `max_retries` in the deployed
config).

Three guards exist because a probe found each of them, not because they seemed
prudent:

- **The heartbeat is not where the source says it is.** `_process_hermes_home()`
  reads `HERMES_HOME` (`/opt/data`), but `stat /opt/data/state/gateway.heartbeat`
  on a live seat is *No such file or directory* — it sits under the **profile**
  home (`vfy_01M0H9BKDCTFKSC5WSS9Z9DYVG`). The path is derived from the gateway's
  own argv, not by mtime-ordering `profiles/*`: a seat may carry several persona
  homes (ADR 0011), and "newest mtime" identifies the right one only while it is
  healthy — the exact assumption that stops holding here.
- **A live fleet seat has no heartbeat at all.** `hermes-smd-staging` runs 0.18.0
  (`7c1a029`), a pin that predates the feature entirely
  (`vfy_01M0HBR1NZHSRMWSFPSQM32D1E`). There, "no heartbeat ever appeared" means
  the build has none, not that the gateway is wedged — so the supervisor gates on
  the writer module existing and otherwise goes inert and loud, the same
  import-gate discipline as the establishment intake.
- **SIGUSR2's default disposition is terminate.** It is sent only when the
  heartbeat's pid equals the container main **and** `faulthandler.register` is
  present in the installed pin. If a future pin drops that registration, an
  unguarded send stops being a diagnostic and becomes an unlogged kill.

And a kill ledger on the volume caps restarts at 3/hour. A seat flapping every
four minutes is not better than a seat that is down — it is the same outage plus
churn, and it destroys in-flight work each cycle. Past the budget the supervisor
refuses and keeps saying so, so the next thing to touch that Machine is a human.

## Why the tests run the script instead of grepping it

`operator/templates/tests/test_gateway_liveness_supervisor.py` extracts the real
loop text out of `entrypoint.sh` and drives it against a fake process tree. That
is deliberate: a grep-only guard would have passed against the very defect that
opened this issue — a recovery path that logs its intent and never performs it.

Mutation-checked rather than assumed. Deleting `set +e` from the subshell (the
inherited `set -euo pipefail` would otherwise end the supervisor on its first
failed probe, silently, for the life of the container) fails 2 of 10 pytest cases
and 2 of 11 vitest guards. That run also **falsified one of my own claims**: the
vanished-heartbeat test still passed, because bash exempts a failing non-final
member of an `&&` list from errexit. Its docstring now says so and names the two
cases that do detect it, rather than leaving the overclaim in place.

`tests/operator-entrypoint.test.ts` keeps shape locks so the block cannot be
quietly removed. Boot-smoke gets two checks — deliberately **tick freshness, not
a pid file**, per that file's own note about the 2026-07-16 scheduler outage that
ran eight days green because a check confirmed a process existed rather than that
it worked. Both were falsified locally: they fail on absent, fail on stale, pass
on fresh.

One unrelated bug fixed in passing: the boot-time `chown` sweep over `/opt/data`
prunes only the audit subtree, so the kill ledger would have flipped to
agent-owned on the second boot. It is pruned now, for the same reason and in the
same place as the audit dir.

## Scope

Repo layer only. The runtime ACs on ss#2488 stay open: the falsifier (wedge a
non-client seat, observe an unattended restart) has not run, and
`hermes-ashton-price` needs a reprovision to carry any of this —
`sos-session-7` owns that seat and relaunched it at 04:15Z, so this rides their
next build. **I did not touch the client seat.**

Left open deliberately, and worth building next: `/health` is a literal constant
(`self._json(200, {"status": "ok"})`, overlay `webhook_gate.py:985`) and answered
200 every 30 seconds throughout the outage; `fly machine status` still prints that
exact string as the check output. The ADR 0023 heartbeat is emitted by the *gate*,
not the gateway, so it stayed fresh too, and `fleet-alerts`' work-liveness
condition was disarmed by A&P's crons being off for go-live (ss#2332). Every
liveness instrument on that seat is blind by construction. That is a second
vertical slice across two repos plus a migration, blocked on the peer who owns the
overlay ref this week; the supervisor's per-iteration tick file is designed as its
input.

Not explained and not guessed at: why Hermes' watchdog took 22 minutes to notice a
loop it should trip in 90 seconds, and how the gateway pid moved 655 → 657 with
the container never restarting (the gate process ran unbroken across it). The kill
target is therefore **unproven**, and the design is built not to depend on it: it
kills `SMD_GATEWAY_PID`, verifies the process actually went away, falls back to the
pid the heartbeat names, and the ledger bounds the damage if both are wrong.

Post-incident note: `docs/runbooks/operator/incidents/2026-08-20-gateway-wedge-no-restart.md`.

Refs #2488, #2444
