### PR TITLE
feat(operator): the stand-up script can be spoken to the seat on the firm's own mail system (ADR 0078)

### DIFF
--- a/operator/bin/rehearse-card.py
+++ b/operator/bin/rehearse-card.py
@@ -23,13 +23,38 @@ SILENCE IS NEVER A PASS. A command that draws no reply is written as NO REPLY
 with its timeout, because "the seat said nothing" and "the seat answered well"
 must never look alike in the record.
 
-USAGE
-    infisical run --env=prod --path=/ss -- \\
-        operator/bin/rehearse-card.py <slug> --as <admin@address> [--out FILE]
+WHY A SECOND TRANSPORT (2026-08-20). The paying client's seat runs its Email
+connector on Microsoft Graph (ADR 0078: the operator lives on the client's own
+mail system), so it has no AgentMail inbox and an AgentMail-only harness could
+not reach it at all. The tool that proves a seat is client-ready could not speak
+to the only production client. Channel coupling in the instrument is the same
+defect class ADR 0078 names in the product, so the transport is now selected
+from config rather than assumed.
 
+USAGE
+    AgentMail seat (the seat owns an AgentMail inbox):
+        infisical run --env=prod --path=/ss -- \\
+            operator/bin/rehearse-card.py pilot-smokeball --as <admin@address>
+
+    Microsoft Graph seat (the seat mailbox lives in the client's own tenant):
+        infisical run --env=prod --path=/ss -- \\
+            operator/bin/rehearse-card.py ashton-price --as <admin@address>
+
+    --out FILE      transcript path (default card-transcript-<slug>.txt)
     --only N        run just command N (1-based, as printed by --list)
     --list          print the commands and exit; sends nothing
     --timeout SECS  per-command wait (default 420)
+
+TRANSPORT is chosen from the seat's own `connectors.Email.adapter`, never from a
+flag. `msgraph` sends through Resend from the admin address and reads the reply
+out of the SEAT mailbox's Sent Items over app-only Graph, because the admin
+address is a human mailbox this tool holds no credential for. Any other adapter
+keeps the AgentMail path exactly as it was.
+
+ENVIRONMENT
+    AgentMail seats:  AGENTMAIL_API_KEY
+    msgraph seats:    RESEND_API_KEY and MSGRAPH_CLIENT_SECRET__<SLUG>
+                      (slug upper-cased, hyphens as underscores)
 
 Exit codes: 0 = every attempted command drew a reply; 1 = at least one did not;
 2 = the seat/card/config could not be read, or the sender is not an authored
@@ -48,6 +73,7 @@ import time
 import urllib.error
 import urllib.parse
 import urllib.request
+from datetime import datetime, timezone
 from pathlib import Path
 
 import yaml
@@ -55,6 +81,32 @@ import yaml
 REPO_ROOT = Path(__file__).resolve().parents[2]
 CUSTOMERS = REPO_ROOT / "operator" / "customers"
 API_BASE = "https://api.agentmail.to/v0"
+
+RESEND_URL = "https://api.resend.com/emails"
+TOKEN_HOST = "https://login.microsoftonline.com"
+GRAPH_BASE = "https://graph.microsoft.com/v1.0"
+GRAPH_SCOPE = "https://graph.microsoft.com/.default"
+
+# Cloudflare sits in front of api.resend.com and answers urllib's default
+# User-Agent with `403 error code: 1010` (observed live 2026-08-20), so every
+# outbound request this module makes names itself.
+USER_AGENT = "smd-rehearse-card/1.0"
+
+# The seat mailbox's own outbound folder, newest first. The space in $orderby is
+# written %20 because urllib refuses a literal space in a URL.
+SENT_ITEMS_QUERY = (
+    "?$top=10&$orderby=sentDateTime%20desc"
+    "&$select=id,subject,sentDateTime,toRecipients,body"
+)
+
+# Ask Graph for a plain-text body so the transcript holds words rather than HTML.
+TEXT_BODY_PREFER = {"Prefer": 'outlook.body-content-type="text"'}
+
+INFISICAL_RECIPE = "run under `infisical run --env=prod --path=/ss`"
+
+# The subject stem both transports match a reply on. Long enough to be unique per
+# command, short enough to survive a mail client's own subject rewriting.
+SUBJECT_STEM = 38
 
 
 def _die(msg: str, code: int = 2) -> None:
@@ -75,8 +127,8 @@ def load(slug: str) -> tuple[dict, dict]:
     )
 
 
-def seat_inbox(cfg: dict) -> str:
-    """The seat's own inbox, from its authored Email connector."""
+def email_connector(cfg: dict) -> dict:
+    """The seat's authored Email connector, or a loud exit."""
     conns = cfg.get("connectors") or {}
     email = conns.get("Email") if isinstance(conns, dict) else None
     if not isinstance(email, dict) or not email.get("enabled"):
@@ -84,6 +136,35 @@ def seat_inbox(cfg: dict) -> str:
             "this seat authors no enabled Email connector, so there is no channel "
             "to speak the card on — nothing to rehearse"
         )
