### PR TITLE
fix(operator): the broker accepts the act proposal the seat actually sends, names included

### DIFF
--- a/operator/customers/ashton-price/customer.yaml
+++ b/operator/customers/ashton-price/customer.yaml
@@ -1007,6 +1007,13 @@ self_initiation:
       # a different one is an edit to this line, never a free-text value from an
       # email.
       matter_type_id: '42cc724c-f046-451c-8452-4284f7a82b66_CA'
+      # The two names the read-back shows the administrator. Authored beside the
+      # identifiers, so the sentence she says yes to and the bytes the act
+      # carries come from one file; the seat resolves nothing and composes
+      # nothing. Read live 2026-08-21: the company contact's name and the type's
+      # catalog name.
+      client_contact_name: 'Ashton and Price'
+      matter_type_name: 'Personal Injury - Plaintiff'
 
 # ---- VOICE COHORTS ----
 # The audience classes this seat's voice profiles are partitioned by. An

--- a/operator/customers/pilot-smokeball/customer.yaml
+++ b/operator/customers/pilot-smokeball/customer.yaml
@@ -1011,6 +1011,10 @@ self_initiation:
       # This seat's own "SMD Operations" person contact.
       client_contact_id: '7236214f-628e-412b-ad0e-099c61371cd4'
       matter_type_id: '42cc724c-f046-451c-8452-4284f7a82b66_CA'
+      # The two names the read-back shows the administrator (read live
+      # 2026-08-21 from this tenant's contact and type catalog).
+      client_contact_name: 'SMD Operations'
+      matter_type_name: 'Personal Injury - Plaintiff'
 
 # ---- VOICE COHORTS ----
 # The audience classes this seat's voice profiles are partitioned by. An

--- a/operator/workspace_broker/establishment.py
+++ b/operator/workspace_broker/establishment.py
@@ -199,6 +199,18 @@ ACT_TOOLS: dict[str, tuple[str, ...]] = {
     ),
 }
 
+# The two display names the read-back shows the administrator, authored beside
+# the identifiers in the same block so the sentence a person says yes to and the
+# bytes the act carries come from one file. The overlay hook sends the block
+# whole (identifiers and names together, hermes-smd-overlay#303/#305); the tool
+# itself takes only ACT_TOOLS' fields. Names are accepted in the payload, at the
+# request top level (``contact_name`` / ``matter_type_name``), or from the
+# authored block, in that order of precedence, and must agree with the block
+# when both are present.
+ACT_NAME_KEYS: dict[str, tuple[str, ...]] = {
+    "mcp_smokeball_create_matter": ("client_contact_name", "matter_type_name"),
+}
+
 # Where the authored act payload is read from on a live seat. The broker holds
 # its own handle on this file (``SMD_CUSTOMER_YAML``, server.py) and re-reads it
 # per proposal rather than caching: the file is root-owned and can be re-applied
@@ -1248,15 +1260,33 @@ class EstablishmentStore:
                 + f" block is missing {sorted(missing)}; every field the readback "
                 "names has to be authored before the act can be proposed"
             )
-        extra = sorted(set(block) - set(fields))
+        names = ACT_NAME_KEYS.get(tool, ())
+        extra = sorted(set(block) - set(fields) - set(names))
         if extra:
             raise EstablishmentValidationError(
                 "the authored "
                 + ".".join(ACT_CONFIG_KEYS)
                 + f" block carries unknown keys {extra}; the act carries exactly "
-                f"{sorted(fields)} and nothing else"
+                f"{sorted(fields)} plus the display names {sorted(names)} and nothing else"
             )
         return {f: block[f].strip() for f in fields}
+
+    def _authored_act_names(self, tool: str) -> dict[str, str]:
+        """The authored display names beside the act payload, if the block
+        carries them. Empty when it does not; the caller then needs them from
+        the request, and refuses by name when nobody supplied them."""
+        data = self._seat_config()
+        block: Any = data
+        for key in ACT_CONFIG_KEYS:
+            block = block.get(key) if isinstance(block, dict) else None
+        if not isinstance(block, dict):
+            return {}
+        out: dict[str, str] = {}
+        for key in ACT_NAME_KEYS.get(tool, ()):
+            value = block.get(key)
+            if isinstance(value, str) and value.strip():
+                out[key] = value.strip()
+        return out
 
     @staticmethod
     def _require_act_tool(value: Any) -> str:
@@ -1278,13 +1308,26 @@ class EstablishmentStore:
         if not isinstance(value, dict):
             raise EstablishmentValidationError("payload must be an object")
         fields = ACT_TOOLS[tool]
-        unknown = sorted(set(value) - set(fields))
+        names = ACT_NAME_KEYS.get(tool, ())
+        unknown = sorted(set(value) - set(fields) - set(names))
         if unknown:
             raise EstablishmentValidationError(
                 f"payload carries fields {unknown} that {tool} does not take; "
-                f"it takes exactly {sorted(fields)}"
+                f"it takes exactly {sorted(fields)} (plus the display names {sorted(names)})"
             )
         return {f: _require_text(value.get(f), f"payload.{f}", _MAX_SHORT_TEXT) for f in fields}
+
+    @staticmethod
+    def _payload_names(value: Any, tool: str) -> dict[str, str]:
+        """The display names riding in a payload, if any (the hook sends the
+        authored block whole). Shape-checked like every other caller string."""
+        if not isinstance(value, dict):
+            return {}
+        out: dict[str, str] = {}
+        for key in ACT_NAME_KEYS.get(tool, ()):
+            if value.get(key) is not None:
+                out[key] = _require_text(value.get(key), f"payload.{key}", _MAX_SHORT_TEXT)
+        return out
 
     def act_propose(self, request: dict[str, Any]) -> dict[str, Any]:
         """Record one TOOL CALL as pending and return the line to send.
@@ -1303,12 +1346,31 @@ class EstablishmentStore:
         payload = self._require_act_payload(request.get("payload"), tool)
         instructed_by = require_address(request.get("instructed_by"), "instructed_by")
         source_ref = _require_text(request.get("source_ref"), "source_ref", _MAX_SHORT_TEXT)
-        contact_name = _require_display_name(request.get("contact_name"), "contact_name")
-        matter_type_name = _require_display_name(
-            request.get("matter_type_name"), "matter_type_name"
-        )
-
         authored = self._authored_act_payload(tool)
+        authored_names = self._authored_act_names(tool)
+        payload_names = self._payload_names(request.get("payload"), tool)
+        # Names in the payload must be the authored names: the read-back the
+        # administrator says yes to is rendered from them, so a caller-composed
+        # name is the one fabrication this verb exists to refuse.
+        for key, value in payload_names.items():
+            if key in authored_names and value != authored_names[key]:
+                raise EstablishmentValidationError(
+                    f"the proposed payload's {key} does not match the authored "
+                    + ".".join(ACT_CONFIG_KEYS)
+                    + " block; the read-back carries the authored name"
+                )
+        contact_name = _require_display_name(
+            request.get("contact_name")
+            or payload_names.get("client_contact_name")
+            or authored_names.get("client_contact_name"),
+            "contact_name (or an authored client_contact_name)",
+        )
+        matter_type_name = _require_display_name(
+            request.get("matter_type_name")
+            or payload_names.get("matter_type_name")
+            or authored_names.get("matter_type_name"),
+            "matter_type_name (or an authored matter_type_name)",
+        )
         if payload != authored:
             # The refusal names the FIELDS, never the two values: a refusal that
             # printed both sides would put a caller-supplied string into the

--- a/operator/workspace_broker/tests/test_rule_proposals.py
+++ b/operator/workspace_broker/tests/test_rule_proposals.py
@@ -1068,3 +1068,71 @@ def test_ensure_schema_is_idempotent_over_an_already_migrated_table(tmp_path):
     broker.establishment.pending.ensure_schema()
     result = _act_propose(broker)
     assert result["ok"] is True
+
+
+# ---- the shape the overlay hook actually sends (hermes-smd-overlay#303/#305) ----
+#
+# The hook sends the authored block WHOLE as ``payload`` (identifiers and the
+# two display names together) and nothing at the request top level. Found on
+# 2026-08-21 by reading both halves after they merged: the broker accepted four
+# payload keys and required the names top-level, so every live proposal would
+# have been refused. These pin the contract from the hook's side.
+
+AUTHORED_YAML_WITH_NAMES = AUTHORED_YAML + f"""\
+      client_contact_name: '{CONTACT_NAME}'
+      matter_type_name: '{TYPE_NAME}'
+"""
+
+HOOK_PAYLOAD = {
+    **AUTHORED_PAYLOAD,
+    "client_contact_name": CONTACT_NAME,
+    "matter_type_name": TYPE_NAME,
+}
+
+
+def _hook_propose(broker: Broker, payload: dict):
+    """Exactly the hook's request: six-key payload, no top-level names."""
+    return _call(
+        broker,
+        action="act_propose",
+        tool=ACT_TOOL,
+        payload=payload,
+        instructed_by=ADMIN,
+        source_ref="msg-77",
+    )
+
+
+def test_the_hooks_six_key_payload_proposes_and_renders_the_authored_names(tmp_path):
+    broker = _act_broker(tmp_path, AUTHORED_YAML_WITH_NAMES)
+    result = _hook_propose(broker, dict(HOOK_PAYLOAD))
+    assert result["ok"] is True
+    assert CONTACT_NAME in result["readback"] and TYPE_NAME in result["readback"]
+    assert ACT_CONTACT_ID not in result["readback"]
+
+
+def test_names_authored_in_the_block_suffice_when_the_payload_carries_only_identifiers(tmp_path):
+    broker = _act_broker(tmp_path, AUTHORED_YAML_WITH_NAMES)
+    result = _hook_propose(broker, dict(AUTHORED_PAYLOAD))
+    assert result["ok"] is True
+    assert CONTACT_NAME in result["readback"]
+
+
+def test_no_names_anywhere_is_refused_by_name(tmp_path):
+    broker = _act_broker(tmp_path)  # block without names
+    with pytest.raises(EstablishmentValidationError, match="client_contact_name"):
+        _hook_propose(broker, dict(AUTHORED_PAYLOAD))
+
+
+def test_a_payload_name_that_differs_from_the_authored_name_is_refused(tmp_path):
+    broker = _act_broker(tmp_path, AUTHORED_YAML_WITH_NAMES)
+    payload = dict(HOOK_PAYLOAD)
+    payload["client_contact_name"] = "Somebody Else LLP"
+    with pytest.raises(EstablishmentValidationError, match="client_contact_name"):
+        _hook_propose(broker, payload)
+
+
+def test_the_hooks_six_key_payload_commits_against_the_four_key_row(tmp_path):
+    broker = _act_broker(tmp_path, AUTHORED_YAML_WITH_NAMES)
+    proposal_id = _hook_propose(broker, dict(HOOK_PAYLOAD))["proposal_id"]
+    result = _act_commit(broker, proposal_id, payload=dict(HOOK_PAYLOAD))
+    assert result["ok"] is True


### PR DESCRIPTION
The two halves of the admin-confirmed act (ss#2537 here, hermes-smd-overlay#303/#305
on the seat) were built in parallel against one contract and shipped with a
seam gap: the hook sends the authored operator_matter block whole as the
payload (four identifiers plus client_contact_name and matter_type_name) and
nothing at the request top level; the broker accepted only the four
identifiers in the payload, would have refused the two names as fields the
tool "does not take", and required the names as top-level request fields.
Every live proposal would have been refused at the broker, and the
administrator would have read a withheld reply with no act line in it.

Found by reading both merged halves before the first reprovision, not on a
seat. The broker now accepts the names in the payload, at the top level, or
from the authored block (that order), refuses a payload name that differs
from the authored one, projects the six-key payload to the four stored fields
on propose and on commit, and allows the two name keys in the authored block.
Both seats author the names beside the identifiers (values read live from
each tenant on 2026-08-21).

Falsifier: the five hook-shape tests run against the pre-fix broker: 4 fail,
1 refuses for a different reason. With the fix: 80/80 in test_rule_proposals,

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016U9H1VbtZdmBo2t6UBAAPr