### PR TITLE
feat(audit): the firm's audit record names the person, the message, and the matter (#2497)

### DIFF
--- a/operator/workspace_broker/agentmail_auth.py
+++ b/operator/workspace_broker/agentmail_auth.py
@@ -43,6 +43,7 @@ from .recipient_policy import (
     authored_policy,
     canonicalize,
     normalize_address,
+    sender_key,
 )
 
 #: Env var carrying the SEND-capable, inbox-scoped AgentMail key. Deliberately a
@@ -107,4 +108,5 @@ __all__ = [
     "materialize_credential",
     "normalize_address",
     "seat_inbox_address",
+    "sender_key",
 ]

--- a/operator/workspace_broker/agentmail_ops.py
+++ b/operator/workspace_broker/agentmail_ops.py
@@ -34,6 +34,7 @@ from .agentmail_auth import (
     load_send_key,
     normalize_address,
     seat_inbox_address,
+    sender_key,
 )
 
 API_BASE = "https://api.agentmail.to/v0"
@@ -249,4 +250,9 @@ class AgentMailOps:
             "message_id": _message_id(response),
             "recipients": [sender],
             "inbox_id": self.inbox_id(),
+            # ss#2497 — the twin of the msgraph verb. The broker is the only
+            # party that knows who this answered, because it fetched the source
+            # message rather than trusting a caller to name the sender. Hashed,
+            # so the join exists and the address does not.
+            "sender_key": sender_key(sender),
         }

--- a/operator/workspace_broker/msgraph_ops.py
+++ b/operator/workspace_broker/msgraph_ops.py
@@ -49,7 +49,7 @@ from pathlib import Path
 from typing import Any
 
 from .msgraph_auth import load_credential, seat_mailbox
-from .recipient_policy import RecipientPolicy, authored_policy, normalize_address
+from .recipient_policy import RecipientPolicy, authored_policy, normalize_address, sender_key
 
 GRAPH_BASE = "https://graph.microsoft.com/v1.0"
 TOKEN_HOST = "https://login.microsoftonline.com"
@@ -447,7 +447,17 @@ class MsGraphOps:
             "POST",
             self._reply_body(comment, html),
         )
-        return {"message_id": "", "recipients": [sender], "mailbox": self.mailbox()}
+        return {
+            "message_id": "",
+            "recipients": [sender],
+            "mailbox": self.mailbox(),
+            # ss#2497. The broker is the ONLY party that knows who this answered:
+            # it fetched the source message itself precisely because a caller
+            # naming the sender could name any sender. So the row's join to the
+            # INBOUND_RECEIVED row is minted here, from the verified sender, and
+            # hashed because the ledger must not hold an address.
+            "sender_key": sender_key(sender),
+        }
 
     @staticmethod
     def _reply_body(comment: str, html: str) -> dict[str, Any]:

--- a/operator/workspace_broker/recipient_policy.py
+++ b/operator/workspace_broker/recipient_policy.py
@@ -36,6 +36,7 @@ on none of them, so all four are refused.
 
 from __future__ import annotations
 
+import hashlib
 import unicodedata
 from dataclasses import dataclass
 from email.utils import parseaddr
@@ -107,6 +108,32 @@ def normalize_address(value: Any) -> str:
     # the raw string would let an unparseable value be compared against the
     # roster, and the only safe comparison for garbage is one that fails.
     return canonicalize(parsed) if parsed else ""
+
+
+def sender_key(value: Any) -> str | None:
+    """The audit row's answer to "which person" — ``sha256`` of the canonical
+    address, or ``None`` when there is no address (ss#2497).
+
+    HASHED, NOT STORED. The audit record is a file a firm exports and forwards,
+    and the issue's non-goal is explicit: no row carries a raw address. A firm
+    that holds its own people's addresses reproduces the key and finds every row
+    that person caused; a reader who does not already know the address learns
+    nothing. A rostered display name may ride alongside as a LABEL and is never
+    the identity, because a display name is attacker-controlled text in every
+    mail system.
+
+    Built on :func:`normalize_address` and therefore on :func:`canonicalize`,
+    which is the whole reason it lives in THIS module rather than beside a
+    writer. A key is only a join if both ends reduce the same human to the same
+    bytes, and the overlay's twin (``shared/audit_contract.sender_key``) applies
+    the identical NFC + strip + lower before hashing. Hashing the raw string
+    instead would give the same person two identities the day one mail client
+    sends a decomposed ``é``.
+    """
+    address = normalize_address(value)
+    if not address:
+        return None
+    return hashlib.sha256(address.encode("utf-8")).hexdigest()
 
 
 def domain_of(address: str) -> str:

--- a/operator/workspace_broker/server.py
+++ b/operator/workspace_broker/server.py
@@ -577,7 +577,13 @@ class Broker:
     # -- ss#2258 transmit --------------------------------------------------
 
     def _append_send_row(
-        self, action_type: str, verb: str, metadata: dict[str, Any]
+        self,
+        action_type: str,
+        verb: str,
+        metadata: dict[str, Any],
+        *,
+        session_id: str = "",
+        matter_ref: str | None = None,
     ) -> None:
         """Record a transmit attempt. Body digests only — never the body.
 
@@ -585,21 +591,45 @@ class Broker:
         unaudited messages of 2026-08 were possible because emission lived in
         plugin code that returned early whenever its audit client was unset; a
         row written here has no such branch.
+
+        THE TWO JOINS (ss#2497). Measured on the live A&P ledger 2026-08-21
+        (``vfy_01M0H8DR6JAPYVHFMNJZXQZ517``): ``session_id`` appeared on 0 of 9
+        CONFIRM_SEND_DISPATCHED rows and ``matter_ref`` on none of them, so a
+        send could not be tied to the turn that composed it or to the matter it
+        concerned. Neither is knowable HERE — this process has no session and
+        does not read matters — so both travel on the request beside the payload
+        and are written straight through, unexamined. That is deliberate: they
+        are attribution the agent asserts about its own turn, not authorization,
+        and the broker's authority is over WHO may be written to, which it still
+        decides for itself from the seat's own config.
+
+        ``matter_ref`` goes to its COLUMN (``LedgerWriter`` accepts it as an
+        agent column) rather than into metadata, because the column is what the
+        portal audit record filters and indexes on. Empty values are omitted
+        rather than written as ``""``, which the hash chain canonicalizes
+        distinctly from NULL and which reads as a reference that is present and
+        blank.
         """
         if self.ledger is None:
             return
-        self.ledger.append(
-            {
-                "action_type": action_type,
-                "actor": "operator",
-                "actor_role": "agent",
-                "metadata": json.dumps(
-                    {"customer": self.customer_slug, "verb": verb, **metadata},
-                    sort_keys=True,
-                    separators=(",", ":"),
-                ),
-            }
-        )
+        row: dict[str, Any] = {
+            "action_type": action_type,
+            "actor": "operator",
+            "actor_role": "agent",
+            "metadata": json.dumps(
+                {
+                    "customer": self.customer_slug,
+                    "verb": verb,
+                    **({"session_id": session_id} if session_id else {}),
+                    **metadata,
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+            ),
+        }
+        if matter_ref:
+            row["matter_ref"] = matter_ref
+        self.ledger.append(row)
 
     def _dispatch_transmit(
         self,
@@ -625,6 +655,16 @@ class Broker:
         payload = request.get("payload")
         if not isinstance(payload, dict):
             raise ValueError(f"{action} requires a 'payload' object")
+        # ss#2497 — the audit joins, read from the REQUEST and never from the
+        # payload. The payload is what reaches the vendor and is rebuilt from a
+        # closed allowlist, so an audit field placed there would be dropped
+        # silently. Both are optional: a caller that predates them writes exactly
+        # the row it writes today, which is what lets the overlay and this
+        # process be deployed in either order.
+        session_id = request.get("session_id")
+        session_id = session_id.strip() if isinstance(session_id, str) else ""
+        matter_ref = request.get("matter_ref")
+        matter_ref = matter_ref.strip() if isinstance(matter_ref, str) else ""
         # Digest what the caller asked to send, computed here, so the row proves
         # which content went out without the ledger ever holding the content.
         digest = hashlib.sha256(_canonical(payload)).hexdigest()
@@ -644,6 +684,8 @@ class Broker:
                     "recipients": attempted,
                     "input_digest": digest,
                 },
+                session_id=session_id,
+                matter_ref=matter_ref,
             )
             raise
         except transport as exc:
@@ -660,6 +702,8 @@ class Broker:
                     "recipients": attempted,
                     "input_digest": digest,
                 },
+                session_id=session_id,
+                matter_ref=matter_ref,
             )
             raise
         self._append_send_row(
@@ -671,9 +715,25 @@ class Broker:
                 "message_id": result.get("message_id") or "",
                 identity_key: result.get(identity_key) or "",
                 "input_digest": digest,
+                # ss#2497 — on a REPLY the ops verb resolved the original sender
+                # itself (it had to: a caller naming the sender could name any
+                # sender), so the row can name the person it answered without an
+                # address entering the ledger. A send names no such person and
+                # contributes no key.
+                **(
+                    {"sender_key": result["sender_key"]}
+                    if isinstance(result.get("sender_key"), str) and result["sender_key"]
+                    else {}
+                ),
             },
+            session_id=session_id,
+            matter_ref=matter_ref,
         )
-        return {"ok": True, **result}
+        # ``sender_key`` is audit provenance, not a transmit result: it stays in
+        # the row and does not travel back to the agent, which has no use for it
+        # and which the fence deliberately does not tell who it just wrote to
+        # beyond what it already knew.
+        return {"ok": True, **{k: v for k, v in result.items() if k != "sender_key"}}
 
     def _handle_agentmail(self, action: str, request: dict[str, Any]) -> dict[str, Any]:
         if self.agentmail is None or self.ledger is None:

--- a/operator/workspace_broker/tests/test_msgraph_send.py
+++ b/operator/workspace_broker/tests/test_msgraph_send.py
@@ -47,6 +47,7 @@ from workspace_broker.msgraph_ops import (  # noqa: E402
     MsGraphRefused,
     MsGraphTransportError,
 )
+from workspace_broker.recipient_policy import sender_key  # noqa: E402
 from workspace_broker.server import Broker  # noqa: E402
 
 GATEWAY_PID = 42
@@ -816,3 +817,156 @@ def test_the_reply_verb_writes_its_own_row(tmp_path: Path) -> None:
     meta = _meta(broker)
     assert meta["verb"] == "msgraph_reply"
     assert meta["recipients"] == ["scott@smd.services"]
+
+
+# ---------------------------------------------------------------------------
+# The audit joins (ss#2497)
+#
+# Measured on the live ashton-price ledger 2026-08-21
+# (vfy_01M0H8DR6JAPYVHFMNJZXQZ517): session_id appeared on 0 of 9
+# CONFIRM_SEND_DISPATCHED rows and matter_ref on none of them. A send row that
+# cannot say which turn composed it or which matter it concerned is what the
+# cross-matter question (ss#2167) falls into: the ledger shows the reads and the
+# sends and cannot connect them, and that silence reads as innocence.
+# ---------------------------------------------------------------------------
+
+
+def test_the_send_row_carries_the_session_and_the_matter(tmp_path: Path) -> None:
+    """FALSIFIER: drop the two kwargs from the _append_send_row call and both
+    assertions fail while every other row assertion in this file stays green,
+    which is exactly how the gap survived."""
+    broker = _broker(tmp_path, FakeGraph())
+    broker.handle(
+        {
+            "action": "msgraph_send",
+            "payload": {"to": ["scott@smd.services"], "body_text": "hi"},
+            "session_id": "20260820_195837_68d654ce",
+            "matter_ref": "matter-uuid-1",
+        },
+        peer_pid=GATEWAY_PID,
+        peer_uid=AGENT_UID,
+    )
+    row = broker.ledger.rows[0]
+    # matter_ref goes to the COLUMN, which is what the portal record filters on.
+    assert row["matter_ref"] == "matter-uuid-1"
+    assert _meta(broker)["session_id"] == "20260820_195837_68d654ce"
+
+
+def test_a_refusal_row_carries_them_too(tmp_path: Path) -> None:
+    """A refused send is the row an investigator most wants to place in a
+    session. FALSIFIER: thread the joins only through the success path."""
+    broker = _broker(tmp_path, FakeGraph())
+    with pytest.raises(MsGraphRefused):
+        broker.handle(
+            {
+                "action": "msgraph_send",
+                "payload": {"to": [UNAUTHORED], "body_text": "x"},
+                "session_id": "sess-2",
+                "matter_ref": "matter-uuid-2",
+            },
+            peer_pid=GATEWAY_PID,
+            peer_uid=AGENT_UID,
+        )
+    assert broker.ledger.rows[0]["matter_ref"] == "matter-uuid-2"
+    assert _meta(broker)["session_id"] == "sess-2"
+
+
+def test_a_caller_that_sends_no_joins_writes_the_row_it_writes_today(tmp_path: Path) -> None:
+    """The deployment-order property. An overlay that predates this change sends
+    neither field, and the row must be exactly what it was, with no empty
+    strings: the chain canonicalizes "" distinctly from NULL, and an empty
+    matter_ref reads as a reference that is present and blank."""
+    broker = _broker(tmp_path, FakeGraph())
+    broker.handle(
+        {
+            "action": "msgraph_send",
+            "payload": {"to": ["scott@smd.services"], "body_text": "hi"},
+        },
+        peer_pid=GATEWAY_PID,
+        peer_uid=AGENT_UID,
+    )
+    assert "matter_ref" not in broker.ledger.rows[0]
+    assert "session_id" not in _meta(broker)
+
+
+def test_the_joins_never_reach_the_vendor(tmp_path: Path) -> None:
+    """They are audit attribution, not content. The Graph message is built from a
+    closed allowlist, so this also proves the fields were read from the REQUEST
+    and not smuggled through the payload."""
+    http = FakeGraph()
+    broker = _broker(tmp_path, http)
+    broker.handle(
+        {
+            "action": "msgraph_send",
+            "payload": {"to": ["scott@smd.services"], "body_text": "hi"},
+            "session_id": "sess-3",
+            "matter_ref": "matter-uuid-3",
+        },
+        peer_pid=GATEWAY_PID,
+        peer_uid=AGENT_UID,
+    )
+    wire = json.dumps(http.graph_posts()[0][2])
+    assert "sess-3" not in wire
+    assert "matter-uuid-3" not in wire
+
+
+def test_a_reply_row_names_the_person_it_answered_without_an_address(tmp_path: Path) -> None:
+    """The broker is the ONLY party that can do this: it fetched the source
+    message itself precisely because a caller naming the sender could name any
+    sender. Hashed, because this row is exported.
+
+    FALSIFIER: return the sender address instead of its key and the last
+    assertion fails; drop the field and the first two do.
+    """
+    broker = _broker(tmp_path, FakeGraph(source_from="scott@smd.services"))
+    response = broker.handle(
+        {
+            "action": "msgraph_reply",
+            "payload": {"message_id": "AAMk123", "comment": "sure"},
+            "session_id": "sess-4",
+        },
+        peer_pid=GATEWAY_PID,
+        peer_uid=AGENT_UID,
+    )
+    meta = _meta(broker)
+    assert meta["sender_key"] == sender_key("scott@smd.services")
+    assert "@" not in meta["sender_key"]
+    assert "scott@smd.services" not in json.dumps(meta["sender_key"])
+    # Audit provenance stays in the row: the agent is told nothing new about who
+    # it just wrote to beyond what it already knew.
+    assert "sender_key" not in response
+
+
+def test_a_plain_send_contributes_no_sender_key(tmp_path: Path) -> None:
+    """Law 12 control for the test above: a send names no inbound person, so a
+    key on that row would be invented rather than resolved."""
+    broker = _broker(tmp_path, FakeGraph())
+    broker.handle(
+        {
+            "action": "msgraph_send",
+            "payload": {"to": ["scott@smd.services"], "body_text": "hi"},
+        },
+        peer_pid=GATEWAY_PID,
+        peer_uid=AGENT_UID,
+    )
+    assert "sender_key" not in _meta(broker)
+
+
+def test_the_sender_key_matches_the_overlay_recipe(tmp_path: Path) -> None:
+    """A key is only a join if both ends reduce the same human to the same bytes.
+    The overlay hashes NFC + strip + lower of the address
+    (``shared/audit_contract.sender_key``); this pins the identical recipe on
+    the broker side, so the two ends meet.
+
+    FALSIFIER: hash the raw string here and the case/spacing variants below stop
+    matching, which is a person appearing in the ledger as three people.
+    """
+    import hashlib
+
+    assert sender_key("scott@smd.services") == hashlib.sha256(
+        b"scott@smd.services"
+    ).hexdigest()
+    assert sender_key("  Scott@SMD.Services  ") == sender_key("scott@smd.services")
+    assert sender_key("Scott Durgan <scott@smd.services>") == sender_key("scott@smd.services")
+    assert sender_key("") is None
+    assert sender_key(None) is None