+    return email
+
+
+def email_adapter(cfg: dict) -> str:
+    """Which transport can reach this seat, read from the seat's own config.
+
+    The seat, not a flag, decides. A flag would let a rehearsal be run over a
+    channel the seat does not actually serve clients on, which is the failure
+    this harness exists to rule out.
+    """
+    return str(email_connector(cfg).get("adapter", "")).strip().lower()
+
+
+def seat_inbox(cfg: dict) -> str:
+    """The seat's own inbox, from its authored Email connector.
+
+    On a `msgraph` seat the address is authored outright (the mailbox lives in
+    the client's tenant, ADR 0078). On every other seat it is still derived from
+    the AgentMail webhook host, unchanged.
+    """
+    email = email_connector(cfg)
+    if str(email.get("adapter", "")).strip().lower() == "msgraph":
+        mailbox = str((email.get("msgraph_auth") or {}).get("mailbox", "")).strip()
+        if not mailbox:
+            _die(
+                "this seat's Email connector is msgraph but authors no "
+                "msgraph_auth.mailbox, so there is no address to speak to"
+            )
+        return mailbox
     url = str(email.get("webhook_url", ""))
     m = re.search(r"hermes-([a-z0-9-]+)\.fly\.dev", url)
     if not m:
@@ -144,7 +225,7 @@ def ask(sender: str, seat: str, subject: str, text: str, key: str, timeout: int)
         s2, res = api("GET", f"/inboxes/{urllib.parse.quote(sender)}/messages?limit=12", key)
         if s2 == 200:
             for m in res.get("messages") or []:
