### PR TITLE
test(operator): pin every separator spelling to one canonical caption, so the two citation-filter copies cannot diverge silently

### DIFF
--- a/operator/safety-substrate/tests/test_citation_caption_allowlist.py
+++ b/operator/safety-substrate/tests/test_citation_caption_allowlist.py
@@ -90,3 +90,33 @@ def test_empty_or_bad_allowlist_narrows_never_widens() -> None:
 def test_canonical_caption_folds_separator_and_case() -> None:
     assert canonical_caption("ALVAREZ VS. DRAPER") == canonical_caption("alvarez v draper")
     assert canonical_caption("In re  Ramirez") == "in re ramirez"
+
+
+def test_every_separator_spelling_canonicalizes_the_same() -> None:
+    """All seven spellings of the party separator collapse to one canonical form.
+
+    This is a PAIR-PARITY test, mirrored in the overlay's copy of this suite
+    (hermes-smd-overlay#300). The manifest sha gates catch an UNRECORDED edit to
+    either copy; they cannot catch two edits that are both consciously recorded
+    and differ. That is the drift that bites: _canonical_allowlist compares
+    canonical forms, so if one copy folds a spelling the other does not, a
+    caption the firm's own record contains is exempt on one seat and refused on
+    the other, silently, with nothing red anywhere.
+
+    The trailing-dot case is the one that found a real divergence between the
+    two copies: `\\bv(?:ersus|s)?\\.?\\s` folds "versus." because the optional
+    dot follows the whole alternation, where `\\b(?:v(?:s)?\\.?|versus)\\s` does
+    not, because its dot sits inside the short branch and the longhand branch
+    never reaches one. Keep the two regexes character-identical.
+    """
+    canon = "smith v. jones"
+    for spelling in (
+        "Smith v. Jones",
+        "Smith v Jones",
+        "Smith vs. Jones",
+        "Smith vs Jones",
+        "Smith versus Jones",
+        "Smith versus. Jones",
+        "SMITH VERSUS JONES",
+    ):
+        assert canonical_caption(spelling) == canon, spelling


### PR DESCRIPTION
## Why

Follow-up to #2527, which added `CASE_NAME_VERSUS_RE` and the matching `versus` fold in `canonical_caption`, mirroring the companion overlay change.

The overlay author and I reached the same conclusion independently about where the fold belongs. Our regexes still differed on one spelling:

```
'smith versus. jones' -> \bv(?:ersus|s)?\.?\s      -> 'smith v. jones'      (ss #2527, and now both)
                      -> \b(?:v(?:s)?\.?|versus)\s -> 'smith versus. jones' (overlay, pre-fix)
```

The optional dot has to follow the whole alternation. Inside the short branch it never reaches the longhand one.

That is a real divergence rather than a cosmetic one. `_canonical_allowlist` compares canonical forms, so a caption the firm's own record actually contains would be exempt from the citation gate on one seat and refused on the other, silently, with nothing red anywhere. The overlay has since adopted this repo's form (hermes-smd-overlay#300, `349d86b`), so the two copies agree today.

## What this adds

`test_every_separator_spelling_canonicalizes_the_same` in `operator/safety-substrate/tests/test_citation_caption_allowlist.py`, pinning all seven spellings (`v.`, `v`, `vs.`, `vs`, `versus`, `versus.`, `SMITH VERSUS JONES`) to `"smith v. jones"`. Mirrored in the overlay's copy of the same suite.

The point is that it pins **behavior, not bytes**. The manifest sha gates in `operator/contracts/overlay-pairs.json` catch an *unrecorded* edit to either copy. They cannot catch two edits that are both consciously recorded and differ, which is exactly what happened here and what a hash gate is structurally unable to see.

## Falsifier

The fixture fails under the pre-fix overlay regex and passes under the one both copies now carry:

```
'Smith v. Jones'      ours='smith v. jones'  theirs(old)='smith v. jones'
'Smith versus Jones'  ours='smith v. jones'  theirs(old)='smith v. jones'
'Smith versus. Jones' ours='smith v. jones'  theirs(old)='smith versus. jones'
```

Only the trailing-dot row separates them, which is why a fixture covering only the common spellings would have passed on both and caught nothing.

## Verification

`operator/safety-substrate/tests`: 197 passed.

## Note on how this became a separate PR

This commit was written while #2527 was still open and was intended for it. Auto-merge fired between the state check and the push, so the push was rejected against a deleted branch. Rebased onto `a7bab95d` and shipped on its own rather than left sitting locally.
