### PR TITLE
feat(operator): the audit record can be shown intact to a third party, not just self-consistent (ss#2500)

### DIFF
--- a/.github/workflows/audit-chain-verify.yml
+++ b/.github/workflows/audit-chain-verify.yml
@@ -1,0 +1,168 @@
+# Prove daily that no seat's audit record was truncated or rewritten, and keep a
+# copy of it somewhere the seat cannot reach.
+#
+# WHY (ss#2500). The ledger is a hash chain and NOTHING CALLED THE VERIFIER: not
+# a workflow, not the evidence packet, not the portal export. It ran when a human
+# ran it. Worse, running it would not have caught the thing a firm's insurer
+# actually asks about, because the chain walk alone cannot see tail truncation --
+# the surviving prefix is a valid chain. Measured against a live 1,473-row export
+# (vfy_01M0H8D1CV2X8J9ZACMAC8E6E2): deleting the last 50 rows, deleting the last
+# 1 row, and mutate-then-re-hash-everything-after all reported INTACT.
+#
+# The missing input is a head recorded off the Machine. The heartbeat now carries
+# one and the console pins every one into `audit_head_history` (migration 0108).
+# This job pulls each seat's full export over the ADR-0043 seam and requires the
+# newest pinned head to still be in it.
+#
+# AND THE COPY. The only copy of the ledger off the broker's file was Fly's daily
+# volume snapshot on 5-DAY retention. The A&P ledger already lost its
+# pre-2026-07-29 rows once when the seat was rebuilt on a new volume. This job
+# writes audit/<slug>/<date>.json.gz to R2 and records the key and sha256 in the
+# run summary, so the record survives loss of the Machine.
+#
+# HOLDS vs FINDS, and a hold is loud (#2395, the control-probes contract). Exit 1
+# is a finding (an alert row is written to the shared sink, source
+# `audit_integrity`, and the dashboard banner renders it). Exit 2 is a hold: a
+# transport failure, an unreadable D1, an archive that would not write, a bucket
+# whose immutability could not be confirmed, or -- most importantly -- a seat
+# with NO PINNED HEAD YET, because a run with no pin proves only self-consistency
+# and that is the property already shown insufficient. Both exits fail the run.
+# There is no path where this workflow is green because it asked nothing.
+#
+# WHAT THIS STILL DOES NOT PROVE. A pin protects rows OLDER than the last pin.
+# Rows written since the last heartbeat are unpinned, so root on the Machine has
+# a beat-sized window. That limit is stated on the client-facing pages rather
+# than papered over.
+
+name: audit-chain-verify
+
+on:
+  schedule:
+    # 04:23 UTC daily. Off the hour and off every other scheduled job here
+    # (06:41 control-probes, 09:41 config-reconcile, 13:17 send-reconcile).
+    - cron: '23 4 * * *'
+  workflow_dispatch:
+    inputs:
+      seat:
+        description: 'Limit to one customer slug (blank = every authored seat)'
+        required: false
+      no_archive:
+        description: 'Verify only; write no off-box copy (any value = on)'
+        required: false
+  pull_request:
+    paths:
+      - 'operator/bin/audit-chain-watch.py'
+      - 'operator/bin/verify-audit-chain.py'
+      - 'operator/bin/lib/chain_pin.py'
+      - 'operator/bin/tests/test_audit_chain_watch.py'
+      - 'operator/bin/tests/test_chain_pin.py'
+      - '.github/workflows/audit-chain-verify.yml'
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: '>=3.11'
+
+      - name: Install pytest
+        run: python3 -m pip install --quiet pytest
+
+      # The falsifier gates the scheduled run. test_chain_pin.py contains a
+      # NEGATIVE CONTROL that asserts a truncated export still passes the chain
+      # walk alone -- so if the pin check silently stopped doing anything, these
+      # tests go red rather than the daily job going quietly green.
+      - name: Prove the tail check can fail
+        run: |
+          python3 -m pytest \
+            operator/bin/tests/test_chain_pin.py \
+            operator/bin/tests/test_audit_chain_watch.py -q
+
+      # On pull_request there are no secrets, no seats and no R2. The tests above
+      # are the whole job.
+      - name: Verify every seat's chain and copy it off-box
+        if: github.event_name != 'pull_request'
+        id: watch
+        env:
+          OPERATOR_RUNTIME_READ_SECRET: ${{ secrets.OPERATOR_RUNTIME_READ_SECRET }}
+          OPERATOR_RUNTIME_READ_URL: ${{ secrets.OPERATOR_RUNTIME_READ_URL }}
+          # The R2 S3 credentials are DERIVED from these two inside the runner,
+          # exactly as ci-reconcile-r2-customer-configs.sh derives them. Derive,
+          # never mint, and one credential shape for every console-side CI job.
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          # Via env, never interpolated into the script body: a workflow_dispatch
+          # input is user-supplied and would otherwise be a shell-injection seam.
+          WATCH_SEAT: ${{ github.event.inputs.seat }}
+          WATCH_NO_ARCHIVE: ${{ github.event.inputs.no_archive }}
+        run: |
+          set -u
+          ARGS=""
+          if [ -n "${WATCH_SEAT:-}" ]; then ARGS="${ARGS} --seat ${WATCH_SEAT}"; fi
+          if [ -n "${WATCH_NO_ARCHIVE:-}" ]; then ARGS="${ARGS} --no-archive"; fi
+          # `|| STATUS=$?` is load-bearing, not style (ss#2307/ss#2309). This
+          # body runs under `bash -e`, so an unguarded non-zero exit would abort
+          # HERE, before the report prints and before `status` reaches
+          # GITHUB_OUTPUT, silently skipping the alert step below -- going quiet
+          # in exactly the cases the control exists for.
+          # shellcheck disable=SC2086 - ARGS is built above, not caller-supplied.
+          STATUS=0
+          python3 operator/bin/audit-chain-watch.py $ARGS > watch.txt 2>&1 || STATUS=$?
+          cat watch.txt
+          echo "status=${STATUS}" >> "$GITHUB_OUTPUT"
+          # Contract (operator/bin/audit-chain-watch.py): 0 clean, 1 finding,
+          # 2 hold. Anything else is the control itself breaking and must fail
+          # the run immediately.
+          if [ "${STATUS}" -gt 2 ]; then exit "${STATUS}"; fi
+
+      # A FINDING opens an issue. A HOLD does not: an instrument failure is not
+      # a finding about a client's records, and a control that pages on its own
+      # blips gets muted within a week. The hold still reddens the run below.
+      - name: Open an issue when a seat's audit record does not hold up
+        if: github.event_name != 'pull_request' && steps.watch.outputs.status == '1'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          {
+            echo "A seat's audit ledger no longer contains a chain head this console pinned."
+            echo
+            echo "The audit log is what a client firm is offered as the record of what its"
+            echo "Operator did, and what its insurer or the State Bar would be shown. A head"
+            echo "that was pinned and is now absent means rows that existed at that moment"
+            echo "are gone: the ledger was truncated, rewritten, or rolled back to an older"
+            echo "copy. The agent cannot do this. Root on the Machine can."
+            echo
+            echo "An \`audit_integrity\` alert row is already on the dashboard banner."
+            echo "Do not clear it until the cause is known."
+            echo
+            echo '```'
+            cat watch.txt
+            echo '```'
+            echo
+            echo "Runner: \`operator/bin/audit-chain-watch.py\` (ss#2500)."
+            echo "Pin source: \`audit_head_history\`, written from every heartbeat."
+            echo "Run: ${RUN_URL}"
+          } > body.md
+          gh issue create \
+            --repo "${REPO}" \
+            --title "Audit chain head missing from a seat export $(date -u +%Y-%m-%d)" \
+            --label "prio:P0" --label "type:bug" \
+            --body-file body.md
+
+      # Anything but a clean run fails, including a hold. A green check mark on a
+      # run that could not evaluate a seat is the defect this job exists to make
+      # impossible -- and until the heartbeat field reaches a seat, EVERY run
+      # holds, which is the honest state and looks like one.
+      - name: Fail the run when the check was not clean
+        if: github.event_name != 'pull_request' && steps.watch.outputs.status != '0'
+        run: exit 1

--- a/docs/handbook/security-trust.md
+++ b/docs/handbook/security-trust.md
@@ -14,6 +14,10 @@ sources:
     href: https://github.com/venturecrane/ss-console/blob/main/docs/security/operator-threat-model.md
   - label: docs/security/smd-services-security-overview.md
     href: https://github.com/venturecrane/ss-console/blob/main/docs/security/smd-services-security-overview.md
+  - label: operator/bin/lib/chain_pin.py
+    href: https://github.com/venturecrane/ss-console/blob/main/operator/bin/lib/chain_pin.py
+  - label: .github/workflows/audit-chain-verify.yml
+    href: https://github.com/venturecrane/ss-console/blob/main/.github/workflows/audit-chain-verify.yml
 ---
 
 ## Two halves of trust
@@ -68,6 +72,20 @@ A prospect's compliance reviewer gets the same story in three client-visible art
 The Operator is an autonomous agent acting on a client's live business data, so its security model is about constraining action, not just constraining output. The full analysis is `docs/security/operator-threat-model.md` - a maintained, adversarially-tested register, not a one-time design doc. Its shape:
 
 - **A strong perimeter, a softer core.** The front door (the capability broker plus authored entitlement ceilings on registered tools) is verified-strong. The historically harder problems were ungoverned code execution defaulting to read, an account-wide secret in the agent's environment, a broker that validated identity but not intent, and an inbound fence that covered the webhook channel but not the managed mailbox. These are tracked as P0/P1 findings with live-exploit verification and a remediation program (see the threat model's "Closed" section for what has been shut, including the broker-owned audit ledger).