-                if seat in str(m.get("from", "")) and subject[:38] in str(m.get("subject", "")):
+                if seat in str(m.get("from", "")) and subject[:SUBJECT_STEM] in str(m.get("subject", "")):
                     s3, full = api(
                         "GET",
                         f"/inboxes/{urllib.parse.quote(sender)}/messages/{urllib.parse.quote(m['message_id'])}",
@@ -153,6 +234,278 @@ def ask(sender: str, seat: str, subject: str, text: str, key: str, timeout: int)
                     return strip_quote_trail(full.get("text") or "")
         time.sleep(10)
     return None
+
+
+# ---------------------------------------------------------------------------
+# Microsoft Graph transport (ADR 0078 seats).
+#
+# Asymmetric on purpose. OUT: the admin address on scope.admins is a human
+# mailbox in some tenant this tool has no credential for, so the ask ships
+# through Resend from a domain we control. BACK: the reply is read from the SEAT
+# mailbox's Sent Items with the seat's own app-only Graph credential, because
+# that folder is the one place the Operator's answer is observable to us.
+# ---------------------------------------------------------------------------
+
+
+def slug_env_suffix(slug: str) -> str:
+    """`ashton-price` -> `ASHTON_PRICE`.
+
+    Mirrors provision-customer.sh (`tr '[:lower:]-' '[:upper:]_' | tr -cd
+    'A-Z0-9_'`) so this tool reaches for the same variable the provisioner
+    staged. A private derivation here would fail on exactly the seat it is
+    meant to reach.
+    """
+    return re.sub(r"[^A-Z0-9_]", "", slug.upper().replace("-", "_"))
+
+
+def msgraph_secret_env_names(slug: str, email: dict) -> tuple[str, str]:
+    """(per-seat variable, global fallback) holding the Graph client secret.
+
+    The NAME comes from `msgraph_auth.secret_ref` with its `fly-secret:` prefix
+    stripped, same as the provisioner; the value is never in customer.yaml
+    (ADR 0010, client custody).
+    """
+    ref = str((email.get("msgraph_auth") or {}).get("secret_ref", "")).strip()
+    base = ref[len("fly-secret:") :] if ref.startswith("fly-secret:") else ""
+    base = base or "MSGRAPH_CLIENT_SECRET"
+    return f"{base}__{slug_env_suffix(slug)}", base
+
+
+def _open(req: urllib.request.Request, timeout: int = 45) -> tuple[int, str]:
+    """One HTTP round trip, returning (status, truncated body).
+
+    Errors are returned rather than raised so a caller decides what a non-2xx
+    means. No request header is ever echoed, so a bearer cannot reach a log.
+    """
+    try:
+        # Every URL here is one of this module's own constants concatenated with
+        # a path this module builds; no caller supplies a scheme or host, so the
+        # file:// concern the rule guards does not arise. Same suppression and
+        # reasoning as `api` above.
+        # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            return r.status, r.read().decode()[:400]
+    except urllib.error.HTTPError as e:
+        return e.code, e.read().decode()[:400]
+
+
+def graph_token(tenant_id: str, client_id: str, client_secret: str) -> tuple[str, int]:
+    """Mint an app-only bearer. Returns (token, seconds until it expires)."""
+    body = urllib.parse.urlencode(
+        {
+            "client_id": client_id,
+            "client_secret": client_secret,
+            "scope": GRAPH_SCOPE,
+            "grant_type": "client_credentials",
+        }
+    ).encode()
+    req = urllib.request.Request(
+        f"{TOKEN_HOST}/{urllib.parse.quote(tenant_id)}/oauth2/v2.0/token",
+        data=body,
+        method="POST",
+        headers={
+            "Content-Type": "application/x-www-form-urlencoded",
+            "Accept": "application/json",
+            "User-Agent": USER_AGENT,
+        },
+    )
+    status, raw = _open(req)
+    if status < 200 or status >= 300:
+        # Status only. The response body is not echoed, because a rejected grant
+        # is exactly the moment a credential is most likely to end up in a log.
+        _die(
+            f"the Microsoft identity platform refused the client-credentials grant "
+            f"(HTTP {status}). Check msgraph_auth.tenant_id and client_id in "
+            f"customer.yaml, and that the vaulted client secret has not expired."
+        )
+    payload = json.loads(raw or "{}") or {}
+    token = str(payload.get("access_token") or "")
+    ttl = int(payload.get("expires_in") or 3600)
+    if not token:
+        _die("the token response carried no access_token")
+    return token, ttl
+
+
+class GraphToken:
+    """Holds the app-only bearer and re-mints it on expiry.
+
+    A full card is 17 commands at up to 420s each, which outlasts a Graph
+    token's hour. The value is never printed, logged, or written to the
+    transcript.
+    """
+
+    def __init__(self, tenant_id: str, client_id: str, client_secret: str) -> None:
+        self._tenant = tenant_id
+        self._client = client_id
+        self._secret = client_secret
+        self._token = ""
+        self._expires_at = 0.0
+
+    def value(self) -> str:
+        if not self._token or time.time() >= self._expires_at:
+            self._token, ttl = graph_token(self._tenant, self._client, self._secret)
+            self._expires_at = time.time() + max(ttl - 300, 60)
+        return self._token
+
+
+def graph_get(path: str, token: str, headers: dict | None = None) -> tuple[int, dict]:
+    req = urllib.request.Request(
+        GRAPH_BASE + path,
+        method="GET",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/json",
+            "User-Agent": USER_AGENT,
+            **(headers or {}),
+        },
+    )
+    status, raw = _open(req)
+    if status != 200:
+        return status, {"raw": raw}
+    try:
+        return status, json.loads(raw or "{}")
+    except json.JSONDecodeError:
+        return status, {}
+
+
+def resend_send(sender: str, seat: str, subject: str, text: str, key: str) -> tuple[int, str]:
+    """Ship the ask from the admin address through Resend.
+
+    The sender's domain must be Resend-verified with sending enabled, or Resend
+    refuses; smd.services is. A non-2xx is returned, never swallowed, so the
+    caller can record a refusal rather than invent silence.
+    """
+    req = urllib.request.Request(
+        RESEND_URL,
+        data=json.dumps({"from": sender, "to": [seat], "subject": subject, "text": text}).encode(),
+        method="POST",
+        headers={
+            "Authorization": f"Bearer {key}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "User-Agent": USER_AGENT,
+        },
+    )
+    return _open(req)
+
+
+def parse_stamp(raw: object) -> datetime | None:
+    """Graph's ISO-8601 timestamp as an aware datetime, or None if unreadable.
+
+    Parsed rather than string-compared: Graph emits up to seven fractional
+    digits, and `...06.0000000Z` sorts BELOW `...06Z` lexically, so a text
+    compare would call a later message earlier inside the same second.
+    """
+    s = str(raw or "").strip()
+    if not s:
+        return None
+    s = s[:-1] + "+00:00" if s.endswith("Z") else s
+    trimmed = re.match(r"^(.*\.\d{6})\d*([+-]\d{2}:\d{2})$", s)
+    if trimmed:
+        s = trimmed.group(1) + trimmed.group(2)
+    try:
+        dt = datetime.fromisoformat(s)
+    except ValueError:
+        return None
+    return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+
+
+def recipient_addresses(msg: dict) -> set[str]:
+    out = set()
+    for r in msg.get("toRecipients") or []:
+        addr = ((r or {}).get("emailAddress") or {}).get("address")
+        if addr:
+            out.add(str(addr).strip().lower())
+    return out
+
+
+def msgraph_reply_matches(msg: dict, sender: str, subject: str, floor: datetime) -> bool:
+    """True only for the answer to THIS ask.
+
+    Three conjuncts, each closing a different way the record could be wrong. The
+    recipient, because a reply to somebody else is not our reply. The subject
+    stem, the same rule the AgentMail path uses. And the send time, because a
+    prior rehearsal's answer sits in that folder forever: reading one as this
+    ask's reply is a silent false positive, and a harness that can report a
+    stale answer as a fresh one measures nothing.
+    """
+    if sender.strip().lower() not in recipient_addresses(msg):
+        return False
+    if subject[:SUBJECT_STEM] not in str(msg.get("subject", "")):
+        return False
+    stamp = parse_stamp(msg.get("sentDateTime"))
+    return stamp is not None and stamp > floor
+
+
+def ask_msgraph(
+    sender: str,
+    seat: str,
+    subject: str,
+    text: str,
+    resend_key: str,
+    token: GraphToken,
+    timeout: int,
+) -> str | None:
+    floor = datetime.now(timezone.utc)
+    status, body = resend_send(sender, seat, subject, text, resend_key)
+    if status < 200 or status >= 300:
+        print(f"    SEND REFUSED by Resend (HTTP {status}): {body}")
+        return None
+    path = f"/users/{urllib.parse.quote(seat)}/mailFolders/SentItems/messages{SENT_ITEMS_QUERY}"
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        st, res = graph_get(path, token.value(), TEXT_BODY_PREFER)
+        if st == 200:
+            for m in res.get("value") or []:
+                if msgraph_reply_matches(m, sender, subject, floor):
+                    return strip_quote_trail(str((m.get("body") or {}).get("content") or ""))
+        time.sleep(10)
+    return None
+
+
+def agentmail_asker(sender: str, seat: str, timeout: int):
+    key = os.environ.get("AGENTMAIL_API_KEY")
+    if not key:
+        _die("AGENTMAIL_API_KEY unset — run under `infisical run --env=prod --path=/ss`")
+
+    def asker(subject: str, text: str) -> str | None:
+        return ask(sender, seat, subject, text, key, timeout)
+
+    return asker
+
+
+def msgraph_asker(slug: str, cfg: dict, sender: str, seat: str, timeout: int):
+    """Bind the Graph transport, or exit naming the one thing that is missing."""
+    resend_key = os.environ.get("RESEND_API_KEY")
+    if not resend_key:
+        _die(
+            f"RESEND_API_KEY unset. This seat's Email connector is msgraph, so the "
+            f"ask is sent from {sender} through Resend rather than an AgentMail "
+            f"inbox. To fix: {INFISICAL_RECIPE}."
+        )
+    email = email_connector(cfg)
+    auth = email.get("msgraph_auth") or {}
+    per_seat, fallback = msgraph_secret_env_names(slug, email)
+    secret = os.environ.get(per_seat) or os.environ.get(fallback)
+    if not secret:
+        _die(
+            f"{per_seat} unset (and no {fallback} fallback). It holds this seat's "
+            f"Graph client secret, which is how the reply is read back out of "
+            f"{seat}'s Sent Items. To fix: {INFISICAL_RECIPE}."
+        )
+    tenant = str(auth.get("tenant_id") or "").strip()
+    client = str(auth.get("client_id") or "").strip()
+    if not tenant or not client:
+        _die(
+            "msgraph_auth is missing tenant_id or client_id, so no app-only token "
+            "can be minted and the reply could never be read"
+        )
+    token = GraphToken(tenant, client, secret)
+
+    def asker(subject: str, text: str) -> str | None:
+        return ask_msgraph(sender, seat, subject, text, resend_key, token, timeout)
+
+    return asker
 
 
 def main() -> int:
@@ -193,11 +546,13 @@ def main() -> int:
             f"{', '.join(sorted(admins)) or '(none)'}"
         )
 
-    key = os.environ.get("AGENTMAIL_API_KEY")
-    if not key:
-        _die("AGENTMAIL_API_KEY unset — run under `infisical run --env=prod --path=/ss`")
-
+    adapter = email_adapter(cfg)
     seat = seat_inbox(cfg)
+    if adapter == "msgraph":
+        ask_one = msgraph_asker(args.slug, cfg, args.sender, seat, args.timeout)
+    else:
+        ask_one = agentmail_asker(args.sender, seat, args.timeout)
+
     chosen = [commands[args.only - 1]] if args.only else commands
     if args.only and not (1 <= args.only <= len(commands)):
         _die(f"--only must be 1..{len(commands)}")
@@ -206,6 +561,7 @@ def main() -> int:
     silent = 0
     with out_path.open("w") as fh:
         fh.write(f"REHEARSAL TRANSCRIPT — {args.slug} — spoken as {args.sender}\n")
+        fh.write(f"Seat: {seat} (transport: {adapter or 'agentmail'})\n")
         fh.write(
             "\nThis file is EVIDENCE, not a verdict. Each reply is paired with the "
             "card's own expected and falsifier so a reader who did not run the "
@@ -216,7 +572,7 @@ def main() -> int:
             say = " ".join(str(c.get("say", "")).split())
             subject = f"Card {n} - {c.get('backed_by', 'command')}"
             print(f"[{n}/{len(commands)}] {say[:70]}")
-            reply = ask(args.sender, seat, subject, say, key, args.timeout)
+            reply = ask_one(subject, say)
             fh.write(f"\n\n{'=' * 72}\n### Command {n} [{c['stage']}] backed_by: {c.get('backed_by')}\n")
             fh.write(f"SAID: {say}\n\nEXPECTED: {' '.join(str(c.get('expected', '')).split())}\n")
             fh.write(f"\nFALSIFIER: {' '.join(str(c.get('falsifier', '')).split())}\n\n")

--- a/operator/bin/tests/test_rehearse_card.py
+++ b/operator/bin/tests/test_rehearse_card.py
@@ -10,7 +10,12 @@ answer. Each has a test.
 from __future__ import annotations
 
 import importlib.util
+import io
+import json
+import re
+import subprocess
 import sys
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
@@ -108,3 +113,371 @@ def test_harness_does_not_grade() -> None:
     would industrialise that error. If a `grade`/`verdict` helper ever appears,
     this test should be the argument against it."""
     assert not [n for n in dir(rc) if n.lower() in {"grade", "judge", "verdict", "score"}]
+
+
+# ---------------------------------------------------------------------------
+# Microsoft Graph transport (ADR 0078).
+#
+# The AgentMail path proves itself against a seat we own. This one has to reach
+# a mailbox in the CLIENT's tenant, so its failure modes are different: sending
+# from an address with no inbox we can read, and reading a folder that keeps
+# every prior rehearsal's reply forever. Both get a test.
+# ---------------------------------------------------------------------------
+
+_MSGRAPH_CFG = {
+    "connectors": {
+        "Email": {
+            "enabled": True,
+            "adapter": "msgraph",
+            "backend": "mcp:msgraph-mail",
+            "msgraph_auth": {
+                "tenant_id": "tenant-guid",
+                "client_id": "client-guid",
+                "mailbox": "operator@example.test",
+                "secret_ref": "fly-secret:MSGRAPH_CLIENT_SECRET",
+            },
+        }
+    }
+}
+
+_FLOOR = datetime(2026, 8, 20, 12, 0, 0, tzinfo=timezone.utc)
+_SUBJECT = "Card 3 - matter-inbox-router answers the request"
+
+
+class _FakeResponse:
+    def __init__(self, status: int, body: str) -> None:
+        self.status = status
+        self._body = body.encode()
+
+    def read(self) -> bytes:
+        return self._body
+
+    def __enter__(self) -> _FakeResponse:
+        return self
+
+    def __exit__(self, *_exc: object) -> bool:
+        return False
+
+
+class _StubToken:
+    def value(self) -> str:
+        return "stub-bearer"
+
+
+class _ExplodingToken:
+    """A token that fails if anyone asks for it, so a test can assert that a
+    given path never reached Graph at all."""
+
+    def value(self) -> str:
+        raise AssertionError("Graph must not be polled on this path")
+
+
+def _sent_message(to: str, subject: str, stamp: str, body: str = "the answer") -> dict:
+    return {
+        "id": "msg-1",
+        "subject": subject,
+        "sentDateTime": stamp,
+        "toRecipients": [{"emailAddress": {"address": to}}],
+        "body": {"contentType": "text", "content": body},
+    }
+
+
+def test_msgraph_seat_address_is_the_authored_mailbox() -> None:
+    """A msgraph seat's address is authored, not derived: the mailbox lives in
+    the client's own tenant (ADR 0078) and has no hermes-<slug>.fly.dev host to
+    parse it out of."""
+    assert rc.email_adapter(_MSGRAPH_CFG) == "msgraph"
+    assert rc.seat_inbox(_MSGRAPH_CFG) == "operator@example.test"
+
+
+def test_msgraph_seat_without_a_mailbox_is_refused() -> None:
+    cfg = {"connectors": {"Email": {"enabled": True, "adapter": "msgraph", "msgraph_auth": {}}}}
+    with pytest.raises(SystemExit) as e:
+        rc.seat_inbox(cfg)
+    assert e.value.code == 2
+
+
+def test_agentmail_derivation_is_untouched_by_the_second_transport() -> None:
+    """The regression this whole change must not cause. Adding a transport that
+    reads an authored address must not change how the AgentMail seat finds
+    its own."""
+    cfg = {
+        "connectors": {
+            "Email": {
+                "enabled": True,
+                "adapter": "agentmail",
+                "webhook_url": "https://hermes-pilot-smokeball.fly.dev/webhooks/agentmail",
+            }
+        }
+    }
+    assert rc.email_adapter(cfg) == "agentmail"
+    assert rc.seat_inbox(cfg) == "pilot-smokeball@agentmail.to"
+
+
+def test_the_real_seats_resolve_as_authored() -> None:
+    """Pinned against the two real customer.yaml files, because the whole point
+    of reading the adapter from config is that config is what changes. If the
+    paying client's channel moves, this fails here rather than at a rehearsal.
+
+    The client's own mailbox address is read out of its config rather than
+    written here: client identity belongs in operator/customers/, never in a
+    test file (tests/client-identity-gate.test.ts)."""
+    ap = yaml.safe_load((rc.CUSTOMERS / "ashton-price" / "customer.yaml").read_text())
+    pilot = yaml.safe_load((rc.CUSTOMERS / "pilot-smokeball" / "customer.yaml").read_text())
+    authored_mailbox = rc.email_connector(ap)["msgraph_auth"]["mailbox"]
+    assert rc.email_adapter(ap) == "msgraph"
+    assert rc.seat_inbox(ap) == authored_mailbox
+    assert "@" in authored_mailbox and not authored_mailbox.endswith("@agentmail.to")
+    assert rc.email_adapter(pilot) == "agentmail"
+    assert rc.seat_inbox(pilot) == "pilot-smokeball@agentmail.to"
+
+
+# ---- the per-seat secret name -------------------------------------------
+
+_PROVISIONER = rc.REPO_ROOT / "operator" / "bin" / "provision-customer.sh"
+_TR_PIPELINE = r"tr '\[:lower:\]-' '\[:upper:\]_' \| tr -cd 'A-Z0-9_'"
+
+
+def test_slug_suffix_matches_the_provisioner_by_running_it() -> None:
+    """The provisioner stages the client secret under a name it derives with a
+    `tr` pipeline. If this tool derives a different name it reaches for a
+    variable nobody set, on exactly the seat it exists to reach. So the
+    pipeline is read out of the script and RUN, not paraphrased here: a change
+    to either side fails this test."""
+    found = re.search(_TR_PIPELINE, _PROVISIONER.read_text())
+    assert found, "provision-customer.sh no longer derives the per-seat suffix as expected"
+    pipeline = found.group(0).replace("\\", "")
+    for slug in ("ashton-price", "pilot-smokeball", "a-b-c", "acme"):
+        shell = subprocess.run(
+            ["sh", "-c", f"printf '%s' '{slug}' | {pipeline}"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+        assert rc.slug_env_suffix(slug) == shell, slug
+
+
+def test_hyphenated_slug_becomes_an_underscored_variable() -> None:
+    assert rc.slug_env_suffix("ashton-price") == "ASHTON_PRICE"
+    assert rc.msgraph_secret_env_names("ashton-price", _MSGRAPH_CFG["connectors"]["Email"]) == (
+        "MSGRAPH_CLIENT_SECRET__ASHTON_PRICE",
+        "MSGRAPH_CLIENT_SECRET",
+    )
+
+
+def test_secret_name_follows_the_authored_secret_ref() -> None:
+    """The NAME is authored (msgraph_auth.secret_ref); only the VALUE is
+    vaulted (ADR 0010). A seat that names a different Fly secret must be read
+    from a differently named variable."""
+    email = {"msgraph_auth": {"secret_ref": "fly-secret:FIRM_GRAPH_SECRET"}}
+    assert rc.msgraph_secret_env_names("acme-co", email) == (
+        "FIRM_GRAPH_SECRET__ACME_CO",
+        "FIRM_GRAPH_SECRET",
+    )
+
+
+def test_unauthored_secret_ref_falls_back_to_the_default_name() -> None:
+    assert rc.msgraph_secret_env_names("acme", {}) == (
+        "MSGRAPH_CLIENT_SECRET__ACME",
+        "MSGRAPH_CLIENT_SECRET",
+    )
+
+
+def test_the_paying_seat_names_the_variable_infisical_actually_holds() -> None:
+    cfg = yaml.safe_load((rc.CUSTOMERS / "ashton-price" / "customer.yaml").read_text())
+    per_seat, _ = rc.msgraph_secret_env_names("ashton-price", rc.email_connector(cfg))
+    assert per_seat == "MSGRAPH_CLIENT_SECRET__ASHTON_PRICE"
+
+
+# ---- environment, and what a failure is allowed to say -------------------
+
+
+def test_missing_graph_secret_names_the_variable_and_leaks_no_others(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A missing credential must be diagnosable without dumping the environment.
+    The message names the one variable and the recipe; every other secret in the
+    process stays out of the transcript."""
+    monkeypatch.setenv("RESEND_API_KEY", "re_live_should_not_appear")
+    monkeypatch.setenv("AGENTMAIL_API_KEY", "am_should_not_appear")
+    monkeypatch.setenv("SMOKEBALL_PROD_CLIENT_SECRET", "sb_should_not_appear")
+    monkeypatch.delenv("MSGRAPH_CLIENT_SECRET__ASHTON_PRICE", raising=False)
+    monkeypatch.delenv("MSGRAPH_CLIENT_SECRET", raising=False)
+
+    with pytest.raises(SystemExit) as e:
+        rc.msgraph_asker("ashton-price", _MSGRAPH_CFG, "scott@smd.services", "operator@example.test", 5)
+    assert e.value.code == 2
+
+    err = capsys.readouterr().err
+    assert "MSGRAPH_CLIENT_SECRET__ASHTON_PRICE" in err
+    assert "infisical run --env=prod --path=/ss" in err
+    for leaked in ("re_live_should_not_appear", "am_should_not_appear", "sb_should_not_appear"):
+        assert leaked not in err
+
+
+def test_missing_resend_key_names_resend_not_agentmail(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.delenv("RESEND_API_KEY", raising=False)
+    with pytest.raises(SystemExit):
+        rc.msgraph_asker("ashton-price", _MSGRAPH_CFG, "scott@smd.services", "operator@example.test", 5)
+    err = capsys.readouterr().err
+    assert "RESEND_API_KEY" in err
+    assert "AGENTMAIL" not in err
+
+
+# ---- matching the reply --------------------------------------------------
+
+
+def test_the_genuine_reply_is_matched() -> None:
+    """The positive case, so the three rejections below are known to be
+    rejecting something this function would otherwise accept."""
+    msg = _sent_message("scott@smd.services", _SUBJECT, "2026-08-20T12:04:00Z")
+    assert rc.msgraph_reply_matches(msg, "scott@smd.services", _SUBJECT, _FLOOR)
+
+
+def test_a_prior_rehearsals_reply_is_not_this_ones(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The silent false positive this transport could have had. Sent Items keeps
+    every earlier rehearsal's answer forever, and one of them carries the same
+    recipient and the same subject stem. Matching on those two alone would
+    report an answer the seat did not just give."""
+    stale = _sent_message("scott@smd.services", _SUBJECT, "2026-08-20T11:59:59Z")
+    assert not rc.msgraph_reply_matches(stale, "scott@smd.services", _SUBJECT, _FLOOR)
+
+
+def test_a_reply_sent_at_the_floor_is_not_counted() -> None:
+    """Strictly after. The floor is stamped immediately before the send, so a
+    message at that instant predates the ask."""
+    msg = _sent_message("scott@smd.services", _SUBJECT, "2026-08-20T12:00:00Z")
+    assert not rc.msgraph_reply_matches(msg, "scott@smd.services", _SUBJECT, _FLOOR)
+
+
+def test_a_reply_to_someone_else_is_not_ours() -> None:
+    msg = _sent_message("someone.else@firm.example", _SUBJECT, "2026-08-20T12:04:00Z")
+    assert not rc.msgraph_reply_matches(msg, "scott@smd.services", _SUBJECT, _FLOOR)
+
+
+def test_a_reply_about_another_command_is_not_ours() -> None:
+    msg = _sent_message("scott@smd.services", "Card 9 - something else entirely", "2026-08-20T12:04:00Z")
+    assert not rc.msgraph_reply_matches(msg, "scott@smd.services", _SUBJECT, _FLOOR)
+
+
+def test_an_unreadable_timestamp_is_not_a_pass() -> None:
+    """Silence is never a pass, and neither is a message we cannot date. Failing
+    open here would let any Sent Items row stand in for the reply."""
+    for stamp in ("", "not-a-date", None):
+        msg = _sent_message("scott@smd.services", _SUBJECT, stamp)  # type: ignore[arg-type]
+        assert not rc.msgraph_reply_matches(msg, "scott@smd.services", _SUBJECT, _FLOOR)
+
+
+def test_recipient_match_ignores_case() -> None:
+    msg = _sent_message("Scott@SMD.Services", _SUBJECT, "2026-08-20T12:04:00Z")
+    assert rc.msgraph_reply_matches(msg, "scott@smd.services", _SUBJECT, _FLOOR)
+
+
+def test_seven_digit_fractions_sort_later_not_earlier() -> None:
+    """Why the timestamp is parsed and not string-compared. Graph emits up to
+    seven fractional digits, and '.' sorts below 'Z', so a lexical compare calls
+    a message later in the same second EARLIER and discards a genuine reply."""
+    assert "2026-08-20T12:00:00.5000000Z" < "2026-08-20T12:00:00Z"
+    later = rc.parse_stamp("2026-08-20T12:00:00.5000000Z")
+    floor = rc.parse_stamp("2026-08-20T12:00:00Z")
+    assert later is not None and floor is not None
+    assert later > floor
+
+
+# ---- the wire ------------------------------------------------------------
+
+
+def test_resend_request_names_itself_to_cloudflare(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Cloudflare fronts api.resend.com and answers urllib's default User-Agent
+    with `403 error code: 1010` (observed live 2026-08-20). Without an explicit
+    one, every ask on a msgraph seat is refused before Resend ever sees it."""
+    seen: dict = {}
+
+    def fake(req: object, timeout: int = 45) -> _FakeResponse:
+        seen["url"] = req.full_url  # type: ignore[attr-defined]
+        seen["headers"] = dict(req.headers)  # type: ignore[attr-defined]
+        seen["body"] = json.loads(req.data.decode())  # type: ignore[attr-defined]
+        return _FakeResponse(200, '{"id": "re_1"}')
+
+    monkeypatch.setattr(rc.urllib.request, "urlopen", fake)
+    status, _ = rc.resend_send("scott@smd.services", "operator@example.test", "Card 1 - x", "say", "k")
+
+    assert status == 200
+    assert seen["url"] == rc.RESEND_URL
+    # urllib capitalizes header names as it stores them.
+    assert seen["headers"]["User-agent"] == rc.USER_AGENT
+    assert seen["body"] == {
+        "from": "scott@smd.services",
+        "to": ["operator@example.test"],
+        "subject": "Card 1 - x",
+        "text": "say",
+    }
+
+
+def test_sent_items_query_encodes_the_orderby_space() -> None:
+    """urllib refuses a literal space in a URL, so `$orderby=sentDateTime desc`
+    has to ship as %20 or the poll never runs."""
+    assert "%20" in rc.SENT_ITEMS_QUERY
+    assert " " not in rc.SENT_ITEMS_QUERY
+
+
+def test_graph_read_asks_for_a_plain_text_body(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without the Prefer header Graph returns HTML and the transcript fills with
+    markup instead of the Operator's words."""
+    seen: dict = {}
+
+    def fake(req: object, timeout: int = 45) -> _FakeResponse:
+        seen["headers"] = dict(req.headers)  # type: ignore[attr-defined]
+        return _FakeResponse(200, '{"value": []}')
+
+    monkeypatch.setattr(rc.urllib.request, "urlopen", fake)
+    rc.graph_get("/users/x/mailFolders/SentItems/messages", "tok", rc.TEXT_BODY_PREFER)
+    assert seen["headers"]["Prefer"] == 'outlook.body-content-type="text"'
+    assert seen["headers"]["Authorization"] == "Bearer tok"
+
+
+def test_a_refused_send_is_recorded_as_no_reply(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Fail closed and say so. A refused send that returned a reply from an
+    earlier run, or that polled at all, would put an answer in the transcript
+    for a command the seat never received."""
+
+    def refuse(req: object, timeout: int = 45) -> _FakeResponse:
+        raise rc.urllib.error.HTTPError(
+            req.full_url, 403, "Forbidden", {}, io.BytesIO(b"error code: 1010")  # type: ignore[attr-defined,arg-type]
+        )
+
+    monkeypatch.setattr(rc.urllib.request, "urlopen", refuse)
+    out = rc.ask_msgraph(
+        "scott@smd.services", "operator@example.test", "Card 1 - x", "say", "k", _ExplodingToken(), 5
+    )
+    assert out is None
+    assert "SEND REFUSED" in capsys.readouterr().out
+
+
+def test_the_reply_comes_back_from_the_seats_sent_items(monkeypatch: pytest.MonkeyPatch) -> None:
+    """End to end over a mocked wire: ship through Resend, read the seat's own
+    outbound folder, strip the quoted trail, return the Operator's words."""
+    urls: list[str] = []
+    fresh = (datetime.now(timezone.utc) + timedelta(seconds=5)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    reply = "The matter is open.\n\nOn Thu, Aug 20, 2026 someone wrote:\n> the original"
+
+    def fake(req: object, timeout: int = 45) -> _FakeResponse:
+        url = req.full_url  # type: ignore[attr-defined]
+        urls.append(url)
+        if url == rc.RESEND_URL:
+            return _FakeResponse(200, '{"id": "re_1"}')
+        payload = {"value": [_sent_message("scott@smd.services", "Card 1 - x", fresh, reply)]}
+        return _FakeResponse(200, json.dumps(payload))
+
+    monkeypatch.setattr(rc.urllib.request, "urlopen", fake)
+    out = rc.ask_msgraph(
+        "scott@smd.services", "operator@example.test", "Card 1 - x", "say", "k", _StubToken(), 30
+    )
+
+    assert out == "The matter is open."
+    assert urls[0] == rc.RESEND_URL
+    assert "/users/operator%40example.test/mailFolders/SentItems/messages" in urls[1]


### PR DESCRIPTION
## What could not be done before

`operator/bin/rehearse-card.py` is the harness that says the stand-up script to a seat and writes the transcript, so a seat is only called client-ready after the card was actually spoken to it. It could reach exactly one kind of seat: one that owns an AgentMail inbox. `seat_inbox()` parsed the address out of a `hermes-<slug>.fly.dev` webhook URL, and `ask()` sent and polled through the AgentMail API.

The paying client's seat does not have an AgentMail inbox. Its Email connector is Microsoft Graph on the firm's own tenant (`operator/customers/ashton-price/customer.yaml`, `connectors.Email.adapter: msgraph`), per ADR 0078 (client-custody email). The tool died at `seat_inbox` before sending anything. The harness that decides whether a seat is client-ready could not reach the only production client. Channel coupling in the instrument, which is the same defect class ADR 0078 names in the product.

## What can be done now

The transport is selected from the seat's own `connectors.Email.adapter`, never from a flag. A flag would let a rehearsal run over a channel the seat does not actually serve clients on, which is the failure the harness exists to rule out.

- **Seat address.** `msgraph` reads `connectors.Email.msgraph_auth.mailbox` (authored, because a client-tenant mailbox has no `hermes-<slug>` host to parse). Everything else keeps the existing derivation.
- **Sending.** The `--as` sender is a human address on `scope.admins` with no AgentMail inbox, so the ask ships through Resend from a domain we control.
- **Reading the reply.** Polled from the SEAT mailbox's Sent Items over app-only Graph client credentials, because the human sender's own mailbox is not something this tool holds a credential for. A message counts as the reply only if `toRecipients` contains the sender, the subject carries the first 38 characters of the sent subject (the same rule the AgentMail path uses), **and** `sentDateTime` is after the moment the ask was sent.
- **Secret hygiene.** The bearer and the client secret are never printed, logged, or written to the transcript. A rejected token grant reports its HTTP status only, since that is the moment a credential is most likely to reach a log.
- **Fail closed.** A non-2xx from Resend is recorded as `SEND REFUSED` and returns no reply; Graph is never polled on that path. The existing `scope.admins` sender gate is untouched and still runs before any transport is bound.

Three facts the wire forced, each pinned by a test:

1. Cloudflare fronts `api.resend.com` and answers urllib's default User-Agent with `403 error code: 1010`, so every request names itself.
2. urllib refuses a literal space in a URL, so `$orderby=sentDateTime desc` ships as `%20`.
3. Sent Items keeps every prior rehearsal's answer forever, under the same recipient and the same subject stem. Matching on those two alone would report a stale answer as this ask's reply. That is the silent false positive this harness must not have, so the send time is the third conjunct.

**AgentMail behavior is byte-identical.** Same address derivation, same API calls, same match rule, same `AGENTMAIL_API_KEY`. The only edit on that path is `subject[:38]` becoming `subject[:SUBJECT_STEM]`, where `SUBJECT_STEM = 38`.

## Env recipe

```
# AgentMail seat
infisical run --env=prod --path=/ss -- \
    operator/bin/rehearse-card.py pilot-smokeball --as <admin@address>

# Microsoft Graph seat
infisical run --env=prod --path=/ss -- \
    operator/bin/rehearse-card.py ashton-price --as <admin@address>
```

AgentMail seats need `AGENTMAIL_API_KEY` (unchanged). msgraph seats need `RESEND_API_KEY` and `MSGRAPH_CLIENT_SECRET__<SLUG>` (slug upper-cased, hyphens as underscores), both present in Infisical `/ss` prod. The secret NAME is derived from the authored `msgraph_auth.secret_ref`, and the per-seat suffix mirrors `provision-customer.sh` so the tool reaches for the variable the provisioner actually staged. A missing variable exits 2 naming that one variable and this recipe, and never dumps the environment.

## Tests

`operator/bin/tests/test_rehearse_card.py`: 11 existing tests unchanged, 24 added, 35 passed.

Adapter selection and addressing:

- `test_msgraph_seat_address_is_the_authored_mailbox`
- `test_msgraph_seat_without_a_mailbox_is_refused`
- `test_agentmail_derivation_is_untouched_by_the_second_transport`
- `test_the_real_seats_resolve_as_authored` (pinned against both real `customer.yaml` files; the client's mailbox is read out of config rather than written into the test, per `tests/client-identity-gate.test.ts`)

The per-seat secret name:

- `test_slug_suffix_matches_the_provisioner_by_running_it` (reads the `tr` pipeline out of `provision-customer.sh` and runs it, so a change to either side fails)
- `test_hyphenated_slug_becomes_an_underscored_variable`
- `test_secret_name_follows_the_authored_secret_ref`
- `test_unauthored_secret_ref_falls_back_to_the_default_name`
- `test_the_paying_seat_names_the_variable_infisical_actually_holds`

Environment failures:

- `test_missing_graph_secret_names_the_variable_and_leaks_no_others` (three decoy secrets are set in the environment and asserted absent from stderr)
- `test_missing_resend_key_names_resend_not_agentmail`

Matching the reply:

- `test_the_genuine_reply_is_matched` (the positive case, so the rejections below are known to be rejecting something otherwise accepted)
- `test_a_prior_rehearsals_reply_is_not_this_ones`
- `test_a_reply_sent_at_the_floor_is_not_counted`
- `test_a_reply_to_someone_else_is_not_ours`
- `test_a_reply_about_another_command_is_not_ours`
- `test_an_unreadable_timestamp_is_not_a_pass`
- `test_recipient_match_ignores_case`
- `test_seven_digit_fractions_sort_later_not_earlier` (why the timestamp is parsed and not string-compared: `.` sorts below `Z`, so a lexical compare discards a genuine reply landing in the same second)

The wire, with `urllib.request.urlopen` mocked:

- `test_resend_request_names_itself_to_cloudflare`
- `test_sent_items_query_encodes_the_orderby_space`
- `test_graph_read_asks_for_a_plain_text_body`
- `test_a_refused_send_is_recorded_as_no_reply` (asserts Graph is never polled after a refused send, via a token stub that raises if touched)
- `test_the_reply_comes_back_from_the_seats_sent_items`

**Falsifier pass.** Six mutations were applied to the implementation and the suite went red on each: dropping the `sentDateTime` conjunct, dropping the recipient conjunct, dropping the subject conjunct, removing the Resend `User-Agent`, removing the Graph `Prefer` header, and removing the hyphen mapping from the slug suffix. Nine tests failed on the first round and three on the second, in each case the ones that name the mutated behavior.

```
35 passed in 0.20s
```

Whole `operator/bin/tests` suite: `471 passed in 14.51s`. Run with `PYTHONDONTWRITEBYTECODE=1`.

`npm run verify` exits 0 (13 pre-existing lint warnings, 0 errors, under the `--max-warnings 13` ceiling).

## Not done here

No rehearsal was run. This PR adds the capability; speaking the card to the live seat is a separate act.

References ADR 0078.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017NcRcv8JotFDQxYnGWoaSz
