### PR TITLE
fix(operator): the rehearsal harness reads a whole token grant, so the first poll against the firm's seat no longer dies

### DIFF
--- a/operator/bin/rehearse-card.py
+++ b/operator/bin/rehearse-card.py
@@ -272,10 +272,17 @@ def msgraph_secret_env_names(slug: str, email: dict) -> tuple[str, str]:
 
 
 def _open(req: urllib.request.Request, timeout: int = 45) -> tuple[int, str]:
-    """One HTTP round trip, returning (status, truncated body).
+    """One HTTP round trip, returning (status, body).
 
     Errors are returned rather than raised so a caller decides what a non-2xx
     means. No request header is ever echoed, so a bearer cannot reach a log.
+
+    A 2xx body is returned WHOLE. The first live run against the paying seat
+    crashed because this cap was 400 characters on every path: a token grant
+    is about 1,500 characters and its access_token string opens near character
+    78, so the truncated JSON was unterminated and the harness died before the
+    first poll. The mocked tests never saw a wire-sized body. Only the error
+    body is capped, since that is the one a caller may echo.
     """
     try:
         # Every URL here is one of this module's own constants concatenated with
@@ -284,7 +291,7 @@ def _open(req: urllib.request.Request, timeout: int = 45) -> tuple[int, str]:
         # reasoning as `api` above.
         # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected
         with urllib.request.urlopen(req, timeout=timeout) as r:
-            return r.status, r.read().decode()[:400]
+            return r.status, r.read().decode()
     except urllib.error.HTTPError as e:
         return e.code, e.read().decode()[:400]
 

--- a/operator/bin/tests/test_rehearse_card.py
+++ b/operator/bin/tests/test_rehearse_card.py
@@ -481,3 +481,43 @@ def test_the_reply_comes_back_from_the_seats_sent_items(monkeypatch: pytest.Monk
     assert out == "The matter is open."
     assert urls[0] == rc.RESEND_URL
     assert "/users/operator%40example.test/mailFolders/SentItems/messages" in urls[1]
+
+
+def test_a_wire_sized_token_grant_survives_open(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The first live run against the paying seat died before its first poll.
+
+    `_open` capped every body at 400 characters. A real client-credentials grant
+    is about 1,500 characters and its access_token string opens near character
+    78, so the JSON came back unterminated and `graph_token` raised instead of
+    returning a bearer. The mocked bodies in this file were all short, which is
+    how the cap passed 35 tests and failed on the wire. A 2xx body must come
+    back whole; only an error body is capped.
+    """
+    jwt = "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9." + "a" * 1400 + ".sig"
+    grant = json.dumps(
+        {"token_type": "Bearer", "expires_in": 3599, "ext_expires_in": 3599, "access_token": jwt}
+    )
+    assert grant.index('"access_token"') < 400 < len(grant)
+
+    def fake(req: object, timeout: int = 45) -> _FakeResponse:
+        return _FakeResponse(200, grant)
+
+    monkeypatch.setattr(rc.urllib.request, "urlopen", fake)
+    token, ttl = rc.graph_token("tenant", "client", "secret")
+    assert token == jwt
+    assert ttl == 3599
+
+
+def test_an_error_body_is_still_capped(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The cap exists so a caller that echoes a non-2xx body cannot spill a
+    page of it into a log. Lifting it from success bodies must not lift it
+    from error bodies."""
+    import urllib.error
+
+    def fake(req: object, timeout: int = 45) -> _FakeResponse:
+        raise urllib.error.HTTPError("https://x", 500, "boom", None, io.BytesIO(b"e" * 1000))  # type: ignore[arg-type]
+
+    monkeypatch.setattr(rc.urllib.request, "urlopen", fake)
+    status, body = rc._open(rc.urllib.request.Request("https://graph.microsoft.com/v1.0/x"))
+    assert status == 500
+    assert len(body) == 400


### PR DESCRIPTION
## What broke

The first live run of #2504 against `hermes-ashton-price` sent card 1 and crashed before its first poll:

```
File ".../rehearse-card.py", line 457, in ask_msgraph
    st, res = graph_get(path, token.value(), TEXT_BODY_PREFER)
json.decoder.JSONDecodeError: Unterminated string starting at: line 1 column 79 (char 78)
```

`_open` capped every response body at 400 characters. A client-credentials grant is about 1,500 characters and its `access_token` string opens near character 78, so the JSON came back unterminated and `graph_token` raised.

All 35 mocked tests in #2504 used short bodies. That is how the cap passed them and failed on the wire: the instrument could not observe its own layer.

## The fix

A 2xx body is returned whole. The error body keeps its 400-character cap, because that is the one a caller may echo and the cap exists so a rejected grant cannot spill into a log. One line in `_open`, plus its docstring.

## Tests (35 -> 37)

- `test_a_wire_sized_token_grant_survives_open`: a 1,400-character JWT inside a grant body, asserted to start past the old cap, through `graph_token`. **Falsifier run:** with the cap restored on the success path this test fails with `JSONDecodeError: Unterminated string starting at: line 1 column 86`, the live error. Reverted after.
- `test_an_error_body_is_still_capped`: a 1,000-byte HTTP 500 body comes back at exactly 400.

`npm run verify` exit 0. AgentMail path untouched (its `api()` helper never used `_open`).

## Why this is a fix and not a filed issue

The harness is the gate for the A&P stand-up rehearsal, which is the Captain's current ask. Card 1 has already been sent to the seat twice by the crashed runs; the replies will sit in the Operator's Sent Items and will be matched by send-time on the re-run, so no rehearsal artifact needs cleaning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017NcRcv8JotFDQxYnGWoaSz
