### PR TITLE
chore(operator): park the staging msgraph connector so the seat can be rebuilt again

### DIFF
--- a/operator/bin/tests/test_killtest_msgraph_send.py
+++ b/operator/bin/tests/test_killtest_msgraph_send.py
@@ -60,7 +60,7 @@ def test_the_fence_is_not_a_flag(capsys):
     assert "is not a sandbox seat" in capsys.readouterr().err
 
 
-def test_a_dry_run_transmits_nothing(monkeypatch, capsys):
+def test_a_dry_run_transmits_nothing(monkeypatch, capsys, authored_staging):
     def explode(*_a, **_k):  # pragma: no cover - must never be reached
         raise AssertionError("a dry run reached the network")
 
@@ -111,6 +111,24 @@ _STAGING_CONFIG = {
 }
 
 
+@pytest.fixture
+def authored_staging(monkeypatch):
+    """Pin ``_seat_config`` for the tests that exercise ``main()``.
+
+    Those tests assert argument handling, the dry-run contract and the plant
+    path. None of them is about what ``smd-staging`` currently authors -- yet
+    reading the live customer.yaml made them depend on it, and parking that
+    seat's msgraph connector on 2026-08-21 (the M365 licences are not being
+    retained) turned six unrelated unit tests red. A unit test of this tool
+    should not move when an operator parks a connector.
+
+    The yaml-reading path keeps its own direct coverage: ``guard`` is tested
+    against the real allowlist above, and ``read_credential`` is tested against
+    ``_STAGING_CONFIG`` below.
+    """
+    monkeypatch.setattr(kill, "_seat_config", lambda slug: dict(_STAGING_CONFIG))
+
+
 class _Created:
     def __init__(self, payload):
         self._payload = json.dumps(payload).encode()
@@ -154,7 +172,7 @@ def _clear_graph_env(monkeypatch):
         monkeypatch.delenv(name, raising=False)
 
 
-def test_plant_is_not_the_default_mode(monkeypatch, capsys):
+def test_plant_is_not_the_default_mode(monkeypatch, capsys, authored_staging):
     """The original invocation keeps its original meaning. A mode flag that
     changes what an unchanged command line does is a trap, not a feature."""
     monkeypatch.setattr(kill, "mint_token", lambda *_a, **_k: "tok")
@@ -167,7 +185,7 @@ def test_plant_is_not_the_default_mode(monkeypatch, capsys):
     assert "mode=send" in capsys.readouterr().out
 
 
-def test_both_modes_parse_and_an_invented_mode_does_not(capsys):
+def test_both_modes_parse_and_an_invented_mode_does_not(capsys, authored_staging):
     """A typo'd mode must not fall through to a default that transmits."""
     assert kill.main(["--seat", "smd-staging", "--mode", "plant"]) == 0
     assert "mode plant" in capsys.readouterr().out
@@ -189,7 +207,7 @@ def test_the_paying_firms_seat_is_refused_in_plant_mode_too(capsys):
     assert "is not a sandbox seat" in capsys.readouterr().err
 
 
-def test_a_plant_dry_run_reaches_no_network(monkeypatch, capsys):
+def test_a_plant_dry_run_reaches_no_network(monkeypatch, capsys, authored_staging):
     def explode(*_a, **_k):  # pragma: no cover - must never be reached
         raise AssertionError("a dry run reached the network")
 
@@ -325,7 +343,7 @@ def test_there_is_no_fallback_for_the_secret(monkeypatch):
     assert "MSGRAPH_CLIENT_SECRET" in str(exc.value)
 
 
-def test_plant_never_asks_for_the_send_credential(monkeypatch):
+def test_plant_never_asks_for_the_send_credential(monkeypatch, authored_staging):
     """The whole reason plant exists is that smd-staging has no SEND app
     (ss#2467). If it reached for one it would refuse on the seat it was built
     for, and the falsifier would still have nowhere to run."""
@@ -343,7 +361,7 @@ def test_plant_never_asks_for_the_send_credential(monkeypatch):
     assert kill.main(["--seat", "smd-staging", "--mode", "plant", "--confirm"]) == 0
 
 
-def test_plant_prints_both_ids_so_the_baseline_entry_is_exact(monkeypatch, capsys):
+def test_plant_prints_both_ids_so_the_baseline_entry_is_exact(monkeypatch, capsys, authored_staging):
     """Send mode cannot do this -- Graph answers sendMail with 202 and no body.
     Plant gets the created message back, so the id is printed rather than hunted
     for by subject in a mailbox."""

