### PR TITLE
chore(operator): the planted staging kill-test item is on record (ss#2499)

### DIFF
--- a/operator/bin/reconcile-sends-baseline.json
+++ b/operator/bin/reconcile-sends-baseline.json
@@ -93,6 +93,15 @@
       "to": "scott@smd.services",
       "subject": "[UNAUDITED-KILLTEST-2258] deliberate unaudited send — reconciler kill test",
       "reported_in": 2344
+    },
+    {
+      "inbox": "operator@smdopslab.onmicrosoft.com",
+      "channel": "msgraph",
+      "message_id": "<PH0PR03MB7160198B9C993AE58D51BACC97A32@PH0PR03MB7160.namprd03.prod.outlook.com>",
+      "timestamp": "2026-08-21T09:46:57Z",
+      "to": "operator@smdopslab.onmicrosoft.com",
+      "subject": "[UNAUDITED-KILLTEST-2258] 2026-08-21T09:46Z mode=plant deliberate unaudited send, reconciler kill test",
+      "reported_in": 2499
     }
   ]
 }


### PR DESCRIPTION
The msgraph unaudited-send reconciler was proven able to fail today: an item planted in the staging seat's Sent Items with no ledger row was reported as a FIND (`vfy_01M0HVJ48Z1NY3N7AF1H50JJMA`), and again after ss#2519 cleared the audited A&P sends (`vfy_01M0J92ABYH136GPTCSKV96589`). This records that one send in the baseline so the daily run stops re-reporting it.

Proof the entry takes: same run with this file → `ok operator@smdopslab.onmicrosoft.com [smd-staging] (msgraph) sent=1 ... already-reported=1`, `0 inbox(es) with unaccounted sends`.

Closes the (runtime) AC on #2499: the daily run on ashton-price reports all sends accounted, and the out-of-band falsifier on the sandbox is reported. An entry here means reported and tracked, never resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016U9H1VbtZdmBo2t6UBAAPr