### PR TITLE
fix(operator): park commitment: confirm on both seats until the on-box validator accepts it, so a reprovision boots

### DIFF
--- a/operator/customers/ashton-price/customer.yaml
+++ b/operator/customers/ashton-price/customer.yaml
@@ -199,7 +199,11 @@ personas:
         # answers in their own words, and only then does the act happen. There
         # is deliberately no exposure_ceiling entry for this class, so the
         # runtime entitlement dial cannot raise it at all.
-        commitment: confirm
+        # commitment: confirm
+        # PARKED 2026-08-21: the on-box validator at overlay 07ed486 refuses 'confirm' on a
+        # non-send class and the seat crash-loops at boot (pilot, 22:57Z). Re-enabled by the
+        # PR that bumps to the overlay whose validator accepts it. Parked means the
+        # commitment class is unauthored, so it is REFUSED, fail-closed.
       # Letter-commitment bounds for the runtime entitlement dial (ss#2003
       # Q7). Derived from routine-grid.yaml ceiling_tier per send class
       # (auto-handle -> autonomous, prepare-and-route -> draft_for_review),

--- a/operator/customers/pilot-smokeball/customer.yaml
+++ b/operator/customers/pilot-smokeball/customer.yaml
@@ -177,7 +177,11 @@ personas:
         # A&P posture: an admin-confirmed act proposal is the only path, never
         # autonomous. No exposure_ceiling entry, so the entitlement dial cannot
         # raise it.
-        commitment: confirm
+        # commitment: confirm
+        # PARKED 2026-08-21: the on-box validator at overlay 07ed486 refuses 'confirm' on a
+        # non-send class and the seat crash-loops at boot (pilot, 22:57Z). Re-enabled by the
+        # PR that bumps to the overlay whose validator accepts it. Parked means the
+        # commitment class is unauthored, so it is REFUSED, fail-closed.
       # Letter-commitment bounds for the runtime entitlement dial (ss#2003
       # Q7), mirroring the A&P seat (this seat rehearses that grid). Derived
       # from routine-grid.yaml ceiling_tier per send class; the Machine clamps


### PR DESCRIPTION
ss#2537 authored `commitment: confirm` on pilot-smokeball and ashton-price. The
overlay's on-box config validator (bootstrap/validate.py:545-552 at 07ed486)
refuses 'confirm' on any non-send class, so the first reprovision from main
(pilot, 2026-08-21 22:57Z) refused the R2 customer.yaml at boot and the seat
crash-looped to its restart cap. ashton-price carries the same line; a
reprovision of the paying client's seat from main would have done the same.

This parks the two lines as comments. Parked means the commitment class is
unauthored on both seats, which ADR 0056 treats as REFUSED: the admin-confirmed
act stays unreachable, fail-closed, until the PR that bumps to an overlay whose
validator accepts 'confirm' on 'commitment' re-enables them. Nothing else in
the feature moves.

Follow-on (separate PRs): overlay validator accepts 'confirm' on 'commitment'; the bump to that overlay re-enables these two lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016U9H1VbtZdmBo2t6UBAAPr