### PR TITLE
fix(operator): the report templates the Operator copies verbatim stop carrying the one character its own gate refuses

### DIFF
--- a/operator/skills/operator-introduce/SKILL.md
+++ b/operator/skills/operator-introduce/SKILL.md
@@ -309,13 +309,13 @@ N routines: X on a schedule, Y that start when something happens, Z when you
 ask. Ask me to walk through them and I'll list every one with the state it's in.
 
 How I work:
-- [Send posture, from `working_rules.send_posture` — one sentence per outbound
+- [Send posture, from `working_rules.send_posture` | one sentence per outbound
   class, in the firm's words. Never a blanket review promise when the classes
   disagree, and never "I send nothing outward" when the reason is that no class
   is authored: that reads as freedom when it is a refusal.]
 - I read deadlines from your systems. I never calculate them myself.
 - [The identifier sentence, verbatim from `working_rules.identifier_gate.says`
-  — it differs between a seat that refuses and a seat running the gate in
+ | it differs between a seat that refuses and a seat running the gate in
   report mode.]
 - I don't give legal advice or opinions on the merits.
 

--- a/operator/skills/operator-self-initiation/SKILL.md
+++ b/operator/skills/operator-self-initiation/SKILL.md
@@ -171,17 +171,17 @@ proposal, because the firm blesses what it sees. Never approximate to fit the tu
 One reply, to the requester only:
 
 ```
-OPERATOR SELF-INITIATION — [seat display name] — [date, time, timezone]
+OPERATOR SELF-INITIATION | [seat display name] | [date, time, timezone]
 
 1. Self-test          [ran this turn / see results below]
-2. Voice              [established / partial (open classes named) / proposal below — awaiting your blessing / not started]
-3. Document library   [established, N templates at <location> / proposal below — awaiting your blessing / not started / unknown — ask the admin]
+2. Voice              [established / partial (open classes named) / proposal below | awaiting your blessing / not started]
+3. Document library   [established, N templates at <location> / proposal below | awaiting your blessing / not started / unknown | ask the admin]
 
 [the self-test report, if it ran]
 [the voice survey proposal, if one was produced]
 [the document library proposal, if one was produced]
 
-To continue: [exactly what to reply, per open item — e.g. "reply approving or
+To continue: [exactly what to reply, per open item | e.g. "reply approving or
 amending the voice corpus", "reply approving or amending the template list",
 "reply 'continue initiation'"]
 ```

--- a/operator/skills/operator-self-test/SKILL.md
+++ b/operator/skills/operator-self-test/SKILL.md
@@ -156,7 +156,7 @@ report says so in one line.
 ## The report (fixed shape — a page, not a novel)
 
 ```
-OPERATOR SELF-TEST — [seat display name] — [date, time, timezone]
+OPERATOR SELF-TEST | [seat display name] | [date, time, timezone]
 
 1. Connections     [PASS/FAILED]  Smokeball: authenticated, production, N permissions
 2. Read            [PASS/FAILED]  I can see N matters

--- a/tests/skill-reply-rules.test.ts
+++ b/tests/skill-reply-rules.test.ts
@@ -36,7 +36,7 @@
  */
 
 import { describe, it, expect } from 'vitest'
-import { readFileSync } from 'fs'
+import { existsSync, readFileSync, readdirSync } from 'fs'
 import { resolve } from 'path'
 
 // Literal path constants (never interpolated) so the paths are auditable.
@@ -158,6 +158,40 @@ describe('setup-turn reply rules are pinned in skill prose', () => {
           `${SKILL_PATHS[skill]} models the shape the outbound citation filter reads as a ` +
             `court-case caption. Rewrite as "compared with" or restructure the sentence. ` +
             `Hits: ${JSON.stringify(hits)}`
+        ).toEqual([])
+      })
+    }
+  })
+
+  describe('no fenced report template carries a tier-1 fabrication marker', () => {
+    // The fixed-shape boards inside fenced blocks are what the model reproduces
+    // verbatim on the reply. On 2026-08-21 the self-initiation board header
+    // ("OPERATOR SELF-INITIATION | [seat] | [date]", then written with dashes)
+    // cost two refused drafts per turn on the A&P seat (tier1_marker em-dash)
+    // before the model substituted a pipe. Every operator skill is checked, not
+    // just the four setup ones: the introduce skill's rule template had the
+    // same dash.
+    const allSkills = readdirSync(resolve(__dirname, '..', 'operator', 'skills'), {
+      withFileTypes: true,
+    })
+      .filter((d) => d.isDirectory())
+      .map((d) => resolve(__dirname, '..', 'operator', 'skills', d.name, 'SKILL.md'))
+      .filter((f) => existsSync(f))
+    for (const file of allSkills) {
+      it(`${file.split('/operator/')[1]} fenced blocks have no em dash`, () => {
+        const fenced: string[] = []
+        let inFence = false
+        for (const line of readFileSync(file, 'utf-8').split('\n')) {
+          if (line.trim().startsWith('```')) {
+            inFence = !inFence
+            continue
+          }
+          if (inFence && line.includes('\u2014')) fenced.push(line)
+        }
+        expect(
+          fenced,
+          `${file}: a fenced template line carries an em dash; the model copies it and the ` +
+            `tier-1 fabrication marker refuses the draft. Use " | " or a comma.`
         ).toEqual([])
       })
     }


### PR DESCRIPTION
The fixed-shape boards inside the skills' fenced blocks (self-initiation,
self-test, introduce) were written with em dashes. The model reproduces the
template verbatim on the reply, the tier-1 fabrication marker refuses the
draft, and the model tries again: two refused drafts per kickoff turn on the
Ashton & Price seat today (vfy_01M0JW78YYBJKY1T537AYNFNAR), harmless to the
reader but pure waste, and the same defect would surface on every seat that
ships these skills.

Dashes inside fenced blocks become " | ". Prose outside fences is untouched
(the model does not copy it). tests/skill-reply-rules.test.ts gains a gate
over every operator skill: no fenced line carries an em dash. Falsifier: the
gate fails against main's self-initiation body.

Merged is not deployed: this reaches a seat on its next reprovision (skill bodies are baked into the image). A&P runs 349d86b3 with the pre-fix templates; the cost there is two refused drafts per setup turn, not a wrong reply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016U9H1VbtZdmBo2t6UBAAPr