-- **The verified strengths to protect from regression.** Per-customer Machine isolation, the fail-closed authority model (unconfigured can read but not act), the hard ban on principal-identity send, and the tamper-resistant audit log the agent cannot rewrite (hash-chained since 2026-07-04, #1686: every row commits to its predecessor, so deletion and reordering are detectable, not just mutation; the verifier is `operator/bin/verify-audit-chain.py`). The threat model names these explicitly so a future change does not quietly undo them.
+- **The verified strengths to protect from regression.** Per-customer Machine isolation, the fail-closed authority model (unconfigured can read but not act), the hard ban on principal-identity send, and the tamper-resistant audit log the agent cannot rewrite (hash-chained since 2026-07-04, #1686). The threat model names these explicitly so a future change does not quietly undo them.
+
+### What the audit record can and cannot prove
+
+This is the claim a firm's insurer, the State Bar, or opposing counsel would test, so it is stated exactly rather than generously.
+
+**The agent cannot alter or erase the record.** One process writes the ledger (the capability broker), the agent's user account has read-only access to the file, and the write surface exposes no update or delete verb. That part is structural.
+
+**The chain catches a row changed, removed, or inserted before the end of the log.** Every row's hash commits to the row before it, so any of those breaks the chain at a point a verifier can name.
+
+**The chain alone does not catch rows cut off the end of the log.** What remains after such a cut is itself a valid chain, and a verifier reading only the export says so. This was measured on 2026-08-20 against a copy of a live 1,473-row export, not reasoned about: deleting the last fifty rows, deleting the last one row, and altering a row then recomputing every hash after it all reported the chain intact.
+
+**What closes that is a head pinned off the machine.** Every heartbeat carries the hash of the newest row, and the control plane appends it to a table on our side that nothing on the client's machine can reach backwards into (`audit_head_history`, migration 0108). A daily job (`.github/workflows/audit-chain-verify.yml`) pulls each seat's full ledger and requires the newest pinned hash to still be in it. If it is gone, rows that existed at that moment are gone, and that opens a P0 issue and an alert on the fleet dashboard. The same job writes the ledger to object storage under `audit/<slug>/<date>.json.gz`, so the record survives loss of the machine. Before that job existed, the only copy off the machine was a five day volume snapshot, and one seat's ledger had already lost its early rows once during a rebuild.
+
+**The honest limit.** A pinned head protects the rows older than the last pinned head. Rows newer than it stay rewritable by a root user on the machine until the next heartbeat lands. That window is one heartbeat wide and shortening it means beating more often, not a different mechanism. A forged row appended with a correct hash also descends from the pin like a real one; per-row signing was considered and rejected (ADR 0074). Both limits are stated on the public security page too, in the same words.
 
 The controls themselves - the action-class ceilings, the capability broker, the inbound-content taint gate, and the fail-closed default - are owned and explained in `/admin/playbook/autonomy-governance`. The secrets and credential-custody side (Infisical, per-customer OAuth tokens, the broker-only secret materialization) is owned by `/admin/playbook/secrets-access`. This page does not duplicate them; it points to them so the two halves of trust read as one map.

--- a/docs/specs/operator/audit-log-immutability.md
+++ b/docs/specs/operator/audit-log-immutability.md
@@ -1,14 +1,32 @@
 # Audit log immutability
 
-> **Status — pending rehome (2026-05-25):** the original implementation
-> (`operator/adapter/audit_log_immutability.py` + `audit_log_integrity.py`)
-> was retired when the in-tree Hermes adapter was removed per ADR 0015
-> rewrite. The immutability **requirement** stands; its new home is the
-> overlay's `hermes-smd-audit` plugin (write-side rejection of
-> UPDATE/DELETE) plus a control-plane Worker for the integrity check.
-> Code samples below reference paths that no longer exist; treat them as
-> design intent until the spec is rewritten against the new substrate.
-> Follow-on: refresh this spec against the post-2026-05-24 architecture.
+> **Status — SUPERSEDED (2026-08-20, ss#2500). Do not build from this
+> document.** It specifies a D1-era design: a `D1Executor` wrapper rejecting
+> UPDATE/DELETE, a Cloudflare Logpush mirror of D1 query logs into an
+> Object-Locked R2 bucket, and a `check_audit_integrity` comparator between
+> the two. None of its three layers describes the running system, and the
+> substrate each one assumed is gone.
+>
+> **What actually holds the requirement now**, layer by layer:
+>
+> | This spec's layer                                          | What ships instead                                                                                                                                                                                                                                                                                                                  |
+> | ---------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+> | 1. Worker-layer UPDATE/DELETE rejection against D1         | The ledger is not in D1. It is Machine-local sqlite owned by the capability broker, the single process holding the RW handle; the agent uid has read-only access and the IPC surface exposes no update or delete verb (`operator/workspace_broker/audit_ledger.py`, `server.py`).                                                   |
+> | 2. Logpush mirror into an Object-Locked bucket             | `.github/workflows/audit-chain-verify.yml` pulls each seat's full export over the ADR-0043 runtime-read seam daily and writes it to R2 at `audit/<slug>/<date>.json.gz`. Logpush mirrors D1 query logs and there are no D1 queries to mirror.                                                                                       |
+> | 3. `check_audit_integrity` comparing D1 against the mirror | `operator/workspace_broker/chain.py` (`verify_chain`) plus `operator/bin/lib/chain_pin.py` (the descends check against a head pinned off the Machine, `audit_head_history`, migration 0108). There is no second store to diff against, so the tamper evidence is the chain itself plus an external pin, not a two-store comparison. |
+>
+> The **Captain exception process** below (court-ordered redaction: counsel
+> review, multi-confirmation script, exceptions ledger, disclosure in the next
+> evidence packet) was never implemented and is not superseded by anything. It
+> stands as unbuilt design intent. Nothing in the current system provides a
+> sanctioned redaction path, which is the honest state: today a court-ordered
+> redaction would be performed by root on the Machine and would show up as a
+> chain break in the daily verifier.
+>
+> Kept rather than deleted because the failure-mode table and the exception
+> process are the parts worth reading, and because a reader who arrives here
+> from an old link needs to be told where the live design went rather than
+> finding nothing. Everything below this box is historical.
 
 **Spec for issue #892.** Worker-layer enforcement that rejects UPDATE/DELETE
 against the per-customer `audit_log` table, plus an immutable Logpush

--- a/migrations/0108_audit_head_history.sql
+++ b/migrations/0108_audit_head_history.sql
@@ -1,0 +1,72 @@
+-- 0108: the audit chain head, pinned off the Machine (ss#2500)
+--
+-- WHAT WAS MISSING. The per-seat audit ledger is a SHA-256 hash chain
+-- (operator/workspace_broker/chain.py). Mutating or deleting a row in the
+-- MIDDLE of that chain breaks it at a verifiable point. Removing rows off the
+-- END does not: the remaining prefix is a perfectly valid chain, and
+-- `verify-audit-chain.py` reports it INTACT. Proven, not assumed
+-- (vfy_01M0H8D1CV2X8J9ZACMAC8E6E2, run against copies of a live 1,473-row
+-- export): deleting the last 50 rows, deleting the last 1 row, appending a
+-- forged row with a valid hash, and mutate-then-rehash-everything-after all
+-- passed the verifier.
+--
+-- The verifier's own header already named the fix -- "tail truncation is caught
+-- by comparing the reported head against an externally pinned head" -- and
+-- nothing pinned one. The head never left the Machine: the heartbeat shipped
+-- `last_audit_ts` and nothing else about the chain.
+--
+-- WHAT THIS TABLE IS. Every heartbeat's chain head, persisted OFF the Machine,
+-- so a later export can be required to descend from a head root already holds.
+-- Root on the Machine can still rewrite the ledger; what it cannot do is reach
+-- back and change what this table already recorded.
+--
+-- APPEND-ONLY, AND WHY THE ONE UPDATE IS NOT A HOLE. `audit_head`, `audit_rows`
+-- and `first_seen_heartbeat_ts` are written once and never updated -- those are
+-- the pin. `last_seen_heartbeat_ts` and `beats` are refreshed while the SAME
+-- head keeps arriving, which is how a row records "this head was still current
+-- at T" without storing 1,440 identical rows per seat per day. A NEW head is
+-- always a new row, so no head can ever be overwritten by a later one. The
+-- issue asks for every head persisted rather than a daily sample, and that is
+-- exactly what this stores: one row per distinct head, none dropped.
+--
+-- NOT fleet_status. fleet_status is a one-row-per-seat CURRENT-state projection
+-- whose columns are overwritten every beat by design; a pin that a later beat
+-- can overwrite is not a pin. ss#2498 adds `audit_head` / `audit_rows` columns
+-- there for the live dashboard read. Same two wire fields, two different jobs:
+-- that projection answers "what is the head now", this table answers "what
+-- heads has root already been unable to take back".
+--
+-- The heartbeat handler writes both from one intake
+-- (src/pages/api/internal/heartbeat.ts -> src/lib/operator/audit-head.ts).
+
+CREATE TABLE IF NOT EXISTS audit_head_history (
+  id                      INTEGER PRIMARY KEY AUTOINCREMENT,
+  customer_slug           TEXT NOT NULL,
+  -- Refreshed from the request like fleet_status does: several seats can share
+  -- one entity, so the slug is the identity and this is a convenience join key.
+  entity_id               TEXT,
+  -- row_hash of the chain tip: sha256 hexdigest, 64 lowercase hex characters.
+  -- NOT NULL by construction -- a beat with no head has nothing to pin and
+  -- writes no row at all, rather than pinning a NULL that later reads as "the
+  -- ledger was empty then".
+  audit_head              TEXT NOT NULL,
+  -- COUNT(*) of the ledger at the moment the head was read. Nullable: an
+  -- overlay that reports a head without a count is still worth pinning, and
+  -- inventing a number here would make a shrink undetectable in the direction
+  -- that matters.
+  audit_rows              INTEGER,
+  first_seen_heartbeat_ts TEXT NOT NULL,
+  last_seen_heartbeat_ts  TEXT NOT NULL,
+  beats                   INTEGER NOT NULL DEFAULT 1,
+  recorded_at             TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- The daily verifier's only read: newest pinned head for one seat.
+CREATE INDEX IF NOT EXISTS idx_audit_head_history_seat
+  ON audit_head_history(customer_slug, id DESC);
+
+-- Answers "was this head ever pinned" without a table scan. That question is
+-- the descends check run backwards, and an auditor asking it about a specific
+-- hash is the point of keeping the whole history rather than the last row.
+CREATE INDEX IF NOT EXISTS idx_audit_head_history_head
+  ON audit_head_history(audit_head);

--- a/migrations/rollbacks/0108_audit_head_history_down.sql
+++ b/migrations/rollbacks/0108_audit_head_history_down.sql
@@ -1,0 +1,16 @@
+-- Rollback for 0108_audit_head_history.sql (ss#2500).
+--
+-- READ THIS BEFORE RUNNING IT. This table is the only copy of the audit chain
+-- heads that root on a seat cannot reach. Dropping it discards every pin ever
+-- recorded, and no later heartbeat backfills them: a heartbeat can only report
+-- the head as it is now. After this runs, the daily verifier has nothing to
+-- compare against and every seat reports a HOLD until a fresh pin lands, which
+-- is the honest state but not a recoverable one.
+--
+-- Export first if there is any chance the history is wanted:
+--   npx wrangler d1 execute ss-console-db --remote --json \
+--     --command "SELECT * FROM audit_head_history ORDER BY id"
+
+DROP INDEX IF EXISTS idx_audit_head_history_head;
+DROP INDEX IF EXISTS idx_audit_head_history_seat;
+DROP TABLE IF EXISTS audit_head_history;

--- a/operator/adapter/evidence/__init__.py
+++ b/operator/adapter/evidence/__init__.py
@@ -20,6 +20,8 @@ from __future__ import annotations
 from .manifest import EvidenceManifest, build_manifest, manifest_sha256_hex
 from .packet import (
     AuditCoverage,
+    CHAIN_PIN_SOURCE,
+    ChainPin,
     EvidencePacketBuilder,
     EvidencePacketError,
     EvidencePacketResult,
@@ -32,6 +34,8 @@ from .pdf import render_summary_pdf
 
 __all__ = [
     "AuditCoverage",
+    "CHAIN_PIN_SOURCE",
+    "ChainPin",
     "EvidenceManifest",
     "EvidencePacketBuilder",
     "EvidencePacketError",

--- a/operator/adapter/evidence/packet.py
+++ b/operator/adapter/evidence/packet.py
@@ -178,6 +178,13 @@ class PacketRequest:
     the packet says: the gap is disclosed either way, and the
     acknowledgement itself is recorded in the manifest and the
     ``COMPLIANCE_PACKET_EXPORTED`` audit row.
+
+    ``pinned_head`` is a chain head recorded OFF the Machine before this export
+    (ss#2500). Supplying one turns the packet's audit section from "these rows
+    are internally consistent" into "these rows still contain a head recorded at
+    a moment nobody on the Machine could reach". Without it, tail truncation is
+    invisible -- and the packet says so on its face rather than implying a
+    completeness it did not test.
     """
 
     customer_slug: str
@@ -189,6 +196,7 @@ class PacketRequest:
     actor: str
     actor_role: PacketActor
     acknowledge_unattributed_gap: bool = False
+    pinned_head: Optional[str] = None
 
     def validate(self) -> None:
         if not self.customer_slug:
@@ -212,6 +220,15 @@ class PacketRequest:
                 f"actor_role {self.actor_role.value!r} not in "
                 f"{sorted(REQUIRED_ACTOR_ROLES)}"
             )
+        if self.pinned_head is not None and not _CHAIN_HEAD_RE.match(self.pinned_head):
+            # Refused here rather than reported as a missing head later. A
+            # malformed pin can never match any row, so carrying it forward
+            # would print "the record was truncated" on a packet about a healthy
+            # ledger -- a false accusation in a document written for a court.
+            raise EvidencePacketError(
+                "pinned_head must be a sha256 hexdigest (64 lowercase hex "
+                "characters), the shape row_hash takes in the audit ledger"
+            )
 
 
 @dataclass
@@ -225,6 +242,13 @@ class EvidencePacketResult:
     counts: Mapping[str, int]
     manifest: EvidenceManifest
     coverage: "AuditCoverage"
+    # ss#2500. Present even when no pin was supplied, carrying checked=False, so
+    # a caller reading the result cannot mistake "not asked" for "asked and fine".
+    chain_pin: "ChainPin" = field(
+        default_factory=lambda: ChainPin(
+            pinned_head=None, present=False, chain_readable=True, source=CHAIN_PIN_SOURCE
+        )
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -238,6 +262,89 @@ class EvidencePacketResult:
 # scope in metadata. Counting it would make every repeat export of a
 # quiet matter look like an unresolvable gap.
 _COVERAGE_EXCLUDED_ACTION_TYPE = "COMPLIANCE_PACKET_EXPORTED"
+
+#: A chain head is a sha256 hexdigest -- ``compute_row_hash`` in
+#: ``operator/workspace_broker/chain.py``. Matched, never trusted: see
+#: PacketRequest.validate for why a malformed pin is refused up front.
+_CHAIN_HEAD_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+@dataclass(frozen=True)
+class ChainPin:
+    """Whether a head recorded off the Machine is still in this ledger (ss#2500).
+
+    THE PROBLEM IT ANSWERS. The ledger is a hash chain, and this packet has
+    always been able to say a mutated or deleted MIDDLE row would show. It could
+    never say anything about rows cut off the END, because the surviving prefix
+    is a valid chain -- shown, not argued: against a live 1,473-row export,
+    deleting the last 50 rows and deleting the last 1 row both verified INTACT
+    (vfy_01M0H8D1CV2X8J9ZACMAC8E6E2).
+
+    A pin is the missing input. The console records the chain head from every
+    heartbeat into ``audit_head_history``; a packet built with one of those heads
+    can state that the ledger still contains a row that existed at a moment the
+    Machine could not reach backwards into.
+
+    ``present`` False with a pin supplied is a BREAK, and the builder halts on
+    it: a compliance packet asserting a complete record over a ledger that lost
+    rows is the exact artifact this whole mechanism exists to prevent.
+    """
+
+    #: False when the export source could not be asked at all -- no audit_log
+    #: table, or a snapshot taken before the hash-chain columns were preserved.
+    #: Kept distinct from ``present`` for the reason AuditCoverage.table_present
+    #: exists: "could not look" and "looked and it is gone" are different facts
+    #: and a compliance artifact must not present one as the other.
+    pinned_head: Optional[str]
+    present: bool
+    chain_readable: bool
+    source: str
+
+    @property
+    def was_checked(self) -> bool:
+        return self.pinned_head is not None
+
+    def narrative_lines(self) -> List[str]:
+        """Plain-language statement for the README. One wording, one surface."""
+        if not self.was_checked:
+            return [
+                "No externally pinned chain head was supplied for this export, so "
+                "the audit rows here were checked for internal consistency only. "
+                "Internal consistency does not detect rows removed from the END "
+                "of the log: what remains after such a removal is itself a valid "
+                "chain. Read this packet's audit section as complete only if you "
+                "have an independent record of where the log ended.",
+                "Such a record exists and was not used for this export: "
+                f"{self.source}. Request a packet built against one if "
+                "completeness of the log itself is the question you need "
+                "answered.",
+            ]
+        return [
+            "This export was checked against a chain head recorded outside the "
+            f"Operator's own machine before the export was taken ({self.source}). "
+            f"That head, {self.pinned_head}, is still present in this ledger, so "
+            "no row that existed when it was recorded has since been removed, "
+            "reordered, or altered.",
+            "That check covers rows OLDER than the recorded head. Rows written "
+            "after it were not yet covered by any external record when this "
+            "export was taken.",
+        ]
+
+    def to_dict(self) -> dict:
+        return {
+            "pinned_head": self.pinned_head,
+            "checked": self.was_checked,
+            "present": self.present,
+            "chain_readable": self.chain_readable,
+            "source": self.source,
+        }
+
+
+#: Where a pin comes from, stated in the packet so a reader can go and check it.
+CHAIN_PIN_SOURCE = (
+    "the audit_head_history table on the SMD control plane, appended from every "
+    "heartbeat the Operator sends"
+)
 
 
 def _rows_phrase(count: int) -> str:
@@ -584,6 +691,68 @@ async def _fetch_audit_log(
     return await _fetch_safe(reader, sql, params)
 
 
+async def _fetch_chain_pin(
+    reader: ReadExecutor,
+    *,
+    pinned_head: Optional[str],
+) -> ChainPin:
+    """Is the pinned head still somewhere in this ledger?
+
+    Deliberately NOT scoped to the packet's period or matter. The question is
+    whether the LEDGER still holds the row, and a period-scoped lookup would
+    report a break every time the pin predated the export window -- a false
+    accusation with the same words as a real one.
+
+    A missing ``audit_log`` table is reported as ``table_present=False`` rather
+    than as an absent head, for the reason :func:`_fetch_optional` exists: "the
+    table is not there" and "the row is not there" are different facts and a
+    packet must not present one as the other.
+    """
+    if pinned_head is None:
+        return ChainPin(None, present=False, chain_readable=True, source=CHAIN_PIN_SOURCE)
+    try:
+        rows = await reader.fetch_all(
+            "SELECT row_hash FROM audit_log WHERE row_hash = ? LIMIT 1", [pinned_head]
+        )
+    except Exception as exc:  # noqa: BLE001
+        # Two ways the question cannot be asked, and neither is an answer: no
+        # audit_log table, and an audit_log without the chain columns (a
+        # snapshot written before they were preserved). Anything else re-raises
+        # rather than being flattened into a reassuring shape.
+        msg = str(exc).lower()
+        if "no such table" in msg or "no such column" in msg or "does not exist" in msg:
+            log.warning("chain pin lookup skipped (chain columns unreadable): %s", exc)
+            return ChainPin(
+                pinned_head, present=False, chain_readable=False, source=CHAIN_PIN_SOURCE
+            )
+        raise
+    return ChainPin(
+        pinned_head, present=len(rows) > 0, chain_readable=True, source=CHAIN_PIN_SOURCE
+    )
+
+
+def _chain_pin_refusal_message(pin: ChainPin) -> str:
+    if not pin.chain_readable:
+        return (
+            "A pinned chain head was supplied but this export source carries no "
+            "hash-chain columns to look it up in: either there is no audit_log "
+            "table, or the snapshot predates the chain columns being preserved. "
+            "A packet cannot assert an unbroken record it did not read. Point "
+            "--read-db at a current ledger snapshot, or omit --pinned-head and "
+            "accept a packet that states its audit section is unchecked for "
+            "truncation."
+        )
+    return (
+        f"HALTED: the pinned chain head {pin.pinned_head} is NOT present in this "
+        "ledger. A head recorded off the Machine before this export has since "
+        "disappeared from the log, which means rows that existed at that moment "
+        "are gone: truncated, rewritten, or rolled back to an older copy. There "
+        "is no acknowledge flag for this. Do not ship a compliance packet over "
+        "it. Escalate per the invariants runbook and preserve the export as it "
+        "stands."
+    )
+
+
 async def _fetch_audit_coverage(
     reader: ReadExecutor,
     *,
@@ -835,6 +1004,7 @@ def _readme_text(
     actor_role: str,
     manifest_sha256: str,
     coverage: AuditCoverage,
+    chain_pin: ChainPin,
     signed: bool = False,
     key_id: str = "",
 ) -> bytes:
@@ -849,6 +1019,7 @@ def _readme_text(
     packet cannot answer.
     """
     coverage_body = "\n\n".join(coverage.narrative_lines())
+    pin_body = "\n\n".join(chain_pin.narrative_lines())
     body = (
         f"# Compliance Evidence -- {customer_name}\n\n"
         f"**Customer slug:** {customer_slug}\n"
@@ -869,6 +1040,8 @@ def _readme_text(
         "summary PDF.\n\n"
         "## What this package covers, and what it cannot\n\n"
         f"{coverage_body}\n\n"
+        "## Whether the log itself is complete\n\n"
+        f"{pin_body}\n\n"
         "## What is in the package\n\n"
         "- `00-README.md` -- this document\n"
         "- `01-summary.pdf` -- the Susan-readable narrative\n"
@@ -931,9 +1104,11 @@ def _readme_text(
                 "The signature covers origin and integrity after export. It "
                 "says nothing about whether the underlying audit log is "
                 "correct. Tamper evidence within the log itself is a separate "
-                "mechanism: the ledger is hash chained, so a deleted, "
-                "reordered, or inserted row breaks the chain at a verifiable "
-                "point.\n\n"
+                "mechanism: the ledger is hash chained, so a row altered, "
+                "removed, or inserted anywhere before the end of the log "
+                "breaks the chain at a verifiable point. Rows removed from the "
+                "END of the log are a separate question, answered by the "
+                "section above.\n\n"
             )
             if signed
             else (
@@ -1062,6 +1237,12 @@ class EvidencePacketBuilder:
         if coverage.is_unanswerable_empty and not coverage.gap_acknowledged:
             raise EvidencePacketError(_coverage_refusal_message(coverage))
 
+        # ss#2500. Checked BEFORE any file is rendered, so a packet over a
+        # truncated ledger never reaches disk in the first place.
+        chain_pin = await _fetch_chain_pin(self.reader, pinned_head=request.pinned_head)
+        if chain_pin.was_checked and not chain_pin.present:
+            raise EvidencePacketError(_chain_pin_refusal_message(chain_pin))
+
         audit_rows = await _fetch_audit_log(
             self.reader,
             period_start=request.period_start,
@@ -1115,6 +1296,7 @@ class EvidencePacketBuilder:
             extra={
                 "counts": counts,
                 "coverage": coverage.to_dict(),
+                "chain_pin": chain_pin.to_dict(),
                 "stage": "provisional",
             },
         )
@@ -1155,6 +1337,7 @@ class EvidencePacketBuilder:
             actor_role=request.actor_role.value,
             manifest_sha256=provisional_sha,
             coverage=coverage,
+            chain_pin=chain_pin,
             signed=signer is not None,
             key_id=signer.key_id if signer else "",
         )
@@ -1183,6 +1366,7 @@ class EvidencePacketBuilder:
             extra={
                 "counts": counts,
                 "coverage": coverage.to_dict(),
+                "chain_pin": chain_pin.to_dict(),
                 "provisional_manifest_sha256": provisional_sha,
             },
         )
@@ -1217,6 +1401,7 @@ class EvidencePacketBuilder:
             file_count=len(entries),
             bytes_written=bytes_written,
             coverage=coverage,
+            chain_pin=chain_pin,
         )
 
         return EvidencePacketResult(
@@ -1227,6 +1412,7 @@ class EvidencePacketBuilder:
             counts=counts,
             manifest=manifest,
             coverage=coverage,
+            chain_pin=chain_pin,
         )
 
     # ------------------------------------------------------------------
@@ -1298,6 +1484,7 @@ class EvidencePacketBuilder:
         file_count: int,
         bytes_written: int,
         coverage: AuditCoverage,
+        chain_pin: ChainPin,
     ) -> None:
         # Import locally to mirror the bin/lib/decommission.py pattern
         # (avoids hard adapter import at module load time).
@@ -1346,6 +1533,11 @@ class EvidencePacketBuilder:
                 "output_path": str(request.output_path),
                 "counts": dict(counts),
                 "coverage": coverage.to_dict(),
+                # The pin this packet was checked against, recorded INSIDE the
+                # chain it attests to. A later reader can take this row's own
+                # row_hash as the next pin, which is how the chain of custody
+                # keeps going without a new mechanism.
+                "chain_pin": chain_pin.to_dict(),
             },
         )
         try:
@@ -1365,6 +1557,8 @@ class EvidencePacketBuilder:
 
 __all__ = [
     "AuditCoverage",
+    "CHAIN_PIN_SOURCE",
+    "ChainPin",
     "EvidencePacketBuilder",
     "EvidencePacketError",
     "EvidencePacketResult",

--- a/operator/adapter/evidence/tests/test_packet.py
+++ b/operator/adapter/evidence/tests/test_packet.py
@@ -941,3 +941,146 @@ def test_readme_and_pdf_state_the_same_coverage_wording(tmp_path):
         # The PDF wraps at 88 chars, so check the token's first word
         # survives rather than the whole phrase.
         assert token.split()[0] in pdf
+
+
+# ---------------------------------------------------------------------------
+# Pinned chain head (ss#2500)
+#
+# The packet could always say a mutated or deleted MIDDLE row would show. It
+# could never say anything about rows cut off the END, because what survives
+# such a cut is itself a valid chain. A head recorded off the Machine is the
+# only input that closes that, and these tests hold the three outcomes apart:
+# checked and present, checked and gone (halt), and not checked (disclosed).
+# ---------------------------------------------------------------------------
+
+_CHAIN_SCHEMA_EXTRA = (
+    "ALTER TABLE audit_log ADD COLUMN prev_hash TEXT;"
+    "ALTER TABLE audit_log ADD COLUMN row_hash TEXT;"
+)
+
+_PIN_A = "a" * 64
+_PIN_B = "b" * 64
+
+
+def _build_pair_with_chain_columns(tmp_path: Path):
+    """A read source shaped like a real ledger: audit_log plus the link columns."""
+    builder, conn = _build_pair(tmp_path)
+    conn.executescript(_CHAIN_SCHEMA_EXTRA)
+    conn.commit()
+    return builder, conn
+
+
+def _seed_chained_row(conn: sqlite3.Connection, *, id_: str, ts: str, row_hash: str) -> None:
+    _seed_audit_row(conn, id=id_, ts=ts, action_type="DRAFT_CREATED", matter_ref="m-1")
+    conn.execute("UPDATE audit_log SET row_hash = ? WHERE id = ?", [row_hash, id_])
+    conn.commit()
+
+
+def test_a_present_pinned_head_is_stated_in_the_readme(tmp_path):
+    builder, conn = _build_pair_with_chain_columns(tmp_path)
+    _seed_chained_row(
+        conn, id_="01HZZ00000000000000000P1", ts="2026-04-10T09:00:00.000Z", row_hash=_PIN_A
+    )
+    customer_yaml = _write_customer_yaml(tmp_path, {"customer_name": "Acme"})
+
+    result = _run(builder.build(_request(tmp_path, customer_yaml, pinned_head=_PIN_A)))
+
+    assert result.chain_pin.present is True
+    assert result.chain_pin.was_checked is True
+    readme = _member_bytes(result.output_path, "00-README.md").decode("utf-8")
+    assert "Whether the log itself is complete" in readme
+    assert _PIN_A in readme
+    # The pin's SOURCE is named, so a reader can go and ask for it.
+    assert "audit_head_history" in readme
+    # And the limit is stated in the same breath, not omitted.
+    assert "Rows written" in readme
+
+
+def test_a_missing_pinned_head_halts_the_build(tmp_path):
+    """THE falsifier for the packet half.
+
+    The ledger holds a different head; the one recorded off the Machine is gone.
+    Before ss#2500 this built a clean packet asserting a complete record.
+    """
+    builder, conn = _build_pair_with_chain_columns(tmp_path)
+    _seed_chained_row(
+        conn, id_="01HZZ00000000000000000P2", ts="2026-04-10T09:00:00.000Z", row_hash=_PIN_B
+    )
+    customer_yaml = _write_customer_yaml(tmp_path, {"customer_name": "Acme"})
+
+    with pytest.raises(EvidencePacketError) as exc:
+        _run(builder.build(_request(tmp_path, customer_yaml, pinned_head=_PIN_A)))
+    assert "is NOT present in this ledger" in str(exc.value)
+    # No partial artifact: the halt happens before anything is rendered.
+    assert not (tmp_path / "out" / "evidence.tar.gz").exists()
+
+
+def test_the_same_ledger_builds_cleanly_when_the_pin_is_omitted(tmp_path):
+    """The negative control for the test above.
+
+    Same ledger, same rows. The only difference is whether a pin was supplied,
+    which is what makes the halt attributable to the pin check and not to
+    something else about the fixture.
+    """
+    builder, conn = _build_pair_with_chain_columns(tmp_path)
+    _seed_chained_row(
+        conn, id_="01HZZ00000000000000000P3", ts="2026-04-10T09:00:00.000Z", row_hash=_PIN_B
+    )
+    customer_yaml = _write_customer_yaml(tmp_path, {"customer_name": "Acme"})
+
+    result = _run(builder.build(_request(tmp_path, customer_yaml)))
+
+    assert result.chain_pin.was_checked is False
+    readme = _member_bytes(result.output_path, "00-README.md").decode("utf-8")
+    assert "checked for internal consistency only" in readme
+    assert "removed from the END" in readme
+
+
+def test_a_malformed_pin_is_refused_before_any_read(tmp_path):
+    """A junk pin matches nothing, so carrying it forward would print
+    "the record was truncated" on a packet about a healthy ledger."""
+    builder, _ = _build_pair_with_chain_columns(tmp_path)
+    customer_yaml = _write_customer_yaml(tmp_path, {"customer_name": "Acme"})
+    with pytest.raises(EvidencePacketError) as exc:
+        _run(builder.build(_request(tmp_path, customer_yaml, pinned_head="not-a-hash")))
+    assert "sha256 hexdigest" in str(exc.value)
+
+
+def test_a_source_without_chain_columns_halts_rather_than_reporting_a_break(tmp_path):
+    """"Could not look" must never be reported as "looked and it is gone"."""
+    builder, conn = _build_pair(tmp_path)  # no prev_hash / row_hash columns
+    _seed_audit_row(
+        conn,
+        id="01HZZ00000000000000000P4",
+        ts="2026-04-10T09:00:00.000Z",
+        action_type="DRAFT_CREATED",
+        matter_ref="m-1",
+    )
+    customer_yaml = _write_customer_yaml(tmp_path, {"customer_name": "Acme"})
+    with pytest.raises(EvidencePacketError) as exc:
+        _run(builder.build(_request(tmp_path, customer_yaml, pinned_head=_PIN_A)))
+    message = str(exc.value)
+    assert "carries no hash-chain columns" in message
+    assert "NOT present" not in message
+
+
+def test_the_pin_is_recorded_on_the_chain_of_custody_row(tmp_path):
+    """The pin travels INSIDE the chain it attests to, so a later reader can
+    take this row's own hash as the next pin without a new mechanism."""
+    builder, conn = _build_pair_with_chain_columns(tmp_path)
+    _seed_chained_row(
+        conn, id_="01HZZ00000000000000000P5", ts="2026-04-10T09:00:00.000Z", row_hash=_PIN_A
+    )
+    customer_yaml = _write_customer_yaml(tmp_path, {"customer_name": "Acme"})
+
+    _run(builder.build(_request(tmp_path, customer_yaml, pinned_head=_PIN_A)))
+
+    row = conn.execute(
+        "SELECT metadata FROM audit_log WHERE action_type = 'COMPLIANCE_PACKET_EXPORTED'"
+    ).fetchone()
+    metadata = json.loads(row["metadata"])
+    assert metadata["chain_pin"]["pinned_head"] == _PIN_A
+    assert metadata["chain_pin"]["present"] is True
+    manifest = _manifest_of(tmp_path / "out" / "evidence.tar.gz")
+    assert manifest["extra"]["chain_pin"]["checked"] is True
+    assert manifest["extra"]["chain_pin"]["present"] is True

--- a/operator/bin/audit-chain-watch.py
+++ b/operator/bin/audit-chain-watch.py
@@ -1,0 +1,649 @@
+#!/usr/bin/env python3
+"""Daily off-box check on every seat's audit chain, plus the off-box copy (ss#2500).
+
+WHAT WAS TRUE BEFORE THIS. The ledger was hash chained and nothing called the
+verifier -- not a workflow, not the evidence packet, not the portal export. It
+ran when a human ran it. The only copy of the ledger off the broker's file was
+Fly's daily volume snapshot on 5-day retention, and the A&P ledger had already
+lost its pre-2026-07-29 rows once when the seat was rebuilt on a new volume.
+
+WHAT THIS DOES, per seat, once a day:
+
+  1. Pulls the full ``audit_export`` over the ADR-0043 runtime-read seam.
+  2. Runs ``verify_chain`` over it (internal consistency).
+  3. Requires the newest head the console pinned from a heartbeat
+     (``audit_head_history``, migration 0108) to still appear in that export.
+     That is the only check that can see tail truncation; see
+     ``bin/lib/chain_pin.py`` for why, with the falsification that proves it.
+  4. Copies the export to R2 under ``audit/<slug>/<date>.json.gz`` and records
+     the object key and its sha256 in the run summary.
+  5. Writes an ``audit_integrity`` row into ``cost_anomaly_alerts`` on any
+     finding, so it lands on the same dashboard banner and the same alert-sink
+     notifier as every other observability source.
+
+TRI-STATE, AND A HOLD IS LOUD (#2395, the control-probes contract):
+
+  0  clean   -- every seat evaluated, every chain intact, every pin descended
+  1  finding -- at least one seat's record does not hold up. Alert row written.
+  2  hold    -- at least one seat could not be evaluated at all.
+
+A hold files no alert row -- an instrument failure is not a finding about a
+client's records -- and it still fails the run, because a control that reports
+green after asking nothing is indistinguishable from a healthy one. That is how
+the send reconciler sat inert for weeks with its secrets unset.
+
+NO PIN IS A HOLD, NOT A PASS. Until the heartbeat carries ``audit_head``
+(ss#2498) and a seat has beaten at least once since, there is nothing to compare
+against, and this run proves only that the export is self-consistent -- which is
+precisely the property already shown insufficient. Reporting that as clean would
+re-tell the lie this issue exists to end.
+
+WHAT IT STILL CANNOT PROVE. A pin protects rows OLDER than the pin. Rows written
+after the last heartbeat are unpinned and root can still remove them unnoticed
+until the next beat. And a forged row appended with a correct hash descends from
+the pin like any real one. Both are stated on the client-facing pages rather
+than papered over; per-row signing was considered and rejected (ADR 0074).
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import hashlib
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import urllib.request
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Optional, Sequence
+
+_HERE = Path(__file__).resolve()
+_OPERATOR = _HERE.parents[1]
+_REPO = _HERE.parents[2]
+sys.path.insert(0, str(_OPERATOR))
+sys.path.insert(0, str(_OPERATOR / "workspace_broker"))
+
+from bin.lib.chain_pin import (  # noqa: E402
+    PIN_ABSENT,
+    PIN_MALFORMED,
+    PIN_NOT_SUPPLIED,
+    check_pinned_head,
+)
+from bin.lib.seam_pull import seam_client_from_env  # noqa: E402
+from chain import verify_chain  # noqa: E402
+
+EXIT_CLEAN = 0
+EXIT_FINDING = 1
+EXIT_HOLD = 2
+
+CLEAN = "clean"
+FINDING = "finding"
+HOLD = "hold"
+
+#: The alert row's driver. Per SEAT, not per entity: several seats can share one
+#: entity and the alert PK is (entity_id, alert_date, driver), so a bare
+#: 'audit_chain' would let one seat's finding overwrite another's on the same
+#: day. It also cannot collide with the healthchecks writer, which uses ''.
+ALERT_DRIVER_PREFIX = "audit_chain:"
+
+DEFAULT_DB = "ss-console-db"
+DEFAULT_BUCKET = "smd-audit-archive"
+
+
+# ---------------------------------------------------------------------------
+# Verdict (pure -- the part worth unit testing)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SeatOutcome:
+    slug: str
+    state: str
+    headline: str
+    details: dict = field(default_factory=dict)
+
+    @property
+    def is_finding(self) -> bool:
+        return self.state == FINDING
+
+
+def evaluate_export(slug: str, rows: Sequence[dict], pin: Optional[dict]) -> SeatOutcome:
+    """Turn one export plus one pin row into a verdict.
+
+    ``pin`` is the newest ``audit_head_history`` row for this seat, or None.
+
+    Order matters. A broken chain is reported before a missing pin, because a
+    chain that does not verify is a finding no pin could rescue; and a malformed
+    pin is a hold rather than a finding, because the fault is ours.
+    """
+    report = verify_chain(rows)
+    pinned_head = (pin or {}).get("audit_head")
+    pin_check = check_pinned_head(rows, pinned_head=pinned_head, current_head=report["head"])
+
+    details: dict[str, Any] = {
+        "slug": slug,
+        "rows_in_export": len(rows),
+        "chained": report["chained"],
+        "legacy": report["legacy"],
+        "head": report["head"],
+        "pinned_head": pinned_head,
+        "pin_verdict": pin_check["verdict"],
+        "pin_first_seen": (pin or {}).get("first_seen_heartbeat_ts"),
+        "pin_last_seen": (pin or {}).get("last_seen_heartbeat_ts"),
+    }
+
+    if not report["ok"]:
+        details["breaks"] = report["breaks"][:20]
+        return SeatOutcome(
+            slug,
+            FINDING,
+            f"{slug}: the hash chain does not verify ({len(report['breaks'])} break(s)).",
+            details,
+        )
+
+    if pin_check["verdict"] == PIN_NOT_SUPPLIED:
+        return SeatOutcome(
+            slug,
+            HOLD,
+            f"{slug}: no head has been pinned off the Machine yet, so the tail is unchecked.",
+            details,
+        )
+
+    if pin_check["verdict"] == PIN_MALFORMED:
+        return SeatOutcome(
+            slug,
+            HOLD,
+            f"{slug}: the stored pin is not a sha256 hexdigest; that is a broken "
+            "instrument, not a finding about the ledger.",
+            details,
+        )
+
+    if pin_check["verdict"] == PIN_ABSENT:
+        details["reason"] = pin_check["reason"]
+        return SeatOutcome(
+            slug,
+            FINDING,
+            f"{slug}: a head this console pinned is gone from the export. "
+            "The ledger was truncated, rewritten, or rolled back.",
+            details,
+        )
+
+    shrink = _row_count_shrink(pin, len(rows))
+    if shrink is not None:
+        details["reason"] = shrink
+        return SeatOutcome(slug, FINDING, f"{slug}: {shrink}", details)
+
+    return SeatOutcome(
+        slug,
+        CLEAN,
+        f"{slug}: chain intact, {report['chained']} chained rows, pin {pin_check['verdict']}.",
+        details,
+    )
+
+
+def _row_count_shrink(pin: Optional[dict], rows_now: int) -> Optional[str]:
+    """A second, independent signal: the ledger got SMALLER than a pin recorded.
+
+    Weaker than the head check and kept anyway, because it costs one comparison
+    and it survives the one case the head check does not -- a rewrite that ends
+    on a head which happens to have been pinned before. Absent counts are
+    skipped rather than treated as zero; counting a NULL as zero is how a
+    fill-rate audit passes an all-zero column.
+    """
+    pinned_rows = (pin or {}).get("audit_rows")
+    if not isinstance(pinned_rows, int) or isinstance(pinned_rows, bool):
+        return None
+    if pinned_rows <= rows_now:
+        return None
+    return (
+        f"the export holds {rows_now} rows but a pinned heartbeat recorded "
+        f"{pinned_rows}; the ledger shrank by {pinned_rows - rows_now}."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Seat enumeration
+# ---------------------------------------------------------------------------
+
+
+def authored_seats(repo_root: Path) -> list[str]:
+    """Every seat main authors a customer.yaml for. Template dirs are skipped."""
+    base = repo_root / "operator" / "customers"
+    if not base.is_dir():
+        return []
+    return sorted(
+        d.name
+        for d in base.iterdir()
+        if d.is_dir() and not d.name.startswith("_") and (d / "customer.yaml").exists()
+    )
+
+
+# ---------------------------------------------------------------------------
+# Console D1 (through wrangler, the pattern the other CI reconcilers use)
+# ---------------------------------------------------------------------------
+
+Runner = Callable[[Sequence[str]], "subprocess.CompletedProcess[str]"]
+
+
+def _run(cmd: Sequence[str]) -> "subprocess.CompletedProcess[str]":
+    return subprocess.run(list(cmd), capture_output=True, text=True, check=False)
+
+
+def sql_text(value: Optional[str]) -> str:
+    """A TEXT literal that cannot be escaped out of, whatever the value contains.
+
+    `wrangler d1 execute` takes `--command` and `--file` and NOTHING ELSE --
+    checked against the installed CLI's own `--help`, not assumed -- so there is
+    no parameter binding on this path and every value has to be inlined. Quote
+    doubling is the usual answer and it is the wrong one here: part of what gets
+    inlined is break text lifted out of a seat's own export, which is exactly
+    the untrusted input an injection needs, and a control that could be made to
+    rewrite the alerts table by a compromised seat would be worse than no
+    control.
+
+    A blob literal has no escape sequences to get wrong: every byte is two hex
+    characters and the literal terminates at a fixed length. Cast back to TEXT
+    on the way in so the column holds a string, not a blob.
+    """
+    if value is None:
+        return "NULL"
+    return f"CAST(x'{value.encode('utf-8').hex()}' AS TEXT)"
+
+
+def sql_int(value: int) -> str:
+    """An INTEGER literal. Typed, so a non-int raises here rather than inlining."""
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError(f"sql_int refuses a non-integer: {value!r}")
+    return str(value)
+
+
+class ConsoleD1:
+    """Read pins and write alert rows through ``npx wrangler d1 execute``.
+
+    Same access path as ci-reconcile-customer-configs.sh, deliberately: one
+    credential shape (CLOUDFLARE_API_TOKEN + CLOUDFLARE_ACCOUNT_ID) for every
+    console-side CI job, and no second D1 client to keep in step with the first.
+    """
+
+    def __init__(self, db: str = DEFAULT_DB, runner: Runner = _run) -> None:
+        self._db = db
+        self._run = runner
+
+    def execute(self, sql: str) -> list[dict]:
+        proc = self._run(
+            ["npx", "wrangler", "d1", "execute", self._db, "--remote", "--json", "--command", sql]
+        )
+        if proc.returncode != 0:
+            raise RuntimeError(f"d1 execute failed: {proc.stderr.strip() or proc.stdout.strip()}")
+        return first_result_set(proc.stdout)
+
+    def newest_pin(self, slug: str) -> Optional[dict]:
+        sql = (
+            "SELECT audit_head, audit_rows, first_seen_heartbeat_ts, last_seen_heartbeat_ts "
+            f"FROM audit_head_history WHERE customer_slug = {sql_text(slug)} "
+            "ORDER BY id DESC LIMIT 1"
+        )
+        # See sql_text for why an inlined literal is the safe form here.
+        # nosemgrep: python.lang.security.audit.formatted-sql-query.formatted-sql-query,python.sqlalchemy.security.sqlalchemy-execute-raw-query.sqlalchemy-execute-raw-query
+        rows = self.execute(sql)
+        return rows[0] if rows else None
+
+    def entity_id(self, slug: str) -> Optional[str]:
+        # nosemgrep: python.lang.security.audit.formatted-sql-query.formatted-sql-query — see sql_text: no parameter binding exists on this CLI path; the interpolated text is a hex blob literal.
+        # nosemgrep: python.sqlalchemy.security.sqlalchemy-execute-raw-query.sqlalchemy-execute-raw-query — not SQLAlchemy; the only interpolation is sql_text's fixed-alphabet hex literal.
+        sql = f"SELECT entity_id FROM customer_configs WHERE customer_slug = {sql_text(slug)}"
+        # See sql_text: wrangler d1 execute has no parameter binding (checked
+        # against the installed CLI's own --help), and sql_text emits a hex blob
+        # literal, which carries no escape sequence to break out of.
+        # nosemgrep: python.lang.security.audit.formatted-sql-query.formatted-sql-query,python.sqlalchemy.security.sqlalchemy-execute-raw-query.sqlalchemy-execute-raw-query
+        rows = self.execute(sql)
+        return rows[0].get("entity_id") if rows else None
+
+    def write_alert(self, *, entity_id: str, slug: str, summary: str, details: dict) -> None:
+        """One ``audit_integrity`` row on the shared alert sink.
+
+        Existing snooze / acknowledged columns are left alone: this control
+        never undoes a Captain action on a row it wrote yesterday.
+        """
+        values = ", ".join(
+            [
+                sql_text(entity_id),
+                sql_text(slug),
+                sql_text(utc_date()),
+                sql_text(f"{ALERT_DRIVER_PREFIX}{slug}"),
+                "'audit_integrity'",
+                sql_int(0),
+                sql_int(0),
+                sql_int(0),
+                sql_int(0),
+                sql_text(summary),
+                sql_text(json.dumps(details, sort_keys=True)),
+                "datetime('now')",
+            ]
+        )
+        # Every interpolated value came through sql_text / sql_int above, so the
+        # only thing reaching the statement is a hex blob literal or a bare
+        # integer. That matters here more than anywhere else in this file: part
+        # of `details` is break text lifted out of a seat's own export, which is
+        # precisely the untrusted input an injection needs.
+        # nosemgrep: python.lang.security.audit.formatted-sql-query.formatted-sql-query,python.sqlalchemy.security.sqlalchemy-execute-raw-query.sqlalchemy-execute-raw-query
+        self.execute(
+            "INSERT INTO cost_anomaly_alerts ("
+            "entity_id, customer_slug, alert_date, driver, source, "
+            "daily_cents, rolling_avg_cents, ratio_bps, threshold_bps, "
+            "summary, details_json, detected_at"
+            f") VALUES ({values}) "
+            "ON CONFLICT(entity_id, alert_date, driver) DO UPDATE SET "
+            "summary = excluded.summary, details_json = excluded.details_json, "
+            "detected_at = excluded.detected_at"
+        )
+
+
+def first_result_set(stdout: str) -> list[dict]:
+    """Pull the rows out of wrangler's --json envelope.
+
+    Parsed, never assumed: wrangler prints a list of result objects for a
+    multi-statement command and has also printed a bare object, so both are
+    handled and anything else RAISES. Returning [] on an unrecognized envelope
+    would read as "no pin recorded", which is the one wrong answer that turns
+    into a HOLD nobody investigates.
+    """
+    payload = json.loads(stdout)
+    if isinstance(payload, list):
+        payload = payload[0] if payload else {}
+    if not isinstance(payload, dict):
+        raise RuntimeError("d1 execute returned an unrecognized envelope")
+    results = payload.get("results")
+    if results is None:
+        return []
+    if not isinstance(results, list):
+        raise RuntimeError("d1 execute returned a non-list results field")
+    return [r for r in results if isinstance(r, dict)]
+
+
+def utc_date() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+
+# ---------------------------------------------------------------------------
+# R2 archive
+# ---------------------------------------------------------------------------
+
+
+def r2_credentials() -> tuple[str, str, str]:
+    """Derive the S3 credentials exactly as ci-reconcile-r2-customer-configs.sh does.
+
+    Derive, never mint, and never print: the values reach the aws CLI through
+    its environment, never through a command line or a log line.
+    """
+    key_id = os.environ.get("R2_ACCESS_KEY_ID")
+    secret = os.environ.get("R2_SECRET_ACCESS_KEY")
+    if not key_id or not secret:
+        token = os.environ.get("CLOUDFLARE_API_TOKEN")
+        if not token:
+            raise RuntimeError("no R2 credentials and no CLOUDFLARE_API_TOKEN to derive them from")
+        key_id = cloudflare_token_id(token)
+        secret = hashlib.sha256(token.encode("utf-8")).hexdigest()
+    endpoint = os.environ.get("R2_ENDPOINT_URL")
+    if not endpoint:
+        account = os.environ.get("CLOUDFLARE_ACCOUNT_ID")
+        if not account:
+            raise RuntimeError("R2_ENDPOINT_URL unset and CLOUDFLARE_ACCOUNT_ID not available")
+        endpoint = f"https://{account}.r2.cloudflarestorage.com"
+    return key_id, secret, endpoint
+
+
+def cloudflare_token_id(token: str) -> str:
+    req = urllib.request.Request(
+        "https://api.cloudflare.com/client/v4/user/tokens/verify",
+        headers={"Authorization": f"Bearer {token}"},
+        method="GET",
+    )
+    # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected — constant https URL, no interpolation.
+    with urllib.request.urlopen(req, timeout=20) as resp:  # noqa: S310 — constant https URL
+        payload = json.loads(resp.read().decode("utf-8"))
+    token_id = (payload.get("result") or {}).get("id")
+    if not payload.get("success") or not token_id:
+        raise RuntimeError("/user/tokens/verify did not return a token id")
+    return str(token_id)
+
+
+@dataclass
+class ArchiveResult:
+    key: str
+    sha256: str
+    bytes_written: int
+
+
+def _aws_upload(local: Path, destination: str) -> None:
+    key_id, secret, endpoint = r2_credentials()
+    proc = subprocess.run(
+        [
+            "aws", "s3", "cp", str(local), destination,
+            "--endpoint-url", endpoint, "--only-show-errors",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=dict(os.environ, AWS_ACCESS_KEY_ID=key_id, AWS_SECRET_ACCESS_KEY=secret),
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(f"R2 upload failed for {destination}: {proc.stderr.strip()}")
+
+
+Uploader = Callable[[Path, str], None]
+
+
+def archive_export(
+    slug: str,
+    rows: Sequence[dict],
+    *,
+    bucket: str,
+    uploader: Uploader = _aws_upload,
+    work_dir: Optional[Path] = None,
+) -> ArchiveResult:
+    """Write one gzipped export to ``audit/<slug>/<date>.json.gz``.
+
+    The sha256 is taken over the GZIPPED BYTES that are uploaded, not over the
+    JSON, so the recorded digest is one an auditor reproduces by hashing the
+    downloaded object with no knowledge of our serialization. ``mtime=0`` so two
+    identical exports produce identical bytes; a gzip header timestamp would
+    make every archive's digest unique for no reason and defeat that.
+    """
+    key = f"audit/{slug}/{utc_date()}.json.gz"
+    tmp_dir = Path(work_dir) if work_dir else Path(tempfile.mkdtemp(prefix="audit-archive-"))
+    tmp_dir.mkdir(parents=True, exist_ok=True)
+    local = tmp_dir / f"{slug}.json.gz"
+
+    payload = json.dumps({"slug": slug, "entries": list(rows)}, sort_keys=True).encode("utf-8")
+    blob = gzip.compress(payload, mtime=0)
+    local.write_bytes(blob)
+
+    uploader(local, f"s3://{bucket}/{key}")
+    return ArchiveResult(key=key, sha256=hashlib.sha256(blob).hexdigest(), bytes_written=len(blob))
+
+
+def probe_bucket_lock(bucket: str, *, runner: Runner = _run) -> tuple[bool, str]:
+    """Is the archive prefix actually immutable?
+
+    An off-box copy on a bucket anyone can delete from is a backup, not a
+    compliance record, and calling this control done without asking would be the
+    built-but-not-wired shape exactly. So it is asked every run, and an
+    unconfirmed lock is a HOLD.
+
+    THE R2 SHAPE HERE IS UNVERIFIED and deliberately not guessed. There is no R2
+    access from a build session, and Cloudflare's bucket-lock feature is not
+    necessarily reachable through the S3 object-lock API this probes for. The
+    probe reports what it got rather than assuming what it should get: whichever
+    way the first live run answers is the shape, and the message says so.
+    """
+    proc = runner(["aws", "s3api", "get-object-lock-configuration", "--bucket", bucket])
+    if proc.returncode == 0 and "ObjectLockEnabled" in (proc.stdout or ""):
+        return True, f"Object lock is configured on s3://{bucket}."
+    detail = (proc.stderr or proc.stdout or "").strip().splitlines()
+    tail = detail[-1] if detail else "no output"
+    return False, (
+        f"Could not confirm object lock on s3://{bucket} ({tail}). The copy is being written to "
+        "a prefix whose immutability is unproven, which makes it a backup and not a compliance "
+        "record. Either configure a lock rule covering the audit/ prefix, or record here what "
+        "the R2 API actually answers so this probe can ask the right question."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Orchestration
+# ---------------------------------------------------------------------------
+
+
+def _hold(slug: str, message: str) -> SeatOutcome:
+    return SeatOutcome(slug, HOLD, f"{slug}: {message}", {"slug": slug})
+
+
+def process_seat(slug: str, console: ConsoleD1, *, bucket: str, archive: bool) -> SeatOutcome:
+    client = seam_client_from_env(slug)
+    if client is None:
+        return _hold(slug, "the runtime-read seam is not configured (no secret or no URL).")
+    try:
+        rows = client.read_all("audit_export")
+    except Exception as exc:  # noqa: BLE001 -- any transport failure is a hold
+        return _hold(slug, f"the audit export could not be pulled ({type(exc).__name__}: {exc}).")
+
+    try:
+        pin = console.newest_pin(slug)
+    except Exception as exc:  # noqa: BLE001
+        return _hold(slug, f"the pinned head could not be read from D1 ({exc}).")
+
+    outcome = evaluate_export(slug, rows, pin)
+    if not archive:
+        return outcome
+
+    try:
+        result = archive_export(slug, rows, bucket=bucket)
+    except Exception as exc:  # noqa: BLE001
+        # The copy is half the issue, so failing to write it is a hold on its
+        # own. It must not DOWNGRADE a finding that was already found, though:
+        # a truncated ledger stays the headline and carries the note.
+        outcome.details["archive_error"] = str(exc)
+        if outcome.state == CLEAN:
+            return _hold(slug, f"the off-box copy could not be written ({exc}).")
+        return outcome
+
+    outcome.details["archive_key"] = result.key
+    outcome.details["archive_sha256"] = result.sha256
+    outcome.details["archive_bytes"] = result.bytes_written
+    return outcome
+
+
+def emit_alert(console: ConsoleD1, outcome: SeatOutcome) -> Optional[str]:
+    """Write the finding to the shared sink. Returns a hold message on failure."""
+    try:
+        entity = console.entity_id(outcome.slug)
+        if not entity:
+            return f"{outcome.slug}: no customer_configs row, so no alert row could be written."
+        console.write_alert(
+            entity_id=entity,
+            slug=outcome.slug,
+            summary=outcome.headline,
+            details=outcome.details,
+        )
+    except Exception as exc:  # noqa: BLE001
+        return f"{outcome.slug}: the alert row could not be written ({exc})."
+    return None
+
+
+def summary_lines(outcomes: Sequence[SeatOutcome], lock_note: str) -> list[str]:
+    lines = ["", "-- audit chain watch summary --"]
+    for o in outcomes:
+        lines.append(f"{o.state.upper():>7}  {o.headline}")
+        key = o.details.get("archive_key")
+        if key:
+            lines.append(f"         archive {key} sha256 {o.details['archive_sha256']}")
+    lines += ["", lock_note]
+    return lines
+
+
+def write_step_summary(outcomes: Sequence[SeatOutcome], lock_note: str) -> None:
+    """The object key and sha256 the issue asks to be recorded in the run summary."""
+    path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not path:
+        return
+    lines = [
+        "### Audit chain watch",
+        "",
+        "| seat | state | archive key | sha256 |",
+        "|---|---|---|---|",
+    ]
+    for o in outcomes:
+        lines.append(
+            f"| {o.slug} | {o.state} | {o.details.get('archive_key', '-')} | "
+            f"{o.details.get('archive_sha256', '-')} |"
+        )
+    lines += ["", lock_note, ""]
+    with open(path, "a", encoding="utf-8") as fp:
+        fp.write("\n".join(lines) + "\n")
+
+
+def resolve_exit(
+    outcomes: Sequence[SeatOutcome], alert_holds: Sequence[str], lock_ok: bool
+) -> int:
+    """A finding outranks a hold; either outranks clean.
+
+    A finding outranks because it is the louder fact and it is already written
+    to the alert sink. A hold still fails the run through the workflow's final
+    step, which fires on any non-zero exit, so nothing is swallowed.
+    """
+    if any(o.is_finding for o in outcomes):
+        return EXIT_FINDING
+    if alert_holds or not lock_ok or any(o.state == HOLD for o in outcomes):
+        return EXIT_HOLD
+    return EXIT_CLEAN
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--seat", action="append", help="Limit to one seat (repeatable)")
+    ap.add_argument("--db", default=os.environ.get("D1_DATABASE", DEFAULT_DB))
+    ap.add_argument("--bucket", default=os.environ.get("R2_BUCKET_AUDIT", DEFAULT_BUCKET))
+    ap.add_argument(
+        "--no-archive",
+        action="store_true",
+        help="Verify only; do not write the off-box copy. For a manual re-check.",
+    )
+    args = ap.parse_args(argv)
+
+    seats = args.seat or authored_seats(_REPO)
+    if not seats:
+        print("HOLD: no authored seats found; this run measured nothing.")
+        return EXIT_HOLD
+
+    console = ConsoleD1(db=args.db)
+    archive = not args.no_archive
+    if archive:
+        lock_ok, lock_note = probe_bucket_lock(args.bucket)
+    else:
+        lock_ok, lock_note = True, "Off-box copy skipped (--no-archive); no lock probe was run."
+
+    outcomes = [process_seat(s, console, bucket=args.bucket, archive=archive) for s in seats]
+
+    alert_holds: list[str] = []
+    for outcome in outcomes:
+        if outcome.is_finding:
+            problem = emit_alert(console, outcome)
+            if problem:
+                alert_holds.append(problem)
+
+    for line in summary_lines(outcomes, lock_note):
+        print(line)
+    for line in alert_holds:
+        print(f"HOLD  {line}")
+
+    write_step_summary(outcomes, lock_note)
+    return resolve_exit(outcomes, alert_holds, lock_ok)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/operator/bin/generate-evidence-packet.sh
+++ b/operator/bin/generate-evidence-packet.sh
@@ -16,7 +16,20 @@
 #     --output <path> \
 #     --actor <name> \
 #     [--actor-role captain|compliance] \
-#     [--acknowledge-unattributed-gap]
+#     [--acknowledge-unattributed-gap] \
+#     [--pinned-head <sha256 hex>]
+#
+# Completeness of the log itself (ss#2500):
+#   The hash chain proves that a row altered, removed, or inserted BEFORE the
+#   end of the log breaks it at a verifiable point. It proves nothing about rows
+#   cut off the END, because what survives such a cut is itself a valid chain.
+#   --pinned-head takes a chain head recorded off the Machine before the export
+#   (the newest audit_head_history row for this seat on the control plane); the
+#   ledger must still contain it. If it does not, the build HALTS (exit 3) and
+#   there is no acknowledge flag, because a compliance packet asserting a
+#   complete record over a ledger that lost rows is the artifact the whole
+#   mechanism exists to prevent. Without the flag the packet states on its face
+#   that its audit section was not checked for truncation.
 #
 # Captain CLI integration (when bin/smd-cli lands):
 #   smd-cli evidence <slug> --matter <m> --from <a> --to <b>
@@ -52,7 +65,8 @@ Usage: generate-evidence-packet.sh --customer <slug> --matter <id|all> \
                                    --from <ISO> --to <ISO> \
                                    --output <path> --actor <name> \
                                    [--actor-role captain|compliance] \
-                                   [--acknowledge-unattributed-gap]
+                                   [--acknowledge-unattributed-gap] \
+                                   [--pinned-head <sha256 hex>]
 USAGE
   exit 2
 fi

--- a/operator/bin/lib/chain_pin.py
+++ b/operator/bin/lib/chain_pin.py
@@ -1,0 +1,172 @@
+"""Descends check: does this export still contain a head we already pinned?
+
+ss#2500. ``verify_chain`` (operator/workspace_broker/chain.py) proves internal
+consistency and nothing more. That is enough to catch a mutated or deleted row
+in the MIDDLE of the chain, and it is provably not enough to catch a truncated
+TAIL, because the surviving prefix is a valid chain in its own right.
+
+Falsified rather than reasoned about (vfy_01M0H8D1CV2X8J9ZACMAC8E6E2, run
+against mutated copies of a live 1,473-row export, baseline INTACT):
+
+    mutate a middle row .................. BROKEN
+    delete a middle row .................. BROKEN
+    delete the last 50 rows .............. INTACT   <- this module
+    delete the last 1 row ................ INTACT   <- this module
+    append a forged row with a valid hash. INTACT
+    mutate a row, re-hash everything after INTACT   <- this module
+
+The missing input is external: a head recorded somewhere the seat cannot reach.
+The console records one from every heartbeat (``audit_head_history``, migration
+0108). Given such a head, one question answers all three cases this module
+covers -- **does the pinned head still appear as some row's ``row_hash`` in the
+export?**
+
+* present and equal to the current head -> the ledger has not moved since the
+  pin. Fine.
+* present and not the head -> the chain GREW past the pin. Fine, and the only
+  shape a healthy ledger produces.
+* absent -> the pin was rolled back out of existence. Tail truncation, a
+  rewrite that re-hashed everything after some row, or a head regression all
+  land here, and this module does not try to tell them apart: which one it was
+  is a question for a human with two exports, and calling it wrong in a
+  compliance artifact is worse than calling it a break.
+
+WHAT THIS STILL CANNOT DO, stated because the docs quote it. A pin protects the
+rows OLDER than the last pin. Rows written after it are unpinned until the next
+heartbeat lands, so root on the Machine has a beat-sized window in which a
+freshly written row can be removed with nothing to notice. Shortening that
+window means beating more often, not a different mechanism. It also cannot
+distinguish a forged append from a real one: an appended row with a correct
+hash still descends from the pin. That case is out of scope by design (ADR 0074
+rejected per-row signing) and is stated rather than papered over.
+
+Nothing here imports the chain module. This file deliberately does not touch
+``operator/workspace_broker/chain.py``, which is a byte-identical twin of the
+overlay's ``shared/audit_chain.py`` (SEC-32, operator/contracts/overlay-pairs.json)
+and cannot take a one-sided edit.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable, Mapping
+from typing import Any, Optional
+
+#: A chain head is a sha256 hexdigest: 64 lowercase hex characters.
+HEAD_RE = re.compile(r"^[0-9a-f]{64}$")
+
+#: Verdicts. ``PIN_ABSENT`` is the only one that is a break.
+PIN_UNCHANGED = "pin_unchanged"
+PIN_DESCENDS = "pin_descends"
+PIN_ABSENT = "pin_absent"
+PIN_NOT_SUPPLIED = "pin_not_supplied"
+PIN_MALFORMED = "pin_malformed"
+
+
+def is_head(value: Any) -> bool:
+    return isinstance(value, str) and bool(HEAD_RE.match(value))
+
+
+def check_pinned_head(
+    rows: Iterable[Mapping[str, Any]],
+    *,
+    pinned_head: Optional[str],
+    current_head: Optional[str],
+) -> dict:
+    """Answer the descends question for one export.
+
+    ``rows`` are the export's rows (each carrying ``row_hash``);
+    ``current_head`` is ``verify_chain``'s reported head for the same export.
+
+    Returns::
+
+        {
+          "ok": bool,            # False ONLY on an absent or malformed pin
+          "verdict": str,        # one of the PIN_* constants
+          "pinned_head": str|None,
+          "current_head": str|None,
+          "reason": str,         # one plain sentence, safe to print verbatim
+        }
+
+    A missing pin is ``ok=True`` and ``PIN_NOT_SUPPLIED``: this function is not
+    the place that decides whether "nobody pinned anything" is acceptable. The
+    daily watcher treats it as a HOLD and fails its run; a local operator
+    verifying an export by hand does not need a pin to get a useful answer. Both
+    callers need the same fact reported the same way, and only one of them
+    should be turning it into a verdict about the fleet.
+    """
+    if pinned_head is None or pinned_head == "":
+        return {
+            "ok": True,
+            "verdict": PIN_NOT_SUPPLIED,
+            "pinned_head": None,
+            "current_head": current_head,
+            "reason": (
+                "No pinned head was supplied, so this export was checked for "
+                "internal consistency only. Tail truncation is not detectable "
+                "without a pin."
+            ),
+        }
+
+    if not is_head(pinned_head):
+        # Loud rather than lenient. A malformed pin can never appear in any
+        # export, so treating it as absent would report a break on a healthy
+        # ledger every single day -- a false accusation about a client's audit
+        # record, which is the one failure this control must not produce.
+        return {
+            "ok": False,
+            "verdict": PIN_MALFORMED,
+            "pinned_head": pinned_head,
+            "current_head": current_head,
+            "reason": (
+                "The supplied pinned head is not a sha256 hexdigest, so it "
+                "could not appear in any export. This is a broken instrument, "
+                "not a finding about the ledger."
+            ),
+        }
+
+    if pinned_head == current_head:
+        return {
+            "ok": True,
+            "verdict": PIN_UNCHANGED,
+            "pinned_head": pinned_head,
+            "current_head": current_head,
+            "reason": "The chain tip is still the pinned head; no rows were added since the pin.",
+        }
+
+    for row in rows:
+        if row.get("row_hash") == pinned_head:
+            return {
+                "ok": True,
+                "verdict": PIN_DESCENDS,
+                "pinned_head": pinned_head,
+                "current_head": current_head,
+                "reason": (
+                    "The pinned head is still in this export and the chain has "
+                    "grown past it."
+                ),
+            }
+
+    return {
+        "ok": False,
+        "verdict": PIN_ABSENT,
+        "pinned_head": pinned_head,
+        "current_head": current_head,
+        "reason": (
+            "The pinned head does not appear anywhere in this export. Rows that "
+            "existed when the head was pinned are gone: the ledger was "
+            "truncated, rewritten, or rolled back."
+        ),
+    }
+
+
+__all__ = [
+    "HEAD_RE",
+    "PIN_ABSENT",
+    "PIN_DESCENDS",
+    "PIN_MALFORMED",
+    "PIN_NOT_SUPPLIED",
+    "PIN_UNCHANGED",
+    "check_pinned_head",
+    "is_head",
+]

--- a/operator/bin/lib/evidence.py
+++ b/operator/bin/lib/evidence.py
@@ -179,6 +179,19 @@ def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
         ),
     )
     p.add_argument(
+        "--pinned-head",
+        default=None,
+        help=(
+            "A chain head recorded off the Machine before this export -- the "
+            "newest audit_head_history row for this seat on the control plane. "
+            "The ledger must still contain it; if it does not, rows that existed "
+            "when it was recorded are gone and the build HALTS (exit 3). There "
+            "is no acknowledge flag for that case. Without this flag the packet "
+            "states on its face that its audit section was not checked for "
+            "truncation."
+        ),
+    )
+    p.add_argument(
         "--customer-yaml",
         type=Path,
         default=None,
@@ -276,6 +289,7 @@ async def _run(args: argparse.Namespace) -> int:
         actor=args.actor,
         actor_role=PacketActor(args.actor_role),
         acknowledge_unattributed_gap=args.acknowledge_unattributed_gap,
+        pinned_head=args.pinned_head,
     )
 
     try:
@@ -306,6 +320,7 @@ async def _run(args: argparse.Namespace) -> int:
         "bytes_written": result.bytes_written,
         "counts": dict(result.counts),
         "coverage": result.coverage.to_dict(),
+        "chain_pin": result.chain_pin.to_dict(),
     }
     print(json.dumps(summary, sort_keys=True, indent=2))
 
@@ -315,6 +330,13 @@ async def _run(args: argparse.Namespace) -> int:
     if result.coverage.has_unattributed_rows or not result.coverage.table_present:
         for line in result.coverage.narrative_lines():
             print(f"[coverage] {line}", file=sys.stderr)
+
+    # Same reason, one layer down. A packet built without a pin cannot speak to
+    # truncation, and the operator forwarding it should see that before they
+    # send it, not discover it in the README afterwards.
+    if not result.chain_pin.was_checked:
+        for line in result.chain_pin.narrative_lines():
+            print(f"[chain] {line}", file=sys.stderr)
     return 0
 
 

--- a/operator/bin/lib/seam_pull.py
+++ b/operator/bin/lib/seam_pull.py
@@ -26,7 +26,11 @@ Outputs land in the per-customer archive dir:
 * ``machine-snapshot-{date}.sqlite`` — ``audit_log`` + memory tables as real
   sqlite tables. This file doubles as the evidence generator's ``--read-db``
   input, which was always specified as "the per-customer audit-export
-  snapshot" — the seam pull is what finally makes that input real.
+  snapshot" — the seam pull is what finally makes that input real. The
+  snapshot's ``audit_log`` carries the hash-chain link columns as well as the
+  12 compliance columns (ss#2500), because a snapshot without them cannot
+  answer any question about the chain, including whether a pinned head is
+  still in it.
 * ``audit-log-manifest-{date}.json`` / key counts in the step manifest.
 """
 
@@ -73,6 +77,14 @@ MEMORY_EXPORT_TABLES: tuple[str, ...] = (
     "agent_skills_inventory",
     "peer_preferences",
 )
+
+# The hash-chain link columns (#1686). NOT part of AUDIT_COLUMNS, which is the
+# frozen compliance-CSV column order, and preserved in the sqlite snapshot
+# anyway (ss#2500): the snapshot is what the evidence generator reads as
+# --read-db, and without these the packet cannot check a pinned head against the
+# ledger at all. Written as NULL when the Machine's overlay does not serve them,
+# so an older seat degrades to "unchecked" rather than to a crash.
+CHAIN_LINK_COLUMNS: tuple[str, ...] = ("prev_hash", "row_hash")
 
 _PAGE_LIMIT = 200  # overlay MAX_LIMIT
 
@@ -178,18 +190,19 @@ def _snapshot_conn(snapshot_path: Path) -> sqlite3.Connection:
 
 
 def _write_audit_snapshot(conn: sqlite3.Connection, rows: list[dict]) -> None:
-    cols = ", ".join(AUDIT_COLUMNS)
-    placeholders = ", ".join("?" for _ in AUDIT_COLUMNS)
+    snapshot_columns = AUDIT_COLUMNS + CHAIN_LINK_COLUMNS
+    cols = ", ".join(snapshot_columns)
+    placeholders = ", ".join("?" for _ in snapshot_columns)
     conn.execute(
         "CREATE TABLE IF NOT EXISTS audit_log ("
         "id TEXT PRIMARY KEY, ts TEXT NOT NULL, action_type TEXT NOT NULL, "
         "actor TEXT NOT NULL, actor_role TEXT, skill_name TEXT, matter_ref TEXT, "
         "input_digest TEXT, output_digest TEXT, diff_digest TEXT, "
-        "trust_ceiling TEXT, metadata TEXT)"
+        "trust_ceiling TEXT, metadata TEXT, prev_hash TEXT, row_hash TEXT)"
     )
     conn.executemany(
         f"INSERT OR REPLACE INTO audit_log ({cols}) VALUES ({placeholders})",
-        [tuple(row.get(c) for c in AUDIT_COLUMNS) for row in rows],
+        [tuple(row.get(c) for c in snapshot_columns) for row in rows],
     )
     conn.commit()
 
@@ -311,6 +324,7 @@ class SeamAuditLogPreserver:
 
 __all__ = [
     "AUDIT_COLUMNS",
+    "CHAIN_LINK_COLUMNS",
     "MEMORY_EXPORT_TABLES",
     "SeamAuditLogPreserver",
     "SeamClient",

--- a/operator/bin/tests/test_audit_chain_watch.py
+++ b/operator/bin/tests/test_audit_chain_watch.py
@@ -1,0 +1,308 @@
+"""Tests for bin/audit-chain-watch.py, the daily off-box chain check (ss#2500).
+
+Everything here is driven through injected runners and uploaders. Nothing in
+this file touches a seat, D1, or R2: a control's test suite that needed the
+live system to run would be skipped in CI, which is how a control ends up
+shipping with detection nobody has ever seen fire.
+
+The load-bearing assertions:
+
+  * a tail-truncated export against a real pin is a FINDING, and the same export
+    with no pin is a HOLD rather than a pass;
+  * a hold and a finding are distinguishable in the exit code, and a hold is
+    never silently upgraded to clean by a successful archive;
+  * the SQL builder cannot be escaped out of by a hostile break string, which is
+    the one place seat-controlled text reaches a statement.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_HERE = Path(__file__).resolve()
+_OPERATOR = _HERE.parents[2]
+sys.path.insert(0, str(_OPERATOR))
+sys.path.insert(0, str(_OPERATOR / "workspace_broker"))
+
+from chain import CHAIN_COLUMNS, GENESIS, compute_row_hash  # noqa: E402
+
+# The script has a dash in its name, so it is loaded by path rather than
+# imported. Same shape the other bin/ script tests use.
+_spec = importlib.util.spec_from_file_location(
+    "audit_chain_watch", _OPERATOR / "bin" / "audit-chain-watch.py"
+)
+watch = importlib.util.module_from_spec(_spec)
+assert _spec.loader is not None
+# Registered BEFORE exec: @dataclass resolves its own module out of sys.modules,
+# and an unregistered module makes the decorator raise at import time.
+sys.modules["audit_chain_watch"] = watch
+_spec.loader.exec_module(watch)
+
+
+def _chain(n: int) -> list[dict]:
+    rows: list[dict] = []
+    prev = GENESIS
+    for i in range(n):
+        row = {
+            "id": f"01J0000000000000000000{i:04d}",
+            "ts": f"2026-08-20T00:00:{i % 60:02d}Z",
+            "action_type": "TOOL_CALL_COMPLETED",
+            "actor": "agent",
+            "actor_role": "agent",
+            "skill_name": "unit-test",
+            "matter_ref": None,
+            "input_digest": None,
+            "output_digest": None,
+            "diff_digest": None,
+            "trust_ceiling": "draft",
+            "metadata": None,
+        }
+        row["prev_hash"] = prev
+        row["row_hash"] = compute_row_hash(prev, [row[c] for c in CHAIN_COLUMNS])
+        prev = row["row_hash"]
+        rows.append(row)
+    return rows
+
+
+def _pin(rows: list[dict], index: int, *, audit_rows: int | None = None) -> dict:
+    return {
+        "audit_head": rows[index]["row_hash"],
+        "audit_rows": len(rows) if audit_rows is None else audit_rows,
+        "first_seen_heartbeat_ts": "2026-08-20T00:00:00Z",
+        "last_seen_heartbeat_ts": "2026-08-20T00:05:00Z",
+    }
+
+
+# ---------------------------------------------------------------------------
+# evaluate_export
+# ---------------------------------------------------------------------------
+
+
+def test_truncated_tail_against_a_real_pin_is_a_finding():
+    rows = _chain(30)
+    pin = _pin(rows, -1)
+    outcome = watch.evaluate_export("seat", rows[:-1], pin)
+    assert outcome.state == watch.FINDING
+    assert "truncated" in outcome.headline
+    assert outcome.details["pin_verdict"] == "pin_absent"
+
+
+def test_the_same_truncated_export_with_no_pin_is_a_hold_not_a_pass():
+    """The negative control for the test above.
+
+    Without a pin the export is self-consistent and there is nothing to say.
+    Saying "clean" would repeat exactly the claim this issue exists to retire.
+    """
+    rows = _chain(30)
+    outcome = watch.evaluate_export("seat", rows[:-1], None)
+    assert outcome.state == watch.HOLD
+    assert outcome.details["pin_verdict"] == "pin_not_supplied"
+
+
+def test_a_descending_pin_is_clean():
+    rows = _chain(30)
+    outcome = watch.evaluate_export("seat", rows, _pin(rows, 10))
+    assert outcome.state == watch.CLEAN
+    assert outcome.details["pin_verdict"] == "pin_descends"
+
+
+def test_a_regressed_head_is_a_finding():
+    rows = _chain(30)
+    outcome = watch.evaluate_export("seat", rows[:12], _pin(rows, -1))
+    assert outcome.state == watch.FINDING
+
+
+def test_a_shrunken_row_count_is_a_finding_even_when_the_head_still_descends():
+    """The second signal, isolated.
+
+    The pin's head is row 5 and it IS in the export, so the head check passes.
+    The pin also recorded 30 rows and the export holds 10.
+    """
+    rows = _chain(30)
+    pin = _pin(rows, 5, audit_rows=30)
+    outcome = watch.evaluate_export("seat", rows[:10], pin)
+    assert outcome.state == watch.FINDING
+    assert "shrank" in outcome.headline
+
+
+def test_a_null_row_count_does_not_manufacture_a_shrink():
+    rows = _chain(30)
+    pin = _pin(rows, 5, audit_rows=None)
+    pin["audit_rows"] = None
+    assert watch.evaluate_export("seat", rows, pin).state == watch.CLEAN
+
+
+def test_a_malformed_pin_is_a_hold_not_an_accusation():
+    rows = _chain(10)
+    pin = _pin(rows, -1)
+    pin["audit_head"] = "garbage"
+    outcome = watch.evaluate_export("seat", rows, pin)
+    assert outcome.state == watch.HOLD
+    assert "instrument" in outcome.headline
+
+
+def test_a_broken_chain_outranks_the_pin_check():
+    rows = _chain(10)
+    pin = _pin(rows, -1)
+    rows[4]["skill_name"] = "tampered"  # breaks its own recomputation
+    outcome = watch.evaluate_export("seat", rows, pin)
+    assert outcome.state == watch.FINDING
+    assert "does not verify" in outcome.headline
+
+
+# ---------------------------------------------------------------------------
+# SQL construction
+# ---------------------------------------------------------------------------
+
+
+def test_sql_text_cannot_be_escaped_out_of():
+    hostile = "'; DROP TABLE cost_anomaly_alerts; --"
+    literal = watch.sql_text(hostile)
+    # No quote, no semicolon, no comment marker survives into the statement:
+    # the whole value is hex between a fixed opener and a fixed closer.
+    assert literal.startswith("CAST(x'") and literal.endswith("' AS TEXT)")
+    body = literal[len("CAST(x'") : -len("' AS TEXT)")]
+    assert all(c in "0123456789abcdef" for c in body)
+    assert bytes.fromhex(body).decode("utf-8") == hostile
+
+
+def test_sql_int_refuses_anything_that_is_not_an_integer():
+    assert watch.sql_int(0) == "0"
+    for bad in ("1", 1.0, True, None):
+        with pytest.raises(TypeError):
+            watch.sql_int(bad)
+
+
+def test_first_result_set_raises_rather_than_returning_empty_on_a_strange_envelope():
+    """"Could not read" must never be indistinguishable from "no pin recorded"."""
+    assert watch.first_result_set(json.dumps([{"results": [{"a": 1}]}])) == [{"a": 1}]
+    assert watch.first_result_set(json.dumps({"results": []})) == []
+    with pytest.raises(RuntimeError):
+        watch.first_result_set(json.dumps("nope"))
+    with pytest.raises(RuntimeError):
+        watch.first_result_set(json.dumps({"results": "nope"}))
+
+
+def test_the_alert_row_is_written_with_the_audit_integrity_source():
+    seen: list[list[str]] = []
+
+    def runner(cmd):
+        seen.append(list(cmd))
+        return subprocess.CompletedProcess(cmd, 0, json.dumps([{"results": []}]), "")
+
+    console = watch.ConsoleD1(db="test-db", runner=runner)
+    console.write_alert(
+        entity_id="ent-1",
+        slug="seat",
+        summary="seat: the ledger was truncated.",
+        details={"note": "'; DROP TABLE x; --"},
+    )
+    sql = seen[-1][-1]
+    assert "'audit_integrity'" in sql
+    assert "audit_chain:" in bytes.fromhex(_first_hex(sql, 3)).decode("utf-8")
+    assert "DROP TABLE x" not in sql
+
+
+def _first_hex(sql: str, index: int) -> str:
+    """The nth hex blob literal in a statement, for asserting on inlined values."""
+    parts = sql.split("CAST(x'")
+    return parts[index + 1].split("'")[0]
+
+
+# ---------------------------------------------------------------------------
+# Archive
+# ---------------------------------------------------------------------------
+
+
+def test_the_archive_key_and_digest_are_reproducible(tmp_path):
+    rows = _chain(5)
+    uploaded: list[tuple[Path, str]] = []
+
+    def uploader(local: Path, destination: str) -> None:
+        uploaded.append((local, destination))
+
+    first = watch.archive_export(
+        "seat", rows, bucket="b", uploader=uploader, work_dir=tmp_path / "one"
+    )
+    second = watch.archive_export(
+        "seat", rows, bucket="b", uploader=uploader, work_dir=tmp_path / "two"
+    )
+    assert first.key.startswith("audit/seat/") and first.key.endswith(".json.gz")
+    assert uploaded[0][1] == f"s3://b/{first.key}"
+    # Same rows, same bytes, same digest -- a gzip mtime would break this and
+    # make every day's digest incomparable for no reason.
+    assert first.sha256 == second.sha256
+    # And the digest is over the bytes on the wire, so an auditor reproduces it
+    # by hashing the object they downloaded.
+    assert first.sha256 == __import__("hashlib").sha256(uploaded[0][0].read_bytes()).hexdigest()
+
+
+def test_an_unconfirmed_bucket_lock_is_not_treated_as_configured():
+    def denied(cmd):
+        return subprocess.CompletedProcess(cmd, 255, "", "An error occurred (NotImplemented)")
+
+    ok, note = watch.probe_bucket_lock("smd-audit-archive", runner=denied)
+    assert ok is False
+    assert "immutability is unproven" in note
+
+
+def test_a_configured_bucket_lock_is_recognized():
+    def allowed(cmd):
+        return subprocess.CompletedProcess(
+            cmd, 0, json.dumps({"ObjectLockConfiguration": {"ObjectLockEnabled": "Enabled"}}), ""
+        )
+
+    ok, note = watch.probe_bucket_lock("smd-audit-archive", runner=allowed)
+    assert ok is True
+    assert "configured" in note
+
+
+# ---------------------------------------------------------------------------
+# Exit contract
+# ---------------------------------------------------------------------------
+
+
+def _outcome(state: str) -> "watch.SeatOutcome":
+    return watch.SeatOutcome("seat", state, "headline", {})
+
+
+def test_exit_codes_are_the_control_probes_tri_state():
+    assert watch.resolve_exit([_outcome(watch.CLEAN)], [], True) == watch.EXIT_CLEAN
+    assert watch.resolve_exit([_outcome(watch.HOLD)], [], True) == watch.EXIT_HOLD
+    assert watch.resolve_exit([_outcome(watch.FINDING)], [], True) == watch.EXIT_FINDING
+    # A finding outranks a hold: it is the louder fact and it is already on the
+    # alert sink. The hold still shows in the report.
+    assert (
+        watch.resolve_exit([_outcome(watch.FINDING), _outcome(watch.HOLD)], [], True)
+        == watch.EXIT_FINDING
+    )
+    # An unlocked archive prefix reddens an otherwise clean run. An off-box copy
+    # anyone can delete is a backup, not a record.
+    assert watch.resolve_exit([_outcome(watch.CLEAN)], [], False) == watch.EXIT_HOLD
+    # So does a finding that could not be written to the sink.
+    assert watch.resolve_exit([_outcome(watch.CLEAN)], ["could not write"], True) == watch.EXIT_HOLD
+
+
+def test_zero_seats_is_a_hold(monkeypatch, tmp_path):
+    """A run that measured nothing must never exit 0.
+
+    This is the send-reconciler shape: the job was green for weeks while
+    scanning an empty set.
+    """
+    monkeypatch.setattr(watch, "_REPO", tmp_path)
+    assert watch.main([]) == watch.EXIT_HOLD
+
+
+def test_authored_seats_skips_template_dirs(tmp_path):
+    base = tmp_path / "operator" / "customers"
+    for name in ("_template", "_hosted-template", "real-seat", "no-yaml"):
+        (base / name).mkdir(parents=True)
+    for name in ("_template", "real-seat"):
+        (base / name / "customer.yaml").write_text("slug: x\n")
+    assert watch.authored_seats(tmp_path) == ["real-seat"]

--- a/operator/bin/tests/test_chain_pin.py
+++ b/operator/bin/tests/test_chain_pin.py
@@ -1,0 +1,233 @@
+"""The falsifier for ss#2500: tail truncation must stop passing.
+
+READ THE FIRST TEST FIRST. ``test_truncated_tail_passes_without_a_pin`` asserts
+the OLD behaviour on purpose -- an export with its last rows deleted still walks
+as a valid chain and ``verify_chain`` still says ok. That test is the negative
+control for every other test in this file. Without it, a bug that made the
+truncated fixture fail for some unrelated reason would make the pin tests pass
+while proving nothing about the pin (Law 12: build the falsifier into the
+instrument, and test the probe on a known case).
+
+The fixture is a REAL chain built through ``compute_row_hash`` from
+``operator/workspace_broker/chain.py`` -- the same function the broker writes
+with -- not hand-written hashes. A hand-written fixture would be pinned to this
+test's idea of the canonicalization rather than to the shipped one, and would
+keep passing after a canonicalization change that broke every real ledger.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_HERE = Path(__file__).resolve()
+_OPERATOR = _HERE.parents[2]
+sys.path.insert(0, str(_OPERATOR))
+sys.path.insert(0, str(_OPERATOR / "workspace_broker"))
+
+from bin.lib.chain_pin import (  # noqa: E402
+    PIN_ABSENT,
+    PIN_DESCENDS,
+    PIN_MALFORMED,
+    PIN_NOT_SUPPLIED,
+    PIN_UNCHANGED,
+    check_pinned_head,
+)
+from chain import CHAIN_COLUMNS, GENESIS, compute_row_hash, verify_chain  # noqa: E402
+
+_VERIFIER = _OPERATOR / "bin" / "verify-audit-chain.py"
+
+
+def _build_chain(n: int) -> list[dict]:
+    """A real n-row chain, linked exactly as the broker links one."""
+    rows: list[dict] = []
+    prev = GENESIS
+    for i in range(n):
+        row = {
+            "id": f"01J0000000000000000000{i:04d}",
+            "ts": f"2026-08-20T00:{i // 60:02d}:{i % 60:02d}Z",
+            "action_type": "TOOL_CALL_COMPLETED",
+            "actor": "agent",
+            "actor_role": "agent",
+            "skill_name": "unit-test",
+            "matter_ref": None,
+            "input_digest": None,
+            "output_digest": None,
+            "diff_digest": None,
+            "trust_ceiling": "draft",
+            "metadata": None,
+        }
+        row["prev_hash"] = prev
+        row["row_hash"] = compute_row_hash(prev, [row[c] for c in CHAIN_COLUMNS])
+        prev = row["row_hash"]
+        rows.append(row)
+    return rows
+
+
+@pytest.fixture()
+def full_chain() -> list[dict]:
+    return _build_chain(40)
+
+
+# ---------------------------------------------------------------------------
+# The negative control: what the chain walk alone cannot see
+# ---------------------------------------------------------------------------
+
+
+def test_truncated_tail_passes_without_a_pin(full_chain):
+    """The defect, reproduced. This is what the live verifier did on 2026-08-20.
+
+    Both shapes the live run exercised: the last 1 row removed, and a 50-row
+    block removed. Both leave a valid chain, and the walk cannot tell.
+    """
+    for keep in (len(full_chain) - 1, len(full_chain) - 20):
+        truncated = full_chain[:keep]
+        report = verify_chain(truncated)
+        assert report["ok"] is True, "the chain walk alone should still pass; if it does not, this file's other tests prove nothing"
+        assert report["breaks"] == []
+        # And the head it reports is simply the new last row -- nothing about
+        # the report says rows are missing.
+        assert report["head"] == truncated[-1]["row_hash"]
+
+
+def test_rehash_after_mutation_passes_without_a_pin(full_chain):
+    """The fourth live tamper: mutate a row, re-hash everything after it.
+
+    The result is internally perfect. Only an external head disagrees.
+    """
+    rows = [dict(r) for r in full_chain]
+    rows[10]["skill_name"] = "tampered"
+    prev = rows[9]["row_hash"]
+    for row in rows[10:]:
+        row["prev_hash"] = prev
+        row["row_hash"] = compute_row_hash(prev, [row[c] for c in CHAIN_COLUMNS])
+        prev = row["row_hash"]
+    assert verify_chain(rows)["ok"] is True
+    # ...and the pin catches it, because the post-mutation re-hash necessarily
+    # produced a different tip than the one that was pinned.
+    pin = check_pinned_head(
+        rows, pinned_head=full_chain[-1]["row_hash"], current_head=verify_chain(rows)["head"]
+    )
+    assert pin["ok"] is False
+    assert pin["verdict"] == PIN_ABSENT
+
+
+# ---------------------------------------------------------------------------
+# check_pinned_head
+# ---------------------------------------------------------------------------
+
+
+def test_truncated_tail_with_the_pre_truncation_head_is_a_break(full_chain):
+    """THE falsifier named in ss#2500. Fails before chain_pin.py exists."""
+    pinned = full_chain[-1]["row_hash"]
+    truncated = full_chain[:-1]
+    pin = check_pinned_head(
+        truncated, pinned_head=pinned, current_head=verify_chain(truncated)["head"]
+    )
+    assert pin["ok"] is False
+    assert pin["verdict"] == PIN_ABSENT
+    assert "truncated" in pin["reason"]
+
+
+def test_a_descending_head_passes(full_chain):
+    """The healthy shape: the ledger grew past the pin."""
+    pinned = full_chain[20]["row_hash"]
+    pin = check_pinned_head(
+        full_chain, pinned_head=pinned, current_head=verify_chain(full_chain)["head"]
+    )
+    assert pin["ok"] is True
+    assert pin["verdict"] == PIN_DESCENDS
+
+
+def test_an_unchanged_head_passes(full_chain):
+    """A quiet seat. No rows written since the pin is not a finding."""
+    pin = check_pinned_head(
+        full_chain,
+        pinned_head=full_chain[-1]["row_hash"],
+        current_head=verify_chain(full_chain)["head"],
+    )
+    assert pin["ok"] is True
+    assert pin["verdict"] == PIN_UNCHANGED
+
+
+def test_a_regressed_head_fails(full_chain):
+    """Head regression: today's export ends BEFORE a head already pinned.
+
+    Distinct from truncation in cause -- a restored snapshot, a volume rolled
+    back, a seat rebuilt on an older copy -- and identical in what it means for
+    the record: rows that were pinned are not there.
+    """
+    later_pin = full_chain[-1]["row_hash"]
+    older_export = full_chain[:15]
+    pin = check_pinned_head(
+        older_export, pinned_head=later_pin, current_head=verify_chain(older_export)["head"]
+    )
+    assert pin["ok"] is False
+    assert pin["verdict"] == PIN_ABSENT
+
+
+def test_no_pin_is_reported_not_assumed(full_chain):
+    pin = check_pinned_head(
+        full_chain, pinned_head=None, current_head=verify_chain(full_chain)["head"]
+    )
+    assert pin["ok"] is True
+    assert pin["verdict"] == PIN_NOT_SUPPLIED
+    assert "not detectable" in pin["reason"]
+
+
+def test_a_malformed_pin_is_an_instrument_failure_not_a_finding(full_chain):
+    """A junk pin can never appear in any export.
+
+    Reporting it as a break would accuse a healthy ledger every day until a
+    human read the row. It gets its own verdict so the watcher can tell "the
+    record was tampered with" apart from "we stored garbage".
+    """
+    pin = check_pinned_head(
+        full_chain, pinned_head="not-a-hash", current_head=verify_chain(full_chain)["head"]
+    )
+    assert pin["ok"] is False
+    assert pin["verdict"] == PIN_MALFORMED
+    assert "instrument" in pin["reason"]
+
+
+# ---------------------------------------------------------------------------
+# The CLI, end to end
+# ---------------------------------------------------------------------------
+
+
+def _run_verifier(tmp_path: Path, rows: list[dict], *args: str) -> subprocess.CompletedProcess:
+    payload = tmp_path / "export.json"
+    payload.write_text(json.dumps({"entries": rows}))
+    return subprocess.run(
+        [sys.executable, str(_VERIFIER), "--json", str(payload), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_cli_truncated_export_passes_without_the_flag_and_fails_with_it(tmp_path, full_chain):
+    """One test, both sides, so the flag is provably what changed the verdict."""
+    pinned = full_chain[-1]["row_hash"]
+    truncated = full_chain[:-1]
+
+    without = _run_verifier(tmp_path, truncated)
+    assert without.returncode == 0, without.stdout + without.stderr
+    assert "INTACT" in without.stdout
+    assert "TAIL UNCHECKED" in without.stdout
+
+    with_pin = _run_verifier(tmp_path, truncated, "--pinned-head", pinned)
+    assert with_pin.returncode == 1, with_pin.stdout + with_pin.stderr
+    assert "BROKEN" in with_pin.stdout
+    assert f"BREAK pin={pinned}" in with_pin.stdout
+
+
+def test_cli_intact_export_with_a_descending_pin_exits_zero(tmp_path, full_chain):
+    result = _run_verifier(tmp_path, full_chain, "--pinned-head", full_chain[20]["row_hash"])
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "INTACT" in result.stdout
+    assert PIN_DESCENDS in result.stdout

--- a/operator/bin/verify-audit-chain.py
+++ b/operator/bin/verify-audit-chain.py
@@ -4,9 +4,25 @@
 Walks a full ledger and proves the chain: every chained row's ``row_hash``
 recomputes from its content + its parent's hash, exactly one chain start
 (GENESIS or the legacy anchor), no forks, no unreachable segments. A mutated,
-deleted, or inserted row is reported with its id and reason. Tail truncation
-is caught by comparing the reported ``head`` against an externally pinned
-head (the evidence-packet flow records it at export time).
+deleted, or inserted row is reported with its id and reason.
+
+TAIL TRUNCATION IS NOT AN INTERNAL PROPERTY (ss#2500). Cutting rows off the END
+leaves a valid chain behind, so this walk alone reports it INTACT. Measured, not
+reasoned about: against a live 1,473-row export, deleting the last 50 rows,
+deleting the last 1 row, and mutate-then-re-hash-everything-after all passed
+(vfy_01M0H8D1CV2X8J9ZACMAC8E6E2). This header used to promise that comparing the
+reported head "against an externally pinned head" caught it, and nothing pinned
+one, so the promise was load-bearing and unfulfilled.
+
+  --pinned-head HEX   a head recorded earlier, off the Machine. The export must
+                      still contain it as some row's ``row_hash``; if it does
+                      not, rows that existed when it was pinned are gone and
+                      that is reported as a BREAK. Without this flag the tail is
+                      unchecked, and the summary says so rather than implying a
+                      completeness it did not test.
+
+The console pins a head from every heartbeat into ``audit_head_history``
+(migration 0108); ``.github/workflows/audit-chain-verify.yml`` supplies it daily.
 
 Two input modes:
 
@@ -28,6 +44,9 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "workspace_broker"))
 from chain import CHAIN_COLUMNS, verify_chain  # noqa: E402
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from lib.chain_pin import PIN_NOT_SUPPLIED, check_pinned_head  # noqa: E402
 
 
 def rows_from_sqlite(path: str) -> list[dict]:
@@ -54,18 +73,42 @@ def main() -> int:
     src = ap.add_mutually_exclusive_group(required=True)
     src.add_argument("--sqlite", help="path to a ledger sqlite file")
     src.add_argument("--json", help="audit_export JSON path, or '-' for stdin")
+    ap.add_argument(
+        "--pinned-head",
+        default=None,
+        help=(
+            "A chain head recorded earlier, off the Machine (audit_head_history "
+            "in the console D1). The export must still contain it; if it does "
+            "not, the tail was truncated or rewritten and that is a BREAK."
+        ),
+    )
     args = ap.parse_args()
 
     rows = rows_from_sqlite(args.sqlite) if args.sqlite else rows_from_json(args.json)
     report = verify_chain(rows)
+    pin = check_pinned_head(rows, pinned_head=args.pinned_head, current_head=report["head"])
+
+    # Both halves gate the verdict. An internally consistent chain whose pinned
+    # head has vanished is not intact in any sense a client cares about, and
+    # printing INTACT above a BREAK line would be read as the headline.
+    ok = report["ok"] and pin["ok"]
 
     print(
-        f"chain {'INTACT' if report['ok'] else 'BROKEN'}: "
+        f"chain {'INTACT' if ok else 'BROKEN'}: "
         f"{report['chained']} chained, {report['legacy']} legacy, head={report['head']}"
     )
     for b in report["breaks"]:
         print(f"  BREAK id={b['id']}: {b['reason']}")
-    return 0 if report["ok"] else 1
+    if pin["verdict"] == PIN_NOT_SUPPLIED:
+        # Never silent. A run with no pin proves strictly less than a run with
+        # one, and a summary that does not say so is how this file's header came
+        # to describe a check nobody was performing.
+        print(f"  TAIL UNCHECKED: {pin['reason']}")
+    elif pin["ok"]:
+        print(f"  pin {pin['verdict']}: {pin['reason']}")
+    else:
+        print(f"  BREAK pin={pin['pinned_head']}: {pin['reason']}")
+    return 0 if ok else 1
 
 
 if __name__ == "__main__":

--- a/src/lib/operator/audit-head.ts
+++ b/src/lib/operator/audit-head.ts
@@ -1,0 +1,120 @@
+/**
+ * The audit chain head, pinned off the Machine (ss#2500).
+ *
+ * The per-seat audit ledger is a SHA-256 hash chain. Breaking it in the MIDDLE
+ * is detectable from the export alone; truncating the TAIL is not, because the
+ * surviving prefix is a valid chain. The only thing that makes tail truncation
+ * detectable is a head recorded somewhere the seat cannot reach, which a later
+ * export must then be shown to descend from.
+ *
+ * This module is that recording half. The heartbeat carries `audit_head` (the
+ * `row_hash` of the chain tip) and `audit_rows` (the ledger's row count); the
+ * ingest hands them here and this appends the pin to `audit_head_history`
+ * (migration 0108).
+ *
+ * WHY A SEPARATE MODULE AND NOT MORE LINES IN heartbeat.ts. The same two wire
+ * fields also land in `fleet_status` (ss#2498) for the live dashboard read.
+ * That is a current-state projection whose columns are overwritten every beat;
+ * this is an append-only pin history. Two destinations, one parse: the handler
+ * parses each field once and hands the result to both, so a future change to
+ * what counts as a valid head cannot make the dashboard and the pin disagree
+ * about the same beat. The write below is the part that is genuinely different
+ * -- append-with-dedupe rather than overwrite -- and that is what lives here.
+ *
+ * WHAT THIS DOES NOT DO. It does not verify anything. A pin is a fact recorded
+ * about a moment, and the seat is the one asserting it: a root user who
+ * rewrites the ledger AND controls the next heartbeat can pin the rewritten
+ * head. What root cannot do is reach back and change a pin already stored here,
+ * which is what makes every row OLDER than the rewrite an accusation. The
+ * comparison itself runs daily off-box in
+ * `.github/workflows/audit-chain-verify.yml`.
+ */
+
+/**
+ * ss#2498 landed the two parsers for these fields inside the heartbeat handler
+ * itself (`parseAuditHead` for the head, the file's existing `parseNonNegInt`
+ * for the row count), and this module deliberately does NOT define a second
+ * pair. Both destinations -- the `fleet_status` projection the dashboard reads
+ * and the pin history below -- take their values from that one parse, so they
+ * cannot disagree about what a given beat said. Two parsers with the same rule
+ * written twice is exactly how they start to differ.
+ *
+ * What that parse guarantees, and what this module therefore relies on: a head
+ * is 64 lowercase hex characters or it is null. Junk is never pinned, because a
+ * pinned value that could never appear in any export would make the daily
+ * verifier accuse a healthy ledger every day until someone read the row.
+ */
+
+export interface AuditHeadBeat {
+  entityId: string
+  slug: string
+  heartbeatTs: string
+  auditHead: string | null
+  auditRows: number | null
+}
+
+/**
+ * Append this beat's head to the pin history.
+ *
+ * Three behaviours worth stating because each is a decision:
+ *
+ * 1. A beat with no parseable head writes NOTHING. A seat whose ledger has no
+ *    chained rows yet, or an overlay that predates the field, has no head to
+ *    pin; writing a NULL row would later read as "the ledger was empty at T",
+ *    which is a claim neither side made.
+ *
+ * 2. A beat whose head equals the newest pinned head for this seat refreshes
+ *    that row's `last_seen_heartbeat_ts` and `beats` instead of inserting. The
+ *    pin fields (`audit_head`, `audit_rows`, `first_seen_heartbeat_ts`) are
+ *    never touched. At a 60s beat this is the difference between one row per
+ *    distinct head and 1,440 identical rows per seat per day; no head is lost
+ *    either way, because a DIFFERENT head always inserts.
+ *
+ * 3. A head that reappears after a different head was pinned in between still
+ *    INSERTS a new row. That is a head regression -- the ledger moved backwards
+ *    -- and collapsing it into the earlier row would erase the evidence. The
+ *    comparison is against the NEWEST pin only, never against the whole set.
+ */
+export async function recordAuditHead(db: D1Database, beat: AuditHeadBeat): Promise<void> {
+  if (beat.auditHead === null) return
+
+  const newest = await db
+    .prepare(
+      `SELECT id, audit_head FROM audit_head_history
+        WHERE customer_slug = ?
+        ORDER BY id DESC LIMIT 1`
+    )
+    .bind(beat.slug)
+    .first<{ id: number; audit_head: string }>()
+
+  if (newest && newest.audit_head === beat.auditHead) {
+    await db
+      .prepare(
+        `UPDATE audit_head_history
+            SET last_seen_heartbeat_ts = ?,
+                beats                  = beats + 1,
+                entity_id              = ?
+          WHERE id = ?`
+      )
+      .bind(beat.heartbeatTs, beat.entityId, newest.id)
+      .run()
+    return
+  }
+
+  await db
+    .prepare(
+      `INSERT INTO audit_head_history
+         (customer_slug, entity_id, audit_head, audit_rows,
+          first_seen_heartbeat_ts, last_seen_heartbeat_ts, beats, recorded_at)
+       VALUES (?, ?, ?, ?, ?, ?, 1, datetime('now'))`
+    )
+    .bind(
+      beat.slug,
+      beat.entityId,
+      beat.auditHead,
+      beat.auditRows,
+      beat.heartbeatTs,
+      beat.heartbeatTs
+    )
+    .run()
+}

--- a/src/pages/api/internal/heartbeat.ts
+++ b/src/pages/api/internal/heartbeat.ts
@@ -32,6 +32,11 @@
  *     "audit_rows":              <integer>         // optional (ss#2500 chain pin)
  *   }
  *
+ * `audit_head` / `audit_rows` are the one pair here that does NOT land only in
+ * `fleet_status`. They are also appended to `audit_head_history` (migration
+ * 0108) as an off-Machine pin, because tail truncation of the seat's hash chain
+ * is undetectable from an export alone -- see `src/lib/operator/audit-head.ts`.
+ *
  * The authoritative list of fields the pinned overlay can emit is
  * `operator/observability/heartbeat-fields.json`, enforced by
  * `tests/heartbeat-field-parity.test.ts` — a field the seat sends that this
@@ -55,6 +60,7 @@ import type { APIRoute } from 'astro'
 import { env } from 'cloudflare:workers'
 import { verifyMachineRequest } from '../../../lib/auth/machine-key'
 import { captureError, captureWarning } from '../../../lib/observability/sentry'
+import { recordAuditHead } from '../../../lib/operator/audit-head'
 
 const DEFAULT_PERIOD_SECONDS = 60
 const DEFAULT_GRACE_MINUTES = 5
@@ -364,6 +370,23 @@ export const POST: APIRoute = async ({ request }) => {
     webhookSurfaceOk,
     cronContainment,
     auditWriteFailures,
+    auditHead,
+    auditRows,
+  })
+
+  // ss#2500. Appended, not upserted: this is the off-Machine pin history, and a
+  // pin a later beat could overwrite would not be a pin. Deliberately AFTER the
+  // fleet_status upsert so a failure here cannot cost the health projection --
+  // the Machine retries the whole beat, and the append is idempotent for an
+  // unchanged head.
+  // The values come from `parseObservability` above, NOT from a second parse of
+  // the body. One intake, two destinations: the fleet_status projection ss#2498
+  // writes and this pin history read the identical parsed beat, so the
+  // dashboard and the pin can never disagree about what the seat said.
+  await recordAuditHead(env.DB, {
+    entityId: auth.entityId,
+    slug: auth.slug,
+    heartbeatTs: body.heartbeat_ts,
     auditHead,
     auditRows,
   })

--- a/src/pages/security.astro
+++ b/src/pages/security.astro
@@ -106,6 +106,21 @@ const H2 =
             staff through outside tools is authorized per request against a live grant table, so
             revoking a person's access takes effect on their next call, not at some future expiry.
           </p>
+          <p class="mt-4">
+            The log is hash chained: each entry commits to the one before it, so an entry changed,
+            removed, or inserted anywhere before the end of the log breaks the chain at a point
+            anyone can verify. Entries removed from the end of the log are a different problem,
+            because what remains after such a removal is still a valid chain. We close that by
+            recording the hash of the newest entry on our own systems every minute, where nothing on
+            your dedicated machine can reach it. A daily job pulls your whole log and requires a
+            hash we recorded earlier to still be present in it. If it is not, we are paged.
+          </p>
+          <p class="mt-4">
+            Plainly, so you can rely on it: a recorded hash protects every entry older than itself.
+            Entries written since the last recording are not yet covered, a window of about one
+            minute. The same daily job writes a copy of your log to separate storage, so the record
+            survives the loss of your machine.
+          </p>
         </section>
 
         <section id="data">

--- a/tests/audit-head-history.test.ts
+++ b/tests/audit-head-history.test.ts
@@ -1,0 +1,201 @@
+/**
+ * ss#2500 - the off-Machine pin history.
+ *
+ * WHAT THIS PROTECTS. The audit ledger is a hash chain, and a chain walk cannot
+ * see rows cut off the END: the surviving prefix is a valid chain. Measured, not
+ * argued (vfy_01M0H8D1CV2X8J9ZACMAC8E6E2). The only input that closes it is a
+ * head recorded somewhere the seat cannot reach, and this table is that
+ * recording. Every property below is one a later verifier depends on:
+ *
+ *  - a pin is never overwritten by a later beat (a pin that could be is not one);
+ *  - a repeated head does not multiply rows, so the table stays readable at a
+ *    60-second beat without dropping any distinct head;
+ *  - a head that comes BACK after a different one still inserts, because that is
+ *    a ledger regression and collapsing it would erase the evidence;
+ *  - a junk head is dropped rather than pinned, because a pin that can never
+ *    match would accuse a healthy ledger every day until someone read the row.
+ *
+ * Posted at the REAL ingest handler rather than calling recordAuditHead
+ * directly: the defect class this closes (ss#2287) is a field that reaches the
+ * wire and is dropped at ingest, and only the handler proves the wiring.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  createTestD1,
+  discoverNumericMigrations,
+  runMigrations,
+  installWorkerdPolyfills,
+} from '@venturecrane/crane-test-harness'
+import path from 'node:path'
+import { POST } from '../src/pages/api/internal/heartbeat'
+import { env as testEnv } from 'cloudflare:workers'
+
+installWorkerdPolyfills()
+
+const migrationsDir = path.join(path.resolve(__dirname, '..'), 'migrations')
+
+const MACHINE_KEY = 'test-machine-heartbeat-key-32-chars'
+const ORG_ID = 'org-pin'
+const ENTITY = 'ent-pin'
+const SLUG = 'pin-co'
+
+const HEAD_A = 'a'.repeat(64)
+const HEAD_B = 'b'.repeat(64)
+
+interface PinRow {
+  audit_head: string
+  audit_rows: number | null
+  first_seen_heartbeat_ts: string
+  last_seen_heartbeat_ts: string
+  beats: number
+}
+
+async function seed(db: D1Database): Promise<void> {
+  await db
+    .prepare(
+      `INSERT INTO organizations (id, name, slug, created_at, updated_at)
+       VALUES (?, 'Pin Org', 'pin-org', datetime('now'), datetime('now'))`
+    )
+    .bind(ORG_ID)
+    .run()
+  await db
+    .prepare(
+      `INSERT INTO entities (id, org_id, name, slug, stage, stage_changed_at, created_at, updated_at)
+       VALUES (?, ?, ?, ?, 'ongoing', datetime('now'), datetime('now'), datetime('now'))`
+    )
+    .bind(ENTITY, ORG_ID, SLUG, SLUG)
+    .run()
+  await db
+    .prepare(
+      `INSERT INTO customer_configs
+         (entity_id, org_id, customer_slug, schema_version, personas_json, git_sha, synced_at)
+       VALUES (?, ?, ?, '1.0.0', '[]', 'sha', '2026-08-20T00:00:00Z')`
+    )
+    .bind(ENTITY, ORG_ID, SLUG)
+    .run()
+}
+
+async function beat(body: Record<string, unknown>): Promise<Response> {
+  const request = new Request('http://test.local/api/internal/heartbeat', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${MACHINE_KEY}`,
+      'X-Tenant-Slug': SLUG,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  })
+  return POST({ request, params: {}, locals: {} } as unknown as Parameters<typeof POST>[0])
+}
+
+async function pins(db: D1Database): Promise<PinRow[]> {
+  const result = await db
+    .prepare(
+      `SELECT audit_head, audit_rows, first_seen_heartbeat_ts, last_seen_heartbeat_ts, beats
+         FROM audit_head_history WHERE customer_slug = ? ORDER BY id ASC`
+    )
+    .bind(SLUG)
+    .all<PinRow>()
+  return result.results
+}
+
+describe('audit head history - the pin the seat cannot reach (ss#2500)', () => {
+  let db: D1Database
+
+  beforeEach(async () => {
+    db = createTestD1()
+    await runMigrations(db, { files: discoverNumericMigrations(migrationsDir) })
+    await seed(db)
+    for (const k of Object.keys(testEnv)) delete (testEnv as unknown as Record<string, unknown>)[k]
+    Object.assign(testEnv, { DB: db, MACHINE_HEARTBEAT_KEY: MACHINE_KEY })
+  })
+
+  it('a heartbeat carrying a head pins it', async () => {
+    const response = await beat({
+      heartbeat_ts: '2026-08-20T00:00:00.000Z',
+      audit_head: HEAD_A,
+      audit_rows: 1473,
+    })
+    expect(response.status).toBe(200)
+
+    const rows = await pins(db)
+    expect(rows).toHaveLength(1)
+    expect(rows[0].audit_head).toBe(HEAD_A)
+    expect(rows[0].audit_rows).toBe(1473)
+    expect(rows[0].first_seen_heartbeat_ts).toBe('2026-08-20T00:00:00.000Z')
+    expect(rows[0].beats).toBe(1)
+  })
+
+  it('a repeated head refreshes liveness without touching the pin or adding a row', async () => {
+    await beat({ heartbeat_ts: '2026-08-20T00:00:00.000Z', audit_head: HEAD_A, audit_rows: 10 })
+    await beat({ heartbeat_ts: '2026-08-20T00:01:00.000Z', audit_head: HEAD_A, audit_rows: 10 })
+    await beat({ heartbeat_ts: '2026-08-20T00:02:00.000Z', audit_head: HEAD_A, audit_rows: 10 })
+
+    const rows = await pins(db)
+    expect(rows).toHaveLength(1)
+    expect(rows[0].beats).toBe(3)
+    // The pin fields are untouched; only the liveness field moved.
+    expect(rows[0].first_seen_heartbeat_ts).toBe('2026-08-20T00:00:00.000Z')
+    expect(rows[0].last_seen_heartbeat_ts).toBe('2026-08-20T00:02:00.000Z')
+  })
+
+  it('a new head appends rather than replacing, so no pin is ever lost', async () => {
+    await beat({ heartbeat_ts: '2026-08-20T00:00:00.000Z', audit_head: HEAD_A, audit_rows: 10 })
+    await beat({ heartbeat_ts: '2026-08-20T00:01:00.000Z', audit_head: HEAD_B, audit_rows: 11 })
+
+    const rows = await pins(db)
+    expect(rows.map((r) => r.audit_head)).toEqual([HEAD_A, HEAD_B])
+  })
+
+  it('a head that comes back after another one inserts again (a ledger regression is evidence)', async () => {
+    await beat({ heartbeat_ts: '2026-08-20T00:00:00.000Z', audit_head: HEAD_A, audit_rows: 10 })
+    await beat({ heartbeat_ts: '2026-08-20T00:01:00.000Z', audit_head: HEAD_B, audit_rows: 11 })
+    await beat({ heartbeat_ts: '2026-08-20T00:02:00.000Z', audit_head: HEAD_A, audit_rows: 10 })
+
+    const rows = await pins(db)
+    expect(rows.map((r) => r.audit_head)).toEqual([HEAD_A, HEAD_B, HEAD_A])
+  })
+
+  it('a beat with no head pins nothing rather than pinning a NULL', async () => {
+    const response = await beat({ heartbeat_ts: '2026-08-20T00:00:00.000Z' })
+    expect(response.status).toBe(200)
+    expect(await pins(db)).toHaveLength(0)
+  })
+
+  it('NEGATIVE CONTROL: a junk head is dropped, not pinned', async () => {
+    // Without this the parser could be accepting anything and every test above
+    // would still pass. A pinned junk head can never match an export, so the
+    // daily verifier would report a break on a healthy ledger every day.
+    for (const junk of ['not-a-hash', 'A'.repeat(64), 'a'.repeat(63), 12345, null]) {
+      await beat({ heartbeat_ts: '2026-08-20T00:00:00.000Z', audit_head: junk })
+    }
+    expect(await pins(db)).toHaveLength(0)
+  })
+
+  it('a junk row count is stored NULL rather than coerced', async () => {
+    for (const junk of ['lots', -1, 1.5]) {
+      await beat({
+        heartbeat_ts: '2026-08-20T00:00:00.000Z',
+        audit_head: HEAD_A,
+        audit_rows: junk,
+      })
+    }
+    const rows = await pins(db)
+    // One pin (the head never changed), and the count it was pinned with is
+    // NULL rather than a number nobody sent.
+    expect(rows).toHaveLength(1)
+    expect(rows[0].audit_rows).toBeNull()
+  })
+
+  it('an all-zero digest pins like any other head', async () => {
+    // Not a hypothetical: the heartbeat parity manifest (ss#2498) uses 64 zeros
+    // as its sample, so this exact value reaches this handler on every parity
+    // run. It is valid hex and must pin; a parser that special-cased a
+    // zero-looking digest would silently drop a real beat.
+    await beat({ heartbeat_ts: '2026-08-20T00:00:00.000Z', audit_head: '0'.repeat(64) })
+    const rows = await pins(db)
+    expect(rows).toHaveLength(1)
+    expect(rows[0].audit_head).toBe('0'.repeat(64))
+  })
+})


### PR DESCRIPTION
Closes #2500.

## The sentence

A third party — the firm's insurer, the State Bar, opposing counsel, or the firm itself at offboarding — can be shown that the audit record was **not truncated or rewritten by anyone, SMD included**, and that it **survives loss of the Machine**.

## What changed

**The head leaves the Machine.** Migration `0108_audit_head_history.sql` adds an append-only per-seat table, and `src/pages/api/internal/heartbeat.ts` writes every heartbeat's `audit_head` / `audit_rows` into it via `src/lib/operator/audit-head.ts`. Pin fields (`audit_head`, `audit_rows`, `first_seen_heartbeat_ts`) are written once and never updated; a repeated head refreshes only `last_seen_heartbeat_ts` / `beats`, so one row per distinct head with none dropped. A *different* head always inserts, including a head that comes back after another one — that is a ledger regression and collapsing it would erase the evidence.

**The check runs daily, off-box.** `.github/workflows/audit-chain-verify.yml` (shaped on `control-probes.yml`) runs `operator/bin/audit-chain-watch.py`: pull each seat's `audit_export` over the seam (`operator/bin/lib/seam_pull.py`), `verify_chain`, then require the newest pinned head to still appear as some row's `row_hash`. A break, a head mismatch, a head regression, or a row-count shrink writes an `audit_integrity` row into `cost_anomaly_alerts` (existing `AlertSource`; no new source invented) and opens a P0. Tri-state per #2395: transport failure, unreadable D1, unconfirmed bucket lock, and **a seat with no pin yet** are all HOLDs, and a hold fails the run.

**The copy leaves the Machine.** The same job writes `audit/<slug>/<date>.json.gz` to R2 using the credential derivation `customer-config-reconcile.yml` uses (derived from `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID`, never minted), and records the object key + sha256 of the uploaded bytes in the run summary. `gzip(mtime=0)` so identical exports produce identical digests.

**`--pinned-head` on both verifiers.** `operator/bin/verify-audit-chain.py` and the evidence packet accept it. A packet whose pinned head is missing **halts** with no acknowledge flag; a packet built without one states on its face that its audit section was not checked for truncation, and names where a pin comes from. `seam_pull.py`'s sqlite snapshot now preserves `prev_hash` / `row_hash` — without them the packet's `--read-db` cannot answer any chain question at all.

**Two designs no longer stand.** `docs/specs/operator/audit-log-immutability.md` is marked SUPERSEDED with a layer-by-layer table of what ships instead. Its Captain redaction process is called out as unbuilt rather than superseded, because nothing replaced it.

## The falsifier

`operator/bin/tests/test_chain_pin.py` leads with the **negative control**: a truncated export still passes the chain walk alone. Without that assertion, a fixture broken for some unrelated reason would make the pin tests pass while proving nothing.

```
$ verify-audit-chain.py --json truncated.json
chain INTACT: 39 chained, 0 legacy, head=d251203...
  TAIL UNCHECKED: No pinned head was supplied...
exit=0

$ verify-audit-chain.py --json truncated.json --pinned-head 9ef0fc4d...
chain BROKEN: 39 chained, 0 legacy, head=d251203...
  BREAK pin=9ef0fc4d...: The pinned head does not appear anywhere in this export.
exit=1
```

Same export, same rows; only the flag differs. Fixtures are a real chain built through `compute_row_hash` from `operator/workspace_broker/chain.py`, not hand-written hashes.

## Evidence

| AC | Status | Evidence |
|---|---|---|
| (repo) Console persists **every** head into an append-only per-seat table | met | `migrations/0108_audit_head_history.sql`; `src/lib/operator/audit-head.ts`; `tests/audit-head-history.test.ts` (7 cases incl. a negative control that a junk head is dropped, not pinned). The heartbeat *emitter* half is #2498's. |
| (repo) Daily workflow pulls `audit_export`, runs `verify_chain`, checks descent, writes an `audit_integrity` alert; tri-state, hold fails the run | met | `.github/workflows/audit-chain-verify.yml`; `operator/bin/audit-chain-watch.py`; `operator/bin/tests/test_audit_chain_watch.py` (18 cases, incl. the exit contract and that a truncated export with no pin is a HOLD not a pass) |
| (repo) Same workflow writes `audit/<slug>/<date>.json.gz` to R2 on an immutable prefix; key + sha256 in the run summary | **partly met** | Write path + digest + run-summary table: `archive_export`, `write_step_summary`, tests `test_the_archive_key_and_digest_are_reproducible`. **The prefix is not yet object-locked** — see Captain decision below. The job probes for it every run and HOLDs until confirmed rather than assuming. |
| (repo) `verify-audit-chain.py` and the evidence packet accept `--pinned-head` and report tail truncation as a break; packet README states the pin source | met | `vfy_01M0HFXTH44EJW85MDEGG341RR` (CLI, both sides of the flag); `operator/adapter/evidence/packet.py` (`ChainPin`, `_fetch_chain_pin`, halt); 6 new cases in `test_packet.py` incl. `test_a_present_pinned_head_is_stated_in_the_readme` asserting `audit_head_history` appears in `00-README.md` |
| (repo) `docs/handbook/security-trust.md` and `src/pages/security.astro` say what is now true, including the honesty line | met | Both updated; the limit is stated in both, in the same words. `npm run verify` exit 0 (4575 tests) covers `handbook-integrity` and `forbidden-strings`. |
| (runtime) Pilot tail-truncation caught by the workflow; A&P first head pinned, first R2 copy present; alert fires on a synthetic mismatch | **UNMET** | No seat access from this session, and there is nothing to pin yet: the heartbeat does not carry `audit_head` until #2498 merges **and** the Captain-gated `OVERLAY_REF` bump + reprovision puts it on a seat. Until then every scheduled run correctly HOLDs. |

Test runs: `npm run verify` exit 0 (288 files, 4575 passed). Operator python: 475 passed (`bin/tests`), 798 passed / 2 skipped (`adapter`, `safety-substrate`, `workspace_broker`).

## Captain decisions needed

1. **The R2 archive bucket and its lock.** The job writes to `smd-audit-archive` (override `R2_BUCKET_AUDIT`); the bucket does not exist yet and no lock rule is configured. **The exact R2 object-lock API shape is unprobed** — there is no R2 access from a build session, and Cloudflare's bucket-lock feature may not be reachable through the S3 `get-object-lock-configuration` call the probe uses. Rather than guess, the probe reports what it got and HOLDs; the first live run will tell us which shape is real and the probe gets corrected to match. Until then the daily job is red for this reason alone, which is the honest state for "the copy exists but its immutability is unproven".
2. **The schedule turning red before the pin exists.** `23 4 * * *` starts holding on every seat the day this merges, because no head has been pinned yet. That is intentional (a hold is not a pass) but it is noise until #2498's field reaches a seat. Say the word and I will land it with the `schedule:` trigger commented out and a follow-up to enable it after the pin-bump.

## Coordination

Split with the peer building #2498, agreed by message: they own `fleet_status.audit_head` / `audit_rows` (migration 0107), the `operator/observability/heartbeat-fields.json` entries for those fields, `audit_write_failures`, and `shared/heartbeat.py` in the overlay. This PR touches none of them. Both PRs edit `src/pages/api/internal/heartbeat.ts`; whichever lands second should re-read the file. No overlay change here, so no pin move is needed for this PR — but nothing in it reaches a seat until #2498's overlay change is pinned and the seats reprovision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016U9H1VbtZdmBo2t6UBAAPr
