### PR TITLE
fix(operator): the send reconciler stops reporting the Operator's own audited msgraph replies as unaudited (ss#2499)

### DIFF
--- a/operator/bin/reconcile-sends.py
+++ b/operator/bin/reconcile-sends.py
@@ -29,7 +29,7 @@ half produces, and hands it to the SAME two-pass matcher. One matcher on
 purpose: two hand-maintained copies of an audit comparison drift silently, and
 in the direction of the copy nobody is reading.
 
-MATCHING, two passes:
+MATCHING, three passes:
   1. EXACT. Every audited send records the AgentMail message id -- REPLY_SENT
      carries ``sent_message_id``, REPLY_HELD carries ``message_id`` (121 of 121
      rows observed). This pass needs no tolerance and cannot drift.
@@ -45,6 +45,30 @@ MATCHING, two passes:
      available key. Observed skew is sub-second (341 ms on 2026-08-01), so the
      window is deliberately tight and each audit row is CONSUMED once -- two
      messages can never claim the same row.
+  3. BROKER DISPATCH (ss#2499, second live run). The msgraph half's first real
+     run reported 14 of 14 sends unaccounted on the paying seat, and all 14 were
+     the Operator's own audited replies: the seat predates the header, so its
+     rows carry ``sent_message_id: '(sent via msgraph, id unavailable)'`` and
+     ``message_id: ''`` -- nothing for pass 1 to join on. Pass 2 could not reach
+     them either, because msgraph sends are dispatched by the BROKER and never
+     produce a TOOL_CALL_COMPLETED/external_send row. So every legitimate,
+     fully-audited msgraph send read as unaudited, which is a control that
+     accuses the Operator of everything it did.
+     This pass takes the broker's own dispatch rows -- CONFIRM_SEND_DISPATCHED
+     with ``outcome == "sent"``, and REPLY_SENT, whose action type IS its
+     outcome -- as time candidates, on the SAME window as pass 2 and with the
+     same one-row-one-message consumption. A confirm row and the reply row for
+     the same send are ONE event seconds apart, so the pair is folded to a
+     single candidate before matching; otherwise one reply would account for two
+     messages.
+     Candidacy is gated on the row carrying NO usable exact key, which is what
+     keeps this pass from weakening pass 1. An AgentMail dispatch row records a
+     real vendor id and is therefore never a time candidate; a post-header
+     msgraph row records ``audit_row_token`` and is not one either. The reported
+     ``broker=N`` is the count of sends matched by TIME rather than identity, and
+     it is expected to fall to zero on a seat once its overlay stamps the header
+     -- it stays reachable only for rows that predate it and for the id lookup
+     that could not run (recorded on the row as ``lookup: failed``, ss#2514).
 
 FAIL-CLOSED, THE OTHER WAY. A failed seam read must never read as "zero audit
 rows", which would mark every send unaccounted and mute this within a week. A
@@ -158,6 +182,27 @@ TOOL_PATH_WINDOW_S = 5.0
 #: Metadata keys that carry an AgentMail message id on an audited send.
 _ID_KEY_SUBSTRING = "message_id"
 
+#: Audit action types the BROKER writes when it has dispatched a message itself
+#: (ss#2499). CONFIRM_SEND_DISPATCHED is written for both sends and replies and
+#: carries its own outcome; REPLY_SENT is written by the reply plugin and its
+#: action type IS the outcome (the failure is a different type, REPLY_FAILED).
+_BROKER_DISPATCH_TYPES = ("CONFIRM_SEND_DISPATCHED", "REPLY_SENT")
+
+#: The only ``outcome`` a CONFIRM row may carry and still account for a message
+#: that demonstrably left the mailbox. ``refused`` and ``transport_error`` rows
+#: exist precisely because the send did NOT go, and a refusal must never be
+#: readable as a send.
+_DISPATCH_OUTCOME_SENT = "sent"
+
+#: A recorded id that is not an id. The overlay writes this literal on a msgraph
+#: REPLY_SENT row when Graph's 202 returned nothing to record (8 of 8 rows on the
+#: live seat before the header landed), and it is honest there -- inventing an id
+#: would name a message the mailbox does not contain. It must not be treated as
+#: an exact key, and a row carrying only this is a row with no usable id. Matched
+#: on the leading parenthesis rather than the exact sentence: no RFC2822 id and
+#: no Graph id begins with one, so any future note in that field is caught too.
+_UNRESOLVED_ID_PREFIX = "("
+
 #: Inboxes that deliberately have no Operator seat behind them, and why. These
 #: are OUR OWN rigs on the shared account -- test harnesses, an opposing-counsel
 #: simulator, other ventures' mailboxes -- so their sends have no seat ledger to
@@ -213,6 +258,11 @@ class InboxReport:
     sent_total: int = 0
     matched_exact: int = 0
     matched_tool_path: int = 0
+    #: Sends matched by TIME against a broker dispatch row rather than by id
+    #: (ss#2499). Reported as its own bucket so a reader can see how much of a
+    #: clean run rests on proximity instead of identity -- and so it can be
+    #: watched falling to zero as seats pick up the audit header.
+    matched_broker: int = 0
     unaccounted: list[dict] = field(default_factory=list)
     baselined: int = 0  # unaccounted, but already reported (ss#2386)
     held: str | None = None  # set when we could not evaluate
@@ -515,9 +565,10 @@ def reconcile_mailbox(
         report.held = f"audit_export returned no rows for {seat.slug}"
         return report
 
-    exact, tool_path, unaccounted = reconcile(sent, rows)
+    exact, tool_path, broker, unaccounted = reconcile(sent, rows)
     report.matched_exact = exact
     report.matched_tool_path = tool_path
+    report.matched_broker = broker
     report.unaccounted, report.baselined = split_baselined(
         report.inbox, unaccounted, baseline or set()
     )
@@ -534,8 +585,83 @@ def _metadata(row: dict) -> dict:
     return raw if isinstance(raw, dict) else {}
 
 
-def index_audit(rows: list[dict]) -> tuple[set[str], list[dict]]:
-    """Split audit rows into (exact keys ever recorded, tool-path send rows).
+def _usable_ids(meta: dict) -> set[str]:
+    """Every value in one row's metadata that can serve as an EXACT join key.
+
+    A key is usable when it is a non-empty string under a ``*message_id*`` key or
+    under ``audit_row_token``, and is not the overlay's "no id available" note
+    (see ``_UNRESOLVED_ID_PREFIX``). The note is excluded on purpose: left in, it
+    would be a string a mailbox could theoretically carry as an id, and it would
+    also make a row with no id at all look like a row that has one.
+    """
+    ids: set[str] = set()
+    for key, value in meta.items():
+        if not isinstance(value, str) or not value:
+            continue
+        if value.startswith(_UNRESOLVED_ID_PREFIX):
+            continue
+        if _ID_KEY_SUBSTRING in key or key == _AUDIT_TOKEN_KEY:
+            ids.add(value)
+    return ids
+
+
+def _is_broker_dispatch(row: dict, meta: dict) -> bool:
+    """Did the BROKER transmit a message for this row, with no id to prove it?
+
+    Two halves, and both matter. The action type says a message went out: a
+    CONFIRM row must additionally say ``outcome: sent``, because the same type's
+    siblings record a refusal and a transport error and neither of those sent
+    anything. REPLY_SENT needs no outcome -- its type is the outcome, and its
+    failure is a different type entirely.
+
+    The second half is what keeps this pass from weakening the exact one: a row
+    that recorded ANY usable id is not a time candidate. That row is already
+    joinable by identity, so letting it also be claimed by proximity would let a
+    legitimate send launder an unaudited neighbour. It also means this pass
+    empties itself out: once a seat's overlay stamps the audit header, its rows
+    carry a usable key and stop being candidates at all.
+    """
+    action = row.get("action_type")
+    if action not in _BROKER_DISPATCH_TYPES:
+        return False
+    if action == "CONFIRM_SEND_DISPATCHED" and meta.get("outcome") != _DISPATCH_OUTCOME_SENT:
+        return False
+    return not _usable_ids(meta)
+
+
+def _fold_broker_pairs(candidates: list[dict]) -> list[dict]:
+    """One send, one candidate.
+
+    A msgraph reply writes TWO rows -- the broker's CONFIRM_SEND_DISPATCHED and
+    the reply plugin's REPLY_SENT -- describing one event seconds apart. Left
+    unfolded they would account for two messages, so one legitimate reply could
+    absorb an unaudited send beside it, which is the absorption failure this
+    control cannot have.
+
+    Folding is CROSS-TYPE only, and each row may be folded once: two confirms in
+    the same second are two sends, not one, and must stay two candidates.
+    """
+    kept: list[dict] = []
+    for candidate in sorted(candidates, key=lambda c: c["ts"]):
+        twin = next(
+            (
+                other
+                for other in kept
+                if other["kind"] != candidate["kind"]
+                and not other["paired"]
+                and abs((candidate["ts"] - other["ts"]).total_seconds()) <= TOOL_PATH_WINDOW_S
+            ),
+            None,
+        )
+        if twin is not None:
+            twin["paired"] = True
+            continue
+        kept.append(candidate)
+    return kept
+
+
+def index_audit(rows: list[dict]) -> tuple[set[str], list[dict], list[dict]]:
+    """Split audit rows into (exact keys, tool-path send rows, broker dispatches).
 
     The key set is deliberately a UNION rather than a per-channel switch. It
     holds every vendor message id a row recorded (any metadata key containing
@@ -545,28 +671,61 @@ def index_audit(rows: list[dict]) -> tuple[set[str], list[dict]]:
     that transmitted fine and could not read its own vendor id back afterwards.
     The two key spaces cannot collide: one is an RFC2822/vendor id, the other a
     26-character ULID.
+
+    The third list is the ss#2499 second-run fix. A msgraph send is dispatched by
+    the broker and produces no TOOL_CALL_COMPLETED row, so on a seat whose rows
+    predate the audit header there is nothing for either existing pass to reach
+    and every audited send read as unaudited. The broker's own dispatch rows are
+    that seat's only evidence, and time is the only key they offer.
     """
     known_ids: set[str] = set()
     tool_sends: list[dict] = []
+    broker_sends: list[dict] = []
     for row in rows:
         meta = _metadata(row)
-        for key, value in meta.items():
-            if not isinstance(value, str) or not value:
-                continue
-            if _ID_KEY_SUBSTRING in key or key == _AUDIT_TOKEN_KEY:
-                known_ids.add(value)
+        known_ids |= _usable_ids(meta)
         if (
             row.get("action_type") == "TOOL_CALL_COMPLETED"
             and meta.get("action_class") == "external_send"
             and meta.get("outcome") == "ok"
         ):
             tool_sends.append({"ts": _parse_ts(row["ts"]), "claimed": False})
-    return known_ids, tool_sends
+        elif _is_broker_dispatch(row, meta):
+            broker_sends.append(
+                {
+                    "ts": _parse_ts(row["ts"]),
+                    "kind": row.get("action_type"),
+                    "paired": False,
+                    "claimed": False,
+                }
+            )
+    return known_ids, tool_sends, _fold_broker_pairs(broker_sends)
 
 
-def reconcile(sent: list[dict], rows: list[dict]) -> tuple[int, int, list[dict]]:
-    """Return (matched_exact, matched_tool_path, unaccounted)."""
-    known_ids, tool_sends = index_audit(rows)
+def _claim(candidates: list[dict], stamp: datetime) -> bool:
+    """Consume the oldest unclaimed candidate within the window, if any.
+
+    CONSUMED, not merely matched: two messages can never claim the same row, so
+    one audited send never accounts for an unaudited one beside it.
+    """
+    claim = next(
+        (
+            candidate
+            for candidate in candidates
+            if not candidate["claimed"]
+            and abs((candidate["ts"] - stamp).total_seconds()) <= TOOL_PATH_WINDOW_S
+        ),
+        None,
+    )
+    if claim is None:
+        return False
+    claim["claimed"] = True
+    return True
+
+
+def reconcile(sent: list[dict], rows: list[dict]) -> tuple[int, int, int, list[dict]]:
+    """Return (matched_exact, matched_tool_path, matched_broker, unaccounted)."""
+    known_ids, tool_sends, broker_sends = index_audit(rows)
 
     remaining = [
         m
@@ -578,24 +737,17 @@ def reconcile(sent: list[dict], rows: list[dict]) -> tuple[int, int, list[dict]]
 
     unaccounted: list[dict] = []
     matched_tool = 0
+    matched_broker = 0
     # Oldest-first so the pairing is deterministic regardless of page order.
     for message in sorted(remaining, key=lambda m: str(m.get("timestamp") or "")):
         stamp = _parse_ts(message.get("timestamp"))
-        claim = next(
-            (
-                candidate
-                for candidate in tool_sends
-                if not candidate["claimed"]
-                and abs((candidate["ts"] - stamp).total_seconds()) <= TOOL_PATH_WINDOW_S
-            ),
-            None,
-        )
-        if claim is None:
-            unaccounted.append(message)
-        else:
-            claim["claimed"] = True  # consumed: no second message may claim it
+        if _claim(tool_sends, stamp):
             matched_tool += 1
-    return matched_exact, matched_tool, unaccounted
+        elif _claim(broker_sends, stamp):
+            matched_broker += 1
+        else:
+            unaccounted.append(message)
+    return matched_exact, matched_tool, matched_broker, unaccounted
 
 
 def fingerprint(inbox: str, message: dict) -> str:
@@ -755,9 +907,10 @@ def reconcile_inbox(inbox: str, slugs: list[str], api_key: str, since, *, opener
         report.held = f"audit_export returned no rows for {slug}"
         return report
 
-    exact, tool_path, unaccounted = reconcile(sent, rows)
+    exact, tool_path, broker, unaccounted = reconcile(sent, rows)
     report.matched_exact = exact
     report.matched_tool_path = tool_path
+    report.matched_broker = broker
     # Baselining is the LAST step, applied to sends the audit log genuinely does
     # not account for. A held inbox returns above and can never be quieted by it:
     # "already reported" is a statement about a finding, and a hold is not one.
@@ -783,7 +936,8 @@ def render(reports: list[InboxReport]) -> str:
         lines.append(
             f"{'FIND' if report.is_finding else 'ok  '}  {report.inbox} [{owner}] "
             f"({report.channel}) sent={report.sent_total} exact={report.matched_exact} "
-            f"tool={report.matched_tool_path} unaccounted={len(report.unaccounted)} "
+            f"tool={report.matched_tool_path} broker={report.matched_broker} "
+            f"unaccounted={len(report.unaccounted)} "
             f"already-reported={report.baselined}"
         )
         for message in sorted(report.unaccounted, key=lambda m: str(m.get("timestamp") or "")):
@@ -870,6 +1024,7 @@ def main(argv: list[str] | None = None) -> int:
                         "sent_total": r.sent_total,
                         "matched_exact": r.matched_exact,
                         "matched_tool_path": r.matched_tool_path,
+                        "matched_broker": r.matched_broker,
                         "baselined": r.baselined,
                         "held": r.held,
                         "unaccounted": [

--- a/operator/bin/tests/test_reconcile_sends.py
+++ b/operator/bin/tests/test_reconcile_sends.py
@@ -13,7 +13,7 @@ import json
 import sys
 import tempfile
 import urllib.error
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
@@ -56,7 +56,7 @@ def _tool_row(ts, outcome="ok", action_class="external_send"):
 def test_exact_match_on_recorded_message_id():
     sent = [_msg("<a>", "2026-08-01T10:00:00.000Z")]
     rows = [_reply_row("2026-08-01T10:00:00.100Z", "<a>")]
-    exact, tool, unaccounted = rec.reconcile(sent, rows)
+    exact, tool, _broker, unaccounted = rec.reconcile(sent, rows)
     assert (exact, tool, unaccounted) == (1, 0, [])
 
 
@@ -65,7 +65,7 @@ def test_exact_match_ignores_clock_skew_entirely():
     still matches. This is why pass 1 is preferred over pass 2."""
     sent = [_msg("<a>", "2026-08-01T10:00:00.000Z")]
     rows = [_reply_row("2026-08-01T10:47:00.000Z", "<a>")]
-    exact, _, unaccounted = rec.reconcile(sent, rows)
+    exact, _, _broker, unaccounted = rec.reconcile(sent, rows)
     assert exact == 1 and unaccounted == []
 
 
@@ -78,14 +78,14 @@ def test_tool_path_matches_within_the_window():
     """Real observed skew was 341ms (2026-08-01)."""
     sent = [_msg("<a>", "2026-08-01T10:00:00.285Z")]
     rows = [_tool_row("2026-08-01T10:00:00.626Z")]
-    exact, tool, unaccounted = rec.reconcile(sent, rows)
+    exact, tool, _broker, unaccounted = rec.reconcile(sent, rows)
     assert (exact, tool, unaccounted) == (0, 1, [])
 
 
 def test_tool_path_does_not_match_outside_the_window():
     sent = [_msg("<a>", "2026-08-01T10:00:00.000Z")]
     rows = [_tool_row("2026-08-01T10:00:30.000Z")]  # 30s -> way outside
-    _, tool, unaccounted = rec.reconcile(sent, rows)
+    _, tool, _broker, unaccounted = rec.reconcile(sent, rows)
     assert tool == 0 and len(unaccounted) == 1
 
 
@@ -95,7 +95,7 @@ def test_one_audit_row_cannot_cover_two_messages():
     launders every neighbouring unaudited send."""
     sent = [_msg("<a>", "2026-08-01T10:00:00.000Z"), _msg("<b>", "2026-08-01T10:00:01.000Z")]
     rows = [_tool_row("2026-08-01T10:00:00.500Z")]
-    _, tool, unaccounted = rec.reconcile(sent, rows)
+    _, tool, _broker, unaccounted = rec.reconcile(sent, rows)
     assert tool == 1
     assert len(unaccounted) == 1
 
@@ -105,14 +105,14 @@ def test_errored_tool_call_does_not_cover_a_send():
     message that demonstrably left the mailbox."""
     sent = [_msg("<a>", "2026-08-01T10:00:00.000Z")]
     rows = [_tool_row("2026-08-01T10:00:00.100Z", outcome="error")]
-    _, tool, unaccounted = rec.reconcile(sent, rows)
+    _, tool, _broker, unaccounted = rec.reconcile(sent, rows)
     assert tool == 0 and len(unaccounted) == 1
 
 
 def test_non_send_tool_call_does_not_cover_a_send():
     sent = [_msg("<a>", "2026-08-01T10:00:00.000Z")]
     rows = [_tool_row("2026-08-01T10:00:00.100Z", action_class="read")]
-    _, tool, unaccounted = rec.reconcile(sent, rows)
+    _, tool, _broker, unaccounted = rec.reconcile(sent, rows)
     assert tool == 0 and len(unaccounted) == 1
 
 
@@ -129,7 +129,7 @@ def test_the_2026_08_11_incident_is_reported():
         _msg("<incident>", "2026-08-11T14:03:14.543Z", subject="Escalator woke but..."),
     ]
     rows = [_reply_row("2026-08-11T14:00:00.100Z", "<legit>")]
-    exact, tool, unaccounted = rec.reconcile(sent, rows)
+    exact, tool, _broker, unaccounted = rec.reconcile(sent, rows)
     assert exact == 1 and tool == 0
     assert [m["message_id"] for m in unaccounted] == ["<incident>"]
 
@@ -140,7 +140,7 @@ def test_a_busy_legitimate_mailbox_produces_no_finding():
     sent += [_msg(f"<t{i}>", f"2026-08-01T11:0{i}:00.000Z") for i in range(4)]
     rows = [_reply_row(f"2026-08-01T10:0{i}:00.200Z", f"<r{i}>") for i in range(5)]
     rows += [_tool_row(f"2026-08-01T11:0{i}:00.300Z") for i in range(4)]
-    exact, tool, unaccounted = rec.reconcile(sent, rows)
+    exact, tool, _broker, unaccounted = rec.reconcile(sent, rows)
     assert (exact, tool, unaccounted) == (5, 4, [])
 
 
@@ -464,7 +464,7 @@ def test_the_audit_header_is_an_exact_match(tmp_path):
     the broker could not read its own vendor id back after the 202."""
     sent = [rec.normalize_graph_message(_graph_message(token="01ABC"))]
     rows = [_audited_row("2026-08-20T10:00:05Z", audit_row_token="01ABC")]
-    exact, tool, unaccounted = rec.reconcile(sent, rows)
+    exact, tool, _broker, unaccounted = rec.reconcile(sent, rows)
     assert (exact, tool, unaccounted) == (1, 0, [])
 
 
@@ -473,7 +473,7 @@ def test_the_vendor_id_is_also_an_exact_match(tmp_path):
     and this joins on that alone -- so a run is not hostage to the header."""
     sent = [rec.normalize_graph_message(_graph_message(mid="<b@firm.example>"))]
     rows = [_audited_row("2026-08-20T10:00:05Z", vendor_message_id="<b@firm.example>")]
-    exact, _tool, unaccounted = rec.reconcile(sent, rows)
+    exact, _tool, _broker, unaccounted = rec.reconcile(sent, rows)
     assert exact == 1 and unaccounted == []
 
 
@@ -482,7 +482,7 @@ def test_a_send_with_no_header_and_no_row_is_the_finding(tmp_path):
     Sent Items that did not come through the broker."""
     sent = [rec.normalize_graph_message(_graph_message(subject="[UNAUDITED-KILLTEST-2258] x"))]
     rows = [_audited_row("2026-08-20T10:00:05Z", audit_row_token="SOMETHINGELSE")]
-    exact, tool, unaccounted = rec.reconcile(sent, rows)
+    exact, tool, _broker, unaccounted = rec.reconcile(sent, rows)
     assert (exact, tool) == (0, 0)
     assert unaccounted[0]["subject"].startswith("[UNAUDITED-KILLTEST-2258]")
 
@@ -538,6 +538,198 @@ def test_the_baseline_quiets_a_reported_msgraph_send_and_only_that_one(tmp_path)
     remaining, quieted = rec.split_baselined(_MSG_MAILBOX, [reported, fresh], baseline)
     assert quieted == 1
     assert [m["message_id"] for m in remaining] == ["<new@firm.example>"]
+
+
+# --- pass 3: broker dispatch, the second-live-run fix ------------------------
+#
+# The first live msgraph run reported 14 of 14 sends on the paying seat as
+# unaudited, and all 14 were the Operator's own audited replies: the seat
+# predates the audit header, so its rows carry no id at all, and msgraph sends
+# are broker-dispatched and never produce a TOOL_CALL_COMPLETED row. The control
+# was accusing the Operator of everything it did.
+
+#: What the overlay writes on a msgraph REPLY_SENT row when Graph's 202 returned
+#: no id to record -- 8 of 8 rows on the live seat before the header landed.
+_NO_ID_NOTE = "(sent via msgraph, id unavailable)"
+
+
+def _confirm_row(ts, **meta):
+    """The broker's dispatch row as the live seat writes it, pre-header: the
+    outcome, and an EMPTY message_id because Graph's 202 carries none."""
+    return {
+        "ts": ts,
+        "action_type": "CONFIRM_SEND_DISPATCHED",
+        "metadata": {"outcome": "sent", "message_id": "", "input_digest": "d", **meta},
+    }
+
+
+def _msgraph_reply_row(ts, sent_message_id=_NO_ID_NOTE):
+    """The reply plugin's row as the live seat writes it, carrying the note."""
+    return {
+        "ts": ts,
+        "action_type": "REPLY_SENT",
+        "metadata": {"adapter": "msgraph", "sent_message_id": sent_message_id},
+    }
+
+
+def _idless_pair(sent_ts, confirm_offset=0.2, reply_offset=0.4):
+    """The two rows one msgraph reply writes, seconds apart: the broker's confirm
+    and the reply plugin's own row."""
+    base = datetime.fromisoformat(sent_ts.replace("Z", "+00:00"))
+
+    def at(offset):
+        return (base + timedelta(seconds=offset)).isoformat().replace("+00:00", "Z")
+
+    return [_confirm_row(at(confirm_offset)), _msgraph_reply_row(at(reply_offset))]
+
+
+def _graph_sent(mid, ts):
+    return rec.normalize_graph_message(_graph_message(mid=mid, ts=ts))
+
+
+def test_an_audited_msgraph_send_with_no_id_anywhere_is_accounted_for():
+    """The defect, pinned. Three sends, three audited dispatches, no ids on
+    either side -- and before pass 3 all three were reported unaudited.
+
+    FALSIFIER: delete the ``_is_broker_dispatch`` branch in ``index_audit`` and
+    this goes red with broker == 0 and three unaccounted."""
+    stamps = ["2026-08-21T09:00:00Z", "2026-08-21T09:10:00Z", "2026-08-21T09:20:00Z"]
+    sent = [_graph_sent(f"<m{i}@firm.example>", t) for i, t in enumerate(stamps)]
+    rows = [row for t in stamps for row in _idless_pair(t)]
+    exact, tool, broker, unaccounted = rec.reconcile(sent, rows)
+    assert (exact, tool, broker, unaccounted) == (0, 0, 3, [])
+
+
+def test_a_send_whose_dispatch_row_is_missing_is_still_the_finding():
+    """The same ledger minus one pair. Pass 3 must not become a blanket amnesty:
+    a send the broker never recorded stays a find."""
+    stamps = ["2026-08-21T09:00:00Z", "2026-08-21T09:10:00Z", "2026-08-21T09:20:00Z"]
+    sent = [_graph_sent(f"<m{i}@firm.example>", t) for i, t in enumerate(stamps)]
+    rows = [row for t in stamps[:2] for row in _idless_pair(t)]
+    _exact, _tool, broker, unaccounted = rec.reconcile(sent, rows)
+    assert broker == 2
+    assert [m["message_id"] for m in unaccounted] == ["<m2@firm.example>"]
+
+
+def test_the_staging_plant_is_still_a_finding_beside_audited_sends():
+    """THE CANONICAL CASE, from the live run of 2026-08-21: the kill-test plant
+    was correctly reported while the 14 legitimate replies beside it were not.
+    Pass 3 must keep the first half of that sentence true. The plant carries the
+    ids the real run observed, so this fixture is captured, not invented."""
+    plant = _graph_sent(
+        "<PH0PR03MB7160198B9C993AE58D51BACC97A32@PH0PR03MB7160.namprd03.prod.outlook.com>",
+        "2026-08-21T09:46:57Z",
+    )
+    plant["subject"] = "[UNAUDITED-KILLTEST-2258] reconciler kill test mode=plant"
+    audited = _graph_sent("<legit@firm.example>", "2026-08-21T09:40:00Z")
+    rows = _idless_pair("2026-08-21T09:40:00Z")
+    _exact, _tool, broker, unaccounted = rec.reconcile([audited, plant], rows)
+    assert broker == 1
+    assert [m["message_id"] for m in unaccounted] == [plant["message_id"]]
+    assert unaccounted[0]["subject"].startswith("[UNAUDITED-KILLTEST-2258]")
+
+
+def test_one_broker_row_cannot_cover_two_messages():
+    """The absorption failure, on the new pass. Two sends ten seconds apart with
+    one dispatch row: the second is still a find."""
+    sent = [
+        _graph_sent("<a@f.example>", "2026-08-21T09:00:00Z"),
+        _graph_sent("<b@f.example>", "2026-08-21T09:00:10Z"),
+    ]
+    _exact, _tool, broker, unaccounted = rec.reconcile(sent, _idless_pair("2026-08-21T09:00:00Z"))
+    assert broker == 1
+    assert [m["message_id"] for m in unaccounted] == ["<b@f.example>"]
+
+
+def test_one_broker_row_cannot_cover_two_messages_inside_the_window():
+    """The ten-second case above is also outside the window, so it would pass on
+    windowing alone. Here both sends are within reach of the single row, and
+    CONSUMPTION is the only thing that separates them."""
+    sent = [
+        _graph_sent("<a@f.example>", "2026-08-21T09:00:00Z"),
+        _graph_sent("<b@f.example>", "2026-08-21T09:00:02Z"),
+    ]
+    _exact, _tool, broker, unaccounted = rec.reconcile(sent, _idless_pair("2026-08-21T09:00:01Z"))
+    assert broker == 1
+    assert [m["message_id"] for m in unaccounted] == ["<b@f.example>"]
+
+
+def test_a_confirm_and_its_reply_row_are_one_candidate_not_two():
+    """The pair fold. One reply writes TWO rows seconds apart; unfolded they
+    would account for two messages, and the send beside the reply would be
+    laundered by a row describing the reply itself.
+
+    FALSIFIER: return the candidates unfolded from ``index_audit`` and this goes
+    red with broker == 2 and nothing unaccounted."""
+    sent = [
+        _graph_sent("<a@f.example>", "2026-08-21T09:00:00Z"),
+        _graph_sent("<b@f.example>", "2026-08-21T09:00:01Z"),
+    ]
+    _exact, _tool, broker, unaccounted = rec.reconcile(sent, _idless_pair("2026-08-21T09:00:00Z"))
+    assert broker == 1
+    assert [m["message_id"] for m in unaccounted] == ["<b@f.example>"]
+
+
+def test_two_confirms_in_the_same_second_stay_two_candidates():
+    """Folding is CROSS-TYPE only. Two sends dispatched a second apart write two
+    confirm rows, and collapsing them would turn a real second send into a find."""
+    sent = [
+        _graph_sent("<a@f.example>", "2026-08-21T09:00:00Z"),
+        _graph_sent("<b@f.example>", "2026-08-21T09:00:01Z"),
+    ]
+    rows = [_confirm_row("2026-08-21T09:00:00.200Z"), _confirm_row("2026-08-21T09:00:01.200Z")]
+    _exact, _tool, broker, unaccounted = rec.reconcile(sent, rows)
+    assert (broker, unaccounted) == (2, [])
+
+
+@pytest.mark.parametrize("outcome", ["refused", "transport_error", "failed"])
+def test_a_dispatch_row_that_did_not_send_cannot_account_for_a_message(outcome):
+    """A refusal and a transport error exist precisely because nothing went out.
+    Reading either as a send would let the ledger's record of NOT sending account
+    for a message that demonstrably left the mailbox."""
+    sent = [_graph_sent("<a@f.example>", "2026-08-21T09:00:00Z")]
+    rows = [_confirm_row("2026-08-21T09:00:00.200Z", outcome=outcome)]
+    _exact, _tool, broker, unaccounted = rec.reconcile(sent, rows)
+    assert broker == 0 and len(unaccounted) == 1
+
+
+def test_a_dispatch_row_carrying_a_real_id_is_never_a_time_candidate():
+    """What keeps pass 3 from weakening pass 1. An AgentMail dispatch records a
+    real vendor id, so it is joinable by identity; letting it ALSO be claimed by
+    proximity would let a legitimate send launder an unaudited neighbour -- which
+    is the 2026-08-11 incident's own shape."""
+    sent = [
+        _msg("<legit>", "2026-08-11T14:00:00.000Z"),
+        _msg("<incident>", "2026-08-11T14:00:01.000Z"),
+    ]
+    rows = [_reply_row("2026-08-11T14:00:00.100Z", "<legit>")]
+    exact, _tool, broker, unaccounted = rec.reconcile(sent, rows)
+    assert (exact, broker) == (1, 0)
+    assert [m["message_id"] for m in unaccounted] == ["<incident>"]
+
+
+def test_the_no_id_note_is_not_read_as_an_id():
+    """``(sent via msgraph, id unavailable)`` is a note, not a key. Treated as an
+    id it would make a row with no id look like a row that has one, which is
+    exactly the row pass 3 exists to reach."""
+    known, _tool, broker_rows = rec.index_audit([_msgraph_reply_row("2026-08-21T09:00:00Z")])
+    assert known == set()
+    assert len(broker_rows) == 1
+
+
+def test_the_report_names_how_many_sends_were_matched_by_time():
+    """``broker=N`` is the count of sends matched by proximity rather than
+    identity. It is expected to fall to zero as seats pick up the audit header,
+    and a reader cannot watch a number the report does not print."""
+    rendered = rec.render(
+        [
+            rec.InboxReport(
+                inbox=_MSG_MAILBOX, slug="a-seat", channel="msgraph",
+                sent_total=3, matched_broker=3,
+            )
+        ]
+    )
+    assert "broker=3" in rendered
 
 
 # --- the Graph read itself --------------------------------------------------


### PR DESCRIPTION
Every send the Operator did make can be located in the firm's mailbox — and until now, on the seat that actually pays, none of them could.

Follows ss#2499 (merged #2514, #2517). No new issue; this is that issue's second live run turning up a defect in its own instrument.

## What the live run showed

`reconcile-sends.py --channel msgraph --days 2`, first live run 2026-08-21T09:47Z:

```
FIND operator@… [ashton-price] sent=14 exact=0 tool=0 unaccounted=14
```

All 14 were the Operator's own replies. Every one has a `CONFIRM_SEND_DISPATCHED` **and** a `REPLY_SENT` row within 120s of the Sent Items `sentDateTime` (14/14, checked against the seat's audit export). They carry no vendor id because the seat predates the audit header — `sent_message_id: '(sent via msgraph, id unavailable)'`, `message_id: ''` — so pass 1 has nothing to join on. Pass 2 cannot reach them either: it collects only `TOOL_CALL_COMPLETED` rows with `action_class == "external_send"`, and msgraph sends are dispatched by the broker and never produce one. The control was accusing the Operator of everything it did, which is how a watchdog gets muted inside a week.

The staging plant on the same run was correctly a FIND — it has no ledger row of any kind. That half must stay true, and is pinned here as a fixture-shaped test using the observed ids.

## What changed

`operator/bin/reconcile-sends.py` gains a third matching pass:

- **Candidates.** `CONFIRM_SEND_DISPATCHED` with `metadata.outcome == "sent"`, and `REPLY_SENT` (whose action type *is* its outcome — the failure is `REPLY_FAILED`). A `refused` / `transport_error` confirm records that nothing went out and can never account for a message.
- **Pair fold.** One msgraph reply writes both rows, seconds apart. Unfolded they would account for two messages, so a legitimate reply could launder the send beside it. Folding is cross-type only — two confirms in the same second are two sends.
- **Gate that keeps pass 1 strong.** A row that recorded any usable id is never a time candidate. That excludes AgentMail dispatch rows (real vendor ids) and post-header msgraph rows (`audit_row_token`), so this pass empties itself out as seats pick up the header. The overlay's `(sent via msgraph, id unavailable)` note is treated as a note, not a key.
- **Same window, same consumption.** `TOOL_PATH_WINDOW_S`, oldest-first, one candidate per message — exactly as the tool path works today.
- **Its own bucket.** `broker=N` renders beside `exact=` / `tool=` and appears in `--json` as `matched_broker`, so a reader can see how much of a clean run rests on proximity rather than identity, and watch it fall to zero.

Module docstring updated: "MATCHING, two passes" → three, with why the third exists (pre-header rows, and the id lookup that could not run — recorded on the row as `lookup: failed`, #2514).

`reconcile()` now returns a 4-tuple; the 12 existing test call sites are updated.

## Note on the window constant

Pass 3 reuses `TOOL_PATH_WINDOW_S` (5s) as instructed. Worth stating plainly: the live evidence bounded the confirm-row skew at **120s**, which is the bound the checker chose, not a measured skew. The rows this pass must reach are pre-header ones, written promptly after the 202 with no Sent Items lookup in the path, so 5s should hold. Post-header rows do not need this pass at all — a successful lookup gives a vendor id and a failed one still carries `audit_row_token`, and both are pass-1 keys. **If the next live run still shows `broker=0` with sends unaccounted, the constant is the knob** — and widening it is a Captain call, because a wider window lets one row absorb a neighbouring message.

## Evidence

| AC | Met | Evidence |
| --- | --- | --- |
| (repo) Broker-dispatch rows are window-matchable candidates | met | `index_audit` returns a third list; `test_an_audited_msgraph_send_with_no_id_anywhere_is_accounted_for` → `(exact, tool, broker, unaccounted) == (0, 0, 3, [])` |
| (repo) Confirm + reply for one send is one candidate | met | `test_a_confirm_and_its_reply_row_are_one_candidate_not_two`; `test_two_confirms_in_the_same_second_stay_two_candidates` proves the fold is cross-type only |
| (repo) Exact first, window second, one candidate per message | met | `test_one_broker_row_cannot_cover_two_messages` (10s apart) and `..._inside_the_window` (2s apart — both sends in reach, consumption is the only separator) |
| (repo) `outcome != "sent"` cannot satisfy a send | met | `test_a_dispatch_row_that_did_not_send_cannot_account_for_a_message[refused/transport_error/failed]` |
| (repo) Plant with no ledger row is still a FIND | met | `test_the_staging_plant_is_still_a_finding_beside_audited_sends`, using the observed internetMessageId and 09:46:57Z |
| (repo) Pass 3 does not weaken pass 1 | met | `test_a_dispatch_row_carrying_a_real_id_is_never_a_time_candidate` — the 2026-08-11 incident's own shape |
| (repo) `broker=N` reported beside exact/tool | met | `test_the_report_names_how_many_sends_were_matched_by_time`; rendered line: `sent=15 exact=0 tool=0 broker=14 unaccounted=1` |
| (repo) Docstring explains the third path | met | module header, "MATCHING, three passes", pass 3 |
| (runtime) The daily run on the paid seat reports `unaccounted=0` with N>0 | **unmet** | Requires a live run against the seat mailbox. Not performed here: no seat was touched and no live API was called. Awaits the Captain-gated run. |

### Falsifiers (each mutation, and exactly what went red)

| Mutation | Red |
| --- | --- |
| Remove the `_is_broker_dispatch` branch in `index_audit` | 8 failed — incl. `test_an_audited_msgraph_send_with_no_id_anywhere_is_accounted_for` (`broker == 0`, 3 unaccounted) |
| Return candidates unfolded | 2 failed — `test_a_confirm_and_its_reply_row_are_one_candidate_not_two` (`assert 2 == 1`), `..._inside_the_window` |
| Drop the `outcome == "sent"` guard | 3 failed — all three `test_a_dispatch_row_that_did_not_send...` params |
| Drop the usable-id gate (`return True`) | 1 failed — `test_a_dispatch_row_carrying_a_real_id_is_never_a_time_candidate` |

### Suites

- `operator/bin/tests/test_reconcile_sends.py` — 73 passed (was 60)
- `operator/bin/tests/` — 584 passed
- `npm run verify` — exit 0

No live API was called and no seat was touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016U9H1VbtZdmBo2t6UBAAPr
