### PR TITLE
fix(operator): the gateway supervisor publishes its state where the heartbeat can read it (ss#2488 part 2, PR 1/3)

### DIFF
--- a/operator/bin/boot-smoke-test.sh
+++ b/operator/bin/boot-smoke-test.sh
@@ -266,6 +266,16 @@ ssh_exec_script "broker-socket-answers-health" "setpriv --reuid=hermes --regid=h
 # invisible, an inherited `set -e` killing the subshell on its first failed probe.
 ssh_exec "gateway-liveness-supervisor-ticking" "t=/run/smd-gateway-liveness/tick; [ -f \$t ] && [ \$(( \$(date -u +%s) - \$(stat -c %Y \$t) )) -lt 90 ]"
 
+# Ticking proves the loop turns; it does not prove the loop ever found the
+# heartbeat and ARMED. A supervisor stuck on `inert` (argv unresolvable) or
+# `not-armed` (it has never seen a fresh beat) ticks identically to a healthy
+# one and would kill nothing. The state file is one word per transition, written
+# for exactly this question and for the gate to ship on the heartbeat (part 2).
+# Bounded wait: arming happens on the first poll AFTER the gateway's first beat,
+# which on 1 vCPU can land a minute or more into boot. The failing branch prints
+# the state it did see, so a red run says WHICH wrong state, not just "failed".
+ssh_exec "gateway-liveness-supervisor-armed" "n=0; while [ \$n -lt 36 ]; do s=\$(head -c 16 /run/smd-gateway-liveness/state 2>/dev/null); [ \"\$s\" = armed ] && exit 0; n=\$((n+1)); sleep 5; done; echo supervisor-state=\$s >&2; exit 1"
+
 # The supervisor is only as good as the signal it reads, and that signal is
 # UPSTREAM's: an asyncio task on the gateway loop rewrites this file every 30s.
 # This check is the tripwire for the whole mechanism rotting silently. The path

--- a/operator/templates/entrypoint.sh
+++ b/operator/templates/entrypoint.sh
@@ -660,8 +660,31 @@ SMD_GATEWAY_LIVENESS_KILL_VERIFY_SECONDS="${SMD_GATEWAY_LIVENESS_KILL_VERIFY_SEC
 # it and buy itself unlimited restarts. That is why the authoritative record of
 # every kill and every refusal is the log line, which reaches `fly logs` and
 # which the agent cannot reach at all.
-install -d -o root -g root -m 0700 "${GATEWAY_LIVENESS_RUN_DIR}"
-install -d -o root -g root -m 0700 "${GATEWAY_LIVENESS_LEDGER_DIR}"
+#
+# 0755 / 0644, NOT 0700 (ss#2488 part 2). The webhook gate -- hermes uid, and
+# the one process that survives a wedge -- reads the tick, the state line and
+# the ledger below and puts them on the control-plane heartbeat, so a stale
+# pulse, a restart, a refusing supervisor or one that never armed reaches an
+# inbox instead of only `fly logs`. Read-only for the agent is still the whole
+# security property: root is the sole writer, and under a root-owned directory
+# with no group/other write bit the agent uid can neither forge, edit, nor
+# unlink a line. (The unlink caveat in the paragraph above is about the PARENT
+# /opt/data, and is unchanged by this.) The cross-repo threshold contract lives
+# here too: fleet-alerts' GATEWAY_LOOP_RED_SECONDS must stay BELOW
+# SMD_GATEWAY_LIVENESS_STALE_SECONDS x 2 samples + the dump and TERM graces
+# (~270s at defaults), or the page lands after the restart it was meant to
+# precede. wrangler.toml carries the same sentence.
+install -d -o root -g root -m 0755 "${GATEWAY_LIVENESS_RUN_DIR}"
+install -d -o root -g root -m 0755 "${GATEWAY_LIVENESS_LEDGER_DIR}"
+# The supervisor's state machine, one word, rewritten on every transition so the
+# gate (and boot-smoke) can tell an ARMED supervisor from one that is inert,
+# not-watching this pin, or refusing further restarts. Same loud-not-silent
+# discipline as the log lines; this is the copy that leaves the Machine.
+gateway_liveness_state() {
+  printf '%s\n' "$1" > "${GATEWAY_LIVENESS_RUN_DIR}/state.tmp" \
+    && chmod 0644 "${GATEWAY_LIVENESS_RUN_DIR}/state.tmp" \
+    && mv -f "${GATEWAY_LIVENESS_RUN_DIR}/state.tmp" "${GATEWAY_LIVENESS_RUN_DIR}/state"
+}
 
 # Resolve the ACTIVE profile from the gateway's own argv, not by mtime-ordering
 # /opt/data/profiles/*. A seat may carry several persona homes (ADR 0011;
@@ -693,6 +716,8 @@ gateway_heartbeat_path() {
 
 # Epoch first so the window comparison is integer arithmetic, no date parsing.
 gateway_liveness_record_kill() {
+  [ -f "${GATEWAY_LIVENESS_LEDGER_DIR}/kills" ] \
+    || install -m 0644 -o root -g root /dev/null "${GATEWAY_LIVENESS_LEDGER_DIR}/kills"
   printf '%s %s %s\n' "$(date -u +%s)" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$1" \
     >> "${GATEWAY_LIVENESS_LEDGER_DIR}/kills"
 }
@@ -758,6 +783,7 @@ gateway_liveness_escalate() {
     # destroys in-flight work each cycle. Stop, and keep saying so, so that the
     # next thing to touch this Machine is a human.
     gateway_liveness_nag "REFUSING to restart (${reason}): ${SMD_GATEWAY_LIVENESS_MAX_KILLS} kill(s) already inside ${SMD_GATEWAY_LIVENESS_KILL_WINDOW_SECONDS}s. This seat is flapping and needs a human."
+    gateway_liveness_state refusing
     return 0
   fi
   gateway_liveness_record_kill "${reason}"
@@ -815,12 +841,14 @@ gateway_liveness_escalate() {
   if [ ! -f "${GATEWAY_LIVENESS_HEARTBEAT_WRITER}" ] || \
      ! grep -q 'loop_heartbeat_forever' "${GATEWAY_LIVENESS_HEARTBEAT_WRITER}"; then
     log "GATEWAY LIVENESS: NOT watching — this Hermes pin has no loop heartbeat (${GATEWAY_LIVENESS_HEARTBEAT_WRITER} absent or without loop_heartbeat_forever). A wedged gateway on this seat will NOT self-recover."
+    gateway_liveness_state not-watching
     exit 0
   fi
   armed=0
   stale_streak=0
   last_nag=0
   boot_epoch="$(date -u +%s)"
+  gateway_liveness_state not-armed
   while true; do
     # Tick FIRST, every iteration. This file is the supervisor's own liveness
     # proof and boot-smoke asserts its freshness. A pid file would only prove a
@@ -828,12 +856,14 @@ gateway_liveness_escalate() {
     # than that it WORKED" shape boot-smoke-test.sh warns about after the
     # 2026-07-16 scheduler outage ran eight days green on exactly that.
     touch "${GATEWAY_LIVENESS_RUN_DIR}/tick"
+    chmod 0644 "${GATEWAY_LIVENESS_RUN_DIR}/tick" 2>/dev/null
     sleep "${SMD_GATEWAY_LIVENESS_POLL_SECONDS}"
     now="$(date -u +%s)"
 
     hb="$(gateway_heartbeat_path)"
     if [ -z "${hb}" ]; then
       gateway_liveness_nag "cannot resolve the gateway profile from ${GATEWAY_LIVENESS_PROC_DIR}/${SMD_GATEWAY_PID}/cmdline; supervisor is INERT and this seat has no automatic recovery"
+      gateway_liveness_state inert
       continue
     fi
 
@@ -859,6 +889,7 @@ gateway_liveness_escalate() {
 
     if [ "${age}" -le "${SMD_GATEWAY_LIVENESS_STALE_SECONDS}" ]; then
       [ "${armed}" -eq 0 ] && log "Gateway liveness supervisor ARMED (loop heartbeat ${hb} is ${age}s fresh)"
+      [ "${armed}" -eq 0 ] && gateway_liveness_state armed
       armed=1
       stale_streak=0
       continue
@@ -888,6 +919,7 @@ gateway_liveness_escalate() {
     # here.
     if ! gateway_liveness_kill_budget_ok; then
       gateway_liveness_nag "REFUSING to restart (loop-wedge, heartbeat ${age}s stale): ${SMD_GATEWAY_LIVENESS_MAX_KILLS} kill(s) already inside ${SMD_GATEWAY_LIVENESS_KILL_WINDOW_SECONDS}s. This seat is flapping and needs a human."
+      gateway_liveness_state refusing
       stale_streak=0
       continue
     fi

--- a/operator/templates/tests/test_gateway_liveness_supervisor.py
+++ b/operator/templates/tests/test_gateway_liveness_supervisor.py
@@ -39,7 +39,7 @@ ENTRYPOINT = REPO_ROOT / "operator" / "templates" / "entrypoint.sh"
 # closes the backgrounded supervisor subshell. Anchored on comment text that is
 # load-bearing prose, so a rewrite that moves the block fails here loudly rather
 # than silently testing nothing.
-_START = "# Resolve the ACTIVE profile from the gateway's own argv"
+_START = "# The supervisor's state machine, one word, rewritten on every transition"
 _END = "\n) &\n"
 
 GATEWAY_PID = "4242"
@@ -57,6 +57,7 @@ def _extract_supervisor() -> str:
 def test_extraction_anchors_still_match():
     """If this fails, every other test in this file is measuring nothing."""
     block = _extract_supervisor()
+    assert "gateway_liveness_state()" in block
     assert "gateway_heartbeat_path()" in block
     assert "gateway_liveness_escalate()" in block
     assert "set +e" in block
@@ -202,6 +203,19 @@ wait
         tick = self.run_dir / "tick"
         return tick.stat().st_mtime if tick.exists() else 0.0
 
+    def state(self) -> str | None:
+        """The one-word state file the gate ships on the heartbeat (part 2)."""
+        f = self.run_dir / "state"
+        return f.read_text().strip() if f.exists() else None
+
+    def wait_for_state(self, want: str, timeout: float = 20.0) -> None:
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            if self.state() == want:
+                return
+            time.sleep(0.2)
+        raise AssertionError(f"state never reached {want!r}; last={self.state()!r}; log:\n{self.log_text()}")
+
 
 @pytest.fixture
 def harness(tmp_path):
@@ -216,6 +230,7 @@ def test_arms_on_a_fresh_beat_then_restarts_the_seat_when_the_loop_wedges(harnes
     harness.write_heartbeat("crane", age_seconds=0)
     harness.start()
     harness.wait_for_log(r"ARMED")
+    harness.wait_for_state("armed")
     # Stop refreshing the heartbeat — this is the wedge.
     harness.wait_for_log(r"GATEWAY WEDGE")
     harness.wait_for_log(r"SIGTERM to container main")
@@ -237,6 +252,7 @@ def test_never_arms_on_a_stale_beat_left_by_the_previous_boot(harness):
     time.sleep(4)
     assert "GATEWAY WEDGE" not in harness.log_text()
     assert harness.kill_text() == ""
+    assert harness.state() == "not-armed"
 
 
 def test_loop_survives_a_vanished_heartbeat(harness):
@@ -288,6 +304,7 @@ def test_kill_ledger_refuses_once_the_budget_is_spent(harness):
     harness.wait_for_log(r"ARMED")
     harness.wait_for_log(r"REFUSING to restart")
     assert harness.kill_text() == "", "refused escalation still signalled the process"
+    harness.wait_for_state("refusing")
 
 
 def test_profile_comes_from_argv_not_from_mtime(harness):
@@ -313,6 +330,7 @@ def test_is_inert_and_loud_when_argv_does_not_name_hermes(harness):
     harness.start()
     harness.wait_for_log(r"supervisor is INERT")
     assert harness.kill_text() == ""
+    harness.wait_for_state("inert")
 
 
 def test_refuses_to_watch_a_pin_that_has_no_loop_heartbeat(harness):
@@ -335,6 +353,7 @@ def test_refuses_to_watch_a_pin_that_has_no_loop_heartbeat(harness):
     time.sleep(3)
     assert harness.kill_text() == ""
     assert "ARMED" not in harness.log_text()
+    assert harness.state() == "not-watching"
 
 
 def test_skips_the_dump_when_the_pin_registers_no_sigusr2_handler(harness):
@@ -350,3 +369,29 @@ def test_skips_the_dump_when_the_pin_registers_no_sigusr2_handler(harness):
     harness.wait_for_log(r"ARMED")
     harness.wait_for_log(r"registers no SIGUSR2 faulthandler; skipping the stack dump")
     assert "-USR2" not in harness.kill_text()
+
+
+
+def test_state_tick_and_ledger_are_world_readable_for_the_gate(harness):
+    """Part 2 reads these from the webhook gate, which runs as the agent uid.
+
+    A 0700 dir or a 0600 file would make every heartbeat field derived from them
+    NULL forever -- and NULL is a hold, so the console would never page. The
+    integrity property is unchanged: the harness cannot chmod-test root
+    ownership, but the mode bits it CAN check are the ones that grant reading
+    without granting writing.
+    """
+    import stat as st
+
+    ledger = harness.ledger_dir / "kills"
+    now = int(time.time())
+    ledger.write_text(f"{now - 10} iso loop-wedge\n{now - 5} iso loop-wedge\n")
+    harness.write_heartbeat("crane", age_seconds=0)
+    harness.start()
+    harness.wait_for_state("armed")
+    harness.wait_for_state("refusing")  # drives the ledger path
+    for name in ("state", "tick"):
+        mode = (harness.run_dir / name).stat().st_mode
+        assert mode & st.S_IROTH, f"{name} is not world-readable"
+        assert not (mode & st.S_IWOTH), f"{name} is world-writable"
+        assert not (mode & st.S_IWGRP), f"{name} is group-writable"

--- a/tests/operator-entrypoint.test.ts
+++ b/tests/operator-entrypoint.test.ts
@@ -312,4 +312,29 @@ describe('Operator customer Machine entrypoint — gateway liveness supervisor (
       'a pid file would prove a number was written once, not that the loop turns'
     ).toBe(false)
   })
+
+  it('publishes its state machine as one word the webhook gate can read (part 2)', () => {
+    // The gate is the hermes uid and the one process that survives a wedge; it
+    // ships these on the control-plane heartbeat so a refusing or never-armed
+    // supervisor reaches an inbox instead of only `fly logs`. Read-only for the
+    // agent is the whole security property: root-owned dirs with no group/other
+    // write bit, so the agent can neither forge, edit nor unlink a line.
+    expect(ENTRYPOINT_CODE).toMatch(
+      /install -d -o root -g root -m 0755 "\$\{GATEWAY_LIVENESS_RUN_DIR\}"/
+    )
+    expect(ENTRYPOINT_CODE).toMatch(
+      /install -d -o root -g root -m 0755 "\$\{GATEWAY_LIVENESS_LEDGER_DIR\}"/
+    )
+    expect(
+      /install -d -o root -g root -m 0700 "\$\{GATEWAY_LIVENESS_(RUN|LEDGER)_DIR\}"/.test(
+        ENTRYPOINT_CODE
+      ),
+      'a 0700 dir would make every gate-derived heartbeat field NULL forever, and NULL is a hold'
+    ).toBe(false)
+    for (const word of ['not-armed', 'armed', 'inert', 'not-watching', 'refusing']) {
+      expect(ENTRYPOINT_CODE, `state transition "${word}" must be written`).toMatch(
+        new RegExp(`gateway_liveness_state ${word}\\b`)
+      )
+    }
+  })
 })


### PR DESCRIPTION
Part 1 (#2502) made a wedged gateway restart itself, and it is now proven on
hermes-scott: wedge at 05:54:12Z, container replaced by 05:59:17Z, nobody
involved (vfy_01M0HEM5VM26XFVD8W4XW19AQF). It did not change the fact that
during that window every signal a human could see said healthy -- and that
the supervisor's loudest states (REFUSING after its kill budget, INERT when
it cannot resolve the profile, NOT watching on a pin without the heartbeat)
exist only in `fly logs`. Part 2 puts the gateway's pulse and the supervisor's
own state on the control-plane heartbeat, which the webhook gate emits and
which survives a wedge. This PR is the seat-side half that has no overlay
dependency, so it can merge first.

Three changes, all in the part-1 supervisor:

- /run/smd-gateway-liveness and /opt/data/gateway-liveness go 0755, their files
  0644. The gate is the hermes uid; under 0700 every field it derived from
  these would be NULL forever, and NULL is a HOLD, so the console would never
  page. The integrity property is unchanged: root is the sole writer, and
  under a root-owned dir with no group/other write bit the agent can neither
  forge, edit nor unlink a line. (The unlink caveat already documented is about
  the PARENT /opt/data and is untouched.)
- A one-word state file, rewritten on every transition:
  not-armed | armed | inert | not-watching | refusing. Same loud-not-silent
  discipline as the log lines; this is the copy that leaves the Machine.
- The cross-repo threshold contract is written down where the seat side of it
  lives: fleet-alerts' GATEWAY_LOOP_RED_SECONDS must stay below
  SMD_GATEWAY_LIVENESS_STALE_SECONDS x 2 + the graces (~270s at defaults), or
  the page lands after the restart it was meant to precede.

Boot-smoke gains `gateway-liveness-supervisor-armed` with a bounded wait. The
existing tick check proves the loop turns; it cannot tell an armed supervisor
from one stuck on inert or not-armed, which tick identically and would kill
nothing. The failing branch prints the state it saw, so a red run names WHICH
wrong state.

Tests: the extracted-loop harness asserts the state word at every transition
and that state/tick are world-readable and not writable by group or other
(11/11). The vitest shape lock asserts 0755 on both dirs, rejects a 0700
regression, and requires all five transition words to be written (26/26).

Refs #2488


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UKqinsMSpv17sH2YM4C1Cr
