### PR TITLE
fix(operator): the pending view names an act's tool where the seat reads it, so an administrator's confirmation lands

### DIFF
--- a/operator/workspace_broker/establishment.py
+++ b/operator/workspace_broker/establishment.py
@@ -1155,6 +1155,13 @@ class EstablishmentStore:
             "text": row["text"],
             "readback": readback_for(row["proposal_id"], row["text"], row["kind"]),
             "payload": row["payload"],
+            # The tool an act row names, at the top level, because that is where
+            # the seat reads it (hermes-smd-establishment._act_confirmation_note:
+            # ``row.get("tool")``). It also lives inside ``subject``; read live on
+            # pilot-smokeball 2026-08-22, a confirmed act came back "no longer
+            # held" because this view left the top-level key out and the seat
+            # took the empty string as "names no tool".
+            "tool": (row["subject"] or {}).get("tool") if row["kind"] == "tool_call" else None,
             "instructed_by": row["instructed_by"],
             "for_admin": row["for_admin"],
             "created_at": row["created_at"],

--- a/operator/workspace_broker/tests/test_rule_proposals.py
+++ b/operator/workspace_broker/tests/test_rule_proposals.py
@@ -1136,3 +1136,15 @@ def test_the_hooks_six_key_payload_commits_against_the_four_key_row(tmp_path):
     proposal_id = _hook_propose(broker, dict(HOOK_PAYLOAD))["proposal_id"]
     result = _act_commit(broker, proposal_id, payload=dict(HOOK_PAYLOAD))
     assert result["ok"] is True
+
+
+def test_the_pending_view_names_the_tool_at_the_top_level_for_an_act(tmp_path):
+    """The seat reads ``row["tool"]`` when an administrator confirms an act. Read
+    live on pilot-smokeball 2026-08-22: with the tool only inside ``subject``,
+    the confirmation came back "no longer holding that as something to do"."""
+    broker = _act_broker(tmp_path, AUTHORED_YAML_WITH_NAMES)
+    proposal_id = _hook_propose(broker, dict(HOOK_PAYLOAD))["proposal_id"]
+    listing = _call(broker, action="establish_pending", proposal_id=proposal_id)
+    rows = [r for r in listing["pending"] if r["proposal_id"] == proposal_id]
+    assert rows and rows[0]["tool"] == ACT_TOOL
+    assert rows[0]["kind"] == "tool_call" and rows[0]["payload"]["number"] == ACT_NUMBER


### PR DESCRIPTION
Read live on pilot-smokeball 2026-08-22: the administrator replied
'[act a6bc3c0c] yes, create it' to a real proposal; the seat re-fetched the
row, read row['tool'], got nothing (the view carried the tool only inside
subject), and told her the seat was no longer holding the act. Nothing was
created and the row stayed open.

The view now carries 'tool' at the top level for tool_call rows (None for
rules). Falsifier: the new test fails on the previous view (1 failed / 80
passed); with the fix 81/81, broker suite 426/426, npm run verify exit 0.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016U9H1VbtZdmBo2t6UBAAPr