--- a/operator/customers/smd-staging/customer.yaml
+++ b/operator/customers/smd-staging/customer.yaml
@@ -16,10 +16,13 @@ schema_version: 1
 #     never used for a live Google call by boot-smoke or the voice gate.
 #     Staged at provision time, NEVER committed.
 #   - No managed_mailboxes  -> touches no real Google inbox.
-#   - No Telegram, no cron. The ONE inbound path is the msgraph Email binding
-#     below (ADR 0078 / ss#1978 sandbox e2e): the client-custody mail loop is
-#     proven here against the smdopslab SANDBOX tenant (a throwaway M365 we
-#     own — operator@smdopslab.onmicrosoft.com), never a real client mailbox.
+#   - No Telegram, no cron. The msgraph Email binding (ADR 0078 / ss#1978
+#     sandbox e2e) was the one inbound path, proven against the smdopslab
+#     tenant we own — operator@smdopslab.onmicrosoft.com, never a real client
+#     mailbox. PARKED 2026-08-21: the M365 licences are not being retained
+#     unless a future troubleshoot needs them, and the connector cannot work
+#     without a licensed mailbox. The seat currently has NO inbound path.
+#     See the parked block under connectors: for how to revive it.
 #   - Own R2 prefix (vaults/smd-staging/), own D1 namespace, own skill-bodies
 #     bucket. Shares no mutable state with smd.
 #
@@ -126,8 +129,10 @@ personas:
         initiation:
           manual: true
           scheduled: false
-          # webhook: the msgraph message.received trigger below wakes this
-          # skill — the ADR 0078 sandbox e2e inbound path.
+          # webhook: WAS woken by the msgraph message.received trigger — the
+          # ADR 0078 sandbox e2e inbound path, parked 2026-08-21 with the
+          # connector. Left true so reviving the connector needs no edit here;
+          # with no trigger authored, nothing wakes this skill by webhook.
           webhook: true
         enabled: true
       - name: workspace
@@ -146,7 +151,11 @@ personas:
 # broker — NOT the connector mechanism. The broker holds the DWD service-account
 # credential (see google_auth:) and exposes the governed workspace_* tools; no CLI to
 # shell out to.
-connectors:
+# EXPLICIT EMPTY MAP, not an oversight: the seat's only connector is the msgraph
+# Email one parked below, and a bare `connectors:` with every child commented out
+# parses as null, which the validator rejects with "connectors is required".
+# Restore this to `connectors:` when the Email block below is uncommented.
+connectors: {}
   # Client-custody email (ADR 0078 / email-channel-seam spec / ss#1978) — the
   # sandbox END-TO-END proof binding. The mailbox is operator@smdopslab
   # .onmicrosoft.com on the smdopslab SANDBOX tenant we own (app-only
@@ -175,25 +184,43 @@ connectors:
   # staged as MSGRAPH_CLIENT_ID — handing the agent the app that can transmit and
   # undoing the fence. The read-only app is 9301fd6f-… , which is what the live
   # seat actually runs.
-  Email:
-    adapter: msgraph
-    backend: mcp:msgraph-mail
-    enabled: true
-    msgraph_auth:
-      tenant_id: 'f11d2887-b7f2-4464-a9c6-d4db2166b43c'
-      client_id: '9301fd6f-1d97-4ed4-abc3-e99e3cf326f0'
-      mailbox: operator@smdopslab.onmicrosoft.com
-      secret_ref: 'fly-secret:MSGRAPH_CLIENT_SECRET'
-    poll_seconds: 45
+  # ---- MSGRAPH PARKED 2026-08-21 ----
+  # The smdopslab M365 licences are not being retained unless a future
+  # troubleshoot needs them, and without a licensed mailbox this connector
+  # cannot work regardless of how fresh its credentials are. Parked rather
+  # than deleted: the provisioner derives its authored-channel facts with
+  # yaml.safe_load, so a commented block is invisible to the msgraph gate
+  # (the gate that refuses a seat carrying no SEND app credential) while
+  # every id below stays on hand. Commenting only became safe on
+  # 2026-08-18 -- before that the gates grepped the raw file and read
+  # comments as config.
+  #
+  # TO REVIVE: re-licence the mailbox, uncomment this block and the
+  # webhook_triggers block below (indentation is preserved -- strip the
+  # leading "# " and nothing else), mint a SEND secret on the EXISTING
+  # send registration, vault it as MSGRAPH_SEND_CLIENT_ID__SMD_STAGING /
+  # MSGRAPH_SEND_CLIENT_SECRET__SMD_STAGING, and replace the stale
+  # MSGRAPH_CLIENT_SECRET__SMD_STAGING in /ss prod -- it is invalid
+  # (AADSTS7000215); the bare MSGRAPH_CLIENT_SECRET is the good read value.
+  # Email:
+  # adapter: msgraph
+  # backend: mcp:msgraph-mail
+  # enabled: true
+  # msgraph_auth:
+  # tenant_id: 'f11d2887-b7f2-4464-a9c6-d4db2166b43c'
+  # client_id: '9301fd6f-1d97-4ed4-abc3-e99e3cf326f0'
+  # mailbox: operator@smdopslab.onmicrosoft.com
+  # secret_ref: 'fly-secret:MSGRAPH_CLIENT_SECRET'
+  # poll_seconds: 45
 
 # ---- WEBHOOK TRIGGERS ----
 # The e2e wake path: a new message in the operator's sandbox inbox (delivered
 # by the delta poller through the signed loopback) routes to inbox-triage.