--- a/src/lib/portal/operator/object-audit-record.ts
+++ b/src/lib/portal/operator/object-audit-record.ts
@@ -85,6 +85,39 @@ export interface ObjectAuditRow {
   rowHash: string | null
   /** `metadata.routine` — the scheduled routine that opened the session. */
   routine: string | null
+  /**
+   * The joins (ss#2497). Every one of these is `null` on rows written before
+   * the overlay change that emits them, and that is a real state of the ledger
+   * rather than a parse failure: the writers gained the fields after seats had
+   * begun writing, exactly as `matterRef` and `trustCeiling` did. The surface
+   * says "Not recorded" and never guesses.
+   *
+   * `metadata.session_id` — the agent turn this row belongs to. It is what ties
+   * an inbound message to the reply it produced and to every tool call between
+   * them; before it, that trace was a join by timestamp adjacency.
+   *
+   * `metadata.sender_key` — sha256 of the canonical address of the person who
+   * caused this. Deliberately NOT an address: this record is exported and
+   * forwarded, and the firm can reproduce the key from an address it holds.
+   *
+   * `metadata.vendor_message_id` — the provider's own id for the inbound
+   * message, so a row can be matched against the mailbox itself.
+   *
+   * `objectId` / `objectKind` — the document, memo, or draft the action
+   * touched. One field rather than three, because a row names at most one and a
+   * table column that is sometimes `memo_id` and sometimes `document_id` reads
+   * as three sparse columns to anyone scanning it. The kind is carried beside
+   * it so nothing is lost.
+   *
+   * `writtenBodySha256` — sha256 of the body a write actually wrote. It is what
+   * lets a firm prove the memo in its own system is the one this row describes.
+   */
+  sessionId: string | null
+  senderKey: string | null
+  vendorMessageId: string | null
+  objectId: string | null
+  objectKind: 'document' | 'memo' | 'draft' | null
+  writtenBodySha256: string | null
 }
 
 /**
@@ -143,6 +176,32 @@ export function describeAuthorization(basis: AuthorizationBasis): string {
   return `Not recorded (${ceiling})`
 }
 
+/**
+ * One line naming WHAT the action touched (ss#2497), for a reader who is not
+ * technical. Written for the same audience as `describeAuthorization` and under
+ * the same rule: it reports only fields the writer populated, and says "Not
+ * recorded" rather than describing a row it cannot describe.
+ *
+ * The digest is shown as a short prefix. A firm verifying a document computes
+ * the full hash and compares; a firm reading the table needs to see that a
+ * digest EXISTS and that two rows carry different ones. Sixty-four hex
+ * characters in a table cell communicate neither. Contains no em dashes (house
+ * style).
+ */
+export function describeObject(row: ObjectAuditRow): string {
+  const parts: string[] = []
+  if (row.objectId !== null && row.objectKind !== null) {
+    parts.push(`${row.objectKind} ${row.objectId}`)
+  }
+  if (row.writtenBodySha256 !== null) {
+    parts.push(`content ${row.writtenBodySha256.slice(0, 12)}`)
+  }
+  if (parts.length === 0 && row.vendorMessageId !== null) {
+    parts.push(`message ${row.vendorMessageId}`)
+  }
+  return parts.length === 0 ? 'Not recorded' : parts.join(', ')
+}
+
 // ---------------------------------------------------------------------------
 // Wire parsing
 // ---------------------------------------------------------------------------
