### PR TITLE
test(migrations): two PRs can no longer merge the same migration number

### DIFF
--- a/tests/migration-numbering.test.ts
+++ b/tests/migration-numbering.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Merge gate on migration filenames in migrations/.
+ *
+ * WHY. On 2026-08-21 two PRs merged within an hour of each other and both
+ * claimed the number 0107: `0107_audit_ledger_observability.sql` (ss#2500) and
+ * `0107_gateway_loop_observability.sql` (ss#2488). Each PR was green on its own
+ * branch, because the number a migration claims is a property of the MERGED
+ * directory and neither branch could see the other. Nothing in `npm run verify`
+ * or in CI looked at the directory as a whole, so main took the collision
+ * silently and Deploy stayed green.
+ *
+ * Writing this gate turned up FIVE MORE that nobody had ever noticed -- 0011,
+ * 0013, 0027, 0028, 0029 -- so the count is six, not one, and the failure is a
+ * standing property of parallel merges rather than one bad afternoon.
+ *
+ * All six pairs happen to be inert: disjoint objects, no ordering dependency
+ * between the two halves of any pair. This is therefore a gate against the
+ * seventh, not a repair of the six. The seventh will not be inert by default.
+ *
+ * WHY THEY ARE GRANDFATHERED RATHER THAN RENUMBERED. Wrangler records applied
+ * migrations in the `d1_migrations` table keyed by FILENAME. Renaming a
+ * migration that has already run makes it read as unapplied, and the next
+ * `d1 migrations apply` re-runs it against prod. For an `ADD COLUMN` that is a
+ * hard error; for anything with an INSERT it is silent duplication. Every one
+ * of these twelve files has long since been applied. So the entries below are
+ * exact filename pairs, not exemptions for the numbers: a third file claiming
+ * 0107 -- or any of the other five -- fails this test like any other collision.
+ *
+ * THE FALSIFIER IS IN THE FILE. `findCollisions` is a pure function and the
+ * third test runs it against a synthetic duplicate. If the detector were ever
+ * gutted to return an empty map, that test goes red rather than this gate
+ * quietly passing forever -- Law 12, a check that cannot fail has measured
+ * nothing.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { readdirSync } from 'fs'
+import { resolve, join } from 'path'
+
+const MIGRATIONS = resolve('migrations')
+const ROLLBACKS = join(MIGRATIONS, 'rollbacks')
+
+/** `0107_audit_ledger_observability.sql` -> `0107`. Null if unnumbered. */
+function numberOf(filename: string): string | null {
+  const match = /^(\d{4})_[a-z0-9_]+\.sql$/.exec(filename)
+  return match ? match[1] : null
+}
+
+/** Every number claimed by more than one file, in directory order. */
+function findCollisions(filenames: string[]): Map<string, string[]> {
+  const byNumber = new Map<string, string[]>()
+  for (const name of filenames) {
+    const n = numberOf(name)
+    if (n === null) continue
+    byNumber.set(n, [...(byNumber.get(n) ?? []), name])
+  }
+  return new Map([...byNumber].filter(([, files]) => files.length > 1))
+}
+
+/**
+ * The six collisions already on main when this gate was written, all applied to
+ * prod and therefore unrenameable. Exact filenames, so a NEW file claiming any
+ * of these numbers is still a failure.
+ *
+ * Do not add to this list to make a red build green. Renumber the unapplied
+ * migration instead. If it has already been applied to prod, that is a Captain
+ * conversation, not a list entry.
+ */
+const GRANDFATHERED: Record<string, string[]> = {
+  '0011': ['0011_booking_tables.sql', '0011_verify.sql'],
+  '0013': ['0013_add_alert_context_type.sql', '0013_contacts_add_entity_id.sql'],
+  '0027': ['0027_create_enrichment_runs.sql', '0027_harden_magic_links_context_and_milestones.sql'],
+  '0028': ['0028_create_outreach_events.sql', '0028_originating_signal_attribution.sql'],
+  '0029': ['0029_create_pipeline_settings.sql', '0029_create_scan_requests.sql'],
+  '0107': ['0107_audit_ledger_observability.sql', '0107_gateway_loop_observability.sql'],
+}
+
+function sqlFilesIn(dir: string): string[] {
+  return readdirSync(dir)
+    .filter((f) => f.endsWith('.sql'))
+    .sort()
+}
+
+describe('migration numbering', () => {
+  it('gives every migration a unique number', () => {
+    const collisions = findCollisions(sqlFilesIn(MIGRATIONS))
+
+    const unexpected = [...collisions].filter(([number, files]) => {
+      const allowed = GRANDFATHERED[number]
+      if (!allowed) return true
+      return !(files.length === allowed.length && files.every((f) => allowed.includes(f)))
+    })
+
+    expect(
+      unexpected,
+      unexpected
+        .map(([n, files]) => `migrations/: ${n} claimed by ${files.join(' and ')}`)
+        .join('\n')
+    ).toEqual([])
+  })
+
+  it('gives every rollback a unique number', () => {
+    const collisions = findCollisions(sqlFilesIn(ROLLBACKS))
+
+    // Rollbacks mirror their migration, so they inherit the same exemption.
+    const unexpected = [...collisions].filter(([number, files]) => {
+      const allowed = GRANDFATHERED[number]?.map((f) => f.replace(/\.sql$/, '_down.sql'))
+      if (!allowed) return true
+      return !(files.length === allowed.length && files.every((f) => allowed.includes(f)))
+    })
+
+    expect(
+      unexpected,
+      unexpected
+        .map(([n, files]) => `migrations/rollbacks/: ${n} claimed by ${files.join(' and ')}`)
+        .join('\n')
+    ).toEqual([])
+  })
+
+  it('detects a collision when one exists', () => {
+    // The falsifier. Without this, a gutted findCollisions would leave the two
+    // tests above passing on any directory at all.
+    const collisions = findCollisions([
+      '0001_first.sql',
+      '0002_second.sql',
+      '0002_second_again.sql',
+    ])
+
+    expect([...collisions.keys()]).toEqual(['0002'])
+    expect(collisions.get('0002')).toEqual(['0002_second.sql', '0002_second_again.sql'])
+  })
+
+  it('names every migration <4-digit>_<lower_snake>.sql', () => {
+    const malformed = sqlFilesIn(MIGRATIONS).filter((f) => numberOf(f) === null)
+
+    expect(malformed, `unnumbered or misnamed: ${malformed.join(', ')}`).toEqual([])
+  })
+})


### PR DESCRIPTION
## What this closes

Two PRs merged a migration numbered `0107` within an hour of each other today — `0107_audit_ledger_observability.sql` (ss#2500) and `0107_gateway_loop_observability.sql` (ss#2488). Both branches were green. Neither could have been anything else: the number a migration claims is a property of the **merged** directory, and nothing in `npm run verify` or CI read the directory as a whole.

Writing the gate surfaced five more collisions nobody had ever noticed — **0011, 0013, 0027, 0028, 0029**. Six, not one. This is a standing property of parallel merges, not one bad afternoon.

## Why the six are grandfathered rather than renumbered

Wrangler records applied migrations in `d1_migrations` **keyed by filename**. Renaming a migration that has already run makes it read as unapplied, and the next `d1 migrations apply` re-runs it against prod — a hard error for `ADD COLUMN`, silent duplication for anything with an `INSERT`. All twelve files are long applied.

They are grandfathered as **exact filename pairs**, not as exemptions for the numbers, so a *third* file claiming 0107 (or any of the other five) still fails.

All six pairs are inert as they stand: disjoint objects, no ordering dependency inside any pair. Verified for the 0107 pair — disjoint `ALTER TABLE fleet_status ADD COLUMN` sets, and only the gateway half touches `fleet_alert_state`. This PR is the gate against the seventh, which will not be inert by default.

## Evidence the check can fail

Law 12, three ways:

1. **Synthetic, in the file.** `findCollisions` is pure; one test runs it against `['0001_first.sql', '0002_second.sql', '0002_second_again.sql']`. Gutting the detector turns that red rather than leaving the directory tests passing on anything.
2. **Real artifact.** Planted `migrations/0108_bogus_third_claimant.sql` → `migrations/: 0108 claimed by 0108_audit_head_history.sql and 0108_bogus_third_claimant.sql`, test red. Removed.
3. **Past the grandfather entry.** Planted `migrations/0107_smuggled.sql` → red, naming all three files. The allowlist is a floor, not a hole.

## Scope

One new test file. No migration renamed, moved, or edited; no schema change; nothing touches applied state. `npm run verify` green: 4,656 passed, 0 errors.

Refs #2488, #2500
