### PR TITLE
chore(operator): the pilot rehearses its Operator Library under a description its own dedupe will not refuse

### DIFF
--- a/operator/customers/pilot-smokeball/customer.yaml
+++ b/operator/customers/pilot-smokeball/customer.yaml
@@ -1008,7 +1008,7 @@ self_initiation:
     # and this feature does not move it.
     operator_matter:
       number: '2026-OPS-LIBRARY'
-      description: 'Operator Library'
+      description: 'Operator Library (rehearsal)'
       # This seat's own "SMD Operations" person contact.
       client_contact_id: '7236214f-628e-412b-ad0e-099c61371cd4'
       matter_type_id: '42cc724c-f046-451c-8452-4284f7a82b66_CA'


### PR DESCRIPTION
The step-0 vendor probe on 2026-08-21 created the pilot's first Operator
Library matter (OPS-OPERATOR-LIBRARY, description 'Operator Library') on the
SMD Operations contact. The pilot's authored act then used the same
description on the same contact, which create_matter's fail-closed duplicate
check refuses by design, so the propose -> yes -> create rehearsal could not
reach the create. The rehearsal act now carries a distinct description. A&P
is unaffected (no such matter exists there).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016U9H1VbtZdmBo2t6UBAAPr