@@ -160,12 +219,12 @@ function optString(v: unknown): string | null {
 }
 
 /**
- * Pull `metadata.routine` out of the row's metadata column. The column is
- * serialized JSON on the wire; a malformed or absent blob yields null rather
- * than throwing, because an unparseable metadata blob must not cost us the row
- * itself (the row's own facts are still evidence).
+ * The row's `metadata` column as a record, or null. The column is serialized
+ * JSON on the wire; a malformed or absent blob yields null rather than throwing,
+ * because an unparseable metadata blob must not cost us the row itself (the
+ * row's own facts are still evidence).
  */
-function routineFromMetadata(raw: unknown): string | null {
+function parseMetadata(raw: unknown): Record<string, unknown> | null {
   let parsed: unknown = raw
   if (typeof raw === 'string') {
     if (raw.length === 0) return null
@@ -175,8 +234,64 @@ function routineFromMetadata(raw: unknown): string | null {
       return null
     }
   }
-  if (!isRecord(parsed)) return null
-  return optString(parsed['routine'])
+  return isRecord(parsed) ? parsed : null
+}
+
+/**
+ * The object a read or write touched, as one `(kind, id)` pair (ss#2497).
+ *
+ * A row names at most one, and the overlay writes them under their own names so
+ * a query can ask for memos specifically. The precedence below is a display
+ * decision, not a semantic one: it only ever chooses between keys that cannot
+ * co-occur on a row the overlay wrote.
+ *
+ * A file LISTING carries `document_ids` (plural) and is deliberately not folded
+ * in here: it names many objects and the single-object column would have to
+ * pick one, which is the same "name one of several and it reads as the only
+ * one" failure the matter column avoids by staying null.
+ */
+function objectFromMetadata(
+  metadata: Record<string, unknown> | null
+): { id: string; kind: 'document' | 'memo' | 'draft' } | null {
+  if (metadata === null) return null
+  const document = optString(metadata['document_id'])
+  if (document !== null) return { id: document, kind: 'document' }
+  const memo = optString(metadata['memo_id'])
+  if (memo !== null) return { id: memo, kind: 'memo' }
+  const draft = optString(metadata['draft_id'])
+  if (draft !== null) return { id: draft, kind: 'draft' }
+  return null
+}
+
+/**
+ * The metadata-derived half of a row: the routine, the three joins, and the
+ * object. Lifted out of the row builder so that builder stays a flat mapping of
+ * wire keys to fields and the null-handling for an unparseable blob lives in
+ * exactly one place rather than seven ternaries.
+ */
+function metadataFields(
+  raw: unknown
+): Pick<
+  ObjectAuditRow,
+  | 'routine'
+  | 'sessionId'
+  | 'senderKey'
+  | 'vendorMessageId'
+  | 'objectId'
+  | 'objectKind'
+  | 'writtenBodySha256'
+> {
+  const metadata = parseMetadata(raw)
+  const object = objectFromMetadata(metadata)
+  return {
+    routine: metadata === null ? null : optString(metadata['routine']),
+    sessionId: metadata === null ? null : optString(metadata['session_id']),
+    senderKey: metadata === null ? null : optString(metadata['sender_key']),
+    vendorMessageId: metadata === null ? null : optString(metadata['vendor_message_id']),
+    objectId: object === null ? null : object.id,
+    objectKind: object === null ? null : object.kind,
+    writtenBodySha256: metadata === null ? null : optString(metadata['written_body_sha256']),
+  }
 }
 
 /** Parse a Machine `audit_export` payload. Malformed rows are dropped. */
@@ -205,7 +320,7 @@ export function parseObjectAuditRows(data: unknown): ObjectAuditRow[] {
       diffDigest: optString(item['diff_digest']),
       prevHash: optString(item['prev_hash']),
       rowHash: optString(item['row_hash']),
-      routine: routineFromMetadata(item['metadata']),
+      ...metadataFields(item['metadata']),
     })
   }
   return out
