### PR TITLE
feat(operator): the reconciler kill test can run on the sandbox, which has no send app (ss#2499)

### DIFF
--- a/operator/bin/killtest-msgraph-send.py
+++ b/operator/bin/killtest-msgraph-send.py
@@ -16,6 +16,36 @@ nothing in the ledger to account for it. The AgentMail twin of this test is on
 record: ``[UNAUDITED-KILLTEST-2258]``, 2026-08-13, reported and then baselined
 (``operator/bin/reconcile-sends-baseline.json``).
 
+TWO MODES, BECAUSE THE SANDBOX HAS NO SEND APP. ``--mode send`` is the original
+and needs the seat's SEND app credential. ``smd-staging`` has none: that app
+registration does not exist (ss#2467, OPEN), and its READ app's token was
+OBSERVED on 2026-08-21 carrying app roles ``['Mail.ReadWrite']`` and nothing
+else. So the only channel that could exercise the reconciler on a sandbox was
+closed, and the falsifier had nowhere to run.
+
+``--mode plant`` opens it. ``Mail.ReadWrite`` is enough to CREATE a message
+directly in Sent Items without transmitting anything:
+
+    POST /users/{mailbox}/mailFolders/sentitems/messages
+
+(Graph v1.0 "Create Message" in a mail folder; ``sentitems`` is a documented
+well-known folder name; the application permission is ``Mail.ReadWrite``; the
+answer is 201 with the created message, ``id`` included. Docs:
+https://learn.microsoft.com/en-us/graph/api/user-post-messages and
+https://learn.microsoft.com/en-us/graph/api/resources/mailfolder .)
+
+WHAT PLANT PROVES, AND WHAT IT DOES NOT. To the reconciler, an item sitting in
+Sent Items with no ``X-SMD-Audit-Row`` header and no ledger row is byte-for-byte
+the event this control exists to catch, and it reads Sent Items through exactly
+the same query either way. So plant proves THE RECONCILER: that a foreign item
+in that folder is found, reported, and not silently absorbed.
+
+It does not prove the transmit path, and it must not be read as proving it. It
+does not exercise ``sendMail``, the SEND app, the two-app fence, or the broker's
+header stamping -- an item that was never transmitted cannot show that a
+transmitted one gets stamped. Nothing leaves the tenant, which is the point:
+the sandbox gets a real artifact in a real folder and no recipient anywhere.
+
 WHERE IT MAY RUN, AND WHY THAT IS A HARD FENCE. Only a sandbox seat named in
 ``SANDBOX_SEATS`` below. A client's mailbox is the client's; deliberately posting
 a message into it to see whether our watchdog barks would be an unannounced
@@ -23,17 +53,22 @@ artifact in a firm's live correspondence, and the firm is the only party that ca
 see its own Sent Items UI. The refusal is by SEAT SLUG rather than by a flag,
 because a flag is a thing an operator in a hurry passes.
 
-RUNNING IT (a Captain act, not an agent's -- it transmits):
+RUNNING IT (a Captain act, not an agent's -- both modes leave a real artifact in
+a real mailbox, and plant is no less deliberate for never having transmitted):
 
     infisical run --env=prod --path=/ss -- \\
-        python3 operator/bin/killtest-msgraph-send.py --seat smd-staging --confirm
+        python3 operator/bin/killtest-msgraph-send.py \\
+            --seat smd-staging --mode plant --confirm
 
     # then, after the daily run or a manual dispatch:
     infisical run --env=prod --path=/ss -- \\
         python3 operator/bin/reconcile-sends.py --channel msgraph --days 2
 
 The second command must report the message this one prints, as a FIND. If it does
-not, the control does not work and the green runs before it meant nothing.
+not, the control does not work and the green runs before it meant nothing. Plant
+mode has an advantage here that send mode does not: Graph answers the create with
+the whole message, so the id to look for is PRINTED rather than hunted for by
+subject.
 
 AFTER IT PASSES (operator/CLAUDE.md, probe-artifact contract): add the printed
 message id to ``reconcile-sends-baseline.json`` in a PR with ``reported_in``
@@ -78,6 +113,17 @@ SANDBOX_SEATS: dict[str, str] = {
 #: client one: a kill test that reaches a client is not a test.
 KILLTEST_RECIPIENT = "team@smd.services"
 
+#: ``send`` transmits through ``sendMail`` on the SEND app. ``plant`` creates the
+#: item directly in Sent Items on the READ app and transmits nothing. Default is
+#: ``send``, so the original invocation keeps its original meaning.
+MODE_SEND = "send"
+MODE_PLANT = "plant"
+MODES = (MODE_SEND, MODE_PLANT)
+
+#: The well-known Graph folder name. Not an id we discovered and cached: Graph
+#: resolves this name per mailbox, so it cannot drift to another seat's folder.
+SENT_ITEMS_FOLDER = "sentitems"
+
 
 class KillTestRefused(RuntimeError):
     """This may not run here. Never retried, never overridden by a flag."""
@@ -102,7 +148,15 @@ def _seat_config(slug: str) -> dict:
     tenant = str(auth.get("tenant_id") or "")
     if not (mailbox and tenant):
         raise KillTestRefused(f"{slug} authors no complete msgraph_auth")
-    return {"mailbox": mailbox, "tenant_id": tenant}
+    return {
+        "mailbox": mailbox,
+        "tenant_id": tenant,
+        # The READ app's client id as the seat authors it. A public identifier,
+        # not a credential, and the same one reconcile-sends.py authenticates
+        # with (reconcile-sends.py:320) -- so plant mode cannot end up talking to
+        # a different app than the control it is meant to falsify.
+        "client_id": str(auth.get("client_id") or ""),
+    }
 
 
 def send_credential(slug: str) -> tuple[str, str]:
@@ -120,6 +174,45 @@ def send_credential(slug: str) -> tuple[str, str]:
         raise KillTestRefused(
             f"MSGRAPH_SEND_CLIENT_ID__{key} / MSGRAPH_SEND_CLIENT_SECRET__{key} "
             "are not in this environment; run under infisical"
+        )
+    return client_id, secret
+
+
+def read_credential(slug: str, config: dict) -> tuple[str, str]:
+    """The READ app's client id and secret for this seat, for plant mode.
+
+    The READ app on purpose, and for the opposite reason send mode wants the SEND
+    app: plant never transmits, so ``Mail.Send`` would buy nothing, and
+    ``Mail.ReadWrite`` -- which the staging app OBSERVABLY has and which is the
+    documented permission for creating a message in a mail folder -- is exactly
+    enough. Nothing here can transmit even if it were asked to.
+
+    Resolution order, most specific first. The suffixed pair is how provisioning
+    stages a seat's own credentials; the unsuffixed pair is how the sandbox's are
+    staged in Infisical today, which is the only reason the fallback exists; the
+    authored ``client_id`` is the last resort for the ID ONLY. There is
+    deliberately no fallback for the SECRET beyond the two env names: a shared
+    secret picked up by accident would authenticate as somebody else's app
+    against somebody else's mailbox, and that is a worse outcome than a refusal.
+    """
+    key = slug.upper().replace("-", "_")
+    client_id = (
+        os.environ.get(f"MSGRAPH_CLIENT_ID__{key}")
+        or os.environ.get("MSGRAPH_CLIENT_ID")
+        or str(config.get("client_id") or "")
+    )
+    secret = os.environ.get(f"MSGRAPH_CLIENT_SECRET__{key}") or os.environ.get(
+        "MSGRAPH_CLIENT_SECRET"
+    )
+    if not client_id:
+        raise KillTestRefused(
+            f"no READ client id for {slug}: MSGRAPH_CLIENT_ID__{key}, "
+            "MSGRAPH_CLIENT_ID, and customer.yaml msgraph_auth.client_id are all empty"
+        )
+    if not secret:
+        raise KillTestRefused(
+            f"MSGRAPH_CLIENT_SECRET__{key} / MSGRAPH_CLIENT_SECRET are not in "
+            "this environment; run under infisical"
         )
     return client_id, secret
 
@@ -153,16 +246,21 @@ def mint_token(tenant_id: str, client_id: str, secret: str, *, opener=None) -> s
     return str(token)
 
 
-def killtest_subject(now: datetime | None = None) -> str:
+def killtest_subject(now: datetime | None = None, mode: str = MODE_SEND) -> str:
     """The subject, stamped so a human reading the mailbox knows what it is.
 
-    Two markers, both deliberate. ``KILLTEST_MARKER`` is what the reconciler
+    Three markers, all deliberate. ``KILLTEST_MARKER`` is what the reconciler
     report and the baseline entry will show. The creation stamp is the
     probe-artifact contract in operator/CLAUDE.md: firm staff reading a task or
     message list are the other consumer that can mistake a probe for real work.
+    The mode is here because the two modes prove different things, and six months
+    from now the subject is all the baseline file will have to say which ran.
     """
     stamp = (now or datetime.now(timezone.utc)).strftime("%Y-%m-%dT%H:%MZ")
-    return f"{KILLTEST_MARKER} {stamp} deliberate unaudited send, reconciler kill test"
+    return (
+        f"{KILLTEST_MARKER} {stamp} mode={mode} "
+        "deliberate unaudited send, reconciler kill test"
+    )
 
 
 def killtest_message(subject: str) -> dict:
@@ -190,6 +288,88 @@ def killtest_message(subject: str) -> dict:
     }
 
 
+def planted_message(subject: str, mailbox: str, now: datetime | None = None) -> dict:
+    """The Graph payload for an item created straight into Sent Items.
+
+    Carries NO ``internetMessageHeaders``, same as the send payload and for the
+    same reason: a stamped item would be matched by the header and the run would
+    come back clean, which is a kill test that always passes.
+
+    ``toRecipients`` is the seat's own mailbox. Not SMD's operational address and
+    certainly not anyone else's -- this item is never transmitted, so a recipient
+    outside the tenant would be a fiction printed in a folder that firm staff
+    read as a record of what was actually sent.
+
+    ``sentDateTime`` matters more than it looks. The reconciler pages Sent Items
+    ``$orderby=sentDateTime desc`` and stops at the ``--days`` boundary
+    (reconcile-sends.py:446, :454), so an item with no sent time sorts to the far
+    end of the mailbox and the window never reaches it -- the plant would be
+    invisible and the clean run would be read as the control working. The Graph
+    create-in-mailFolder samples set it explicitly, so it is set here explicitly.
+
+    ``isDraft: false`` is asked for because an item in Sent Items is not a draft.
+    The v1.0 message resource does not document it as read-only, but Exchange may
+    compute it from the underlying message flags regardless, so the caller PRINTS
+    what came back rather than assuming the request won. Nothing downstream
+    depends on it either way: the reconciler does not filter on ``isDraft``.
+    """
+    stamp = (now or datetime.now(timezone.utc)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    return {
+        "subject": subject,
+        "body": {
+            "contentType": "Text",
+            "content": (
+                "Deliberate reconciler kill test. This item was CREATED directly "
+                "in Sent Items and was never transmitted -- no message left this "
+                "tenant and no recipient received anything. It bypassed the "
+                "workspace broker, so no audit row exists for it and it carries "
+                "no X-SMD-Audit-Row header.\n\n"
+                "The next unaudited-send-reconcile run must report it. If it does "
+                "not, the control is not working (ss#2499).\n\n"
+                "Once it has been reported, add it to "
+                "operator/bin/reconcile-sends-baseline.json in a PR."
+            ),
+        },
+        "toRecipients": [{"emailAddress": {"address": mailbox}}],
+        "isDraft": False,
+        "sentDateTime": stamp,
+    }
+
+
+def plant(mailbox: str, token: str, payload: dict, *, opener=None) -> dict:
+    """Create the item in Sent Items and return the message Graph created.
+
+    A 201 that carries no ``id`` is an ERROR, never a quiet success. Without an
+    id there is nothing to print, nothing exact to baseline, and nothing to go
+    and delete -- and a plant nobody can name is an unexplained item in a mailbox
+    dressed up as a passing test.
+    """
+    request = urllib.request.Request(
+        f"{GRAPH_API_BASE}/users/{mailbox}/mailFolders/{SENT_ITEMS_FOLDER}/messages",
+        data=json.dumps(payload).encode(),
+        method="POST",
+        headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
+    )
+    open_fn = opener or urllib.request.urlopen
+    try:
+        with open_fn(request, timeout=TIMEOUT_S) as response:
+            body = response.read()
+    except urllib.error.HTTPError as exc:
+        raise KillTestRefused(
+            f"create in {SENT_ITEMS_FOLDER} failed with HTTP {exc.code}"
+        ) from exc
+    try:
+        created = json.loads(body)
+    except ValueError as exc:
+        raise KillTestRefused("Graph answered the create with a non-JSON body") from exc
+    if not isinstance(created, dict) or not created.get("id"):
+        raise KillTestRefused(
+            "Graph accepted the create but returned no message id; nothing was "
+            "planted that this run can name, so it is not reported as planted"
+        )
+    return created
+
+
 def transmit(mailbox: str, token: str, payload: dict, *, opener=None) -> None:
     request = urllib.request.Request(
         f"{GRAPH_API_BASE}/users/{mailbox}/sendMail",
@@ -211,55 +391,107 @@ def guard(slug: str) -> str:
     By slug rather than by flag: a flag is a thing an operator in a hurry passes,
     and the cost of getting this wrong is an unexplained message in a client's
     own correspondence that only the client can see.
+
+    The fence is on the SEAT and applies to every mode. Plant transmits nothing,
+    which makes it tempting to treat as harmless; it is not. It leaves a real
+    item in a real Sent Items folder, and on a client's seat that folder is the
+    firm's own record of what it sent. An entry there that the firm did not send
+    is a worse artifact than a message, not a better one.
     """
     if slug not in SANDBOX_SEATS:
         raise KillTestRefused(
-            f"{slug!r} is not a sandbox seat. This script transmits a real message "
+            f"{slug!r} is not a sandbox seat. This script puts a real message "
             "into a real mailbox and may only do so on: "
             + ", ".join(f"{k} ({v})" for k, v in SANDBOX_SEATS.items())
         )
     return SANDBOX_SEATS[slug]
 
 
-def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--seat", required=True, help="sandbox seat slug to send from")
-    parser.add_argument(
-        "--confirm",
-        action="store_true",
-        help="actually transmit; without it this prints what it would send",
-    )
-    args = parser.parse_args(argv)
+def _next_step() -> None:
+    """What the operator does next. Identical in both modes, because the run that
+    matters is the reconciler's, not this one's."""
+    print()
+    print("  python3 operator/bin/reconcile-sends.py --channel msgraph --days 2")
+    print()
+    print("It must appear as a FIND. Then baseline it in a PR.")
 
-    try:
-        why_allowed = guard(args.seat)
-        config = _seat_config(args.seat)
-        subject = killtest_subject()
-        payload = killtest_message(subject)
-        if not args.confirm:
-            print(f"DRY RUN. {args.seat} is allowed: {why_allowed}")
-            print(f"would send from {config['mailbox']} to {KILLTEST_RECIPIENT}")
-            print(f"subject: {subject}")
-            print("re-run with --confirm to transmit.")
-            return 0
-        client_id, secret = send_credential(args.seat)
-        token = mint_token(config["tenant_id"], client_id, secret)
-        transmit(config["mailbox"], token, payload)
-    except KillTestRefused as exc:
-        print(f"REFUSED: {exc}", file=sys.stderr)
-        return 2
 
+def _run_send(seat: str, config: dict, subject: str) -> int:
+    client_id, secret = send_credential(seat)
+    token = mint_token(config["tenant_id"], client_id, secret)
+    transmit(config["mailbox"], token, killtest_message(subject))
     print(f"sent from {config['mailbox']}")
     print(f"subject: {subject}")
     print()
     print("Graph answers sendMail with 202 and no body, so this script cannot")
     print("print the message id -- find it by subject in Sent Items, or in the")
     print("reconciler report, which is the point of the exercise:")
-    print()
-    print("  python3 operator/bin/reconcile-sends.py --channel msgraph --days 2")
-    print()
-    print("It must appear as a FIND. Then baseline it in a PR.")
+    _next_step()
     return 0
+
+
+def _run_plant(seat: str, config: dict, subject: str) -> int:
+    mailbox = config["mailbox"]
+    client_id, secret = read_credential(seat, config)
+    token = mint_token(config["tenant_id"], client_id, secret)
+    created = plant(mailbox, token, planted_message(subject, mailbox))
+    print(f"planted in {mailbox} Sent Items. Nothing was transmitted.")
+    print(f"subject: {subject}")
+    print(f"id: {created.get('id')}")
+    print(f"internetMessageId: {created.get('internetMessageId') or '(not returned)'}")
+    # Echoed rather than asserted. The reconciler's window keys on sentDateTime,
+    # so an operator who sees it come back empty knows the plant will sort out of
+    # every --days window before the clean run gets misread as a passing control.
+    print(f"sentDateTime: {created.get('sentDateTime') or '(not returned)'}")
+    print(f"isDraft: {created.get('isDraft')}")
+    print()
+    print("Both ids are exact, so the baseline entry needs no subject matching.")
+    print("Now prove the reconciler finds an item it was never told about:")
+    _next_step()
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--seat", required=True, help="sandbox seat slug to act on")
+    parser.add_argument(
+        "--mode",
+        choices=MODES,
+        default=MODE_SEND,
+        help=(
+            "send: transmit via sendMail on the SEND app (the original). "
+            "plant: create the item directly in Sent Items on the READ app, "
+            "transmitting nothing -- the only mode a seat with no SEND app can run"
+        ),
+    )
+    parser.add_argument(
+        "--confirm",
+        action="store_true",
+        help="actually do it; without it this prints what it would do",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        why_allowed = guard(args.seat)
+        config = _seat_config(args.seat)
+        subject = killtest_subject(mode=args.mode)
+        if not args.confirm:
+            destination = (
+                f"{config['mailbox']} Sent Items, transmitting nothing"
+                if args.mode == MODE_PLANT
+                else f"{config['mailbox']} to {KILLTEST_RECIPIENT}"
+            )
+            print(f"DRY RUN. {args.seat} is allowed: {why_allowed}")
+            print(f"mode {args.mode} would write into {destination}")
+            print(f"subject: {subject}")
+            print("re-run with --confirm to do it.")
+            return 0
+        if args.mode == MODE_PLANT:
+            return _run_plant(args.seat, config, subject)
+        return _run_send(args.seat, config, subject)
+    except KillTestRefused as exc:
+        print(f"REFUSED: {exc}", file=sys.stderr)
+        return 2
 
 
 if __name__ == "__main__":

--- a/operator/bin/killtest-msgraph-send.py
+++ b/operator/bin/killtest-msgraph-send.py
@@ -5,14 +5,18 @@ WHY A HARNESS AND NOT A UNIT TEST. Every assertion in
 ``operator/bin/tests/test_reconcile_sends.py`` is made against a fake Graph this
 repo also wrote, so all of them together prove the matcher agrees with our model
 of a mailbox. None of them can prove the model is the mailbox. The only thing
-that settles that is a real message, sent around the broker, into a real Sent
-Items folder, found by a real scheduled run. That is what this script sends.
+that settles that is a real message, put around the broker into a real Sent
+Items folder and found by a real scheduled run. That is what this script puts
+there -- by transmitting one in ``--mode send``, or by creating one in
+``--mode plant`` on a seat where transmitting is not available.
 
-WHAT IT DELIBERATELY DOES WRONG. It transmits with the SEND app credential
-directly, bypassing the workspace broker entirely -- so no audit row is written
-and no ``X-SMD-Audit-Row`` header is stamped. That is precisely the shape of the
-event this control exists for: a message that left the Operator's mailbox with
-nothing in the ledger to account for it. The AgentMail twin of this test is on
+WHAT IT DELIBERATELY DOES WRONG. It goes around the workspace broker entirely --
+so no audit row is written and no ``X-SMD-Audit-Row`` header is stamped. That is
+precisely the shape of the event this control exists for: an item in the
+Operator's Sent Items with nothing in the ledger to account for it. In send mode
+that item also left the mailbox; in plant mode it never did, and the reconciler
+cannot tell the difference, which is what makes plant a usable falsifier at all.
+The AgentMail twin of this test is on
 record: ``[UNAUDITED-KILLTEST-2258]``, 2026-08-13, reported and then baselined
 (``operator/bin/reconcile-sends-baseline.json``).
 

--- a/operator/bin/tests/test_killtest_msgraph_send.py
+++ b/operator/bin/tests/test_killtest_msgraph_send.py
@@ -1,13 +1,19 @@
 """The kill test's own guardrails (ss#2499).
 
-A script that deliberately transmits an unaudited message into a real mailbox is
-worth exactly as much as its fence. These tests pin the fence and the shape of
-what it sends; the send itself is a Captain act and is not performed here.
+A script that deliberately puts an unaudited message into a real mailbox is worth
+exactly as much as its fence. These tests pin the fence and the shape of what it
+writes, in BOTH modes; the run itself is a Captain act and is not performed here.
+
+Plant mode is fenced identically to send mode on purpose. It transmits nothing,
+which makes it read as harmless, and that reading is the thing these tests exist
+to refuse: an item in a firm's Sent Items that the firm did not send is a worse
+artifact than a message, because that folder is the firm's own record.
 """
 
 from __future__ import annotations
 
 import importlib.util
+import json
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -43,10 +49,15 @@ def test_the_sandbox_seat_is_allowed():
     assert kill.guard("smd-staging")
 
 
-def test_the_fence_is_not_a_flag(monkeypatch):
+def test_the_fence_is_not_a_flag(capsys):
     """--confirm gates the transmit; it does not widen WHERE it may transmit. A
-    flag is a thing an operator in a hurry passes."""
+    flag is a thing an operator in a hurry passes.
+
+    Same reason as the plant twin below for reading stderr: this seat exits 2 on
+    a missing credential too, so the exit code alone does not say the fence is
+    what stopped it."""
     assert kill.main(["--seat", "ashton-price", "--confirm"]) == 2
+    assert "is not a sandbox seat" in capsys.readouterr().err
 
 
 def test_a_dry_run_transmits_nothing(monkeypatch, capsys):
@@ -85,3 +96,273 @@ def test_the_message_is_addressed_to_smd_and_never_a_client():
         r["emailAddress"]["address"] for r in payload["message"]["toRecipients"]
     ]
     assert recipients == ["team@smd.services"]
+
+
+# --------------------------------------------------------------------------
+# plant mode
+# --------------------------------------------------------------------------
+
+
+_STAGING_MAILBOX = "operator@smdopslab.onmicrosoft.com"
+_STAGING_CONFIG = {
+    "mailbox": _STAGING_MAILBOX,
+    "tenant_id": "f11d2887-b7f2-4464-a9c6-d4db2166b43c",
+    "client_id": "authored-from-customer-yaml",
+}
+
+
+class _Created:
+    def __init__(self, payload):
+        self._payload = json.dumps(payload).encode()
+
+    def read(self):
+        return self._payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_exc):
+        return False
+
+
+class FakeGraph:
+    """Replays one create response and RECORDS the request, so the URL, method
+    and body are asserted from the wire rather than trusted."""
+
+    def __init__(self, payload):
+        self._payload = payload
+        self.requests = []
+
+    def __call__(self, request, timeout=None):
+        self.requests.append(
+            (
+                request.get_method(),
+                request.full_url,
+                json.loads(request.data.decode()),
+            )
+        )
+        return _Created(self._payload)
+
+
+def _clear_graph_env(monkeypatch):
+    for name in (
+        "MSGRAPH_CLIENT_ID",
+        "MSGRAPH_CLIENT_SECRET",
+        "MSGRAPH_CLIENT_ID__SMD_STAGING",
+        "MSGRAPH_CLIENT_SECRET__SMD_STAGING",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_plant_is_not_the_default_mode(monkeypatch, capsys):
+    """The original invocation keeps its original meaning. A mode flag that
+    changes what an unchanged command line does is a trap, not a feature."""
+    monkeypatch.setattr(kill, "mint_token", lambda *_a, **_k: "tok")
+    monkeypatch.setattr(kill, "plant", lambda *_a, **_k: {"id": "should-not-happen"})
+    reached = []
+    monkeypatch.setattr(kill, "send_credential", lambda _s: reached.append(1) or ("i", "s"))
+    monkeypatch.setattr(kill, "transmit", lambda *_a, **_k: None)
+    assert kill.main(["--seat", "smd-staging", "--confirm"]) == 0
+    assert reached == [1], "an omitted --mode must still take the send path"
+    assert "mode=send" in capsys.readouterr().out
+
+
+def test_both_modes_parse_and_an_invented_mode_does_not(capsys):
+    """A typo'd mode must not fall through to a default that transmits."""
+    assert kill.main(["--seat", "smd-staging", "--mode", "plant"]) == 0
+    assert "mode plant" in capsys.readouterr().out
+    with pytest.raises(SystemExit):
+        kill.main(["--seat", "smd-staging", "--mode", "planted"])
+
+
+def test_the_paying_firms_seat_is_refused_in_plant_mode_too(capsys):
+    """Plant transmits nothing, which makes it read as harmless. It is not: it
+    leaves an item in a folder the firm reads as its own record of what it sent.
+    The fence is on the SEAT, not on whether the wire carried anything.
+
+    Asserts WHICH gate fired, not just the exit code. With the fence removed this
+    run still exits 2 -- on a missing credential, several steps later and only by
+    luck -- so an exit-code-only assertion would go on passing with no fence at
+    all. (Falsifier 2026-08-21: deleting the guard call for plant mode left the
+    code-only version green and this version red.)"""
+    assert kill.main(["--seat", "ashton-price", "--mode", "plant", "--confirm"]) == 2
+    assert "is not a sandbox seat" in capsys.readouterr().err
+
+
+def test_a_plant_dry_run_reaches_no_network(monkeypatch, capsys):
+    def explode(*_a, **_k):  # pragma: no cover - must never be reached
+        raise AssertionError("a dry run reached the network")
+
+    monkeypatch.setattr(kill, "mint_token", explode)
+    monkeypatch.setattr(kill, "plant", explode)
+    assert kill.main(["--seat", "smd-staging", "--mode", "plant"]) == 0
+    out = capsys.readouterr().out
+    assert "DRY RUN" in out
+    assert "transmitting nothing" in out
+
+
+def test_plant_builds_the_documented_graph_create_request():
+    """POST /users/{mailbox}/mailFolders/sentitems/messages, per Graph v1.0
+    'Create Message' in a mail folder. Asserted from the recorded request because
+    a vendor shape that is assumed rather than pinned is the shape that drifts."""
+    http = FakeGraph({"id": "AAMk-planted", "internetMessageId": "<planted@x>"})
+    subject = kill.killtest_subject(mode=kill.MODE_PLANT)
+    kill.plant(
+        _STAGING_MAILBOX,
+        "tok",
+        kill.planted_message(subject, _STAGING_MAILBOX),
+        opener=http,
+    )
+    method, url, body = http.requests[-1]
+    assert method == "POST"
+    assert url == (
+        "https://graph.microsoft.com/v1.0/users/"
+        f"{_STAGING_MAILBOX}/mailFolders/sentitems/messages"
+    )
+    # Every property the documented create needs, and no envelope around them:
+    # this is a message resource posted to a folder, not a sendMail payload.
+    assert set(body) == {
+        "subject",
+        "body",
+        "toRecipients",
+        "isDraft",
+        "sentDateTime",
+    }
+    assert body["subject"] == subject
+    assert body["isDraft"] is False
+    assert body["body"]["contentType"] == "Text"
+
+
+def test_the_planted_item_carries_no_audit_header():
+    """Same experiment as send mode. A stamped item would be matched by the
+    header and the run would come back clean -- a kill test that always passes."""
+    payload = kill.planted_message("s", _STAGING_MAILBOX)
+    assert "internetMessageHeaders" not in payload
+
+
+def test_the_planted_item_carries_a_sent_time():
+    """Not cosmetic. The reconciler pages Sent Items ordered by sentDateTime and
+    stops at the --days boundary (reconcile-sends.py:446, :454), so an item with
+    no sent time sorts past every window and is never reached -- the plant would
+    be invisible and the clean run would be misread as the control working."""
+    stamped = kill.planted_message(
+        "s", _STAGING_MAILBOX, datetime(2026, 8, 21, 14, 30, 5, tzinfo=timezone.utc)
+    )
+    assert stamped["sentDateTime"] == "2026-08-21T14:30:05Z"
+
+
+def test_the_planted_item_is_addressed_to_the_seats_own_mailbox():
+    """It is never transmitted, so a recipient outside the tenant would be a
+    fiction printed in a folder that staff read as a record of real sends."""
+    payload = kill.planted_message("s", _STAGING_MAILBOX)
+    addresses = [r["emailAddress"]["address"] for r in payload["toRecipients"]]
+    assert addresses == [_STAGING_MAILBOX]
+
+
+def test_the_planted_subject_says_which_mode_made_it():
+    subject = kill.killtest_subject(
+        datetime(2026, 8, 21, 14, 30, tzinfo=timezone.utc), mode=kill.MODE_PLANT
+    )
+    assert subject.startswith("[UNAUDITED-KILLTEST-2258] 2026-08-21T14:30Z mode=plant")
+
+
+def test_a_created_response_without_an_id_is_an_error():
+    """A 201 is not a success. Without an id there is nothing exact to baseline
+    and nothing to go and delete, so an unnamed item in a mailbox would be
+    reported as a passing test."""
+    http = FakeGraph({"internetMessageId": "<no-graph-id@x>"})
+    with pytest.raises(kill.KillTestRefused) as exc:
+        kill.plant(_STAGING_MAILBOX, "tok", {"subject": "s"}, opener=http)
+    assert "no message id" in str(exc.value)
+
+
+def test_a_created_response_with_an_id_is_returned_whole():
+    """Law 12 control: an error path that fires on everything proves nothing."""
+    http = FakeGraph({"id": "AAMk-planted", "internetMessageId": "<planted@x>"})
+    created = kill.plant(_STAGING_MAILBOX, "tok", {"subject": "s"}, opener=http)
+    assert created["id"] == "AAMk-planted"
+    assert created["internetMessageId"] == "<planted@x>"
+
+
+def test_plant_prefers_the_seats_own_read_credentials(monkeypatch):
+    _clear_graph_env(monkeypatch)
+    monkeypatch.setenv("MSGRAPH_CLIENT_ID__SMD_STAGING", "per-seat-id")
+    monkeypatch.setenv("MSGRAPH_CLIENT_SECRET__SMD_STAGING", "per-seat-secret")
+    monkeypatch.setenv("MSGRAPH_CLIENT_ID", "shared-id")
+    monkeypatch.setenv("MSGRAPH_CLIENT_SECRET", "shared-secret")
+    client_id, secret = kill.read_credential("smd-staging", _STAGING_CONFIG)
+    assert (client_id, secret) == ("per-seat-id", "per-seat-secret")
+
+
+def test_plant_falls_back_to_the_unsuffixed_pair(monkeypatch):
+    """How the sandbox's are staged in Infisical today. Without this the plant
+    refuses on a seat the reconciler itself authenticates against fine."""
+    _clear_graph_env(monkeypatch)
+    monkeypatch.setenv("MSGRAPH_CLIENT_ID", "shared-id")
+    monkeypatch.setenv("MSGRAPH_CLIENT_SECRET", "shared-secret")
+    assert kill.read_credential("smd-staging", _STAGING_CONFIG) == (
+        "shared-id",
+        "shared-secret",
+    )
+
+
+def test_the_authored_client_id_is_the_last_resort_for_the_id(monkeypatch):
+    """The client id is a public identifier the seat already authors. Falling
+    back to it means plant talks to the same app reconcile-sends.py does."""
+    _clear_graph_env(monkeypatch)
+    monkeypatch.setenv("MSGRAPH_CLIENT_SECRET__SMD_STAGING", "per-seat-secret")
+    client_id, _secret = kill.read_credential("smd-staging", _STAGING_CONFIG)
+    assert client_id == "authored-from-customer-yaml"
+
+
+def test_there_is_no_fallback_for_the_secret(monkeypatch):
+    """A shared secret picked up by accident would authenticate as another app
+    against another mailbox. A refusal is the better outcome."""
+    _clear_graph_env(monkeypatch)
+    monkeypatch.setenv("MSGRAPH_CLIENT_ID", "shared-id")
+    with pytest.raises(kill.KillTestRefused) as exc:
+        kill.read_credential("smd-staging", _STAGING_CONFIG)
+    assert "MSGRAPH_CLIENT_SECRET" in str(exc.value)
+
+
+def test_plant_never_asks_for_the_send_credential(monkeypatch):
+    """The whole reason plant exists is that smd-staging has no SEND app
+    (ss#2467). If it reached for one it would refuse on the seat it was built
+    for, and the falsifier would still have nowhere to run."""
+
+    def explode(*_a, **_k):  # pragma: no cover - must never be reached
+        raise AssertionError("plant mode reached for the SEND credential")
+
+    monkeypatch.setattr(kill, "send_credential", explode)
+    monkeypatch.setattr(kill, "mint_token", lambda *_a, **_k: "tok")
+    monkeypatch.setattr(
+        kill, "plant", lambda *_a, **_k: {"id": "i", "internetMessageId": "<m>"}
+    )
+    _clear_graph_env(monkeypatch)
+    monkeypatch.setenv("MSGRAPH_CLIENT_SECRET", "shared-secret")
+    assert kill.main(["--seat", "smd-staging", "--mode", "plant", "--confirm"]) == 0
+
+
+def test_plant_prints_both_ids_so_the_baseline_entry_is_exact(monkeypatch, capsys):
+    """Send mode cannot do this -- Graph answers sendMail with 202 and no body.
+    Plant gets the created message back, so the id is printed rather than hunted
+    for by subject in a mailbox."""
+    monkeypatch.setattr(kill, "mint_token", lambda *_a, **_k: "tok")
+    monkeypatch.setattr(
+        kill,
+        "plant",
+        lambda *_a, **_k: {
+            "id": "AAMk-planted",
+            "internetMessageId": "<planted@x>",
+            "sentDateTime": "2026-08-21T14:30:05Z",
+            "isDraft": False,
+        },
+    )
+    _clear_graph_env(monkeypatch)
+    monkeypatch.setenv("MSGRAPH_CLIENT_SECRET", "shared-secret")
+    assert kill.main(["--seat", "smd-staging", "--mode", "plant", "--confirm"]) == 0
+    out = capsys.readouterr().out
+    assert "AAMk-planted" in out
+    assert "<planted@x>" in out
+    assert "2026-08-21T14:30:05Z" in out
+    assert "Nothing was transmitted." in out


### PR DESCRIPTION
The falsifier that proves the unaudited-send control actually catches something can now run, on the one seat SMD is allowed to run it on.

Against ss#2499. No new issue opened.

## What changed

`operator/bin/killtest-msgraph-send.py` gains `--mode {send,plant}`, default `send`.

`send` is unchanged: transmit via `sendMail` on the seat's SEND app credential. It could never run on `smd-staging`, because that seat has no SEND app registration (ss#2467, OPEN). The orchestrating session OBSERVED on 2026-08-21 that the existing staging app's token carries app roles `['Mail.ReadWrite']` and nothing else. So the only falsifier for this control had nowhere it was permitted to run.

`plant` uses that permission instead of working around it. `Mail.ReadWrite` is the documented application permission for creating a message directly in a mail folder:

```
POST /users/{mailbox}/mailFolders/sentitems/messages
```

Docs consulted and recorded in the module docstring: <https://learn.microsoft.com/en-us/graph/api/user-post-messages> and <https://learn.microsoft.com/en-us/graph/api/resources/mailfolder> (`sentitems` is a documented well-known folder name; the answer is 201 carrying the created message with its `id`). The wire shape is pinned in a test against a recording fake rather than assumed.

To the reconciler, an item in Sent Items with no `X-SMD-Audit-Row` header and no ledger row is byte-for-byte the event this control exists to catch, and `reconcile-sends.py` reads that folder with the same query either way. Nothing leaves the tenant.

**What plant does not prove**, stated in the docstring so it cannot be read as more than it is: it never exercises `sendMail`, the SEND app, the two-app fence, or the broker's header stamping. An item that was never transmitted cannot show that a transmitted one gets stamped.

Details worth naming:

- **The fence is unchanged and covers both modes.** `ashton-price` stays refused by slug. Plant transmits nothing, which makes it read as harmless; it is not. It leaves a real item in a real Sent Items folder, and on a client seat that folder is the firm's own record of what it sent.
- **`sentDateTime` is set deliberately, not decoratively.** The reconciler pages Sent Items `$orderby=sentDateTime desc` and stops at the `--days` boundary (`reconcile-sends.py:446`, `:454`). An item with no sent time sorts past every window and is never reached, so the plant would be invisible and the clean run would be misread as the control working. The runner also echoes what Graph returned for `sentDateTime` and `isDraft` rather than assuming the request won.
- **Both ids are printed.** Send mode cannot do this (`sendMail` answers 202 with no body), so its message has to be hunted by subject. Plant gets the created message back, so the baseline entry can be exact. A 201 carrying no `id` is an error, never a silent success.
- **Credential order:** `MSGRAPH_CLIENT_ID__<SLUG>` / `MSGRAPH_CLIENT_SECRET__<SLUG>`, then the unsuffixed pair (how the sandbox's are staged in Infisical today), then the authored `customer.yaml` `client_id` for the **id only**. There is deliberately no third fallback for the secret: a shared secret picked up by accident would authenticate as another app against another mailbox, and a refusal is the better outcome.

## Falsifiers

11 mutations applied to the real script, real suite run against each, script restored. All 11 caught; none survived.

| Mutation | Gate that fired |
| --- | --- |
| drop `sentDateTime` | `test_the_planted_item_carries_a_sent_time`, request-shape test |
| POST to `/messages` not the folder | `test_plant_builds_the_documented_graph_create_request` |
| stamp `X-SMD-Audit-Row` on the plant | `test_the_planted_item_carries_no_audit_header` |
| accept a 201 with no `id` | `test_a_created_response_without_an_id_is_an_error` |
| make plant the default mode | `test_plant_is_not_the_default_mode` |
| let plant skip the sandbox fence | `test_the_paying_firms_seat_is_refused_in_plant_mode_too` |
| have plant reach for the SEND credential | `test_plant_never_asks_for_the_send_credential` |
| prefer the shared client id over the seat's | `test_plant_prefers_the_seats_own_read_credentials` |
| give the secret a yaml fallback | `test_there_is_no_fallback_for_the_secret` |
| address the plant outside the tenant | `test_the_planted_item_is_addressed_to_the_seats_own_mailbox` |
| drop `mode=` from the subject | `test_the_planted_subject_says_which_mode_made_it` |

The fence mutation **survived the first pass** and found a real weakness: both fence tests asserted only the exit code, and a fence-free build still exits 2 on a missing credential several steps later and by luck. Both now assert which gate fired, from stderr. That is the "a test can pass for the wrong gate" class, caught by the falsifier rather than by reading.

## Evidence

| AC | Status | Evidence |
| --- | --- | --- |
| (repo) `--mode {send,plant}`, default `send`, existing behaviour unchanged | met | `killtest-msgraph-send.py` `main()`; `test_plant_is_not_the_default_mode` asserts an omitted `--mode` still takes the send path; falsifier "make plant the default mode" caught |
| (repo) plant authenticates with the READ app, with the documented fallbacks | met | `read_credential()`; 4 credential tests incl. the no-secret-fallback refusal; falsifiers "prefer the shared client id", "give the secret a yaml fallback", "reach for the SEND credential" all caught |
| (repo) plant builds the exact Graph create request | met | `test_plant_builds_the_documented_graph_create_request` asserts method, URL and the exact body key set from a recording fake; doc URLs in the module docstring |
| (repo) fence refuses a non-sandbox slug in plant mode | met | `test_the_paying_firms_seat_is_refused_in_plant_mode_too` (asserts the fence message, not just exit 2); falsifier caught |
| (repo) a 201 without `id` is an error, never silent success | met | `test_a_created_response_without_an_id_is_an_error` + its Law 12 twin `test_a_created_response_with_an_id_is_returned_whole`; falsifier caught |
| (repo) docstring explains why plant exists, what it proves, what it does not | met | module docstring, "TWO MODES" and "WHAT PLANT PROVES, AND WHAT IT DOES NOT" |
| (runtime) the plant runs on the sandbox and the next reconciler run reports it as a FIND | **unmet** | Not mine to run. Per the build brief this session touches no seat and runs nothing against a live mailbox; the orchestrator runs it (Captain-authorized) after merge, then baselines the printed id in a follow-up PR. |

`npm run verify` exits 0. Operator pytest: 1832 passed, 25 of them this module's (up from 8).

One unrelated pre-existing failure in this local environment: `adapter/evidence/tests/test_packet.py::test_build_emits_targz_with_every_expected_file` (packet gains a `manifest.sig`). Proven pre-existing rather than assumed: it fails identically on clean `origin/main` with my two files stashed. This PR touches only `operator/bin/killtest-msgraph-send.py` and its test.

No overlay change, so no pin to move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016U9H1VbtZdmBo2t6UBAAPr