-webhook_triggers:
-  - source: msgraph
-    event_type: message.received
-    skill: inbox-triage
-    persona: crane
+# webhook_triggers:
+# - source: msgraph
+# event_type: message.received
+# skill: inbox-triage
+# persona: crane
 
 # ---- SCOPE ----
 scope:


### PR DESCRIPTION
## Why

`smd-staging` has been **un-reprovisionable since 2026-08-13**, when provisioning began requiring two Graph registrations and refusing a seat with no SEND app credential (`c6f0df7f`, ss#2258). That credential was never vaulted — it exists only as a deployed Fly secret from the day the two-app fence was proven — so every reprovision since has died at the gate.

Nothing reported it. The seat kept serving on an eight-day-old overlay, and it surfaced only because that same staleness is why `audit-chain-verify` holds on this seat: no `audit_head` on the heartbeat (ss#2500). A seat that cannot be rebuilt reads exactly like a seat that hasn't needed rebuilding.

The M365 licences are not being retained unless a future troubleshoot needs them (Captain, 2026-08-21). Without a licensed mailbox the connector cannot work however fresh its credentials are, so minting a secret would buy nothing.

## Parked, not deleted

The provisioner derives its authored-channel facts with `yaml.safe_load`, so a commented block is invisible to the msgraph gate. That only became true on **2026-08-18**, when those gates stopped grepping the raw file and reading comments as config — before that, this change would have been a no-op with a false sense of safety.

Verified in both directions with the provisioner's own derivation:

| | committed file | this branch |
|---|---|---|
| authored channel facts | `adapter=msgraph`, `backend=mcp:msgraph-mail` | none |
| msgraph gate fires | **True** — refuses the seat | **False** |
| `webhook_triggers` | 1 msgraph trigger | none |
| validator | OK | OK |

`connectors: {}` is load-bearing, not a typo: Email is this seat's only connector, and a bare `connectors:` with every child commented out parses as null, which the validator rejects with `connectors is required`. The file says so at the line.

## Revival lives in the file

Both app ids, the tenant, that `MSGRAPH_CLIENT_SECRET__SMD_STAGING` is invalid (AADSTS7000215) while the bare `MSGRAPH_CLIENT_SECRET` mints a token fine, and that uncommenting is a pure `# ` strip because indentation is preserved.

Two comments the parking made false are corrected here rather than left to mislead: the header's "the ONE inbound path is the msgraph Email binding" and the `inbox-triage` webhook note.

## Scope and effect

One customer.yaml. No code, no schema, no other seat. After this merges I'll reprovision `smd-staging`, which puts it on the current overlay and should take `audit-chain-verify` to CLEAN on all five provisioned seats (it currently holds on this one alone).

**Known unknown, stated rather than papered over:** the overlay's own `bootstrap/validate.py` re-checks config at boot and I cannot test whether it accepts a zero-connector seat without deploying. If it refuses, staging stays exactly where it is today and I'll report that.

**Peer note:** the `ap-open-fence` session lists a falsifier on `smd-staging`. Its msgraph path is already dead (1,180 consecutive 401s), so nothing usable is being removed, and getting the seat onto the current overlay should help rather than hinder that work.

`npm run verify` green. Refs ss#2500, ss#2258