@@ -279,7 +394,13 @@ export function scopeToRef(rows: ObjectAuditRow[], query: ObjectAuditQuery): Obj
 // CSV
 // ---------------------------------------------------------------------------
 
-/** Header row of the exported CSV. Order is stable: a firm may diff two exports. */
+/**
+ * Header row of the exported CSV. Order is stable: a firm may diff two exports.
+ *
+ * The ss#2497 join columns are APPENDED rather than interleaved, for that
+ * reason: a firm diffing this month's export against last month's must see new
+ * columns arrive at the end, not every existing column shift one place right.
+ */
 export const OBJECT_AUDIT_CSV_COLUMNS = [
   'id',
   'ts',
@@ -297,6 +418,12 @@ export const OBJECT_AUDIT_CSV_COLUMNS = [
   'diff_digest',
   'prev_hash',
   'row_hash',
+  'session_id',
+  'sender_key',
+  'vendor_message_id',
+  'object_kind',
+  'object_id',
+  'written_body_sha256',
 ] as const
 
 function csvCell(value: string | null): string {
@@ -332,6 +459,12 @@ export function toObjectAuditCsv(record: ObjectAuditRecord): string {
         csvCell(row.diffDigest),
         csvCell(row.prevHash),
         csvCell(row.rowHash),
+        csvCell(row.sessionId),
+        csvCell(row.senderKey),
+        csvCell(row.vendorMessageId),
+        csvCell(row.objectKind),
+        csvCell(row.objectId),
+        csvCell(row.writtenBodySha256),
       ].join(',')
     )
   }

--- a/src/pages/portal/products/operator/[instance]/compliance/audit-record.astro
+++ b/src/pages/portal/products/operator/[instance]/compliance/audit-record.astro
@@ -9,6 +9,7 @@ import { formatAuditTimestamp } from '../../../../../../lib/portal/operator/audi
 import {
   authorizationOf,
   describeAuthorization,
+  describeObject,
   loadObjectAuditRecord,
   type ObjectAuditRecord,
 } from '../../../../../../lib/portal/operator/object-audit-record'
@@ -237,6 +238,9 @@ const PANEL_HEAD =
                   What authorized it
                 </th>
                 <th scope="col" class={HEAD_CELL}>
+                  What it touched
+                </th>
+                <th scope="col" class={HEAD_CELL}>
                   Skill
                 </th>
                 <th scope="col" class={HEAD_CELL}>
@@ -255,6 +259,9 @@ const PANEL_HEAD =
                   </td>
                   <td class="px-4 py-3 text-[color:var(--ss-color-text-primary)]">
                     {describeAuthorization(authorizationOf(row))}
+                  </td>
+                  <td class="px-4 py-3 font-mono text-xs break-all text-[color:var(--ss-color-text-secondary)]">
+                    {describeObject(row)}
                   </td>
                   <td class="px-4 py-3 font-mono text-[color:var(--ss-color-text-secondary)]">
                     {row.skillName ?? 'Not recorded'}

--- a/tests/object-audit-record.test.ts
+++ b/tests/object-audit-record.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import {
   authorizationOf,
   describeAuthorization,
+  describeObject,
   loadObjectAuditRecord,
   objectAuditCsvFilename,
   OBJECT_AUDIT_CSV_COLUMNS,
@@ -44,6 +45,12 @@ function row(over: Partial<ObjectAuditRow> = {}): ObjectAuditRow {
     prevHash: null,
     rowHash: null,
     routine: null,
+    sessionId: null,
+    senderKey: null,
+    vendorMessageId: null,
+    objectId: null,
+    objectKind: null,
+    writtenBodySha256: null,
     ...over,
   }
 }
@@ -110,6 +117,107 @@ describe('parseObjectAuditRows', () => {
     })
     expect(parsed).toHaveLength(1)
     expect(parsed[0].routine).toBeNull()
