### PR TITLE
fix(operator): the shadow-firm gate can now fail, and the release runbook describes an order that can actually be followed

### DIFF
--- a/docs/handbook/deployment-release.md
+++ b/docs/handbook/deployment-release.md
@@ -90,25 +90,39 @@ customer's Machine image against a new overlay commit. The flow:
    commit it should pin to.
 2. **Bump `OVERLAY_REF`.** The overlay commit is pinned as the `ARG OVERLAY_REF`
    in `operator/templates/Dockerfile`. This is the desired state for every
-   customer Machine.
-   **The bump PR cites the run id of a green shadow-firm run on the candidate
-   ref.** The shadow firm (`operator/rehearsal/`, runbook
-   `docs/runbooks/operator/shadow-firm.md`) replays every incident class this
-   venture has had - an unaudited direct-API send, cross-matter content, a
-   fabricated matter number under failure, an instruction injected through
-   inbound mail, a dead connector mid-task, a privileged instruction from an
-   unauthored sender - against a rig seat, and scores each from audit rows and
-   mailbox observations rather than from how the answers read. Run it as
-   `infisical run --env=prod --path=/ss -- operator/rehearsal/run.py --seat pilot-smokeball --overlay-ref <candidate> --drive`,
-   and cite the run id (with the report's evidence table) in a PR comment -
+   customer Machine. The PR names its tracking issue and carries an acceptance
+   criterion tagged `(runtime)`: a green shadow-firm run on the rig at this ref.
+   Steps 3 and 4 are how that AC is met, and they happen after this PR merges.
+3. **Reprovision the rig, before any client seat.** The rig is
+   `pilot-smokeball`. Run `yes s | operator/bin/reprovision.sh pilot-smokeball`.
+   This step exists here, in this position, because a rig runs a candidate
+   overlay ref only once it has been reprovisioned onto it. The old procedure
+   asked step 2 to cite a green run "on the candidate ref", which no rig could
+   produce yet, and three bumps in a row (#2518, #2525, #2531) cited nothing.
+4. **Drive the shadow firm against the rig, and cite the run id.** The shadow
+   firm (`operator/rehearsal/`, runbook `docs/runbooks/operator/shadow-firm.md`)
+   replays every incident class this venture has had - an unaudited direct-API
+   send, cross-matter content, a fabricated matter number under failure, an
+   instruction injected through inbound mail, a dead connector mid-task, a
+   privileged instruction from an unauthored sender - against the rig seat, and
+   scores each from audit rows and mailbox observations rather than from how the
+   answers read. Run it as
+   `infisical run --env=prod --path=/ss -- operator/rehearsal/run.py --seat pilot-smokeball --overlay-ref <candidate> --drive`.
+   The runner reads the rig's running overlay ref off the live seam and refuses
+   to drive unless it equals the candidate, so the id cannot be produced by a rig
+   still on the previous release, and a ref it cannot read refuses too. Cite the
+   run id, with the report's evidence table, on the tracking issue or as a
+   comment on the merged bump PR: that citation is the `(runtime)` AC's proof.
    `.stitch/shadow-firm/` is gitignored (PR #2407: the provision-source guard
    refuses a dirty tree), so the report is NOT committed; the digest-shaped run
    id is recomputable from the pasted report body, which is what makes the
-   citation auditable. A run id ending in `-notgreen` does not satisfy this, and neither does a
-   run with skipped scenarios: a skipped scenario did not run, so it certifies
-   nothing. The suite never touches a client seat or a client-visible address;
-   that is enforced in `operator/rehearsal/scope.py`, not by convention.
-3. **Reprovision the customer Machine.** Run `operator/bin/reprovision.sh <slug>`
+   citation auditable. A run id ending in `-notgreen` does not satisfy this, and
+   neither does a run with skipped scenarios: a skipped scenario did not run, so
+   it certifies nothing. A bump with no green id once the rig has been
+   reprovisioned is drift, not a completed release. The suite never touches a
+   client seat or a client-visible address; that is enforced in
+   `operator/rehearsal/scope.py`, not by convention.
+5. **Reprovision the customer Machines.** Run `operator/bin/reprovision.sh <slug>`
    from the repo root. That wrapper is exactly
    `infisical run --env=prod --path=/ss --silent -- operator/bin/provision-customer.sh <slug>`;
    it injects the R2 credentials the provisioner needs (historically not stored
@@ -119,18 +133,21 @@ customer's Machine image against a new overlay commit. The flow:
    non-interactively (Machine secrets persist across deploy, so there is nothing
    to re-enter). git is the single source of truth for `customer.yaml`;
    provisioning projects it to R2 unconditionally.
-4. **Pass the verify gate.** Confirm the runtime came up against the live read
+6. **Pass the verify gate.** Confirm the runtime came up against the live read
    seam (a correct key returns 200; a wrong key or wrong slug returns 401) and
    the boot smoke test passed - not just that the config validated.
-5. **Flip secrets** on the website side if the release changes the per-customer
+7. **Flip secrets** on the website side if the release changes the per-customer
    seam keys.
 
 **An `OVERLAY_REF` bump only reaches a Machine when that Machine is
 reprovisioned.** Nothing reprovisions automatically. `overlay-ref-drift.py` reads
 each Machine's running overlay commit from the live read seam and compares it to
 the ref pinned in the Dockerfile, so drift between desired and deployed is a
-surfaced fact rather than something to remember. Run it under Infisical (it needs
-the seam master key) and treat a non-zero exit as drift to resolve.
+surfaced fact rather than something to remember. It is also how you answer "which
+seats did this bump actually reach" after step 5. Run it under Infisical (it needs
+the seam master key) and treat a non-zero exit as drift to resolve. The shadow
+firm's release gate reads a seat's running ref through that same code path, so
+the runner and the drift report cannot disagree about what a seat is running.
 
 ## Never root-SSH a live Operator Machine
 

--- a/docs/runbooks/operator/shadow-firm.md
+++ b/docs/runbooks/operator/shadow-firm.md
@@ -9,7 +9,10 @@ Related: `operator/bin/rehearse-card.py` (ungraded rehearsal), `operator/bin/sea
 A suite that plays the client hostile against a rig seat, replaying every
 incident class this venture has actually had, and scores each scenario from
 artifacts the seat produced rather than from how its answers read. It emits a run
-id, and an `OVERLAY_REF` bump PR cites that id.
+id, and an `OVERLAY_REF` bump cites that id as the proof of its runtime AC. The
+run happens after the rig has been reprovisioned onto the candidate ref, because
+that is the only point at which a rig is running it: see [Release gate:
+OVERLAY_REF bumps](#release-gate-overlay_ref-bumps) below for the whole order.
 
 `rehearse-card.py` deliberately does not grade, and that is still right: it
 replays a script whose replies are prose, and prose graded by the same agent that
@@ -54,6 +57,17 @@ nothing. The AgentMail and seam credentials are ambient in any shell that has ru
 into a seat with no further confirmation. That happened once during development,
 inside a minute, on an invocation meant as a dry run.
 
+**The rig must already be running the candidate.** With `--drive` the runner
+reads the rig's RUNNING overlay ref off the same runtime-read seam
+`operator/bin/overlay-ref-drift.py` uses, and refuses unless it equals the ref
+this run would certify. A ref it cannot read (unreachable Machine, no seam
+configured, a snapshot carrying no ref) refuses too, because "cannot evaluate"
+must not read as "permitted". Before ss#2531 the candidate was a string the
+runner was handed and stamped into the run id without checking, so an id reading
+"green against ref X" could have been produced by a rig still on the previous
+release. That is why the gate sits before the first probe rather than in the
+report.
+
 Useful flags: `--only <id>[,<id>]`, `--overlay-ref <ref>` (defaults to the ref
 pinned in `operator/templates/Dockerfile`), `--inject <fault>` to declare a fault
 you have already put in place on the rig, `--out <dir>` (default
@@ -61,12 +75,12 @@ you have already put in place on the rig, `--out <dir>` (default
 
 Exit codes:
 
-| Code | Meaning                                                                        |
-| ---- | ------------------------------------------------------------------------------ |
-| 0    | GREEN. Every scenario passed. Only this run may be cited by a release gate.    |
-| 1    | A scenario FAILED.                                                             |
-| 3    | Nothing failed, but something was SKIPPED, so the suite is incomplete.         |
-| 2    | Refused before driving anything (scope violation, bad registry, unknown seat). |
+| Code | Meaning                                                                                                                     |
+| ---- | --------------------------------------------------------------------------------------------------------------------------- |
+| 0    | GREEN. Every scenario passed. Only this run may be cited by a release gate.                                                 |
+| 1    | A scenario FAILED.                                                                                                          |
+| 3    | Nothing failed, but something was SKIPPED, so the suite is incomplete.                                                      |
+| 2    | Refused before driving anything (scope violation, bad registry, unknown seat, or the rig is not running the candidate ref). |
 
 **SKIPPED is visibly not PASS.** A scenario whose credentials, channel, or
 declared fault were absent did not run, so it proves nothing, and the run id it
@@ -104,15 +118,52 @@ this reason, and both fail if the control leg does not go through.
 
 ## Release gate: OVERLAY_REF bumps
 
-A PR that bumps `ARG OVERLAY_REF` in `operator/templates/Dockerfile` cites the
-run id of a green shadow-firm run against the candidate ref. See
-`/admin/playbook/deployment-release` (Path B, step 2a) for where this sits in the
-deploy flow.
+**The gate is post-reprovision.** A rig runs a candidate overlay ref only after
+someone reprovisions it onto that ref, so a green run "on the candidate" cannot
+exist before the bump merges. The runbook used to ask for one anyway, and three
+bumps in a row (#2518, #2525, #2531) cited no id at all. The order below is the
+one that can actually be followed:
+
+1. **Cut the overlay release.** Land the change in `venturecrane/hermes-smd-overlay`
+   and take the commit to pin.
+2. **Bump `ARG OVERLAY_REF`** in `operator/templates/Dockerfile`. The PR names its
+   tracking issue and carries an acceptance criterion tagged `(runtime)`: a green
+   shadow-firm run on the rig at this ref.
+3. **Reprovision the rig** onto the new pin, before any client seat:
+   `yes s | operator/bin/reprovision.sh pilot-smokeball`.
+4. **Drive the suite** against the rig. The runner refuses unless the rig's
+   running ref equals the candidate, so the id cannot be produced from a stale
+   rig, and the report records the ref it observed:
+
+   ```bash
+   infisical run --env=prod --path=/ss -- \
+     operator/rehearsal/run.py --seat pilot-smokeball --overlay-ref <candidate> --drive
+   ```
+
+5. **Cite the run id**, with the report's evidence table, on the tracking issue
+   (or as a comment on the merged bump PR). That citation is the `(runtime)` AC's
+   proof. `.stitch/shadow-firm/` is gitignored, so the report is not committed;
+   the digest is recomputable from the pasted body, which is what makes the
+   citation auditable.
+6. **Only then reprovision client seats.**
+
+`/admin/playbook/deployment-release` (Path B) is the same order from the deploy
+side, and is the page someone performing a bump is actually reading.
+
+A bump that has no green run id once the rig has been reprovisioned is drift, not
+a completed release. `operator/bin/overlay-ref-drift.py` reads every Machine's
+running ref off the live seam and reports which seats are behind the pin, so
+"which seats did this bump actually reach" is a surfaced fact rather than
+something to remember.
 
 The run id is a digest over the seat, the candidate ref, and every scenario's
 outcome, and it ends in `-green` or `-notgreen`. Citing a green id for a red run
 therefore takes forgery rather than a typo, and any reader can recompute the
-digest from the committed report body.
+digest from the report body. A `-notgreen` id does not satisfy the AC, and
+neither does a run with skipped scenarios: a skipped scenario did not run, so it
+certifies nothing. None of this relaxes the hard line above. The suite never
+touches a client seat or a client-visible address, and that is enforced in
+`operator/rehearsal/scope.py` rather than by convention.
 
 ## Falsifier for the suite itself
 

--- a/operator/bin/overlay-ref-drift.py
+++ b/operator/bin/overlay-ref-drift.py
@@ -82,6 +82,53 @@ def refs_match(desired: str, running: Optional[str]) -> bool:
     return a == b or a.startswith(b) or b.startswith(a)
 
 
+@dataclass
+class RunningRef:
+    """One Machine's RUNNING overlay ref, as read off the live runtime seam.
+
+    ``status`` is ``read`` only when a value actually came back. Every other
+    status means the running ref is UNKNOWN, and a caller gating on it must
+    refuse rather than assume current: a check that cannot fail measured
+    nothing.
+    """
+
+    slug: str
+    status: str  # read | unknown | unreachable | unconfigured
+    value: Optional[str]
+    source: Optional[str] = None
+    detail: str = ""
+
+
+def read_running_ref(
+    slug: str,
+    make_client: Callable[[str], Optional["seam_pull.SeamClient"]],
+) -> RunningRef:
+    """Resolve one slug's running overlay ref through the runtime-read seam.
+
+    The single transport path for "what is this Machine actually running". The
+    drift report below and the shadow-firm release gate
+    (``operator/rehearsal/run.py``) both call it, so neither can drift from the
+    other's idea of how the running ref is read, or of what counts as having
+    read it.
+    """
+    try:
+        client = make_client(slug)
+    except Exception as exc:  # noqa: BLE001 - defensive; a factory error is unreachable
+        return RunningRef(slug, "unreachable", None, None, f"client init: {exc}")
+    if client is None:
+        return RunningRef(slug, "unconfigured", None, None, "seam env not set")
+    try:
+        snap = client.read_config()
+    except Exception as exc:  # noqa: BLE001 - paused/undeployed/unreachable Machine
+        return RunningRef(slug, "unreachable", None, None, f"{type(exc).__name__}: {exc}")
+    ref_obj = snap.get("overlay_ref") if isinstance(snap, dict) else None
+    value = ref_obj.get("value") if isinstance(ref_obj, dict) else None
+    source = ref_obj.get("source") if isinstance(ref_obj, dict) else None
+    if value is None:
+        return RunningRef(slug, "unknown", None, source, "snapshot has no overlay_ref.value")
+    return RunningRef(slug, "read", value, source)
+
+
 def classify(
     desired: str,
     slugs: list[str],
@@ -92,31 +139,19 @@ def classify(
     ``make_client(slug)`` returns a SeamClient or None (unconfigured). Any
     transport error reading the seam is classified ``unreachable`` (a paused or
     not-yet-deployed Machine), never a crash — drift detection must be total.
+    The read itself is :func:`read_running_ref`; this function only compares.
     """
     results: list[DriftResult] = []
     for slug in slugs:
-        try:
-            client = make_client(slug)
-        except Exception as exc:  # noqa: BLE001 — defensive; a factory error is unreachable
-            results.append(DriftResult(slug, "unreachable", None, None, f"client init: {exc}"))
-            continue
-        if client is None:
-            results.append(DriftResult(slug, "unconfigured", None, None, "seam env not set"))
-            continue
-        try:
-            snap = client.read_config()
-        except Exception as exc:  # noqa: BLE001 — paused/undeployed/unreachable Machine
-            results.append(DriftResult(slug, "unreachable", None, None, f"{type(exc).__name__}: {exc}"))
-            continue
-        ref_obj = snap.get("overlay_ref") if isinstance(snap, dict) else None
-        running = ref_obj.get("value") if isinstance(ref_obj, dict) else None
-        source = ref_obj.get("source") if isinstance(ref_obj, dict) else None
-        if running is None:
-            results.append(DriftResult(slug, "unknown", None, source, "snapshot has no overlay_ref.value"))
-        elif refs_match(desired, running):
-            results.append(DriftResult(slug, "current", running, source))
+        observed = read_running_ref(slug, make_client)
+        if observed.status != "read":
+            results.append(DriftResult(slug, observed.status, None, observed.source, observed.detail))
+        elif refs_match(desired, observed.value):
+            results.append(DriftResult(slug, "current", observed.value, observed.source))
         else:
-            results.append(DriftResult(slug, "drift", running, source, "running ref != pinned ref"))
+            results.append(
+                DriftResult(slug, "drift", observed.value, observed.source, "running ref != pinned ref")
+            )
     return results
 
 

--- a/operator/rehearsal/README.md
+++ b/operator/rehearsal/README.md
@@ -2,8 +2,10 @@
 
 A standing adversarial rehearsal suite (ss#2389). It plays the client hostile
 against a rig seat, replays every incident class this venture has actually had,
-scores each scenario mechanically, and emits a run id an `OVERLAY_REF` bump PR
-cites.
+scores each scenario mechanically, and emits a run id that stands as the proof of
+an `OVERLAY_REF` bump's runtime AC. The run happens after the rig has been
+reprovisioned onto the candidate ref, and the runner refuses to drive unless the
+rig is already running it.
 
 Operating instructions, the exit-code table, and the release-gate procedure live
 in `docs/runbooks/operator/shadow-firm.md`. This file is the map of the code.
@@ -22,9 +24,9 @@ tenant. Enforced in `scope.py` at load time, not in a comment. See the runbook.
 | `scoring.py`  | Pure predicates over an observation bundle. No I/O, no judgement of prose. PASS / FAIL / SKIPPED.                                                 |
 | `drivers.py`  | The I/O half: AgentMail probe sends, the ADR 0043 audit read seam, mailbox reads, and the ss#2258 send reconciliation.                            |
 | `report.py`   | The run artifact and the run id, which is a digest over seat, candidate ref, and outcomes.                                                        |
-| `run.py`      | The CLI.                                                                                                                                          |
+| `run.py`      | The CLI, and the gate that refuses to drive unless the rig's running overlay ref equals the candidate this run would certify.                     |
 | `scenarios/`  | One YAML file per incident class.                                                                                                                 |
-| `tests/`      | The Law 12 falsifier and the scope-guard tests.                                                                                                   |
+| `tests/`      | The Law 12 falsifier, the scope-guard tests, and the running-ref gate's own refusals.                                                             |
 
 ## Why the split between `scoring.py` and `drivers.py`
 

--- a/operator/rehearsal/drivers.py
+++ b/operator/rehearsal/drivers.py
@@ -67,6 +67,17 @@ def _load_bin_module(module_name: str, filename: str):
     return module
 
 
+def load_overlay_ref_drift():
+    """``overlay-ref-drift.py`` as a module, for its read of a seat's RUNNING ref.
+
+    Same reason as the reconciler above: the runner's release gate has to read a
+    Machine's running overlay ref exactly the way the drift report reads it. Two
+    implementations of "what is this seat running" would drift, and the drifted
+    one would be the one nobody watched.
+    """
+    return _load_bin_module("overlay_ref_drift", "overlay-ref-drift.py")
+
+
 def load_seat_config(slug: str) -> dict:
     path = CUSTOMERS / slug / "customer.yaml"
     if not path.is_file():

--- a/operator/rehearsal/report.py
+++ b/operator/rehearsal/report.py
@@ -8,6 +8,11 @@ scenario ids and their outcomes, so an id that ends in ``-green`` cannot have
 been produced by a run with a FAIL or a SKIP in it, and the digest can be
 recomputed from the report body by anyone who doubts it.
 
+The report also prints the ref the rig was OBSERVED running. The runner
+refuses to drive unless that equals the candidate, so the two lines always
+agree; printing both is what lets a reader tell an id produced against the
+candidate from one produced by a rig still sitting on the previous release.
+
 The report always prints SKIPPED as its own outcome. A suite that folded
 SKIPPED into PASS would certify a release on scenarios that never ran, which is
 the exact shape of the built-not-wired failure this program exists to close.
@@ -31,6 +36,13 @@ class Run:
     seat: str
     overlay_ref: str
     started_at: str
+    #: The ref the rig was OBSERVED running when the gate in run.py read its
+    #: seam. Not part of the digest below: the gate refuses to drive unless it
+    #: equals ``overlay_ref``, so it adds no entropy. It is carried and rendered
+    #: so a reader of the report can see that the equality was observed rather
+    #: than assumed, which is the whole difference between this id and the ones
+    #: three earlier bumps could not produce at all.
+    running_ref: str | None = None
     results: list[ScenarioResult] = field(default_factory=list)
     notes: list[str] = field(default_factory=list)
 
@@ -72,6 +84,7 @@ def to_json(run: Run) -> dict:
         "run_id": run.run_id,
         "seat": run.seat,
         "overlay_ref": run.overlay_ref,
+        "running_ref": run.running_ref,
         "started_at": run.started_at,
         "green": run.is_green,
         "counts": run.counts,
@@ -106,6 +119,7 @@ def to_markdown(run: Run, scenarios_by_id: dict[str, dict]) -> str:
         "",
         f"- Seat: `{run.seat}`",
         f"- Candidate overlay ref: `{run.overlay_ref}`",
+        f"- Rig running overlay ref (observed): `{run.running_ref or 'not observed'}`",
         f"- Started: {run.started_at}",
         f"- Result: **{'GREEN' if run.is_green else 'NOT GREEN'}** "
         f"({counts.get(PASS, 0)} pass, {counts.get(FAIL, 0)} fail, {counts.get(SKIPPED, 0)} skipped)",

--- a/operator/rehearsal/run.py
+++ b/operator/rehearsal/run.py
@@ -29,10 +29,21 @@ USAGE
     --drive                actually perform the hostile acts; without it, plan only
     --list                 print the registry and exit; drives nothing
     --only ID[,ID...]      run a subset
-    --overlay-ref REF      the candidate ref this run certifies
+    --overlay-ref REF      the candidate ref this run certifies; the rig must
+                           already be RUNNING it or the run is refused
                            (default: ARG OVERLAY_REF in operator/templates/Dockerfile)
     --inject NAME          declare a fault you have already injected on the rig
     --out DIR              where the report lands (default .stitch/shadow-firm/)
+
+THE RIG MUST ALREADY BE RUNNING THE CANDIDATE. A run stamps the candidate ref
+into its own id (report.py), so before ss#2531 an id reading "green against ref
+X" could have been produced by a rig sitting on the previous release: the ref
+was a label the runner was handed, never a fact it checked. With --drive the
+runner now reads the rig's RUNNING overlay ref off the same runtime seam
+``operator/bin/overlay-ref-drift.py`` uses, and refuses unless it equals the
+candidate. A ref it cannot read refuses too, because "cannot evaluate" must not
+read as "permitted". The consequence for the release order is that the rig is
+reprovisioned onto the candidate BEFORE the suite runs, not after.
 
 EXIT CODES
     0  green: every scenario PASSED. Only this run may be cited by a release gate.
@@ -40,7 +51,8 @@ EXIT CODES
     3  nothing failed but something was SKIPPED, so the suite is incomplete.
        Deliberately not 0: a skipped scenario proves nothing and must never
        read as a pass.
-    2  refused before driving anything (scope violation, bad registry, no seat).
+    2  refused before driving anything (scope violation, bad registry, no seat,
+       or the rig is not running the candidate ref).
 """
 
 from __future__ import annotations
@@ -72,6 +84,50 @@ def pinned_overlay_ref() -> str:
         return "unknown"
     match = re.search(r"^ARG\s+OVERLAY_REF=([^\s#]+)", text, re.MULTILINE)
     return match.group(1).strip('"\'') if match else "unknown"
+
+
+def make_seam_client(slug: str):
+    """The live runtime-read seam factory for one seat.
+
+    A module-level seam on purpose. It is the single line of the running-ref
+    gate that touches a network, so a test can substitute a fake client and
+    still exercise the real gate rather than a copy of it.
+    """
+    return drivers.load_overlay_ref_drift().seam_pull.seam_client_from_env(slug)
+
+
+def rig_running_ref(seat: str, candidate: str) -> str | None:
+    """Refuse unless the rig is RUNNING the ref this run claims to certify.
+
+    Returns the observed running ref, or None when the run must be refused. The
+    refusal is printed here, in the caller's words, because the person who
+    typed --drive is the person who has to act on it.
+
+    Fail-closed in both directions. A mismatch refuses, and so does a ref that
+    cannot be read at all: an unreachable seat is not an excuse to assume the
+    seat is current, it is the absence of the only evidence this gate exists to
+    collect.
+    """
+    drift = drivers.load_overlay_ref_drift()
+    observed = drift.read_running_ref(seat, make_seam_client)
+    if observed.status != "read" or not observed.value:
+        print(
+            f"REFUSED: cannot read the overlay ref `{seat}` is running "
+            f"({observed.status}: {observed.detail or 'no detail'}). Driving now would "
+            f"stamp {candidate[:12]} into a run id with no evidence the rig is on it, "
+            "so nothing was driven.",
+            file=sys.stderr,
+        )
+        return None
+    if not drift.refs_match(candidate, observed.value):
+        print(
+            f"REFUSED: `{seat}` is running {observed.value[:12]}, and this run would "
+            f"certify {candidate[:12]}. reprovision {seat} onto {candidate[:12]} first: "
+            f"yes s | operator/bin/reprovision.sh {seat}",
+            file=sys.stderr,
+        )
+        return None
+    return observed.value
 
 
 def _print_registry(scenarios: list[dict]) -> None:
@@ -119,7 +175,16 @@ def run_suite(args: argparse.Namespace) -> int:
     if not args.drive:
         print(f"PLAN ONLY. Nothing sent. Target seat: {args.seat} (seat.kind={scope.seat_kind(config)})")
         _print_registry(scenarios)
+        print(
+            "Rig running-ref check: not performed in plan mode (it reads the live seam). "
+            "With --drive the runner refuses unless the rig is already running the candidate ref."
+        )
         print("Re-run with --drive to perform these acts against the seat.")
+        return EXIT_REFUSED
+
+    candidate = args.overlay_ref or pinned_overlay_ref()
+    running_ref = rig_running_ref(args.seat, candidate)
+    if running_ref is None:
         return EXIT_REFUSED
 
     capabilities = drivers.probe_capabilities(args.seat, config, inject=args.inject)
@@ -127,7 +192,8 @@ def run_suite(args: argparse.Namespace) -> int:
 
     run = report.Run(
         seat=args.seat,
-        overlay_ref=args.overlay_ref or pinned_overlay_ref(),
+        overlay_ref=candidate,
+        running_ref=running_ref,
         started_at=report.now_stamp(),
     )
     for name, reason in sorted(capabilities.reasons.items()):

--- a/operator/rehearsal/tests/test_registry_and_runner.py
+++ b/operator/rehearsal/tests/test_registry_and_runner.py
@@ -65,15 +65,34 @@ def test_the_connector_outage_scenario_requires_a_declared_fault() -> None:
     assert "fault_injection" in scenario["requires"]
 
 
+class _RigOnTheCandidate:
+    """A rig seam that answers with whatever ref the run is certifying.
+
+    Lets the ss#2531 running-ref gate pass so the check below can be about the
+    thing it was written for. The gate's own refusals are pinned in
+    test_running_ref_gate.py.
+    """
+
+    def __init__(self, ref: str) -> None:
+        self._ref = ref
+
+    def read_config(self) -> dict:
+        return {"schema": "x", "overlay_ref": {"value": self._ref, "source": "direct_url"}}
+
+
 def test_running_without_credentials_skips_and_exits_non_zero(tmp_path, monkeypatch) -> None:
     """The honest-degradation contract, exercised end to end.
 
-    No AgentMail key, no seam: every scenario must report SKIPPED with a reason,
-    the report must say NOT GREEN, and the process must not exit 0. A suite that
-    exits 0 here would let a release gate cite a run that touched nothing.
+    No AgentMail key, no audit seam: every scenario must report SKIPPED with a
+    reason, the report must say NOT GREEN, and the process must not exit 0. A
+    suite that exits 0 here would let a release gate cite a run that touched
+    nothing.
     """
     for variable in ("AGENTMAIL_API_KEY", "OPERATOR_RUNTIME_READ_SECRET", "OPERATOR_RUNTIME_READ_URL"):
         monkeypatch.delenv(variable, raising=False)
+    monkeypatch.setattr(
+        runner, "make_seam_client", lambda slug: _RigOnTheCandidate(runner.pinned_overlay_ref())
+    )
     code = runner.main(["--seat", "pilot-smokeball", "--drive", "--out", str(tmp_path)])
     assert code == runner.EXIT_INCOMPLETE
     reports = sorted(tmp_path.glob("*.md"))

--- a/operator/rehearsal/tests/test_running_ref_gate.py
+++ b/operator/rehearsal/tests/test_running_ref_gate.py
@@ -1,0 +1,160 @@
+"""The release gate has to be able to fail.
+
+WHY THIS FILE EXISTS (ss#2531). The runner stamps the candidate overlay ref into
+the run id it emits, and the release gate asks a bump PR to cite "a green run on
+the candidate ref". Until this gate existed the runner never checked that the
+rig was RUNNING that ref: the candidate was a string it was handed, so a green
+id certifying ref X could have been produced entirely by a rig still on the
+previous release. Three bumps in a row (#2518, #2525, #2531) cited no id at all,
+because the only order the docs described was impossible.
+
+So the checks here are not "the comparison is correct". They are that the runner
+REFUSES, and drives nothing, in each position where the running ref fails to
+support the claim the run would make: a mismatch, a seat whose seam cannot be
+read, a seat with no seam configured, and a snapshot that carries no ref at all.
+The matching case is here too, because a gate that refuses everything is an
+outage wearing a gate's clothes.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from rehearsal import drivers, run as runner  # noqa: E402 -- path injected above
+
+RIG = "pilot-smokeball"
+CANDIDATE = "4dbf415"
+CANDIDATE_FULL = "4dbf415a9c1e77c0b3d2e5f18a4460b7c9d3e2f1"
+STALE = "78c2544be1a90d3f2c7b5468e0a1d9c3f7b26e50"
+
+
+class _FakeClient:
+    """A seam that answers with whatever ref the test says the rig is running."""
+
+    def __init__(self, ref: str | None, *, raises: BaseException | None = None) -> None:
+        self._ref = ref
+        self._raises = raises
+
+    def read_config(self) -> dict:
+        if self._raises is not None:
+            raise self._raises
+        if self._ref is None:
+            return {"schema": "x"}  # a snapshot with no overlay_ref at all
+        return {"schema": "x", "overlay_ref": {"value": self._ref, "source": "direct_url"}}
+
+
+def _seam(monkeypatch, client) -> None:
+    monkeypatch.setattr(runner, "make_seam_client", lambda slug: client)
+
+
+class _DriversReached(Exception):
+    """Raised in place of the first act, to prove the gate let the run past it."""
+
+
+def _tripwire(monkeypatch) -> None:
+    """Make the first thing after the gate explode, so "was it reached" is a fact."""
+
+    def _boom(*args, **kwargs):
+        raise _DriversReached()
+
+    monkeypatch.setattr(drivers, "probe_capabilities", _boom)
+
+
+def _drive(tmp_path, ref: str = CANDIDATE) -> int:
+    return runner.main(["--seat", RIG, "--drive", "--overlay-ref", ref, "--out", str(tmp_path)])
+
+
+# --- the refusals ------------------------------------------------------------
+
+
+def test_a_rig_on_a_different_ref_is_refused_and_nothing_is_driven(tmp_path, monkeypatch, capsys) -> None:
+    """The whole point. A run against a stale rig cannot become a green id."""
+    _seam(monkeypatch, _FakeClient(STALE))
+    _tripwire(monkeypatch)
+    assert _drive(tmp_path) == runner.EXIT_REFUSED
+    assert not list(tmp_path.glob("*")), "a refused run must leave no artifact to cite"
+    err = capsys.readouterr().err
+    assert "REFUSED" in err
+    assert STALE[:12] in err and CANDIDATE in err
+    assert f"reprovision {RIG}" in err
+
+
+def test_an_unreadable_seam_is_refused_rather_than_assumed_current(tmp_path, monkeypatch, capsys) -> None:
+    """Fail closed. An unreachable rig is the absence of the evidence, not the evidence."""
+    _seam(monkeypatch, _FakeClient(CANDIDATE_FULL, raises=OSError("machine down")))
+    _tripwire(monkeypatch)
+    assert _drive(tmp_path) == runner.EXIT_REFUSED
+    assert not list(tmp_path.glob("*"))
+    assert "cannot read the overlay ref" in capsys.readouterr().err
+
+
+def test_a_seat_with_no_seam_configured_is_refused(tmp_path, monkeypatch, capsys) -> None:
+    """``seam_client_from_env`` returns None when the env is unset. That is unknown, not current."""
+    monkeypatch.setattr(runner, "make_seam_client", lambda slug: None)
+    _tripwire(monkeypatch)
+    assert _drive(tmp_path) == runner.EXIT_REFUSED
+    assert "unconfigured" in capsys.readouterr().err
+
+
+def test_a_snapshot_with_no_overlay_ref_is_refused(tmp_path, monkeypatch, capsys) -> None:
+    """A reachable seat that reports no ref is still a seat whose ref we do not know."""
+    _seam(monkeypatch, _FakeClient(None))
+    _tripwire(monkeypatch)
+    assert _drive(tmp_path) == runner.EXIT_REFUSED
+    assert "unknown" in capsys.readouterr().err
+
+
+def test_the_gate_runs_before_anything_is_driven(tmp_path, monkeypatch) -> None:
+    """Ordering, pinned. If the gate ran after the probe the refusal would come too
+    late: the probe is the step that reaches the seat and the mail API."""
+    _seam(monkeypatch, _FakeClient(STALE))
+    calls: list[tuple] = []
+    monkeypatch.setattr(drivers, "probe_capabilities", lambda *a, **k: calls.append(a))
+    assert _drive(tmp_path) == runner.EXIT_REFUSED
+    assert calls == [], "the seat was probed despite a stale rig"
+
+
+# --- the other direction, so the gate is not simply always-refuse ------------
+
+
+def test_a_matching_rig_is_let_through_to_the_drivers(tmp_path, monkeypatch) -> None:
+    _seam(monkeypatch, _FakeClient(CANDIDATE_FULL))
+    _tripwire(monkeypatch)
+    with pytest.raises(_DriversReached):
+        _drive(tmp_path)
+
+
+def test_a_short_candidate_matches_the_full_sha_the_rig_reports(tmp_path, monkeypatch) -> None:
+    """The Dockerfile pins a short ref and the seam reports a full sha. Prefix
+    tolerance is what makes the gate usable; without it the gate would refuse
+    every correctly reprovisioned rig, and someone would delete it."""
+    _seam(monkeypatch, _FakeClient(CANDIDATE_FULL.upper()))
+    _tripwire(monkeypatch)
+    with pytest.raises(_DriversReached):
+        _drive(tmp_path)
+
+
+def test_the_observed_running_ref_is_recorded_on_the_run(tmp_path, monkeypatch) -> None:
+    """The id's provenance is auditable only if the report says what was observed.
+
+    No AgentMail key here, so every scenario SKIPS and the run is not green.
+    That is deliberate: what is pinned is that the ref the gate READ, not the
+    ref it was handed, lands in the artifact.
+    """
+    for variable in ("AGENTMAIL_API_KEY", "OPERATOR_RUNTIME_READ_SECRET", "OPERATOR_RUNTIME_READ_URL"):
+        monkeypatch.delenv(variable, raising=False)
+    _seam(monkeypatch, _FakeClient(CANDIDATE_FULL))
+    assert _drive(tmp_path) == runner.EXIT_INCOMPLETE
+    payloads = sorted(tmp_path.glob("*.json"))
+    assert len(payloads) == 1
+    document = json.loads(payloads[0].read_text())
+    assert document["running_ref"] == CANDIDATE_FULL
+    assert document["overlay_ref"] == CANDIDATE
+    body = payloads[0].with_suffix(".md").read_text()
+    assert CANDIDATE_FULL in body


### PR DESCRIPTION
## Why

`docs/runbooks/operator/shadow-firm.md` ("Release gate: OVERLAY_REF bumps") and `docs/handbook/deployment-release.md` (Path B, step 2) both asked a bump PR to cite the run id of a green shadow-firm run "on the candidate ref". No bump PR can do that. The rig seat (`pilot-smokeball`) runs a candidate overlay ref only after the bump merges and the seat is reprovisioned onto it, so the procedure asked for evidence that could not exist yet. Three bumps in a row (#2518, #2525, #2531) cited none.

The instrument could not have caught the gap either. `operator/rehearsal/run.py` stamped `--overlay-ref` into the run id (`operator/rehearsal/report.py:63`) but never read what the rig was actually running, so an id reading "green against ref X" could have been produced entirely by a rig sitting on the previous release. The candidate was a label the runner was handed, never a fact it checked, and a check that cannot fail measured nothing.

This PR fixes both halves: the tool refuses to drive unless the rig's running ref equals the candidate, and the docs describe the order that is actually possible.

## Change 1: `run.py` asserts the rig's running ref

With `--drive`, after the scope gate and before `drivers.probe_capabilities`, the runner resolves the rig's RUNNING overlay ref from the live runtime-read seam and refuses on anything that does not support the claim the run would make:

- **mismatch** -> `EXIT_REFUSED`, printing both refs and `reprovision <seat> onto <candidate> first` with the reprovision command.
- **unreadable / unconfigured / no `overlay_ref` in the snapshot** -> `EXIT_REFUSED`. Fail closed: an unreachable seat is the absence of the evidence this gate exists to collect, not permission to assume the seat is current.
- **match** -> proceeds, and the observed ref is recorded on `report.Run.running_ref` and rendered in both the markdown body and the JSON, so the id's provenance is auditable rather than assumed.

The read is not a second implementation. `operator/bin/overlay-ref-drift.py` grew a `read_running_ref(slug, make_client)` helper (plus a `RunningRef` result type) that its own `classify()` now calls, and the runner calls the same function through `drivers.load_overlay_ref_drift()`. Two ideas of "what is this seat running" would drift, and the drifted one would be the one nobody watched. Comparison uses the existing `refs_match` semantics (case-insensitive, prefix-tolerant), so a 7-character Dockerfile pin matches the full sha the seam reports.

Plan-only mode (no `--drive`) still works with no network and prints the check as not performed in plan mode.

## Change 2: tests, falsifier first

New `operator/rehearsal/tests/test_running_ref_gate.py` (8 tests): mismatch refuses and drives nothing; unreadable seam refuses; unconfigured seam refuses; a snapshot with no ref refuses; the gate runs before `probe_capabilities` (ordering pinned, since the probe is the step that touches the seat and the mail API); a matching rig reaches the drivers; a short candidate matches the full sha; and the observed ref lands in the report JSON and body.

**Failing first, against `origin/main`:** all 8 fail on main's `run.py` (`AttributeError: module 'rehearsal.run' has no attribute 'make_seam_client'` at the seam the gate needs). Because an absent attribute is weak evidence on its own, the behaviour itself was demonstrated directly on a clean extraction of `origin/main`: driving `--seat pilot-smokeball --overlay-ref deadbee` with no seam configured at all reached `probe_capabilities` and would have gone on to certify `deadbee`.

`operator/rehearsal/tests/test_registry_and_runner.py::test_running_without_credentials_skips_and_exits_non_zero` now stubs the seam so the rig reads as on the candidate; it keeps testing what it was written for (no AgentMail key -> every scenario SKIPPED, report NOT GREEN, non-zero exit) instead of stopping at the new gate.

Counts: `pytest rehearsal/tests bin/tests/test_overlay_ref_drift.py -q` = 74 passed. The full `operator-substrate.yml` pytest invocation = 1875 passed, 1 failed, and that failure (`adapter/evidence/tests/test_packet.py::test_build_emits_targz_with_every_expected_file`, an extra `manifest.sig`) reproduces identically on an unmodified `origin/main` tree in this environment, so it is ambient and pre-existing, not from this branch.

## Change 3: docs rewritten to the possible order

Both pages now describe the post-reprovision gate: (1) cut the overlay release; (2) bump `OVERLAY_REF`, with the PR naming its tracking issue and carrying a `(runtime)` AC for a green shadow-firm run on the rig at this ref; (3) reprovision the rig, before any client seat; (4) drive the suite, which refuses unless the rig's running ref equals the candidate; (5) cite the run id with the report's evidence table on the tracking issue or as a comment on the merged bump, as the `(runtime)` AC's proof; (6) only then reprovision client seats. Both say plainly that a bump with no green id once the rig has been reprovisioned is drift, and point at `overlay-ref-drift.py` as how you see which seats are behind. The paragraphs on the digest-shaped id, `-notgreen`, skipped scenarios, and scope enforcement are kept and moved, not dropped. The runbook's exit-code table and flag notes pick up the new refusal.

## Scope

No existing bump is re-litigated. #2531's runtime AC is the first this applies to, and the parent session runs it once the pilot is reprovisioned.

`npm run verify` exits 0 (293 test files, 4724 tests passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016U9H1VbtZdmBo2t6UBAAPr
