### PR TITLE
fix(operator): the daily audit-record check asks the right question and stops crying wolf over a seat that was never built (ss#2500)

### DIFF
--- a/operator/bin/audit-chain-watch.py
+++ b/operator/bin/audit-chain-watch.py
@@ -21,6 +21,16 @@ WHAT THIS DOES, per seat, once a day:
      finding, so it lands on the same dashboard banner and the same alert-sink
      notifier as every other observability source.
 
+WHICH SEATS. The authority for a seat existing is the console's ``fleet_status``
+table (ADR 0043 B), not the presence of a ``customer.yaml``. Those two answers
+differ: pilot-law has been authored and unprovisioned since 2026-06-05, and
+enumerating from the filesystem made the first live run red forever on a
+connection error to a machine that was never stood up. Seats are the
+intersection, and BOTH differences are named in the report rather than filtered
+away -- authored-but-not-provisioned as a SKIP so the denominator stays visible
+(#2366), provisioned-but-not-authored as a HOLD, because that direction means a
+live seat's ledger is outside this control's reach.
+
 TRI-STATE, AND A HOLD IS LOUD (#2395, the control-probes contract):
 
   0  clean   -- every seat evaluated, every chain intact, every pin descended
@@ -52,6 +62,7 @@ import gzip
 import hashlib
 import json
 import os
+import re
 import subprocess
 import sys
 import tempfile
@@ -83,6 +94,11 @@ EXIT_HOLD = 2
 CLEAN = "clean"
 FINDING = "finding"
 HOLD = "hold"
+
+#: Authored but never provisioned. Named in the report so the denominator stays
+#: visible (#2366: a skipped seat must never be silent), and not a hold, because
+#: a seat that does not exist has no audit record to be wrong about.
+SKIP = "skip"
 
 #: The alert row's driver. Per SEAT, not per entity: several seats can share one
 #: entity and the alert PK is (entity_id, alert_date, driver), so a bare
@@ -222,6 +238,41 @@ def authored_seats(repo_root: Path) -> list[str]:
     )
 
 
+@dataclass
+class SeatRoster:
+    """Which authored seats actually exist, and both directions of the drift."""
+
+    probed: list[str]
+    skipped: list[str]
+    orphaned: list[str]
+
+
+def partition_seats(authored: Sequence[str], provisioned: Sequence[str]) -> SeatRoster:
+    """Intersect the authored dirs with the seats the console knows are running.
+
+    ``operator/customers/*/customer.yaml`` answers "what has someone written a
+    config for", which is not the same question as "what seats exist". The
+    pilot-law directory has sat authored and unprovisioned since 2026-06-05 with
+    no Fly app behind it, so enumerating from the filesystem made the first live
+    run red forever on a URLError for a machine that was never stood up -- an
+    alarm that is always ringing is one nobody hears.
+
+    ``fleet_status`` is the authority for a seat existing (ADR 0043 B); this job
+    already reads the console for pins. Both directions of the difference are
+    reported rather than filtered away: a seat authored but not provisioned is a
+    SKIP with its name in the summary, and a seat in fleet_status with no
+    authored config is a HOLD, because that drift means this control cannot see
+    a live seat's ledger at all.
+    """
+    live = {s for s in provisioned if s}
+    authored_set = {s for s in authored if s}
+    return SeatRoster(
+        probed=sorted(authored_set & live),
+        skipped=sorted(authored_set - live),
+        orphaned=sorted(live - authored_set),
+    )
+
+
 # ---------------------------------------------------------------------------
 # Console D1 (through wrangler, the pattern the other CI reconcilers use)
 # ---------------------------------------------------------------------------
@@ -291,6 +342,18 @@ class ConsoleD1:
         # nosemgrep: python.lang.security.audit.formatted-sql-query.formatted-sql-query,python.sqlalchemy.security.sqlalchemy-execute-raw-query.sqlalchemy-execute-raw-query
         rows = self.execute(sql)
         return rows[0] if rows else None
+
+    def provisioned_slugs(self) -> list[str]:
+        """Every seat the console has a fleet_status row for -- the seats that exist.
+
+        A constant statement: nothing is interpolated, so there is nothing to
+        escape. Failure RAISES rather than returning [], because an empty roster
+        read as "no seats" would turn an unreachable D1 into a quiet green run.
+        """
+        rows = self.execute("SELECT customer_slug FROM fleet_status")
+        return sorted(
+            str(r["customer_slug"]) for r in rows if isinstance(r.get("customer_slug"), str)
+        )
 
     def entity_id(self, slug: str) -> Optional[str]:
         # nosemgrep: python.lang.security.audit.formatted-sql-query.formatted-sql-query — see sql_text: no parameter binding exists on this CLI path; the interpolated text is a hex blob literal.
@@ -467,7 +530,41 @@ def archive_export(
     return ArchiveResult(key=key, sha256=hashlib.sha256(blob).hexdigest(), bytes_written=len(blob))
 
 
-def probe_bucket_lock(bucket: str, *, runner: Runner = _run) -> tuple[bool, str]:
+#: Seven years, the retention the service agreement commits the record to.
+LOCK_MIN_SECONDS = 2555 * 86400
+
+#: The prefix every archived export is written under (see ``archive_export``).
+ARCHIVE_PREFIX = "audit/"
+
+#: Account ids are 32 hex characters and bucket names are lowercase DNS labels.
+#: Nothing else is ever interpolated into an api.cloudflare.com URL.
+_URL_SEGMENT = re.compile(r"\A[a-zA-Z0-9][a-zA-Z0-9-]{1,62}\Z")
+
+
+def bucket_lock_url(account: str, bucket: str) -> str:
+    """The bucket-lock endpoint, built only from values that pass the charset gate."""
+    for label, value in (("CLOUDFLARE_ACCOUNT_ID", account), ("bucket name", bucket)):
+        if not _URL_SEGMENT.match(value or ""):
+            raise RuntimeError(f"refusing to build a Cloudflare API URL from an unsafe {label}")
+    return f"https://api.cloudflare.com/client/v4/accounts/{account}/r2/buckets/{bucket}/lock"
+
+
+def _cf_get_lock(url: str) -> dict:
+    token = os.environ.get("CLOUDFLARE_API_TOKEN")
+    if not token:
+        raise RuntimeError("CLOUDFLARE_API_TOKEN is unset, so the bucket lock cannot be read")
+    req = urllib.request.Request(
+        url, headers={"Authorization": f"Bearer {token}"}, method="GET"
+    )
+    # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected — bucket_lock_url is the only builder and it gates both interpolated segments on a fixed charset.
+    with urllib.request.urlopen(req, timeout=20) as resp:  # noqa: S310 — https, charset-gated
+        return json.loads(resp.read().decode("utf-8"))
+
+
+LockFetcher = Callable[[str], dict]
+
+
+def probe_bucket_lock(bucket: str, *, fetch: LockFetcher = _cf_get_lock) -> tuple[bool, str]:
     """Is the archive prefix actually immutable?
 
     An off-box copy on a bucket anyone can delete from is a backup, not a
@@ -475,22 +572,122 @@ def probe_bucket_lock(bucket: str, *, runner: Runner = _run) -> tuple[bool, str]
     built-but-not-wired shape exactly. So it is asked every run, and an
     unconfirmed lock is a HOLD.
 
-    THE R2 SHAPE HERE IS UNVERIFIED and deliberately not guessed. There is no R2
-    access from a build session, and Cloudflare's bucket-lock feature is not
-    necessarily reachable through the S3 object-lock API this probes for. The
-    probe reports what it got rather than assuming what it should get: whichever
-    way the first live run answers is the shape, and the message says so.
+    ASKED OF THE RIGHT API. The first live run asked S3
+    ``get-object-lock-configuration`` and got
+    ``ObjectLockConfigurationNotFoundError`` even with derived credentials and
+    the R2 endpoint: R2's bucket-lock feature is NOT surfaced through the S3
+    object-lock API. It is its own Cloudflare API resource, and this is the
+    shape it answered with on 2026-08-21::
+
+        {"success": true, "result": {"rules": [
+          {"id": "audit-7y", "enabled": true, "prefix": "audit/",
+           "condition": {"type": "Age", "maxAgeSeconds": 220752000}}]}}
+
+    Confirmed means at least one rule that is enabled, whose prefix COVERS the
+    archive prefix (``audit/`` starts with it, so a narrower per-seat rule does
+    not count), and whose condition holds the record for at least seven years.
+    ``Age`` is the observed condition shape; ``Indefinite`` carries no fields;
+    ``Date``'s field name is documented nowhere we could reach, so an
+    unrecognized ``Date`` payload fails CLOSED with the raw condition in the
+    message rather than being read charitably.
     """
-    proc = runner(["aws", "s3api", "get-object-lock-configuration", "--bucket", bucket])
-    if proc.returncode == 0 and "ObjectLockEnabled" in (proc.stdout or ""):
-        return True, f"Object lock is configured on s3://{bucket}."
-    detail = (proc.stderr or proc.stdout or "").strip().splitlines()
-    tail = detail[-1] if detail else "no output"
-    return False, (
-        f"Could not confirm object lock on s3://{bucket} ({tail}). The copy is being written to "
-        "a prefix whose immutability is unproven, which makes it a backup and not a compliance "
-        "record. Either configure a lock rule covering the audit/ prefix, or record here what "
-        "the R2 API actually answers so this probe can ask the right question."
+    account = os.environ.get("CLOUDFLARE_ACCOUNT_ID", "")
+    try:
+        payload = fetch(bucket_lock_url(account, bucket))
+    except Exception as exc:  # noqa: BLE001 -- any transport or auth failure is a hold
+        return False, _lock_unproven(bucket, f"{type(exc).__name__}: {exc}")
+    return evaluate_lock_payload(bucket, payload)
+
+
+def evaluate_lock_payload(bucket: str, payload: Any) -> tuple[bool, str]:
+    """Turn one bucket-lock API body into a verdict. Pure -- this is what tests drive."""
+    if not isinstance(payload, dict):
+        return False, _lock_unproven(bucket, "the API returned something that is not a JSON object")
+    if payload.get("success") is not True:
+        errors = json.dumps(payload.get("errors"), sort_keys=True)
+        return False, _lock_unproven(bucket, f"the API answered success=false, errors={errors}")
+
+    rules = (payload.get("result") or {}).get("rules")
+    if rules is None:
+        rules = []
+    if not isinstance(rules, list):
+        return False, _lock_unproven(bucket, "the API returned a non-list rules field")
+    if not rules:
+        return False, _lock_unproven(bucket, "the bucket has no lock rules at all")
+
+    rejected: list[str] = []
+    for rule in rules:
+        covers, why = _rule_covers_archive(rule)
+        if covers:
+            rule_id = rule.get("id") if isinstance(rule, dict) else None
+            return True, (
+                f"Bucket lock rule {rule_id!r} covers {ARCHIVE_PREFIX} on {bucket}: {why}."
+            )
+        rejected.append(why)
+    return False, _lock_unproven(bucket, "; ".join(rejected))
+
+
+def _rule_covers_archive(rule: Any) -> tuple[bool, str]:
+    """Does this one rule hold every archived object for the full retention?"""
+    if not isinstance(rule, dict):
+        return False, "a rule that is not an object"
+    rule_id = rule.get("id")
+    if rule.get("enabled") is not True:
+        return False, f"rule {rule_id!r} is not enabled"
+
+    prefix = rule.get("prefix") or ""
+    if not isinstance(prefix, str) or not ARCHIVE_PREFIX.startswith(prefix):
+        return False, f"rule {rule_id!r} covers {prefix!r}, which does not cover {ARCHIVE_PREFIX!r}"
+
+    condition = rule.get("condition")
+    if not isinstance(condition, dict):
+        return False, f"rule {rule_id!r} has no condition object"
+    kind = condition.get("type")
+
+    if kind == "Indefinite":
+        return True, "retained indefinitely"
+
+    if kind == "Age":
+        seconds = condition.get("maxAgeSeconds")
+        if isinstance(seconds, bool) or not isinstance(seconds, int):
+            return False, f"rule {rule_id!r} has a non-integer maxAgeSeconds"
+        if seconds < LOCK_MIN_SECONDS:
+            return False, (
+                f"rule {rule_id!r} retains for {seconds}s, short of the "
+                f"{LOCK_MIN_SECONDS}s the record is committed to"
+            )
+        return True, f"retained for {seconds}s"
+
+    if kind == "Date":
+        raw = condition.get("date")
+        parsed = _parse_lock_date(raw)
+        if parsed is None:
+            return False, (
+                f"rule {rule_id!r} has a Date condition this probe cannot read "
+                f"({json.dumps(condition, sort_keys=True, default=str)})"
+            )
+        if parsed <= datetime.now(timezone.utc):
+            return False, f"rule {rule_id!r} retains only until {raw}, which has passed"
+        return True, f"retained until {raw}"
+
+    return False, f"rule {rule_id!r} has an unrecognized condition type {kind!r}"
+
+
+def _parse_lock_date(raw: Any) -> Optional[datetime]:
+    if not isinstance(raw, str) or not raw:
+        return None
+    try:
+        parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+
+
+def _lock_unproven(bucket: str, detail: str) -> str:
+    return (
+        f"Could not confirm a bucket lock covering {ARCHIVE_PREFIX} on {bucket} ({detail}). "
+        "The copy is being written to a prefix whose immutability is unproven, which makes it "
+        "a backup and not a compliance record."
     )
 
 
@@ -536,6 +733,30 @@ def process_seat(slug: str, console: ConsoleD1, *, bucket: str, archive: bool) -
     outcome.details["archive_sha256"] = result.sha256
     outcome.details["archive_bytes"] = result.bytes_written
     return outcome
+
+
+def roster_notices(roster: SeatRoster) -> list[SeatOutcome]:
+    """One reported line per seat the probe did NOT pull, in either direction."""
+    notices = [
+        SeatOutcome(
+            slug,
+            SKIP,
+            f"{slug}: authored but never provisioned (no fleet_status row).",
+            {"slug": slug},
+        )
+        for slug in roster.skipped
+    ]
+    notices += [
+        SeatOutcome(
+            slug,
+            HOLD,
+            f"{slug}: a fleet_status row exists but no customer.yaml is authored for it, "
+            "so this control cannot reach that seat's ledger.",
+            {"slug": slug},
+        )
+        for slug in roster.orphaned
+    ]
+    return notices
 
 
 def emit_alert(console: ConsoleD1, outcome: SeatOutcome) -> Optional[str]:
@@ -615,19 +836,38 @@ def main(argv: Optional[list[str]] = None) -> int:
     )
     args = ap.parse_args(argv)
 
-    seats = args.seat or authored_seats(_REPO)
-    if not seats:
-        print("HOLD: no authored seats found; this run measured nothing.")
+    console = ConsoleD1(db=args.db)
+
+    if args.seat:
+        # An explicit --seat is a person naming what to look at; honour it
+        # exactly, including a seat the console has no row for.
+        roster = SeatRoster(probed=sorted(set(args.seat)), skipped=[], orphaned=[])
+    else:
+        authored = authored_seats(_REPO)
+        if not authored:
+            print("HOLD: no authored seats found; this run measured nothing.")
+            return EXIT_HOLD
+        try:
+            provisioned = console.provisioned_slugs()
+        except Exception as exc:  # noqa: BLE001
+            print(f"HOLD: the seat roster could not be read from D1 ({exc}).")
+            return EXIT_HOLD
+        roster = partition_seats(authored, provisioned)
+
+    if not roster.probed and not roster.orphaned:
+        print("HOLD: no provisioned seat matched an authored config; this run measured nothing.")
         return EXIT_HOLD
 
-    console = ConsoleD1(db=args.db)
     archive = not args.no_archive
     if archive:
         lock_ok, lock_note = probe_bucket_lock(args.bucket)
     else:
         lock_ok, lock_note = True, "Off-box copy skipped (--no-archive); no lock probe was run."
 
-    outcomes = [process_seat(s, console, bucket=args.bucket, archive=archive) for s in seats]
+    outcomes = [
+        process_seat(s, console, bucket=args.bucket, archive=archive) for s in roster.probed
+    ]
+    outcomes += roster_notices(roster)
 
     alert_holds: list[str] = []
     for outcome in outcomes:

--- a/operator/bin/reconcile-outcomes.py
+++ b/operator/bin/reconcile-outcomes.py
@@ -543,6 +543,12 @@ def customers_dir() -> Path:
 
 
 def seat_slugs() -> list[str]:
+    # Authored dirs, not provisioned seats. audit-chain-watch.py intersects this
+    # same enumeration against `fleet_status` (`partition_seats` /
+    # `ConsoleD1.provisioned_slugs`, ss#2500) because an authored-but-never-
+    # provisioned slug made every run of it red; this reconciler has no D1
+    # credentials to do that with, and an unreachable seat only sets that seat's
+    # `held` here rather than failing the run, so it is left as-is deliberately.
     return sorted(
         d.name
         for d in customers_dir().iterdir()

--- a/operator/bin/tests/test_audit_chain_watch.py
+++ b/operator/bin/tests/test_audit_chain_watch.py
@@ -243,24 +243,133 @@ def test_the_archive_key_and_digest_are_reproducible(tmp_path):
     assert first.sha256 == __import__("hashlib").sha256(uploaded[0][0].read_bytes()).hexdigest()
 
 
-def test_an_unconfirmed_bucket_lock_is_not_treated_as_configured():
-    def denied(cmd):
-        return subprocess.CompletedProcess(cmd, 255, "", "An error occurred (NotImplemented)")
+# The rule body the LIVE bucket answered with on 2026-08-21. Pinned to the
+# observed wire shape, not to a shape this file invented: the previous probe
+# asked S3 get-object-lock-configuration and got ObjectLockConfigurationNotFound
+# even with credentials, because R2's bucket lock is a Cloudflare API resource
+# and not S3 object lock at all.
+_OBSERVED_RULE = {
+    "id": "audit-7y",
+    "enabled": True,
+    "prefix": "audit/",
+    "condition": {"type": "Age", "maxAgeSeconds": 220752000},
+}
 
-    ok, note = watch.probe_bucket_lock("smd-audit-archive", runner=denied)
+
+def _lock_body(*rules) -> dict:
+    return {"success": True, "result": {"rules": list(rules)}}
+
+
+def test_the_lock_probe_asks_the_r2_bucket_lock_endpoint(monkeypatch):
+    monkeypatch.setenv("CLOUDFLARE_ACCOUNT_ID", "a" * 32)
+    asked: list[str] = []
+
+    def fetch(url):
+        asked.append(url)
+        return _lock_body(_OBSERVED_RULE)
+
+    ok, note = watch.probe_bucket_lock("smd-audit-archive", fetch=fetch)
+    assert ok is True
+    assert asked == [
+        f"https://api.cloudflare.com/client/v4/accounts/{'a' * 32}"
+        "/r2/buckets/smd-audit-archive/lock"
+    ]
+    assert "audit-7y" in note
+
+
+def test_the_observed_seven_year_age_rule_confirms_the_lock():
+    ok, note = watch.evaluate_lock_payload("smd-audit-archive", _lock_body(_OBSERVED_RULE))
+    assert ok is True
+    assert "220752000" in note
+
+
+def test_an_indefinite_rule_confirms_the_lock():
+    rule = dict(_OBSERVED_RULE, condition={"type": "Indefinite"})
+    ok, note = watch.evaluate_lock_payload("smd-audit-archive", _lock_body(rule))
+    assert ok is True
+    assert "indefinitely" in note
+
+
+def test_a_date_rule_in_the_future_confirms_the_lock():
+    rule = dict(_OBSERVED_RULE, condition={"type": "Date", "date": "2099-01-01T00:00:00Z"})
+    ok, _ = watch.evaluate_lock_payload("smd-audit-archive", _lock_body(rule))
+    assert ok is True
+
+
+def test_a_date_rule_already_past_does_not_confirm_the_lock():
+    rule = dict(_OBSERVED_RULE, condition={"type": "Date", "date": "2020-01-01T00:00:00Z"})
+    ok, note = watch.evaluate_lock_payload("smd-audit-archive", _lock_body(rule))
     assert ok is False
+    assert "has passed" in note
+
+
+def test_a_disabled_rule_does_not_confirm_the_lock():
+    rule = dict(_OBSERVED_RULE, enabled=False)
+    ok, note = watch.evaluate_lock_payload("smd-audit-archive", _lock_body(rule))
+    assert ok is False
+    assert "not enabled" in note
     assert "immutability is unproven" in note
 
 
-def test_a_configured_bucket_lock_is_recognized():
-    def allowed(cmd):
-        return subprocess.CompletedProcess(
-            cmd, 0, json.dumps({"ObjectLockConfiguration": {"ObjectLockEnabled": "Enabled"}}), ""
-        )
+def test_a_rule_scoped_below_the_archive_prefix_does_not_confirm_the_lock():
+    """A per-seat rule locks one seat's objects and leaves every other seat's loose."""
+    rule = dict(_OBSERVED_RULE, prefix="audit/ashton-price/")
+    ok, note = watch.evaluate_lock_payload("smd-audit-archive", _lock_body(rule))
+    assert ok is False
+    assert "does not cover" in note
 
-    ok, note = watch.probe_bucket_lock("smd-audit-archive", runner=allowed)
+
+def test_a_rule_covering_the_whole_bucket_does_confirm_the_lock():
+    """The other side of the prefix check: broader than audit/ still covers audit/."""
+    ok, _ = watch.evaluate_lock_payload(
+        "smd-audit-archive", _lock_body(dict(_OBSERVED_RULE, prefix=""))
+    )
     assert ok is True
-    assert "configured" in note
+
+
+def test_an_age_shorter_than_the_retention_commitment_does_not_confirm_the_lock():
+    rule = dict(_OBSERVED_RULE, condition={"type": "Age", "maxAgeSeconds": 604800})
+    ok, note = watch.evaluate_lock_payload("smd-audit-archive", _lock_body(rule))
+    assert ok is False
+    assert "short of the" in note
+
+
+def test_a_success_false_body_does_not_confirm_the_lock():
+    payload = {"success": False, "errors": [{"code": 10006, "message": "Bucket not found"}]}
+    ok, note = watch.evaluate_lock_payload("smd-audit-archive", payload)
+    assert ok is False
+    assert "success=false" in note
+    assert "Bucket not found" in note
+
+
+def test_no_rules_at_all_does_not_confirm_the_lock():
+    ok, note = watch.evaluate_lock_payload("smd-audit-archive", _lock_body())
+    assert ok is False
+    assert "no lock rules at all" in note
+
+
+def test_an_api_error_is_reported_verbatim_and_does_not_confirm_the_lock(monkeypatch):
+    monkeypatch.setenv("CLOUDFLARE_ACCOUNT_ID", "a" * 32)
+
+    def fetch(url):
+        raise RuntimeError("HTTP Error 403: Forbidden")
+
+    ok, note = watch.probe_bucket_lock("smd-audit-archive", fetch=fetch)
+    assert ok is False
+    assert "HTTP Error 403: Forbidden" in note
+    assert "immutability is unproven" in note
+
+
+def test_an_unsafe_account_id_never_reaches_a_url(monkeypatch):
+    """The only interpolation into an api.cloudflare.com URL is charset-gated."""
+    monkeypatch.setenv("CLOUDFLARE_ACCOUNT_ID", "abc/../../evil")
+
+    def fetch(url):  # pragma: no cover - reaching this is the failure
+        raise AssertionError(f"a URL was built from an unsafe account id: {url}")
+
+    ok, note = watch.probe_bucket_lock("smd-audit-archive", fetch=fetch)
+    assert ok is False
+    assert "unsafe CLOUDFLARE_ACCOUNT_ID" in note
 
 
 # ---------------------------------------------------------------------------
@@ -306,3 +415,80 @@ def test_authored_seats_skips_template_dirs(tmp_path):
     for name in ("_template", "real-seat"):
         (base / name / "customer.yaml").write_text("slug: x\n")
     assert watch.authored_seats(tmp_path) == ["real-seat"]
+
+
+# ---------------------------------------------------------------------------
+# Seat roster: authored config is not the same question as "the seat exists"
+# ---------------------------------------------------------------------------
+
+
+def test_a_seat_that_is_both_authored_and_provisioned_is_probed():
+    roster = watch.partition_seats(["live-seat"], ["live-seat"])
+    assert roster.probed == ["live-seat"]
+    assert roster.skipped == []
+    assert roster.orphaned == []
+
+
+def test_an_authored_seat_with_no_fleet_status_row_is_skipped_by_name():
+    """The pilot-law shape: a config authored 2026-06-05 and never provisioned.
+
+    Enumerating from the filesystem made the first live run red forever on a
+    connection error to a machine that was never stood up.
+    """
+    roster = watch.partition_seats(["live-seat", "never-provisioned"], ["live-seat"])
+    assert roster.probed == ["live-seat"]
+    assert roster.skipped == ["never-provisioned"]
+
+    notices = watch.roster_notices(roster)
+    assert [(n.slug, n.state) for n in notices] == [("never-provisioned", watch.SKIP)]
+    # Named in the report, never silent (#2366): the denominator has to be visible.
+    line = "\n".join(watch.summary_lines(notices, "lock note"))
+    assert "SKIP" in line
+    assert "never-provisioned: authored but never provisioned (no fleet_status row)." in line
+
+
+def test_a_skipped_seat_does_not_redden_the_run():
+    """A seat that does not exist has no audit record to be wrong about."""
+    skip = watch.SeatOutcome("never-provisioned", watch.SKIP, "headline", {})
+    assert watch.resolve_exit([_outcome(watch.CLEAN), skip], [], True) == watch.EXIT_CLEAN
+
+
+def test_a_provisioned_seat_with_no_authored_config_is_a_hold():
+    """Drift the other way, and that direction IS a finding worth waking up to.
+
+    A fleet_status row with no customer.yaml means a live seat's ledger is
+    outside this control's reach entirely. Silently narrowing to the
+    intersection would hide exactly that.
+    """
+    roster = watch.partition_seats(["live-seat"], ["live-seat", "unauthored-seat"])
+    assert roster.probed == ["live-seat"]
+    assert roster.orphaned == ["unauthored-seat"]
+
+    notices = watch.roster_notices(roster)
+    assert [(n.slug, n.state) for n in notices] == [("unauthored-seat", watch.HOLD)]
+    assert watch.resolve_exit(notices, [], True) == watch.EXIT_HOLD
+
+
+def test_main_holds_when_the_seat_roster_cannot_be_read(monkeypatch, tmp_path, capsys):
+    """An unreadable D1 must not read as "no seats", which would be a quiet green."""
+    base = tmp_path / "operator" / "customers" / "live-seat"
+    base.mkdir(parents=True)
+    (base / "customer.yaml").write_text("slug: live-seat\n")
+    monkeypatch.setattr(watch, "_REPO", tmp_path)
+
+    def explode(self):
+        raise RuntimeError("d1 execute failed: unauthorized")
+
+    monkeypatch.setattr(watch.ConsoleD1, "provisioned_slugs", explode)
+    assert watch.main([]) == watch.EXIT_HOLD
+    assert "seat roster could not be read" in capsys.readouterr().out
+
+
+def test_main_holds_when_no_authored_seat_is_provisioned(monkeypatch, tmp_path, capsys):
+    base = tmp_path / "operator" / "customers" / "never-provisioned"
+    base.mkdir(parents=True)
+    (base / "customer.yaml").write_text("slug: never-provisioned\n")
+    monkeypatch.setattr(watch, "_REPO", tmp_path)
+    monkeypatch.setattr(watch.ConsoleD1, "provisioned_slugs", lambda self: [])
+    assert watch.main([]) == watch.EXIT_HOLD
+    assert "measured nothing" in capsys.readouterr().out


### PR DESCRIPTION
A third party can be shown that the audit record was not truncated or rewritten by anyone, SMD included, and that it survives loss of the Machine.

Two defects the first live run of `audit-chain-watch.py` surfaced ([run 32461138548](https://github.com/venturecrane/ss-console/actions/runs/32461138548)). Fixes ss#2500, which is reopened for them.

## Defect 1: the immutability probe was asking the wrong API, with no credentials

`probe_bucket_lock` shelled out to `aws s3api get-object-lock-configuration` with neither the derived R2 credentials nor `--endpoint-url` (the sibling `_aws_upload` has both), so it failed `NoCredentials` and every run held. Supplying both does not fix it, because it is the wrong question. Observed on the live bucket 2026-08-21:

- S3, derived creds + R2 endpoint: `An error occurred (ObjectLockConfigurationNotFoundError) ... Object Lock configuration does not exist for this bucket.` R2's bucket lock is not surfaced through S3 object lock.
- `GET https://api.cloudflare.com/client/v4/accounts/{account}/r2/buckets/smd-audit-archive/lock`: `{"success":true,"result":{"rules":[{"id":"audit-7y","enabled":true,"prefix":"audit/","condition":{"type":"Age","maxAgeSeconds":220752000}}]}}`

The probe now asks that endpoint. The lock is confirmed only when some rule is `enabled`, its `prefix` covers the whole archive prefix (`audit/` starts with it, so a narrower per-seat rule does not count), and its condition holds the record for at least seven years: `Age` at or above 220,752,000s, a `Date` in the future, or `Indefinite`. Anything else stays a HOLD carrying the API's actual answer. The account id and bucket are charset-gated before they are interpolated into the URL; the token reaches the request through a header, never a command line.

`Age` is the observed shape and `Indefinite` carries no fields. `Date`'s field name is documented nowhere reachable, so an unrecognized `Date` payload fails **closed** with the raw condition in the message rather than being read charitably. The docstring's "UNVERIFIED" paragraph is gone, replaced by the observed body.

## Defect 2: a seat that was never built made every run red

`authored_seats()` enumerated `operator/customers/*/customer.yaml`. That answers "who has a config", not "which seats exist" — `operator/customers/pilot-law/customer.yaml:12` records external setup "in flight 2026-06-05" and no `hermes-pilot-law` app was ever stood up, so the watcher held on `pilot-law: URLError Name or service not known` forever. An alarm that is always ringing is one nobody hears.

`fleet_status` is the authority for a seat existing (ADR 0043 B) and this job already reads the console for pins. Seats are now the intersection, and **both** directions of the difference are named rather than filtered away:

- authored, no `fleet_status` row → `SKIP <slug>: authored but never provisioned (no fleet_status row).` in the run summary, and not a hold (#2366 — a skipped seat must never be silent, but a seat that does not exist has no audit record to be wrong about);
- `fleet_status` row, no authored config → a HOLD, because that drift means a live seat's ledger is outside this control's reach entirely.

An unreadable roster is its own hold: returning `[]` would turn an unauthorized D1 into a quiet green run. An explicit `--seat` still probes exactly what a person named.

`reconcile-outcomes.py:545` has the same enumeration and is **left as-is**, with a comment pointing at the helper. It has no D1 credentials to intersect against, and an unreachable seat only sets that seat's `held` there rather than failing the run.

## Falsifiers

Ten mutations of the real artifact, one per gate. Each turns exactly the test that covers it red; source restored and 35/35 green after.

| mutation | test that fired |
|---|---|
| `enabled` check removed | `test_a_disabled_rule_does_not_confirm_the_lock` |
| prefix-coverage check removed | `test_a_rule_scoped_below_the_archive_prefix_does_not_confirm_the_lock` |
| seven-year minimum removed | `test_an_age_shorter_than_the_retention_commitment_does_not_confirm_the_lock` |
| `success:false` accepted | `test_a_success_false_body_does_not_confirm_the_lock` |
| expired `Date` accepted | `test_a_date_rule_already_past_does_not_confirm_the_lock` |
| URL charset gate removed | `test_an_unsafe_account_id_never_reaches_a_url` |
| intersection removed (the shipped defect) | `test_an_authored_seat_with_no_fleet_status_row_is_skipped_by_name`, `test_main_holds_when_no_authored_seat_is_provisioned` |
| orphan drift swallowed | `test_a_provisioned_seat_with_no_authored_config_is_a_hold` |
| SKIP collapsed into HOLD | `test_a_skipped_seat_does_not_redden_the_run` (+ the skip test) |
| unreadable roster swallowed | `test_main_holds_when_the_seat_roster_cannot_be_read` |

No test touches the live Cloudflare API, D1, R2, or a seat: every fixture is the observed wire body, driven through an injected fetcher.

## Evidence

| AC | state | evidence |
|---|---|---|
| (repo) The lock probe asks R2's bucket-lock API, not S3 object lock, and confirms only an enabled rule covering `audit/` for >= 7 years | met | `operator/bin/audit-chain-watch.py` `probe_bucket_lock` / `evaluate_lock_payload` / `_rule_covers_archive`; fixtures pinned to the 2026-08-21 live body; 6 lock-gate mutations, table above |
| (repo) An unconfirmed lock stays a HOLD carrying the API's actual answer | met | `_lock_unproven`; `test_an_api_error_is_reported_verbatim_and_does_not_confirm_the_lock`, `test_a_success_false_body_does_not_confirm_the_lock` |
| (repo) Docstring states the now-known shape; the "UNVERIFIED" paragraph is deleted | met | `probe_bucket_lock` docstring |
| (repo) Seats are the intersection of authored dirs and `fleet_status.customer_slug` | met | `partition_seats`, `ConsoleD1.provisioned_slugs`; `test_a_seat_that_is_both_authored_and_provisioned_is_probed` |
| (repo) A skipped seat is named in the run summary and does not count as a hold | met | `roster_notices`, `SKIP`; `test_an_authored_seat_with_no_fleet_status_row_is_skipped_by_name`, `test_a_skipped_seat_does_not_redden_the_run` |
| (repo) Drift the other way (fleet_status row, no config) is surfaced, not swallowed | met | `test_a_provisioned_seat_with_no_authored_config_is_a_hold` |
| (repo) `reconcile-outcomes.py` shares the helper or carries a pointer | met | `operator/bin/reconcile-outcomes.py:545` comment; it has no D1 credentials, so the helper cannot be shared cleanly |
| (runtime) The next scheduled run confirms the lock and reports pilot-law as SKIP rather than a hold | unmet | Requires re-running the workflow, which is the orchestrator's to dispatch after merge. No seat, no R2, and no live API were touched from this session. |

Green: `npm run verify` exit 0; `pytest operator/bin/tests operator/tests operator/workspace_broker/tests` 945 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016U9H1VbtZdmBo2t6UBAAPr