+  })
+
+  /**
+   * The joins (ss#2497). Measured on the live A&P ledger 2026-08-21
+   * (vfy_01M0H8DR6JAPYVHFMNJZXQZ517), every one of these was absent: the record
+   * could not name the person behind an action, the message it answered, or the
+   * object it touched, so a Named Administrator reading this page saw a list of
+   * verbs. The parser is where they become readable.
+   */
+  it('lifts the session, the sender key, the vendor message id and the object', () => {
+    const parsed = parseObjectAuditRows({
+      entries: [
+        {
+          id: 'A',
+          ts: '2026-08-01T00:00:00.000Z',
+          action_type: 'TOOL_CALL_COMPLETED',
+          actor: 'agent',
+          metadata: JSON.stringify({
+            session_id: '20260820_195837_68d654ce',
+            sender_key: 'a'.repeat(64),
+            vendor_message_id: 'am-msg-77',
+            memo_id: 'memo-9',
+            written_body_sha256: 'b'.repeat(64),
+          }),
+        },
+      ],
+    })
+    expect(parsed[0]).toMatchObject({
+      sessionId: '20260820_195837_68d654ce',
+      senderKey: 'a'.repeat(64),
+      vendorMessageId: 'am-msg-77',
+      objectId: 'memo-9',
+      objectKind: 'memo',
+      writtenBodySha256: 'b'.repeat(64),
+    })
+  })
+
+  it('reports the joins as absent on a row written before the writers emitted them', () => {
+    // A real state of the ledger, not a parse failure: the overlay gained these
+    // fields after seats had begun writing, exactly as matter_ref and
+    // trust_ceiling did. Rows written before them carry NULL forever, and
+    // naming that state is the whole point.
+    const parsed = parseObjectAuditRows({
+      entries: [
+        {
+          id: 'A',
+          ts: '2026-08-01T00:00:00.000Z',
+          action_type: 'REPLY_SENT',
+          actor: 'agent',
+          metadata: JSON.stringify({ reply_channel: true }),
+        },
+      ],
+    })
+    expect(parsed[0]).toMatchObject({
+      sessionId: null,
+      senderKey: null,
+      vendorMessageId: null,
+      objectId: null,
+      objectKind: null,
+      writtenBodySha256: null,
+    })
+    expect(describeObject(parsed[0])).toBe('Not recorded')
+  })
+
+  it('names one object per row, in a stable order, and never folds in a listing', () => {
+    // A file LISTING carries document_ids (plural) and names many objects. The
+    // single-object column would have to pick one, which reads as "this is the
+    // only one it touched" -- the same failure the matter column avoids by
+    // staying null.
+    const parsed = parseObjectAuditRows({
+      entries: [
+        {
+          id: 'A',
+          ts: '2026-08-01T00:00:00.000Z',
+          action_type: 'TOOL_CALL_COMPLETED',
+          actor: 'agent',
+          metadata: JSON.stringify({ document_ids: ['f1', 'f2'] }),
+        },
+      ],
+    })
+    expect(parsed[0].objectId).toBeNull()
+    expect(parsed[0].objectKind).toBeNull()
+  })
+})
+
+describe('describeObject', () => {
+  it('names the object and a checkable prefix of the content digest', () => {
+    const line = describeObject(
+      row({ objectId: 'memo-9', objectKind: 'memo', writtenBodySha256: 'c'.repeat(64) })
+    )
+    expect(line).toBe('memo memo-9, content cccccccccccc')
+    // House style: no em dashes reach a client-facing surface.
+    expect(line).not.toContain('\u2014')
+  })
+
+  it('falls back to the vendor message when there is no object', () => {
+    expect(describeObject(row({ vendorMessageId: 'am-msg-77' }))).toBe('message am-msg-77')
+  })
+
+  it('says Not recorded rather than describing a row it cannot describe', () => {
+    expect(describeObject(row())).toBe('Not recorded')
   })
 })
 
@@ -213,6 +321,76 @@ describe('toObjectAuditCsv', () => {
       to: null,
     })
     expect(toObjectAuditCsv(rec)).toContain('"a,""b"""')
+  })
+
+  it('exports the joins, appended so an existing column never shifts', () => {
+    // ss#2497. A firm diffing this month's export against last month's must see
+    // new columns arrive at the END; interleaving them would move every existing
+    // column one place right and make the diff unreadable.
+    const before = [
+      'id',
+      'ts',
+      'action_type',
+      'matter_ref',
+      'authorized_by',
+      'authorization_basis',
+      'trust_ceiling',
+      'actor',
+      'actor_role',
+      'routine',
+      'skill_name',
+      'input_digest',
+      'output_digest',
+      'diff_digest',
+      'prev_hash',
+      'row_hash',
+    ]
+    expect(OBJECT_AUDIT_CSV_COLUMNS.slice(0, before.length)).toEqual(before)
+    expect(OBJECT_AUDIT_CSV_COLUMNS.slice(before.length)).toEqual([
+      'session_id',
+      'sender_key',
+      'vendor_message_id',
+      'object_kind',
+      'object_id',
+      'written_body_sha256',
+    ])
+
+    const rec = scopeToRef(
+      [
+        row({
+          sessionId: 'sess-1',
+          senderKey: 'd'.repeat(64),
+          vendorMessageId: 'am-msg-77',
+          objectId: 'memo-9',
+          objectKind: 'memo',
+          writtenBodySha256: 'e'.repeat(64),
+        }),
+      ],
+      { ref: 'M-1', from: null, to: null }
+    )
+    const dataLine = toObjectAuditCsv(rec).trimEnd().split('\n')[1]
+    const cells = dataLine.split(',')
+    expect(cells).toHaveLength(OBJECT_AUDIT_CSV_COLUMNS.length)
+    expect(cells.slice(-6)).toEqual([
+      'sess-1',
+      'd'.repeat(64),
+      'am-msg-77',
+      'memo',
+      'memo-9',
+      'e'.repeat(64),
+    ])
+  })
+
+  it('never exports a raw email address', () => {
+    // The issue's non-goal, enforced where it matters: this file leaves the
+    // Machine. The sender is a KEY, and there is no column that could carry an
+    // address for it to hide in.
+    const rec = scopeToRef([row({ senderKey: 'f'.repeat(64) })], {
+      ref: 'M-1',
+      from: null,
+      to: null,
+    })
+    expect(toObjectAuditCsv(rec)).not.toContain('@')
   })
 })
 


### PR DESCRIPTION
A Named Administrator at the firm pulls the audit record for one Operator action and sees **who caused it**, **which message it answered**, and **which matter it concerned**.

ss-console half of #2497. The overlay half is venturecrane/hermes-smd-overlay#294.

## What changed

**The broker's send rows can be placed in a session and on a matter.** `CONFIRM_SEND_DISPATCHED` / `CONFIRM_SEND_FAILED` had `session_id` on 0 of 9 rows and `matter_ref` on none. Neither is knowable inside the broker, so both travel on the request beside the payload and are written straight through, unexamined. That is the deliberate split: they are attribution the agent asserts about its own turn, never authorization, and the broker's authority over WHO may be written to is untouched. `matter_ref` goes to its COLUMN, which is what the portal record filters on.

**A reply row can name the person it answered.** Only the broker can mint this, because it fetches the original sender itself rather than trusting a caller to name one. `recipient_policy.sender_key` hashes the address after the same NFC + strip + lower canonicalization the fence already uses, so the same human always produces the same key, and the overlay's twin produces the identical value. Hashed rather than stored because this record is exported: a firm holding an address reproduces the key, and a reader who does not learns nothing.

**The portal record reads them.** `object-audit-record.ts` parses the session, the sender key, the vendor message id, the object a read or write touched, and the digest of what a write wrote; the page gains a "What it touched" column; the CSV exports all six, appended so a firm diffing two exports does not see every existing column shift one place right.

## Evidence

| AC | Status | Evidence |
|---|---|---|
| (repo) `INBOUND_RECEIVED` carries `sender_key` + vendor message id | met | overlay PR #294 |
| (repo) send rows carry `session_id` + `matter_ref`, matter in the COLUMN | met | `operator/workspace_broker/tests/test_msgraph_send.py::test_the_send_row_carries_the_session_and_the_matter`, `::test_a_refusal_row_carries_them_too`, `::test_a_caller_that_sends_no_joins_writes_the_row_it_writes_today`, `::test_the_joins_never_reach_the_vendor` |
| (repo) the row can name the person a reply answered, without an address | met | `::test_a_reply_row_names_the_person_it_answered_without_an_address`, `::test_a_plain_send_contributes_no_sender_key`, `::test_the_sender_key_matches_the_overlay_recipe` |
| (repo) read/write tools carry object id + written-body sha256 | met | overlay PR #294 |
| (repo) no new columns; chain canonicalization unchanged | met | `LedgerWriter._AGENT_COLUMNS` is unchanged; `matter_ref` was already one of them. `operator/workspace_broker/chain.py` untouched (SEC-32 pair hash unchanged) |
| (repo) `object-audit-record.ts` parses + renders + exports the new fields | met | `tests/object-audit-record.test.ts` (24 passing): parse test, the pre-change-rows-report-absent test, the listing-is-not-folded test, `describeObject` tests, the CSV column-order test, and `::never exports a raw email address` |
| (runtime) one real inbound → reply trace on ashton-price shows all four | **unmet** | Awaits the Captain-gated `OVERLAY_REF` bump + reprovision, which this session did not touch. Nothing here reaches a seat until the overlay merges and the pin moves. |

`npm run verify`: exit 0. `operator/` pytest: `1674 passed`, one pre-existing failure unrelated to this change (`adapter/evidence/tests/test_packet.py::test_build_emits_targz_with_every_expected_file`, extra `manifest.sig` — reproduces identically on the primary checkout at origin/main, so it is not introduced here).

**Falsifiers run, not asserted.** Seven mutations against the broker implementation, each caught by the test that claims to guard it: the send row losing the joins; the refusal row losing them; empty joins written as `""` instead of omitted; the reply row losing the sender key; `sender_key` storing the raw address; `sender_key` hashing the raw string instead of the canonical form; and `sender_key` leaking back to the agent in the transmit response.

## The pin

**This PR does not move `OVERLAY_REF`.** After overlay#294 merges the pin must move and the seat be reprovisioned before any of this reaches ashton-price; that is the Captain-gated step the runtime AC waits on.

Both new request fields are OPTIONAL on the wire, so the two sides deploy in either order: a broker that predates the overlay ignores unknown request keys and writes exactly the row it writes today, and an overlay that predates the broker sends none. `test_a_caller_that_sends_no_joins_writes_the_row_it_writes_today` pins that property.

Subsumes #2152 (capture the verified replying sender on an ack): the ack slice is met by `sender_key` on the reply row here and on `INBOUND_RECEIVED` in the overlay PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016U9H1VbtZdmBo2t6UBAAPr
